### PR TITLE
Fix dropdown duplicate id usage

### DIFF
--- a/projects/fundamental-ngx/src/lib/dropdown/dropdown.component.html
+++ b/projects/fundamental-ngx/src/lib/dropdown/dropdown.component.html
@@ -15,7 +15,7 @@
       <ng-content></ng-content>
     </button>
   </ng-container>
-  <nav class="fd-dropdown__menu" [attr.aria-hidden]="(this.disabled === true ? true : !isOpen)" [id]="id" [ngClass]="(isContextualMenu ? ' fd-contextual-menu' : '')">
+  <nav class="fd-dropdown__menu" [attr.aria-hidden]="(this.disabled === true ? true : !isOpen)" [id]="(id + '--items')" [ngClass]="(isContextualMenu ? ' fd-contextual-menu' : '')">
     <ul class="fd-dropdown__list">
       <ng-content select="fd-dropdown-item"></ng-content>
       <ng-content select="fd-dropdown-group"></ng-content>

--- a/projects/fundamental-ngx/src/lib/dropdown/dropdown.component.html
+++ b/projects/fundamental-ngx/src/lib/dropdown/dropdown.component.html
@@ -1,17 +1,17 @@
 <div class="fd-dropdown">
   <ng-container *ngIf="isContextualMenu && buttonText.length === 0">
-    <button [tabindex]="disabled ? -1 : 0" [attr.aria-controls]="id" [attr.aria-expanded]="isOpen"
+    <button [tabindex]="disabled ? -1 : 0" [attr.aria-controls]="(id + '--items')" [attr.aria-expanded]="isOpen"
       [attr.aria-label]="'More'" [attr.aria-disabled]="disabled" aria-haspopup="true" [ngClass]="{' fd-button fd-button--secondary fd-button--l sap-icon--vertical-grip' : true}">
     </button>
   </ng-container>
   <ng-container *ngIf="isContextualMenu && buttonText.length !== 0">
-      <button [tabindex]="disabled ? -1 : 0" class="fd-button" [ngClass]="(noBorder ? ' fd-button--secondary' : '') " [attr.aria-controls]="id" [attr.aria-expanded]="isOpen"
+      <button [tabindex]="disabled ? -1 : 0" class="fd-button" [ngClass]="(noBorder ? ' fd-button--secondary' : '') " [attr.aria-controls]="(id + '--items')" [attr.aria-expanded]="isOpen"
         [attr.aria-label]="'More'" [attr.aria-disabled]="disabled" aria-haspopup="true"> {{buttonText}}
       </button>
     </ng-container>
   <ng-container *ngIf="!isContextualMenu">
     <button [tabindex]="disabled ? -1 : 0" class="fd-dropdown__control fd-button--toolbar"
-      [attr.aria-controls]="id" [attr.aria-expanded]="isOpen" [attr.aria-disabled]="disabled" aria-haspopup="true" [ngClass]="(glyph ? 'sap-icon--' + glyph + ' ' : ' ') + (size ? 'fd-button--' + size : '') + (noBorder ? ' fd-dropdown__control--no-border' : '') ">
+      [attr.aria-controls]="(id + '--items')" [attr.aria-expanded]="isOpen" [attr.aria-disabled]="disabled" aria-haspopup="true" [ngClass]="(glyph ? 'sap-icon--' + glyph + ' ' : ' ') + (size ? 'fd-button--' + size : '') + (noBorder ? ' fd-dropdown__control--no-border' : '') ">
       <ng-content></ng-content>
     </button>
   </ng-container>


### PR DESCRIPTION
#### Please provide a link to the associated issue
Resolves #109 

#### Please provide a brief summary of this pull request
The dropdown was duplicating the id for the fd-dropdown element and the nav child. Instead of using the same id it now appends '--items' to maintain id uniqueness.
The '--items' refers to the 'fd-dropdown-item' (s) nested in the nav element.