### PR TITLE
fix: temporary fix for coveralls failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
     include:
         - stage: 'Fundamental-ngx build'
           name: 'Unit tests'
-          script: './ci-scripts/unit-tests.sh'
+          script: npm run test && npm run test:coveralls
 notifications:
     email:
         on_failure: always

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "hmr": "ng serve --hmr -e=hmr",
     "build": "ng build",
     "test": "ng test fundamental-ngx --watch false --code-coverage true --browsers=ChromeHeadless",
-    "test:coveralls": "ng test fundamental-ngx --watch false --code-coverage true --browsers=ChromeHeadless && cat ./coverage/lcov.info  | ./node_modules/coveralls/bin/coveralls.js",
+    "test:coveralls": "cat ./coverage/lcov.info  | ./node_modules/coveralls/bin/coveralls.js || echo -e \"Coveralls failed.\"",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "build-src": "gulp build-src",


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#### Please provide a brief summary of this pull request.

Fundamental-react Travis builds were failing all day due to a coveralls report error. This is a known recurring issue on their end:
[lemurheavy/coveralls-public#1264](https://github.com/lemurheavy/coveralls-public/issues/1264)

This is the same method we used to fix the failure in fundamental-react, see: https://github.com/SAP/fundamental-react/pull/417

The travis build will still fail if any tests fail, but will not fail the build if the coverage cannot be reported to coveralls.

#### If this is a new feature, have you updated the documentation?
