### PR TITLE
multi-input better object support

### DIFF
--- a/docs/modules/documentation/containers/multi-input/examples/multi-input-displaywith-example/multi-input-displaywith-example.component.html
+++ b/docs/modules/documentation/containers/multi-input/examples/multi-input-displaywith-example/multi-input-displaywith-example.component.html
@@ -1,6 +1,6 @@
 <fd-multi-input [dropdownValues]="values"
                 [placeholder]="'Search here...'"
                 [(ngModel)]="selected"
-                [displayWith]="'name'"></fd-multi-input>
+                [displayFn]="displayFunc"></fd-multi-input>
 
-Selected: [<span *ngFor="let item of selected; let i = index">{{i === selected.length ? item.name : item.name + ','}}</span>]
+Selected: [<span *ngFor="let item of selected; let i = index">{{i === selected.length - 1 ? item.name : item.name + ','}}</span>]

--- a/docs/modules/documentation/containers/multi-input/examples/multi-input-displaywith-example/multi-input-displaywith-example.component.ts
+++ b/docs/modules/documentation/containers/multi-input/examples/multi-input-displaywith-example/multi-input-displaywith-example.component.ts
@@ -14,4 +14,8 @@ export class MultiInputDisplaywithExampleComponent {
     ];
 
     selected = [];
+
+    displayFunc(obj: any): string {
+        return obj.name.toLocaleUpperCase();
+    }
 }

--- a/docs/modules/documentation/containers/multi-input/multi-input-docs.component.html
+++ b/docs/modules/documentation/containers/multi-input/multi-input-docs.component.html
@@ -17,10 +17,10 @@
     { name: 'compact', description: 'Boolean. Set to \'true\' for the compact input.'},
     { name: 'glyph', description: 'String. Use to select what icon appears in the button. Defaults to down arrow.' },
     { name: 'maxHeight', description: 'String. Assigns the max height of the popover. Supports all css units.' },
-    { name: 'displayWith', description: 'String. Attribute of an object to display to the user.' },
     { name: 'searchTerm', description: 'String. The value term of the input.' },
     { name: 'selected', description: 'Array. The selected elements.' },
-    { name: 'filterFn', description: 'Function. Filter function to apply to the list. See example below.' }
+    { name: 'filterFn', description: 'Function. Filter function to apply to the list. See example below.' },
+    { name: 'displayFn', description: 'Function. Display function to apply to the list items. See example below.' }
   ],
   outputs: [
     { name: 'searchTermChange', description: 'Fired when the input changes.'},
@@ -40,7 +40,7 @@
 <separator></separator>
 
 <h2>Display Object Property</h2>
-<description>The input supports objects through the <code>displayWith</code> input. Simply tell the component what field of the object should be displayed to the user.</description>
+<description>The input supports objects through the <code>displayFn</code> input. The way the object is displayed to the user is fully customizable through providing a function that accepts the object and returns the string to be displayed. The example below shows displaying an object field in full uppercase.</description>
 <component-example [name]="'ex2'">
     <fd-multi-input-displaywith-example></fd-multi-input-displaywith-example>
 </component-example>
@@ -50,7 +50,7 @@
 <separator></separator>
 
 <h2>Custom Filter</h2>
-<description>The input supports custom filters through the <code>filterFn</code> input function.</description>
+<description>The input supports custom filters through the <code>filterFn</code> input function. Simply pass a function which accepts an array and a search term, and then returns the desired filtered array.</description>
 <component-example [name]="'ex3'">
     <fd-multi-input-filter-example></fd-multi-input-filter-example>
 </component-example>

--- a/library/src/lib/multi-input/multi-input.component.html
+++ b/library/src/lib/multi-input/multi-input.component.html
@@ -34,7 +34,7 @@
                             <label class="fd-menu__item">
                                 <input type="checkbox" class="fd-checkbox" [ngModel]="selected ? selected.indexOf(value) !== -1 : false"
                                        (ngModelChange)="handleSelect($event, value)">
-                                {{value[displayWith] ? value[displayWith] : value}}
+                                {{displayFn(value)}}
                             </label>
                         </li>
                     </fd-menu-list>
@@ -47,7 +47,7 @@
         <fd-token *ngFor="let token of selected"
                   (onCloseClick)="handleSelect(false, token)"
                   class="fd-multi-input-token-spacing">
-            {{token[displayWith] ? token[displayWith] : token}}
+            {{displayFn(token)}}
         </fd-token>
     </div>
 </div>

--- a/library/src/lib/multi-input/multi-input.component.spec.ts
+++ b/library/src/lib/multi-input/multi-input.component.spec.ts
@@ -174,7 +174,7 @@ describe('MultiInputComponent', () => {
         component.dropdownValues = [{name: text}];
         component.ngOnInit();
         component.isOpen = false;
-        component.displayWith = 'name';
+        component.displayFn = (obj: any) => obj.name;
         fixture.detectChanges();
 
         const menuItem = fixture.nativeElement.querySelector('.fd-menu__item');

--- a/library/src/lib/multi-input/multi-input.component.ts
+++ b/library/src/lib/multi-input/multi-input.component.ts
@@ -114,8 +114,8 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor {
         });
     }
 
-    private defaultDisplay(obj: any): void {
-        return obj;
+    private defaultDisplay(str: string): string {
+        return str;
     }
 
     @HostListener('document:click', ['$event'])

--- a/library/src/lib/multi-input/multi-input.component.ts
+++ b/library/src/lib/multi-input/multi-input.component.ts
@@ -37,9 +37,6 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor {
     dropdownValues: any[] = [];
 
     @Input()
-    displayWith: string;
-
-    @Input()
     searchTerm: string;
 
     @Input()
@@ -47,6 +44,9 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor {
 
     @Input()
     filterFn: Function = this.defaultFilter;
+
+    @Input()
+    displayFn: Function = this.defaultDisplay;
 
     @Output()
     searchTermChange: EventEmitter<string> = new EventEmitter<string>();
@@ -108,12 +108,14 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor {
     private defaultFilter(contentArray: any[], searchTerm: string): any[] {
         const searchLower = searchTerm.toLocaleLowerCase();
         return contentArray.filter(item => {
-            if (item[this.displayWith]) {
-                return item[this.displayWith].toLocaleLowerCase().includes(searchLower);
-            } else {
-                return item.toLocaleLowerCase().includes(searchLower);
+            if (item) {
+                return this.displayFn(item).toLocaleLowerCase().includes(searchLower);
             }
         });
+    }
+
+    private defaultDisplay(obj: any): void {
+        return obj;
     }
 
     @HostListener('document:click', ['$event'])


### PR DESCRIPTION
Allows users to provide a displayFn function, which then handles the display. With this method, users can display the text however they like. Pretty flexible compared to the previous [displayWith] property that only allowed 1-level deep object support.