### PR TITLE
chore: add packing library to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 jobs:
   include:
   - stage: Lint and Test
-    script: npm run test && npm run test:coveralls
+    script: npm run test && npm run test:coveralls && npm run build-pack-library
   - stage: Pre-release
     if: branch = master
     before_deploy:


### PR DESCRIPTION
This will prevent us from pushing something that doesn't build as an Angular library.

**The build for this PR will be fixed by #826. **
