### PR TITLE
chore: Release notes

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -21,8 +21,6 @@ cd ..
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" master > /dev/null 2>&1;
 
-npm run release:create -- --repo $TRAVIS_REPO_SLUG --tag $release_tag --branch master
-
 npm run build-deploy-library
 
 cd dist/fundamental-ngx
@@ -30,6 +28,9 @@ cd dist/fundamental-ngx
 npm publish
 
 cd ../..
+
+# run this after publish to make sure GitHub finishes updating from the push
+npm run release:create -- --repo $TRAVIS_REPO_SLUG --tag $release_tag --branch master
 
 npm run build-docs
 npm run deploy-docs -- --repo "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG"


### PR DESCRIPTION
#### Please provide a link to the associated issue.
n/a

#### Please provide a brief summary of this pull request.
It was found in the `fundamental` repo that the calls to GitHub API to build the release notes _could_ happen prior to the commits being pushed (or updated within GitHub).  To help ensure this works, I have moved the create release call below publish.

#### If this is a new feature, have you updated the documentation?
n/a