### PR TITLE
fix: breadcrumb links now styled correctly

### DIFF
--- a/docs/styles.scss
+++ b/docs/styles.scss
@@ -106,14 +106,6 @@ pre {
         }
     }
 
-    .fd-breadcrumb__link {
-        color: #0a6ed1;
-        &:hover {
-            color: #0a6ed1;
-            text-decoration: none;
-        }
-    }
-
     .fd-side-nav {
         max-width: 250px;
     }

--- a/projects/fundamental-ngx/src/lib/breadcrumb/breadcrumb-item.component.html
+++ b/projects/fundamental-ngx/src/lib/breadcrumb/breadcrumb-item.component.html
@@ -1,3 +1,9 @@
-<span [ngClass]="{'fd-breadcrumb__link': url }" [ngStyle]="{'cursor': getCursor(url) }" [routerLink]="url ? [url] : []">
-  <ng-content></ng-content>
+<a *ngIf="url" class="fd-breadcrumb__link" [ngStyle]="{'cursor': getCursor(url) }" [routerLink]="url ? [url] : []">
+  <ng-container *ngTemplateOutlet="tempOutlet"></ng-container>
+</a>
+<span *ngIf="!url" [ngStyle]="{'cursor': getCursor(url) }">
+  <ng-container *ngTemplateOutlet="tempOutlet"></ng-container>
 </span>
+<ng-template #tempOutlet>
+  <ng-content></ng-content>
+</ng-template>


### PR DESCRIPTION
#### Please provide a link to the associated issue
#68 

#### Please provide a brief summary of this pull request
Previously we were using only spans for the breadcrumb input, and conditionally applying the link class depending on whether or not the user provided a url.  However the fundamental-ui only applies the styling to anchors, so we had to hardcode the styling on spans.  No longer the case with this PR