### PR TITLE
Documentation/#414 multi modal

### DIFF
--- a/docs/modules/documentation/components/example-background/example-background.component.ts
+++ b/docs/modules/documentation/components/example-background/example-background.component.ts
@@ -3,26 +3,12 @@ import { Component, Input } from '@angular/core';
 @Component({
     selector: 'background-toggle',
     template: `
-        <span class="background-toggle--wrapper">
-            <label class="fd-form__label " for="{{id}}">
-            <span class="fd-toggle fd-toggle--s fd-form__control">
-                <input type="checkbox" name="" value="" id="{{id}}" class="{{id}}" [attr.aria-controls]="label" (change)="onChange($event)" [(ngModel)]="isChecked">
-                <span class="fd-toggle__switch" role="presentation"></span>
-            </span>
-            Toggle background
-            </label>  
-        </span>`,
+        <fd-toggle style="margin-bottom: 18px" [size]="'s'" (checkedChange)="onChange()">Toggle background</fd-toggle>
+    `,
     styles: [
-        `
-            .background-toggle--wrapper {
-                display: inline-block;
-            }
-        `
     ]
 })
 export class ExampleBackgroundComponent {
-    id = Date.now() + 1234 + '';
-    isChecked: boolean = false;
     @Input()
     label: string;
 
@@ -32,7 +18,7 @@ export class ExampleBackgroundComponent {
     @Input()
     className: string;
 
-    onChange(event) {
+    onChange() {
         const className = 'fd-has-background-color-background-1';
         if (this.label) {
             document.getElementById(this.label).classList.toggle(className);

--- a/docs/modules/documentation/containers/home/home.component.html
+++ b/docs/modules/documentation/containers/home/home.component.html
@@ -1,4 +1,4 @@
-<header>Fundamental NGX Home</header>
+<header>Fundamental NGX</header>
 <description>Fundamental NGX is an Angular component library on top of Fiori Fundamentals. We assume the user has some knowledge of Angular before using this library.</description>
 
 <separator></separator>

--- a/docs/modules/documentation/containers/modal/examples/modal-in-modal-example.component.ts
+++ b/docs/modules/documentation/containers/modal/examples/modal-in-modal-example.component.ts
@@ -5,15 +5,15 @@ import { ModalInModalComponent } from './modal-in-modal.component';
 @Component({
     selector: 'fd-modal-in-modal-example',
     template: `
-    <button fd-button (click)="openComponentAsContentModal()">Launch First Modal</button>`,
-    providers: [ModalService]
+    <button fd-button (click)="openModal()">Launch First Modal</button>`,
 })
 export class ModalInModalExampleComponent {
     modalRef;
 
-    openComponentAsContentModal() {
-        this.modalRef = this.modalService.open(ModalInModalComponent);
-        this.modalRef.instance.title = 'First Modal'
-    }
     constructor(private modalService: ModalService) {}
+
+    openModal() {
+        this.modalRef = this.modalService.open(ModalInModalComponent);
+        this.modalRef.instance.title = 'First Modal';
+    }
 }

--- a/docs/modules/documentation/containers/modal/examples/modal-in-modal-example.component.ts
+++ b/docs/modules/documentation/containers/modal/examples/modal-in-modal-example.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { ModalService } from '../../../../../../library/src/lib/modal/modal.service';
+import { ModalInModalComponent } from './modal-in-modal.component';
+
+@Component({
+    selector: 'fd-modal-in-modal-example',
+    template: `
+    <button fd-button (click)="openComponentAsContentModal()">Launch First Modal</button>`,
+    providers: [ModalService]
+})
+export class ModalInModalExampleComponent {
+    modalRef;
+
+    openComponentAsContentModal() {
+        this.modalRef = this.modalService.open(ModalInModalComponent);
+        this.modalRef.instance.title = 'First Modal'
+    }
+    constructor(private modalService: ModalService) {}
+}

--- a/docs/modules/documentation/containers/modal/examples/modal-in-modal-second.component.ts
+++ b/docs/modules/documentation/containers/modal/examples/modal-in-modal-second.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, ViewChild } from '@angular/core';
 import { ModalComponent } from '../../../../../../library/src/lib/modal/modal.component';
+import { ModalService } from '../../../../../../library/src/lib/modal/modal.service';
 
 @Component({
     selector: 'fd-modal-in-modal-second',
@@ -8,7 +9,8 @@ import { ModalComponent } from '../../../../../../library/src/lib/modal/modal.co
             {{title}}
         </fd-modal-header>
         <fd-modal-body>
-            This is the second modal!
+            This is the second modal! <br />
+            It needs to be closed before the first modal is closed.
             <button fd-button (click)="modal.close()">Close</button>
         </fd-modal-body>
     </fd-modal>`
@@ -19,5 +21,5 @@ export class ModalInModalSecondComponent {
 
     @Input() title: string;
 
-    constructor()  {}
+    constructor(public modalService: ModalService)  {}
 }

--- a/docs/modules/documentation/containers/modal/examples/modal-in-modal-second.component.ts
+++ b/docs/modules/documentation/containers/modal/examples/modal-in-modal-second.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input, ViewChild } from '@angular/core';
+import { ModalComponent } from '../../../../../../library/src/lib/modal/modal.component';
+
+@Component({
+    selector: 'fd-modal-in-modal-second',
+    template: `<fd-modal #modal>
+        <fd-modal-header>
+            {{title}}
+        </fd-modal-header>
+        <fd-modal-body>
+            This is the second modal!
+            <button fd-button (click)="modal.close()">Close</button>
+        </fd-modal-body>
+    </fd-modal>`
+})
+export class ModalInModalSecondComponent {
+
+    @ViewChild('modal') modal: ModalComponent;
+
+    @Input() title: string;
+
+    constructor()  {}
+}

--- a/docs/modules/documentation/containers/modal/examples/modal-in-modal.component.ts
+++ b/docs/modules/documentation/containers/modal/examples/modal-in-modal.component.ts
@@ -1,0 +1,33 @@
+import { Component, Input, ViewChild } from '@angular/core';
+import { ModalService } from '../../../../../../library/src/lib/modal/modal.service';
+import { ModalInModalSecondComponent } from './modal-in-modal-second.component';
+import { ModalComponent } from '../../../../../../library/src/lib/modal/modal.component';
+
+@Component({
+    selector: 'fd-modal-in-modal',
+    template: `<fd-modal #modal>
+        <fd-modal-header>
+            {{title}}
+        </fd-modal-header>
+        <fd-modal-body>
+            This is the first modal! Click the button to open the second modal.
+            <button fd-button (click)="openModal()" style="margin-right: 10px">Open Second Modal</button>
+            <button fd-button (click)="modal.close()">Close Modal</button>
+        </fd-modal-body>
+    </fd-modal>`,
+    providers: [ModalService]
+})
+export class ModalInModalComponent {
+    @ViewChild('modal') modal: ModalComponent;
+
+    @Input() title: string;
+
+    modalRef;
+
+    constructor(public modalService: ModalService)  {}
+
+    openModal() {
+        this.modalRef = this.modalService.open(ModalInModalSecondComponent);
+        this.modalRef.instance.title = 'Second Modal'
+    }
+}

--- a/docs/modules/documentation/containers/modal/examples/modal-in-modal.component.ts
+++ b/docs/modules/documentation/containers/modal/examples/modal-in-modal.component.ts
@@ -14,8 +14,7 @@ import { ModalComponent } from '../../../../../../library/src/lib/modal/modal.co
             <button fd-button (click)="openModal()" style="margin-right: 10px">Open Second Modal</button>
             <button fd-button (click)="modal.close()">Close Modal</button>
         </fd-modal-body>
-    </fd-modal>`,
-    providers: [ModalService]
+    </fd-modal>`
 })
 export class ModalInModalComponent {
     @ViewChild('modal') modal: ModalComponent;
@@ -28,6 +27,6 @@ export class ModalInModalComponent {
 
     openModal() {
         this.modalRef = this.modalService.open(ModalInModalSecondComponent);
-        this.modalRef.instance.title = 'Second Modal'
+        this.modalRef.instance.title = 'Second Modal';
     }
 }

--- a/docs/modules/documentation/containers/modal/modal-docs.component.html
+++ b/docs/modules/documentation/containers/modal/modal-docs.component.html
@@ -49,7 +49,8 @@ by the modal service's <code>open()</code> function.</p>
 <code-example [code]="contentSource" [language]="'typescript'"></code-example>
 
 <h2>Modal in a Modal</h2>
-<p>The modal component heavily relies on the ModalService, which can only support one modal at a time. To get around this limitation, you can provide the ModalService inside the modal that you create first. This allows the modal to have a different instance of the ModalService, and hence allows it to support a different nested modal.</p>
+<p>The modal component heavily relies on the ModalService, which contains every active Modal instance. To create nested modals, the service has an array of modal component references.</p>
+<p>It treats this array like a stack, adding new modals to the top and calling pop() when they are closed. For this reason, nested modals must be closed in the order they were first opened.</p>
 <component-example [name]="'ex4'">
     <fd-modal-in-modal-example></fd-modal-in-modal-example>
 </component-example>

--- a/docs/modules/documentation/containers/modal/modal-docs.component.html
+++ b/docs/modules/documentation/containers/modal/modal-docs.component.html
@@ -47,3 +47,12 @@ by the modal service's <code>open()</code> function.</p>
 </component-example>
 <code-example [code]="componentAsContentSource" [language]="'typescript'"></code-example>
 <code-example [code]="contentSource" [language]="'typescript'"></code-example>
+
+<h2>Modal in a Modal</h2>
+<p>The modal component heavily relies on the ModalService, which can only support one modal at a time. To get around this limitation, you can provide the ModalService inside the modal that you create first. This allows the modal to have a different instance of the ModalService, and hence allows it to support a different nested modal.</p>
+<component-example [name]="'ex4'">
+    <fd-modal-in-modal-example></fd-modal-in-modal-example>
+</component-example>
+<code-example [code]="modalInModalExample" [language]="'typescript'"></code-example>
+<code-example [code]="modalInModal" [language]="'typescript'"></code-example>
+<code-example [code]="modalInModalSecond" [language]="'typescript'"></code-example>

--- a/docs/modules/documentation/containers/modal/modal-docs.component.ts
+++ b/docs/modules/documentation/containers/modal/modal-docs.component.ts
@@ -6,6 +6,9 @@ import * as modalSrc from '!raw-loader!./examples/modal-example.component.ts';
 import * as modalConfirmationSrc from '!raw-loader!./examples/modal-confirmation-example.component.ts';
 import * as componentAsContentSrc from '!raw-loader!./examples/modal-component-as-content-example.component.ts';
 import * as contentSrc from '!raw-loader!./examples/modal-content.component.ts';
+import * as modalInModalExample from '!raw-loader!./examples/modal-in-modal-example.component.ts';
+import * as modalInModalComponent from '!raw-loader!./examples/modal-in-modal.component.ts';
+import * as modalInModalSecondComponent from '!raw-loader!./examples/modal-in-modal-second.component.ts';
 
 @Component({
     selector: 'app-modal',
@@ -57,6 +60,12 @@ export class ModalDocsComponent implements OnInit {
     componentAsContentSource = componentAsContentSrc;
 
     contentSource = contentSrc;
+
+    modalInModalExample = modalInModalExample;
+
+    modalInModal = modalInModalComponent;
+
+    modalInModalSecond = modalInModalSecondComponent;
 
     constructor(private schemaFactory: SchemaFactoryService) {
         this.schema = this.schemaFactory.getComponent('modal');

--- a/docs/modules/documentation/documentation.module.ts
+++ b/docs/modules/documentation/documentation.module.ts
@@ -206,6 +206,9 @@ import { ToggleDocsComponent } from './containers/toggle/toggle-docs.component';
 import { ToggleSizesExampleComponent } from './containers/toggle/examples/toggle-sizes-example/toggle-sizes-example.component';
 import { DisabledToggleExampleComponent } from './containers/toggle/examples/disabled-toggle-example/disabled-toggle-example.component';
 import { ToggleBindingExampleComponent } from './containers/toggle/examples/toggle-binding-example/toggle-binding-example.component';
+import { ModalInModalComponent } from './containers/modal/examples/modal-in-modal.component';
+import { ModalInModalSecondComponent } from './containers/modal/examples/modal-in-modal-second.component';
+import { ModalInModalExampleComponent } from './containers/modal/examples/modal-in-modal-example.component';
 
 export function highlightJsFactory() {
     return hljs;
@@ -369,6 +372,9 @@ const ROUTES: Routes = [
         ModalConfirmationExampleComponent,
         ModalContentComponent,
         ModalComponentAsContentExampleComponent,
+        ModalInModalComponent,
+        ModalInModalSecondComponent,
+        ModalInModalExampleComponent,
         PanelColumnsExampleComponent,
         PanelEdgeBleedExampleComponent,
         PanelExampleComponent,
@@ -417,7 +423,9 @@ const ROUTES: Routes = [
         ToggleBindingExampleComponent
     ],
     entryComponents: [
-        ModalContentComponent
+        ModalContentComponent,
+        ModalInModalComponent,
+        ModalInModalSecondComponent
     ],
     imports: [
         HighlightJsModule.forRoot({

--- a/library/src/lib/modal/modal.component.ts
+++ b/library/src/lib/modal/modal.component.ts
@@ -20,14 +20,22 @@ export class ModalComponent implements OnInit {
 
     constructor(@Inject(ModalService) private modalService: ModalService, private elRef: ElementRef) {}
 
-    close(result?) {
+    close(result?, closedByService: boolean = false) {
         this.elRef.nativeElement.style.display = 'none';
         this.resolve(result);
+
+        if (!closedByService) {
+            this.modalService.popModal();
+        }
     }
 
-    dismiss(reason?) {
+    dismiss(reason?, closedByService: boolean = false) {
         this.elRef.nativeElement.style.display = 'none';
         this.reject(reason);
+
+        if (!closedByService) {
+            this.modalService.popModal();
+        }
     }
 
     open() {

--- a/library/src/lib/modal/modal.service.ts
+++ b/library/src/lib/modal/modal.service.ts
@@ -1,39 +1,39 @@
 import { ComponentFactoryResolver, Injectable, ApplicationRef, Injector, EmbeddedViewRef } from '@angular/core';
 
-@Injectable({
-    providedIn: 'root'
-})
+@Injectable()
 export class ModalService {
-    private modalRef;
+    private modalRef = [];
 
     constructor(private componentFactoryResolver: ComponentFactoryResolver, private appRef: ApplicationRef, private injector: Injector) {
         this.componentFactoryResolver = componentFactoryResolver;
     }
 
     close(result?) {
-        this.modalRef.close(result);
-        this.modalRef = null;
+        this.modalRef.pop().close(result, true);
     }
 
     dismiss(reason?) {
-        this.modalRef.dismiss(reason);
-        this.modalRef = null;
+        this.modalRef.pop().dismiss(reason, true);
+    }
+
+    popModal() {
+        return this.modalRef.pop();
     }
 
     open(modalType) {
         if (typeof modalType === 'object') { // template reference variable
-            this.modalRef = modalType;
+            this.modalRef.push(modalType);
         } else if (typeof modalType === 'function') { // component as content
             const componentRef = this.componentFactoryResolver.resolveComponentFactory(modalType).create(this.injector);
-            this.modalRef = (componentRef.instance as any).modal;
-            this.modalRef.instance = componentRef.instance;
+            this.modalRef.push((componentRef.instance as any).modal);
+            this.modalRef[this.modalRef.length - 1].instance = componentRef.instance;
             this.appRef.attachView(componentRef.hostView);
             const domElem = (componentRef.hostView as EmbeddedViewRef < any > )
                 .rootNodes[0] as HTMLElement;
             document.body.appendChild(domElem);
             this.appRef.tick();
         }
-        this.modalRef.open();
-        return this.modalRef;
+        this.modalRef[this.modalRef.length - 1].open();
+        return this.modalRef[this.modalRef.length - 1];
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#414 

#### Please provide a brief summary of this pull request.
So initially it was possible to create multiple modals, but attempting to close them with the 'X' would fail due to the ModalService only being able to contain one instance of a modalRef.

I've upgraded the ModalService slightly, and it can now handle multiple modals at once. The only drawback to this method, if it even is one, is that the modals must be closed in the order in which they appear. Then again, there really is no way to close a lower-level modal from a top-level modal in our current design.

#### If this is a new feature, have you updated the documentation?
Yes