### PR TITLE
fix: fixed datetime picker global listener

### DIFF
--- a/library/src/lib/date-picker/date-picker.component.ts
+++ b/library/src/lib/date-picker/date-picker.component.ts
@@ -131,10 +131,9 @@ export class DatePickerComponent implements OnInit, OnDestroy, ControlValueAcces
         this.closeCalendar();
     }
 
-    @HostListener('document:click', ['$event.path'])
-    public onGlobalClick(targetElementPath: Array<any>) {
-        const elementRefInPath = targetElementPath.find(e => e === this.eRef.nativeElement);
-        if (!elementRefInPath) {
+    @HostListener('document:click', ['$event'])
+    public onGlobalClick(event: MouseEvent) {
+        if (!this.eRef.nativeElement.contains(event.target)) {
             this.closeCalendar();
         }
     }

--- a/library/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/library/src/lib/datetime-picker/datetime-picker.component.ts
@@ -225,10 +225,9 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     }
 
     /** @hidden */
-    @HostListener('document:click', ['$event.path'])
-    public onGlobalClick(targetElementPath: Array<any>): void {
-        const elementRefInPath = targetElementPath.find(e => e === this.elRef.nativeElement);
-        if (!elementRefInPath) {
+    @HostListener('document:click', ['$event'])
+    public onGlobalClick(event: MouseEvent): void {
+        if (!this.elRef.nativeElement.contains(event.target)) {
             this.closePopover();
         }
     }


### PR DESCRIPTION
Bug was occurring in Safari and Firefox.

The fix is to use more conventional ways of checking for the element contents.
