### PR TITLE
fix: time/date/datetime picker should all handle null values the same

### DIFF
--- a/library/src/lib/date-picker/date-picker.component.ts
+++ b/library/src/lib/date-picker/date-picker.component.ts
@@ -86,6 +86,10 @@ export class DatePickerComponent implements OnInit, OnDestroy, ControlValueAcces
     @Input()
     displayCalendarToggleLabel: string = 'Display calendar toggle';
 
+    /** Whether a null input is considered valid. */
+    @Input()
+    allowNull: boolean = true;
+
     @Input()
     disableFunction = function(d): boolean {
         return false;
@@ -182,7 +186,7 @@ export class DatePickerComponent implements OnInit, OnDestroy, ControlValueAcces
             this.dateFromDatePicker.subscribe(date => {
                 if (date && typeof date === 'object') {
                     this.updateDatePickerInputHandler(date);
-                } else if (date === '') {
+                } else if (date === '' && this.allowNull) {
                     if (this.type === 'single') {
                         this.selectedDay.date = null;
                         this.selectedDay.selected = null;
@@ -194,6 +198,8 @@ export class DatePickerComponent implements OnInit, OnDestroy, ControlValueAcces
                         this.selectedRangeLast.selected = null;
                         this.onChange({date: this.selectedRangeFirst.date, rangeEnd: this.selectedRangeLast.date});
                     }
+                } else {
+                    this.isInvalidDateInput = true;
                 }
             })
         }

--- a/library/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/library/src/lib/datetime-picker/datetime-picker.component.ts
@@ -92,6 +92,10 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     @Input()
     displayDatetimeToggleLabel: string = 'Display calendar toggle';
 
+    /** Whether a null input is considered valid. */
+    @Input()
+    allowNull: boolean = true;
+
     /** Event emitted when the date changes. This can be a time or day change. */
     @Output()
     readonly dateChange: EventEmitter<Date> = new EventEmitter<Date>();
@@ -255,6 +259,8 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
                 this.setTime(true);
             }
             this.dateFromInput.next(temp.toLocaleDateString());
+        } else if (e === '' && this.allowNull) {
+            this.dateFromInput.next('');
         } else {
             this.isInvalidDateInput = true;
         }

--- a/library/src/lib/time-picker/time-picker.component.ts
+++ b/library/src/lib/time-picker/time-picker.component.ts
@@ -66,6 +66,10 @@ export class TimePickerComponent implements ControlValueAccessor, OnInit {
     @Input()
     timePickerInputLabel: string = 'Time picker input';
 
+    /** Whether a null input is considered valid. */
+    @Input()
+    allowNull: boolean = true;
+
     /** @hidden Whether the input time is valid. Internal use. */
     isInvalidTimeInput: boolean = false;
 
@@ -167,6 +171,13 @@ export class TimePickerComponent implements ControlValueAccessor, OnInit {
                     this.time.second = parseInt(splitString[2], 10);
                 }
                 this.isInvalidTimeInput = false;
+                this.onChange(this.time);
+            } else if (timeFromInput === '' && this.allowNull) {
+                this.isInvalidTimeInput = false;
+                this.time.second = null;
+                this.time.minute = null;
+                this.time.hour = null;
+                this.child.setDisplayedHour();
                 this.onChange(this.time);
             } else {
                 this.isInvalidTimeInput = true;


### PR DESCRIPTION
fixes #831 

also adds a boolean "allowNull" input to these components, so the dev can decide if a null input would be considered valid or not