### PR TITLE
fix: fixed missed example number in tab docs

### DIFF
--- a/docs/modules/documentation/containers/tabs/tabs-docs.component.html
+++ b/docs/modules/documentation/containers/tabs/tabs-docs.component.html
@@ -30,7 +30,7 @@
 <description>
     The tab component is very flexible, and supports dynamically adding or removing tabs.
 </description>
-<component-example [name]="'ex3'">
+<component-example [name]="'ex4'">
     <fd-adding-tab-example></fd-adding-tab-example>
 </component-example>
 <code-example [code]="addingH" [language]="'HTML'"></code-example>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#698 

#### Please provide a brief summary of this pull request.

Just fixes an example number. My bad for forgetting to change it earlier.

Now that I think about it, it'd be nice to remove this dependency on an example number 🤔 
