### PR TITLE
chore: manual upgrade for bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 <a name="0.2.0-rc.9"></a>
-# manual upgrade for bug fix
+# manual upgrade for bug fix  
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.2.0-rc.9"></a>
+# manual upgrade for bug fix
+
+
+
 <a name="0.2.0-rc.8"></a>
 # manual upgrade for bug fix
 

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fundamental-ngx",
-  "version": "0.2.0-rc.8",
+  "version": "0.2.0-rc.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/library/package.json
+++ b/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fundamental-ngx",
-  "version": "0.2.0-rc.8",
+  "version": "0.2.0-rc.9",
   "description": "SAP Fiori Fundamentals, implemented in Angular",
   "license": "Apache-2.0",
   "homepage": "https://sap.github.io/fundamental-ngx/home",


### PR DESCRIPTION
#### Please provide a link to the associated issue.

fixes #572 

fundamental-bot's admin rights have been reinstated, we need to manually bump the version because of the where the failure occurred in the travis script. version 0.2.0-rc.9 was published to npm, but the changes were not pushed back to the repo. 

#### Please provide a brief summary of this pull request.

#### If this is a new feature, have you updated the documentation?
