### PR TITLE
fix: fixed maxHeight multi-input property

### DIFF
--- a/docs/modules/documentation/containers/multi-input/examples/multi-input-displaywith-example/multi-input-displaywith-example.component.ts
+++ b/docs/modules/documentation/containers/multi-input/examples/multi-input-displaywith-example/multi-input-displaywith-example.component.ts
@@ -10,7 +10,11 @@ export class MultiInputDisplaywithExampleComponent {
         {name: 'Apple'},
         {name: 'Banana'},
         {name: 'Pineapple'},
-        {name: 'Tomato'}
+        {name: 'Tomato'},
+        {name: 'Kiwi'},
+        {name: 'Strawberry'},
+        {name: 'Blueberry'},
+        {name: 'Orange'},
     ];
 
     selected = [];

--- a/library/src/lib/multi-input/multi-input.component.html
+++ b/library/src/lib/multi-input/multi-input.component.html
@@ -19,17 +19,17 @@
                     <span class="fd-input-group__addon fd-input-group__addon--after
                         fd-input-group__addon--button">
                             <button class="fd-button--light" type="button"
-                                    [ngClass]="('sap-icon--' + this.glyph)"
+                                    [ngClass]="('sap-icon--' + glyph)"
                                     [disabled]="disabled"
                                     (click)="isOpen = !isOpen"></button>
                         </span>
                 </div>
             </div>
         </fd-popover-control>
-        <fd-popover-body
-            [style.maxHeight]="this.maxHeight"
-            [attr.aria-hidden]="!isOpen">
-            <fd-menu *ngIf="displayedValues && displayedValues.length">
+        <fd-popover-body [attr.aria-hidden]="!isOpen">
+            <fd-menu class="fd-multi-input-menu-overflow"
+                     *ngIf="displayedValues && displayedValues.length"
+                     [style.maxHeight]="maxHeight">
                 <ul fd-menu-list>
                     <li fd-menu-item *ngFor="let value of displayedValues">
                         <label class="fd-menu__item">

--- a/library/src/lib/multi-input/multi-input.component.scss
+++ b/library/src/lib/multi-input/multi-input.component.scss
@@ -18,3 +18,7 @@
 .fd-multi-input-popover-custom {
     display: block;
 }
+
+.fd-multi-input-menu-overflow {
+    overflow: auto;
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #650 

#### Please provide a brief summary of this pull request.
The maxHeight property had broken with our migration to Popper.js.
