### PR TITLE
fix: Add min-width option on alerts with default value

### DIFF
--- a/docs/app/documentation/component-docs/alert/examples/alert-component-as-content-example.component.ts
+++ b/docs/app/documentation/component-docs/alert/examples/alert-component-as-content-example.component.ts
@@ -14,7 +14,7 @@ export class AlertComponentAsContentExampleComponent {
     openFromComponent() {
         this.alertService.open(AlertContentComponent, {
             type: 'warning',
-            minWidth: '400px',
+            minWidth: '300px',
             mousePersist: true,
             duration: 7500,
             data: {

--- a/docs/app/documentation/component-docs/alert/examples/alert-component-as-content-example.component.ts
+++ b/docs/app/documentation/component-docs/alert/examples/alert-component-as-content-example.component.ts
@@ -14,6 +14,7 @@ export class AlertComponentAsContentExampleComponent {
     openFromComponent() {
         this.alertService.open(AlertContentComponent, {
             type: 'warning',
+            minWidth: '400px',
             mousePersist: true,
             duration: 7500,
             data: {

--- a/library/src/lib/alert/alert-service/alert.service.ts
+++ b/library/src/lib/alert/alert-service/alert.service.ts
@@ -49,6 +49,11 @@ export class AlertService {
         // Get default values from alert model
         alertConfig = Object.assign(new AlertConfig(), alertConfig);
 
+        // Ensure default minimum width
+        if (alertConfig && !alertConfig.minWidth) {
+            alertConfig.minWidth = '300px';
+        }
+
         // Config setup
         const configMap = new WeakMap();
         const alertRef = new AlertRef();

--- a/library/src/lib/alert/alert-service/alert.service.ts
+++ b/library/src/lib/alert/alert-service/alert.service.ts
@@ -49,11 +49,6 @@ export class AlertService {
         // Get default values from alert model
         alertConfig = Object.assign(new AlertConfig(), alertConfig);
 
-        // Ensure default minimum width
-        if (alertConfig && !alertConfig.minWidth) {
-            alertConfig.minWidth = '300px';
-        }
-
         // Config setup
         const configMap = new WeakMap();
         const alertRef = new AlertRef();

--- a/library/src/lib/alert/alert-utils/alert-config.ts
+++ b/library/src/lib/alert/alert-utils/alert-config.ts
@@ -16,6 +16,9 @@ export class AlertConfig {
     /** Width of the alert. */
     width?: string = '33vw';
 
+    /** Minimum width of the alert. */
+    minWidth?: string = '300px';
+
     /** Data being injected into the child component or template. */
     data?: any;
 

--- a/library/src/lib/alert/alert.component.ts
+++ b/library/src/lib/alert/alert.component.ts
@@ -34,6 +34,7 @@ let alertUniqueId: number = 0;
         '[attr.aria-labelledby]': 'ariaLabelledBy',
         '[attr.aria-label]': 'ariaLabel',
         '[style.width]': 'width',
+        '[style.min-width]': 'minWidth',
         'role': 'alert',
         '[attr.id]': 'id',
         '[@fadeAlertNgIf]': ''
@@ -84,6 +85,10 @@ export class AlertComponent extends AbstractFdNgxClass implements OnInit, AfterV
     /** Width of the alert. */
     @Input()
     width: string;
+
+    /** Minimum width of the alert. */
+    @Input()
+    minWidth: string;
 
     /** Alternative way of passing in a message to the alert. */
     @Input()


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/654
#### Please provide a brief summary of this pull request.
I included minimum width option to alert component which handles responsive problems. By default right now min-width is set to 300px, which means that it will look good on every device.
#### If this is a new feature, have you updated the documentation?
I put this option usage into one example