### PR TITLE
docs: separated api properties into input/output

### DIFF
--- a/docs/fd-typedoc-theme/helpers/main.helpers.js
+++ b/docs/fd-typedoc-theme/helpers/main.helpers.js
@@ -1,18 +1,18 @@
 module.exports = {
-    ifEquals: function (value1, value2, options) {
+    ifEquals: function(value1, value2, options) {
         return value1 === value2 ? options.fn(this) : options.inverse(this);
     },
-    ifNotEquals: function (value1, value2, options) {
+    ifNotEquals: function(value1, value2, options) {
         return value1 !== value2 ? options.fn(this) : options.inverse(this);
     },
-    ifDecoratorsContain: function (element, compareValue, options) {
+    ifDecoratorsContain: function(element, compareValue, options) {
         if (!element || !element.decorators) {
             return options.inverse(this);
         }
         const found = element.decorators.find(item => item.name.toLocaleUpperCase() === compareValue.toLocaleUpperCase());
         return found ? options.fn(this) : options.inverse(this);
     },
-    ifNoDecorators: function (element, options) {
+    ifNoDecorators: function(element, options) {
         if (!element || !element.decorators) {
             return options.fn(this);
         }
@@ -24,7 +24,7 @@ module.exports = {
         }
         return options.fn(this);
     },
-    ifChildrenContainDecorator: function (array, compareValue, options) {
+    ifChildrenContainDecorator: function(array, compareValue, options) {
         if (!array || array.length === 0) {
             return options.inverse(this);
         }
@@ -40,25 +40,46 @@ module.exports = {
         }
         return options.inverse(this);
     },
-    NOTifChildrenContainDecorator: function (array, options) {
+    ifChildrenContainNonDecorators: function(array, options) {
         if (!array || array.length === 0) {
-            return options.fn(this);
+            return options.inverse(this);
         }
 
         for (item of array) {
             if (item.decorators) {
                 for (dec of item.decorators) {
-                    if (dec && (dec.name.toLocaleUpperCase() === 'INPUT' || dec.name.toLocaleUpperCase() === 'OUTPUT')) {
-                        return options.inverse(this);
+                    if (dec && (dec.name.toLocaleUpperCase() !== 'INPUT' && dec.name.toLocaleUpperCase() !== 'OUTPUT')) {
+                        return options.fn(this);
                     }
                 }
+            } else {
+                return options.fn(this);
             }
         }
-        return options.fn(this);
+        return options.inverse(this);
     },
-    parseSelector: function (str) {
+    parseSelector: function(str) {
         let selectorStr = str.match(/(selector: '(.*?)')/g) + '';
         selectorStr = selectorStr.replace('selector: ', '').replace(/['\[\]]/g, '');
         return selectorStr;
+    },
+    getAllWithDecorator: function(groups, decorator, options) {
+        if (!groups || !decorator) {
+            return;
+        }
+
+        let total = [];
+        groups.forEach(group => {
+            if (group.children)
+            group.children.forEach(child => {
+                if (child.decorators)
+                child.decorators.forEach(dec => {
+                    if (dec && dec.name.toLocaleUpperCase() === decorator.toLocaleUpperCase()) {
+                        total.push(child);
+                    }
+                });
+            })
+        });
+        return options.fn(total);
     }
 };

--- a/docs/fd-typedoc-theme/helpers/main.helpers.js
+++ b/docs/fd-typedoc-theme/helpers/main.helpers.js
@@ -1,0 +1,30 @@
+module.exports = {
+    ifEquals: function (value1, value2, options) {
+        return value1 === value2 ? options.fn(this) : options.inverse(this);
+    },
+    ifDecoratorsContain: function (element, compareValue, options) {
+        if (!element || !element.decorators) {
+            return options.inverse(this);
+        }
+        const found = element.decorators.find(element => element.name.toLocaleUpperCase() === compareValue.toLocaleUpperCase());
+        return found ? options.fn(this) : options.inverse(this);
+    },
+    ifNotPreProcessedDecorator: function (element, options) {
+
+        if (!element || !element.decorators) {
+            return options.inverse(this);
+        }
+
+        const preprocessedDecorators = [
+            'INPUT',
+            'OUTPUT'
+        ];
+
+        preprocessedDecorators.forEach(decorator => {
+            if (element.decorators.find(element => element.name.toLocaleUpperCase() === decorator)) {
+                return options.inverse(this);
+            }
+        });
+        return options.fn(this);
+    }
+};

--- a/docs/fd-typedoc-theme/helpers/main.helpers.js
+++ b/docs/fd-typedoc-theme/helpers/main.helpers.js
@@ -2,29 +2,58 @@ module.exports = {
     ifEquals: function (value1, value2, options) {
         return value1 === value2 ? options.fn(this) : options.inverse(this);
     },
+    ifNotEquals: function (value1, value2, options) {
+        return value1 !== value2 ? options.fn(this) : options.inverse(this);
+    },
     ifDecoratorsContain: function (element, compareValue, options) {
         if (!element || !element.decorators) {
             return options.inverse(this);
         }
-        const found = element.decorators.find(element => element.name.toLocaleUpperCase() === compareValue.toLocaleUpperCase());
+        const found = element.decorators.find(item => item.name.toLocaleUpperCase() === compareValue.toLocaleUpperCase());
         return found ? options.fn(this) : options.inverse(this);
     },
-    ifNotPreProcessedDecorator: function (element, options) {
-
+    ifNoDecorators: function (element, options) {
         if (!element || !element.decorators) {
+            return options.fn(this);
+        }
+
+        for (item of element.decorators) {
+            if (item.name.toLocaleUpperCase() === 'OUTPUT' || item.name.toLocaleUpperCase() === 'INPUT') {
+                return options.inverse(this);
+            }
+        }
+        return options.fn(this);
+    },
+    ifChildrenContainDecorator: function (array, compareValue, options) {
+        if (!array || array.length === 0) {
             return options.inverse(this);
         }
 
-        const preprocessedDecorators = [
-            'INPUT',
-            'OUTPUT'
-        ];
-
-        preprocessedDecorators.forEach(decorator => {
-            if (element.decorators.find(element => element.name.toLocaleUpperCase() === decorator)) {
-                return options.inverse(this);
+        for (item of array) {
+            if (item.decorators) {
+                for (dec of item.decorators) {
+                    if (dec && dec.name.toLocaleUpperCase() === compareValue.toLocaleUpperCase()) {
+                        return options.fn(this);
+                    }
+                }
             }
-        });
+        }
+        return options.inverse(this);
+    },
+    NOTifChildrenContainDecorator: function (array, options) {
+        if (!array || array.length === 0) {
+            return options.fn(this);
+        }
+
+        for (item of array) {
+            if (item.decorators) {
+                for (dec of item.decorators) {
+                    if (dec && (dec.name.toLocaleUpperCase() === 'INPUT' || dec.name.toLocaleUpperCase() === 'OUTPUT')) {
+                        return options.inverse(this);
+                    }
+                }
+            }
+        }
         return options.fn(this);
     }
 };

--- a/docs/fd-typedoc-theme/helpers/main.helpers.js
+++ b/docs/fd-typedoc-theme/helpers/main.helpers.js
@@ -55,5 +55,10 @@ module.exports = {
             }
         }
         return options.fn(this);
+    },
+    parseSelector: function (str) {
+        let selectorStr = str.match(/(selector: '(.*?)')/g) + '';
+        selectorStr = selectorStr.replace('selector: ', '').replace(/['\[\]]/g, '');
+        return selectorStr;
     }
 };

--- a/docs/fd-typedoc-theme/partials/comment.hbs
+++ b/docs/fd-typedoc-theme/partials/comment.hbs
@@ -1,4 +1,14 @@
 {{#with comment}}
+    {{#with ../decorators}}
+        {{#each this}}
+            {{#ifEquals this.name 'Component'}}
+                <p class="lead"><strong>Selector:&nbsp;</strong>&lt;{{parseSelector this.arguments.obj}}&gt;</p>
+            {{/ifEquals}}
+            {{#ifEquals this.name 'Directive'}}
+                <p class="lead"><strong>Selector:&nbsp;</strong>{{parseSelector this.arguments.obj}}</p>
+            {{/ifEquals}}
+        {{/each}}
+    {{/with}}
     {{#if hasVisibleComponent}}
         <div class="tsd-comment tsd-typography">
             {{#if shortText}}

--- a/docs/fd-typedoc-theme/partials/member.hbs
+++ b/docs/fd-typedoc-theme/partials/member.hbs
@@ -1,0 +1,25 @@
+<section class="tsd-panel tsd-member {{cssClasses}}">
+    <a name="{{anchor}}" class="tsd-anchor"></a>
+    {{#if name}}
+        <h3>{{#each flags}}<span class="tsd-flag ts-flag{{this}}">{{this}}</span> {{/each}}{{{wbr name}}}</h3>
+    {{/if}}
+
+    <!-- THIS IS WHERE YOU ACCESS DECORATORS -->
+    <!-- {log decorators} -->
+
+    {{#if signatures}}
+        {{> member.signatures}}
+    {{else}}{{#if hasGetterOrSetter}}
+        {{> member.getterSetter}}
+    {{else}}
+        {{> member.declaration}}
+    {{/if}}{{/if}}
+
+    {{#each groups}}
+        {{#each children}}
+            {{#unless hasOwnDocument}}
+                {{> member}}
+            {{/unless}}
+        {{/each}}
+    {{/each}}
+</section>

--- a/docs/fd-typedoc-theme/partials/member.hbs
+++ b/docs/fd-typedoc-theme/partials/member.hbs
@@ -4,7 +4,6 @@
         <h3>{{#each flags}}<span class="tsd-flag ts-flag{{this}}">{{this}}</span> {{/each}}{{{wbr name}}}</h3>
     {{/if}}
 
-    <!-- THIS IS WHERE YOU ACCESS DECORATORS -->
     <!-- {log decorators} -->
 
     {{#if signatures}}

--- a/docs/fd-typedoc-theme/partials/members.group.hbs
+++ b/docs/fd-typedoc-theme/partials/members.group.hbs
@@ -1,19 +1,51 @@
-<section class="tsd-panel-group tsd-member-group {{cssClasses}}">
-    <h2>{{title}}</h2>
-    {{#each children}}
-        {{#unless hasOwnDocument}}
-            {{> member}}
-        {{/unless}}
-    {{/each}}
-</section>
+{{#ifEquals title 'Properties'}}
+    {{#ifChildrenContainDecorator children 'Input'}}
+        <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
+            <h2>Inputs</h2>
+            {{#each children}}
+                {{#ifDecoratorsContain this 'Input'}}
+                    {{#unless hasOwnDocument}}
+                        {{> member}}
+                    {{/unless}}
+                {{/ifDecoratorsContain}}
+            {{/each}}
+        </section>
+    {{/ifChildrenContainDecorator}}
 
-<section class="tsd-panel-group tsd-member-group {{cssClasses}}">
-    <h2>Inputs</h2>
-    {{#each children}}
-        {{#ifDecoratorsContain this 'Input'}}
+    {{#ifChildrenContainDecorator children 'Output'}}
+        <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
+            <h2>Outputs</h2>
+            {{#each children}}
+                {{#ifDecoratorsContain this 'Output'}}
+                    {{#unless hasOwnDocument}}
+                        {{> member}}
+                    {{/unless}}
+                {{/ifDecoratorsContain}}
+            {{/each}}
+        </section>
+    {{/ifChildrenContainDecorator}}
+
+    {{#NOTifChildrenContainDecorator children}}
+        <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
+            <h2>{{title}}</h2>
+            {{#each children}}
+                {{#ifNoDecorators this}}
+                    {{#unless hasOwnDocument}}
+                        {{> member}}
+                    {{/unless}}
+                {{/ifNoDecorators}}
+            {{/each}}
+        </section>
+    {{/NOTifChildrenContainDecorator}}
+{{/ifEquals}}
+
+{{#ifNotEquals title 'Properties'}}
+    <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
+        <h2>{{title}}</h2>
+        {{#each children}}
             {{#unless hasOwnDocument}}
                 {{> member}}
             {{/unless}}
-        {{/ifDecoratorsContain}}
-    {{/each}}
-</section>
+        {{/each}}
+    </section>
+{{/ifNotEquals}}

--- a/docs/fd-typedoc-theme/partials/members.group.hbs
+++ b/docs/fd-typedoc-theme/partials/members.group.hbs
@@ -1,51 +1,12 @@
-{{#ifEquals title 'Properties'}}
-    {{#ifChildrenContainDecorator children 'Input'}}
-        <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
-            <h2>Inputs</h2>
-            {{#each children}}
-                {{#ifDecoratorsContain this 'Input'}}
-                    {{#unless hasOwnDocument}}
-                        {{> member}}
-                    {{/unless}}
-                {{/ifDecoratorsContain}}
-            {{/each}}
-        </section>
-    {{/ifChildrenContainDecorator}}
-
-    {{#ifChildrenContainDecorator children 'Output'}}
-        <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
-            <h2>Outputs</h2>
-            {{#each children}}
-                {{#ifDecoratorsContain this 'Output'}}
-                    {{#unless hasOwnDocument}}
-                        {{> member}}
-                    {{/unless}}
-                {{/ifDecoratorsContain}}
-            {{/each}}
-        </section>
-    {{/ifChildrenContainDecorator}}
-
-    {{#NOTifChildrenContainDecorator children}}
-        <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
-            <h2>{{title}}</h2>
-            {{#each children}}
-                {{#ifNoDecorators this}}
-                    {{#unless hasOwnDocument}}
-                        {{> member}}
-                    {{/unless}}
-                {{/ifNoDecorators}}
-            {{/each}}
-        </section>
-    {{/NOTifChildrenContainDecorator}}
-{{/ifEquals}}
-
-{{#ifNotEquals title 'Properties'}}
+{{#ifChildrenContainNonDecorators children}}
     <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
         <h2>{{title}}</h2>
         {{#each children}}
-            {{#unless hasOwnDocument}}
-                {{> member}}
-            {{/unless}}
+            {{#ifNoDecorators this}}
+                {{#unless hasOwnDocument}}
+                    {{> member}}
+                {{/unless}}
+            {{/ifNoDecorators}}
         {{/each}}
     </section>
-{{/ifNotEquals}}
+{{/ifChildrenContainNonDecorators}}

--- a/docs/fd-typedoc-theme/partials/members.group.hbs
+++ b/docs/fd-typedoc-theme/partials/members.group.hbs
@@ -1,0 +1,19 @@
+<section class="tsd-panel-group tsd-member-group {{cssClasses}}">
+    <h2>{{title}}</h2>
+    {{#each children}}
+        {{#unless hasOwnDocument}}
+            {{> member}}
+        {{/unless}}
+    {{/each}}
+</section>
+
+<section class="tsd-panel-group tsd-member-group {{cssClasses}}">
+    <h2>Inputs</h2>
+    {{#each children}}
+        {{#ifDecoratorsContain this 'Input'}}
+            {{#unless hasOwnDocument}}
+                {{> member}}
+            {{/unless}}
+        {{/ifDecoratorsContain}}
+    {{/each}}
+</section>

--- a/docs/fd-typedoc-theme/partials/members.hbs
+++ b/docs/fd-typedoc-theme/partials/members.hbs
@@ -1,0 +1,5 @@
+{{#each groups}}
+    {{#unless allChildrenHaveOwnDocument}}
+        {{> members.group}}
+    {{/unless}}
+{{/each}}

--- a/docs/fd-typedoc-theme/partials/members.hbs
+++ b/docs/fd-typedoc-theme/partials/members.hbs
@@ -1,3 +1,29 @@
+{{#getAllWithDecorator groups 'Input'}}
+    {{#if this}}
+        <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
+            <h2>Inputs</h2>
+            {{#each this}}
+                {{#unless hasOwnDocument}}
+                    {{> member}}
+                {{/unless}}
+            {{/each}}
+        </section>
+    {{/if}}
+{{/getAllWithDecorator}}
+
+{{#getAllWithDecorator groups 'Output'}}
+    {{#if this}}
+        <section class="tsd-panel-group tsd-member-group {{cssClasses}}">
+            <h2>Outputs</h2>
+            {{#each this}}
+                {{#unless hasOwnDocument}}
+                    {{> member}}
+                {{/unless}}
+            {{/each}}
+        </section>
+    {{/if}}
+{{/getAllWithDecorator}}
+
 {{#each groups}}
     {{#unless allChildrenHaveOwnDocument}}
         {{> members.group}}

--- a/docs/styles.scss
+++ b/docs/styles.scss
@@ -180,6 +180,12 @@ a:focus {
 }
 
 .fd-playground--markdown {
+
+    #fundamental-ngx {
+        margin-top: calc(2rem + 10px);
+        font-size: 2.2rem;
+    }
+
     ol,
     ul {
         padding-left: 2rem;

--- a/library/src/lib/alert/alert.component.ts
+++ b/library/src/lib/alert/alert.component.ts
@@ -50,43 +50,43 @@ export class AlertComponent extends AbstractFdNgxClass implements OnInit, AfterV
     @ViewChild('container', {read: ViewContainerRef})
     containerRef: ViewContainerRef;
 
-    /** @Input Whether the alert is dismissible. */
+    /** Whether the alert is dismissible. */
     @Input()
     dismissible: boolean = true;
 
-    /** @Input The type of the alert. Can be one of *warning*, *success*, *information*, *error* or null. */
+    /** The type of the alert. Can be one of *warning*, *success*, *information*, *error* or null. */
     @Input()
     type: string;
 
-    /** @Input Id for the alert component. If omitted, a unique one is generated. */
+    /** Id for the alert component. If omitted, a unique one is generated. */
     @Input()
     id: string;
 
-    /** @Input Duration of time *in milliseconds* that the alert will be visible. Set to -1 for indefinite. */
+    /** Duration of time *in milliseconds* that the alert will be visible. Set to -1 for indefinite. */
     @Input()
     duration: number = 10000;
 
-    /** @Input Whether the alert should stay open if the mouse is hovering over it. */
+    /** Whether the alert should stay open if the mouse is hovering over it. */
     @Input()
     mousePersist: boolean = false;
 
-    /** @Input Id of the element that labels the alert. */
+    /** Id of the element that labels the alert. */
     @Input()
     ariaLabelledBy: string = null;
 
-    /** @Input Aria label for the alert component element. */
+    /** Aria label for the alert component element. */
     @Input()
     ariaLabel: string = null;
 
-    /** @Input Width of the alert. */
+    /** Width of the alert. */
     @Input()
     width: string;
 
-    /** @Input Alternative way of passing in a message to the alert. */
+    /** Alternative way of passing in a message to the alert. */
     @Input()
     message: string;
 
-    /** @Output Event fired when the alert is dismissed. */
+    /** Event fired when the alert is dismissed. */
     @Output()
     onDismiss: EventEmitter<undefined> = new EventEmitter<undefined>();
 

--- a/library/src/lib/badge-label/badge.component.ts
+++ b/library/src/lib/badge-label/badge.component.ts
@@ -10,10 +10,10 @@ import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
     templateUrl: './badge-label.component.html'
 })
 export class BadgeComponent extends AbstractFdNgxClass {
-    /** @Input Color coded status for the badge. Options are 'success', 'warning', and 'error'. Leave empty for default badge. */
+    /** Color coded status for the badge. Options are 'success', 'warning', and 'error'. Leave empty for default badge. */
     @Input() status;
 
-    /** @Input Modifier for the badge. Options are 'pill' and 'filled'. Leave empty for normal. */
+    /** Modifier for the badge. Options are 'pill' and 'filled'. Leave empty for normal. */
     @Input() modifier;
 
     /** @hidden */

--- a/library/src/lib/badge-label/label.component.ts
+++ b/library/src/lib/badge-label/label.component.ts
@@ -10,16 +10,16 @@ import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
     templateUrl: './badge-label.component.html'
 })
 export class LabelComponent extends AbstractFdNgxClass {
-    /** @Input Color coded status for the label. Options are 'success', 'warning', and 'error'. Leave empty for default label. */
+    /** Color coded status for the label. Options are 'success', 'warning', and 'error'. Leave empty for default label. */
     @Input() status: string = '';
 
-    /** @Input When set to 'true', the type of the label is 'Status Indicator Label'. Leave empty for default type. */
+    /** When set to 'true', the type of the label is 'Status Indicator Label'. Leave empty for default type. */
     @Input() isStatusLabel: boolean = false;
 
-    /** @Input Built-in status icon. Options include 'available', 'away', 'busy', and 'offline'. */
+    /** Built-in status icon. Options include 'available', 'away', 'busy', and 'offline'. */
     @Input() statusIcon: string = '';
 
-    /** @Input The icon used with the status indicator. See the icon page for the list of icons. */
+    /** The icon used with the status indicator. See the icon page for the list of icons. */
     @Input() icon: string = '';
 
     /** @hidden */

--- a/library/src/lib/button/button.directive.ts
+++ b/library/src/lib/button/button.directive.ts
@@ -15,23 +15,23 @@ import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 })
 export class ButtonDirective extends AbstractFdNgxClass {
 
-    /** @Input Whether to apply compact mode to the button. */
+    /** Whether to apply compact mode to the button. */
     @Input() compact: boolean;
 
-    /** @Input The icon to include in the button. See the icon page for the list of icons. */
+    /** The icon to include in the button. See the icon page for the list of icons. */
     @Input() glyph: string;
 
-    /** @Input The type of the button. Types include 'standard', 'positive', 'medium', and 'negative'.
+    /** The type of the button. Types include 'standard', 'positive', 'medium', and 'negative'.
      * Leave empty for default (Action button).'*/
     @Input() fdType: string;
 
     /** @hidden */
     @Input() semantic: string; // TODO: deprecated, leaving for backwards compatibility
 
-    /** @Input The state of the button. Options include 'normal', 'selected', and 'disabled'. Leave empty for normal. */
+    /** The state of the button. Options include 'normal', 'selected', and 'disabled'. Leave empty for normal. */
     @Input() state: string;
 
-    /** @Input Button options.  Options include 'emphasized' and 'light'. Leave empty for default.' */
+    /** Button options.  Options include 'emphasized' and 'light'. Leave empty for default.' */
     @Input() options: string | string[];
 
     /** @hidden */

--- a/library/src/lib/file-input/directives/file-dragndrop.directive.ts
+++ b/library/src/lib/file-input/directives/file-dragndrop.directive.ts
@@ -8,35 +8,35 @@ import { Directive, EventEmitter, HostListener, Input, Output } from '@angular/c
 })
 export class FileDragndropDirective {
 
-    /** @Input Whether multiple files can be dropped at once. */
+    /** Whether multiple files can be dropped at once. */
     @Input()
     multiple: boolean = true;
 
-    /** @Input Accepted file extensions. Format: `'.png,.jpg'`. */
+    /** Accepted file extensions. Format: `'.png,.jpg'`. */
     @Input()
     accept: string;
 
-    /** @Input Whether selecting of new files is disabled. */
+    /** Whether selecting of new files is disabled. */
     @Input()
     disabled: boolean = false;
 
-    /** @hidden */
+    /** Whether drag and drop is enabled. Disables this directive. */
     @Input()
     dragndrop: boolean = true;
 
-    /** @Output Event emitted when files are selected. Passes back an array of files. */
+    /** Event emitted when files are selected. Passes back an array of files. */
     @Output()
     onFileChange: EventEmitter<File[]> = new EventEmitter<File[]>();
 
-    /** @Output Event emitted when invalid files are selected. Passes back an array of files. */
+    /** Event emitted when invalid files are selected. Passes back an array of files. */
     @Output()
     onInvalidFiles: EventEmitter<File[]> = new EventEmitter<File[]>();
 
-    /** @Output Event emitted when the dragged file enters the dropzone. */
+    /** Event emitted when the dragged file enters the dropzone. */
     @Output()
     onDragEnter: EventEmitter<null> = new EventEmitter<null>();
 
-    /** @Output Event emitted when the dragged file exits the dropzone. */
+    /** Event emitted when the dragged file exits the dropzone. */
     @Output()
     onDragLeave: EventEmitter<null> = new EventEmitter<null>();
 

--- a/library/src/lib/file-input/directives/file-dragndrop.directive.ts
+++ b/library/src/lib/file-input/directives/file-dragndrop.directive.ts
@@ -26,19 +26,19 @@ export class FileDragndropDirective {
 
     /** Event emitted when files are selected. Passes back an array of files. */
     @Output()
-    onFileChange: EventEmitter<File[]> = new EventEmitter<File[]>();
+    readonly onFileChange: EventEmitter<File[]> = new EventEmitter<File[]>();
 
     /** Event emitted when invalid files are selected. Passes back an array of files. */
     @Output()
-    onInvalidFiles: EventEmitter<File[]> = new EventEmitter<File[]>();
+    readonly onInvalidFiles: EventEmitter<File[]> = new EventEmitter<File[]>();
 
     /** Event emitted when the dragged file enters the dropzone. */
     @Output()
-    onDragEnter: EventEmitter<null> = new EventEmitter<null>();
+    readonly onDragEnter: EventEmitter<void> = new EventEmitter<void>();
 
     /** Event emitted when the dragged file exits the dropzone. */
     @Output()
-    onDragLeave: EventEmitter<null> = new EventEmitter<null>();
+    readonly onDragLeave: EventEmitter<void> = new EventEmitter<void>();
 
     private elementStateCounter: number = 0;
 

--- a/library/src/lib/file-input/directives/file-select.directive.ts
+++ b/library/src/lib/file-input/directives/file-select.directive.ts
@@ -9,11 +9,11 @@ import { HostListener, HostBinding } from '@angular/core';
 })
 export class FileSelectDirective {
 
-    /** @Input Whether the input should accept multiple file selections. */
+    /** Whether the input should accept multiple file selections. */
     @Input()
     private multiple: boolean = true;
 
-    /** @Output Event emitted when files are selected. */
+    /** Event emitted when files are selected. */
     @Output()
     onFileSelect: EventEmitter<File[]> = new EventEmitter<File[]>();
 

--- a/library/src/lib/file-input/directives/file-select.directive.ts
+++ b/library/src/lib/file-input/directives/file-select.directive.ts
@@ -15,7 +15,7 @@ export class FileSelectDirective {
 
     /** Event emitted when files are selected. */
     @Output()
-    onFileSelect: EventEmitter<File[]> = new EventEmitter<File[]>();
+    readonly onFileSelect: EventEmitter<File[]> = new EventEmitter<File[]>();
 
     /** @hidden */
     @HostBinding('attr.multiple')

--- a/library/src/lib/file-input/file-input.component.ts
+++ b/library/src/lib/file-input/file-input.component.ts
@@ -47,19 +47,19 @@ export class FileInputComponent implements ControlValueAccessor {
 
     /** Event fired when files are selected. Passed object is the array of files selected. */
     @Output()
-    onSelect: EventEmitter<File[]> = new EventEmitter<File[]>();
+    readonly onSelect: EventEmitter<File[]> = new EventEmitter<File[]>();
 
     /** Event fired when some invalid files are selected. Passed object is the array of invalid files. */
     @Output()
-    onInvalidFiles: EventEmitter<File[]> = new EventEmitter<File[]>();
+    readonly onInvalidFiles: EventEmitter<File[]> = new EventEmitter<File[]>();
 
     /** Event fired when the dragged file enters the component boundaries. */
     @Output()
-    onDragEnter: EventEmitter<null> = new EventEmitter<null>();
+    readonly onDragEnter: EventEmitter<void> = new EventEmitter<void>();
 
     /** Event fired when the dragged file exits the component boundaries. */
     @Output()
-    onDragLeave: EventEmitter<null> = new EventEmitter<null>();
+    readonly onDragLeave: EventEmitter<void> = new EventEmitter<void>();
 
     /** @hidden */
     onChange: Function = () => {};

--- a/library/src/lib/file-input/file-input.component.ts
+++ b/library/src/lib/file-input/file-input.component.ts
@@ -25,39 +25,39 @@ export class FileInputComponent implements ControlValueAccessor {
     @ViewChild('input')
     inputRef: ElementRef;
 
-    /** @Input Whether the file input is disabled. */
+    /** Whether the file input is disabled. */
     @Input()
     disabled: boolean = false;
 
-    /** @Input Whether the file input should accept multiple files. */
+    /** Whether the file input should accept multiple files. */
     @Input()
     multiple: boolean = true;
 
-    /** @Input Accepted file extensions. Format: `'.png,.jpg'`. */
+    /** Accepted file extensions. Format: `'.png,.jpg'`. */
     @Input()
     accept: string;
 
-    /** @Input Whether the file input accepts drag and dropped files. */
+    /** Whether the file input accepts drag and dropped files. */
     @Input()
     dragndrop: boolean = true;
 
-    /** @Input Max file size in bytes that the input will accept. */
+    /** Max file size in bytes that the input will accept. */
     @Input()
     maxFileSize: number;
 
-    /** @Output Event fired when files are selected. Passed object is the array of files selected. */
+    /** Event fired when files are selected. Passed object is the array of files selected. */
     @Output()
     onSelect: EventEmitter<File[]> = new EventEmitter<File[]>();
 
-    /** @Output Event fired when some invalid files are selected. Passed object is the array of invalid files. */
+    /** Event fired when some invalid files are selected. Passed object is the array of invalid files. */
     @Output()
     onInvalidFiles: EventEmitter<File[]> = new EventEmitter<File[]>();
 
-    /** @Output Event fired when the dragged file enters the component boundaries. */
+    /** Event fired when the dragged file enters the component boundaries. */
     @Output()
     onDragEnter: EventEmitter<null> = new EventEmitter<null>();
 
-    /** @Output Event fired when the dragged file exits the component boundaries. */
+    /** Event fired when the dragged file exits the component boundaries. */
     @Output()
     onDragLeave: EventEmitter<null> = new EventEmitter<null>();
 

--- a/library/src/lib/multi-input/multi-input.component.ts
+++ b/library/src/lib/multi-input/multi-input.component.ts
@@ -44,60 +44,60 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
     @HostBinding('class.fd-multi-input')
     multiInputClass = true;
 
-    /** @Input Placeholder for the input field. */
+    /** Placeholder for the input field. */
     @Input()
     placeholder: string = '';
 
-    /** @Input Whether the input is disabled. */
+    /** Whether the input is disabled. */
     @Input()
     disabled: boolean = false;
 
-    /** @Input Whether the input is in compact mode. */
+    /** Whether the input is in compact mode. */
     @Input()
     compact: boolean = false;
 
-    /** @Input Max height of the popover. Any overflowing elements will be accessible through scrolling. */
+    /** Max height of the popover. Any overflowing elements will be accessible through scrolling. */
     @Input()
     maxHeight: string = '300px';
 
-    /** @Input Icon of the button on the right of the input field. */
+    /** Icon of the button on the right of the input field. */
     @Input()
     glyph: string = 'navigation-down-arrow';
 
-    /** @Input Values to be displayed in the unfiltered dropdown. */
+    /** Values to be displayed in the unfiltered dropdown. */
     @Input()
     dropdownValues: any[] = [];
 
-    /** @Input Search term, or more specifically the value of the inner input field. */
+    /** Search term, or more specifically the value of the inner input field. */
     @Input()
     searchTerm: string;
 
-    /** @Input Whether the search term should be highlighted in results. */
+    /** Whether the search term should be highlighted in results. */
     @Input()
     highlight: boolean = true;
 
-    /** @Input Selected dropdown items. */
+    /** Selected dropdown items. */
     @Input()
     selected: any[] = [];
 
-    /** @Input Filter function. Accepts an array and a string as arguments, and outputs an array.
+    /** Filter function. Accepts an array and a string as arguments, and outputs an array.
      * An arrow function can be used to access the *this* keyword in the calling component.
      * See multi input examples for details. */
     @Input()
     filterFn: Function = this.defaultFilter;
 
-    /** @Input Display function. Accepts an object of the same type as the
+    /** Display function. Accepts an object of the same type as the
      * items passed to dropdownValues as argument, and outputs a string.
      * An arrow function can be used to access the *this* keyword in the calling component.
      * See multi input examples for details. */
     @Input()
     displayFn: Function = this.defaultDisplay;
 
-    /** @Output Event emitted when the search term changes. Use *$event* to access the new term. */
+    /** Event emitted when the search term changes. Use *$event* to access the new term. */
     @Output()
     readonly searchTermChange: EventEmitter<string> = new EventEmitter<string>();
 
-    /** @Output Event emitted when the selected items change. Use *$event* to access the new selected array. */
+    /** Event emitted when the selected items change. Use *$event* to access the new selected array. */
     @Output()
     readonly selectedChange: EventEmitter<any[]> = new EventEmitter<any[]>();
 

--- a/library/src/lib/popover/popover-directive/popover.directive.ts
+++ b/library/src/lib/popover/popover-directive/popover.directive.ts
@@ -26,49 +26,49 @@ import Popper, { Placement, PopperOptions } from 'popper.js';
 })
 export class PopoverDirective implements OnInit, OnDestroy, OnChanges {
 
-    /** @Input Content of the popover. Used through the actual directive tag. Accepts strings or TemplateRefs. */
+    /** Content of the popover. Used through the actual directive tag. Accepts strings or TemplateRefs. */
     @Input('fdPopover')
     content: TemplateRef<any> | string;
 
-    /** @Input Whether the popover is open. Can be used through two-way binding. */
+    /** Whether the popover is open. Can be used through two-way binding. */
     @Input()
     isOpen: boolean = false;
 
-    /** @Input The trigger events that will open/close the popover.
+    /** The trigger events that will open/close the popover.
      *  Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp). */
     @Input()
     triggers: string[] = ['click'];
 
-    /** @Input Whether the popover should display the default arrow. */
+    /** Whether the popover should display the default arrow. */
     @Input()
     defaultArrow: boolean = false;
 
-    /** @Input The placement of the popover. It can be one of: top, top-start, top-end, bottom,
+    /** The placement of the popover. It can be one of: top, top-start, top-end, bottom,
      *  bottom-start, bottom-end, right, right-start, right-end, left, left-start, left-end. */
     @Input()
     placement: Placement;
 
-    /** @Input Whether the popover should be focusTrapped. */
+    /** Whether the popover should be focusTrapped. */
     @Input()
     focusTrapped: boolean = false;
 
-    /** @Input Whether the popover should close when the escape key is pressed. */
+    /** Whether the popover should close when the escape key is pressed. */
     @Input()
     closeOnEscapeKey: boolean = true;
 
-    /** @Input Whether the popover is disabled. */
+    /** Whether the popover is disabled. */
     @Input()
     disabled: boolean = false;
 
-    /** @Input Whether the popover should close when a click is made outside its boundaries. */
+    /** Whether the popover should close when a click is made outside its boundaries. */
     @Input()
     closeOnOutsideClick: boolean = true;
 
-    /** @Input The element to which the popover should be appended. */
+    /** The element to which the popover should be appended. */
     @Input()
     appendTo: HTMLElement | 'body' = 'body';
 
-    /** @Input The Popper.js options to attach to this popover.
+    /** The Popper.js options to attach to this popover.
      * See the [Popper.js Documentation](https://popper.js.org/popper-documentation.html) for details. */
     @Input()
     options: PopperOptions = {
@@ -82,11 +82,11 @@ export class PopoverDirective implements OnInit, OnDestroy, OnChanges {
         }
     };
 
-    /** @Input Whether the Popover Body should try to have the same width as the Popover Control. */
+    /** Whether the Popover Body should try to have the same width as the Popover Control. */
     @Input()
     fillControl: boolean = false;
 
-    /** @Output Event emitted when the state of the isOpen property changes. */
+    /** Event emitted when the state of the isOpen property changes. */
     @Output()
     isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 

--- a/library/src/lib/popover/popover.component.ts
+++ b/library/src/lib/popover/popover.component.ts
@@ -27,53 +27,53 @@ export class PopoverComponent implements OnInit {
     @ViewChild(PopoverDirective)
     directiveRef: PopoverDirective;
 
-    /** @Input Whether the popover should have an arrow. */
+    /** Whether the popover should have an arrow. */
     @Input()
     arrow: boolean = false;
 
-    /** @Input Whether the popover is disabled. */
+    /** Whether the popover is disabled. */
     @Input()
     disabled: boolean = false;
 
-    /** @Input Whether the popover should be treated as a dropdown. */
+    /** Whether the popover should be treated as a dropdown. */
     @Input()
     isDropdown: boolean = false;
 
-    /** @Input The element to which the popover should be appended. */
+    /** The element to which the popover should be appended. */
     @Input()
     appendTo: HTMLElement | 'body';
 
-    /** @Input The trigger events that will open/close the popover.
+    /** The trigger events that will open/close the popover.
      *  Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp). */
     @Input()
     triggers: string[] = ['click'];
 
-    /** @Input The placement of the popover. It can be one of: top, top-start, top-end, bottom,
+    /** The placement of the popover. It can be one of: top, top-start, top-end, bottom,
      *  bottom-start, bottom-end, right, right-start, right-end, left, left-start, left-end. */
     @Input()
     placement: Placement;
 
-    /** @Input Only to be used when the popover is used as a dropdown. The glyph to display. */
+    /** Only to be used when the popover is used as a dropdown. The glyph to display. */
     @Input()
     glyph: string;
 
-    /** @Input Only to be used when the popover is used as a dropdown. The btnType to display. */
+    /** Only to be used when the popover is used as a dropdown. The btnType to display. */
     @Input()
     btnType: string = '';
 
-    /** @Input Whether the popover is open. Can be used through two-way binding. */
+    /** Whether the popover is open. Can be used through two-way binding. */
     @Input()
     isOpen: boolean = false;
 
-    /** @Input Only to be used when the popover is used as a dropdown. Whether the dropdown is in compact format. */
+    /** Only to be used when the popover is used as a dropdown. Whether the dropdown is in compact format. */
     @Input()
     compact: boolean = false;
 
-    /** @Input Only to be used when the popover is used as a dropdown. Whether the dropdown is in a toolbar. */
+    /** Only to be used when the popover is used as a dropdown. Whether the dropdown is in a toolbar. */
     @Input()
     toolbar: boolean = false;
 
-    /** @Input The Popper.js options to attach to this popover.
+    /** The Popper.js options to attach to this popover.
      * See the [Popper.js Documentation](https://popper.js.org/popper-documentation.html) for details. */
     @Input()
     options: PopperOptions = {
@@ -87,23 +87,23 @@ export class PopoverComponent implements OnInit {
         }
     };
 
-    /** @Input Whether the popover should be focusTrapped. */
+    /** Whether the popover should be focusTrapped. */
     @Input()
     focusTrapped: boolean = false;
 
-    /** @Input Whether the Popover Body should try to have the same width as the Popover Control. */
+    /** Whether the Popover Body should try to have the same width as the Popover Control. */
     @Input()
     fillControl: boolean = false;
 
-    /** @Input Whether the popover should close when a click is made outside its boundaries. */
+    /** Whether the popover should close when a click is made outside its boundaries. */
     @Input()
     closeOnOutsideClick: boolean = true;
 
-    /** @Input Whether the popover should close when the escape key is pressed. */
+    /** Whether the popover should close when the escape key is pressed. */
     @Input()
     closeOnEscapeKey: boolean = true;
 
-    /** @Output Event emitted when the state of the isOpen property changes. */
+    /** Event emitted when the state of the isOpen property changes. */
     @Output()
     isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 

--- a/library/src/lib/search-input/search-input.component.ts
+++ b/library/src/lib/search-input/search-input.component.ts
@@ -35,63 +35,63 @@ import { MenuItemDirective } from '../menu/menu-item.directive';
 })
 export class SearchInputComponent implements ControlValueAccessor, OnInit, OnChanges {
 
-    /** @Input Values to be filtered in the search input. */
+    /** Values to be filtered in the search input. */
     @Input()
     dropdownValues: any[] = [];
 
-    /** @Input Filter function. Accepts an array of objects and a search term as arguments
+    /** Filter function. Accepts an array of objects and a search term as arguments
      * and returns a string. See search input examples for details. */
     @Input()
     filterFn: Function = this.defaultFilter;
 
-    /** @Input Whether the search input is disabled. **/
+    /** Whether the search input is disabled. **/
     @Input()
     disabled: boolean;
 
-    /** @Input Placeholder of the search input. **/
+    /** Placeholder of the search input. **/
     @Input()
     placeholder: string;
 
-    /** @Input Whether the search input is in a shellbar **/
+    /** Whether the search input is in a shellbar **/
     @Input()
     inShellbar: boolean = false;
 
-    /** @Input Icon to display in the right-side button. */
+    /** Icon to display in the right-side button. */
     @Input()
     glyph: string = 'search';
 
-    /** @Input Max height of the popover. Any overflowing elements will be accessible through scrolling. */
+    /** Max height of the popover. Any overflowing elements will be accessible through scrolling. */
     @Input()
     maxHeight: string = '200px';
 
-    /** @Input Search function to execute when the Enter key is pressed on the main input. */
+    /** Search function to execute when the Enter key is pressed on the main input. */
     @Input()
     searchFunction: Function;
 
-    /** @Input Whether the search input should be displayed in compact mode. */
+    /** Whether the search input should be displayed in compact mode. */
     @Input()
     compact: boolean = false;
 
-    /** @Input Whether the matching string should be highlighted during filtration. */
+    /** Whether the matching string should be highlighted during filtration. */
     @Input()
     highlight: boolean = true;
 
-    /** @Input Whether the popover should close when a user selects a result. */
+    /** Whether the popover should close when a user selects a result. */
     @Input()
     closeOnSelect: boolean = true;
 
-    /** @Input Whether the input field should be populated with the result picked by the user. */
+    /** Whether the input field should be populated with the result picked by the user. */
     @Input()
     fillOnSelect: boolean = true;
 
-    /** @Input Display function. Accepts an object of the same type as the
+    /** Display function. Accepts an object of the same type as the
      * items passed to dropdownValues as argument, and outputs a string.
      * An arrow function can be used to access the *this* keyword in the calling component.
      * See search input examples for details. */
     @Input()
     displayFn: Function = this.defaultDisplay;
 
-    /** @Output Event emitted when an item is clicked. Use *$event* to retrieve it. */
+    /** Event emitted when an item is clicked. Use *$event* to retrieve it. */
     @Output()
     itemClicked: EventEmitter<{item: any, index: number}> = new EventEmitter<{item: any, index: number}>();
 

--- a/library/src/lib/tabs/tab-list.component.ts
+++ b/library/src/lib/tabs/tab-list.component.ts
@@ -27,11 +27,11 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
     @ViewChildren('tabLink')
     tabLinks: QueryList<ElementRef>;
 
-    /** @Input Index of the selected tab panel. */
+    /** Index of the selected tab panel. */
     @Input()
     selectedIndex: number = 0;
 
-    /** @Output Event emitted when the selected panel changes. */
+    /** Event emitted when the selected panel changes. */
     @Output()
     selectedIndexChange = new EventEmitter<number>();
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "start": "npm run build-doc && ng serve",
         "test": "ng test fundamental-ngx --watch false --code-coverage true --browsers=ChromeHeadless",
         "test:coveralls": "cat ./coverage/lcov.info  | ./node_modules/coveralls/bin/coveralls.js || echo -e \"Coveralls failed.\"",
-        "compile-typedoc": "rm -rf docs/assets/typedoc && typedoc --out docs/assets/typedoc library/src/lib --module commonjs --mode file --exclude **/*.spec.ts --hideGenerator --excludePrivate --theme docs/fd-typedoc-theme"
+        "compile-typedoc": "rm -rf docs/assets/typedoc && typedoc --out docs/assets/typedoc library/src/lib --module commonjs --mode file --exclude **/*.spec.ts --hideGenerator --excludePrivate --theme docs/fd-typedoc-theme",
+        "compile-typedoc-json": "typedoc --json docs/assets/typedoc/typedoc.json --module commonjs --mode file --exclude **/*.spec.ts --hideGenerator --excludePrivate --theme docs/fd-typedoc-theme library/src/lib"
     },
     "publishConfig": {
         "registry": "https://repository.hybris.com/api/npm/npm-repository/"


### PR DESCRIPTION
- Separates API properties into inputs/outputs
- Adds selector of components/directives
- Removes need for @Input/@Output in the property docs
- Adds some spacing between the markdown 'home' and the top

Basically this makes the docs better