### PR TITLE
Added proper npm link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
       <a href="https://travis-ci.org/SAP/fundamental-ngx">
             <img src="https://travis-ci.org/SAP/fundamental-ngx.svg?branch=develop" alt="Build Status">
       </a>
-      <a href="https://badge.fury.io/js/fundamental-ngx">
+      <a href="https://www.npmjs.com/package/fundamental-ngx">
             <img src="https://badge.fury.io/js/fundamental-ngx.svg" alt="npm version">
       </a>
       <a href="https://ui-fundamentals.slack.com">


### PR DESCRIPTION
#### Please provide a link to the associated issue.
None

#### Please provide a brief summary of this pull request.
ReadMe npm badge was linking to the actual image, which we don't want obviously.

#### If this is a new feature, have you updated the documentation?
