### PR TITLE
chore: add netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+# Global settings applied to the whole site.
+#
+# “publish” is the directory to publish (relative to root of your repo),
+# “command” is your build command,
+# “base” is directory to change to before starting build. if you set base:
+#    that is where we will look for package.json/.nvmrc/etc not repo root!
+
+[build]
+  publish = "dist"
+  command = "npm run build-docs-netlify"


### PR DESCRIPTION
After discussing with the other fundamental-* libraries, it was decided that having the `netlify.toml` file in the root provides more transparency about how netlify is working. 
