### PR TITLE
modal service - pass over modal configuration (#433)

### DIFF
--- a/docs/modules/documentation/containers/modal/examples/modal-component-as-content-example.component.ts
+++ b/docs/modules/documentation/containers/modal/examples/modal-component-as-content-example.component.ts
@@ -5,14 +5,16 @@ import { ModalContentComponent } from './modal-content.component';
 @Component({
     selector: 'fd-modal-component-as-content-example',
     template: `
-    <button fd-button (click)="openComponentAsContentModal()">Launch Component As Content Modal</button>`
+        <button fd-button (click)="openComponentAsContentModal()">Launch Component As Content Modal</button>
+    `
 })
 export class ModalComponentAsContentExampleComponent {
     modalRef;
 
     openComponentAsContentModal() {
-        this.modalRef = this.modalService.open(ModalContentComponent);
-        this.modalRef.instance.title = 'Modal Title'
+        this.modalRef = this.modalService.open(ModalContentComponent, {
+            title: 'Modal Title'
+        });
     }
     constructor(private modalService: ModalService) {}
 }

--- a/library/src/lib/modal/modal.service.ts
+++ b/library/src/lib/modal/modal.service.ts
@@ -6,7 +6,11 @@ import { ComponentFactoryResolver, Injectable, ApplicationRef, Injector, Embedde
 export class ModalService {
     private modalRef;
 
-    constructor(private componentFactoryResolver: ComponentFactoryResolver, private appRef: ApplicationRef, private injector: Injector) {
+    constructor(
+        private componentFactoryResolver: ComponentFactoryResolver,
+        private appRef: ApplicationRef,
+        private injector: Injector
+    ) {
         this.componentFactoryResolver = componentFactoryResolver;
     }
 
@@ -20,16 +24,20 @@ export class ModalService {
         this.modalRef = null;
     }
 
-    open(modalType) {
-        if (typeof modalType === 'object') { // template reference variable
+    open(modalType, modalConfig?) {
+        if (typeof modalType === 'object') {
+            // template reference variable
             this.modalRef = modalType;
-        } else if (typeof modalType === 'function') { // component as content
-            const componentRef = this.componentFactoryResolver.resolveComponentFactory(modalType).create(this.injector);
+        } else if (typeof modalType === 'function') {
+            // component as content
+            let componentRef = this.componentFactoryResolver.resolveComponentFactory(modalType).create(this.injector);
             this.modalRef = (componentRef.instance as any).modal;
+            if (modalConfig) {
+                Object.keys(modalConfig).forEach(key => (componentRef.instance[key] = modalConfig[key]));
+            }
             this.modalRef.instance = componentRef.instance;
             this.appRef.attachView(componentRef.hostView);
-            const domElem = (componentRef.hostView as EmbeddedViewRef < any > )
-                .rootNodes[0] as HTMLElement;
+            const domElem = (componentRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement;
             document.body.appendChild(domElem);
             this.appRef.tick();
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4402,12 +4402,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4422,17 +4424,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4549,7 +4554,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4561,6 +4567,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4575,6 +4582,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4582,12 +4590,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4606,6 +4616,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4686,7 +4697,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4698,6 +4710,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4819,6 +4832,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
Please provide a link to the associated issue.
#433

Please provide a brief summary of this pull request.
Initially, it was not possible when using a "component as content" model, to pass over a modal configuration.
It was necessary to update the modal instance afterwards to set the properties.

With this feature, someone can now directly reach in the modal configuration to provide specific properties, which may be required from the modal.

If this is a new feature, have you updated the documentation?
Yes
