### PR TITLE
fix: classes no longer overriden by custom classes for some components

### DIFF
--- a/library/src/lib/calendar/calendar.component.ts
+++ b/library/src/lib/calendar/calendar.component.ts
@@ -9,7 +9,7 @@ import {
     Inject,
     forwardRef,
     OnDestroy,
-    AfterViewChecked
+    AfterViewChecked, HostBinding
 } from '@angular/core';
 import { HashService } from '../utils/hash.service';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -61,6 +61,8 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, C
     newFocusedDayId: string;
 
     init = false;
+
+    @HostBinding('class.fd-calendar') true;
 
     @Input()
     dateFromDatePicker: BehaviorSubject<any>;

--- a/library/src/lib/date-picker/date-picker.component.ts
+++ b/library/src/lib/date-picker/date-picker.component.ts
@@ -1,4 +1,15 @@
-import { Component, Input, OnInit, HostListener, ElementRef, EventEmitter, Output, forwardRef, ChangeDetectorRef } from '@angular/core';
+import {
+    Component,
+    Input,
+    OnInit,
+    HostListener,
+    ElementRef,
+    EventEmitter,
+    Output,
+    forwardRef,
+    ChangeDetectorRef,
+    HostBinding
+} from '@angular/core';
 import { CalendarDay, CalendarType } from '../calendar/calendar.component';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
@@ -8,8 +19,7 @@ import { BehaviorSubject } from 'rxjs';
     templateUrl: './date-picker.component.html',
     styleUrls: ['./date-picker.component.scss'],
     host: {
-        '(blur)': 'onTouched()',
-        class: 'fd-date-picker'
+        '(blur)': 'onTouched()'
     },
     providers: [
         {
@@ -24,6 +34,8 @@ export class DatePickerComponent implements OnInit, ControlValueAccessor {
     isValidDateInput: boolean = false;
     isOpen: boolean = false;
     dateFromDatePicker = new BehaviorSubject<string>('');
+
+    @HostBinding('class.fd-date-picker') true;
 
     @Input()
     type: CalendarType = 'single';

--- a/library/src/lib/input-group/input-group.component.ts
+++ b/library/src/lib/input-group/input-group.component.ts
@@ -1,12 +1,8 @@
 import { Component, Input, Output, EventEmitter, forwardRef } from '@angular/core';
-import { InputGroupSearchComponent } from './input-group-search.component';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({
     selector: 'fd-input-group',
-    host: {
-        class: ''
-    },
     templateUrl: './input-group.component.html',
     providers: [
         {

--- a/library/src/lib/list/list-item.component.ts
+++ b/library/src/lib/list/list-item.component.ts
@@ -1,14 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 
 @Component({
     // TODO to be discussed
     // tslint:disable-next-line:component-selector
     selector: '[fd-list-item]',
-    host: {
-        class: 'fd-list-group__item'
-    },
     template: `
         <ng-content></ng-content>
     `
 })
-export class ListItemComponent {}
+export class ListItemComponent {
+    @HostBinding('class.fd-list-group__item') true;
+}

--- a/library/src/lib/menu/menu-group.component.ts
+++ b/library/src/lib/menu/menu-group.component.ts
@@ -1,11 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 
 @Component({
     selector: 'fd-menu-group',
     templateUrl: './menu-group.component.html',
-    host: {
-        class: 'fd-menu__group'
-    },
     styles: [':host {display: block;}']
 })
-export class MenuGroupComponent {}
+export class MenuGroupComponent {
+    @HostBinding('class.fd-menu__group') true;
+}

--- a/library/src/lib/menu/menu.component.ts
+++ b/library/src/lib/menu/menu.component.ts
@@ -1,11 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 
 @Component({
     selector: 'fd-menu',
     templateUrl: './menu.component.html',
-    host: {
-        class: 'fd-menu'
-    },
     styles: [':host {display: block;}']
 })
-export class MenuComponent {}
+export class MenuComponent {
+    @HostBinding('class.fd-menu') true;
+}

--- a/library/src/lib/panel/panel-actions.component.ts
+++ b/library/src/lib/panel/panel-actions.component.ts
@@ -1,10 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 
 @Component({
     selector: 'fd-panel-actions',
-    host: {
-        class: 'fd-panel__actions'
-    },
     templateUrl: './panel-actions.component.html'
 })
-export class PanelActionsComponent {}
+export class PanelActionsComponent {
+    @HostBinding('class.fd-panel__actions') true;
+}

--- a/library/src/lib/panel/panel-body.component.ts
+++ b/library/src/lib/panel/panel-body.component.ts
@@ -3,12 +3,11 @@ import { Component, HostBinding, Input } from '@angular/core';
 @Component({
     selector: 'fd-panel-body',
     templateUrl: './panel-body.component.html',
-    host: {
-        class: 'fd-panel__body'
-    },
     styles: [':host {display: block;}']
 })
 export class PanelBodyComponent {
+
+    @HostBinding('class.fd-panel__body') true;
 
     @Input()
     @HostBinding('class.fd-panel__body--bleed')

--- a/library/src/lib/panel/panel-filters.component.ts
+++ b/library/src/lib/panel/panel-filters.component.ts
@@ -1,11 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 
 @Component({
     selector: 'fd-panel-filters',
     templateUrl: './panel-filters.component.html',
-    host: {
-        class: 'fd-panel__filters'
-    },
     styles: [':host {display: block}']
 })
-export class PanelFiltersComponent {}
+export class PanelFiltersComponent {
+    @HostBinding('class.fd-panel__filters') true;
+}

--- a/library/src/lib/panel/panel-footer.component.ts
+++ b/library/src/lib/panel/panel-footer.component.ts
@@ -1,10 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 
 @Component({
     selector: 'fd-panel-footer',
-    templateUrl: './panel-footer.component.html',
-    host: {
-        class: 'fd-panel__footer'
-    }
+    templateUrl: './panel-footer.component.html'
 })
-export class PanelFooterComponent {}
+export class PanelFooterComponent {
+    @HostBinding('class.fd-panel__footer') true;
+}

--- a/library/src/lib/panel/panel-head.component.ts
+++ b/library/src/lib/panel/panel-head.component.ts
@@ -1,10 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 
 @Component({
     selector: 'fd-panel-head',
-    templateUrl: './panel-head.component.html',
-    host: {
-        class: 'fd-panel__head'
-    }
+    templateUrl: './panel-head.component.html'
 })
-export class PanelHeadComponent {}
+export class PanelHeadComponent {
+    @HostBinding('class.fd-panel__head') true;
+}

--- a/library/src/lib/panel/panel-header.component.ts
+++ b/library/src/lib/panel/panel-header.component.ts
@@ -1,9 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 @Component({
     selector: 'fd-panel-header',
-    templateUrl: './panel-header.component.html',
-    host: {
-        class: 'fd-panel__header'
-    }
+    templateUrl: './panel-header.component.html'
 })
-export class PanelHeaderComponent {}
+export class PanelHeaderComponent {
+    @HostBinding('class.fd-panel__header') true;
+}

--- a/library/src/lib/panel/panel.component.ts
+++ b/library/src/lib/panel/panel.component.ts
@@ -1,18 +1,17 @@
-import { Component, ElementRef, Inject, Input } from '@angular/core';
+import { Component, ElementRef, HostBinding, Inject, Input } from '@angular/core';
 import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 
 @Component({
     selector: 'fd-panel',
     templateUrl: './panel.component.html',
-    host: {
-        class: 'fd-panel'
-    },
     styles: [':host {display: block;}']
 })
 export class PanelComponent extends AbstractFdNgxClass {
     @Input() columnSpan: number;
 
     @Input() backgroundImage: string;
+
+    @HostBinding('class.fd-panel') true;
 
     _setProperties() {
         if (this.columnSpan) {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #609 

#### Please provide a brief summary of this pull request.
Not sure why that wasn't working with custom classes. I think behaviour with this changed between Angular versions and the docs never reflected it. Using @HostBinding is a more modern approach to this anyways.

Fixed:

Calendar
Datepicker
InputGroup
Menu
List
Panel