### PR TITLE
Date parser data/month switch fix

### DIFF
--- a/library/src/lib/calendar/format/date-parser.ts
+++ b/library/src/lib/calendar/format/date-parser.ts
@@ -42,7 +42,7 @@ export class DateFormatParserDefault extends DateFormatParser {
      * @param value String to convert to a date.
      */
     public parse(value: string): Date {
-        return new Date(value);
+        return new Date(value.split('.').reverse().join('.'));
     }
 
     /**


### PR DESCRIPTION
#### Please provide a link to the associated issue.
It's possible to reproduce error on docs:  {{baseurl}}/datetime-picker
#### Please provide a brief summary of this pull request.
Every time the datepicker popup is opened the days and months chenge their places
It's caused by wrong usage of parsing function.

`public parse(value: string): Date {
        console.log(value); // 5.06.2019
        console.log(new Date(value)); // Mon May 06 2019 00:00:00 GMT+0200
        return new Date(value);
    }`
#### If this is a new feature, have you updated the documentation?
