### PR TITLE
add input for panel background image

### DIFF
--- a/docs/modules/documentation/containers/panel/panel-docs.component.html
+++ b/docs/modules/documentation/containers/panel/panel-docs.component.html
@@ -19,7 +19,8 @@
   inputs: [
     { name: 'col',   description: 'The number of columns in the Panel Grid. Leave empty for default (3 columns).'},
     { name: 'nogap', description: 'When set to \'true\' removes the margins between the panels.'},
-    { name: 'span',  description: 'The number of columns the panel expands. Option ranges from 2 to 6.'}
+    { name: 'span',  description: 'The number of columns the panel expands. Option ranges from 2 to 6.'},
+    { name: 'backgroundImage', description: 'Optional string URL for the panel background image.'}
   ]
 }"></properties>
 

--- a/projects/fundamental-ngx/src/lib/panel/panel.component.html
+++ b/projects/fundamental-ngx/src/lib/panel/panel.component.html
@@ -1,4 +1,4 @@
-<div class="fd-panel">
+<div class="fd-panel" [ngStyle]="{'background-image': 'url(' + backgroundImage + ')'}">
   <ng-content select="fd-panel-header"></ng-content>
   <ng-content select="fd-panel-filters"></ng-content>
   <ng-content select="fd-panel-body"></ng-content>

--- a/projects/fundamental-ngx/src/lib/panel/panel.component.ts
+++ b/projects/fundamental-ngx/src/lib/panel/panel.component.ts
@@ -8,6 +8,8 @@ import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 export class PanelComponent extends AbstractFdNgxClass {
     @Input() span;
 
+    @Input() backgroundImage: string;
+
     _setProperties() {
         this._addClassToElement('fd-panel');
         if (this.span) {


### PR DESCRIPTION
So you can add inline styles to a panel like so: `<fd-panel style="color: blue;">` to change the text color of the panel to blue.  However, I was unable to change the background (color, image, etc) in this manner.  Any ideas why?  In this pull request I expose a backgroundImage input on the popover component to get around this issue.