### PR TITLE
fix: update directives that use host classes so that they can accept …

### DIFF
--- a/projects/fundamental-ngx/src/lib/badge-label/badge.component.ts
+++ b/projects/fundamental-ngx/src/lib/badge-label/badge.component.ts
@@ -1,14 +1,26 @@
-import { Input, Component } from '@angular/core';
+import { Input, Component, Inject, ElementRef } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Component({
     selector: 'fd-badge',
-    host: {
-        '[class]': '"fd-badge" + (status ? " fd-badge--" + status : "") + (modifier ? " fd-badge--" + modifier : "")'
-    },
     templateUrl: './badge-label.component.html'
 })
-export class BadgeComponent {
+export class BadgeComponent extends CustomClassBaseComponent {
     @Input() status;
 
     @Input() modifier;
+
+    _setProperties() {
+        this._addClassToElement('fd-badge');
+        if (this.status) {
+            this._addClassToElement('fd-badge--' + this.status);
+        }
+        if (this.modifier) {
+            this._addClassToElement('fd-badge--' + this.modifier);
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/badge-label/badge.component.ts
+++ b/projects/fundamental-ngx/src/lib/badge-label/badge.component.ts
@@ -1,11 +1,11 @@
 import { Input, Component, Inject, ElementRef } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Component({
     selector: 'fd-badge',
     templateUrl: './badge-label.component.html'
 })
-export class BadgeComponent extends CustomClassBaseComponent {
+export class BadgeComponent extends AbstractCustomClassManager {
     @Input() status;
 
     @Input() modifier;

--- a/projects/fundamental-ngx/src/lib/badge-label/label.component.ts
+++ b/projects/fundamental-ngx/src/lib/badge-label/label.component.ts
@@ -1,11 +1,11 @@
 import { Component, ElementRef, Inject, Input } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Component({
     selector: 'fd-label',
     templateUrl: './badge-label.component.html'
 })
-export class LabelComponent extends CustomClassBaseComponent {
+export class LabelComponent extends AbstractCustomClassManager {
     @Input() status;
 
     _setProperties() {

--- a/projects/fundamental-ngx/src/lib/badge-label/label.component.ts
+++ b/projects/fundamental-ngx/src/lib/badge-label/label.component.ts
@@ -1,12 +1,21 @@
-import { Component, Input } from '@angular/core';
+import { Component, ElementRef, Inject, Input } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Component({
     selector: 'fd-label',
-    host: {
-        '[class]': '"fd-label" + (status ? " fd-label--" + status : "")'
-    },
     templateUrl: './badge-label.component.html'
 })
-export class LabelComponent {
+export class LabelComponent extends CustomClassBaseComponent {
     @Input() status;
+
+    _setProperties() {
+        this._addClassToElement('fd-label');
+        if (this.status) {
+            this._addClassToElement('fd-label--' + this.status);
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/button-group/button-grouped.directive.ts
+++ b/projects/fundamental-ngx/src/lib/button-group/button-grouped.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, ElementRef, Inject, Input } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Directive({
     selector: '[fd-button-grouped]',
@@ -7,7 +8,7 @@ import { Directive, Input } from '@angular/core';
             '"fd-button--grouped" + (size ? " fd-button--" + size : "") + (glyph ? " sap-icon--" + glyph : "") + (compact ? " fd-button--compact" : "") + (state ? " is-" + state : "")'
     }
 })
-export class ButtonGroupedDirective {
+export class ButtonGroupedDirective extends CustomClassBaseComponent {
     @Input() id: string;
 
     @Input() size: string;
@@ -17,4 +18,24 @@ export class ButtonGroupedDirective {
     @Input() state: string;
 
     @Input() compact: boolean = false;
+
+    _setProperties() {
+        this._addClassToElement('fd-button--grouped');
+        if (this.size) {
+            this._addClassToElement('fd-button--' + this.size);
+        }
+        if (this.glyph) {
+            this._addClassToElement('sap-icon--' + this.glyph);
+        }
+        if (this.compact) {
+            this._addClassToElement('fd-button--compact');
+        }
+        if (this.state) {
+            this._addClassToElement('is-' + this.state);
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/button-group/button-grouped.directive.ts
+++ b/projects/fundamental-ngx/src/lib/button-group/button-grouped.directive.ts
@@ -2,11 +2,7 @@ import { Directive, ElementRef, Inject, Input } from '@angular/core';
 import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Directive({
-    selector: '[fd-button-grouped]',
-    host: {
-        '[class]':
-            '"fd-button--grouped" + (size ? " fd-button--" + size : "") + (glyph ? " sap-icon--" + glyph : "") + (compact ? " fd-button--compact" : "") + (state ? " is-" + state : "")'
-    }
+    selector: '[fd-button-grouped]'
 })
 export class ButtonGroupedDirective extends CustomClassBaseComponent {
     @Input() id: string;

--- a/projects/fundamental-ngx/src/lib/button-group/button-grouped.directive.ts
+++ b/projects/fundamental-ngx/src/lib/button-group/button-grouped.directive.ts
@@ -1,10 +1,10 @@
 import { Directive, ElementRef, Inject, Input } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Directive({
     selector: '[fd-button-grouped]'
 })
-export class ButtonGroupedDirective extends CustomClassBaseComponent {
+export class ButtonGroupedDirective extends AbstractCustomClassManager {
     @Input() id: string;
 
     @Input() size: string;

--- a/projects/fundamental-ngx/src/lib/button/button.directive.ts
+++ b/projects/fundamental-ngx/src/lib/button/button.directive.ts
@@ -1,13 +1,10 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, ElementRef, Inject, Input } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Directive({
-    selector: '[fd-button]',
-    host: {
-        '[class]':
-            '"fd-button" + (size ? " fd-button--" + size : "") + (glyph ? " sap-icon--" + glyph : "") + (type ? " fd-button--" + type : "") + (semantic ? " fd-button--" + semantic : "") + (state ? " is-" + state : "")'
-    }
+    selector: '[fd-button]'
 })
-export class ButtonDirective {
+export class ButtonDirective extends CustomClassBaseComponent {
     @Input() size;
 
     @Input() glyph;
@@ -17,4 +14,27 @@ export class ButtonDirective {
     @Input() semantic;
 
     @Input() state;
+
+    _setProperties() {
+        this._addClassToElement('fd-button');
+        if (this.size) {
+            this._addClassToElement('fd-button--' + this.size);
+        }
+        if (this.glyph) {
+            this._addClassToElement('sap-icon--' + this.glyph);
+        }
+        if (this.type) {
+            this._addClassToElement('fd-button--' + this.type);
+        }
+        if (this.semantic) {
+            this._addClassToElement('fd-button--' + this.semantic);
+        }
+        if (this.state) {
+            this._addClassToElement('is-' + this.state);
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/button/button.directive.ts
+++ b/projects/fundamental-ngx/src/lib/button/button.directive.ts
@@ -1,10 +1,10 @@
 import { Directive, ElementRef, Inject, Input } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Directive({
     selector: '[fd-button]'
 })
-export class ButtonDirective extends CustomClassBaseComponent {
+export class ButtonDirective extends AbstractCustomClassManager {
     @Input() size;
 
     @Input() glyph;

--- a/projects/fundamental-ngx/src/lib/form/form-control.directive.ts
+++ b/projects/fundamental-ngx/src/lib/form/form-control.directive.ts
@@ -1,10 +1,10 @@
 import { Directive, Input, ElementRef, Inject } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Directive({
     selector: '[fd-form-control]'
 })
-export class FormControlDirective extends CustomClassBaseComponent {
+export class FormControlDirective extends AbstractCustomClassManager {
     @Input() state: string = '';
 
     _setProperties() {

--- a/projects/fundamental-ngx/src/lib/form/form-control.directive.ts
+++ b/projects/fundamental-ngx/src/lib/form/form-control.directive.ts
@@ -1,11 +1,20 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, Input, ElementRef, Inject } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Directive({
-    selector: '[fd-form-control]',
-    host: {
-        '[class]': '"fd-form__control" + (state ? " is-" + state : "")'
-    }
+    selector: '[fd-form-control]'
 })
-export class FormControlDirective {
+export class FormControlDirective extends CustomClassBaseComponent {
     @Input() state: string = '';
+
+    _setProperties() {
+        this._addClassToElement('fd-form__control');
+        if (this.state) {
+            this._addClassToElement('is-' + this.state);
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/form/form-item.component.ts
+++ b/projects/fundamental-ngx/src/lib/form/form-item.component.ts
@@ -1,10 +1,10 @@
 import { Directive, Inject, ElementRef, Input } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Directive({
     selector: '[fd-form-item]'
 })
-export class FormItemComponent extends CustomClassBaseComponent {
+export class FormItemComponent extends AbstractCustomClassManager {
     @Input() isCheck: boolean = false;
     @Input() isInline: boolean = false;
 

--- a/projects/fundamental-ngx/src/lib/form/form-item.component.ts
+++ b/projects/fundamental-ngx/src/lib/form/form-item.component.ts
@@ -1,13 +1,24 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, Inject, ElementRef, Input } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Directive({
-    selector: '[fd-form-item]',
-    host: {
-      '[class]': '"fd-form__item" + (isCheck ? " fd-form__item--check" : "") + (isInline ? " fd-form__item--inline" : "")'
-    }
-
+    selector: '[fd-form-item]'
 })
-export class FormItemComponent {
+export class FormItemComponent extends CustomClassBaseComponent {
     @Input() isCheck: boolean = false;
     @Input() isInline: boolean = false;
+
+    _setProperties() {
+        this._addClassToElement('fd-form__item');
+        if (this.isCheck) {
+            this._addClassToElement('fd-form__item--check');
+        }
+        if (this.isInline) {
+            this._addClassToElement('fd-form__item--inline');
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/icon/icon.directive.ts
+++ b/projects/fundamental-ngx/src/lib/icon/icon.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, Input, ElementRef } from '@angular/core';
+import { Directive, Input, ElementRef, Inject } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 export type IconSize = 's' | '' | 'm' | 'l' | 'xl';
 
@@ -14,37 +15,22 @@ const PREFIX_ICON_CLASS = BASE_ICON_CLASS + '--';
         role: 'presentation'
     }
 })
-export class IconDirective {
-    private _elementRef: ElementRef;
-
-    constructor(elementRef: ElementRef) {
-        this._elementRef = elementRef;
-        this._addClassToIcon(BASE_ICON_CLASS);
-        this._setProperties();
-    }
+export class IconDirective extends CustomClassBaseComponent {
     @Input() glyph;
 
     @Input() size: IconSize = '';
 
-    _addClassToIcon(classname: string) {
-        (this._elementRef.nativeElement as HTMLElement).classList.add(classname);
-    }
-
-    ngOnInit() {
-        this._setProperties();
-    }
-
     _setProperties() {
         if (this.glyph) {
-            this._addClassToIcon(PREFIX_ICON_CLASS + this.glyph);
+            this._addClassToElement(PREFIX_ICON_CLASS + this.glyph);
         }
 
         if (this.size) {
-            this._addClassToIcon(PREFIX_ICON_CLASS + this.size);
+            this._addClassToElement(PREFIX_ICON_CLASS + this.size);
         }
     }
 
-    ngOnChanges() {
-        this._setProperties();
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
     }
 }

--- a/projects/fundamental-ngx/src/lib/icon/icon.directive.ts
+++ b/projects/fundamental-ngx/src/lib/icon/icon.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, Input, ElementRef, Inject } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 export type IconSize = 's' | '' | 'm' | 'l' | 'xl';
 
@@ -15,7 +15,7 @@ const PREFIX_ICON_CLASS = BASE_ICON_CLASS + '--';
         role: 'presentation'
     }
 })
-export class IconDirective extends CustomClassBaseComponent {
+export class IconDirective extends AbstractCustomClassManager {
     @Input() glyph;
 
     @Input() size: IconSize = '';

--- a/projects/fundamental-ngx/src/lib/identifier/identifier.directive.ts
+++ b/projects/fundamental-ngx/src/lib/identifier/identifier.directive.ts
@@ -1,14 +1,13 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, ElementRef, Inject, Input } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Directive({
     selector: '[fd-identifier]',
     host: {
-        '[class]':
-            '((size) ? " fd-identifier--" + size : "") + ((circle) ? " fd-identifier--circle" : "") + ((transparent) ? " fd-identifier--transparent" : "") + ((colorAccent) ? " fd-has-background-color-accent-" + colorAccent : "") + ((glyph) ? " sap-icon--" + glyph : "") ',
         role: 'presentation'
     }
 })
-export class IdentifierDirective {
+export class IdentifierDirective extends CustomClassBaseComponent {
     @Input() size: string = '';
 
     @Input() circle: boolean = false;
@@ -18,4 +17,26 @@ export class IdentifierDirective {
     @Input() colorAccent;
 
     @Input() glyph: string = '';
+
+    _setProperties() {
+        if (this.size) {
+            this._addClassToElement('fd-identifier--' + this.size);
+        }
+        if (this.circle) {
+            this._addClassToElement('fd-identifier--circle');
+        }
+        if (this.transparent) {
+            this._addClassToElement('fd-identifier--transparent');
+        }
+        if (this.colorAccent) {
+            this._addClassToElement('fd-has-background-color-accent-' + this.colorAccent);
+        }
+        if (this.glyph) {
+            this._addClassToElement('sap-icon--' + this.glyph);
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/identifier/identifier.directive.ts
+++ b/projects/fundamental-ngx/src/lib/identifier/identifier.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, ElementRef, Inject, Input } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Directive({
     selector: '[fd-identifier]',
@@ -7,7 +7,7 @@ import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
         role: 'presentation'
     }
 })
-export class IdentifierDirective extends CustomClassBaseComponent {
+export class IdentifierDirective extends AbstractCustomClassManager {
     @Input() size: string = '';
 
     @Input() circle: boolean = false;

--- a/projects/fundamental-ngx/src/lib/navbar/navbar-group.directive.ts
+++ b/projects/fundamental-ngx/src/lib/navbar/navbar-group.directive.ts
@@ -1,12 +1,24 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, Input, ElementRef, Inject } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Directive({
-    selector: '[fd-navbar-group]',
-    host: {
-        '[class]': '"fd-global-nav__group" + (position ? " fd-global-nav__group--" + position : "") + (hasLaunchpad ? " fd-global-nav__launchpad" : "")'
-    }
+    selector: '[fd-navbar-group]'
 })
-export class NavbarGroupDirective {
+export class NavbarGroupDirective extends CustomClassBaseComponent {
     @Input() position: string = '';
     @Input() hasLaunchpad: boolean = false;
+
+    _setProperties() {
+        this._addClassToElement('fd-global-nav__group');
+        if (this.position) {
+            this._addClassToElement('fd-global-nav__group--' + this.position);
+        }
+        if (this.hasLaunchpad) {
+            this._addClassToElement('fd-global-nav__launchpad');
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/navbar/navbar-group.directive.ts
+++ b/projects/fundamental-ngx/src/lib/navbar/navbar-group.directive.ts
@@ -1,10 +1,10 @@
 import { Directive, Input, ElementRef, Inject } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Directive({
     selector: '[fd-navbar-group]'
 })
-export class NavbarGroupDirective extends CustomClassBaseComponent {
+export class NavbarGroupDirective extends AbstractCustomClassManager {
     @Input() position: string = '';
     @Input() hasLaunchpad: boolean = false;
 

--- a/projects/fundamental-ngx/src/lib/side-navigation/side-navigation-icons.directive.ts
+++ b/projects/fundamental-ngx/src/lib/side-navigation/side-navigation-icons.directive.ts
@@ -1,9 +1,0 @@
-import { Directive } from '@angular/core';
-
-@Directive({
-    selector: '[fd-side-nav-icons]',
-    host: {
-        '[class]': "'fd-side-nav--icons'"
-    }
-})
-export class SideNavigationIconsDirective { }

--- a/projects/fundamental-ngx/src/lib/side-navigation/side-navigation.component.ts
+++ b/projects/fundamental-ngx/src/lib/side-navigation/side-navigation.component.ts
@@ -2,8 +2,8 @@ import { Component, Input } from '@angular/core';
 
 @Component({
     selector: 'fd-side-nav',
-    templateUrl: './side-navigation.component.html' 
+    templateUrl: './side-navigation.component.html'
 })
-export class SideNavigationComponent { 
+export class SideNavigationComponent {
     @Input() collapsed: boolean = false;
 }

--- a/projects/fundamental-ngx/src/lib/side-navigation/side-navigation.module.ts
+++ b/projects/fundamental-ngx/src/lib/side-navigation/side-navigation.module.ts
@@ -10,7 +10,6 @@ import { SideNavigationLinkComponent } from './side-navigation-link.component';
 import { SideNavigationSubListComponent } from './side-navigation-sublist.component';
 import { SideNavigationSubItemComponent } from './side-navigation-subitem.component';
 import { SideNavigationIconComponent } from './side-navigation-icon.component';
-import { SideNavigationIconsDirective } from './side-navigation-icons.directive';
 
 @NgModule({
     imports: [CommonModule],
@@ -23,8 +22,7 @@ import { SideNavigationIconsDirective } from './side-navigation-icons.directive'
         SideNavigationLinkComponent,
         SideNavigationSubListComponent,
         SideNavigationSubItemComponent,
-        SideNavigationIconComponent,
-        SideNavigationIconsDirective
+        SideNavigationIconComponent
     ],
     declarations: [
         SideNavigationComponent,
@@ -35,8 +33,7 @@ import { SideNavigationIconsDirective } from './side-navigation-icons.directive'
         SideNavigationLinkComponent,
         SideNavigationSubListComponent,
         SideNavigationSubItemComponent,
-        SideNavigationIconComponent,
-        SideNavigationIconsDirective
+        SideNavigationIconComponent
     ]
 })
 export class SideNavigationModule {}

--- a/projects/fundamental-ngx/src/lib/tile/product-tile.component.ts
+++ b/projects/fundamental-ngx/src/lib/tile/product-tile.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Inject, Input } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Component({
     selector: 'fd-product-tile',
@@ -8,7 +8,7 @@ import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
     },
     templateUrl: './product-tile.component.html'
 })
-export class ProductTileComponent extends CustomClassBaseComponent {
+export class ProductTileComponent extends AbstractCustomClassManager {
     @Input() disabled: boolean = false;
 
     @Input() isButton: boolean = false;

--- a/projects/fundamental-ngx/src/lib/tile/product-tile.component.ts
+++ b/projects/fundamental-ngx/src/lib/tile/product-tile.component.ts
@@ -1,15 +1,26 @@
-import { Component, Input } from '@angular/core';
+import { Component, ElementRef, Inject, Input } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Component({
     selector: 'fd-product-tile',
     host: {
-        '[class]': ' "fd-product-tile" + (disabled ? " is-disabled" : "")',
         '[attr.role]': "(this.isButton === true ? 'button' : '')"
     },
     templateUrl: './product-tile.component.html'
 })
-export class ProductTileComponent {
+export class ProductTileComponent extends CustomClassBaseComponent {
     @Input() disabled: boolean = false;
 
     @Input() isButton: boolean = false;
+
+    _setProperties() {
+        this._addClassToElement('fd-product-tile');
+        if (this.disabled) {
+            this._addClassToElement('is-disabled');
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/tile/tile-grid.directive.ts
+++ b/projects/fundamental-ngx/src/lib/tile/tile-grid.directive.ts
@@ -1,10 +1,10 @@
 import { Directive, ElementRef, Inject, Input } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Directive({
     selector: 'fd-tile-grid'
 })
-export class TileGridDirective extends CustomClassBaseComponent {
+export class TileGridDirective extends AbstractCustomClassManager {
     @Input() col;
 
     _setProperties() {

--- a/projects/fundamental-ngx/src/lib/tile/tile-grid.directive.ts
+++ b/projects/fundamental-ngx/src/lib/tile/tile-grid.directive.ts
@@ -1,11 +1,20 @@
-import { Directive, Input } from '@angular/core';
+import { Directive, ElementRef, Inject, Input } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Directive({
-    selector: 'fd-tile-grid',
-    host: {
-        '[class]': '"fd-tile-grid" + (col ? "  fd-tile-grid--" + col + "col" : "") '
-    }
+    selector: 'fd-tile-grid'
 })
-export class TileGridDirective {
+export class TileGridDirective extends CustomClassBaseComponent {
     @Input() col;
+
+    _setProperties() {
+        this._addClassToElement('fd-tile-grid');
+        if (this.col) {
+            this._addClassToElement('fd-tile-grid--' + this.col + 'col');
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/tile/tile.component.ts
+++ b/projects/fundamental-ngx/src/lib/tile/tile.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Inject, Input } from '@angular/core';
-import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
+import { AbstractCustomClassManager } from '../utils/AbstractCustomClassManager';
 
 @Component({
     selector: 'fd-tile',
@@ -8,7 +8,7 @@ import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
     },
     templateUrl: './tile.component.html'
 })
-export class TileComponent extends CustomClassBaseComponent {
+export class TileComponent extends AbstractCustomClassManager {
     @Input() disabled: boolean = false;
 
     @Input() isButton: boolean = false;

--- a/projects/fundamental-ngx/src/lib/tile/tile.component.ts
+++ b/projects/fundamental-ngx/src/lib/tile/tile.component.ts
@@ -1,15 +1,14 @@
-import { Component, Input } from '@angular/core';
+import { Component, ElementRef, Inject, Input } from '@angular/core';
+import { CustomClassBaseComponent } from '../utils/custom-class-base-component';
 
 @Component({
     selector: 'fd-tile',
     host: {
-        '[class]':
-            ' "fd-tile" + (disabled ? " is-disabled" : "") + (rowSpan ? " fd-has-grid-row-span-" + rowSpan : "")  + (columnSpan ? " fd-has-grid-column-span-" + columnSpan : "") + (colorAccent ? " fd-has-background-color-accent-" + colorAccent : "")',
         '[attr.role]': "(this.isButton === true ? 'button' : '')"
     },
     templateUrl: './tile.component.html'
 })
-export class TileComponent {
+export class TileComponent extends CustomClassBaseComponent {
     @Input() disabled: boolean = false;
 
     @Input() isButton: boolean = false;
@@ -19,4 +18,24 @@ export class TileComponent {
     @Input() columnSpan;
 
     @Input() colorAccent;
+
+    _setProperties() {
+        this._addClassToElement('fd-tile');
+        if (this.disabled) {
+            this._addClassToElement('is-disabled');
+        }
+        if (this.rowSpan) {
+            this._addClassToElement('fd-has-grid-row-span-' + this.rowSpan);
+        }
+        if (this.columnSpan) {
+            this._addClassToElement('fd-has-grid-column-span-' + this.columnSpan);
+        }
+        if (this.colorAccent) {
+            this._addClassToElement('fd-has-background-color-accent-' + this.colorAccent);
+        }
+    }
+
+    constructor(@Inject(ElementRef) elementRef: ElementRef) {
+        super(elementRef);
+    }
 }

--- a/projects/fundamental-ngx/src/lib/utils/AbstractCustomClassManager.ts
+++ b/projects/fundamental-ngx/src/lib/utils/AbstractCustomClassManager.ts
@@ -1,10 +1,21 @@
 import { ElementRef, OnChanges, OnInit, Input } from '@angular/core';
 
-export abstract class CustomClassBaseComponent implements OnInit, OnChanges {
+/*
+ This abstract class allows the user to set their own custom classes on a Fundamental NGX directive, in addition to the
+ classes the library needs to add itself.
+ When library classes were added through the directive's host: {'[class]'} property, any classes the user added would be
+ overwritten.  By extending this class, we instead add library classes to the user's classList rather than replace them.
+ */
+
+export abstract class AbstractCustomClassManager implements OnInit, OnChanges {
     private _elementRef: ElementRef;
 
     @Input() class; // user's custom classes
 
+    /*
+     each directive that extends this class will implement this function and populate it with one or more calls to
+     the '_addClassToElement' function, passing the class names to be added with each call
+     */
     abstract _setProperties(): void;
 
     _addClassToElement(className: string) {

--- a/projects/fundamental-ngx/src/lib/utils/custom-class-base-component.ts
+++ b/projects/fundamental-ngx/src/lib/utils/custom-class-base-component.ts
@@ -1,0 +1,33 @@
+import { ElementRef, OnChanges, OnInit, Input } from '@angular/core';
+
+export abstract class CustomClassBaseComponent implements OnInit, OnChanges {
+    private _elementRef: ElementRef;
+
+    @Input() class; // user's custom classes
+
+    abstract _setProperties(): void;
+
+    _addClassToElement(className: string) {
+        (this._elementRef.nativeElement as HTMLElement).classList.add(className);
+    }
+
+    protected constructor(elementRef: ElementRef) {
+        this._elementRef = elementRef;
+        this._setProperties();
+    }
+
+    ngOnChanges() {
+        const classList = (this._elementRef.nativeElement as HTMLElement).classList;
+        while (classList.length > 0) {
+            classList.remove(classList.item(0));
+        }
+        if (this.class) {
+            this._addClassToElement(this.class);
+        }
+        this._setProperties();
+    }
+
+    ngOnInit() {
+        this._setProperties();
+    }
+}


### PR DESCRIPTION
…custom classes from the user on the directive element

#### Please provide a link to the associated issue
#100 

#### Please provide a brief summary of this pull request
Using "host: {'[class]'}" in the directive declaration overwrites any class the user sets on the directive's HTML element.  In this pull request we add the necessary styles to the component one-by-one without overwriting any classes the user has added on the element.  Each directive that requires this functionality extends an abstract class that handles the construction of the element and will reset and repopulate the classList when any changes are made to the directive's Inputs.
