### PR TITLE
fix: better handling of dropdown open/close

### DIFF
--- a/projects/fundamental-ngx/src/lib/dropdown/dropdown.component.html
+++ b/projects/fundamental-ngx/src/lib/dropdown/dropdown.component.html
@@ -1,12 +1,12 @@
 <div class="fd-dropdown">
   <ng-container *ngIf="isContextualMenu">
-    <button (focus)="open()" (blur)="close()" [tabindex]="disabled ? -1 : 0" [attr.aria-controls]="id" [attr.aria-expanded]="isOpen"
+    <button [tabindex]="disabled ? -1 : 0" [attr.aria-controls]="id" [attr.aria-expanded]="isOpen"
       [attr.aria-label]="'More'" [attr.aria-disabled]="disabled" aria-haspopup="true" [ngClass]="{' fd-button fd-button--secondary fd-button--l sap-icon--vertical-grip' : true}">
       <ng-content></ng-content>
     </button>
   </ng-container>
   <ng-container *ngIf="!isContextualMenu">
-    <button (focus)="open()" (blur)="close()" [tabindex]="disabled ? -1 : 0" class="fd-dropdown__control fd-button--toolbar"
+    <button [tabindex]="disabled ? -1 : 0" class="fd-dropdown__control fd-button--toolbar"
       [attr.aria-controls]="id" [attr.aria-expanded]="isOpen" [attr.aria-disabled]="disabled" aria-haspopup="true" [ngClass]="(glyph ? 'sap-icon--' + glyph + ' ' : ' ') + (size ? 'fd-button--' + size : '')">
       <ng-content></ng-content>
     </button>

--- a/projects/fundamental-ngx/src/lib/dropdown/dropdown.component.ts
+++ b/projects/fundamental-ngx/src/lib/dropdown/dropdown.component.ts
@@ -1,9 +1,10 @@
-import { Directive, Component, Input, HostListener } from '@angular/core';
+import { Component, Input, HostListener, ElementRef } from '@angular/core';
 
 @Component({
     selector: 'fd-dropdown',
     host: {
-        class: 'fd-dropdown'
+        class: 'fd-dropdown',
+        '(document:click)': 'documentClick($event)'
     },
     templateUrl: './dropdown.component.html'
 })
@@ -20,12 +21,25 @@ export class DropdownComponent {
 
     isOpen = false;
 
-    open() {
-        this.isOpen = true;
+    dropdownClicked() {
+        if (this.isOpen) {
+            this.close();
+        } else {
+            this.isOpen = true;
+        }
     }
 
     close() {
         this.isOpen = false;
+    }
+
+    documentClick($event) {
+        const target = $event.target;
+        if (this.eRef.nativeElement.contains(target)) {
+            this.dropdownClicked();
+        } else {
+            this.close();
+        }
     }
 
     @HostListener('document:keydown.escape', ['$event'])
@@ -34,4 +48,6 @@ export class DropdownComponent {
             this.close();
         }
     }
+
+    constructor(private eRef: ElementRef) {}
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue
#65 

#### Please provide a brief summary of this pull request
Using (blur) to close the dropdown causes some undesirable effects. If the user clicks and holds one of the selectable options (rather than a quick click), the dropdown perceives this as a blur event and closes the dropdown, and the option the user clicks on does not register as a click.

Also, clicking the main button on an expanded dropdown should close it.