### PR TITLE
#167 allow and document button, icon, and image to be extensible

### DIFF
--- a/docs/modules/documentation/containers/button/button-docs.component.html
+++ b/docs/modules/documentation/containers/button/button-docs.component.html
@@ -9,7 +9,7 @@
   inputs: [
     { name: 'type', description: '(Optional) String - The type of the button.  Options include \'primary\', \'main\', \'secondary\', and \'toolbar\'. Leave empty for default.'},
     { name: 'semantic', description: '(Optional) String - Semantic buttons. Semantic modifiers include \'positive\' and \'negative\'. Leave empty for no modifier.'},
-    { name: 'size', description: '(Optional) String - The size of the button.  Options include \'xs\', \'s\', \'compact\', \'default\', and \'l\'. Leave empty for default.'},
+    { name: 'size', description: '(Optional) String - The size of the button.  Options include \'xs\', \'s\', \'compact\', default, and \'l\'. Leave empty for default.'},
     { name: 'glyph', description: '(Optional) String - The icon to include in the button.  See the icon page for the list of icons.'},
     { name: 'state', description: '(Optional) String - The state of the button. Options include \'normal\', \'selected\', and \'disabled\'. Leave empty for normal.' }
   ]

--- a/docs/modules/documentation/containers/button/button-docs.component.html
+++ b/docs/modules/documentation/containers/button/button-docs.component.html
@@ -15,6 +15,18 @@
   ]
 }"></properties>
 
+<description>The inputs for <code>button</code> will be translated into class attributed respecting fundamental-ui guidelines.
+  <br>For example:
+  <br>if it is passed <code>positive</code> for <code>fdType</code> the class <code>fd-button--positive</code> will be added to the element.
+  <br>if it is passed <code>s</code> for <code>size</code> the class <code>fd-button--s</code> will be added to the element.
+</description>
+
+<separator></separator>
+<h2>Extensibility</h2>
+<description>The button implementation allows certain extensibility in terms of options for the inputs. <code>button</code> inputs doesn't have a restriction for the predefined values.
+  <br>The predefined values for the input <code>size</code> are <code>xs</code>, <code>s</code>, <code>l</code>, but <code>size</code> can accept any other string, for example <code>xxs</code>, which will be translated into class <code>fd-button--xxs</code>.
+</description>
+
 <separator></separator>
 <h2>Button Types</h2>
 <p>

--- a/docs/modules/documentation/containers/icon/icon-docs.component.html
+++ b/docs/modules/documentation/containers/icon/icon-docs.component.html
@@ -9,10 +9,20 @@
 <properties [properties]="{
   inputs: [
     { name: 'glyph', description: 'Icon name.' },
-    { name: 'size', description: 'Size of the icon.  Options include \'xs\', \'s\', \'compact\', and \'l\'.  If no size is provided, default (normal) will be used.' }
+    { name: 'size', description: 'Size of the icon.  The default options include \'xs\', \'s\', \'normal\', \'l\', and \'xl\'.  If no size is provided, default (normal) will be used.' }
   ]
 }"></properties>
+<description>The inputs for <code>fd-icon</code> will be translated into class attributed respecting fundamental-ui guidelines.
+  <br>For example:
+  <br>if it is passed <code>accept</code> for glyph the class <code>sap-icon--accept</code> will be added to the element.
+  <br>if it is passed <code>xs</code> for size the class <code>sap-icon--xs</code> will be added to the element.
+</description>
 <separator></separator>
+
+<h2>Extensibility</h2>
+<description>The icon implementation allows certain extensibility in terms of options for the inputs. <code>fd-icon</code> inputs doesn't have a restriction for the predefined values.
+  <br>The predefined values for the input <code>size</code> are <code>xs</code>, <code>s</code>, <code>l</code>, <code>xl</code>, but <code>size</code> can accept any other string, for example <code>xxs</code>, which will be translated into class <code>sap-icon--xxs</code>.
+</description>
 
 <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
   <div class="fd-tile__content">

--- a/docs/modules/documentation/containers/icon/icon-docs.component.html
+++ b/docs/modules/documentation/containers/icon/icon-docs.component.html
@@ -9,7 +9,7 @@
 <properties [properties]="{
   inputs: [
     { name: 'glyph', description: 'Icon name.' },
-    { name: 'size', description: 'Size of the icon.  The default options include \'xs\', \'s\', \'normal\', \'l\', and \'xl\'.  If no size is provided, default (normal) will be used.' }
+    { name: 'size', description: 'Size of the icon.  The default options include \'xs\', \'s\', default, \'l\', and \'xl\'.  If no size is provided, default will be used.' }
   ]
 }"></properties>
 <description>The inputs for <code>fd-icon</code> will be translated into class attributed respecting fundamental-ui guidelines.

--- a/docs/modules/documentation/containers/image/image-docs.component.html
+++ b/docs/modules/documentation/containers/image/image-docs.component.html
@@ -9,7 +9,16 @@
     { name: 'circle', description: 'Boolean - when set to true renders a round image.' }
   ]
 }"></properties>
+<description>The inputs for <code>fd-image</code> will be translated into class attributed respecting fundamental-ui guidelines.
+  <br>For example:
+  <br>if it is passed <code>s</code> for size the class <code>fd-image--s</code> will be added to the element.
+</description>
 <separator></separator>
+
+<h2>Extensibility</h2>
+<description>The image implementation allows certain extensibility in terms of options for the inputs. <code>fd-image</code> inputs doesn't have a restriction for the predefined values.
+  <br>The predefined values for the input <code>size</code> are <code>s</code>, <code>m</code>, <code>l</code>, but <code>size</code> can accept any other string, for example <code>xxs</code>, which will be translated into class <code>fd-image--xxs</code>.
+</description>
 
 <h2>Sizes</h2>
 

--- a/projects/fundamental-ngx/src/lib/icon/icon.directive.ts
+++ b/projects/fundamental-ngx/src/lib/icon/icon.directive.ts
@@ -1,8 +1,6 @@
 import { Directive, Input, ElementRef, Inject } from '@angular/core';
 import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 
-export type IconSize = 's' | '' | 'm' | 'l' | 'xl';
-
 /** The base class for the icon component */
 const BASE_ICON_CLASS = 'sap-icon';
 
@@ -18,7 +16,7 @@ const PREFIX_ICON_CLASS = BASE_ICON_CLASS + '--';
 export class IconDirective extends AbstractFdNgxClass {
     @Input() glyph;
 
-    @Input() size: IconSize = '';
+    @Input() size: string = '';
 
     _setProperties() {
         if (this.glyph) {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#167 

#### Please provide a brief summary of this pull request.
allow `button`, `fd-icon`, `fd-image` to be extensible. Updated the documentation

#### If this is a new feature, have you updated the documentation?
yes
