### PR TITLE
Documentation/#417 responsive docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Fundamental NGX is a set of Angular components that utilize the Fiori Fundamentals library, making it easy to start developing Angular Fundamental apps.
 
-View documentation and examples of each component: [here](https://sap.github.io/fundamental-ngx/).
+View documentation and examples of each component: [here](https://sap.github.io/fundamental-ngx/docs/home).
 [![Build Status](https://travis-ci.org/SAP/fundamental-ngx.svg?branch=develop)](https://travis-ci.org/SAP/fundamental-ngx)
 
 -   [GitHub repo of Vue implementation of SAP Fiori Fundamentals](https://github.com/SAP/fundamental-vue)

--- a/docs/app/components/app/app.component.scss
+++ b/docs/app/components/app/app.component.scss
@@ -17,6 +17,7 @@ $github-icon-size: 2rem;
     right: $corner-padding;
     width: $github-icon-size;
     height: $github-icon-size;
+    z-index: 100;
 }
 
 .logo-github--white {

--- a/docs/modules/documentation/components/code-example/code-example.component.html
+++ b/docs/modules/documentation/components/code-example/code-example.component.html
@@ -1,5 +1,5 @@
 <div class="docs-html-example-container">
-    <button fd-button (click)="copyText()" class="docs-example-copy-button" [glyph]="'copy'" [size]="'l'"
+    <button fd-button *ngIf="!this.smallScreen" (click)="copyText()" class="docs-example-copy-button" [glyph]="'copy'" [size]="'l'"
     [title]="'Copy example to clipboard'"></button>
     <pre>
         <code mwlHighlightJs [language]="language" [source]="code"></code>

--- a/docs/modules/documentation/components/code-example/code-example.component.ts
+++ b/docs/modules/documentation/components/code-example/code-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input } from '@angular/core';
+import { Component, ElementRef, Input, OnInit } from '@angular/core';
 import { CopyService } from '../../services/copy.service';
 
 @Component({
@@ -6,13 +6,19 @@ import { CopyService } from '../../services/copy.service';
     templateUrl: './code-example.component.html',
     styleUrls: ['./code-example.component.scss']
 })
-export class CodeExampleComponent {
+export class CodeExampleComponent implements OnInit {
     @Input() code: string;
     @Input() language: string;
+
+    smallScreen: boolean;
 
     constructor(private element: ElementRef, private copyService: CopyService) {}
 
     copyText(): void {
         this.copyService.copyText(this.code);
+    }
+
+    ngOnInit() {
+        this.smallScreen = window.innerWidth <= 768;
     }
 }

--- a/docs/modules/documentation/components/documentation/documentation.component.html
+++ b/docs/modules/documentation/components/documentation/documentation.component.html
@@ -1,5 +1,5 @@
 <button (click)="skipNavClicked()" aria-label="skip navigation" class="skip-navigation">Skip Navigation</button>
-<div class="sidebar">
+<div class="sidebar" [ngClass]="{'sidebar-collapsed': sideCollapsed}">
   <h1 class="logo">
     <a routerLink="/"
        class="logo-link">Fundamental
@@ -75,8 +75,18 @@
     </ul>
   </nav>
 </div>
+
 <div class="content">
+  <div class="collapse-button-container">
+    <button class="collapse-button" [size]="'l'" fd-button *ngIf="this.smallScreen || this.sideCollapsed" [fdType]="'standard'" [options]="'light'" [glyph]="'menu2'" (click)="this.sideCollapsed = !this.sideCollapsed"></button>
+  </div>
   <div tabindex="0" #content class="content-margin">
     <router-outlet (activate)="onActivate()"></router-outlet>
   </div>
+</div>
+
+<div class="collapsed-overlay"
+     [ngClass]="{'overlay-init': !this.sideCollapsed}"
+     *ngIf="this.smallScreen"
+     (click)="checkIfCloseSidebar()">
 </div>

--- a/docs/modules/documentation/components/documentation/documentation.component.scss
+++ b/docs/modules/documentation/components/documentation/documentation.component.scss
@@ -35,7 +35,7 @@
     background-color: #f1f3f6;
     height: 100%;
     overflow-y: scroll;
-    transition: 0.4s margin ease-in-out, 0.4s box-shadow ease-in-out;
+    transition: 0.3s margin ease-in-out, 0.3s box-shadow ease-in-out;
     z-index: 3;
 }
 
@@ -100,7 +100,7 @@
     width: 100%;
     height: 100%;
     z-index: 2;
-    transition: 0.4s opacity ease-in-out;
+    transition: 0.3s opacity ease-in-out;
     visibility: hidden;
 
     @media screen and (min-width: 992px){

--- a/docs/modules/documentation/components/documentation/documentation.component.scss
+++ b/docs/modules/documentation/components/documentation/documentation.component.scss
@@ -35,6 +35,8 @@
     background-color: #f1f3f6;
     height: 100%;
     overflow-y: scroll;
+    transition: 0.4s margin ease-in-out, 0.4s box-shadow ease-in-out;
+    z-index: 3;
 }
 
 .nav {
@@ -79,10 +81,9 @@
 
 .content-margin {
     padding: 40px 40px 80px 60px;
-    min-width: 1024px;
-    max-width: 1600px;
     width: 80%;
     outline: 0;
+    transition: 0.5s padding ease-in-out;
 }
 
 .nav-item-container {
@@ -90,4 +91,78 @@
     align-items: center;
     justify-content: space-between;
     padding-right: 20px;
+}
+
+.collapsed-overlay {
+    background-color: black;
+    opacity: 0;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    transition: 0.4s opacity ease-in-out;
+    visibility: hidden;
+
+    @media screen and (min-width: 992px){
+        display: none;
+        width: 0;
+        height: 0;
+        overflow: hidden;
+    }
+}
+
+.overlay-init {
+    opacity: 0.7;
+    visibility: visible;
+}
+
+.sidebar-collapsed {
+    margin-left: -18rem;
+    box-shadow: none !important;
+}
+
+.collapse-button-container {
+    height: 0;
+    width: 0;
+    overflow: visible;
+
+    .collapse-button {
+        position: relative;
+        top: 14px;
+        left: 14px;
+    }
+
+    @media screen and (max-width: 768px){
+        height: 20px;
+        width: 20px;
+
+        .collapse-button {
+            top: 10px;
+            left: 10px;
+        }
+    }
+}
+
+@media (max-width: 992px){
+    .sidebar {
+        position: absolute;
+        box-shadow: 2px 0 50px 0 #292929;
+    }
+
+    .content-margin {
+        padding: 40px 80px;
+        width: 100%;
+    }
+}
+
+@media (max-width: 768px){
+    .content-margin {
+        padding: 20px 40px;
+    }
+}
+
+@media (max-width: 576px){
+    .content-margin {
+        padding: 10px 20px;
+    }
 }

--- a/docs/modules/documentation/components/documentation/documentation.component.ts
+++ b/docs/modules/documentation/components/documentation/documentation.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostListener, OnInit, ViewChild } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
@@ -45,10 +45,13 @@ export class DocumentationComponent implements OnInit {
     ];
 
     search: string = '';
+    smallScreen: boolean = window.innerWidth < 992;
+    sideCollapsed: boolean = window.innerWidth < 576;
 
     constructor(private router: Router) {}
 
     ngOnInit() {
+
         // sort the list alphabetically
         this.components.sort((el1, el2) => {
             if (el1.name < el2.name) {
@@ -80,7 +83,26 @@ export class DocumentationComponent implements OnInit {
     }
 
     onActivate() {
+        if (this.smallScreen && !this.sideCollapsed) {
+            this.sideCollapsed = true;
+        }
+
         this.skipNavClicked();
         this.contentElRef.nativeElement.scrollIntoView();
+    }
+
+    checkIfCloseSidebar() {
+        if (!this.sideCollapsed) {
+            this.sideCollapsed = !this.sideCollapsed;
+        }
+    }
+
+    windowSize() {
+        this.smallScreen = window.innerWidth < 992;
+    }
+
+    @HostListener('window:resize', ['$event'])
+    onResize() {
+        this.windowSize();
     }
 }

--- a/docs/modules/documentation/components/documentation/documentation.component.ts
+++ b/docs/modules/documentation/components/documentation/documentation.component.ts
@@ -99,7 +99,13 @@ export class DocumentationComponent implements OnInit {
     }
 
     windowSize() {
-        this.smallScreen = window.innerWidth < 992;
+        if (window.innerWidth < 992) {
+            this.smallScreen = true;
+            this.onActivate();
+        } else {
+            this.smallScreen = false;
+            this.sideCollapsed = false;
+        }
     }
 
     @HostListener('window:resize', ['$event'])

--- a/docs/modules/documentation/components/playground/playground.component.html
+++ b/docs/modules/documentation/components/playground/playground.component.html
@@ -1,7 +1,7 @@
 
 <h3>Playground</h3>
-<div class="row" [ngClass]="{'schema-block': displayBlock}">
-  <div class="col">
+<div class="row playground-wrap" [ngClass]="{'schema-block': displayBlock}">
+  <div class="col playground-content">
     <div class="json">
       <ng-content></ng-content>
     </div>

--- a/docs/modules/documentation/components/playground/playground.components.scss
+++ b/docs/modules/documentation/components/playground/playground.components.scss
@@ -5,3 +5,10 @@
 .schema-block {
     display: block;
 }
+
+@media (max-width: 576px){
+    .playground-wrap {
+        flex-wrap: wrap;
+        flex-direction: column;
+    }
+}

--- a/docs/modules/documentation/containers/button/button-docs.component.ts
+++ b/docs/modules/documentation/containers/button/button-docs.component.ts
@@ -23,7 +23,7 @@ export class ButtonDocsComponent implements OnInit {
                     },
                     fdType: {
                         type: 'string',
-                        enum: ['','standard', 'positive', 'medium', 'negative']
+                        enum: ['', 'standard', 'positive', 'medium', 'negative']
                     },
                     options: {
                         type: 'string',

--- a/docs/modules/documentation/containers/button/examples/button-icons-example.component.html
+++ b/docs/modules/documentation/containers/button/examples/button-icons-example.component.html
@@ -6,3 +6,5 @@
 <button fd-button [fdType]="'main'" [glyph]="'cart'"></button>
 <button fd-button [fdType]="'toolbar'" [glyph]="'filter'"></button>
 <button fd-button [fdType]="'positive'" [glyph]="'accept'"></button>
+<button fd-button [fdType]="'standard'" [options]="'light'" [glyph]="'menu2'"></button>
+<button fd-button [fdType]="'standard'" [options]="'light'" [glyph]="'menu2'" [size]="'l'"></button>

--- a/docs/modules/documentation/containers/time-picker/time-picker-docs.component.html
+++ b/docs/modules/documentation/containers/time-picker/time-picker-docs.component.html
@@ -7,6 +7,7 @@
 </description>
 <import module="TimePickerModule"
         path="fundamental-ngx"></import>
+<separator></separator>
 <h1>&lt;fd-time-picker&gt;</h1>
 
 <properties [properties]="{


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#417 

#### Please provide a brief summary of this pull request.
Implemented a responsive behaviour for the documentation site. The sidebar now has a collapsing feature _(not included in the fd-sidebar)_ which can be toggled from a button in the top left on small devices. It also brings up a dark overlay when the sidebar is up, which then allows mobile users to close the bar when the click is outside the sidebar.

ReadMe docs link is now a direct path to the docs site.
Made component playground flexible.
Improved button documentation a little.

[![GIF of the sidebar](https://i.gyazo.com/51785de9ade4cf02ffebce2db1288f9b.gif)](https://gyazo.com/51785de9ade4cf02ffebce2db1288f9b)

#### If this is a new feature, have you updated the documentation?
