### PR TITLE
build: adds build scripts for docs and library to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
         "e2e": "ng e2e",
         "build-src": "gulp build-src",
         "precise-commits": "precise-commits",
-        "precommit": "npm run precise-commits"
+        "precommit": "npm run precise-commits",
+        "build-deploy-docs": "ng build --prod --base-href=\"/fundamental-ngx/\" && angular-cli-ghpages",
+        "build-deploy-library": "ng build --prod fundamental-ngx && cd dist/fundamental-ngx && npm publish && cd ../.."
     },
     "publishConfig": {
         "registry": "https://repository.hybris.com/api/npm/npm-repository/"


### PR DESCRIPTION
#### Have you squashed your commits and provided a simple commit message?
Yes

#### Please provide a link to the associated issue
#49 

#### Is this a bug fix, enhancement, or new feature?
Enhancement

#### Please provide a brief summary of this pull request
Needed npm scripts for building and deploying the fundamental-ngx npm library as well as the GitHub Pages documentation site