### PR TITLE
fix: remove the state input from the fd-button

### DIFF
--- a/docs/modules/documentation/containers/button/button-docs.component.html
+++ b/docs/modules/documentation/containers/button/button-docs.component.html
@@ -42,16 +42,14 @@
 </component-example>
 <code-example [code]="buttonHtmlIcon" [language]="'HTML'"></code-example>
 
-<separator></separator>
-<h2>Button State</h2>
-<description>
-  Use
-  <code class="code-snippet">[state]="'disabled'"</code> or
-  <code class="code-snippet">[state]="'selected'"</code> to set button state.
-</description>
-<component-example [name]="'ex4'">
-  <fd-button-state-example></fd-button-state-example>
-</component-example>
+<separator></separator>	
+<h2>Button State</h2>	
+<description>	
+  'disabled' and 'selected' state can be achieved through native 'diasbled' / 'aria-disabled' and 'aria-selected' attributes.
+</description>	
+<component-example [name]="'ex4'">	
+  <fd-button-state-example></fd-button-state-example>	
+</component-example>	
 <code-example [code]="buttonHtmlState" [language]="'HTML'"></code-example>
 
 <separator></separator>
@@ -69,8 +67,6 @@
 <h2>Extensibility</h2>
 <description>The button implementation allows certain extensibility in terms of options for the inputs. <code>button</code>
     inputs don't have a restriction for the predefined values.
-    <br>For example, passing the value "someState" to the <code>state</code> input will result in the class
-    <code>fd-button--someState</code> being added to the button element.
     You can pass a number of custom options to the <code>options</code> input, which accepts as a parameter either a string
     or an array of strings.  For example, <code>[options]="'emphasized'"</code> will add the class <code>fd-button--emphasized</code>
     to the button.  If you'd like to add multiple options, you could use <code>[options]="['emphasized', 'option1', 'option2']"</code>.
@@ -86,7 +82,6 @@
   <button fd-button
           [fdType]="data.properties.fdType"
           [options]="data.properties.options"
-          [state]="data.properties.state"
           [compact]="data.properties.compact"
           [glyph]="data.properties.icon">
     {{data.properties.label}}

--- a/docs/modules/documentation/containers/button/button-docs.component.ts
+++ b/docs/modules/documentation/containers/button/button-docs.component.ts
@@ -658,10 +658,6 @@ export class ButtonDocsComponent implements OnInit {
                             'zoom-in',
                             'zoom-out'
                         ]
-                    },
-                    state: {
-                        type: 'string',
-                        enum: ['default', 'selected', 'disabled']
                     }
                 }
             }
@@ -677,8 +673,7 @@ export class ButtonDocsComponent implements OnInit {
             fdType: 'default',
             option: 'default',
             size: 'default',
-            icon: '',
-            state: 'default'
+            icon: ''
         }
     };
 

--- a/docs/modules/documentation/containers/button/examples/button-examples.component.ts
+++ b/docs/modules/documentation/containers/button/examples/button-examples.component.ts
@@ -28,9 +28,9 @@ export class ButtonSizesExampleComponent {}
 })
 export class ButtonIconsExampleComponent {}
 
-@Component({
-    selector: 'fd-button-state-example',
-    templateUrl: './button-state-example.component.html',
-    styleUrls: ['./button-examples.scss']
-})
+@Component({	
+    selector: 'fd-button-state-example',	
+    templateUrl: './button-state-example.component.html',	
+    styleUrls: ['./button-examples.scss']	
+})	
 export class ButtonStateExampleComponent {}

--- a/docs/modules/documentation/containers/button/examples/button-state-example.component.html
+++ b/docs/modules/documentation/containers/button/examples/button-state-example.component.html
@@ -1,3 +1,3 @@
-<button fd-button>Normal State</button>
-<button fd-button [state]="'selected'">Selected State</button>
-<button fd-button [state]="'disabled'">Disabled State</button>
+<button fd-button aria-selected="true">Selected State</button>
+<button fd-button aria-disabled="true">Disabled State</button>
+<button fd-button disabled>Disabled State</button>

--- a/library/src/lib/button/button.directive.spec.ts
+++ b/library/src/lib/button/button.directive.spec.ts
@@ -47,7 +47,6 @@ describe('ButtonDirective', () => {
         directiveInstance.compact = 'true';
         directiveInstance.glyph = 'someGlyph';
         directiveInstance.fdType = 'someFdType';
-        directiveInstance.state = 'someState';
         directiveInstance.options = 'someOption';
         directiveInstance.ngOnInit();
         expect(directiveInstance._setProperties).toHaveBeenCalled();
@@ -55,7 +54,6 @@ describe('ButtonDirective', () => {
         expect(directiveInstance._addClassToElement).toHaveBeenCalledWith('fd-button--compact');
         expect(directiveInstance._addClassToElement).toHaveBeenCalledWith('sap-icon--someGlyph');
         expect(directiveInstance._addClassToElement).toHaveBeenCalledWith('fd-button--someFdType');
-        expect(directiveInstance._addClassToElement).toHaveBeenCalledWith('is-someState');
         expect(directiveInstance._addClassToElement).toHaveBeenCalledWith('fd-button--someOption');
 
         // should handle an array of options

--- a/library/src/lib/button/button.directive.ts
+++ b/library/src/lib/button/button.directive.ts
@@ -28,9 +28,6 @@ export class ButtonDirective extends AbstractFdNgxClass {
     /** @hidden */
     @Input() semantic: string; // TODO: deprecated, leaving for backwards compatibility
 
-    /** The state of the button. Options include 'normal', 'selected', and 'disabled'. Leave empty for normal. */
-    @Input() state: string;
-
     /** Button options.  Options include 'emphasized' and 'light'. Leave empty for default.' */
     @Input() options: string | string[];
 
@@ -48,9 +45,6 @@ export class ButtonDirective extends AbstractFdNgxClass {
         }
         if (this.fdType) {
             this._addClassToElement('fd-button--' + this.fdType);
-        }
-        if (this.state) {
-            this._addClassToElement('is-' + this.state);
         }
         if (this.options) {
             if (typeof this.options === 'string') {


### PR DESCRIPTION
#### Please provide a link to the associated issue.

[#740](https://github.com/SAP/fundamental-ngx/issues/740)

#### Please provide a brief summary of this pull request.

Removed the `state` input property from the `fd-button` directive. 
 