### PR TITLE
refactor: breadcrumb text should be ng-content, not @Input()

### DIFF
--- a/docs/modules/documentation/containers/breadcrumb/breadcrumb-docs.component.html
+++ b/docs/modules/documentation/containers/breadcrumb/breadcrumb-docs.component.html
@@ -8,15 +8,20 @@
 <separator></separator>
 
 <h1>&lt;fd-breadcrumb&gt;</h1>
+<properties [properties]="{
+  inputs: [
+    { name: 'url', description: '(Optional) Url the breadcrumb should link to.  Leave blank for the current page.'}
+  ]
+}"></properties>
 
 <separator></separator>
 
 <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
   <div class="fd-tile__content">
     <fd-breadcrumb>
-      <fd-breadcrumb-item [url]="'#'" [text]="'Link Text'"></fd-breadcrumb-item>
-      <fd-breadcrumb-item [url]="'#'" [text]="'Link Text'"></fd-breadcrumb-item>
-      <fd-breadcrumb-item [text]="'Link Text'"></fd-breadcrumb-item>
+      <fd-breadcrumb-item [url]="'#'">Link Text</fd-breadcrumb-item>
+      <fd-breadcrumb-item [url]="'#'">Link Text</fd-breadcrumb-item>
+      <fd-breadcrumb-item>Link Text</fd-breadcrumb-item>
     </fd-breadcrumb>
   </div>
 </div>

--- a/docs/modules/documentation/containers/breadcrumb/breadcrumb-docs.component.ts
+++ b/docs/modules/documentation/containers/breadcrumb/breadcrumb-docs.component.ts
@@ -7,9 +7,9 @@ import { Component } from '@angular/core';
 export class BreadcrumbDocsComponent {
     breadcrumbHtml =
         '<fd-breadcrumb>\n' +
-        '  <fd-breadcrumb-item [url]="\'#\'" [text]="\'Link Text\'"></fd-breadcrumb-item>\n' +
-        '  <fd-breadcrumb-item [url]="\'#\'" [text]="\'Link Text\'"></fd-breadcrumb-item>\n' +
-        '  <fd-breadcrumb-item [text]="\'Link Text\'"></fd-breadcrumb-item>\n' +
+        '  <fd-breadcrumb-item [url]="\'#\'">Link Text</fd-breadcrumb-item>\n' +
+        '  <fd-breadcrumb-item [url]="\'#\'">Link Text</fd-breadcrumb-item>\n' +
+        '  <fd-breadcrumb-item>Link Text</fd-breadcrumb-item>\n' +
         '</fd-breadcrumb>\n';
 
     constructor() {}

--- a/projects/fundamental-ngx/src/lib/breadcrumb/breadcrumb-item.component.html
+++ b/projects/fundamental-ngx/src/lib/breadcrumb/breadcrumb-item.component.html
@@ -1,2 +1,3 @@
-<a *ngIf="url;else noUrltemplate" class="fd-breadcrumb__link" [routerLink]="['url']"> {{text}} </a>
-<ng-template #noUrltemplate> {{text}} </ng-template>
+<span [ngClass]="{'fd-breadcrumb__link': url }" [ngStyle]="{'cursor': getCursor(url) }" [routerLink]="url ? [url] : []">
+  <ng-content></ng-content>
+</span>

--- a/projects/fundamental-ngx/src/lib/breadcrumb/breadcrumb-item.component.ts
+++ b/projects/fundamental-ngx/src/lib/breadcrumb/breadcrumb-item.component.ts
@@ -13,5 +13,11 @@ export class BreadcrumbItemComponent {
 
     @Input() url: string;
 
-    @Input() text: string;
+    getCursor(url) {
+        let retVal = 'text';
+        if (url) {
+            retVal = 'pointer';
+        }
+        return retVal;
+    }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue
#57 

#### Is this a bug fix, enhancement, or new feature?
Enhancement/refactor

#### Please provide a brief summary of this pull request
Refactored the breadcrumb component.  User now provides breadcrumb text inside the <fd-breadcrumb-item> tags rather than as input [text]