### PR TITLE
fix: toggle no longer requires FormsModule

### DIFF
--- a/docs/modules/documentation/components/example-background/example-background.component.ts
+++ b/docs/modules/documentation/components/example-background/example-background.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
     selector: 'background-toggle',
     template: `
-        <fd-toggle style="margin-bottom: 18px" [size]="'xs'" (onToggle)="onChange()">Toggle background</fd-toggle>
+        <fd-toggle style="margin-bottom: 18px" [size]="'xs'" (checkedChange)="onChange()">Toggle background</fd-toggle>
     `,
     styles: [
     ]

--- a/docs/modules/documentation/containers/toggle/examples/toggle-binding-example/toggle-binding-example.component.html
+++ b/docs/modules/documentation/containers/toggle/examples/toggle-binding-example/toggle-binding-example.component.html
@@ -1,6 +1,8 @@
+<!-- Requires FormsModule -->
 <fd-toggle [(ngModel)]="firstToggle">Toggle 1</fd-toggle>
 
-<fd-toggle [(ngModel)]="secondToggle">Toggle 2</fd-toggle>
+<!-- Does not require FormsModule -->
+<fd-toggle [(checked)]="secondToggle">Toggle 2</fd-toggle>
 
 <button fd-button (click)="toggleBoth()">Toggle Both</button>
 <button fd-button (click)="toggleOne()">Toggle 1</button>

--- a/docs/modules/documentation/containers/toggle/toggle-docs.component.html
+++ b/docs/modules/documentation/containers/toggle/toggle-docs.component.html
@@ -14,9 +14,10 @@
     { name: 'id', description: 'String, set the id to use for the input and label. If none is provided, it will be generated.'},
     { name: 'size', description: 'Size of the toggle. The options include \'xs\', \'s\', default and \'l\'. If no size is provided, default will be used.\n'},
     { name: 'disabled', description: 'Boolean, disables the toggle when set to true.'},
-    { name: 'ngModel', description: 'Boolean, the state of the toggle. Initially defaults to false.'}  ],
+    { name: 'checked', description: 'Boolean, the status of the toggle.' },
+    { name: 'ngModel', description: 'Boolean, the state of the toggle. Initially defaults to false. Requires FormsModule.'}  ],
   outputs: [
-    { name: 'onToggle', description: 'Fired when the value of the toggle is switched.' }
+    { name: 'checkedChange', description: 'Fired when the value of the toggle is switched.' }
   ]
 }"></properties>
 

--- a/library/src/lib/toggle/toggle.component.spec.ts
+++ b/library/src/lib/toggle/toggle.component.spec.ts
@@ -43,7 +43,7 @@ describe('ToggleComponent', () => {
 
     it('should toggle on click', () => {
         spyOn(component, 'onChange');
-        spyOn(component.onToggle, 'emit');
+        spyOn(component.checkedChange, 'emit');
 
         component.ngOnInit();
         component.checked = false;
@@ -53,13 +53,13 @@ describe('ToggleComponent', () => {
         fixture.detectChanges();
 
         expect(component.onChange).toHaveBeenCalledWith(true);
-        expect(component.onToggle.emit).toHaveBeenCalledWith(true);
+        expect(component.checkedChange.emit).toHaveBeenCalledWith(true);
 
         input.click();
         fixture.detectChanges();
 
         expect(component.onChange).toHaveBeenCalledWith(false);
-        expect(component.onToggle.emit).toHaveBeenCalledWith(false);
+        expect(component.checkedChange.emit).toHaveBeenCalledWith(false);
     });
 
     it('should have a default size', () => {

--- a/library/src/lib/toggle/toggle.component.ts
+++ b/library/src/lib/toggle/toggle.component.ts
@@ -28,9 +28,11 @@ export class ToggleComponent implements OnInit, ControlValueAccessor {
     @Input()
     id: string;
 
+    @Input()
     checked: boolean = false;
 
-    @Output() onToggle = new EventEmitter<boolean>();
+    @Output()
+    checkedChange = new EventEmitter<boolean>();
 
     onChange: any = () => {};
     onTouched: any = () => {};
@@ -43,7 +45,7 @@ export class ToggleComponent implements OnInit, ControlValueAccessor {
         this.checked = value;
         this.onChange(value);
         this.onTouched();
-        this.onToggle.emit(value);
+        this.checkedChange.emit(value);
     }
 
     writeValue(value: any) {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #582 

#### Please provide a brief summary of this pull request.
Exposed the checked property and added checkedChange event for two-way binding without FormsModule.

#### If this is a new feature, have you updated the documentation?
yes