### PR TITLE
feat: add function to select tab by ID, refactor selection algorithm,…

### DIFF
--- a/docs/modules/documentation/containers/tabs/tabs-docs.component.html
+++ b/docs/modules/documentation/containers/tabs/tabs-docs.component.html
@@ -7,9 +7,20 @@
 
 <properties [properties]="{
   childComponents: [
-    { name: '<fd-tab>', description: 'An individual tab.  Has properties \'title\' and \'disabled\'. '}
+    { name: '<fd-tab>', description: 'An individual tab.'}
+  ],
+  inputs: [
+    { name: 'title', description: 'String - Text to display at the top of the tab.'},
+    { name: 'disabled', description: 'Boolean - Prevents the tab from being selected.'},
+    { name: 'id', description: 'String - Allows you to select a tab programmatically using the select() function.'}
+  ],
+  outputs: [
+    { name: 'tabChange', description: 'EventEmitter - emitted when the user selects a tab.  Emits the id of the newly selected tab.'}
   ]
 }"></properties>
+
+<separator></separator>
+
 <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
   <div class="fd-tile__content">
     <fd-tab-list>
@@ -29,6 +40,27 @@
   </div>
 </div>
 <pre><code mwlHighlightJs language="HTML" [source]="tabHtml"></code></pre>
+
+<separator></separator>
+<h2>Selecting a tab programmatically by ID</h2>
+<p>You can set an <code>id</code> on a tab and select it programmatically using the <code>select()</code> function.</p>
+<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
+  <div class="fd-tile__content">
+    <fd-tab-list #tabList>
+      <fd-tab id="tab1" title="Tab 1">
+        Tab 1
+      </fd-tab>
+      <fd-tab id="tab2" title="Tab 2">
+        Tab 2
+      </fd-tab>
+    </fd-tab-list>
+  </div>
+</div>
+<br><br>
+<button fd-button type="main" (click)="this.tabList.select('tab2')">
+  Select Tab 2
+</button>
+<pre><code mwlHighlightJs language="HTML" [source]="selectTabByIdHtml"></code></pre>
 
 <separator></separator>
 

--- a/docs/modules/documentation/containers/tabs/tabs-docs.component.ts
+++ b/docs/modules/documentation/containers/tabs/tabs-docs.component.ts
@@ -96,6 +96,19 @@ export class TabsDocsComponent implements OnInit {
         '  </fd-tab>\n' +
         '</fd-tab-list>';
 
+    selectTabByIdHtml =
+        '<fd-tab-list #tabList>\n' +
+        '  <fd-tab id="tab1" title="Tab 1">\n' +
+        '    Tab 1\n' +
+        '  </fd-tab>\n' +
+        '  <fd-tab id="tab2" title="Tab 2">\n' +
+        '    Tab 2\n' +
+        '  </fd-tab>\n' +
+        '</fd-tab-list>\n' +
+        '<button fd-button type="main" (click)="this.tabList.select(\'tab2\')">\n' +
+        '  Select Tab 2\n' +
+        '</button>';
+
     constructor(private schemaFactory: SchemaFactoryService) {
         this.schema = this.schemaFactory.getComponent('tabs');
     }

--- a/projects/fundamental-ngx/src/lib/tabs/tab-list.component.html
+++ b/projects/fundamental-ngx/src/lib/tabs/tab-list.component.html
@@ -7,7 +7,7 @@
        [attr.aria-selected]="tab.expanded ? true : null"
        [class.is-selected]="tab.expanded"
        [href]="'#' + tab.id"
-       (click)="select($event, tab)">{{ tab.title }}</a>
+       (click)="tabClicked($event, tab.id)">{{ tab.title }}</a>
   </li>
 </ul>
 <ng-content select="fd-tab"></ng-content>

--- a/projects/fundamental-ngx/src/lib/tabs/tab-list.component.ts
+++ b/projects/fundamental-ngx/src/lib/tabs/tab-list.component.ts
@@ -1,4 +1,12 @@
-import { AfterContentInit, Component, ContentChildren, QueryList, ViewEncapsulation } from '@angular/core';
+import {
+    AfterContentInit,
+    Component,
+    ContentChildren,
+    EventEmitter,
+    Output,
+    QueryList,
+    ViewEncapsulation
+} from '@angular/core';
 import { TabPanelComponent } from './tabs.component';
 
 @Component({
@@ -10,6 +18,8 @@ import { TabPanelComponent } from './tabs.component';
 export class TabListComponent implements AfterContentInit {
     @ContentChildren(TabPanelComponent) tabs: QueryList<TabPanelComponent>;
 
+    @Output() tabChange = new EventEmitter<any>();
+
     selected: TabPanelComponent;
 
     ngAfterContentInit() {
@@ -19,17 +29,28 @@ export class TabListComponent implements AfterContentInit {
         });
     }
 
-    select($event: MouseEvent, tab: TabPanelComponent) {
-        $event.preventDefault();
-        if (tab.disabled) {
-            return;
-        } else {
-            this.selected.expanded = false;
-        }
+    select(tabId) {
+        this.tabs.forEach(tab => {
+            if (tab.id === tabId) {
+                if (tab.disabled) {
+                    return;
+                } else {
+                    this.selected.expanded = false;
+                }
 
-        if (this.selected) {
-            this.selected = tab;
-            this.selected.expanded = true;
+                if (this.selected) {
+                    this.selected = tab;
+                    this.selected.expanded = true;
+                    this.tabChange.emit(tab.id);
+                }
+            }
+        });
+    }
+
+    tabClicked($event: MouseEvent, tabId) {
+        if ($event) {
+            $event.preventDefault();
         }
+        this.select(tabId);
     }
 }

--- a/projects/fundamental-ngx/src/lib/tabs/tabs.component.ts
+++ b/projects/fundamental-ngx/src/lib/tabs/tabs.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, Inject } from '@angular/core';
+import { HashService } from '../utils/hash.service';
 
 @Component({
     selector: 'fd-tab',
@@ -9,15 +10,23 @@ import { Component, OnInit, Input } from '@angular/core';
         '[class.is-expanded]': 'expanded',
         '[id]': 'id'
     },
-    templateUrl: './tab.component.html'
+    templateUrl: './tab.component.html',
+    providers: [HashService]
 })
 export class TabPanelComponent implements OnInit {
     @Input() title: string;
 
     @Input() disabled: boolean;
 
-    id: string;
+    @Input() id: string;
+
     expanded = false;
 
-    ngOnInit() {}
+    constructor(@Inject(HashService) private hasher: HashService) {}
+
+    ngOnInit() {
+        if (!this.id) {
+            this.id = this.hasher.hash();
+        }
+    }
 }


### PR DESCRIPTION
… emit tabChange event

#### Please provide a link to the associated issue
#56 

#### Is this a bug fix, enhancement, or new feature?
Enhancement/new feature

#### Please provide a brief summary of this pull request
Tabs can now be selected programmatically by setting an id on the <fd-tab> and calling the select() function of the <fd-tab-list>.  Also, selecting a tab emits a tabChange event that passes the newly selected tab ID.