### PR TITLE
#196 allow table columns to have custom width

### DIFF
--- a/docs/modules/documentation/containers/table/table-docs.component.html
+++ b/docs/modules/documentation/containers/table/table-docs.component.html
@@ -1,13 +1,17 @@
 <header>Table</header>
-<description>The Table component is a common component used to display data that can be compared. Usually a set of item of the same type which data is divided on columns to facilitate the comparison between items.</description>
-<import module="TableModule" path="fundamental/table/table.module"></import>
+<description>The Table component is a common component used to display data that can be compared. Usually a set of item of
+  the same type which data is divided on columns to facilitate the comparison between items.</description>
+<import module="TableModule"
+        path="fundamental/table/table.module"></import>
 <separator></separator>
 
 <h1>&lt;fd-table&gt;</h1>
 
-There are two different types of table cells you can use, the 'simple' cells and the 'rich' cells.  Simple cells can only display text.  Rich cells can contain images, plain text or links.  The table component requires only two root arguments, a 'headers' array and a 'tableData' array.
-<br><br>
-In a table with simple cells, the tableData property is an array of objects containing a 'rowData' property.  This property should contain an array of strings, each string being a cell in the table.
+There are two different types of table cells you can use, the 'simple' cells and the 'rich' cells. Simple cells can only
+display text. Rich cells can contain images, plain text or links. The table component requires only two root arguments, a
+'headers' array and a 'tableData' array.
+<br><br> In a table with simple cells, the tableData property is an array of objects containing a 'rowData' property. This
+property should contain an array of strings, each string being a cell in the table.
 
 <separator></separator>
 
@@ -23,7 +27,8 @@ This is an example of a table with simple cells, where the rowData is an array o
 <br>
 <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
   <div class="fd-tile__content">
-    <fd-table [tableData]="data.properties.simpleTableData" [headers]="data.properties.simpleHeaders">
+    <fd-table [tableData]="data.properties.simpleTableData"
+              [headers]="data.properties.simpleHeaders">
 
     </fd-table>
   </div>
@@ -33,7 +38,8 @@ This is an example of a table with simple cells, where the rowData is an array o
 
 <separator></separator>
 <h2>Rich Table</h2>
-This is an example of a table with rich cells, where the rowData is an array of objects, where each object can have any of the following properties:<br><br>
+This is an example of a table with rich cells, where the rowData is an array of objects, where each object can have any of
+the following properties:<br><br>
 <properties [properties]="{
     properties: [
     { name: 'displayText', description: 'The text to display in the cell.  If omitted, the link url will be displayed.' },
@@ -53,7 +59,9 @@ This is an example of a table with rich cells, where the rowData is an array of 
 <br>
 <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
   <div class="fd-tile__content">
-    <fd-table [tableData]="data.properties.richTableData" [headers]="data.properties.richHeaders">
+    <fd-table [tableData]="data.properties.richTableData"
+              [headers]="data.properties.richHeaders"
+              [headerWidths]="data.properties.richWidths">
 
     </fd-table>
   </div>

--- a/docs/modules/documentation/containers/table/table-docs.component.ts
+++ b/docs/modules/documentation/containers/table/table-docs.component.ts
@@ -45,6 +45,7 @@ export class TableDocsComponent {
                 }
             ],
             richHeaders: ['Avatar', 'email', 'First Name', 'Last Name', 'Date'],
+            richWidths: ['10%', '30%', '20%', '20%', '20%'],
             richTableData: [
                 {
                     rowData: [
@@ -166,112 +167,117 @@ export class TableDocsComponent {
         '  }\n' +
         ']';
 
-    richTableHtml = '<fd-table [headers]="headers" [tableData]="tableData">\n' + '\n' + '</fd-table>';
+    richTableHtml = `<fd-table
+      [headers]="headers"
+      [headerWidths]="headerWidths"
+      [tableData]="tableData">
+      </fd-table>`;
 
-    richTableJson =
-        "headers: ['Avatar', 'email', 'First Name', 'Last Name', 'Date'],\n" +
-        'tableData: [\n' +
-        '    {\n' +
-        '      rowData: [\n' +
-        '        {\n' +
-        "          imageUrl: 'https://robohash.org/green?size=50x50'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'john.brown@qwerty.io',\n" +
-        "          linkUrl: 'mailto:john.brown@qwerty.io'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'John'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'Brown'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: '05/14/17'\n" +
-        '        }\n' +
-        '      ]\n' +
-        '    },\n' +
-        '    {\n' +
-        '      rowData: [\n' +
-        '        {\n' +
-        "          imageUrl: 'https://robohash.org/brown?size=50x50'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'florence.garcia@qwerty.io',\n" +
-        "          linkUrl: 'mailto:florence.garcia@qwerty.io'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'Florence'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'Garcia'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: '05/14/17'\n" +
-        '        }\n' +
-        '      ]\n' +
-        '    },\n' +
-        '    {\n' +
-        '      rowData: [\n' +
-        '        {\n' +
-        "          imageUrl: 'https://robohash.org/Q27.png?set=set1&size=50x50'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'mark.helper@qwerty.io',\n" +
-        "          linkUrl: 'mailto:mark.helper@qwerty.io'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'Mark'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'Helper'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: '07/14/17'\n" +
-        '        }\n' +
-        '      ]\n' +
-        '    },\n' +
-        '    {\n' +
-        '      rowData: [\n' +
-        '        {\n' +
-        "          imageUrl: 'https://robohash.org/water?&size=50x50'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'beth.butler@qwerty.io',\n" +
-        "          linkUrl: 'mailto:beth.butler@qwerty.io'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'Beth'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'Butler'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: '08/14/17'\n" +
-        '        }\n' +
-        '      ]\n' +
-        '    },\n' +
-        '    {\n' +
-        '      rowData: [\n' +
-        '        {\n' +
-        "          imageUrl: 'https://robohash.org/red?size=50x50'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'stephen.johnson@qwerty.io',\n" +
-        "          linkUrl: 'mailto:stephen.johnson@qwerty.io'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'Stephen'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: 'Johnson'\n" +
-        '        },\n' +
-        '        {\n' +
-        "          displayText: '09/14/17'\n" +
-        '        }\n' +
-        '      ]\n' +
-        '    }\n' +
-        '  ]';
+    richTableJson = `
+headers: ['Avatar', 'email', 'First Name', 'Last Name', 'Date'],
+headerWidths: ['10%', '30%', '20%', '20%', '20%']
+tableData: [{
+        rowData: [
+        {
+            imageUrl: 'https://robohash.org/green?size=50x50'
+        },
+        {
+            displayText: 'john.brown@qwerty.io',
+            linkUrl: 'mailto:john.brown@qwerty.io'
+        },
+        {
+            displayText: 'John'
+        },
+        {
+            displayText: 'Brown'
+        },
+        {
+            displayText: '05/14/17'
+        }
+        ]
+    },
+    {
+        rowData: [
+        {
+            imageUrl: 'https://robohash.org/brown?size=50x50'
+        },
+        {
+            displayText: 'florence.garcia@qwerty.io',
+            linkUrl: 'mailto:florence.garcia@qwerty.io'
+        },
+        {
+            displayText: 'Florence'
+        },
+        {
+            displayText: 'Garcia'
+        },
+        {
+            displayText: '05/14/17'
+        }
+        ]
+    },
+    {
+        rowData: [
+        {
+            imageUrl: 'https://robohash.org/Q27.png?set=set1&size=50x50'
+        },
+        {
+            displayText: 'mark.helper@qwerty.io',
+            linkUrl: 'mailto:mark.helper@qwerty.io'
+        },
+        {
+            displayText: 'Mark'
+        },
+        {
+            displayText: 'Helper'
+        },
+        {
+            displayText: '07/14/17'
+        }
+        ]
+    },
+    {
+        rowData: [
+        {
+            imageUrl: 'https://robohash.org/water?&size=50x50'
+        },
+        {
+            displayText: 'beth.butler@qwerty.io',
+            linkUrl: 'mailto:beth.butler@qwerty.io'
+        },
+        {
+            displayText: 'Beth'
+        },
+        {
+            displayText: 'Butler'
+        },
+        {
+            displayText: '08/14/17'
+        }
+        ]
+    },
+    {
+        rowData: [
+        {
+            imageUrl: 'https://robohash.org/red?size=50x50'
+        },
+        {
+            displayText: 'stephen.johnson@qwerty.io',
+            linkUrl: 'mailto:stephen.johnson@qwerty.io'
+        },
+        {
+            displayText: 'Stephen'
+        },
+        {
+            displayText: 'Johnson'
+        },
+        {
+            displayText: '09/14/17'
+        }
+        ]
+    }
+    ]
+`;
 
     constructor(private schemaFactory: SchemaFactoryService) {
         this.schema = this.schemaFactory.getComponent('table');

--- a/projects/fundamental-ngx/src/lib/table/table.component.html
+++ b/projects/fundamental-ngx/src/lib/table/table.component.html
@@ -1,24 +1,30 @@
 <table class="fd-table">
   <thead>
-  <tr>
-    <th *ngFor="let header of headers">
-      {{header}}
-    </th>
-  </tr>
+    <tr>
+      <th *ngFor="let header of headers; let i = index"
+          [style.width]="headerWidths && headerWidths.length > i? headerWidths[i] : calculateColumnWidth(headers.length)">
+        {{header}}
+      </th>
+    </tr>
   </thead>
   <tbody>
-  <tr *ngFor="let tableRow of tableData">
-    <td *ngFor="let cell of tableRow.rowData">
-      <ng-container *ngIf="typeOf(cell) === 'string'">
-        {{cell}}
-      </ng-container>
-      <ng-container *ngIf="typeOf(cell) === 'object'">
-        <img *ngIf="cell.imageUrl" [src]="cell.imageUrl">
-        <a [href]="cell.linkUrl" *ngIf="cell.linkUrl && !cell.displayText" class="fd-has-font-weight-semi">{{cell.linkUrl}}</a>
-        <a [href]="cell.linkUrl" *ngIf="cell.linkUrl && cell.displayText" class="fd-has-font-weight-semi">{{cell.displayText}}</a>
-        <ng-container *ngIf="cell.displayText && !cell.linkUrl">{{cell.displayText}}</ng-container>
-      </ng-container>
-    </td>
-  </tr>
+    <tr *ngFor="let tableRow of tableData">
+      <td *ngFor="let cell of tableRow.rowData">
+        <ng-container *ngIf="typeOf(cell) === 'string'">
+          {{cell}}
+        </ng-container>
+        <ng-container *ngIf="typeOf(cell) === 'object'">
+          <img *ngIf="cell.imageUrl"
+               [src]="cell.imageUrl">
+          <a [href]="cell.linkUrl"
+             *ngIf="cell.linkUrl && !cell.displayText"
+             class="fd-has-font-weight-semi">{{cell.linkUrl}}</a>
+          <a [href]="cell.linkUrl"
+             *ngIf="cell.linkUrl && cell.displayText"
+             class="fd-has-font-weight-semi">{{cell.displayText}}</a>
+          <ng-container *ngIf="cell.displayText && !cell.linkUrl">{{cell.displayText}}</ng-container>
+        </ng-container>
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/projects/fundamental-ngx/src/lib/table/table.component.ts
+++ b/projects/fundamental-ngx/src/lib/table/table.component.ts
@@ -7,9 +7,14 @@ import { TableRowObject } from './table-row-object.model';
     templateUrl: './table.component.html'
 })
 export class TableComponent {
-    @Input() headers: string[];
+    @Input()
+    headers: string[];
 
-    @Input() tableData: TableRowObject[];
+    @Input()
+    headerWidths: string[];
+
+    @Input()
+    tableData: TableRowObject[];
 
     typeOf(variable) {
         let retVal;
@@ -20,5 +25,9 @@ export class TableComponent {
         }
 
         return retVal;
+    }
+
+    private calculateColumnWidth(columns: number = 1): string {
+        return 100 / columns + '%';
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#196 

#### Please provide a brief summary of this pull request.
allow `fd-table` to accept custom column width

#### If this is a new feature, have you updated the documentation?
by default(if no custom widths are passed) the columns will take equal space. In case custom values are passed then the columns will take those values. Example:
`
    <fd-table [tableData]="tableData"
              [headers]="headers"
              [headerWidths]="headerWidths">
    </fd-table>
`
the format of that input `headerWidths` is string[]. Example:
`
headerWidths: string[] = ['10%', '30%', '20%', '20px', '20px'];
`