### PR TITLE
fix: Add removed classes while changed on grid panel

### DIFF
--- a/library/src/lib/panel/panel-grid/panel-grid.component.ts
+++ b/library/src/lib/panel/panel-grid/panel-grid.component.ts
@@ -15,7 +15,7 @@ export class PanelGridComponent extends AbstractFdNgxClass {
     @Input()
     col: number;
 
-    /** Whether the grid shoul have a gap. */
+    /** Whether the grid should have a gap. */
     @Input()
     @HostBinding('class.fd-panel-grid--nogap')
     nogap: boolean = false;
@@ -31,6 +31,14 @@ export class PanelGridComponent extends AbstractFdNgxClass {
 
     /** @hidden */
     _setProperties() {
+        if (this.fdPanelGridClass) {
+            this._addClassToElement('fd-panel-grid');
+        }
+
+        if (this.nogap) {
+            this._addClassToElement('fd-panel-grid--nogap');
+        }
+
         if (this.col) {
             this._addClassToElement('fd-panel-grid--' + this.col + 'col');
         }

--- a/library/src/lib/panel/panel-grid/panel-grid.component.ts
+++ b/library/src/lib/panel/panel-grid/panel-grid.component.ts
@@ -12,17 +12,10 @@ import { AbstractFdNgxClass } from '../../utils/abstract-fd-ngx-class';
 export class PanelGridComponent extends AbstractFdNgxClass {
 
     /** Number of columns for the grid. */
-    @Input()
-    col: number;
+    @Input() col: number;
 
     /** Whether the grid should have a gap. */
-    @Input()
-    @HostBinding('class.fd-panel-grid--nogap')
-    nogap: boolean = false;
-
-    /** @hidden */
-    @HostBinding('class.fd-panel-grid')
-    fdPanelGridClass: boolean = true;
+    @Input() nogap: boolean = false;
 
     /** @hidden */
     constructor(private elementRef: ElementRef) {
@@ -31,9 +24,7 @@ export class PanelGridComponent extends AbstractFdNgxClass {
 
     /** @hidden */
     _setProperties() {
-        if (this.fdPanelGridClass) {
-            this._addClassToElement('fd-panel-grid');
-        }
+        this._addClassToElement('fd-panel-grid');
 
         if (this.nogap) {
             this._addClassToElement('fd-panel-grid--nogap');


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/864
#### Please provide a brief summary of this pull request.
In issue there is noticed that, basic fd-grid-panel classes dissapear, when number of columns is changed 
#### If this is a new feature, have you updated the documentation?
Not needed.