### PR TITLE
fix: month gets skipped when the current date is the 31st and the user clicks next month button

### DIFF
--- a/library/src/lib/calendar/calendar.component.ts
+++ b/library/src/lib/calendar/calendar.component.ts
@@ -614,7 +614,19 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, C
     }
 
     setCurrentMonth(month: number) {
+        // get the current date of the month
+        const currentDate = this.date.getDate();
+        /*
+         set the date to the first for now, to prevent skipping a month
+         in the event that the currentDate is 31 and the next month has 30 days
+         */
+        this.date.setDate(1);
+        // set the month
         this.date.setMonth(month);
+        // get the number of days in this month
+        const daysInMonth = new Date(this.date.getFullYear(), this.date.getMonth() + 1, 0).getDate();
+        // restore the date to whichever number is lower, today's date or the number of days in this month
+        this.date.setDate(Math.min(currentDate, daysInMonth));
         this.month = this.date.getMonth();
         this.monthName = this.monthsFullName[this.date.getMonth()];
         this.year = this.date.getFullYear();

--- a/library/src/lib/calendar/calendar.component.ts
+++ b/library/src/lib/calendar/calendar.component.ts
@@ -616,17 +616,21 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, C
     setCurrentMonth(month: number) {
         // get the current date of the month
         const currentDate = this.date.getDate();
+        // get the number of days in the new month
+        const daysInNewMonth = new Date(this.date.getFullYear(), month + 1, 0).getDate();
         /*
-         set the date to the first for now, to prevent skipping a month
+         if the currentDate > daysInNewMonth, set the date to the first for now, to prevent skipping a month
          in the event that the currentDate is 31 and the next month has 30 days
          */
-        this.date.setDate(1);
+        if (currentDate > daysInNewMonth) {
+            this.date.setDate(1);
+        }
         // set the month
         this.date.setMonth(month);
-        // get the number of days in this month
-        const daysInMonth = new Date(this.date.getFullYear(), this.date.getMonth() + 1, 0).getDate();
-        // restore the date to whichever number is lower, today's date or the number of days in this month
-        this.date.setDate(Math.min(currentDate, daysInMonth));
+        // if currentDate > daysInNewMonth, restore the date to whichever number is lower, today's date or the number of days in this month
+        if (currentDate > daysInNewMonth) {
+            this.date.setDate(Math.min(currentDate, daysInNewMonth));
+        }
         this.month = this.date.getMonth();
         this.monthName = this.monthsFullName[this.date.getMonth()];
         this.year = this.date.getFullYear();


### PR DESCRIPTION
fixes #855 

Fixed bug where if the 31st day of the month is selected and the user clicks the next month button, and the next month has fewer than 31 days, the next month will be skipped and the one after that will be displayed.  So for example if Jan 31 is selected and the next month button is clicked, March will be displayed.