### PR TITLE
fix: added onClose event to datetime picker

### DIFF
--- a/docs/modules/documentation/containers/datetime-picker/examples/datetime-non-meridian-example/datetime-non-meridian-example.component.html
+++ b/docs/modules/documentation/containers/datetime-picker/examples/datetime-non-meridian-example/datetime-non-meridian-example.component.html
@@ -1,5 +1,5 @@
 <fd-datetime-picker [(ngModel)]="this.date" [meridian]="false"></fd-datetime-picker>
 
 <span style="padding-left: 20px;">
-    Selected: {{date.toLocaleString()}}
+    Selected: {{date ? date.toLocaleString() : 'null'}}
 </span>

--- a/docs/modules/documentation/containers/datetime-picker/examples/datetime-program-example/datetime-program-example.component.html
+++ b/docs/modules/documentation/containers/datetime-picker/examples/datetime-program-example/datetime-program-example.component.html
@@ -3,4 +3,4 @@
 <button style="margin-left: 20px;" fd-button (click)="decrementMonth()">-1 Day</button>
 
 <br /> <br />
-Selected: {{date.toLocaleString()}}
+Selected: {{date ? date.toLocaleString() : 'null'}}

--- a/library/src/lib/datetime-picker/datetime-picker.component.html
+++ b/library/src/lib/datetime-picker/datetime-picker.component.html
@@ -1,23 +1,23 @@
 <div class="fd-datetime">
     <fd-popover [(isOpen)]="isOpen"
-                (isOpenChange)="isOpenChange.emit($event)"
+                [closeOnOutsideClick]="false"
+                [closeOnEscapeKey]="false"
                 [triggers]="[]">
         <fd-popover-control>
             <div class="fd-input-group fd-input-group--after"
                  [ngClass]="{'fd-input-group--compact' : compact}">
                 <input type="text"
-                       #dateTimeInput
                        [attr.aria-label]="'datetime input'"
                        [(ngModel)]="inputFieldDate"
                        [placeholder]="placeholder"
-                       (change)="inputValueChange(dateTimeInput.value)"
+                       (change)="inputValueChange(inputFieldDate)"
                        (blur)="onBlurHandler()"
                        (click)="isOpen = true"
                        [ngClass]="{ 'fd-input--compact': compact }"
                        [disabled]="disabled">
                 <span class="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button">
                     <button class="fd-popover__control fd-button--icon fd-button--light sap-icon--date-time"
-                            (click)="openPopover(dateTimeInput.value)" aria-label="display datetime toggle"
+                            (click)="togglePopover()" aria-label="display datetime toggle"
                             [attr.aria-expanded]="isOpen" type="button"></button>
                 </span>
             </div>

--- a/library/src/lib/datetime-picker/datetime-picker.component.html
+++ b/library/src/lib/datetime-picker/datetime-picker.component.html
@@ -1,5 +1,6 @@
 <div class="fd-datetime">
     <fd-popover [(isOpen)]="isOpen"
+                (isOpenChange)="isOpenChange.emit($event)"
                 [triggers]="[]">
         <fd-popover-control>
             <div class="fd-input-group fd-input-group--after"

--- a/library/src/lib/datetime-picker/datetime-picker.component.spec.ts
+++ b/library/src/lib/datetime-picker/datetime-picker.component.spec.ts
@@ -35,7 +35,7 @@ describe('DatetimePickerComponent', () => {
         spyOn(component, 'inputValueChange');
         component.isOpen = false;
         component.isInvalidDateInput = true;
-        component.openPopover({});
+        component.openPopover();
         expect(component.inputValueChange).toHaveBeenCalled();
         expect(component.isOpen).toBe(true);
         expect(component.inputFieldDate).toBeNull();

--- a/library/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/library/src/lib/datetime-picker/datetime-picker.component.ts
@@ -74,9 +74,9 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     @Output()
     readonly timeChange: EventEmitter<Date> = new EventEmitter<Date>();
 
-    /** Event emitted when popover opens or closes. */
+    /** Event emitted when popover closes. */
     @Output()
-    readonly isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+    readonly onClose: EventEmitter<Date> = new EventEmitter<Date>();
 
     /**
      * @hidden Date of the input field. Internal use.
@@ -119,25 +119,39 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     /** @hidden */
     onTouched: any = () => {};
 
-    /** Opens the popover */
-    openPopover(e) {
-        this.isOpen = !this.isOpen;
-        this.inputValueChange(e);
-        if (this.isInvalidDateInput) {
-            this.inputFieldDate = null;
+    /** Toggles the popover. */
+    togglePopover(): void {
+        if (this.isOpen) {
+            this.closePopover();
+        } else {
+            this.openPopover();
         }
     }
 
-    closePopover() {
+    /** Opens the popover. */
+    openPopover(): void {
+        if (!this.isOpen) {
+            this.isOpen = true;
+            this.inputValueChange(this.date);
+            if (this.isInvalidDateInput) {
+                this.inputFieldDate = null;
+            }
+        }
+    }
+
+    /** Closes the popover */
+    closePopover(): void {
         if (this.isOpen) {
             if (this.isInvalidDateInput) {
                 this.inputFieldDate = null;
             }
+            this.onClose.emit(this.date);
             this.isOpen = false;
         }
     }
 
-    onBlurHandler() {
+    /** @hidden */
+    onBlurHandler(): void {
         if (this.isOpen) {
             if (this.isInvalidDateInput) {
                 this.inputFieldDate = null;
@@ -145,7 +159,8 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         }
     }
 
-    updatePickerInputHandler(d) {
+    /** @hidden */
+    updatePickerInputHandler(d): void {
         if (d.selectedDay && d.selectedDay.date) {
             d.selectedDay.date.setHours(this.date.getHours());
             d.selectedDay.date.setMinutes(this.date.getMinutes());
@@ -177,10 +192,12 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         }
     }
 
-    isInvalidDateInputHandler(e) {
+    /** @hidden */
+    isInvalidDateInputHandler(e): void {
         this.isInvalidDateInput = e;
     }
 
+    /** @hidden */
     inputValueChange(e): void {
         if (e !== '') {
             const temp = new Date(e);
@@ -199,19 +216,22 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         }
     }
 
+    /** @hidden */
     @HostListener('document:keydown.escape', [])
-    onEscapeKeydownHandler() {
+    onEscapeKeydownHandler(): void {
         this.closePopover();
     }
 
+    /** @hidden */
     @HostListener('document:click', ['$event.path'])
-    public onGlobalClick(targetElementPath: Array<any>) {
+    public onGlobalClick(targetElementPath: Array<any>): void {
         const elementRefInPath = targetElementPath.find(e => e === this.elRef.nativeElement);
         if (!elementRefInPath) {
             this.closePopover();
         }
     }
 
+    /** @hidden */
     ngOnInit(): void {
         if (this.date && this.inputFieldDate !== null) {
             this.selectedDay.date = this.date;
@@ -224,26 +244,32 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         }
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         if (this.dateFromInputSubscription) {
             this.dateFromInputSubscription.unsubscribe();
         }
     }
 
+    /** @hidden */
     constructor(private elRef: ElementRef) {}
 
+    /** @hidden */
     registerOnChange(fn: (selected: any) => {void}): void {
         this.onChange = fn;
     }
 
+    /** @hidden */
     registerOnTouched(fn: any): void {
         this.onTouched = fn;
     }
 
+    /** @hidden */
     setDisabledState(isDisabled: boolean): void {
         this.disabled = isDisabled;
     }
 
+    /** @hidden */
     writeValue(selected: Date): void {
         if (!selected) {
             return;
@@ -254,6 +280,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         this.setTime();
     }
 
+    /** @hidden */
     setTime(fireEvents = false): void {
         this.date.setHours(this.time.hour);
         this.date.setMinutes(this.time.minute);
@@ -267,7 +294,8 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         }
     }
 
-    focusArrowLeft() {
+    /** @hidden */
+    focusArrowLeft(): void {
         this.elRef.nativeElement.querySelector('#arrowLeft').focus();
     }
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes #749 

Also adds type safety, and cleans up some weird stuff that I don't remember ever seeing? Like accessing the input value directly instead of using what we have as ngModel

