### PR TITLE
docs: documentation should import components from library source (#13)

### DIFF
--- a/docs/modules/documentation/containers/modal/modal-docs.component.ts
+++ b/docs/modules/documentation/containers/modal/modal-docs.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Schema } from '../../../schema/models/schema.model';
 import { SchemaFactoryService } from '../../../schema/services/schema-factory/schema-factory.service';
 
-import { ModalService } from 'fundamental-ngx';
+import { ModalService } from '../../../../../projects/fundamental-ngx/src/lib/modal/modal.service';
 
 @Component({
     selector: 'app-modal',

--- a/docs/modules/documentation/documentation.module.ts
+++ b/docs/modules/documentation/documentation.module.ts
@@ -6,7 +6,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { SchemaModule } from '../schema/schema.module';
 
 // modules
-import { FundamentalNgxModule } from 'fundamental-ngx';
+import { FundamentalNgxModule } from '../../../projects/fundamental-ngx/src/lib/fundamental-ngx.module';
 
 // components
 import { DocumentationComponent } from './components/documentation/documentation.component';

--- a/package-lock.json
+++ b/package-lock.json
@@ -4581,14 +4581,6 @@
             "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
             "dev": true
         },
-        "fundamental-ngx": {
-            "version": "0.0.1-beta",
-            "resolved": "https://registry.npmjs.org/fundamental-ngx/-/fundamental-ngx-0.0.1-beta.tgz",
-            "integrity": "sha512-rIa/HIzBn/3MO7q0GOqPdgF2STpom6uI3yTdVtRA+rtcurVFHcCmwcgWQOfJl/8ek5UeLXwx6whQxbyWrrx1UA==",
-            "requires": {
-                "tslib": "^1.9.0"
-            }
-        },
         "fundamental-ui": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fundamental-ui/-/fundamental-ui-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
         "@ng-bootstrap/ng-bootstrap": "^2.0.0",
         "angular-highlight-js": "^2.0.1",
         "core-js": "~2.5.3",
-        "fundamental-ngx": "0.0.1-beta",
         "fundamental-ui": "^1.0.0",
         "highlight.js": "^9.12.0",
         "ngx-highlightjs": "^2.1.1",


### PR DESCRIPTION
#### Please provide a link to the associated issue
#13 

#### Is this a bug fix, enhancement, or new feature?
Enhancement

#### Please provide a brief summary of this pull request
The documentation application should import components directly from the library source, so that anyone developing components can see their changes reflected in the demo application running locally without having to build the library with each change
