### PR TITLE
Feature/#224 enable right-to-left simulator in playground

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.formatOnSave": true,
+    "prettier.singleQuote": true,
+    "prettier.printWidth": 120
+}

--- a/docs/modules/documentation/components/component-example/component-example.component.ts
+++ b/docs/modules/documentation/components/component-example/component-example.component.ts
@@ -1,0 +1,37 @@
+import { Component, ElementRef, Input } from '@angular/core';
+
+declare let hljs: any;
+
+@Component({
+    selector: 'component-example',
+    template: `
+        <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1" id="{{id}}">
+            <div class="fd-tile__content">
+                <div class="component-example__features">
+                    <rtl-toggle className="fd-doc-component"></rtl-toggle>
+                    <background-toggle [label]="id"></background-toggle>
+                </div>
+                <div class="fd-doc-component">
+                    <ng-content></ng-content>
+                </div>
+            </div>
+        </div>
+    `,
+    styles: [
+        `
+            .component-example__features {
+                display: flex;
+                justify-content: flex-start;
+            }
+
+            background-toggle {
+                padding-left: 20px;
+            }
+        `
+    ]
+})
+export class ComponentExampleComponent {
+    constructor(private element: ElementRef) {}
+
+    id = Date.now() + 13 + '';
+}

--- a/docs/modules/documentation/components/component-example/component-example.component.ts
+++ b/docs/modules/documentation/components/component-example/component-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input } from '@angular/core';
+import { Component, ElementRef, Input, OnInit } from '@angular/core';
 
 declare let hljs: any;
 
@@ -8,10 +8,10 @@ declare let hljs: any;
         <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1" id="{{id}}">
             <div class="fd-tile__content">
                 <div class="component-example__features">
-                    <rtl-toggle className="fd-doc-component"></rtl-toggle>
+                    <rtl-toggle [label]="id2"></rtl-toggle>
                     <background-toggle [label]="id"></background-toggle>
                 </div>
-                <div class="fd-doc-component">
+                <div class="fd-doc-component" id="{{id2}}">
                     <ng-content></ng-content>
                 </div>
             </div>
@@ -30,8 +30,17 @@ declare let hljs: any;
         `
     ]
 })
-export class ComponentExampleComponent {
+export class ComponentExampleComponent implements OnInit {
+    @Input()
+    name: string;
+
     constructor(private element: ElementRef) {}
 
-    id = Date.now() + 13 + '';
+    ngOnInit() {
+        this.id = '' + Date.now() + '_wrapper_' + this.name;
+        this.id2 = '' + Date.now() + this.name;
+    }
+
+    id: string;
+    id2: string;
 }

--- a/docs/modules/documentation/components/directionality/directionality.component.ts
+++ b/docs/modules/documentation/components/directionality/directionality.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+    selector: 'rtl-toggle',
+    template: `
+        <span>
+            <label class="fd-form__label " for="{{id}}">
+            <span class="fd-toggle fd-toggle--xs fd-form__control">
+                <input type="checkbox" name="" value="" id="{{id}}" class="toggle-rtl {{id}}" [attr.aria-controls]="label" (change)="onChange($event)" [(ngModel)]="isChecked">
+                <span class="fd-toggle__switch" role="presentation"></span>
+            </span>
+            Simulate RTL
+            </label>  
+        </span>`,
+    styles: [``]
+})
+export class DirectionalityComponent {
+    id = Date.now() + 1 + '';
+    isChecked: boolean = false;
+    @Input()
+    label: string;
+
+    @Input()
+    element: string;
+
+    @Input()
+    className: string;
+
+    onChange(event) {
+        let dirValue = this.isChecked ? 'rtl' : 'ltr';
+        if (this.className) {
+            Array.from(document.getElementsByClassName(this.className)).forEach(
+                (element: HTMLElement) => (element.dir = dirValue)
+            );
+        }
+        if (this.element) {
+            Array.from(document.getElementsByTagName(this.element)).forEach(
+                (element: HTMLElement) => (element.dir = dirValue)
+            );
+        }
+        if (this.label) {
+            document.getElementById(this.label).dir = dirValue;
+        }
+    }
+}

--- a/docs/modules/documentation/components/directionality/directionality.component.ts
+++ b/docs/modules/documentation/components/directionality/directionality.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
     selector: 'rtl-toggle',
     template: `
-        <span>
+        <span class="rtl-toggle--wrapper">
             <label class="fd-form__label " for="{{id}}">
             <span class="fd-toggle fd-toggle--xs fd-form__control">
                 <input type="checkbox" name="" value="" id="{{id}}" class="toggle-rtl {{id}}" [attr.aria-controls]="label" (change)="onChange($event)" [(ngModel)]="isChecked">
@@ -12,7 +12,13 @@ import { Component, Input } from '@angular/core';
             Simulate RTL
             </label>  
         </span>`,
-    styles: [``]
+    styles: [
+        `
+            .rtl-toggle--wrapper {
+                display: inline-block;
+            }
+        `
+    ]
 })
 export class DirectionalityComponent {
     id = Date.now() + 1 + '';

--- a/docs/modules/documentation/components/directionality/directionality.component.ts
+++ b/docs/modules/documentation/components/directionality/directionality.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 @Component({
     selector: 'rtl-toggle',
@@ -20,8 +20,8 @@ import { Component, Input } from '@angular/core';
         `
     ]
 })
-export class DirectionalityComponent {
-    id = Date.now() + 1 + '';
+export class DirectionalityComponent implements OnInit {
+    id: string;
     isChecked: boolean = false;
     @Input()
     label: string;
@@ -31,6 +31,14 @@ export class DirectionalityComponent {
 
     @Input()
     className: string;
+
+    ngOnInit() {
+        if (this.label) {
+            this.id = this.label + Date.now() + '-rtl';
+        } else {
+            this.id = Date.now() + 6 + '';
+        }
+    }
 
     onChange(event) {
         let dirValue = this.isChecked ? 'rtl' : 'ltr';

--- a/docs/modules/documentation/components/documentation/documentation.component.html
+++ b/docs/modules/documentation/components/documentation/documentation.component.html
@@ -1,41 +1,37 @@
 <div class="sidebar">
   <h1 class="logo">
-    <a routerLink="/"
-       class="logo-link">Fundamental
+    <a routerLink="/" class="logo-link">Fundamental
       <span class="has-accent-color">NGX</span>
     </a>
   </h1>
   <ul class="nav">
     <li class="side-nav__headers">Getting Started</li>
     <li>
-      <a class="nav-item"
-         [routerLink]="['/docs', 'home']"
-         routerLinkActive="nav-item--active">Home</a>
+      <a class="nav-item" [routerLink]="['/docs', 'home']" routerLinkActive="nav-item--active">Home</a>
     </li>
     <li>
-      <a class="nav-item"
-         [routerLink]="['/docs', 'installation']"
-         routerLinkActive="nav-item--active">Installation</a>
+      <a class="nav-item" [routerLink]="['/docs', 'installation']" routerLinkActive="nav-item--active">Installation</a>
     </li>
     <li>
-      <a class="nav-item"
-         [routerLink]="['/docs', 'usage']"
-         routerLinkActive="nav-item--active">Usage</a>
+      <a class="nav-item" [routerLink]="['/docs', 'usage']" routerLinkActive="nav-item--active">Usage</a>
     </li>
     <li>
-      <a class="nav-item"
-         [routerLink]="['/docs', 'rtl']"
-         routerLinkActive="nav-item--active">Internationalization</a>
+      <a class="nav-item" [routerLink]="['/docs', 'rtl']" routerLinkActive="nav-item--active">Internationalization</a>
     </li>
   </ul>
-  <ul class="nav"
-      id="tn-components-selector">
+
+  <!-- <fd-input-group-search [disabled]="false" [inputText]="'Search component'">
+  </fd-input-group-search> -->
+
+  <ul class="nav" id="tn-components-selector">
     <li class="side-nav__headers">Components</li>
-    <li *ngFor="let component of components">
-      <a class="nav-item"
-         [routerLink]="['/docs', component.url]"
-         routerLinkActive="nav-item--active">{{ component.name }}</a>
-    </li>
+    <ng-container *ngFor="let component of components">
+      <li *ngIf="search === '' || component.url.indexOf(search) != -1">
+        <a class="nav-item" [routerLink]="['/docs', component.url]" routerLinkActive="nav-item--active">{{
+          component.name }}</a>
+      </li>
+
+    </ng-container>
   </ul>
 </div>
 <div class="content">

--- a/docs/modules/documentation/components/documentation/documentation.component.ts
+++ b/docs/modules/documentation/components/documentation/documentation.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
@@ -6,8 +6,8 @@ import { Router } from '@angular/router';
     styleUrls: ['./documentation.component.scss'],
     templateUrl: './documentation.component.html'
 })
-export class DocumentationComponent {
-    components: any = [
+export class DocumentationComponent implements OnInit {
+    components = [
         { url: 'action-bar', name: 'Action Bar' },
         { url: 'alert', name: 'Alert' },
         { url: 'badgeLabel', name: 'Badge, Status & Label' },
@@ -20,8 +20,8 @@ export class DocumentationComponent {
         { url: 'form', name: 'Form' },
         { url: 'icon', name: 'Icon' },
         { url: 'identifier', name: 'Identifier' },
-        { url: 'inlineHelp', name: 'Inline Help' },
         { url: 'image', name: 'Image' },
+        { url: 'inlineHelp', name: 'Inline Help' },
         { url: 'inputGroup', name: 'Input Group' },
         { url: 'list', name: 'List' },
         { url: 'megaMenu', name: 'Mega Menu' },
@@ -41,6 +41,20 @@ export class DocumentationComponent {
     ];
 
     constructor(private router: Router) {}
+
+    ngOnInit() {
+        // sort the list alphabetically
+        this.components.sort((el1, el2) => {
+            if (el1.name < el2.name) {
+                return -1;
+            }
+
+            if (el1.name > el2.name) {
+                return 1;
+            }
+            return 0;
+        });
+    }
 
     selectComponent(component: string) {
         this.router.navigate(['/docs', component]);

--- a/docs/modules/documentation/components/documentation/documentation.component.ts
+++ b/docs/modules/documentation/components/documentation/documentation.component.ts
@@ -40,6 +40,8 @@ export class DocumentationComponent implements OnInit {
         { url: 'tree', name: 'Tree' }
     ];
 
+    search: string = '';
+
     constructor(private router: Router) {}
 
     ngOnInit() {
@@ -54,6 +56,14 @@ export class DocumentationComponent implements OnInit {
             }
             return 0;
         });
+    }
+
+    onFilter(filterString) {
+        this.search = filterString;
+    }
+
+    onFilterReset() {
+        this.search = '';
     }
 
     selectComponent(component: string) {

--- a/docs/modules/documentation/components/example-background/example-background.component.ts
+++ b/docs/modules/documentation/components/example-background/example-background.component.ts
@@ -21,7 +21,7 @@ import { Component, Input } from '@angular/core';
     ]
 })
 export class ExampleBackgroundComponent {
-    id = Date.now() + 1 + '';
+    id = Date.now() + 1234 + '';
     isChecked: boolean = false;
     @Input()
     label: string;

--- a/docs/modules/documentation/components/example-background/example-background.component.ts
+++ b/docs/modules/documentation/components/example-background/example-background.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
     selector: 'background-toggle',
     template: `
-        <span>
+        <span class="background-toggle--wrapper">
             <label class="fd-form__label " for="{{id}}">
             <span class="fd-toggle fd-toggle--xs fd-form__control">
                 <input type="checkbox" name="" value="" id="{{id}}" class="{{id}}" [attr.aria-controls]="label" (change)="onChange($event)" [(ngModel)]="isChecked">
@@ -12,7 +12,13 @@ import { Component, Input } from '@angular/core';
             Toggle background
             </label>  
         </span>`,
-    styles: [``]
+    styles: [
+        `
+            .background-toggle--wrapper {
+                display: inline-block;
+            }
+        `
+    ]
 })
 export class ExampleBackgroundComponent {
     id = Date.now() + 1 + '';

--- a/docs/modules/documentation/components/example-background/example-background.component.ts
+++ b/docs/modules/documentation/components/example-background/example-background.component.ts
@@ -1,0 +1,35 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+    selector: 'background-toggle',
+    template: `
+        <span>
+            <label class="fd-form__label " for="{{id}}">
+            <span class="fd-toggle fd-toggle--xs fd-form__control">
+                <input type="checkbox" name="" value="" id="{{id}}" class="{{id}}" [attr.aria-controls]="label" (change)="onChange($event)" [(ngModel)]="isChecked">
+                <span class="fd-toggle__switch" role="presentation"></span>
+            </span>
+            Toggle background
+            </label>  
+        </span>`,
+    styles: [``]
+})
+export class ExampleBackgroundComponent {
+    id = Date.now() + 1 + '';
+    isChecked: boolean = false;
+    @Input()
+    label: string;
+
+    @Input()
+    element: string;
+
+    @Input()
+    className: string;
+
+    onChange(event) {
+        const className = 'fd-has-background-color-background-1';
+        if (this.label) {
+            document.getElementById(this.label).classList.toggle(className);
+        }
+    }
+}

--- a/docs/modules/documentation/containers/action-bar/action-bar-docs.component.html
+++ b/docs/modules/documentation/containers/action-bar/action-bar-docs.component.html
@@ -20,7 +20,7 @@
 <separator></separator>
 <h2>Action bar with back button, description and action buttons.</h2>
 
-<component-example>
+<component-example [name]="'ex1'">
   <fd-action-bar>
     <fd-action-bar-back>
       <button fd-button [fdType]="'secondary'" [size]="'compact'" [glyph]="'nav-back'"></button>
@@ -45,7 +45,7 @@
   area no
   matter what page they are on within the application.</p>
 
-<component-example>
+<component-example [name]="'ex2'">
   <fd-action-bar>
     <fd-action-bar-header>
       <fd-action-bar-title>Page Title</fd-action-bar-title>
@@ -68,7 +68,7 @@
   works
   well for a responsive/adaptive application.</p>
 
-<component-example>
+<component-example [name]="'ex3'">
   <fd-action-bar>
     <fd-action-bar-header>
       <fd-action-bar-title>Page Title</fd-action-bar-title>
@@ -109,7 +109,7 @@
 
 <h2>Action bar mobile view</h2>
 
-<component-example>
+<component-example [name]="'ex4'">
   <fd-action-bar-mobile>
     <fd-action-bar>
       <fd-action-bar-back>

--- a/docs/modules/documentation/containers/action-bar/action-bar-docs.component.html
+++ b/docs/modules/documentation/containers/action-bar/action-bar-docs.component.html
@@ -20,8 +20,97 @@
 <separator></separator>
 <h2>Action bar with back button, description and action buttons.</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
+<component-example>
+  <fd-action-bar>
+    <fd-action-bar-back>
+      <button fd-button [fdType]="'secondary'" [size]="'compact'" [glyph]="'nav-back'"></button>
+    </fd-action-bar-back>
+    <fd-action-bar-header>
+      <fd-action-bar-title>Page Title</fd-action-bar-title>
+      <fd-action-bar-description>Action bar Description</fd-action-bar-description>
+    </fd-action-bar-header>
+    <fd-action-bar-actions>
+      <button fd-button [fdType]="'primary'">Cancel</button>
+      <button fd-button [fdType]="'main'">Save</button>
+    </fd-action-bar-actions>
+  </fd-action-bar>
+</component-example>
+<pre><code mwlHighlightJs [language]="'HTML'" [source]="backButtonHtml"></code></pre>
+
+
+<separator></separator>
+
+<h2>Action bar with main actions and no Back button</h2>
+<p>Display main actions within the Action bar. This allows for users to find important page actions in a consistent
+  area no
+  matter what page they are on within the application.</p>
+
+<component-example>
+  <fd-action-bar>
+    <fd-action-bar-header>
+      <fd-action-bar-title>Page Title</fd-action-bar-title>
+      <fd-action-bar-description>Action bar Description</fd-action-bar-description>
+    </fd-action-bar-header>
+    <fd-action-bar-actions>
+      <button fd-button [fdType]="'primary'">Cancel</button>
+      <button fd-button [fdType]="'main'">Save</button>
+    </fd-action-bar-actions>
+  </fd-action-bar>
+</component-example>
+<pre><code mwlHighlightJs [language]="'HTML'" [source]="noBackButtonHtml"></code></pre>
+
+<separator></separator>
+
+<h2>Several Main Actions in a Contextual Menu</h2>
+<p>When there are several main actions for a page, consider displaying them under a contextual menu. This allows the
+  user to
+  look in the same position they are used to but avoids cluttering the action bar with more than 3-4 actions. This also
+  works
+  well for a responsive/adaptive application.</p>
+
+<component-example>
+  <fd-action-bar>
+    <fd-action-bar-header>
+      <fd-action-bar-title>Page Title</fd-action-bar-title>
+    </fd-action-bar-header>
+    <fd-action-bar-actions>
+      <fd-popover>
+        <fd-popover-control>
+          <button fd-button [fdType]="'secondary'" [glyph]="'vertical-grip'"></button>
+        </fd-popover-control>
+        <fd-popover-body>
+          <fd-menu>
+            <fd-menu-list>
+              <fd-menu-item [url]="'#'">
+                Edit
+              </fd-menu-item>
+              <fd-menu-item [url]="'#'">
+                Delete
+              </fd-menu-item>
+              <fd-menu-item [url]="'#'">
+                Assign
+              </fd-menu-item>
+              <fd-menu-item [url]="'#'">
+                Expire
+              </fd-menu-item>
+              <fd-menu-item [url]="'#'">
+                Archive
+              </fd-menu-item>
+            </fd-menu-list>
+          </fd-menu>
+        </fd-popover-body>
+      </fd-popover>
+    </fd-action-bar-actions>
+  </fd-action-bar>
+</component-example>
+<pre><code mwlHighlightJs [language]="'HTML'" [source]="actionsContextualMenuHtml"></code></pre>
+
+<separator></separator>
+
+<h2>Action bar mobile view</h2>
+
+<component-example>
+  <fd-action-bar-mobile>
     <fd-action-bar>
       <fd-action-bar-back>
         <button fd-button [fdType]="'secondary'" [size]="'compact'" [glyph]="'nav-back'"></button>
@@ -29,51 +118,6 @@
       <fd-action-bar-header>
         <fd-action-bar-title>Page Title</fd-action-bar-title>
         <fd-action-bar-description>Action bar Description</fd-action-bar-description>
-      </fd-action-bar-header>
-      <fd-action-bar-actions>
-        <button fd-button [fdType]="'primary'">Cancel</button>
-        <button fd-button [fdType]="'main'">Save</button>
-      </fd-action-bar-actions>
-    </fd-action-bar>
-  </div>
-</div>
-<pre><code mwlHighlightJs [language]="'HTML'" [source]="backButtonHtml"></code></pre>
-
-
-<separator></separator>
-
-<h2>Action bar with main actions and no Back button</h2>
-<p>Display main actions within the Action bar. This allows for users to find important page actions in a consistent area no
-  matter what page they are on within the application.</p>
-
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-action-bar>
-      <fd-action-bar-header>
-        <fd-action-bar-title>Page Title</fd-action-bar-title>
-        <fd-action-bar-description>Action bar Description</fd-action-bar-description>
-      </fd-action-bar-header>
-      <fd-action-bar-actions>
-        <button fd-button [fdType]="'primary'">Cancel</button>
-        <button fd-button [fdType]="'main'">Save</button>
-      </fd-action-bar-actions>
-    </fd-action-bar>
-  </div>
-</div>
-<pre><code mwlHighlightJs [language]="'HTML'" [source]="noBackButtonHtml"></code></pre>
-
-<separator></separator>
-
-<h2>Several Main Actions in a Contextual Menu</h2>
-<p>When there are several main actions for a page, consider displaying them under a contextual menu. This allows the user to
-  look in the same position they are used to but avoids cluttering the action bar with more than 3-4 actions. This also works
-  well for a responsive/adaptive application.</p>
-
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-action-bar>
-      <fd-action-bar-header>
-        <fd-action-bar-title>Page Title</fd-action-bar-title>
       </fd-action-bar-header>
       <fd-action-bar-actions>
         <fd-popover>
@@ -104,55 +148,6 @@
         </fd-popover>
       </fd-action-bar-actions>
     </fd-action-bar>
-  </div>
-</div>
-<pre><code mwlHighlightJs [language]="'HTML'" [source]="actionsContextualMenuHtml"></code></pre>
-
-<separator></separator>
-
-<h2>Action bar mobile view</h2>
-
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-action-bar-mobile>
-      <fd-action-bar>
-        <fd-action-bar-back>
-          <button fd-button [fdType]="'secondary'" [size]="'compact'" [glyph]="'nav-back'"></button>
-        </fd-action-bar-back>
-        <fd-action-bar-header>
-          <fd-action-bar-title>Page Title</fd-action-bar-title>
-          <fd-action-bar-description>Action bar Description</fd-action-bar-description>
-        </fd-action-bar-header>
-        <fd-action-bar-actions>
-          <fd-popover>
-            <fd-popover-control>
-              <button fd-button [fdType]="'secondary'" [glyph]="'vertical-grip'"></button>
-            </fd-popover-control>
-            <fd-popover-body>
-              <fd-menu>
-                <fd-menu-list>
-                  <fd-menu-item [url]="'#'">
-                    Edit
-                  </fd-menu-item>
-                  <fd-menu-item [url]="'#'">
-                    Delete
-                  </fd-menu-item>
-                  <fd-menu-item [url]="'#'">
-                    Assign
-                  </fd-menu-item>
-                  <fd-menu-item [url]="'#'">
-                    Expire
-                  </fd-menu-item>
-                  <fd-menu-item [url]="'#'">
-                    Archive
-                  </fd-menu-item>
-                </fd-menu-list>
-              </fd-menu>
-            </fd-popover-body>
-          </fd-popover>
-        </fd-action-bar-actions>
-      </fd-action-bar>
-    </fd-action-bar-mobile>
-  </div>
-</div>
+  </fd-action-bar-mobile>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="mobileViewHtml"></code></pre>

--- a/docs/modules/documentation/containers/alert/alert-docs.component.html
+++ b/docs/modules/documentation/containers/alert/alert-docs.component.html
@@ -17,8 +17,36 @@
 
 <separator></separator>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
+<component-example>
+  <p>
+    <fd-alert [dismissible]="true" [type]="'warning'" (close)="showAlert($event)">
+      A dismissible warning type alert.
+    </fd-alert>
+  </p>
+  <p>
+    <fd-alert [dismissible]="true" [type]="'error'" (close)="showAlert($event)">
+      <div>
+        <h3>A dismissible error type alert with template.</h3>
+        <p>More information...</p>
+      </div>
+    </fd-alert>
+  </p>
+  <p>
+    <fd-alert [dismissible]="false">
+      A normal type alert.
+    </fd-alert>
+  </p>
+  <p>
+    <fd-alert [dismissible]="false">
+      An alert with a <a href="#" class="fd-link">link <fd-icon [glyph]="'arrow-right'" [size]="'s'"></fd-icon></a>
+    </fd-alert>
+  </p>
+
+</component-example>
+
+<!-- <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1" id="tile-alert">
   <div class="fd-tile__content">
+    <rtl-toggle label="tile-alert"></rtl-toggle>
     <p>
       <fd-alert [dismissible]="true" [type]="'warning'" (close)="showAlert($event)">
         A dismissible warning type alert.
@@ -44,7 +72,7 @@
     </p>
   </div>
 </div>
-<pre><code mwlHighlightJs [language]="'HTML'" [source]="alertHtml"></code></pre>
+<pre><code mwlHighlightJs [language]="'HTML'" [source]="alertHtml"></code></pre> -->
 
 <separator></separator>
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">

--- a/docs/modules/documentation/containers/alert/alert-docs.component.html
+++ b/docs/modules/documentation/containers/alert/alert-docs.component.html
@@ -41,38 +41,8 @@
       An alert with a <a href="#" class="fd-link">link <fd-icon [glyph]="'arrow-right'" [size]="'s'"></fd-icon></a>
     </fd-alert>
   </p>
-
 </component-example>
-
-<!-- <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1" id="tile-alert">
-  <div class="fd-tile__content">
-    <rtl-toggle label="tile-alert"></rtl-toggle>
-    <p>
-      <fd-alert [dismissible]="true" [type]="'warning'" (close)="showAlert($event)">
-        A dismissible warning type alert.
-      </fd-alert>
-    </p>
-    <p>
-      <fd-alert [dismissible]="true" [type]="'error'" (close)="showAlert($event)">
-        <div>
-          <h3>A dismissible error type alert with template.</h3>
-          <p>More information...</p>
-        </div>
-      </fd-alert>
-    </p>
-    <p>
-      <fd-alert [dismissible]="false">
-        A normal type alert.
-      </fd-alert>
-    </p>
-    <p>
-      <fd-alert [dismissible]="false">
-        An alert with a <a href="#" class="fd-link">link <fd-icon [glyph]="'arrow-right'" [size]="'s'"></fd-icon></a>
-      </fd-alert>
-    </p>
-  </div>
-</div>
-<pre><code mwlHighlightJs [language]="'HTML'" [source]="alertHtml"></code></pre> -->
+<pre><code mwlHighlightJs [language]="'HTML'" [source]="alertHtml"></code></pre>
 
 <separator></separator>
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">

--- a/docs/modules/documentation/containers/alert/alert-docs.component.html
+++ b/docs/modules/documentation/containers/alert/alert-docs.component.html
@@ -17,7 +17,7 @@
 
 <separator></separator>
 
-<component-example>
+<component-example [name]="'ex1'">
   <p>
     <fd-alert [dismissible]="true" [type]="'warning'" (close)="showAlert($event)">
       A dismissible warning type alert.

--- a/docs/modules/documentation/containers/badge-label/badge-label-docs.component.html
+++ b/docs/modules/documentation/containers/badge-label/badge-label-docs.component.html
@@ -28,7 +28,7 @@
 <separator></separator>
 
 <h2>Default Badge</h2>
-<component-example>
+<component-example [name]="'ex1'">
   <fd-badge>Default</fd-badge>
   <fd-badge [status]="'success'">Default</fd-badge>
   <fd-badge [status]="'warning'">Default</fd-badge>
@@ -41,7 +41,7 @@
 <h2>Pill Badge</h2>
 <p>
   <code>fd-badge--pill</code> modifier can be used to render a pill version of the badge.</p>
-<component-example>
+<component-example [name]="'ex2'">
   <fd-badge [modifier]="'pill'">Default</fd-badge>
   <fd-badge [status]="'success'" [modifier]="'pill'">Default</fd-badge>
   <fd-badge [status]="'warning'" [modifier]="'pill'">Default</fd-badge>
@@ -54,7 +54,7 @@
 <h2>Filled Badge</h2>
 <p>
   <code>fd-badge--filled</code> modifier can be used to render a filled version of the badge.</p>
-<component-example>
+<component-example [name]="'ex3'">
   <fd-badge [modifier]="'filled'">Default</fd-badge>
   <fd-badge [status]="'success'" [modifier]="'filled'">Default</fd-badge>
   <fd-badge [status]="'warning'" [modifier]="'filled'">Default</fd-badge>
@@ -65,7 +65,7 @@
 <separator></separator>
 
 <h2>Label</h2>
-<component-example>
+<component-example [name]="'ex4'">
   <fd-label>Default</fd-label>
   <fd-label [status]="'success'">Success</fd-label>
   <fd-label [status]="'warning'">Warning</fd-label>
@@ -76,7 +76,7 @@
 <separator></separator>
 
 <h2>Status Indicator Label with build in status icons</h2>
-<component-example>
+<component-example [name]="'ex5'">
   <fd-label [isStatusLabel]="true" [statusIcon]="'available'">Available</fd-label>
   <fd-label [isStatusLabel]="true" [statusIcon]="'away'">Away</fd-label>
   <fd-label [isStatusLabel]="true" [statusIcon]="'busy'">Busy</fd-label>
@@ -87,7 +87,7 @@
 <separator></separator>
 
 <h2>Status Indicator Label with any icons</h2>
-<component-example>
+<component-example [name]="'ex6'">
   <fd-label [isStatusLabel]="true" [icon]="'history'">Custom Icon</fd-label>
   <fd-label [isStatusLabel]="true" [icon]="'message-success'">Success</fd-label>
   <fd-label [isStatusLabel]="true" [icon]="'message-warning'">Warning</fd-label>
@@ -98,7 +98,7 @@
 <separator></separator>
 
 <h2>Status Indicator Label with sementic colors</h2>
-<component-example>
+<component-example [name]="'ex7'">
   <fd-label [isStatusLabel]="true">Default</fd-label>
   <fd-label [isStatusLabel]="true" [status]="'success'">Success</fd-label>
   <fd-label [isStatusLabel]="true" [status]="'warning'">Warning</fd-label>

--- a/docs/modules/documentation/containers/badge-label/badge-label-docs.component.html
+++ b/docs/modules/documentation/containers/badge-label/badge-label-docs.component.html
@@ -1,6 +1,7 @@
 <header>Badge and Label</header>
 <description>
-  <p>Badges and labels are used to indicate status. Colors, generally in combination with text, are used to easily highlight
+  <p>Badges and labels are used to indicate status. Colors, generally in combination with text, are used to easily
+    highlight
     the state of an object.</p>
   <p> - Black is used to indicate default or inactive status </p>
   <p> - Green indicates positive status, used for active, published, approved </p>
@@ -27,14 +28,12 @@
 <separator></separator>
 
 <h2>Default Badge</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-badge>Default</fd-badge>
-    <fd-badge [status]="'success'">Default</fd-badge>
-    <fd-badge [status]="'warning'">Default</fd-badge>
-    <fd-badge [status]="'error'">Default</fd-badge>
-  </div>
-</div>
+<component-example>
+  <fd-badge>Default</fd-badge>
+  <fd-badge [status]="'success'">Default</fd-badge>
+  <fd-badge [status]="'warning'">Default</fd-badge>
+  <fd-badge [status]="'error'">Default</fd-badge>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="defaultBadgeHtmlType"></code></pre>
 
 <separator></separator>
@@ -42,14 +41,12 @@
 <h2>Pill Badge</h2>
 <p>
   <code>fd-badge--pill</code> modifier can be used to render a pill version of the badge.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-badge [modifier]="'pill'">Default</fd-badge>
-    <fd-badge [status]="'success'" [modifier]="'pill'">Default</fd-badge>
-    <fd-badge [status]="'warning'" [modifier]="'pill'">Default</fd-badge>
-    <fd-badge [status]="'error'" [modifier]="'pill'">Default</fd-badge>
-  </div>
-</div>
+<component-example>
+  <fd-badge [modifier]="'pill'">Default</fd-badge>
+  <fd-badge [status]="'success'" [modifier]="'pill'">Default</fd-badge>
+  <fd-badge [status]="'warning'" [modifier]="'pill'">Default</fd-badge>
+  <fd-badge [status]="'error'" [modifier]="'pill'">Default</fd-badge>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="pillBadgeHtmlType"></code></pre>
 
 <separator></separator>
@@ -57,66 +54,56 @@
 <h2>Filled Badge</h2>
 <p>
   <code>fd-badge--filled</code> modifier can be used to render a filled version of the badge.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-badge [modifier]="'filled'">Default</fd-badge>
-    <fd-badge [status]="'success'" [modifier]="'filled'">Default</fd-badge>
-    <fd-badge [status]="'warning'" [modifier]="'filled'">Default</fd-badge>
-    <fd-badge [status]="'error'" [modifier]="'filled'">Default</fd-badge>
-  </div>
-</div>
+<component-example>
+  <fd-badge [modifier]="'filled'">Default</fd-badge>
+  <fd-badge [status]="'success'" [modifier]="'filled'">Default</fd-badge>
+  <fd-badge [status]="'warning'" [modifier]="'filled'">Default</fd-badge>
+  <fd-badge [status]="'error'" [modifier]="'filled'">Default</fd-badge>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="filledBadgeHtmlType"></code></pre>
 
 <separator></separator>
 
 <h2>Label</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-label>Default</fd-label>
-    <fd-label [status]="'success'">Success</fd-label>
-    <fd-label [status]="'warning'">Warning</fd-label>
-    <fd-label [status]="'error'">Error</fd-label>
-  </div>
-</div>
+<component-example>
+  <fd-label>Default</fd-label>
+  <fd-label [status]="'success'">Success</fd-label>
+  <fd-label [status]="'warning'">Warning</fd-label>
+  <fd-label [status]="'error'">Error</fd-label>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="labelHtmlType"></code></pre>
 
 <separator></separator>
 
 <h2>Status Indicator Label with build in status icons</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-label [isStatusLabel]="true" [statusIcon]="'available'">Available</fd-label>
-    <fd-label [isStatusLabel]="true" [statusIcon]="'away'">Away</fd-label>
-    <fd-label [isStatusLabel]="true" [statusIcon]="'busy'">Busy</fd-label>
-    <fd-label [isStatusLabel]="true" [statusIcon]="'offline'">Appear Offline</fd-label>
-  </div>
-</div>
+<component-example>
+  <fd-label [isStatusLabel]="true" [statusIcon]="'available'">Available</fd-label>
+  <fd-label [isStatusLabel]="true" [statusIcon]="'away'">Away</fd-label>
+  <fd-label [isStatusLabel]="true" [statusIcon]="'busy'">Busy</fd-label>
+  <fd-label [isStatusLabel]="true" [statusIcon]="'offline'">Appear Offline</fd-label>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="statusIconLabelHtmlType"></code></pre>
 
 <separator></separator>
 
 <h2>Status Indicator Label with any icons</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-label [isStatusLabel]="true" [icon]="'history'">Custom Icon</fd-label>
-    <fd-label [isStatusLabel]="true" [icon]="'message-success'">Success</fd-label>
-    <fd-label [isStatusLabel]="true" [icon]="'message-warning'">Warning</fd-label>
-    <fd-label [isStatusLabel]="true" [icon]="'message-error'">Error</fd-label>
-  </div>
-</div>
+<component-example>
+  <fd-label [isStatusLabel]="true" [icon]="'history'">Custom Icon</fd-label>
+  <fd-label [isStatusLabel]="true" [icon]="'message-success'">Success</fd-label>
+  <fd-label [isStatusLabel]="true" [icon]="'message-warning'">Warning</fd-label>
+  <fd-label [isStatusLabel]="true" [icon]="'message-error'">Error</fd-label>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="anyIconLabelHtmlType"></code></pre>
 
 <separator></separator>
 
 <h2>Status Indicator Label with sementic colors</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-label [isStatusLabel]="true">Default</fd-label>
-    <fd-label [isStatusLabel]="true" [status]="'success'">Success</fd-label>
-    <fd-label [isStatusLabel]="true" [status]="'warning'">Warning</fd-label>
-    <fd-label [isStatusLabel]="true" [status]="'error'">Error</fd-label>
-  </div>
-</div>
+<component-example>
+  <fd-label [isStatusLabel]="true">Default</fd-label>
+  <fd-label [isStatusLabel]="true" [status]="'success'">Success</fd-label>
+  <fd-label [isStatusLabel]="true" [status]="'warning'">Warning</fd-label>
+  <fd-label [isStatusLabel]="true" [status]="'error'">Error</fd-label>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="semanticColorLabelHtmlType"></code></pre>
 
 <separator></separator>

--- a/docs/modules/documentation/containers/breadcrumb/breadcrumb-docs.component.html
+++ b/docs/modules/documentation/containers/breadcrumb/breadcrumb-docs.component.html
@@ -1,7 +1,9 @@
 <header>Breadcrumb</header>
 <description>
-  The breadcrumb allows users to see the current page and navigation path to that page. Users can navigate to previous levels
-  in the path by clicking on those levels. By clicking on the current page, a dropdown allows users to access other pages
+  The breadcrumb allows users to see the current page and navigation path to that page. Users can navigate to previous
+  levels
+  in the path by clicking on those levels. By clicking on the current page, a dropdown allows users to access other
+  pages
   at that same level.
 </description>
 <import module="BreadcrumbModule" path="fundamental/breadcrumb/breadcrumb.module"></import>
@@ -16,18 +18,17 @@
 }"></properties>
 <br>
 <span>
-  Instead of the [url] property, you may use any RouterLink properties on each breadcrumb item.  See the official <a href="https://angular.io/api/router/RouterLink">Angular documentation for RouterLink</a> for more information.
+  Instead of the [url] property, you may use any RouterLink properties on each breadcrumb item. See the official <a
+    href="https://angular.io/api/router/RouterLink">Angular documentation for RouterLink</a> for more information.
 </span>
 
 <separator></separator>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-breadcrumb>
-      <fd-breadcrumb-item [url]="'#'">Link Text</fd-breadcrumb-item>
-      <fd-breadcrumb-item [routerLink]="'#'" [queryParams]="'#'">Link Text</fd-breadcrumb-item>
-      <fd-breadcrumb-item>Link Text</fd-breadcrumb-item>
-    </fd-breadcrumb>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <fd-breadcrumb>
+    <fd-breadcrumb-item [url]="'#'">Breakcrumb Level1</fd-breadcrumb-item>
+    <fd-breadcrumb-item [routerLink]="'#'" [queryParams]="'#'">Breakcrumb Level2</fd-breadcrumb-item>
+    <fd-breadcrumb-item>Breakcrumb Level3</fd-breadcrumb-item>
+  </fd-breadcrumb>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="breadcrumbHtml"></code></pre>

--- a/docs/modules/documentation/containers/button-group/button-group-docs.component.html
+++ b/docs/modules/documentation/containers/button-group/button-group-docs.component.html
@@ -18,118 +18,95 @@
 <separator></separator>
 
 <h2>Extra Small Size (XS)</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-button-group style="margin-right: 10px;">
-      <button fd-button-grouped [id]="'1'" [size]="'xs'" [glyph]="'survey'" [state]="'selected'"></button>
-      <button fd-button-grouped [id]="'2'" [size]="'xs'" [glyph]="'pie-chart'"></button>
-      <button fd-button-grouped [id]="'3'" [size]="'xs'" [glyph]="'pool'"></button>
-    </fd-button-group>
-    <fd-button-group>
-      <button fd-button-grouped [id]="'4'" [size]="'xs'">Left</button>
-      <button fd-button-grouped [id]="'5'" [size]="'xs'" [state]="'selected'">Middle</button>
-      <button fd-button-grouped [id]="'6'" [size]="'xs'">Right</button>
-    </fd-button-group>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <fd-button-group style="margin-right: 10px; margin-left: 10px;">
+    <button fd-button-grouped [id]="'1'" [size]="'xs'" [glyph]="'survey'" [state]="'selected'"></button>
+    <button fd-button-grouped [id]="'2'" [size]="'xs'" [glyph]="'pie-chart'"></button>
+    <button fd-button-grouped [id]="'3'" [size]="'xs'" [glyph]="'pool'"></button>
+  </fd-button-group>
+  <fd-button-group>
+    <button fd-button-grouped [id]="'4'" [size]="'xs'">Left</button>
+    <button fd-button-grouped [id]="'5'" [size]="'xs'" [state]="'selected'">Middle</button>
+    <button fd-button-grouped [id]="'6'" [size]="'xs'">Right</button>
+  </fd-button-group>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]=" xsSizeHtml "></code></pre>
 
 <separator></separator>
 
 <h2>Small Size (S)</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-button-group style="margin-right: 10px;">
-      <button fd-button-grouped [size]="'s'" [glyph]="'survey'" [state]="'selected'"></button>
-      <button fd-button-grouped [size]="'s'" [glyph]="'pie-chart'"></button>
-      <button fd-button-grouped [size]="'s'" [glyph]="'pool'"></button>
-    </fd-button-group>
-    <fd-button-group>
-      <button fd-button-grouped [size]="'s'">Left</button>
-      <button fd-button-grouped [size]="'s'" [state]="'selected'">Middle</button>
-      <button fd-button-grouped [size]="'s'">Right</button>
-    </fd-button-group>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <fd-button-group style="margin-right: 10px; margin-left: 10px;">
+    <button fd-button-grouped [size]="'s'" [glyph]="'survey'" [state]="'selected'"></button>
+    <button fd-button-grouped [size]="'s'" [glyph]="'pie-chart'"></button>
+    <button fd-button-grouped [size]="'s'" [glyph]="'pool'"></button>
+  </fd-button-group>
+  <fd-button-group>
+    <button fd-button-grouped [size]="'s'">Left</button>
+    <button fd-button-grouped [size]="'s'" [state]="'selected'">Middle</button>
+    <button fd-button-grouped [size]="'s'">Right</button>
+  </fd-button-group>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]=" sSizeHtml "></code></pre>
 
 <separator></separator>
 
 <h2>Compact Size</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-button-group style="margin-right: 10px;">
-      <button fd-button-grouped [compact]="true" [glyph]="'survey'" [state]="'selected'"></button>
-      <button fd-button-grouped [compact]="true" [glyph]="'pie-chart'"></button>
-      <button fd-button-grouped [compact]="true" [glyph]="'pool'"></button>
-    </fd-button-group>
-    <fd-button-group>
-      <button fd-button-grouped [compact]="true">Left</button>
-      <button fd-button-grouped [compact]="true" [state]="'selected'">Middle</button>
-      <button fd-button-grouped [compact]="true">Right </button>
-    </fd-button-group>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <fd-button-group style="margin-right: 10px; margin-left: 10px;">
+    <button fd-button-grouped [compact]="true" [glyph]="'survey'" [state]="'selected'"></button>
+    <button fd-button-grouped [compact]="true" [glyph]="'pie-chart'"></button>
+    <button fd-button-grouped [compact]="true" [glyph]="'pool'"></button>
+  </fd-button-group>
+  <fd-button-group>
+    <button fd-button-grouped [compact]="true">Left</button>
+    <button fd-button-grouped [compact]="true" [state]="'selected'">Middle</button>
+    <button fd-button-grouped [compact]="true">Right </button>
+  </fd-button-group>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]=" compactSizeHtml "></code></pre>
 
 <separator></separator>
 
 <h2>Default Size (Large)</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-button-group style="margin-right: 10px;">
-      <button fd-button-grouped [glyph]="'survey'" [state]="'selected'"></button>
-      <button fd-button-grouped [glyph]="'pie-chart'" ></button>
-      <button fd-button-grouped [glyph]="'pool'"></button>
-    </fd-button-group>
-    <fd-button-group>
-      <button fd-button-grouped >Left</button>
-      <button fd-button-grouped [state]="'selected'">Middle</button>
-      <button fd-button-grouped >Right</button>
-    </fd-button-group>
-  </div>
-</div>
+<component-example [name]="'ex4'">
+  <fd-button-group style="margin-right: 10px; margin-left: 10px;">
+    <button fd-button-grouped [glyph]="'survey'" [state]="'selected'"></button>
+    <button fd-button-grouped [glyph]="'pie-chart'"></button>
+    <button fd-button-grouped [glyph]="'pool'"></button>
+  </fd-button-group>
+  <fd-button-group>
+    <button fd-button-grouped>Left</button>
+    <button fd-button-grouped [state]="'selected'">Middle</button>
+    <button fd-button-grouped>Right</button>
+  </fd-button-group>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]=" defaultSizeHtml "></code></pre>
 
 <separator></separator>
 
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
   <fd-button-group>
-    <button *ngIf ="data.properties.label1.length > 0" fd-button-grouped
-        [size]="data.properties.size"
-        [compact]="data.properties.compact"
-        [state]="data.properties.state1" >
-        {{data.properties.label1}}
+    <button *ngIf="data.properties.label1.length > 0" fd-button-grouped [size]="data.properties.size" [compact]="data.properties.compact"
+      [state]="data.properties.state1">
+      {{data.properties.label1}}
     </button>
-    <button *ngIf ="data.properties.label2.length > 0" fd-button-grouped
-        [size]="data.properties.size"
-        [compact]="data.properties.compact"
-        [state]="data.properties.state2" >
-        {{data.properties.label2}}
+    <button *ngIf="data.properties.label2.length > 0" fd-button-grouped [size]="data.properties.size" [compact]="data.properties.compact"
+      [state]="data.properties.state2">
+      {{data.properties.label2}}
     </button>
-    <button *ngIf ="data.properties.label3.length > 0" fd-button-grouped
-        [size]="data.properties.size"
-        [compact]="data.properties.compact"
-        [state]="data.properties.state3" >
-        {{data.properties.label3}}
+    <button *ngIf="data.properties.label3.length > 0" fd-button-grouped [size]="data.properties.size" [compact]="data.properties.compact"
+      [state]="data.properties.state3">
+      {{data.properties.label3}}
     </button>
-    <button *ngIf ="data.properties.icon1.length > 0" fd-button-grouped
-        [size]="data.properties.size"
-        [glyph]="data.properties.icon1"
-        [compact]="data.properties.compact"
-        [state]="data.properties.state4" >
+    <button *ngIf="data.properties.icon1.length > 0" fd-button-grouped [size]="data.properties.size" [glyph]="data.properties.icon1"
+      [compact]="data.properties.compact" [state]="data.properties.state4">
     </button>
-    <button *ngIf ="data.properties.icon2.length > 0" fd-button-grouped
-        [size]="data.properties.size"
-        [glyph]="data.properties.icon2"
-        [compact]="data.properties.compact"
-        [state]="data.properties.state5" >
+    <button *ngIf="data.properties.icon2.length > 0" fd-button-grouped [size]="data.properties.size" [glyph]="data.properties.icon2"
+      [compact]="data.properties.compact" [state]="data.properties.state5">
     </button>
-    <button *ngIf ="data.properties.icon3.length > 0" fd-button-grouped
-        [size]="data.properties.size"
-        [glyph]="data.properties.icon3"
-        [compact]="data.properties.compact"
-        [state]="data.properties.state6" >
+    <button *ngIf="data.properties.icon3.length > 0" fd-button-grouped [size]="data.properties.size" [glyph]="data.properties.icon3"
+      [compact]="data.properties.compact" [state]="data.properties.state6">
     </button>
   </fd-button-group>
 </playground>

--- a/docs/modules/documentation/containers/button/button-docs.component.html
+++ b/docs/modules/documentation/containers/button/button-docs.component.html
@@ -1,7 +1,6 @@
 <header>Button</header>
 <description>The Button directive is used to enhance standard HTML buttons.</description>
-<import module="ButtonModule"
-        path="fundamental/button/button.module"></import>
+<import module="ButtonModule" path="fundamental/button/button.module"></import>
 <separator></separator>
 
 <h1>&lt;button fd-button&gt;</h1>
@@ -16,18 +15,23 @@
   ]
 }"></properties>
 
-<description>The inputs for <code>button</code> will be translated into class attributed respecting fundamental-ui guidelines.
+<description>The inputs for <code>button</code> will be translated into class attributed respecting fundamental-ui
+  guidelines.
   <br>For example:
-  <br>if it is passed <code>positive</code> for <code>fdType</code> the class <code>fd-button--positive</code> will be added
+  <br>if it is passed <code>positive</code> for <code>fdType</code> the class <code>fd-button--positive</code> will be
+  added
   to the element.
-  <br>if it is passed <code>s</code> for <code>size</code> the class <code>fd-button--s</code> will be added to the element.
+  <br>if it is passed <code>s</code> for <code>size</code> the class <code>fd-button--s</code> will be added to the
+  element.
 </description>
 
 <separator></separator>
 <h2>Extensibility</h2>
-<description>The button implementation allows certain extensibility in terms of options for the inputs. <code>button</code>  inputs
+<description>The button implementation allows certain extensibility in terms of options for the inputs. <code>button</code>
+  inputs
   doesn't have a restriction for the predefined values.
-  <br>The predefined values for the input <code>size</code> are <code>xs</code>, <code>s</code>, <code>l</code>, but <code>size</code>  can
+  <br>The predefined values for the input <code>size</code> are <code>xs</code>, <code>s</code>, <code>l</code>, but
+  <code>size</code> can
   accept any other string, for example <code>xxs</code>, which will be translated into class <code>fd-button--xxs</code>.
 </description>
 
@@ -40,35 +44,28 @@
   <code class="code-snippet">[fdType]="'negative'"</code> to modify the type of the button.
 </p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <button fd-button>
-        Primary Button
-      </button>
-      <button fd-button
-              [fdType]="'main'">
-        Main Button
-      </button>
-      <button fd-button
-              [fdType]="'secondary'">
-        Secondary Button
-      </button>
-      <button fd-button
-              [fdType]="'toolbar'">
-        Toolbar Button
-      </button>
-      <button fd-button
-              [fdType]="'positive'">
-        Positive Button
-      </button>
-      <button fd-button
-              [fdType]="'negative'">
-        Negative Button
-      </button>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <p>
+    <button fd-button>
+      Primary Button
+    </button>
+    <button fd-button [fdType]="'main'">
+      Main Button
+    </button>
+    <button fd-button [fdType]="'secondary'">
+      Secondary Button
+    </button>
+    <button fd-button [fdType]="'toolbar'">
+      Toolbar Button
+    </button>
+    <button fd-button [fdType]="'positive'">
+      Positive Button
+    </button>
+    <button fd-button [fdType]="'negative'">
+      Negative Button
+    </button>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="buttonHtmlType"></code></pre>
 
 <separator></separator>
@@ -79,31 +76,25 @@
   <code class="code-snippet">[size]="'l'"</code> to modify the size of the button.
 </p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <button fd-button
-              [size]="'xs'">
-        Extra-Small Button
-      </button>
-      <button fd-button
-              [size]="'s'">
-        Small Button
-      </button>
-      <button fd-button
-              [size]="'compact'">
-        Compact Button
-      </button>
-      <button fd-button>
-        Normal Button
-      </button>
-      <button fd-button
-              [size]="'l'">
-        Large Button
-      </button>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <p>
+    <button fd-button [size]="'xs'">
+      Extra-Small Button
+    </button>
+    <button fd-button [size]="'s'">
+      Small Button
+    </button>
+    <button fd-button [size]="'compact'">
+      Compact Button
+    </button>
+    <button fd-button>
+      Normal Button
+    </button>
+    <button fd-button [size]="'l'">
+      Large Button
+    </button>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="buttonHtmlSize"></code></pre>
 
 <separator></separator>
@@ -112,42 +103,26 @@
   Use
   <code class="code-snippet">[glyph]="'{{ '{' }}icon-name}'"</code> to add an icon to the button.
 </p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <button fd-button
-              [glyph]="'cart'">
-        Add to Cart
-      </button>
-      <button fd-button
-              [fdType]="'main'"
-              [glyph]="'cart'">
-        Add to Cart
-      </button>
-      <button fd-button
-              [fdType]="'toolbar'"
-              [glyph]="'filter'">
-        Filter
-      </button>
-      <button fd-button
-              [fdType]="'positive'"
-              [glyph]="'accept'">
-        Approve
-      </button>
-      <button fd-button
-              [glyph]="'cart'"></button>
-      <button fd-button
-              [fdType]="'main'"
-              [glyph]="'cart'"></button>
-      <button fd-button
-              [fdType]="'toolbar'"
-              [glyph]="'filter'"></button>
-      <button fd-button
-              [fdType]="'positive'"
-              [glyph]="'accept'"></button>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <p>
+    <button fd-button [glyph]="'cart'">
+      Add to Cart
+    </button>
+    <button fd-button [fdType]="'main'" [glyph]="'cart'">
+      Add to Cart
+    </button>
+    <button fd-button [fdType]="'toolbar'" [glyph]="'filter'">
+      Filter
+    </button>
+    <button fd-button [fdType]="'positive'" [glyph]="'accept'">
+      Approve
+    </button>
+    <button fd-button [glyph]="'cart'"></button>
+    <button fd-button [fdType]="'main'" [glyph]="'cart'"></button>
+    <button fd-button [fdType]="'toolbar'" [glyph]="'filter'"></button>
+    <button fd-button [fdType]="'positive'" [glyph]="'accept'"></button>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="buttonHtmlIcon"></code></pre>
 
 <separator></separator>
@@ -157,36 +132,26 @@
   <code class="code-snippet">[state]="'disabled'"</code> or
   <code class="code-snippet">[state]="'selected'"</code> to set button state.
 </p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <button fd-button>
-        Normal State
-      </button>
-      <button fd-button
-              [state]="'selected'">
-        Selected State
-      </button>
-      <button fd-button
-              [state]="'disabled'">
-        Disabled State
-      </button>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex4'">
+  <p>
+    <button fd-button>
+      Normal State
+    </button>
+    <button fd-button [state]="'selected'">
+      Selected State
+    </button>
+    <button fd-button [state]="'disabled'">
+      Disabled State
+    </button>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="buttonHtmlState"></code></pre>
 
 <separator></separator>
 
-<playground [schema]="schema"
-            [schemaInitialValues]="data"
-            (onFormChanges)="onSchemaValues($event)">
-  <button fd-button
-          [fdType]="data.properties.type"
-          [semantic]="data.properties.semantic"
-          [state]="data.properties.state"
-          [size]="data.properties.size"
-          [glyph]="data.properties.icon">
+<playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
+  <button fd-button [fdType]="data.properties.type" [semantic]="data.properties.semantic" [state]="data.properties.state"
+    [size]="data.properties.size" [glyph]="data.properties.icon">
     {{data.properties.label}}
   </button>
 </playground>

--- a/docs/modules/documentation/containers/calendar/calendar-docs.component.html
+++ b/docs/modules/documentation/containers/calendar/calendar-docs.component.html
@@ -1,5 +1,6 @@
 <header>Calendar with single selection</header>
-<description>Commonly used as the contents of a popover when composing “date-picker”, rarely used on its own as a standalone component.</description>
+<description>Commonly used as the contents of a popover when composing “date-picker”, rarely used on its own as a
+  standalone component.</description>
 <import module="CalendarModule" path="fundamental/calendar/calendar.module"></import>
 <separator></separator>
 
@@ -18,29 +19,24 @@
 <separator></separator>
 
 <h2>Calendar with single selection, disabled and blocked days</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-        <fd-calendar [calType]="'single'" (updateDatePickerInput)="updateDatePickerInputHandler($event)" 
-         [blockFunction]="myBlockFunction" [disableFunction]="myDisableFunction"></fd-calendar>
+<component-example [name]="'ex1'">
+  <fd-calendar [calType]="'single'" (updateDatePickerInput)="updateDatePickerInputHandler($event)" [blockFunction]="myBlockFunction"
+    [disableFunction]="myDisableFunction"></fd-calendar>
 
-        <br/>
-        <div>Selected Date: {{selectedDate}}</div>
-  </div>
-</div>
+  <br />
+  <div>Selected Date: {{selectedDate}}</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="calendarSingleHtml"></code></pre>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="exampleFunctionsHtml"></code></pre>
 <separator></separator>
 
 <h2>Calendar with range selection</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-        <fd-calendar [calType]="'range'" (updateDatePickerInput)="updateDatePickerInputHandler($event)" [disableFunction]="myDisableFunction2"></fd-calendar>
+<component-example [name]="'ex2'">
+  <fd-calendar [calType]="'range'" (updateDatePickerInput)="updateDatePickerInputHandler($event)" [disableFunction]="myDisableFunction2"></fd-calendar>
 
-        <br/>
-        <div>Selected First Date: {{selectedFirstDate}}</div>
-        <br/>
-        <div>Selected Last Date: {{selectedLastDate}}</div>
-  </div>
-</div>
+  <br />
+  <div>Selected First Date: {{selectedFirstDate}}</div>
+  <br />
+  <div>Selected Last Date: {{selectedLastDate}}</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="calendarRangeHtml"></code></pre>
-

--- a/docs/modules/documentation/containers/date-picker/date-picker-docs.component.html
+++ b/docs/modules/documentation/containers/date-picker/date-picker-docs.component.html
@@ -1,5 +1,6 @@
 <header>Date Picker</header>
-<description>The date-picker component is an opinionated composition of the "input-group", "popover" and "calendar" components to accomplish the UI pattern for picking a date.</description>
+<description>The date-picker component is an opinionated composition of the "input-group", "popover" and "calendar"
+  components to accomplish the UI pattern for picking a date.</description>
 <import module="DatePickerModule" path="fundamental/date-picker/date-picker.module"></import>
 <separator></separator>
 
@@ -14,20 +15,15 @@
 <separator></separator>
 
 <h1>Simple Date Picker</h1>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-       <fd-date-picker [type]="'single'"></fd-date-picker>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <fd-date-picker [type]="'single'"></fd-date-picker>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="datePickerSingleHtml"></code></pre>
 
 <separator></separator>
 
 <h1>Range Date Picker</h1>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-    <div class="fd-tile__content">
-         <fd-date-picker [type]="'range'"></fd-date-picker>
-    </div>
-  </div>
-
-  <pre><code mwlHighlightJs [language]="'HTML'" [source]="datePickerRangeHtml"></code></pre>
+<component-example [name]="'ex2'">
+  <fd-date-picker [type]="'range'"></fd-date-picker>
+</component-example>
+<pre><code mwlHighlightJs [language]="'HTML'" [source]="datePickerRangeHtml"></code></pre>

--- a/docs/modules/documentation/containers/dropdown/dropdown-docs.component.html
+++ b/docs/modules/documentation/containers/dropdown/dropdown-docs.component.html
@@ -1,6 +1,8 @@
 <header>Dropdown</header>
-<description>The dropdown component is an opinionated composition of the “fd-popover” and “fd-menu” components with the use of a styled
-  button. It allows users to make one selection from a list. It is more flexible than the normal Select. Generally, it should
+<description>The dropdown component is an opinionated composition of the “fd-popover” and “fd-menu” components with the
+  use of a styled
+  button. It allows users to make one selection from a list. It is more flexible than the normal Select. Generally, it
+  should
   be used when there are between 3 to 10 or more options.
   <br>
   <br>This component is completely composed from other components and doeszn’t have any of its own.</description>
@@ -9,282 +11,275 @@
 
 <h2>Default Dropdown</h2>
 <p>
-  The dropdown is designed to resemble other Fundamental input components. The options can be divided in groups, which are
+  The dropdown is designed to resemble other Fundamental input components. The options can be divided in groups, which
+  are
   visually separated and can have a small group header text.
 </p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-popover [isDropdown]="true">
-      Dropdown
-      <fd-popover-body>
-        <fd-menu>
+<component-example [name]="'ex1'">
+  <fd-popover [isDropdown]="true">
+    Dropdown
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+        <fd-menu-group>
+          <fd-menu-title>
+            Group header
+          </fd-menu-title>
           <fd-menu-list>
             <fd-menu-item [url]="'#'">
-              Option 1
+              Option 4
             </fd-menu-item>
             <fd-menu-item [url]="'#'">
-              Option 2
+              Option 5
             </fd-menu-item>
             <fd-menu-item [url]="'#'">
-              Option 3
+              Option 6
             </fd-menu-item>
           </fd-menu-list>
-          <fd-menu-group>
-            <fd-menu-title>
-              Group header
-            </fd-menu-title>
-            <fd-menu-list>
-              <fd-menu-item [url]="'#'">
-                Option 4
-              </fd-menu-item>
-              <fd-menu-item [url]="'#'">
-                Option 5
-              </fd-menu-item>
-              <fd-menu-item [url]="'#'">
-                Option 6
-              </fd-menu-item>
-            </fd-menu-list>
-          </fd-menu-group>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
-  </div>
-</div>
+        </fd-menu-group>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="textDropdownHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Disabled State</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-popover [isDropdown]="true" [disabled]="true">
-      Dropdown
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <fd-popover [isDropdown]="true" [disabled]="true">
+    Dropdown
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="disabledDropdownHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Dropdown with Icon</h2>
 <p>It can also include complementary information like an icon.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-popover [isDropdown]="true" [glyph]="'filter'">
-      Dropdown
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <fd-popover [isDropdown]="true" [glyph]="'filter'">
+    Dropdown
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="iconDropdownHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Size Options</h2>
 <p>You can also specify dropdown size:</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-popover [isDropdown]="true" [size]="'xs'">
-      Dropdown
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
+<component-example [name]="'ex4'">
+  <fd-popover [isDropdown]="true" [size]="'xs'">
+    Dropdown
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
 
-    <fd-popover [isDropdown]="true" [size]="'s'">
-      Dropdown
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
+  <fd-popover [isDropdown]="true" [size]="'s'">
+    Dropdown
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
 
-    <fd-popover [isDropdown]="true" [size]="'compact'">
-      Dropdown
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
+  <fd-popover [isDropdown]="true" [size]="'compact'">
+    Dropdown
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
 
-    <fd-popover [isDropdown]="true">
-      Dropdown
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
+  <fd-popover [isDropdown]="true">
+    Dropdown
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
 
-    <fd-popover [isDropdown]="true" [size]="'l'">
-      Dropdown
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
-  </div>
-</div>
+  <fd-popover [isDropdown]="true" [size]="'l'">
+    Dropdown
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="dropdownSizeHtml"></code></pre>
 
 <separator></separator>
 
 <header>Contextual Menu</header>
 <description>
-  The contextual menu component is an opinionated composition of the “fd-popover” and “fd-menu” components with the use of
-  a styled button. A More icon or the word “More”, is used to indicate there are more options than room to display them.
+  The contextual menu component is an opinionated composition of the “fd-popover” and “fd-menu” components with the use
+  of
+  a styled button. A More icon or the word “More”, is used to indicate there are more options than room to display
+  them.
   On click or tap, a contextual menu opens.
 </description>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-popover>
-      <fd-popover-control>
-        <button fd-button [fdType]="'secondary'" [glyph]="'vertical-grip'"></button>
-      </fd-popover-control>
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
+<component-example [name]="'ex5'">
+  <fd-popover>
+    <fd-popover-control>
+      <button fd-button [fdType]="'secondary'" [glyph]="'vertical-grip'"></button>
+    </fd-popover-control>
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
 
-    <fd-popover>
-      <fd-popover-control>
-        <button fd-button>More</button>
-      </fd-popover-control>
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
+  <fd-popover>
+    <fd-popover-control>
+      <button fd-button>More</button>
+    </fd-popover-control>
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
 
-    <fd-popover>
-      <fd-popover-control>
-        <button fd-button [fdType]="'secondary'">More</button>
-      </fd-popover-control>
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
-  </div>
-</div>
+  <fd-popover>
+    <fd-popover-control>
+      <button fd-button [fdType]="'secondary'">More</button>
+    </fd-popover-control>
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="contextualMenuDropdownHtml"></code></pre>
 
 <style>

--- a/docs/modules/documentation/containers/form/form-docs.component.html
+++ b/docs/modules/documentation/containers/form/form-docs.component.html
@@ -1,5 +1,6 @@
 <header>Form</header>
-<description>Form elements include field layout, checkboxes, radio buttons and states of a field. Use these components along with inline
+<description>Form elements include field layout, checkboxes, radio buttons and states of a field. Use these components
+  along with inline
   help and error state.</description>
 <import module="FormModule" path="fundamental/form/form.module"></import>
 <separator></separator>
@@ -27,70 +28,67 @@
 <separator></separator>
 <h2>Inputs</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div fd-form-set>
-      <div fd-form-item>
-        <fd-form-label [forValue]="'input-1'">Default Input</fd-form-label>
-        <input fd-form-control [type]="'text'" id="input-1" placeholder="Field placeholder text">
-      </div>
-    </div>
-    <div fd-form-set>
-      <div fd-form-item>
-        <fd-form-label [forValue]="'input-2'" [isRequired]="true">Required Input*</fd-form-label>
-        <input fd-form-control [type]="'text'" id="input-2" placeholder="Field placeholder text">
-      </div>
-    </div>
-    <div fd-form-set>
-      <div fd-form-item>
-        <fd-form-label [forValue]="'input-3'" [isRequired]="true">Password*</fd-form-label>
-        <input fd-form-control [type]="'password'" id="input-3" placeholder="Field placeholder text">
-      </div>
-    </div>
-    <div fd-form-set>
-      <div fd-form-item>
-        <fd-form-label [forValue]="'textarea-1'">Text area</fd-form-label>
-        <textarea fd-form-control id="textarea-1">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.</textarea>
-      </div>
+<component-example [name]="'ex1'">
+  <div fd-form-set>
+    <div fd-form-item>
+      <fd-form-label [forValue]="'input-1'">Default Input</fd-form-label>
+      <input fd-form-control [type]="'text'" id="input-1" placeholder="Field placeholder text">
     </div>
   </div>
-</div>
+  <div fd-form-set>
+    <div fd-form-item>
+      <fd-form-label [forValue]="'input-2'" [isRequired]="true">Required Input</fd-form-label>
+      <input fd-form-control [type]="'text'" id="input-2" placeholder="Field placeholder text">
+    </div>
+  </div>
+  <div fd-form-set>
+    <div fd-form-item>
+      <fd-form-label [forValue]="'input-3'" [isRequired]="true">Password</fd-form-label>
+      <input fd-form-control [type]="'password'" id="input-3" placeholder="Field placeholder text">
+    </div>
+  </div>
+  <div fd-form-set>
+    <div fd-form-item>
+      <fd-form-label [forValue]="'textarea-1'">Text area</fd-form-label>
+      <textarea fd-form-control id="textarea-1">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.</textarea>
+    </div>
+  </div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="inputsFormHtml"></code></pre>
 
 <separator></separator>
 <h2>Inputs help elements</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div fd-form-set>
-      <div fd-form-item>
-        <fd-form-label [forValue]="'input-41'">
-          Input with inline help
-          <span class="fd-inline-help fd-has-float-right">
-            <span class="fd-inline-help__content fd-inline-help__content--bottom-right">
-              Lorem ipsum dolor sit amet, consectetur adipiscing.
-            </span>
+<component-example [name]="'ex2'">
+  <div fd-form-set>
+    <div fd-form-item>
+      <fd-form-label [forValue]="'input-41'">
+        Input with inline help
+        <span class="fd-inline-help fd-has-float-right">
+          <span class="fd-inline-help__content fd-inline-help__content--bottom-right">
+            Lorem ipsum dolor sit amet, consectetur adipiscing.
           </span>
-        </fd-form-label>
-        <input fd-form-control [type]="'text'" id="input-41">
-      </div>
-    </div>
-    <div fd-form-set>
-      <div fd-form-item>
-        <fd-form-label [forValue]="'input-42'">
-          Input with help message
-        </fd-form-label>
-        <input fd-form-control [type]="'text'" id="input-42">
-        <fd-form-message [type]="'help'">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</fd-form-message>
-      </div>
+        </span>
+      </fd-form-label>
+      <input fd-form-control [type]="'text'" id="input-41">
     </div>
   </div>
-</div>
+  <div fd-form-set>
+    <div fd-form-item>
+      <fd-form-label [forValue]="'input-42'">
+        Input with help message
+      </fd-form-label>
+      <input fd-form-control [type]="'text'" id="input-42">
+      <fd-form-message [type]="'help'">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</fd-form-message>
+    </div>
+  </div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="inputsHelpFormHtml"></code></pre>
 
 <separator></separator>
 <h2>Input States</h2>
-<p>The state of the input field can reflect validity of the data entered, whether the input data is editable or disabled.
+<p>The state of the input field can reflect validity of the data entered, whether the input data is editable or
+  disabled.
   <br>
   <b>Normal:</b> The field is editable but no validation has occurred.
   <br>
@@ -98,231 +96,228 @@
   <br>
   <b>Invalid:</b> The data entered is not valid and must be corrected.
   <br>
-  <b>Warning:</b> The data entered is formatted correctly but there are other issues are problematic but will not stop the user
+  <b>Warning:</b> The data entered is formatted correctly but there are other issues are problematic but will not stop
+  the user
   from moving forward.
   <br>
-  <b>Disabled:</b> This indicates the field is not editable. A common use case is that this field is dependent on a previous
+  <b>Disabled:</b> This indicates the field is not editable. A common use case is that this field is dependent on a
+  previous
   entry or selection within the form.
   <br>
   <b>Read Only:</b> Used to display static information in the context of a form.
   <br>
-  <br> Along with Invalid and Warning, error messages should be displayed below the field so the user can correct the error and
+  <br> Along with Invalid and Warning, error messages should be displayed below the field so the user can correct the
+  error and
   move forward.
 </p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div fd-form-item>
-      <fd-form-label [forValue]="'input-51'">
-        Normal Input
-      </fd-form-label>
-      <input fd-form-control [type]="'text'" id="input-51" placeholder="Field placeholder text">
-      <fd-form-message>Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</fd-form-message>
-    </div>
-    <div fd-form-item>
-      <fd-form-label [forValue]="'input-52'">
-        Valid Input
-      </fd-form-label>
-      <input fd-form-control [state]="'valid'" [type]="'text'" id="input-52">
-    </div>
-    <div fd-form-item>
-      <fd-form-label [forValue]="'input-53'">
-        Invalid Input
-      </fd-form-label>
-      <input fd-form-control [state]="'invalid'" [type]="'text'" id="input-53" placeholder="Field placeholder text">
-      <fd-form-message [type]="'error'">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</fd-form-message>
-    </div>
-    <div fd-form-item>
-      <fd-form-label [forValue]="'input-54'">
-        Warning Input
-      </fd-form-label>
-      <input fd-form-control [state]="'warning'" [type]="'text'" id="input-54" placeholder="Field placeholder text">
-      <fd-form-message [type]="'warning'">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</fd-form-message>
-    </div>
-    <div fd-form-item>
-      <fd-form-label [forValue]="'input-55'">
-        Disables Input
-      </fd-form-label>
-      <input fd-form-control [type]="'text'" id="input-55" placeholder="Field placeholder text" disabled>
-    </div>
-    <div fd-form-item>
-      <fd-form-label [forValue]="'input-56'">
-        Readonly Input
-      </fd-form-label>
-      <input fd-form-control [type]="'text'" id="input-56" placeholder="Field placeholder text" readonly>
-    </div>
+<component-example [name]="'ex3'">
+  <div fd-form-item>
+    <fd-form-label [forValue]="'input-51'">
+      Normal Input
+    </fd-form-label>
+    <input fd-form-control [type]="'text'" id="input-51" placeholder="Field placeholder text">
+    <fd-form-message>Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</fd-form-message>
   </div>
-</div>
+  <div fd-form-item>
+    <fd-form-label [forValue]="'input-52'">
+      Valid Input
+    </fd-form-label>
+    <input fd-form-control [state]="'valid'" [type]="'text'" id="input-52">
+  </div>
+  <div fd-form-item>
+    <fd-form-label [forValue]="'input-53'">
+      Invalid Input
+    </fd-form-label>
+    <input fd-form-control [state]="'invalid'" [type]="'text'" id="input-53" placeholder="Field placeholder text">
+    <fd-form-message [type]="'error'">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</fd-form-message>
+  </div>
+  <div fd-form-item>
+    <fd-form-label [forValue]="'input-54'">
+      Warning Input
+    </fd-form-label>
+    <input fd-form-control [state]="'warning'" [type]="'text'" id="input-54" placeholder="Field placeholder text">
+    <fd-form-message [type]="'warning'">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</fd-form-message>
+  </div>
+  <div fd-form-item>
+    <fd-form-label [forValue]="'input-55'">
+      Disables Input
+    </fd-form-label>
+    <input fd-form-control [type]="'text'" id="input-55" placeholder="Field placeholder text" disabled>
+  </div>
+  <div fd-form-item>
+    <fd-form-label [forValue]="'input-56'">
+      Readonly Input
+    </fd-form-label>
+    <input fd-form-control [type]="'text'" id="input-56" placeholder="Field placeholder text" readonly>
+  </div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="inputStatesFormHtml"></code></pre>
 
 <separator></separator>
 <h2>Select</h2>
-<p>The Select component is similar to a dropdown but is more commonly used within a form. It can also be set to a disabled state.</p>
+<p>The Select component is similar to a dropdown but is more commonly used within a form. It can also be set to a
+  disabled state.</p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div fd-form-set>
-      <div fd-form-item>
-        <fd-form-label [forValue]="'select-1'">
-          Default Select
-        </fd-form-label>
-        <select fd-form-control id="select-1" name="">
-          <option value="1">Duis malesuada odio volutpat elementum</option>
-          <option value="2">Suspendisse ante ligula</option>
-          <option value="3">Sed bibendum sapien at posuere interdum</option>
-        </select>
-      </div>
-    </div>
-    <div fd-form-set>
-      <div fd-form-item>
-        <fd-form-label [forValue]="'select-2'">
-          Disabled Select
-        </fd-form-label>
-        <select fd-form-control id="select-2" name="" disabled>
-          <option value="1">Duis malesuada odio volutpat elementum</option>
-          <option value="2">Suspendisse ante ligula</option>
-          <option value="3">Sed bibendum sapien at posuere interdum</option>
-        </select>
-      </div>
+<component-example [name]="'ex4'">
+  <div fd-form-set>
+    <div fd-form-item>
+      <fd-form-label [forValue]="'select-1'">
+        Default Select
+      </fd-form-label>
+      <select fd-form-control id="select-1" name="">
+        <option value="1">Duis malesuada odio volutpat elementum</option>
+        <option value="2">Suspendisse ante ligula</option>
+        <option value="3">Sed bibendum sapien at posuere interdum</option>
+      </select>
     </div>
   </div>
-</div>
+  <div fd-form-set>
+    <div fd-form-item>
+      <fd-form-label [forValue]="'select-2'">
+        Disabled Select
+      </fd-form-label>
+      <select fd-form-control id="select-2" name="" disabled>
+        <option value="1">Duis malesuada odio volutpat elementum</option>
+        <option value="2">Suspendisse ante ligula</option>
+        <option value="3">Sed bibendum sapien at posuere interdum</option>
+      </select>
+    </div>
+  </div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="selectFormHtml"></code></pre>
 
 <separator></separator>
 <h2>Radio buttons</h2>
-<p>Radio buttons allow the user to see all options and select one. Generally, this is used when there are between 2-3 options.
+<p>Radio buttons allow the user to see all options and select one. Generally, this is used when there are between 2-3
+  options.
   This component can also be disabled and displayed in a row.</p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
+<component-example [name]="'ex5'">
+  <fieldset fd-form-set>
+    <fd-form-legend>Radio buttons</fd-form-legend>
+    <fd-form-group>
+      <div fd-form-item [isCheck]="true">
+        <input fd-form-control [type]="'radio'" id="radio-1" name="radio-name-1" value="" checked>
+        <fd-form-label [forValue]="'radio-1'">Option One</fd-form-label>
+      </div>
+      <div fd-form-item [isCheck]="true">
+        <input fd-form-control [type]="'radio'" id="radio-2" name="radio-name-1" value="">
+        <fd-form-label [forValue]="'radio-2'">Option Two</fd-form-label>
+      </div>
+      <div fd-form-item [isCheck]="true">
+        <input fd-form-control [type]="'radio'" id="radio-3" name="radio-name-1" value="">
+        <fd-form-label [forValue]="'radio-3'">Option Three</fd-form-label>
+      </div>
+    </fd-form-group>
+  </fieldset>
 
-    <fieldset fd-form-set>
-      <fd-form-legend>Radio buttons</fd-form-legend>
-      <fd-form-group>
-        <div fd-form-item [isCheck]="true">
-          <input fd-form-control [type]="'radio'" id="radio-1" name="radio-name-1" value="" checked>
-          <fd-form-label [forValue]="'radio-1'">Option One</fd-form-label>
-        </div>
-        <div fd-form-item [isCheck]="true">
-          <input fd-form-control [type]="'radio'" id="radio-2" name="radio-name-1" value="">
-          <fd-form-label [forValue]="'radio-2'">Option Two</fd-form-label>
-        </div>
-        <div fd-form-item [isCheck]="true">
-          <input fd-form-control [type]="'radio'" id="radio-3" name="radio-name-1" value="">
-          <fd-form-label [forValue]="'radio-3'">Option Three</fd-form-label>
-        </div>
-      </fd-form-group>
-    </fieldset>
+  <fieldset fd-form-set>
+    <fd-form-legend>Radio buttons disabled</fd-form-legend>
+    <fd-form-group>
+      <div fd-form-item [isCheck]="true">
+        <input fd-form-control [type]="'radio'" id="radio-4" name="radio-name-2" value="" checked disabled>
+        <fd-form-label [forValue]="'radio-4'">Option One</fd-form-label>
+      </div>
+      <div fd-form-item [isCheck]="true">
+        <input fd-form-control [type]="'radio'" id="radio-5" name="radio-name-2" value="" disabled>
+        <fd-form-label [forValue]="'radio-5'">Option Two</fd-form-label>
+      </div>
+      <div fd-form-item [isCheck]="true">
+        <input fd-form-control [type]="'radio'" id="radio-6" name="radio-name-2" value="" disabled>
+        <fd-form-label [forValue]="'radio-6'">Option Three</fd-form-label>
+      </div>
+    </fd-form-group>
+  </fieldset>
 
-    <fieldset fd-form-set>
-      <fd-form-legend>Radio buttons disabled</fd-form-legend>
-      <fd-form-group>
-        <div fd-form-item [isCheck]="true">
-          <input fd-form-control [type]="'radio'" id="radio-4" name="radio-name-2" value="" checked disabled>
-          <fd-form-label [forValue]="'radio-4'">Option One</fd-form-label>
-        </div>
-        <div fd-form-item [isCheck]="true">
-          <input fd-form-control [type]="'radio'" id="radio-5" name="radio-name-2" value="" disabled>
-          <fd-form-label [forValue]="'radio-5'">Option Two</fd-form-label>
-        </div>
-        <div fd-form-item [isCheck]="true">
-          <input fd-form-control [type]="'radio'" id="radio-6" name="radio-name-2" value="" disabled>
-          <fd-form-label [forValue]="'radio-6'">Option Three</fd-form-label>
-        </div>
-      </fd-form-group>
-    </fieldset>
-
-    <fieldset fd-form-set>
-      <fd-form-legend>Inline Radio buttons</fd-form-legend>
-      <fd-form-group>
-        <div fd-form-item [isInline]="true" [isCheck]="true">
-          <fd-form-label [forValue]="'radio-7'">
-            <input fd-form-control [type]="'radio'" id="radio-7" name="radio-name-3" value="" checked> Option One
-          </fd-form-label>
-        </div>
-        <div fd-form-item [isInline]="true" [isCheck]="true">
-          <fd-form-label [forValue]="'radio-8'">
-            <input fd-form-control [type]="'radio'" id="radio-8" name="radio-name-3" value=""> Option Two
-          </fd-form-label>
-        </div>
-        <div fd-form-item [isInline]="true" [isCheck]="true">
-          <fd-form-label [forValue]="'radio-9'">
-            <input fd-form-control [type]="'radio'" id="radio-9" name="radio-name-3" value=""> Option Three
-          </fd-form-label>
-        </div>
-      </fd-form-group>
-    </fieldset>
-  </div>
-</div>
+  <fieldset fd-form-set>
+    <fd-form-legend>Inline Radio buttons</fd-form-legend>
+    <fd-form-group>
+      <div fd-form-item [isInline]="true" [isCheck]="true">
+        <fd-form-label [forValue]="'radio-7'">
+          <input fd-form-control [type]="'radio'" id="radio-7" name="radio-name-3" value="" checked> Option One
+        </fd-form-label>
+      </div>
+      <div fd-form-item [isInline]="true" [isCheck]="true">
+        <fd-form-label [forValue]="'radio-8'">
+          <input fd-form-control [type]="'radio'" id="radio-8" name="radio-name-3" value=""> Option Two
+        </fd-form-label>
+      </div>
+      <div fd-form-item [isInline]="true" [isCheck]="true">
+        <fd-form-label [forValue]="'radio-9'">
+          <input fd-form-control [type]="'radio'" id="radio-9" name="radio-name-3" value=""> Option Three
+        </fd-form-label>
+      </div>
+    </fd-form-group>
+  </fieldset>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="radioButtonsFormHtml"></code></pre>
 
 <separator></separator>
 <h2>Checkbox</h2>
-<p>With checkboxes, all options are visible and the user can make one or more selections. This component can be set disabled
+<p>With checkboxes, all options are visible and the user can make one or more selections. This component can be set
+  disabled
   and also displayed in a row.</p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fieldset fd-form-set>
-      <fd-form-legend>Checkboxes</fd-form-legend>
-      <div fd-form-item [isCheck]="true">
-        <input fd-form-control [type]="'checkbox'" id="checkbox-1" name="checkbox-name-1" checked>
-        <fd-form-label [forValue]="'checkbox-1'">Option One</fd-form-label>
-      </div>
-      <div fd-form-item [isCheck]="true">
-        <input fd-form-control [type]="'checkbox'" id="checkbox-2" name="checkbox-name-1">
-        <fd-form-label [forValue]="'checkbox-2'">Option Two</fd-form-label>
-      </div>
-      <div fd-form-item [isCheck]="true">
-        <input fd-form-control [type]="'checkbox'" id="checkbox-3" name="checkbox-name-1">
-        <fd-form-label [forValue]="'checkbox-3'">Option Three</fd-form-label>
-      </div>
-    </fieldset>
-
-    <fieldset fd-form-set>
-      <fd-form-legend>Checkboxes disabled</fd-form-legend>
-      <div fd-form-item [isCheck]="true">
-        <input fd-form-control [type]="'checkbox'" id="checkbox-4" name="checkbox-name-2" disabled>
-        <fd-form-label [forValue]="'checkbox-4'">Option One</fd-form-label>
-      </div>
-      <div fd-form-item [isCheck]="true">
-        <input fd-form-control [type]="'checkbox'" id="checkbox-5" name="checkbox-name-2" checked disabled>
-        <fd-form-label [forValue]="'checkbox-5'">Option Two</fd-form-label>
-      </div>
-      <div fd-form-item [isCheck]="true">
-        <input fd-form-control [type]="'checkbox'" id="checkbox-6" name="checkbox-name-2" disabled>
-        <fd-form-label [forValue]="'checkbox-6'">Option Three</fd-form-label>
-      </div>
-    </fieldset>
-
-    <div fd-form-set>
-        <div fd-form-item>
-            <fd-form-label [forValue]="'input-21'" [isRequired]="true">Required Input*</fd-form-label>
-            <input fd-form-control [type]="'text'" id="input-21" placeholder="Field placeholder text">
-        </div>
+<component-example [name]="'ex6'">
+  <fieldset fd-form-set>
+    <fd-form-legend>Checkboxes</fd-form-legend>
+    <div fd-form-item [isCheck]="true">
+      <input fd-form-control [type]="'checkbox'" id="checkbox-1" name="checkbox-name-1" checked>
+      <fd-form-label [forValue]="'checkbox-1'">Option One</fd-form-label>
     </div>
+    <div fd-form-item [isCheck]="true">
+      <input fd-form-control [type]="'checkbox'" id="checkbox-2" name="checkbox-name-1">
+      <fd-form-label [forValue]="'checkbox-2'">Option Two</fd-form-label>
+    </div>
+    <div fd-form-item [isCheck]="true">
+      <input fd-form-control [type]="'checkbox'" id="checkbox-3" name="checkbox-name-1">
+      <fd-form-label [forValue]="'checkbox-3'">Option Three</fd-form-label>
+    </div>
+  </fieldset>
 
-    <fieldset fd-form-set>
-      <fd-form-legend>Checkboxes inline</fd-form-legend>
-      <fd-form-group>
-        <div fd-form-item [isInline]="true" [isCheck]="true">
-          <fd-form-label [forValue]="'checkbox-7'">
-            <input fd-form-control [type]="'checkbox'" id="checkbox-7" name="checkbox-name-3" checked> Option One
-          </fd-form-label>
-        </div>
-        <div fd-form-item [isInline]="true" [isCheck]="true">
-          <fd-form-label [forValue]="'checkbox-8'">
-            <input fd-form-control [type]="'checkbox'" id="checkbox-8" name="checkbox-name-3"> Option Two
-          </fd-form-label>
-        </div>
-        <div fd-form-item [isInline]="true" [isCheck]="true">
-          <fd-form-label [forValue]="'checkbox-9'">
-            <input fd-form-control [type]="'checkbox'" id="checkbox-9" name="checkbox-name-3"> Option Three
-          </fd-form-label>
-        </div>
-      </fd-form-group>
-    </fieldset>
+  <fieldset fd-form-set>
+    <fd-form-legend>Checkboxes disabled</fd-form-legend>
+    <div fd-form-item [isCheck]="true">
+      <input fd-form-control [type]="'checkbox'" id="checkbox-4" name="checkbox-name-2" disabled>
+      <fd-form-label [forValue]="'checkbox-4'">Option One</fd-form-label>
+    </div>
+    <div fd-form-item [isCheck]="true">
+      <input fd-form-control [type]="'checkbox'" id="checkbox-5" name="checkbox-name-2" checked disabled>
+      <fd-form-label [forValue]="'checkbox-5'">Option Two</fd-form-label>
+    </div>
+    <div fd-form-item [isCheck]="true">
+      <input fd-form-control [type]="'checkbox'" id="checkbox-6" name="checkbox-name-2" disabled>
+      <fd-form-label [forValue]="'checkbox-6'">Option Three</fd-form-label>
+    </div>
+  </fieldset>
+
+  <div fd-form-set>
+    <div fd-form-item>
+      <fd-form-label [forValue]="'input-21'" [isRequired]="true">Required Input</fd-form-label>
+      <input fd-form-control [type]="'text'" id="input-21" placeholder="Field placeholder text">
+    </div>
   </div>
-</div>
+
+  <fieldset fd-form-set>
+    <fd-form-legend>Checkboxes inline</fd-form-legend>
+    <fd-form-group>
+      <div fd-form-item [isInline]="true" [isCheck]="true">
+        <fd-form-label [forValue]="'checkbox-7'">
+          <input fd-form-control [type]="'checkbox'" id="checkbox-7" name="checkbox-name-3" checked> Option One
+        </fd-form-label>
+      </div>
+      <div fd-form-item [isInline]="true" [isCheck]="true">
+        <fd-form-label [forValue]="'checkbox-8'">
+          <input fd-form-control [type]="'checkbox'" id="checkbox-8" name="checkbox-name-3"> Option Two
+        </fd-form-label>
+      </div>
+      <div fd-form-item [isInline]="true" [isCheck]="true">
+        <fd-form-label [forValue]="'checkbox-9'">
+          <input fd-form-control [type]="'checkbox'" id="checkbox-9" name="checkbox-name-3"> Option Three
+        </fd-form-label>
+      </div>
+    </fd-form-group>
+  </fieldset>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="checkboxFormHtml"></code></pre>

--- a/docs/modules/documentation/containers/icon/icon-docs.component.html
+++ b/docs/modules/documentation/containers/icon/icon-docs.component.html
@@ -1,5 +1,6 @@
 <header>Icon</header>
-<description>Icons are used throughout the UI to save space, allow for visual clarity and focus, and for fun. Icons can be used adaptively
+<description>Icons are used throughout the UI to save space, allow for visual clarity and focus, and for fun. Icons can
+  be used adaptively
   if desired, but at this point they are used more as visual elements within other components.</description>
 <import module="IconModule" path="fundamental/icon/icon.module"></import>
 <separator></separator>
@@ -12,28 +13,31 @@
     { name: 'size', description: 'Size of the icon.  The default options include \'xs\', \'s\', default, \'l\', and \'xl\'.  If no size is provided, default will be used.' }
   ]
 }"></properties>
-<description>The inputs for <code>fd-icon</code> will be translated into class attributed respecting fundamental-ui guidelines.
+<description>The inputs for <code>fd-icon</code> will be translated into class attributed respecting fundamental-ui
+  guidelines.
   <br>For example:
-  <br>if it is passed <code>accept</code> for glyph the class <code>sap-icon--accept</code> will be added to the element.
+  <br>if it is passed <code>accept</code> for glyph the class <code>sap-icon--accept</code> will be added to the
+  element.
   <br>if it is passed <code>xs</code> for size the class <code>sap-icon--xs</code> will be added to the element.
 </description>
 <separator></separator>
 
 <h2>Extensibility</h2>
-<description>The icon implementation allows certain extensibility in terms of options for the inputs. <code>fd-icon</code> inputs doesn't have a restriction for the predefined values.
-  <br>The predefined values for the input <code>size</code> are <code>xs</code>, <code>s</code>, <code>l</code>, <code>xl</code>, but <code>size</code> can accept any other string, for example <code>xxs</code>, which will be translated into class <code>sap-icon--xxs</code>.
+<description>The icon implementation allows certain extensibility in terms of options for the inputs. <code>fd-icon</code>
+  inputs doesn't have a restriction for the predefined values.
+  <br>The predefined values for the input <code>size</code> are <code>xs</code>, <code>s</code>, <code>l</code>, <code>xl</code>,
+  but <code>size</code> can accept any other string, for example <code>xxs</code>, which will be translated into class
+  <code>sap-icon--xxs</code>.
 </description>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-      <div *ngFor="let icon of icons">
-        <fd-icon [glyph]="icon" [size]="'l'"></fd-icon>
-        <span>{{ icon }}</span>
-      </div>
+<component-example [name]="'ex1'">
+  <div class="grid">
+    <div *ngFor="let icon of icons">
+      <fd-icon [glyph]="icon" [size]="'l'"></fd-icon>
+      <span>{{ icon }}</span>
     </div>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="iconHtml"></code></pre>
 
 <separator></separator>

--- a/docs/modules/documentation/containers/identifier/identifier-docs.component.html
+++ b/docs/modules/documentation/containers/identifier/identifier-docs.component.html
@@ -18,91 +18,83 @@
 
 <h2>Icon</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-        <span fd-identifier [size]="'s'" [glyph]="'washing-machine'"></span>
-        <span fd-identifier [size]="'m'" [glyph]="'washing-machine'"></span>
-        <span fd-identifier [size]="'l'" [glyph]="'washing-machine'"></span>
-    </div>
+<component-example [name]="'ex1'">
+  <div class="grid">
+    <span fd-identifier [size]="'s'" [glyph]="'washing-machine'"></span>
+    <span fd-identifier [size]="'m'" [glyph]="'washing-machine'"></span>
+    <span fd-identifier [size]="'l'" [glyph]="'washing-machine'"></span>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="iconHtml"></code></pre>
 
 <separator></separator>
 <h2>Initials</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-        <span fd-identifier [size]="'s'" aria-label="Wendy Wallace">WW</span>
-        <span fd-identifier [size]="'m'" aria-label="Wendy Wallace">WW</span>
-        <span fd-identifier [size]="'l'" aria-label="Wendy Wallace">WW</span>
-    </div>
+<component-example [name]="'ex2'">
+  <div class="grid">
+    <span fd-identifier [size]="'s'" aria-label="Wendy Wallace">WW</span>
+    <span fd-identifier [size]="'m'" aria-label="Wendy Wallace">WW</span>
+    <span fd-identifier [size]="'l'" aria-label="Wendy Wallace">WW</span>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="initialsHtml"></code></pre>
 
 <separator></separator>
 <h2>Circle</h2>
 <p>A circle style can be rendered using the <code>--circle modifier</code></p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-        <span fd-identifier [size]="'s'" [glyph]="'money-bills'" [circle]="true"></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [circle]="true"></span>
-        <span fd-identifier [size]="'l'" [glyph]="'money-bills'" [circle]="true"></span>
+<component-example [name]="'ex3'">
+  <div class="grid">
+    <span fd-identifier [size]="'s'" [glyph]="'money-bills'" [circle]="true"></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [circle]="true"></span>
+    <span fd-identifier [size]="'l'" [glyph]="'money-bills'" [circle]="true"></span>
 
-        <span fd-identifier [size]="'s'" [circle]="true" aria-label="Wendy Wallace">WW</span>
-        <span fd-identifier [size]="'m'" [circle]="true" aria-label="Wendy Wallace">WW</span>
-        <span fd-identifier [size]="'l'" [circle]="true" aria-label="Wendy Wallace">WW</span>
-    </div>
+    <span fd-identifier [size]="'s'" [circle]="true" aria-label="Wendy Wallace">WW</span>
+    <span fd-identifier [size]="'m'" [circle]="true" aria-label="Wendy Wallace">WW</span>
+    <span fd-identifier [size]="'l'" [circle]="true" aria-label="Wendy Wallace">WW</span>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="circleHtml"></code></pre>
 
 <separator></separator>
 <h2>Transparent</h2>
 <p>A transparent style can be rendered using the <code>--transparent modifier</code></p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-        <span fd-identifier [size]="'s'" [glyph]="'money-bills'" [transparent]="true"></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [transparent]="true"></span>
-        <span fd-identifier [size]="'l'" [glyph]="'money-bills'" [transparent]="true"></span>
+<component-example [name]="'ex4'">
+  <div class="grid">
+    <span fd-identifier [size]="'s'" [glyph]="'money-bills'" [transparent]="true"></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [transparent]="true"></span>
+    <span fd-identifier [size]="'l'" [glyph]="'money-bills'" [transparent]="true"></span>
 
-        <span fd-identifier [size]="'s'" [transparent]="true">WW</span>
-        <span fd-identifier [size]="'m'" [transparent]="true">WW</span>
-        <span fd-identifier [size]="'l'" [transparent]="true">WW</span>
-    </div>
+    <span fd-identifier [size]="'s'" [transparent]="true">WW</span>
+    <span fd-identifier [size]="'m'" [transparent]="true">WW</span>
+    <span fd-identifier [size]="'l'" [transparent]="true">WW</span>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="transparentHtml"></code></pre>
 
 <separator></separator>
 <h2>Accent Colors</h2>
 <p>Use helpers classes tp change the background colors, e.g., <code>.fd-has-background-color-accent-9</code></p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='1'></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='2'></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='3'></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='4'></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='5'></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='6'></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='7'></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='8'></span>
-        <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='9'></span>
-    </div>
+<component-example [name]="'ex5'">
+  <div class="grid">
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='1'></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='2'></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='3'></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='4'></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='5'></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='6'></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='7'></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='8'></span>
+    <span fd-identifier [size]="'m'" [glyph]="'money-bills'" [colorAccent]='9'></span>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="colorAccentHtml"></code></pre>
 
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
   <div *ngIf="data.properties.glyphs.length > 0 && data.properties.initials.length == 0;else initialsTemplate">
-    <span fd-identifier [size]="data.properties.size" [glyph]="data.properties.glyphs" [colorAccent]="data.properties.colorAccent" [transparent]="data.properties.transparent" [circle]="data.properties.circle" ></span>
+    <span fd-identifier [size]="data.properties.size" [glyph]="data.properties.glyphs" [colorAccent]="data.properties.colorAccent"
+      [transparent]="data.properties.transparent" [circle]="data.properties.circle"></span>
   </div>
   <ng-template #initialsTemplate>
-    <span fd-identifier [size]="data.properties.size" [colorAccent]="data.properties.colorAccent" [transparent]="data.properties.transparent" [circle]="data.properties.circle">{{data.properties.initials}}</span>
+    <span fd-identifier [size]="data.properties.size" [colorAccent]="data.properties.colorAccent" [transparent]="data.properties.transparent"
+      [circle]="data.properties.circle">{{data.properties.initials}}</span>
   </ng-template>
 </playground>

--- a/docs/modules/documentation/containers/image/image-docs.component.html
+++ b/docs/modules/documentation/containers/image/image-docs.component.html
@@ -2,50 +2,50 @@
 <description>When using images you can use our helpers classes to adjust the size and the shape.</description>
 <import module="ImageModule" path="fundamental/image/image.module"></import>
 <separator></separator>
- <properties [properties]="{
+<properties [properties]="{
   inputs: [
     { name: 'size', description: 'String - the size of the image. Size options include \'s\' (24x24), \'m\' (36x36), and \'l\' (48x48).' },
     { name: 'photo', description: 'String - picture url.' },
     { name: 'circle', description: 'Boolean - when set to true renders a round image.' }
   ]
 }"></properties>
-<description>The inputs for <code>fd-image</code> will be translated into class attributed respecting fundamental-ui guidelines.
+<description>The inputs for <code>fd-image</code> will be translated into class attributed respecting fundamental-ui
+  guidelines.
   <br>For example:
   <br>if it is passed <code>s</code> for size the class <code>fd-image--s</code> will be added to the element.
 </description>
 <separator></separator>
 
 <h2>Extensibility</h2>
-<description>The image implementation allows certain extensibility in terms of options for the inputs. <code>fd-image</code> inputs doesn't have a restriction for the predefined values.
-  <br>The predefined values for the input <code>size</code> are <code>s</code>, <code>m</code>, <code>l</code>, but <code>size</code> can accept any other string, for example <code>xxs</code>, which will be translated into class <code>fd-image--xxs</code>.
+<description>The image implementation allows certain extensibility in terms of options for the inputs. <code>fd-image</code>
+  inputs doesn't have a restriction for the predefined values.
+  <br>The predefined values for the input <code>size</code> are <code>s</code>, <code>m</code>, <code>l</code>, but
+  <code>size</code> can accept any other string, for example <code>xxs</code>, which will be translated into class
+  <code>fd-image--xxs</code>.
 </description>
 
 <h2>Sizes</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-      <fd-image style="margin-right: 10px;" [size]="'s'" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
-      <fd-image style="margin-right: 10px;" [size]="'m'" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
-      <fd-image style="margin-right: 10px;" [size]="'l'" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <fd-image style="margin-right: 10px;" [size]="'s'" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
+  <fd-image style="margin-right: 10px;" [size]="'m'" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
+  <fd-image style="margin-right: 10px;" [size]="'l'" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="imageSizesHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Shapes</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-      <fd-image style="margin-right: 10px;" [size]="'s'" [circle]="true" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
-      <fd-image style="margin-right: 10px;" [size]="'m'" [circle]="true" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
-      <fd-image style="margin-right: 10px;" [size]="'l'" [circle]="true" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <fd-image style="margin-right: 10px;" [size]="'s'" [circle]="true" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
+  <fd-image style="margin-right: 10px;" [size]="'m'" [circle]="true" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
+  <fd-image style="margin-right: 10px;" [size]="'l'" [circle]="true" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="imageShapesHtml"></code></pre>
 
 <separator></separator>
 
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
-    <fd-image [size]="data.properties.size" [circle]="data.properties.isCircle" [photo]="data.properties.photo"></fd-image>
+  <fd-image [size]="data.properties.size" [circle]="data.properties.isCircle" [photo]="data.properties.photo"></fd-image>
 </playground>

--- a/docs/modules/documentation/containers/inline-help/inline-help-docs.component.html
+++ b/docs/modules/documentation/containers/inline-help/inline-help-docs.component.html
@@ -1,5 +1,6 @@
 <header>Inline Help</header>
-<description>Inline help is used to display help text in a popover, often inline with headers, body text and form labels.</description>
+<description>Inline help is used to display help text in a popover, often inline with headers, body text and form
+  labels.</description>
 <import module="InlineHelpModule" path="fundamental/inline-help/inline-help.module"></import>
 <separator></separator>
 
@@ -15,73 +16,63 @@
 <h2>Default Position</h2>
 <p>The default positioning of inline help component is bottom right.</p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p class="fd-centered-content">
-      <span>Bottom Right (Default) </span>
-      <fd-inline-help>
-          Lorem ipsum dolor sit amet, consectetur adipiscing.
-      </fd-inline-help>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <p class="fd-centered-content">
+    <span>Bottom Right (Default) </span>
+    <fd-inline-help>
+      Lorem ipsum dolor sit amet, consectetur adipiscing.
+    </fd-inline-help>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="defaultPositionHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Bottom Left Position</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p class="fd-centered-content">
-      <span>Bottom Left </span>
-      <fd-inline-help [position]="'bottom-left'">
-        Lorem ipsum dolor sit amet, consectetur adipiscing.
-      </fd-inline-help>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <p class="fd-centered-content">
+    <span>Bottom Left </span>
+    <fd-inline-help [position]="'bottom-left'">
+      Lorem ipsum dolor sit amet, consectetur adipiscing.
+    </fd-inline-help>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="buttomLeftPositionHtml"></code></pre>
 
 <separator></separator>
 <h2>Right Position</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p class="fd-centered-content">
-      <span>Right </span>
-      <fd-inline-help [position]="'right'">
-        Lorem ipsum dolor sit amet, consectetur adipiscing.
-      </fd-inline-help>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <p class="fd-centered-content">
+    <span>Right </span>
+    <fd-inline-help [position]="'right'">
+      Lorem ipsum dolor sit amet, consectetur adipiscing.
+    </fd-inline-help>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="rightPositionHtml"></code></pre>
 
 <separator></separator>
 <h2>Left Position </h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p class="fd-centered-content">
-      <span>Left </span>
-      <fd-inline-help [position]="'left'">
-        Lorem ipsum dolor sit amet, consectetur adipiscing.
-      </fd-inline-help>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex4'">
+  <p class="fd-centered-content">
+    <span>Left </span>
+    <fd-inline-help [position]="'left'">
+      Lorem ipsum dolor sit amet, consectetur adipiscing.
+    </fd-inline-help>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="leftPositionHtml"></code></pre>
 
 <separator></separator>
 
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
-    <p class="fd-centered-content">
-      <span>{{data.properties.label}} </span>
-      <fd-inline-help [position]="data.properties.position">
-          {{data.properties.helpText}}
-      </fd-inline-help>
-    </p>
+  <p class="fd-centered-content">
+    <span>{{data.properties.label}} </span>
+    <fd-inline-help [position]="data.properties.position">
+      {{data.properties.helpText}}
+    </fd-inline-help>
+  </p>
 </playground>
-
-

--- a/docs/modules/documentation/containers/input-group/input-group-docs.component.html
+++ b/docs/modules/documentation/containers/input-group/input-group-docs.component.html
@@ -1,5 +1,6 @@
 <header>Input Group</header>
-<description>The Input groups component are form inputs with add-ons that allows the user to better understand the information been entered.</description>
+<description>The Input groups component are form inputs with add-ons that allows the user to better understand the
+  information been entered.</description>
 <import module="InputGroupModule" path="fundamental/input-group/input-group.module"></import>
 <separator></separator>
 
@@ -22,65 +23,61 @@
 <separator></separator>
 
 <h2>Text add-on</h2>
-<p>The Input with text add-on component is used mainly to specify the type of the data being entered, like: currency, unit of measure, etc.
+<p>The Input with text add-on component is used mainly to specify the type of the data being entered, like: currency,
+  unit of measure, etc.
   The informational add-on can be left or right aligned.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <label class="fd-form__label">Left Aligned Text Add-on</label>
-    <fd-input-group [placement]="'before'" [addOnText]="'$'" [placeholder]="'Amount'">
+<component-example [name]="'ex1'">
+  <label class="fd-form__label">Left Aligned Text Add-on</label>
+  <fd-input-group [placement]="'before'" [addOnText]="'$'" [placeholder]="'Amount'">
 
-    </fd-input-group>
-    <br/>
-    <label fd-form-label>Right Aligned Text Add-on</label>
-    <fd-input-group [placement]="'after'" [addOnText]="'$'" [placeholder]="'Amount'">
+  </fd-input-group>
+  <br />
+  <label fd-form-label>Right Aligned Text Add-on</label>
+  <fd-input-group [placement]="'after'" [addOnText]="'$'" [placeholder]="'Amount'">
 
-    </fd-input-group>
-  </div>
-</div>
+  </fd-input-group>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="textAddOnHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Icon add-on</h2>
 <p>An icon can be used instead of text by providing a 'glyph' attribute.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <label class="fd-form__label">Left Aligned Icon Add-on</label>
-    <fd-input-group [placement]="'before'" [glyph]="'accelerated'" [placeholder]="'Amount'">
+<component-example [name]="'ex2'">
+  <label class="fd-form__label">Left Aligned Icon Add-on</label>
+  <fd-input-group [placement]="'before'" [glyph]="'accelerated'" [placeholder]="'Amount'">
 
-    </fd-input-group>
-    <br/>
-    <label fd-form-label>Right Aligned Icon Add-on</label>
-    <fd-input-group [placement]="'after'" [glyph]="'accelerated'" [placeholder]="'Amount'">
+  </fd-input-group>
+  <br />
+  <label fd-form-label>Right Aligned Icon Add-on</label>
+  <fd-input-group [placement]="'after'" [glyph]="'accelerated'" [placeholder]="'Amount'">
 
-    </fd-input-group>
-    <br/>
-  </div>
-</div>
+  </fd-input-group>
+  <br />
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="iconAddOnHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Button add-on</h2>
-<p>Adding <code>[button]="true"</code> to the component turns either the icon add-on or text add-on into a button, which emits an event <code>addOnButtonClicked($event)</code>.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <label class="fd-form__label">Left Aligned Icon Button Add-on</label>
-    <fd-input-group [button]="true" [placement]="'before'" [glyph]="'accelerated'" [placeholder]="'Amount'">
+<p>Adding <code>[button]="true"</code> to the component turns either the icon add-on or text add-on into a button,
+  which emits an event <code>addOnButtonClicked($event)</code>.</p>
+<component-example [name]="'ex3'">
+  <label class="fd-form__label">Left Aligned Icon Button Add-on</label>
+  <fd-input-group [button]="true" [placement]="'before'" [glyph]="'accelerated'" [placeholder]="'Amount'">
 
-    </fd-input-group>
-    <br/>
-    <div fd-form-group>
-      <div fd-form-item>
-        <label fd-form-label>Right Aligned Text Button Add-on</label>
-        <fd-input-group [button]="true" [placement]="'after'" [addOnText]="'Submit'" [placeholder]="'Amount'">
+  </fd-input-group>
+  <br />
+  <div fd-form-group>
+    <div fd-form-item>
+      <label fd-form-label>Right Aligned Text Button Add-on</label>
+      <fd-input-group [button]="true" [placement]="'after'" [addOnText]="'Submit'" [placeholder]="'Amount'">
 
-        </fd-input-group>
-      </div>
+      </fd-input-group>
     </div>
-    <br/>
   </div>
-</div>
+  <br />
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="buttonIconAddOnHtml"></code></pre>
 
 <separator></separator>
@@ -96,15 +93,11 @@
 </properties>
 
 <p>The user can increase or decrease a number value using the spinner add-on.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <label fd-form-label>Quantity Spinner</label>
-    <fd-input-group-number
-                           [disabled]="false"
-                           [inputText]="123">
-    </fd-input-group-number>
-  </div>
-</div>
+<component-example [name]="'ex4'">
+  <label fd-form-label>Quantity Spinner</label>
+  <fd-input-group-number [disabled]="false" [inputText]="123">
+  </fd-input-group-number>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="numberInputHtml"></code></pre>
 
 <separator></separator>
@@ -121,23 +114,19 @@
 
 
 <p>This input group automatically shows a clear search button when the user has entered a value in the input.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <label fd-form-label>Search input</label>
-    <fd-input-group-search
-                           [disabled]="false"
-                           [inputText]="'Search term'">
-    </fd-input-group-search>
-  </div>
-</div>
+<component-example [name]="'ex5'">
+  <label fd-form-label>Search input</label>
+  <fd-input-group-search [disabled]="false" [inputText]="'Search term'">
+  </fd-input-group-search>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="searchInputHtml"></code></pre>
 
 <separator></separator>
 
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
 
-  <fd-input-group [addOnText]="data.properties.addOnText" [placeholder]="data.properties.placeholder"
-                  [button]="data.properties.button" [glyph]="data.properties.glyph" [inline]="data.properties.inline"
-                  [inputText]="data.properties.inputText" [placement]="data.properties.placement" [disabled]="data.state.disabled"></fd-input-group>
+  <fd-input-group [addOnText]="data.properties.addOnText" [placeholder]="data.properties.placeholder" [button]="data.properties.button"
+    [glyph]="data.properties.glyph" [inline]="data.properties.inline" [inputText]="data.properties.inputText"
+    [placement]="data.properties.placement" [disabled]="data.state.disabled"></fd-input-group>
 
 </playground>

--- a/docs/modules/documentation/containers/list/list-docs.component.html
+++ b/docs/modules/documentation/containers/list/list-docs.component.html
@@ -1,5 +1,6 @@
 <header>List</header>
-<description>The List Component can be used to display a list of items with simple information such as scopes, names, etc.</description>
+<description>The List Component can be used to display a list of items with simple information such as scopes, names,
+  etc.</description>
 <import module="ListModule" path="fundamental/list/list.module"></import>
 <separator></separator>
 
@@ -15,74 +16,68 @@
 
 <separator></separator>
 <p>A simple list. The list item can contain plain text or links.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-list>
-      <fd-list-item>
-        <a href="#">List item 1</a>
-      </fd-list-item>
-      <fd-list-item>List item 2</fd-list-item>
-      <fd-list-item>
-        <a href="#">List item 3</a>
-      </fd-list-item>
-      <fd-list-item>List item 4</fd-list-item>
-    </fd-list>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <fd-list>
+    <fd-list-item>
+      <a href="#">List item 1</a>
+    </fd-list-item>
+    <fd-list-item>List item 2</fd-list-item>
+    <fd-list-item>
+      <a href="#">List item 3</a>
+    </fd-list-item>
+    <fd-list-item>List item 4</fd-list-item>
+  </fd-list>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="simpleListHtml"></code></pre>
 
 <separator></separator>
 
 <p>The List items can also contain quick actions, such as: remove, edit, copy, etc.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-list>
-      <fd-list-item>List item 1
-        <fd-list-action>
-          <button fd-button [fdType]="'secondary'" [glyph]="'edit'"></button>
-        </fd-list-action>
-      </fd-list-item>
-      <fd-list-item>List item 2
-        <fd-list-action>
-          <button fd-button [fdType]="'secondary'" [glyph]="'edit'"></button>
-        </fd-list-action>
-      </fd-list-item>
-      <fd-list-item>List item 3
-        <fd-list-action>
-          <button fd-button [fdType]="'secondary'" [glyph]="'edit'"></button>
-        </fd-list-action>
-      </fd-list-item>
-      <fd-list-item>List item 4
-        <fd-list-action>
-          <button fd-button [fdType]="'secondary'" [glyph]="'edit'"></button>
-        </fd-list-action>
-      </fd-list-item>
-    </fd-list>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <fd-list>
+    <fd-list-item>List item 1
+      <fd-list-action>
+        <button fd-button [fdType]="'secondary'" [glyph]="'edit'"></button>
+      </fd-list-action>
+    </fd-list-item>
+    <fd-list-item>List item 2
+      <fd-list-action>
+        <button fd-button [fdType]="'secondary'" [glyph]="'edit'"></button>
+      </fd-list-action>
+    </fd-list-item>
+    <fd-list-item>List item 3
+      <fd-list-action>
+        <button fd-button [fdType]="'secondary'" [glyph]="'edit'"></button>
+      </fd-list-action>
+    </fd-list-item>
+    <fd-list-item>List item 4
+      <fd-list-action>
+        <button fd-button [fdType]="'secondary'" [glyph]="'edit'"></button>
+      </fd-list-action>
+    </fd-list-item>
+  </fd-list>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="listActionsHtml"></code></pre>
 
 <separator></separator>
 
 <p>Checkboxes can be used, allowing the user to select multiple items for bulk actions.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-list>
-      <fd-list-item>
-        <fd-list-checkbox>List item 1</fd-list-checkbox>
-      </fd-list-item>
-      <fd-list-item>
-        <fd-list-checkbox>List item 2</fd-list-checkbox>
-      </fd-list-item>
-      <fd-list-item>
-        <fd-list-checkbox>List item 3</fd-list-checkbox>
-      </fd-list-item>
-      <fd-list-item>
-        <fd-list-checkbox>List item 4</fd-list-checkbox>
-      </fd-list-item>
-    </fd-list>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <fd-list>
+    <fd-list-item>
+      <fd-list-checkbox>List item 1</fd-list-checkbox>
+    </fd-list-item>
+    <fd-list-item>
+      <fd-list-checkbox>List item 2</fd-list-checkbox>
+    </fd-list-item>
+    <fd-list-item>
+      <fd-list-checkbox>List item 3</fd-list-checkbox>
+    </fd-list-item>
+    <fd-list-item>
+      <fd-list-checkbox>List item 4</fd-list-checkbox>
+    </fd-list-item>
+  </fd-list>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="listCheckboxesHtml"></code></pre>
 
 <separator></separator>

--- a/docs/modules/documentation/containers/mega-menu/mega-menu-docs.component.html
+++ b/docs/modules/documentation/containers/mega-menu/mega-menu-docs.component.html
@@ -19,41 +19,37 @@
 <separator></separator>
 <h2>Mega Menu</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-mega-menu>
-        <fd-mega-menu-group>
-          <fd-mega-menu-title>
-            Group Name
-          </fd-mega-menu-title>
-          <fd-mega-menu-list>
-            <fd-mega-menu-item>
-              <fd-mega-menu-link [url]="'#'">Link</fd-mega-menu-link>
-            </fd-mega-menu-item>
-            <fd-mega-menu-item>
-              <fd-mega-menu-link [url]="'#'">Link</fd-mega-menu-link>
-            </fd-mega-menu-item>
-          </fd-mega-menu-list>
-        </fd-mega-menu-group>
-        <fd-mega-menu-group>
-          <fd-mega-menu-title>
-            Group Name
-          </fd-mega-menu-title>
-          <fd-mega-menu-list>
-            <fd-mega-menu-item>
-              <fd-mega-menu-link [hasSublist]="true">
-                Link
-                <fd-mega-menu-subitem [url]="'#'">Link</fd-mega-menu-subitem>
-                <fd-mega-menu-subitem [url]="'#'">Link</fd-mega-menu-subitem>
-              </fd-mega-menu-link>
-            </fd-mega-menu-item>
-          </fd-mega-menu-list>
-        </fd-mega-menu-group>
-      </fd-mega-menu>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <p>
+    <fd-mega-menu>
+      <fd-mega-menu-group>
+        <fd-mega-menu-title>
+          Group Name
+        </fd-mega-menu-title>
+        <fd-mega-menu-list>
+          <fd-mega-menu-item>
+            <fd-mega-menu-link [url]="'#'">Link</fd-mega-menu-link>
+          </fd-mega-menu-item>
+          <fd-mega-menu-item>
+            <fd-mega-menu-link [url]="'#'">Link</fd-mega-menu-link>
+          </fd-mega-menu-item>
+        </fd-mega-menu-list>
+      </fd-mega-menu-group>
+      <fd-mega-menu-group>
+        <fd-mega-menu-title>
+          Group Name
+        </fd-mega-menu-title>
+        <fd-mega-menu-list>
+          <fd-mega-menu-item>
+            <fd-mega-menu-link [hasSublist]="true">
+              Link
+              <fd-mega-menu-subitem [url]="'#'">Link</fd-mega-menu-subitem>
+              <fd-mega-menu-subitem [url]="'#'">Link</fd-mega-menu-subitem>
+            </fd-mega-menu-link>
+          </fd-mega-menu-item>
+        </fd-mega-menu-list>
+      </fd-mega-menu-group>
+    </fd-mega-menu>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="megaMenuHtml"></code></pre>
-
-

--- a/docs/modules/documentation/containers/menu/menu-docs.component.html
+++ b/docs/modules/documentation/containers/menu/menu-docs.component.html
@@ -16,63 +16,59 @@
 <separator></separator>
 
 <h2>Menu</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-menu>
-        <fd-menu-list>
-          <fd-menu-item [url]="'#'">
-            Option 1
-          </fd-menu-item>
-          <fd-menu-item [url]="'#'">
-            Option 2
-          </fd-menu-item>
-          <fd-menu-item [url]="'#'">
-            Option 3
-          </fd-menu-item>
-        </fd-menu-list>
-      </fd-menu>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <p>
+    <fd-menu>
+      <fd-menu-list>
+        <fd-menu-item [url]="'#'">
+          Option 1
+        </fd-menu-item>
+        <fd-menu-item [url]="'#'">
+          Option 2
+        </fd-menu-item>
+        <fd-menu-item [url]="'#'">
+          Option 3
+        </fd-menu-item>
+      </fd-menu-list>
+    </fd-menu>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="menuHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Menu with Group</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-menu>
+<component-example [name]="'ex2'">
+  <p>
+    <fd-menu>
+      <fd-menu-list>
+        <fd-menu-item [url]="'#'">
+          Option 1
+        </fd-menu-item>
+        <fd-menu-item [url]="'#'">
+          Option 2
+        </fd-menu-item>
+        <fd-menu-item [url]="'#'">
+          Option 3
+        </fd-menu-item>
+      </fd-menu-list>
+      <fd-menu-group>
+        <fd-menu-title>
+          Group header
+        </fd-menu-title>
         <fd-menu-list>
-          <fd-menu-item [url]="'#'">
-            Option 1
+          <fd-menu-item [routerLink]="'#'">
+            Option 4
           </fd-menu-item>
-          <fd-menu-item [url]="'#'">
-            Option 2
+          <fd-menu-item [routerLink]="'#'">
+            Option 5
           </fd-menu-item>
-          <fd-menu-item [url]="'#'">
-            Option 3
+          <fd-menu-item [routerLink]="'#'">
+            Option 6
           </fd-menu-item>
         </fd-menu-list>
-        <fd-menu-group>
-          <fd-menu-title>
-            Group header
-          </fd-menu-title>
-          <fd-menu-list>
-            <fd-menu-item [routerLink]="'#'">
-              Option 4
-            </fd-menu-item>
-            <fd-menu-item [routerLink]="'#'">
-              Option 5
-            </fd-menu-item>
-            <fd-menu-item [routerLink]="'#'">
-              Option 6
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu-group>
-      </fd-menu>
-    </p>
-  </div>
-</div>
+      </fd-menu-group>
+    </fd-menu>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="menuGroupHtml"></code></pre>

--- a/docs/modules/documentation/containers/modal/modal-docs.component.html
+++ b/docs/modules/documentation/containers/modal/modal-docs.component.html
@@ -1,12 +1,15 @@
 <header>Modal</header>
-<description>The modal is used as a container to be displayed in response to a action. It is commonly used to collect simple information
+<description>The modal is used as a container to be displayed in response to a action. It is commonly used to collect
+  simple information
   with a short form, to get confirmation or display contextual information that does not require a page.</description>
 <import module="ModalModule" path="fundamental/modal/modal.module"></import>
 <separator></separator>
 
-The Modal component utilizes a singleton ModalService to handle opening/closing of the modal. In your component, you'll need
+The Modal component utilizes a singleton ModalService to handle opening/closing of the modal. In your component, you'll
+need
 to create a method that calls ModalService's open() function. First, import the service with
-<code>import {{ '{' }} ModalService } from 'fundamental-ngx';</code>. Then inject the service into your component's constructor with
+<code>import {{ '{' }} ModalService } from 'fundamental-ngx';</code>. Then inject the service into your component's
+constructor with
 <code>private modalService: ModalService</code>. Then you'll need to call
 <code>this.modalService.open(modalName)</code>. Use
 <code>this.modalService.close()</code> to close the modal.
@@ -15,88 +18,50 @@ to create a method that calls ModalService's open() function. First, import the 
 <h1>&lt;fd-modal&gt;</h1>
 
 <h2>Informational Modal</h2>
-<p>Used when you need to inform the user but the Alert Component doesn’t fit all the information. Also when the user have to
+<p>Used when you need to inform the user but the Alert Component doesn’t fit all the information. Also when the user
+  have to
   acknowledge the information, actively, by clicking a button or closing the Modal.
 </p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <ng-template #informationalModal>
-      <fd-modal>
-        <fd-modal-header>
-          Modal Header/Title
-        </fd-modal-header>
-        <fd-modal-body>
-          Modal Body
-        </fd-modal-body>
-      </fd-modal>
-    </ng-template>
-    <button fd-button (click)="openInfoModal(informationalModal)">Launch Demo</button>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <ng-template #informationalModal>
+    <fd-modal>
+      <fd-modal-header>
+        Modal Header/Title
+      </fd-modal-header>
+      <fd-modal-body>
+        Modal Body
+      </fd-modal-body>
+    </fd-modal>
+  </ng-template>
+  <button fd-button (click)="openInfoModal(informationalModal)">Launch Demo</button>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="informationalModalHtml"></code></pre>
 <pre><code mwlHighlightJs [language]="'typescript'" [source]="informationalModalJs"></code></pre>
 
 <separator></separator>
 
 <h2>Confirmation Modal</h2>
-<p>Used to confirm with the user before continuing with destructive or complex actions. In this case the modal have two buttons
+<p>Used to confirm with the user before continuing with destructive or complex actions. In this case the modal have two
+  buttons
   at the bottom. With the “positive” path always been the primary button.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <ng-template #confirmationModal let-c="close">
-      <fd-modal>
-        <fd-modal-header>
-          Modal Header/Title
-        </fd-modal-header>
-        <fd-modal-body>
-          Modal Body
-        </fd-modal-body>
-        <fd-modal-footer>
-          <button fd-button (click)="c('No')" [fdType]="'secondary'">No</button>
-          <button fd-button (click)="c('Yes')" [fdType]="'main'">Yes</button>
-        </fd-modal-footer>
-      </fd-modal>
-    </ng-template>
-    <button fd-button (click)="openConfirmationModal(confirmationModal)">Launch Demo</button>
-    <separator></separator>
-    <span>{{confirmationReason}}</span>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <ng-template #confirmationModal let-c="close">
+    <fd-modal>
+      <fd-modal-header>
+        Modal Header/Title
+      </fd-modal-header>
+      <fd-modal-body>
+        Modal Body
+      </fd-modal-body>
+      <fd-modal-footer>
+        <button fd-button (click)="c('No')" [fdType]="'secondary'">No</button>
+        <button fd-button (click)="c('Yes')" [fdType]="'main'">Yes</button>
+      </fd-modal-footer>
+    </fd-modal>
+  </ng-template>
+  <button fd-button (click)="openConfirmationModal(confirmationModal)">Launch Demo</button>
+  <separator></separator>
+  <span>{{confirmationReason}}</span>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="confirmationModalHtml"></code></pre>
 <pre><code mwlHighlightJs [language]="'typescript'" [source]="confirmationModalJs"></code></pre>
-
-<!--
-<separator></separator>
-
-<h2>Form Modal</h2>
-<p>Used to collect simple information from the user. Please use with care and don’t include more than five inputs on a modal to avoid scrolling inside the modal.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <ng-template #formModal let-c="close">
-      <fd-modal>
-        <fd-modal-header>
-          Modal Header/Title
-        </fd-modal-header>
-        <fd-modal-body>
-          <div class="fd-form__group">
-            <div class="fd-form__item">
-              <label class="fd-form__label is-required" for="input-2">Email*</label>
-              <input class="fd-form__control" type="text" id="input-2">
-            </div>
-          </div>
-        </fd-modal-body>
-        <fd-modal-footer>
-          <button fd-button (click)="c('Cancel')" [fdType]="'secondary'">Cancel</button>
-          <button fd-button (click)="c('Invite')" [fdType]="'main'">Invite</button>
-        </fd-modal-footer>
-      </fd-modal>
-    </ng-template>
-    <button fd-button (click)="openModal(formModal)">Launch Demo</button>
-    <separator></separator>
-    <span>{{reason}}</span>
-  </div>
-</div>
-<pre><code mwlHighlightJs [language]="'HTML'" [source]="formModalHtml"></code></pre>
-
-<separator></separator>
--->

--- a/docs/modules/documentation/containers/navbar/navbar-docs.component.html
+++ b/docs/modules/documentation/containers/navbar/navbar-docs.component.html
@@ -26,47 +26,45 @@
 <separator></separator>
 <h2>Navbar</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-navbar>
-      <div fd-navbar-group [position]="'left'">
-        <div class="fd-global-nav__side-menu">
-          <button fd-button [fdType]="'secondary'" [size]="'l'" [glyph]="'menu2'" aria-label="BUTTON_LABEL"></button>
-        </div>
-        <div class="fd-global-nav__logo fd-has-margin-left-none"></div>
-        <div class="fd-global-nav__product-name">
-          Product Name
-        </div>
+<component-example [name]="'ex1'">
+  <fd-navbar>
+    <div fd-navbar-group [position]="'left'">
+      <div class="fd-global-nav__side-menu">
+        <button fd-button [fdType]="'secondary'" [size]="'l'" [glyph]="'menu2'" aria-label="BUTTON_LABEL"></button>
+      </div>
+      <div class="fd-global-nav__logo fd-has-margin-left-none"></div>
+      <div class="fd-global-nav__product-name">
+        Product Name
+      </div>
+    </div>
+
+    <div fd-navbar-group [hasLaunchpad]="true">
+      <button fd-button [fdType]="'secondary'" [size]="'l'" aria-label="BUTTON_LABEL" [attr.aria-haspopup]="true">Suite
+        Name</button>
+    </div>
+
+    <div fd-navbar-group [position]="'right'">
+      <div fd-navbar-context-menu>
+        <fd-popover [isDropdown]="true" [btnType]="'secondary'">
+          Context Switcher
+          <fd-popover-body>
+            <fd-menu>
+              <fd-menu-list>
+                <fd-menu-item [url]="'#'">Option 1</fd-menu-item>
+                <fd-menu-item [url]="'#'">Option 2</fd-menu-item>
+                <fd-menu-item [url]="'#'">Option 3</fd-menu-item>
+              </fd-menu-list>
+            </fd-menu>
+          </fd-popover-body>
+        </fd-popover>
       </div>
 
-      <div fd-navbar-group [hasLaunchpad]="true">
-        <button fd-button [fdType]="'secondary'" [size]="'l'" aria-label="BUTTON_LABEL" [attr.aria-haspopup]="true">Suite
-          Name</button>
+      <div fd-navbar-actions>
+        <button fd-button [fdType]="'secondary'" [size]="'l'" [glyph]="'search'" aria-label="BUTTON_LABEL"></button>
+        <button fd-button [fdType]="'secondary'" [size]="'l'" [glyph]="'action-settings'" aria-label="BUTTON_LABEL"></button>
+        <span fd-identifier [size]="'s'" [circle]="true">WW</span>
       </div>
-
-      <div fd-navbar-group [position]="'right'">
-        <div fd-navbar-context-menu>
-          <fd-popover [isDropdown]="true" [btnType]="'secondary'">
-            Context Switcher
-            <fd-popover-body>
-              <fd-menu>
-                <fd-menu-list>
-                  <fd-menu-item [url]="'#'">Option 1</fd-menu-item>
-                  <fd-menu-item [url]="'#'">Option 2</fd-menu-item>
-                  <fd-menu-item [url]="'#'">Option 3</fd-menu-item>
-                </fd-menu-list>
-              </fd-menu>
-            </fd-popover-body>
-          </fd-popover>
-        </div>
-
-        <div fd-navbar-actions>
-          <button fd-button [fdType]="'secondary'" [size]="'l'" [glyph]="'search'" aria-label="BUTTON_LABEL"></button>
-          <button fd-button [fdType]="'secondary'" [size]="'l'" [glyph]="'action-settings'" aria-label="BUTTON_LABEL"></button>
-          <span fd-identifier [size]="'s'" [circle]="true">WW</span>
-        </div>
-      </div>
-    </fd-navbar>
-  </div>
-</div>
+    </div>
+  </fd-navbar>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="navbarHtml"></code></pre>

--- a/docs/modules/documentation/containers/pagination/pagination-docs.component.html
+++ b/docs/modules/documentation/containers/pagination/pagination-docs.component.html
@@ -1,5 +1,6 @@
 <header>Pagination</header>
-<description>Use pagination components in conjunction with Lists, Tables, and Trees to allow for more efficient performance and quick access to specific records in the overall data set.</description>
+<description>Use pagination components in conjunction with Lists, Tables, and Trees to allow for more efficient
+  performance and quick access to specific records in the overall data set.</description>
 <import module="PaginationModule" path="fundamental/pagination/pagination.module"></import>
 <separator></separator>
 
@@ -13,11 +14,9 @@
   ]
 }"></properties>
 <separator></separator>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-pagination [class]="'fd-demo-pagination'" [pagination]="{totalItems: data.properties.totalItems, itemsPerPage:  data.properties.itemsPerPage, currentPage: data.properties.currentPage}"></fd-pagination>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <fd-pagination [class]="'fd-demo-pagination'" [pagination]="{totalItems: data.properties.totalItems, itemsPerPage:  data.properties.itemsPerPage, currentPage: data.properties.currentPage}"></fd-pagination>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="paginationHtml"></code></pre>
 <pre>
   totalItems: {{data.properties.totalItems}},

--- a/docs/modules/documentation/containers/panel/panel-docs.component.html
+++ b/docs/modules/documentation/containers/panel/panel-docs.component.html
@@ -1,6 +1,7 @@
 <header>Panel</header>
 <description>The Panel is a layout component that serves many formatting purposes.</description>
-<import module="PanelModule" path="fundamental/panel/panel.module"></import>
+<import module="PanelModule"
+        path="fundamental/panel/panel.module"></import>
 <separator></separator>
 
 <h1>&lt;fd-panel&gt;</h1>
@@ -24,60 +25,62 @@
 }"></properties>
 
 <separator></separator>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-panel>
-        <fd-panel-header>
-          <fd-panel-head>
-            <fd-panel-title>Panel Title</fd-panel-title>
-            <fd-panel-description>Panel Description</fd-panel-description>
-          </fd-panel-head>
-          <fd-panel-actions>
-            <button fd-button [size]="'s'" [glyph]="'add'">Add New Item</button>
-          </fd-panel-actions>
-        </fd-panel-header>
-        <fd-panel-filters>
-          <fd-popover [isDropdown]="true">
-              Color
-          </fd-popover>
-          <fd-popover [isDropdown]="true">
-              Size
-          </fd-popover>
-        </fd-panel-filters>
-        <fd-panel-filters>
-          <span class="fd-tag" role="button">Blue</span>
-          <span class="fd-tag" role="button">Small</span>
-          <button fd-modal-button-secondary size="s">Clear All</button>
-        </fd-panel-filters>
-        <fd-panel-body>
-          Panel Content
-        </fd-panel-body>
-        <fd-panel-footer>
-          Panel Footer
-        </fd-panel-footer>
-      </fd-panel>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <p>
+    <fd-panel>
+      <fd-panel-header>
+        <fd-panel-head>
+          <fd-panel-title>Panel Title</fd-panel-title>
+          <fd-panel-description>Panel Description</fd-panel-description>
+        </fd-panel-head>
+        <fd-panel-actions>
+          <button fd-button
+                  [size]="'s'"
+                  [glyph]="'add'">Add New Item</button>
+        </fd-panel-actions>
+      </fd-panel-header>
+      <fd-panel-filters>
+        <fd-popover [isDropdown]="true">
+          Color
+        </fd-popover>
+        <fd-popover [isDropdown]="true">
+          Size
+        </fd-popover>
+      </fd-panel-filters>
+      <fd-panel-filters>
+        <span class="fd-tag"
+              role="button">Blue</span>
+        <span class="fd-tag"
+              role="button">Small</span>
+        <button fd-modal-button-secondary
+                size="s">Clear All</button>
+      </fd-panel-filters>
+      <fd-panel-body>
+        Panel Content
+      </fd-panel-body>
+      <fd-panel-footer>
+        Panel Footer
+      </fd-panel-footer>
+    </fd-panel>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="panelHtml"></code></pre>
 
 <separator></separator>
 <h2>Panel with edge bleed</h2>
-<p>Use <code>[bleed]="true"</code> on the panel body to have the contents of the panel body bleed to the outer edge.  This is useful for components like tables.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-panel>
-        <fd-panel-body [bleed]="true">
-          <fd-table [tableData]="tableData"
-                    [headers]="tableHeaders">
-          </fd-table>
-        </fd-panel-body>
-      </fd-panel>
-    </p>
-  </div>
-</div>
+<p>Use <code>[bleed]="true"</code> on the panel body to have the contents of the panel body bleed to the outer edge.
+  This is useful for components like tables.</p>
+<component-example [name]="'ex2'">
+  <p>
+    <fd-panel>
+      <fd-panel-body [bleed]="true">
+        <fd-table [tableData]="tableData"
+                  [headers]="tableHeaders">
+        </fd-table>
+      </fd-panel-body>
+    </fd-panel>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="tableBleedHtml"></code></pre>
 
 <separator></separator>
@@ -91,44 +94,42 @@
 }"></properties>
 
 <h2>Default Panel Grid (3 columns)</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-panel-grid>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-      </fd-panel-grid>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <p>
+    <fd-panel-grid>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+    </fd-panel-grid>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="defaultPanelGridHtml"></code></pre>
 
 <separator></separator>
@@ -138,34 +139,33 @@
 </h2>
 <p>
   <code>[nogap]="true"</code> will remove the margins between the panels.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-panel-grid [col]="2" [nogap]="true">
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-      </fd-panel-grid>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <p>
+    <fd-panel-grid [col]="2"
+                   [nogap]="true">
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+    </fd-panel-grid>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="nogapPanelGridHtml"></code></pre>
 
 <separator></separator>
@@ -173,115 +173,112 @@
 <h2>Panel Grid with 2 columns</h2>
 <p>The
   <code>[col]="2"</code> renders a 2 column grid.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-panel-grid [col]="2">
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-      </fd-panel-grid>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex4'">
+  <p>
+    <fd-panel-grid [col]="2">
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+    </fd-panel-grid>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="twoColumnsPanelGridHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Panel Grid with row and column span</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-panel-grid [col]="6">
-        <fd-panel [columnSpan]="2" [rowSpan]="2">
-          <fd-panel-body>
-            Panel Content with span 2
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel [columnSpan]="2">
-          <fd-panel-body>
-            Panel Content with span 2
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel [columnSpan]="4">
-          <fd-panel-body>
-            Panel Content with span 4
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel [columnSpan]="5">
-          <fd-panel-body>
-            Panel Content with span 5
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel>
-          <fd-panel-body>
-            Panel Content
-          </fd-panel-body>
-        </fd-panel>
-        <fd-panel [columnSpan]="6">
-          <fd-panel-body>
-            Panel Content with span 6
-          </fd-panel-body>
-        </fd-panel>
-      </fd-panel-grid>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <p>
+    <fd-panel-grid [col]="6">
+      <fd-panel [columnSpan]="2"
+                [rowSpan]="2">
+        <fd-panel-body>
+          Panel Content with span 2
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel [columnSpan]="2">
+        <fd-panel-body>
+          Panel Content with span 2
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel [columnSpan]="4">
+        <fd-panel-body>
+          Panel Content with span 4
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel [columnSpan]="5">
+        <fd-panel-body>
+          Panel Content with span 5
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel>
+        <fd-panel-body>
+          Panel Content
+        </fd-panel-body>
+      </fd-panel>
+      <fd-panel [columnSpan]="6">
+        <fd-panel-body>
+          Panel Content with span 6
+        </fd-panel-body>
+      </fd-panel>
+    </fd-panel-grid>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="columnSpanPanelGridHtml"></code></pre>

--- a/docs/modules/documentation/containers/popover/popover-docs.component.html
+++ b/docs/modules/documentation/containers/popover/popover-docs.component.html
@@ -1,7 +1,11 @@
 <header>Popover</header>
-<description>The popover is a wrapping component that accepts a "control" as well as a "body". A control can be anything that you want to trigger the interaction from. The body will be the contents of what you reveal on the page after triggering the popover. When paired with the menu component, the popover is commonly used as the interaction/wrapping component for composing "dropdowns", "contextual menus", "mega menus", etc. <br />
+<description>The popover is a wrapping component that accepts a "control" as well as a "body". A control can be
+  anything that you want to trigger the interaction from. The body will be the contents of what you reveal on the page
+  after triggering the popover. When paired with the menu component, the popover is commonly used as the
+  interaction/wrapping component for composing "dropdowns", "contextual menus", "mega menus", etc. <br />
 
-As a general rule, it is suggested that one popover be revealed on the page at any given time. Opening one popover should close all others to prevent multiple layers and collisions of several popovers.
+  As a general rule, it is suggested that one popover be revealed on the page at any given time. Opening one popover
+  should close all others to prevent multiple layers and collisions of several popovers.
 </description>
 
 <import module="PopoverModule" path="fundamental/popover/popover.module"></import>
@@ -21,72 +25,70 @@ As a general rule, it is suggested that one popover be revealed on the page at a
 <separator></separator>
 
 <h2>Popover Example</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-popover>
-      <fd-popover-control>
-        <fd-image [size]="'l'" [circle]="true" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
-      </fd-popover-control>
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
+<component-example [name]="'ex1'">
+  <fd-popover>
+    <fd-popover-control>
+      <fd-image [size]="'l'" [circle]="true" [photo]="'https://placeimg.com/400/400/nature'"></fd-image>
+    </fd-popover-control>
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
 
-    <fd-popover>
-      <fd-popover-control>
-        <fd-icon [glyph]="'menu2'" [size]="'l'"></fd-icon>
-      </fd-popover-control>
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
+  <fd-popover>
+    <fd-popover-control>
+      <fd-icon [glyph]="'menu2'" [size]="'l'"></fd-icon>
+    </fd-popover-control>
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
 
-    <fd-popover>
-      <fd-popover-control>
-        <span fd-identifier [size]="'l'" [glyph]="'money-bills'" [colorAccent]='3'></span>
-      </fd-popover-control>
-      <fd-popover-body>
-        <fd-menu>
-          <fd-menu-list>
-            <fd-menu-item [url]="'#'">
-              Option 1
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 2
-            </fd-menu-item>
-            <fd-menu-item [url]="'#'">
-              Option 3
-            </fd-menu-item>
-          </fd-menu-list>
-        </fd-menu>
-      </fd-popover-body>
-    </fd-popover>
-  </div>
-</div>
+  <fd-popover>
+    <fd-popover-control>
+      <span fd-identifier [size]="'l'" [glyph]="'money-bills'" [colorAccent]='3'></span>
+    </fd-popover-control>
+    <fd-popover-body>
+      <fd-menu>
+        <fd-menu-list>
+          <fd-menu-item [url]="'#'">
+            Option 1
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 2
+          </fd-menu-item>
+          <fd-menu-item [url]="'#'">
+            Option 3
+          </fd-menu-item>
+        </fd-menu-list>
+      </fd-menu>
+    </fd-popover-body>
+  </fd-popover>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="popoverExampleHtml"></code></pre>
 
 <style>

--- a/docs/modules/documentation/containers/side-navigation/side-navigation-docs.component.html
+++ b/docs/modules/documentation/containers/side-navigation/side-navigation-docs.component.html
@@ -1,5 +1,6 @@
 <header>Side Navigation</header>
-<description>The left navigation can always display or expand/collapse using the menu icon within the global navigation.</description>
+<description>The left navigation can always display or expand/collapse using the menu icon within the global
+  navigation.</description>
 <import module="SideNavigationModule" path="fundamental/side-navigation/side-navigation.module"></import>
 <separator></separator>
 
@@ -16,33 +17,33 @@
   ]
 }"></properties>
 <br>
-<span>Each <code>fd-side-nav-link</code> should have either a [url] or [routerLink] property.  If [routerLink] is used, any other property belonging to the RouterLink class can also be used.  See the official <a href="https://angular.io/api/router/RouterLink">Angular documentation for RouterLink</a> for more information.</span>
+<span>Each <code>fd-side-nav-link</code> should have either a [url] or [routerLink] property. If [routerLink] is used,
+  any other property belonging to the RouterLink class can also be used. See the official <a href="https://angular.io/api/router/RouterLink">Angular
+    documentation for RouterLink</a> for more information.</span>
 
 <separator></separator>
 <h2>Side navigation with one level</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-side-nav>
-        <fd-side-nav-list>
-          <fd-side-nav-item>
-            <fd-side-nav-link [routerLink]="'#'" [queryParams]="'#'">Link Item</fd-side-nav-link>
-          </fd-side-nav-item>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-          </fd-side-nav-item>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-          </fd-side-nav-item>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-          </fd-side-nav-item>
-        </fd-side-nav-list>
-      </fd-side-nav>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <p>
+    <fd-side-nav>
+      <fd-side-nav-list>
+        <fd-side-nav-item>
+          <fd-side-nav-link [routerLink]="'#'" [queryParams]="'#'">Link Item</fd-side-nav-link>
+        </fd-side-nav-item>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+        </fd-side-nav-item>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+        </fd-side-nav-item>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+        </fd-side-nav-item>
+      </fd-side-nav-list>
+    </fd-side-nav>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="oneLevelSideNavHtml"></code></pre>
 
 
@@ -50,184 +51,178 @@
 <h2>Side navigation with titles</h2>
 <p>Use this to group navigation. Titles are not clickable.</p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-side-nav>
-        <fd-side-nav-group>
-          <fd-side-nav-title>
-            Group Title
-          </fd-side-nav-title>
-          <fd-side-nav-list>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-          </fd-side-nav-list>
-        </fd-side-nav-group>
-        <fd-side-nav-group>
-          <fd-side-nav-title>
-            Group Title
-          </fd-side-nav-title>
-          <fd-side-nav-list>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-          </fd-side-nav-list>
-        </fd-side-nav-group>
-      </fd-side-nav>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <p>
+    <fd-side-nav>
+      <fd-side-nav-group>
+        <fd-side-nav-title>
+          Group Title
+        </fd-side-nav-title>
+        <fd-side-nav-list>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+        </fd-side-nav-list>
+      </fd-side-nav-group>
+      <fd-side-nav-group>
+        <fd-side-nav-title>
+          Group Title
+        </fd-side-nav-title>
+        <fd-side-nav-list>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+        </fd-side-nav-list>
+      </fd-side-nav-group>
+    </fd-side-nav>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="titlesSideNavHtml"></code></pre>
 
 <separator></separator>
 <h2>Side navigation with multiple levels</h2>
-<p>Use this when there is more than one level of hierarchy in the left navigation. Each level can be expanded and collapsed.</p>
+<p>Use this when there is more than one level of hierarchy in the left navigation. Each level can be expanded and
+  collapsed.</p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-side-nav>
-        <fd-side-nav-group>
-          <fd-side-nav-title>
-            Group Name
-          </fd-side-nav-title>
-          <fd-side-nav-list>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-            <fd-side-nav-item>
-              <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
-            </fd-side-nav-item>
-          </fd-side-nav-list>
-        </fd-side-nav-group>
-        <fd-side-nav-group>
-          <fd-side-nav-title>
-            Group Name
-          </fd-side-nav-title>
-          <fd-side-nav-list>
-            <fd-side-nav-item>
-              <fd-side-nav-link [hasSublist]="true">
-                Link Item
-                <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
-                <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
-                <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
-              </fd-side-nav-link>
-            </fd-side-nav-item>
-            <fd-side-nav-item>
-              <fd-side-nav-link [hasSublist]="true">
-                Link Item
-                <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
-                <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
-                <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
-              </fd-side-nav-link>
-            </fd-side-nav-item>
-            <fd-side-nav-item>
-              <fd-side-nav-link [hasSublist]="true">
-                Link Item
-                <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
-                <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
-                <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
-              </fd-side-nav-link>
-            </fd-side-nav-item>
-          </fd-side-nav-list>
-        </fd-side-nav-group>
-      </fd-side-nav>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <p>
+    <fd-side-nav>
+      <fd-side-nav-group>
+        <fd-side-nav-title>
+          Group Name
+        </fd-side-nav-title>
+        <fd-side-nav-list>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+          <fd-side-nav-item>
+            <fd-side-nav-link [url]="'#'">Link Item</fd-side-nav-link>
+          </fd-side-nav-item>
+        </fd-side-nav-list>
+      </fd-side-nav-group>
+      <fd-side-nav-group>
+        <fd-side-nav-title>
+          Group Name
+        </fd-side-nav-title>
+        <fd-side-nav-list>
+          <fd-side-nav-item>
+            <fd-side-nav-link [hasSublist]="true">
+              Link Item
+              <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
+              <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
+              <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
+            </fd-side-nav-link>
+          </fd-side-nav-item>
+          <fd-side-nav-item>
+            <fd-side-nav-link [hasSublist]="true">
+              Link Item
+              <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
+              <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
+              <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
+            </fd-side-nav-link>
+          </fd-side-nav-item>
+          <fd-side-nav-item>
+            <fd-side-nav-link [hasSublist]="true">
+              Link Item
+              <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
+              <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
+              <fd-side-nav-subitem [url]="'#'">Link Item</fd-side-nav-subitem>
+            </fd-side-nav-link>
+          </fd-side-nav-item>
+        </fd-side-nav-list>
+      </fd-side-nav-group>
+    </fd-side-nav>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="multiLevelsSideNavHtml"></code></pre>
 
 <separator></separator>
 <h2>Side navigation with icons</h2>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-side-nav>
-        <fd-side-nav-list>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">
-              <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
-              Link Icon
-            </fd-side-nav-link>
-          </fd-side-nav-item>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">
-              <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
-              Link Icon
-            </fd-side-nav-link>
-          </fd-side-nav-item>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">
-              <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
-              Link Icon
-            </fd-side-nav-link>
-          </fd-side-nav-item>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">
-              <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
-              Link Icon
-            </fd-side-nav-link>
-          </fd-side-nav-item>
-        </fd-side-nav-list>
-      </fd-side-nav>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex4'">
+  <p>
+    <fd-side-nav>
+      <fd-side-nav-list>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">
+            <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
+            Link Icon
+          </fd-side-nav-link>
+        </fd-side-nav-item>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">
+            <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
+            Link Icon
+          </fd-side-nav-link>
+        </fd-side-nav-item>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">
+            <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
+            Link Icon
+          </fd-side-nav-link>
+        </fd-side-nav-item>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">
+            <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
+            Link Icon
+          </fd-side-nav-link>
+        </fd-side-nav-item>
+      </fd-side-nav-list>
+    </fd-side-nav>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="iconsSideNavHtml"></code></pre>
 
 <separator></separator>
 <h2>Side navigation collapsed with icons</h2>
-<p>The user can identify which level they are on based on the icon displayed as selected when the navigation is collapsed. Note that the suggested use is when there is only one level of navigation as the user can only see one level of navigation when collapsed.</p>
+<p>The user can identify which level they are on based on the icon displayed as selected when the navigation is
+  collapsed. Note that the suggested use is when there is only one level of navigation as the user can only see one
+  level of navigation when collapsed.</p>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-side-nav [collapsed]="true">
-        <fd-side-nav-list>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">
-              <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
-            </fd-side-nav-link>
-          </fd-side-nav-item>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">
-              <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
-            </fd-side-nav-link>
-          </fd-side-nav-item>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">
-              <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
-            </fd-side-nav-link>
-          </fd-side-nav-item>
-          <fd-side-nav-item>
-            <fd-side-nav-link [url]="'#'">
-              <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
-            </fd-side-nav-link>
-          </fd-side-nav-item>
-        </fd-side-nav-list>
-      </fd-side-nav>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex5'">
+  <p>
+    <fd-side-nav [collapsed]="true">
+      <fd-side-nav-list>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">
+            <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
+          </fd-side-nav-link>
+        </fd-side-nav-item>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">
+            <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
+          </fd-side-nav-link>
+        </fd-side-nav-item>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">
+            <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
+          </fd-side-nav-link>
+        </fd-side-nav-item>
+        <fd-side-nav-item>
+          <fd-side-nav-link [url]="'#'">
+            <fd-side-nav-icon [glyph]="'home'" [size]="'l'"></fd-side-nav-icon>
+          </fd-side-nav-link>
+        </fd-side-nav-item>
+      </fd-side-nav-list>
+    </fd-side-nav>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="collapsedSideNavHtml"></code></pre>
-

--- a/docs/modules/documentation/containers/table/table-docs.component.html
+++ b/docs/modules/documentation/containers/table/table-docs.component.html
@@ -1,16 +1,19 @@
 <header>Table</header>
-<description>The Table component is a common component used to display data that can be compared. Usually a set of item of
+<description>The Table component is a common component used to display data that can be compared. Usually a set of item
+  of
   the same type which data is divided on columns to facilitate the comparison between items.</description>
-<import module="TableModule"
-        path="fundamental/table/table.module"></import>
+<import module="TableModule" path="fundamental/table/table.module"></import>
 <separator></separator>
 
 <h1>&lt;fd-table&gt;</h1>
 
-There are two different types of table cells you can use, the 'simple' cells and the 'rich' cells. Simple cells can only
-display text. Rich cells can contain images, plain text or links. The table component requires only two root arguments, a
+There are two different types of table cells you can use, the 'simple' cells and the 'rich' cells. Simple cells can
+only
+display text. Rich cells can contain images, plain text or links. The table component requires only two root arguments,
+a
 'headers' array and a 'tableData' array.
-<br><br> In a table with simple cells, the tableData property is an array of objects containing a 'rowData' property. This
+<br><br> In a table with simple cells, the tableData property is an array of objects containing a 'rowData' property.
+This
 property should contain an array of strings, each string being a cell in the table.
 
 <separator></separator>
@@ -25,20 +28,18 @@ This is an example of a table with simple cells, where the rowData is an array o
   }">
 </properties>
 <br>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-table [tableData]="data.properties.simpleTableData"
-              [headers]="data.properties.simpleHeaders">
+<component-example [name]="'ex1'">
+  <fd-table [tableData]="data.properties.simpleTableData" [headers]="data.properties.simpleHeaders">
 
-    </fd-table>
-  </div>
-</div>
+  </fd-table>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="simpleTableHtml"></code></pre>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="simpleTableJson"></code></pre>
 
 <separator></separator>
 <h2>Rich Table</h2>
-This is an example of a table with rich cells, where the rowData is an array of objects, where each object can have any of
+This is an example of a table with rich cells, where the rowData is an array of objects, where each object can have any
+of
 the following properties:<br><br>
 <properties [properties]="{
     properties: [
@@ -57,14 +58,10 @@ the following properties:<br><br>
   }">
 </properties>
 <br>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-table [tableData]="data.properties.richTableData"
-              [headers]="data.properties.richHeaders"
-              [headerWidths]="data.properties.richWidths">
+<component-example [name]="'ex2'">
+  <fd-table [tableData]="data.properties.richTableData" [headers]="data.properties.richHeaders" [headerWidths]="data.properties.richWidths">
 
-    </fd-table>
-  </div>
-</div>
+  </fd-table>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="richTableHtml"></code></pre>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="richTableJson"></code></pre>

--- a/docs/modules/documentation/containers/table/table-docs.component.html
+++ b/docs/modules/documentation/containers/table/table-docs.component.html
@@ -2,7 +2,8 @@
 <description>The Table component is a common component used to display data that can be compared. Usually a set of item
   of
   the same type which data is divided on columns to facilitate the comparison between items.</description>
-<import module="TableModule" path="fundamental/table/table.module"></import>
+<import module="TableModule"
+        path="fundamental/table/table.module"></import>
 <separator></separator>
 
 <h1>&lt;fd-table&gt;</h1>
@@ -29,7 +30,8 @@ This is an example of a table with simple cells, where the rowData is an array o
 </properties>
 <br>
 <component-example [name]="'ex1'">
-  <fd-table [tableData]="data.properties.simpleTableData" [headers]="data.properties.simpleHeaders">
+  <fd-table [tableData]="data.properties.simpleTableData"
+            [headers]="data.properties.simpleHeaders">
 
   </fd-table>
 </component-example>
@@ -59,8 +61,9 @@ the following properties:<br><br>
 </properties>
 <br>
 <component-example [name]="'ex2'">
-  <fd-table [tableData]="data.properties.richTableData" [headers]="data.properties.richHeaders" [headerWidths]="data.properties.richWidths">
-
+  <fd-table [tableData]="data.properties.richTableData"
+            [headers]="data.properties.richHeaders"
+            [headerWidths]="data.properties.richWidths">
   </fd-table>
 </component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="richTableHtml"></code></pre>

--- a/docs/modules/documentation/containers/tabs/tabs-docs.component.html
+++ b/docs/modules/documentation/containers/tabs/tabs-docs.component.html
@@ -1,6 +1,7 @@
 <header>Tabs</header>
 <description>Tabs organize content in separate views.</description>
-<import module="TabsModule" path="fundamental/tabs/tabs.module"></import>
+<import module="TabsModule"
+        path="fundamental/tabs/tabs.module"></import>
 <separator></separator>
 
 <h1>&lt;fd-tab-list&gt;</h1>
@@ -21,24 +22,25 @@
 
 <separator></separator>
 
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-tab-list>
-      <fd-tab [title]="'Link'">
-        Content Link
-      </fd-tab>
-      <fd-tab [title]="'Selected'" [disabled]="false">
-        Content Selected
-      </fd-tab>
-      <fd-tab [title]="'Link'" [disabled]="false">
-        Content Link Two
-      </fd-tab>
-      <fd-tab [title]="'Disabled'" [disabled]="true">
-        Disabled
-      </fd-tab>
-    </fd-tab-list>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <fd-tab-list>
+    <fd-tab [title]="'Link'">
+      Content Link
+    </fd-tab>
+    <fd-tab [title]="'Selected'"
+            [disabled]="false">
+      Content Selected
+    </fd-tab>
+    <fd-tab [title]="'Link'"
+            [disabled]="false">
+      Content Link Two
+    </fd-tab>
+    <fd-tab [title]="'Disabled'"
+            [disabled]="true">
+      Disabled
+    </fd-tab>
+  </fd-tab-list>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="tabHtml"></code></pre>
 
 <separator></separator>
@@ -46,36 +48,43 @@
 <p>You can set an
   <code>id</code> on a tab and select it programmatically using the
   <code>select()</code> function.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-tab-list #tabList>
-      <fd-tab id="tab1" [title]="'Tab 1'">
-        Tab 1
-      </fd-tab>
-      <fd-tab id="tab2" [title]="'Tab 2'">
-        Tab 2
-      </fd-tab>
-    </fd-tab-list>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <fd-tab-list #tabList>
+    <fd-tab id="tab1"
+            [title]="'Tab 1'">
+      Tab 1
+    </fd-tab>
+    <fd-tab id="tab2"
+            [title]="'Tab 2'">
+      Tab 2
+    </fd-tab>
+  </fd-tab-list>
+</component-example>
 <br>
 <br>
-<button fd-button [fdType]="'main'" (click)="this.tabList.select('tab2')">
+<button fd-button
+        [fdType]="'main'"
+        (click)="this.tabList.select('tab2')">
   Select Tab 2
 </button>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="selectTabByIdHtml"></code></pre>
 
 <separator></separator>
 
-<playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
+<playground [schema]="schema"
+            [schemaInitialValues]="data"
+            (onFormChanges)="onSchemaValues($event)">
   <fd-tab-list>
-    <fd-tab [title]="data.properties.items.label" [disabled]="data.state.disabled">
+    <fd-tab [title]="data.properties.items.label"
+            [disabled]="data.state.disabled">
       {{data.properties.panels.content}}
     </fd-tab>
-    <fd-tab [title]="data.properties.items.label2" [disabled]="data.state.disabled2">
+    <fd-tab [title]="data.properties.items.label2"
+            [disabled]="data.state.disabled2">
       {{data.properties.panels.content2}}
     </fd-tab>
-    <fd-tab [title]="data.properties.items.label3" [disabled]="data.state.disabled3">
+    <fd-tab [title]="data.properties.items.label3"
+            [disabled]="data.state.disabled3">
       {{data.properties.panels.content3}}
     </fd-tab>
   </fd-tab-list>

--- a/docs/modules/documentation/containers/tile/tile-docs.component.html
+++ b/docs/modules/documentation/containers/tile/tile-docs.component.html
@@ -1,8 +1,10 @@
 <header>Tile and Tile Grid</header>
-<description>A Tile component can be used to display information in a simple container format. A collection of tile can be displayed using
+<description>A Tile component can be used to display information in a simple container format. A collection of tile can
+  be displayed using
   <code>fd-tile-grid</code>.
 </description>
-<import module="TileModule" path="fundamental/tile/tile.module"></import>
+<import module="TileModule"
+        path="fundamental/tile/tile.module"></import>
 <separator></separator>
 
 <h1>&lt;fd-tile&gt;</h1>
@@ -29,112 +31,117 @@
 <separator></separator>
 
 <h2>Simple Tile</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-      <fd-tile>
-        <fd-tile-content>
-          <fd-tile-title>
-            Tile Title
-          </fd-tile-title>
-          <p>Tile Description</p>
-        </fd-tile-content>
-      </fd-tile>
-    </div>
+<component-example [name]="'ex1'">
+  <div class="grid">
+    <fd-tile>
+      <fd-tile-content>
+        <fd-tile-title>
+          Tile Title
+        </fd-tile-title>
+        <p>Tile Description</p>
+      </fd-tile-content>
+    </fd-tile>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="simpleTileHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Tile with
   <code>.fd-media</code> container</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-      <fd-tile>
-        <fd-tile-media>
-          <span fd-identifier [size]="'m'" [glyph]="'home'" [transparent]="true"></span>
-        </fd-tile-media>
-        <fd-tile-content>
-          <fd-tile-title>
-            Tile Title
-          </fd-tile-title>
-        </fd-tile-content>
-      </fd-tile>
-      <br>
-      <fd-tile>
-        <fd-tile-media>
-          <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='3'></span>
-        </fd-tile-media>
-        <fd-tile-content>
-          <fd-tile-title>
-            Tile Title
-          </fd-tile-title>
-          <p>Tile Description</p>
-        </fd-tile-content>
-      </fd-tile>
-      <br>
-      <fd-tile>
-        <fd-tile-media>
-          <fd-image [size]="'m'" [photo]="'http://api.adorable.io/avatars/50/rodney.artichoke@hybris.com.png'"></fd-image>
-        </fd-tile-media>
-        <fd-tile-content>
-          <fd-tile-title>
-            Tile Title
-          </fd-tile-title>
-        </fd-tile-content>
-      </fd-tile>
-      <br>
-      <fd-tile>
-        <fd-tile-media>
-          <fd-image [size]="'m'" [circle]="true" [photo]="'http://api.adorable.io/avatars/50/rodney.artichoke@hybris.com.png'"></fd-image>
-        </fd-tile-media>
-        <fd-tile-content>
-          <fd-tile-title>
-            Tile Title
-          </fd-tile-title>
-          <p>Tile Description</p>
-        </fd-tile-content>
-      </fd-tile>
-    </div>
+<component-example [name]="'ex2'">
+  <div class="grid">
+    <fd-tile>
+      <fd-tile-media>
+        <span fd-identifier
+              [size]="'m'"
+              [glyph]="'home'"
+              [transparent]="true"></span>
+      </fd-tile-media>
+      <fd-tile-content>
+        <fd-tile-title>
+          Tile Title
+        </fd-tile-title>
+      </fd-tile-content>
+    </fd-tile>
+    <br>
+    <fd-tile>
+      <fd-tile-media>
+        <span fd-identifier
+              [size]="'m'"
+              [glyph]="'home'"
+              [colorAccent]='3'></span>
+      </fd-tile-media>
+      <fd-tile-content>
+        <fd-tile-title>
+          Tile Title
+        </fd-tile-title>
+        <p>Tile Description</p>
+      </fd-tile-content>
+    </fd-tile>
+    <br>
+    <fd-tile>
+      <fd-tile-media>
+        <fd-image [size]="'m'"
+                  [photo]="'http://api.adorable.io/avatars/50/rodney.artichoke@hybris.com.png'"></fd-image>
+      </fd-tile-media>
+      <fd-tile-content>
+        <fd-tile-title>
+          Tile Title
+        </fd-tile-title>
+      </fd-tile-content>
+    </fd-tile>
+    <br>
+    <fd-tile>
+      <fd-tile-media>
+        <fd-image [size]="'m'"
+                  [circle]="true"
+                  [photo]="'http://api.adorable.io/avatars/50/rodney.artichoke@hybris.com.png'"></fd-image>
+      </fd-tile-media>
+      <fd-tile-content>
+        <fd-tile-title>
+          Tile Title
+        </fd-tile-title>
+        <p>Tile Description</p>
+      </fd-tile-content>
+    </fd-tile>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="mediaTileHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Tile with
   <code>.fd-actions</code> container</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-      <fd-tile>
-        <fd-tile-content>
-          <fd-tile-title>
-            Tile Title
-          </fd-tile-title>
-        </fd-tile-content>
-        <fd-tile-actions>
-          <fd-popover>
-            <fd-popover-control>
-              <button fd-button [fdType]="'secondary'" [glyph]="'vertical-grip'"></button>
-            </fd-popover-control>
-            <fd-popover-body>
-              <fd-menu>
-                <fd-menu-list>
-                  <fd-menu-item [url]="'#'">Option 1</fd-menu-item>
-                  <fd-menu-item [url]="'#'">Option 2</fd-menu-item>
-                  <fd-menu-item [url]="'#'">Option 3</fd-menu-item>
-                </fd-menu-list>
-              </fd-menu>
-            </fd-popover-body>
-          </fd-popover>
-        </fd-tile-actions>
-      </fd-tile>
-    </div>
+<component-example [name]="'ex3'">
+  <div class="grid">
+    <fd-tile>
+      <fd-tile-content>
+        <fd-tile-title>
+          Tile Title
+        </fd-tile-title>
+      </fd-tile-content>
+      <fd-tile-actions>
+        <fd-popover>
+          <fd-popover-control>
+            <button fd-button
+                    [fdType]="'secondary'"
+                    [glyph]="'vertical-grip'"></button>
+          </fd-popover-control>
+          <fd-popover-body>
+            <fd-menu>
+              <fd-menu-list>
+                <fd-menu-item [url]="'#'">Option 1</fd-menu-item>
+                <fd-menu-item [url]="'#'">Option 2</fd-menu-item>
+                <fd-menu-item [url]="'#'">Option 3</fd-menu-item>
+              </fd-menu-list>
+            </fd-menu>
+          </fd-popover-body>
+        </fd-popover>
+      </fd-tile-actions>
+    </fd-tile>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="actionsTileHtml"></code></pre>
 
 <separator></separator>
@@ -142,47 +149,43 @@
 <h2>Tile as a Button</h2>
 <p>Add
   <code>[isButton]="true"</code> to rendering a tile as a button</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-      <p>
-        <fd-tile [isButton]="true">
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-      </p>
-    </div>
+<component-example [name]="'ex4'">
+  <div class="grid">
+    <p>
+      <fd-tile [isButton]="true">
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+    </p>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="buttonTileHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Product Tile</h2>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-      <p>
-        <fd-product-tile>
-          <fd-product-tile-media [photo]="'https://techne.yaas.io/images/product-thumbnail-wide.png'"></fd-product-tile-media>
-          <fd-product-tile-content>
-            <fd-product-tile-title>Default Product Tile</fd-product-tile-title>
-          </fd-product-tile-content>
-        </fd-product-tile>
+<component-example [name]="'ex5'">
+  <div class="grid">
+    <p>
+      <fd-product-tile>
+        <fd-product-tile-media [photo]="'https://techne.yaas.io/images/product-thumbnail-wide.png'"></fd-product-tile-media>
+        <fd-product-tile-content>
+          <fd-product-tile-title>Default Product Tile</fd-product-tile-title>
+        </fd-product-tile-content>
+      </fd-product-tile>
 
-        <fd-product-tile [isButton]="true">
-          <fd-product-tile-media [photo]="'https://techne.yaas.io/images/product-thumbnail-wide.png'"></fd-product-tile-media>
-          <fd-product-tile-content>
-            <fd-product-tile-title>Default Product Tile</fd-product-tile-title>
-          </fd-product-tile-content>
-        </fd-product-tile>
-      </p>
-    </div>
+      <fd-product-tile [isButton]="true">
+        <fd-product-tile-media [photo]="'https://techne.yaas.io/images/product-thumbnail-wide.png'"></fd-product-tile-media>
+        <fd-product-tile-content>
+          <fd-product-tile-title>Default Product Tile</fd-product-tile-title>
+        </fd-product-tile-content>
+      </fd-product-tile>
+    </p>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="productTileHtml"></code></pre>
 
 <separator></separator>
@@ -190,44 +193,45 @@
 <h2>Disabled state</h2>
 <p>Add
   <code>[disabled]="true"</code> for disabled state</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-      <p>
-        <fd-tile [disabled]="true">
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-      </p>
-      <br>
-      <p>
-        <fd-tile [disabled]="true">
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [transparent]="true"></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-      </p>
-      <br>
-      <p>
-        <fd-product-tile [disabled]="true">
-          <fd-product-tile-media [photo]="'https://techne.yaas.io/images/product-thumbnail-wide.png'"></fd-product-tile-media>
-          <fd-product-tile-content>
-            <fd-product-tile-title>Default Product Tile</fd-product-tile-title>
-          </fd-product-tile-content>
-        </fd-product-tile>
-      </p>
-      <br/>
-    </div>
+<component-example [name]="'ex6'">
+  <div class="grid">
+    <p>
+      <fd-tile [disabled]="true">
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+    </p>
+    <br>
+    <p>
+      <fd-tile [disabled]="true">
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [transparent]="true"></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+    </p>
+    <br>
+    <p>
+      <fd-product-tile [disabled]="true">
+        <fd-product-tile-media [photo]="'https://techne.yaas.io/images/product-thumbnail-wide.png'"></fd-product-tile-media>
+        <fd-product-tile-content>
+          <fd-product-tile-title>Default Product Tile</fd-product-tile-title>
+        </fd-product-tile-content>
+      </fd-product-tile>
+    </p>
+    <br />
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="disabledTilesHtml"></code></pre>
 
 <separator></separator>
@@ -237,74 +241,90 @@
   <code>fd-tile</code> components in a gird layout. The default is 3-col grid.</p>
 <p>It's also available as a modifier class
   <code>[col]="3"</code> .</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-      <fd-tile-grid [col]="3">
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='3'></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='3'></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='3'></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='3'></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='3'></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='3'></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-      </fd-tile-grid>
-    </div>
+<component-example [name]="'ex7'">
+  <div class="grid">
+    <fd-tile-grid [col]="3">
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [colorAccent]='3'></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [colorAccent]='3'></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [colorAccent]='3'></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [colorAccent]='3'></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [colorAccent]='3'></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [colorAccent]='3'></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+    </fd-tile-grid>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="defaultGridHtml"></code></pre>
 
 <separator></separator>
@@ -315,124 +335,150 @@
   <code>[columnSpan]="numberOfColumns"</code> </p>
 <p>Use
   <code>[colorAccent]="colorAccentNumber"</code> to add background to the tile.</p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <div class="grid">
-      <fd-tile-grid [col]="6">
-        <fd-tile [rowSpan]="2" [colorAccent]="7">
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='2'></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [transparent]="true"></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='5'></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <span fd-identifier [size]="'m'" [glyph]="'home'" [colorAccent]='5'></span>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-media>
-            <fd-image [size]="'m'" [circle]="true" [photo]="'http://api.adorable.io/avatars/50/rodney.artichoke@hybris.com.png'"></fd-image>
-          </fd-tile-media>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile [colorAccent]='8'>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile>
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-        <fd-tile [columnSpan]="2" [colorAccent]="5">
-          <fd-tile-content>
-            <fd-tile-title>
-              Tile Title
-            </fd-tile-title>
-          </fd-tile-content>
-        </fd-tile>
-      </fd-tile-grid>
-    </div>
+<component-example [name]="'ex8'">
+  <div class="grid">
+    <fd-tile-grid [col]="6">
+      <fd-tile [rowSpan]="2"
+               [colorAccent]="7">
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [colorAccent]='2'></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [transparent]="true"></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [colorAccent]='5'></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <span fd-identifier
+                [size]="'m'"
+                [glyph]="'home'"
+                [colorAccent]='5'></span>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-media>
+          <fd-image [size]="'m'"
+                    [circle]="true"
+                    [photo]="'http://api.adorable.io/avatars/50/rodney.artichoke@hybris.com.png'"></fd-image>
+        </fd-tile-media>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile [colorAccent]='8'>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile>
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+      <fd-tile [columnSpan]="2"
+               [colorAccent]="5">
+        <fd-tile-content>
+          <fd-tile-title>
+            Tile Title
+          </fd-tile-title>
+        </fd-tile-content>
+      </fd-tile>
+    </fd-tile-grid>
   </div>
-</div>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="gridWithHelpersHtml"></code></pre>
 
 <separator></separator>
 
-<playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
+<playground [schema]="schema"
+            [schemaInitialValues]="data"
+            (onFormChanges)="onSchemaValues($event)">
   <div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
     <div class="fd-tile__content">
       <div class="grid">
         <p>
-          <fd-tile [disabled]="data.properties.disabled" [isButton]="data.properties.isButton" [colorAccent]="data.properties.colorAccent"
-            *ngIf="data.properties.type !== 'product'">
+          <fd-tile [disabled]="data.properties.disabled"
+                   [isButton]="data.properties.isButton"
+                   [colorAccent]="data.properties.colorAccent"
+                   *ngIf="data.properties.type !== 'product'">
 
             <fd-tile-media *ngIf="data.properties.type === 'media'">
               <span *ngIf="data.properties.imageUrl.length === 0 ; else urlTemplate ">
-                <span *ngIf="data.properties.transparent === true ; else colorAccentTemplate" fd-identifier [size]="data.properties.size"
-                  [glyph]="data.properties.glyphs" [transparent]="data.properties.transparent"></span>
+                <span *ngIf="data.properties.transparent === true ; else colorAccentTemplate"
+                      fd-identifier
+                      [size]="data.properties.size"
+                      [glyph]="data.properties.glyphs"
+                      [transparent]="data.properties.transparent"></span>
 
                 <ng-template #colorAccentTemplate>
-                  <span fd-identifier [size]="data.properties.size" [glyph]="data.properties.glyphs" [colorAccent]="data.properties.colorAccent"
-                    [circle]="data.properties.circle"></span>
+                  <span fd-identifier
+                        [size]="data.properties.size"
+                        [glyph]="data.properties.glyphs"
+                        [colorAccent]="data.properties.colorAccent"
+                        [circle]="data.properties.circle"></span>
                 </ng-template>
               </span>
 
               <ng-template #urlTemplate>
-                <fd-image [size]="data.properties.size" [circle]="data.properties.circle" [photo]="data.properties.imageUrl"></fd-image>
+                <fd-image [size]="data.properties.size"
+                          [circle]="data.properties.circle"
+                          [photo]="data.properties.imageUrl"></fd-image>
               </ng-template>
             </fd-tile-media>
 
@@ -446,7 +492,9 @@
             <fd-tile-actions *ngIf="data.properties.hasActions === true">
               <fd-popover>
                 <fd-popover-control>
-                  <button fd-button [fdType]="'secondary'" [glyph]="'vertical-grip'"></button>
+                  <button fd-button
+                          [fdType]="'secondary'"
+                          [glyph]="'vertical-grip'"></button>
                 </fd-popover-control>
                 <fd-popover-body>
                   <fd-menu>
@@ -461,7 +509,9 @@
             </fd-tile-actions>
           </fd-tile>
 
-          <fd-product-tile [disabled]="data.properties.disabled" [isButton]="data.properties.isButton" *ngIf="data.properties.type === 'product'">
+          <fd-product-tile [disabled]="data.properties.disabled"
+                           [isButton]="data.properties.isButton"
+                           *ngIf="data.properties.type === 'product'">
             <fd-product-tile-media [photo]="data.properties.imageUrl"></fd-product-tile-media>
             <fd-product-tile-content>
               <fd-product-tile-title>{{data.properties.title}}</fd-product-tile-title>

--- a/docs/modules/documentation/containers/time-picker/time-picker-docs.component.html
+++ b/docs/modules/documentation/containers/time-picker/time-picker-docs.component.html
@@ -1,6 +1,8 @@
 <header>Time Picker</header>
-<description>The Time Picker component allows the user to easily set a time using either an HTML5 time input or the Fundamental NGX Time component.</description>
-<import module="TimePickerModule" path="fundamental/time-picker/time-picker.module"></import>
+<description>The Time Picker component allows the user to easily set a time using either an HTML5 time input or the
+  Fundamental NGX Time component.</description>
+<import module="TimePickerModule"
+        path="fundamental/time-picker/time-picker.module"></import>
 <h1>&lt;fd-time-picker&gt;</h1>
 
 <properties [properties]="{
@@ -15,42 +17,39 @@
 <separator></separator>
 <h2>24-Hour Time Picker</h2>
 <description>This is the default time picker setting.</description>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-time-picker [time]="timeObject"></fd-time-picker><br>
-    <span>timeObject: {{ '{' }}hour: {{timeObject.hour}}, minute: {{timeObject.minute}}, second: {{timeObject.second}}}</span>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <fd-time-picker [time]="timeObject"></fd-time-picker><br>
+  <span>timeObject: {{ '{' }}hour: {{timeObject.hour}}, minute: {{timeObject.minute}}, second: {{timeObject.second}}}</span>
+</component-example>
 <pre><code mwlHighlightJs language="HTML" [source]="timePickerHtml"></code></pre>
 
 <separator></separator>
 <h2>12-Hour Time Picker with AM/PM</h2>
 <description>Set <code>[meridian]="true"</code> to use a 12-hour clock..</description>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-time-picker [meridian]="true" [time]="timeMeridianObject"></fd-time-picker><br>
-    <span>timeMeridianObject: {{ '{' }}hour: {{timeMeridianObject.hour}}, minute: {{timeMeridianObject.minute}}, second: {{timeMeridianObject.second}}}</span>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <fd-time-picker [meridian]="true"
+                  [time]="timeMeridianObject"></fd-time-picker><br>
+  <span>timeMeridianObject: {{ '{' }}hour: {{timeMeridianObject.hour}}, minute: {{timeMeridianObject.minute}}, second:
+    {{timeMeridianObject.second}}}</span>
+</component-example>
 <pre><code mwlHighlightJs language="HTML" [source]="meridianTimePickerHtml"></code></pre>
 
 <separator></separator>
 <h2>Time Picker with No Seconds</h2>
 <description>Use <code>[displaySeconds]=false</code> to turn off seconds for the time picker.</description>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-time-picker [displaySeconds]="false" [time]="timePickerNoSecondsObject"></fd-time-picker><br>
-    <span>timeObject: {{ '{' }}hour: {{timePickerNoSecondsObject.hour}}, minute: {{timePickerNoSecondsObject.minute}}, second: {{timePickerNoSecondsObject.second}}}</span>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <fd-time-picker [displaySeconds]="false"
+                  [time]="timePickerNoSecondsObject"></fd-time-picker><br>
+  <span>timeObject: {{ '{' }}hour: {{timePickerNoSecondsObject.hour}}, minute: {{timePickerNoSecondsObject.minute}},
+    second: {{timePickerNoSecondsObject.second}}}</span>
+</component-example>
 <pre><code mwlHighlightJs language="HTML" [source]="timePickerNoSecondsHtml"></code></pre>
 
 <separator></separator>
 <h2>Disabled Time Picker</h2>
 <description>Set <code>[disabled]="true"</code> to disable the time picker.</description>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-time-picker [disabled]="true" [time]="timeObject"></fd-time-picker><br>
-  </div>
-</div>
+<component-example [name]="'ex4'">
+  <fd-time-picker [disabled]="true"
+                  [time]="timeObject"></fd-time-picker><br>
+</component-example>
 <pre><code mwlHighlightJs language="HTML" [source]="disabledTimePickerHtml"></code></pre>

--- a/docs/modules/documentation/containers/time/time-docs.component.html
+++ b/docs/modules/documentation/containers/time/time-docs.component.html
@@ -1,6 +1,9 @@
 <header>Time</header>
-<description>The time component is used for a single time value. Multiple components can be used in the time-picker to assemble a clock time. A max of four will account for hours, minutes, seconds and period of the day. It will be rare to see this component used outside of it being composed in the time-picker component.</description>
-<import module="TimeModule" path="fundamental/time/time.module"></import>
+<description>The time component is used for a single time value. Multiple components can be used in the time-picker to
+  assemble a clock time. A max of four will account for hours, minutes, seconds and period of the day. It will be rare
+  to see this component used outside of it being composed in the time-picker component.</description>
+<import module="TimeModule"
+        path="fundamental/time/time.module"></import>
 <separator></separator>
 
 <h1>&lt;fd-time&gt;</h1>
@@ -20,65 +23,62 @@
 
 <h2>24-Hour Clock</h2>
 <description>This is the default clock setting.</description>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-time [time]="timeObject"></fd-time>
-      <span>timeObject: {{ '{' }}hour: {{timeObject.hour}}, minute: {{timeObject.minute}}, second: {{timeObject.second}}}</span>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex1'">
+  <p>
+    <fd-time [time]="timeObject"></fd-time>
+    <span>timeObject: {{ '{' }}hour: {{timeObject.hour}}, minute: {{timeObject.minute}}, second: {{timeObject.second}}}</span>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs language="HTML" [source]="timeHtml"></code></pre>
 
 <separator></separator>
 
 <h2>12-Hour Clock</h2>
 <p>You can use a Meridian 12-hour clock by setting <code>[meridian]="true"</code></p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-time [meridian]="true" [time]="timeMeridianObject"></fd-time>
-      <span>timeMeridianObject: {{ '{' }}hour: {{timeMeridianObject.hour}}, minute: {{timeMeridianObject.minute}}, second: {{timeMeridianObject.second}}}</span>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex2'">
+  <p>
+    <fd-time [meridian]="true"
+             [time]="timeMeridianObject"></fd-time>
+    <span>timeMeridianObject: {{ '{' }}hour: {{timeMeridianObject.hour}}, minute: {{timeMeridianObject.minute}},
+      second: {{timeMeridianObject.second}}}</span>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs language="HTML" [source]="timeMeridianHtml"></code></pre>
 
 <separator></separator>
 
 <h2>Clock With No Spinners</h2>
 <description>Use <code>[spinners]="false"</code> to hide the spinners.</description>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-time [spinners]="false" [time]="timeNoSpinnersObject"></fd-time>
-      <span>timeObject: {{ '{' }}hour: {{timeNoSpinnersObject.hour}}, minute: {{timeNoSpinnersObject.minute}}, second: {{timeNoSpinnersObject.second}}}</span>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex3'">
+  <p>
+    <fd-time [spinners]="false"
+             [time]="timeNoSpinnersObject"></fd-time>
+    <span>timeObject: {{ '{' }}hour: {{timeNoSpinnersObject.hour}}, minute: {{timeNoSpinnersObject.minute}}, second:
+      {{timeNoSpinnersObject.second}}}</span>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs language="HTML" [source]="timeNoSpinnersHtml"></code></pre>
 <separator></separator>
 
 <h2>Clock With No Seconds</h2>
 <description>Use <code>[displaySeconds]="false"</code> to hide the seconds input.</description>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-time [displaySeconds]="false" [time]="timeNoSecondsObject"></fd-time>
-      <span>timeObject: {{ '{' }}hour: {{timeNoSecondsObject.hour}}, minute: {{timeNoSecondsObject.minute}}, second: {{timeNoSecondsObject.second}}}</span>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex4'">
+  <p>
+    <fd-time [displaySeconds]="false"
+             [time]="timeNoSecondsObject"></fd-time>
+    <span>timeObject: {{ '{' }}hour: {{timeNoSecondsObject.hour}}, minute: {{timeNoSecondsObject.minute}}, second:
+      {{timeNoSecondsObject.second}}}</span>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs language="HTML" [source]="timeNoSecondsHtml"></code></pre>
 <separator></separator>
 
 <h2>Disabled State</h2>
 <p>You can disable the entire component by setting <code>[disabled]="true"</code></p>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <p>
-      <fd-time [disabled]="true" [time]="{hour: 0, minute: 0, second: 0}"></fd-time>
-    </p>
-  </div>
-</div>
+<component-example [name]="'ex5'">
+  <p>
+    <fd-time [disabled]="true"
+             [time]="{hour: 0, minute: 0, second: 0}"></fd-time>
+  </p>
+</component-example>
 <pre><code mwlHighlightJs language="HTML" [source]="timeDisabledHtml"></code></pre>

--- a/docs/modules/documentation/containers/tree/tree-docs.component.html
+++ b/docs/modules/documentation/containers/tree/tree-docs.component.html
@@ -1,13 +1,21 @@
 <header>Tree</header>
-<description>The Tree component is used to display hierarchical data in tabular way. Permitting the user to dig deeper into the data in an simple way. Along with displaying the hierarchy information it can also contain other data in the same node as well.</description>
-<import module="TreeModule" path="fundamental/tree/tree.module"></import>
+<description>The Tree component is used to display hierarchical data in tabular way. Permitting the user to dig deeper
+  into the data in an simple way. Along with displaying the hierarchy information it can also contain other data in the
+  same node as well.</description>
+<import module="TreeModule"
+        path="fundamental/tree/tree.module"></import>
 <separator></separator>
 
 <h1>&lt;fd-tree&gt;</h1>
 
-There are two different types of tree cells you can use, the 'simple' cells and the 'rich' cells.  Simple cells can only display text.  Rich cells can contain plain text or links.  The tree component requires only two root arguments, a 'headers' array and a 'treeData' array.  The children of the tree are generated recursively from data within the treeData array.
+There are two different types of tree cells you can use, the 'simple' cells and the 'rich' cells. Simple cells can only
+display text. Rich cells can contain plain text or links. The tree component requires only two root arguments, a
+'headers' array and a 'treeData' array. The children of the tree are generated recursively from data within the
+treeData array.
 <br><br>
-In a tree with simple cells, the treeData property is an array of objects that contain two properties, 'rowData' and optionally 'children'.  Simple cell rowData is an array of strings, each string being a cell in the tree.  The 'children' property is an array of objects that match this object's structure.
+In a tree with simple cells, the treeData property is an array of objects that contain two properties, 'rowData' and
+optionally 'children'. Simple cell rowData is an array of strings, each string being a cell in the tree. The 'children'
+property is an array of objects that match this object's structure.
 
 <separator></separator>
 
@@ -22,20 +30,23 @@ This is an example of a tree with simple cells, where the rowData is an array of
   }">
 </properties>
 <br>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-tree (editRowClicked)="editRowClicked($event)" (deleteRowClicked)="deleteRowClicked($event)" [displayTreeActions]="true" [headers]="data.properties.headers" [treeData]="data.properties.simpleTreeData">
+<component-example [name]="'ex1'">
+  <fd-tree (editRowClicked)="editRowClicked($event)"
+           (deleteRowClicked)="deleteRowClicked($event)"
+           [displayTreeActions]="true"
+           [headers]="data.properties.headers"
+           [treeData]="data.properties.simpleTreeData">
 
-    </fd-tree>
-  </div>
-</div>
+  </fd-tree>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="simpleTreeHtml"></code></pre>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="simpleTreeJson"></code></pre>
 
 <separator></separator>
 
 <h2>Rich Tree</h2>
-This is an example of a tree with rich cells, where the rowData is an array of objects, where each object can have one or both of the following properties:<br><br>
+This is an example of a tree with rich cells, where the rowData is an array of objects, where each object can have one
+or both of the following properties:<br><br>
 <properties [properties]="{
     properties: [
     { name: 'displayText', description: 'The text to display in the cell.  If omitted, the link url will be displayed.' },
@@ -52,12 +63,11 @@ This is an example of a tree with rich cells, where the rowData is an array of o
   }">
 </properties>
 <br>
-<div class="fd-tile docs-component docs-component__ fd-has-background-color-background-1">
-  <div class="fd-tile__content">
-    <fd-tree [headers]="data.properties.headers" [treeData]="data.properties.richTreeData">
+<component-example [name]="'ex2'">
+  <fd-tree [headers]="data.properties.headers"
+           [treeData]="data.properties.richTreeData">
 
-    </fd-tree>
-  </div>
-</div>
+  </fd-tree>
+</component-example>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="richTreeHtml"></code></pre>
 <pre><code mwlHighlightJs [language]="'HTML'" [source]="richTreeJson"></code></pre>

--- a/docs/modules/documentation/documentation.module.ts
+++ b/docs/modules/documentation/documentation.module.ts
@@ -17,6 +17,9 @@ import { HeaderComponent } from './components/header/header.component';
 import { DescriptionComponent } from './components/description/description';
 import { SeparatorComponent } from './components/seperator/seperator.component';
 import { ImportComponent } from './components/import/import.component';
+import { DirectionalityComponent } from './components/directionality/directionality.component';
+import { ComponentExampleComponent } from './components/component-example/component-example.component';
+import { ExampleBackgroundComponent } from './components/example-background/example-background.component';
 
 // containers
 import { BadgeLabelDocsComponent } from './containers/badge-label/badge-label-docs.component';
@@ -49,7 +52,6 @@ import { CalendarDocsComponent } from './containers/calendar/calendar-docs.compo
 import { DatePickerDocsComponent } from './containers/date-picker/date-picker-docs.component';
 import { TimeDocsComponent } from './containers/time/time-docs.component';
 import { TimePickerDocsComponent } from './containers/time-picker/time-picker-docs.component';
-
 
 import { InstallationDocsComponent } from './containers/installation/installation.component';
 import { UsageDocsComponent } from './containers/usage/usage.component';
@@ -154,7 +156,10 @@ const ROUTES: Routes = [
         InstallationDocsComponent,
         UsageDocsComponent,
         InternationalizationDocsComponent,
-        HomeDocsComponent
+        HomeDocsComponent,
+        DirectionalityComponent,
+        ComponentExampleComponent,
+        ExampleBackgroundComponent
     ],
     imports: [
         HighlightJsModule.forRoot({


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#224 enable RTL simulation in the playground for the components

#### Please provide a brief summary of this pull request.
In the playground when we show examples with fundamental-ngx components we can allow to the users to enable Right-to-Left text mode.

#### If this is a new feature, have you updated the documentation?
