### PR TITLE
feat: modal service open should return modal ref

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ We ask that you adhere to our coding style as best you can when submitting code.
 1.  Make sure the issue you've filed on our [issue tracker] has the label "contribution welcome" - otherwise, it is not ready to be worked on
 2.  Fork the Fundamental NGX repository to your GitHub account
 3.  Create a branch for your issue or feature and commit/push your changes on that branch
-4.  Please squash your commits into one commit and provide a summary of the changes in the commit message.  Also, please adhere to the [Angular commit message guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
+4.  Please adhere to the [Angular commit message guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
 5.  Create a Pull Request from your forked repository to github.com/SAP/fundamental-ngx.  In the subject of the pull request, briefly describe the bug fix or enhancement you're contributing.  In the pull request description, please provide a link to the issue from our issue tracker
 6.  Follow the link posted by the CLA assistant to your pull request and accept it, as described in detail above.
 7.  Wait for our code review and approval.  We may ask you for additional commits, or make changes to your pull request ourselves

--- a/docs/modules/documentation/containers/modal/modal-docs.component.html
+++ b/docs/modules/documentation/containers/modal/modal-docs.component.html
@@ -22,10 +22,11 @@ The Modal component utilizes a singleton ModalService to handle opening/closing 
         </fd-modal-body>
       </fd-modal>
     </ng-template>
-    <button fd-button (click)="openModal(informationalModal)">Launch Demo</button>
+    <button fd-button (click)="openInfoModal(informationalModal)">Launch Demo</button>
   </div>
 </div>
 <pre><code mwlHighlightJs language="HTML" [source]="informationalModalHtml"></code></pre>
+<pre><code mwlHighlightJs language="typescript" [source]="informationalModalJs"></code></pre>
 
 <separator></separator>
 
@@ -33,7 +34,7 @@ The Modal component utilizes a singleton ModalService to handle opening/closing 
 <p>Used to confirm with the user before continuing with destructive or complex actions. In this case the modal have two buttons at the bottom. With the “positive” path always been the primary button.</p>
 <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
   <div class="fd-tile__content">
-    <ng-template #confirmationModal>
+    <ng-template #confirmationModal let-c="close">
       <fd-modal>
         <fd-modal-header>
           Modal Header/Title
@@ -42,23 +43,27 @@ The Modal component utilizes a singleton ModalService to handle opening/closing 
           Modal Body
         </fd-modal-body>
         <fd-modal-footer>
-          <button fd-button type="secondary">No</button>
-          <button fd-button type="main">Yes</button>
+          <button fd-button (click)="c('No')" type="secondary">No</button>
+          <button fd-button (click)="c('Yes')" type="main">Yes</button>
         </fd-modal-footer>
       </fd-modal>
     </ng-template>
-    <button fd-button (click)="openModal(confirmationModal)">Launch Demo</button>
+    <button fd-button (click)="openConfirmationModal(confirmationModal)">Launch Demo</button>
+    <separator></separator>
+    <span>{{confirmationReason}}</span>
   </div>
 </div>
 <pre><code mwlHighlightJs language="HTML" [source]="confirmationModalHtml"></code></pre>
+<pre><code mwlHighlightJs language="typescript" [source]="confirmationModalJs"></code></pre>
 
+<!--
 <separator></separator>
 
 <h2>Form Modal</h2>
 <p>Used to collect simple information from the user. Please use with care and don’t include more than five inputs on a modal to avoid scrolling inside the modal.</p>
 <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
   <div class="fd-tile__content">
-    <ng-template #formModal>
+    <ng-template #formModal let-c="close">
       <fd-modal>
         <fd-modal-header>
           Modal Header/Title
@@ -72,14 +77,17 @@ The Modal component utilizes a singleton ModalService to handle opening/closing 
           </div>
         </fd-modal-body>
         <fd-modal-footer>
-          <button fd-button type="secondary">Cancel</button>
-          <button fd-button type="main">Invite</button>
+          <button fd-button (click)="c('Cancel')" type="secondary">Cancel</button>
+          <button fd-button (click)="c('Invite')" type="main">Invite</button>
         </fd-modal-footer>
       </fd-modal>
     </ng-template>
     <button fd-button (click)="openModal(formModal)">Launch Demo</button>
+    <separator></separator>
+    <span>{{reason}}</span>
   </div>
 </div>
 <pre><code mwlHighlightJs language="HTML" [source]="formModalHtml"></code></pre>
 
 <separator></separator>
+-->

--- a/docs/modules/documentation/containers/modal/modal-docs.component.ts
+++ b/docs/modules/documentation/containers/modal/modal-docs.component.ts
@@ -48,6 +48,8 @@ export class ModalDocsComponent implements OnInit {
         }
     };
 
+    confirmationReason: string;
+
     informationalModalHtml =
         '<ng-template #informationalModal>\n' +
         '  <fd-modal>\n' +
@@ -59,10 +61,10 @@ export class ModalDocsComponent implements OnInit {
         '    </fd-modal-body>\n' +
         '  </fd-modal>\n' +
         '</ng-template>\n' +
-        '<button fd-button (click)="openModal(informationalModal)">Launch Demo</button>';
+        '<button fd-button (click)="openInfoModal(informationalModal)">Launch Demo</button>';
 
     confirmationModalHtml =
-        '<ng-template #confirmationModal>\n' +
+        '<ng-template #confirmationModal let-c="close">\n' +
         '  <fd-modal>\n' +
         '    <fd-modal-header>\n' +
         '      Modal Header/Title\n' +
@@ -71,12 +73,13 @@ export class ModalDocsComponent implements OnInit {
         '      Modal Body\n' +
         '    </fd-modal-body>\n' +
         '    <fd-modal-footer>\n' +
-        '      <button fd-button type="secondary">No</button>\n' +
-        '      <button fd-button type="main">Yes</button>\n' +
+        '      <button fd-button (click)="c(\'No\')" type="secondary">No</button>\n' +
+        '      <button fd-button (click)="c(\'Yes\')" type="main">Yes</button>\n' +
         '    </fd-modal-footer>\n' +
         '  </fd-modal>\n' +
         '</ng-template>\n' +
-        '<button fd-button (click)="openModal(confirmationModal)">Launch Demo</button>';
+        '<button fd-button (click)="openConfirmationModal(confirmationModal)">Launch Demo</button>\n' +
+        '<span>{{confirmationReason}}</span>';
 
     formModalHtml =
         '<ng-template #formModal>\n' +
@@ -99,6 +102,24 @@ export class ModalDocsComponent implements OnInit {
         '  </fd-modal>\n' +
         '</ng-template>';
 
+    informationalModalJs = 'openModal(modalType) {\n' + '    this.modalService.open(modalType);\n' + '}';
+
+    confirmationModalJs =
+        'openConfirmationModal(modalType) {\n' +
+        '    this.modalService.open(modalType).result.then(\n' +
+        '        result => {\n' +
+        '            if (result === "Yes") {\n' +
+        '                this.confirmationReason = \'Modal closed with "Yes" button\';\n' +
+        '            } else if (result === "No") {\n' +
+        '                this.confirmationReason = \'Modal closed with "No" button\';\n' +
+        '            }\n' +
+        '        },\n' +
+        '        () => {\n' +
+        '            this.confirmationReason = \'Modal dismissed with the "X" button\';\n' +
+        '        }\n' +
+        '    );\n' +
+        '}';
+
     constructor(private schemaFactory: SchemaFactoryService, private modalService: ModalService) {
         this.schema = this.schemaFactory.getComponent('modal');
     }
@@ -109,7 +130,22 @@ export class ModalDocsComponent implements OnInit {
 
     ngOnInit() {}
 
-    openModal(modalType) {
+    openInfoModal(modalType) {
         this.modalService.open(modalType);
+    }
+
+    openConfirmationModal(modalType) {
+        this.modalService.open(modalType).result.then(
+            result => {
+                if (result === 'Yes') {
+                    this.confirmationReason = 'Modal closed with "Yes" button';
+                } else if (result === 'No') {
+                    this.confirmationReason = 'Modal closed with "No" button';
+                }
+            },
+            () => {
+                this.confirmationReason = 'Modal dismissed with the "X" button';
+            }
+        );
     }
 }

--- a/projects/fundamental-ngx/src/lib/modal/modal-header.component.html
+++ b/projects/fundamental-ngx/src/lib/modal/modal-header.component.html
@@ -2,5 +2,5 @@
   <h1 class="fd-modal__title">
     <ng-content></ng-content>
   </h1>
-  <button class="fd-modal__close" aria-label="close" (click)="modalService.close()"></button>
+  <button class="fd-modal__close" aria-label="close" (click)="modalService.dismiss()"></button>
 </div>

--- a/projects/fundamental-ngx/src/lib/modal/modal.component.ts
+++ b/projects/fundamental-ngx/src/lib/modal/modal.component.ts
@@ -10,7 +10,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 export class ModalComponent {
     constructor(@Inject(NgbModal) private modalService: NgbModal) {}
 
-    open() {
-        this.modalService.open(ModalComponent);
+    open(): any {
+        return this.modalService.open(ModalComponent);
     }
 }

--- a/projects/fundamental-ngx/src/lib/modal/modal.service.ts
+++ b/projects/fundamental-ngx/src/lib/modal/modal.service.ts
@@ -10,11 +10,16 @@ export class ModalService {
 
     constructor(private modalService: NgbModal) {}
 
-    close() {
-        this.modalRef.close();
+    close(): any {
+        return this.modalRef.close();
     }
 
-    open(modalType) {
+    dismiss(): any {
+        return this.modalRef.dismiss();
+    }
+
+    open(modalType): any {
         this.modalRef = this.modalService.open(modalType);
+        return this.modalRef;
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue
#60 

#### Is this a bug fix, enhancement, or new feature?
Enhancement

#### Please provide a brief summary of this pull request
Modal service should return modal ref with open, and should return reasons for dismissing/closing the modal