### PR TITLE
fix: support form-disabled toggle

### DIFF
--- a/library/src/lib/toggle/toggle.component.ts
+++ b/library/src/lib/toggle/toggle.component.ts
@@ -84,8 +84,13 @@ export class ToggleComponent implements OnInit, ControlValueAccessor {
     registerOnChange(fn) {
         this.onChange = fn;
     }
+
     registerOnTouched(fn) {
         this.onTouched = fn;
+    }
+
+    setDisabledState(isDisabled: boolean): void {
+        this.disabled = isDisabled;
     }
 
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes #763 

#### Please provide a brief summary of this pull request.
For some reason we didn't implement the disabled state for the toggle used as a form
