### PR TITLE
Fix: Remove isComponent inputs

### DIFF
--- a/docs/app/documentation/component-docs/dropdown/examples/dropdown-default-example.component.html
+++ b/docs/app/documentation/component-docs/dropdown/examples/dropdown-default-example.component.html
@@ -1,6 +1,7 @@
-<fd-popover style="margin-right: 12px;"
-            [isDropdown]="true">
-    Dropdown
+<fd-popover style="margin-right: 12px;">
+    <fd-popover-control>
+        <fd-dropdown>Compact Dropdown</fd-dropdown>
+    </fd-popover-control>
     <fd-popover-body *ngIf="menu1 && menu1.length || menu2 && menu2.length">
         <fd-menu>
             <ul fd-menu-list>
@@ -22,9 +23,10 @@
     </fd-popover-body>
 </fd-popover>
 
-<fd-popover [isDropdown]="true"
-            [compact]="true">
-    Compact Dropdown
+<fd-popover>
+    <fd-popover-control>
+        <fd-dropdown [compact]="true">Compact Dropdown</fd-dropdown>
+    </fd-popover-control>
     <fd-popover-body *ngIf="menu1 && menu1.length">
         <fd-menu>
             <ul fd-menu-list>

--- a/docs/app/documentation/component-docs/dropdown/examples/dropdown-icons-example.component.html
+++ b/docs/app/documentation/component-docs/dropdown/examples/dropdown-icons-example.component.html
@@ -1,6 +1,7 @@
-<fd-popover [isDropdown]="true"
-            [glyph]="'filter'">
-    Dropdown
+<fd-popover>
+    <fd-popover-control>
+        <fd-dropdown [glyph]="'filter'">Dropdown</fd-dropdown>
+    </fd-popover-control>
     <fd-popover-body *ngIf="menu1 && menu1.length">
         <fd-menu>
             <ul fd-menu-list>

--- a/docs/app/documentation/component-docs/dropdown/examples/dropdown-infinite-scroll-example.component.html
+++ b/docs/app/documentation/component-docs/dropdown/examples/dropdown-infinite-scroll-example.component.html
@@ -1,5 +1,7 @@
-<fd-popover [isDropdown]="true">
-    Dropdown
+<fd-popover>
+    <fd-popover-control>
+        <fd-dropdown>Dropdown</fd-dropdown>
+    </fd-popover-control>
     <fd-popover-body>
         <fd-menu>
             <ul fd-menu-list fdInfiniteScroll (onScrollAction)="loadMoreElements()" [scrollPercent]="scrollPercent"

--- a/docs/app/documentation/component-docs/dropdown/examples/dropdown-state-example.component.html
+++ b/docs/app/documentation/component-docs/dropdown/examples/dropdown-state-example.component.html
@@ -1,6 +1,7 @@
-<fd-popover [isDropdown]="true"
-            [disabled]="true">
-    Dropdown
+<fd-popover [disabled]="true">
+    <fd-popover-control>
+        <fd-dropdown [disabled]="true">Dropdown</fd-dropdown>
+    </fd-popover-control>
     <fd-popover-body *ngIf="menu1 && menu1.length">
         <fd-menu>
             <ul fd-menu-list>

--- a/docs/app/documentation/component-docs/dropdown/examples/dropdown-toolbar-example.component.html
+++ b/docs/app/documentation/component-docs/dropdown/examples/dropdown-toolbar-example.component.html
@@ -1,7 +1,7 @@
-<fd-popover style="margin-right: 12px"
-            [isDropdown]="true"
-            [toolbar]="true">
-    Dropdown
+<fd-popover style="margin-right: 12px">
+    <fd-popover-control>
+        <fd-dropdown [toolbar]="true">Dropdown</fd-dropdown>
+    </fd-popover-control>
     <fd-popover-body *ngIf="menu1 && menu1.length || menu2 && menu2.length">
         <fd-menu>
             <ul fd-menu-list>
@@ -23,10 +23,10 @@
     </fd-popover-body>
 </fd-popover>
 
-<fd-popover [isDropdown]="true"
-            [compact]="true"
-            [toolbar]="true">
-    Compact Dropdown
+<fd-popover>
+    <fd-popover-control>
+        <fd-dropdown [toolbar]="true" [compact]="true">Compact Dropdown</fd-dropdown>
+    </fd-popover-control>
     <fd-popover-body *ngIf="menu1 && menu1.length">
         <fd-menu>
             <ul fd-menu-list>

--- a/library/src/lib/calendar/calendar.component.ts
+++ b/library/src/lib/calendar/calendar.component.ts
@@ -98,9 +98,9 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, C
     @Output()
     isInvalidDateInput: EventEmitter<any> = new EventEmitter();
 
-    /** @hidden Used when this calendar is for a date time picker component. For internal use. */
+    /** Whether wants to allow escape focus, otherwise it resets on beginning. */
     @Input()
-    isDateTimePicker: boolean = false;
+    allowFocusEscape: boolean = false;
 
     /** @hidden Whether the date is invalid. Internal use. */
     invalidDate: boolean = false;
@@ -881,7 +881,7 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, C
             }
             newFocusedYearId = '#' + this.id + '-fd-year-' + (year + 1);
         } else if (event.code === 'Tab' && !event.shiftKey) {
-            if (!this.isDateTimePicker) {
+            if (!this.allowFocusEscape) {
                 event.preventDefault();
                 this.focusElement('#arrowLeft');
             }
@@ -918,7 +918,7 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, C
                 newFocusedMonthId = '#' + this.id + '-fd-month-' + (month + 1);
             }
         } else if (event.code === 'Tab' && !event.shiftKey) {
-            if (!this.isDateTimePicker) {
+            if (!this.allowFocusEscape) {
                 event.preventDefault();
                 this.focusElement('#arrowLeft');
             }
@@ -931,7 +931,7 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, C
     /** @hidden */
     onKeydownDayHandler(event, cell) {
         if (event.code === 'Tab' && !event.shiftKey) {
-            if (!this.isDateTimePicker) {
+            if (!this.allowFocusEscape) {
                 event.preventDefault();
                 this.focusElement('#arrowLeft');
             }

--- a/library/src/lib/datetime-picker/datetime-picker.component.html
+++ b/library/src/lib/datetime-picker/datetime-picker.component.html
@@ -37,7 +37,7 @@
                              [(selectedDay)]="selectedDay"
                              (isInvalidDateInput)="isInvalidDateInputHandler($event)"
                              [dateFromDatePicker]="dateFromInput"
-                             [isDateTimePicker]="true"
+                             [allowFocusEscape]="true"
                              [startingDayOfWeek]="startingDayOfWeek"></fd-calendar>
                 <div class="fd-datetime__separator"></div>
                 <fd-time [disabled]="disabled"
@@ -46,7 +46,6 @@
                          (ngModelChange)="setTime(true)"
                          [spinners]="spinners"
                          [displaySeconds]="displaySeconds"
-                         [isDateTimePicker]="true"
                          (focusArrowLeft)="focusArrowLeft()"></fd-time>
             </div>
         </fd-popover-body>

--- a/library/src/lib/popover/popover-dropdown/popover-dropdown.component.html
+++ b/library/src/lib/popover/popover-dropdown/popover-dropdown.component.html
@@ -1,0 +1,19 @@
+<div class="fd-dropdown">
+    <button
+        fd-button
+        class="fd-dropdown__control fd-button"
+        [ngClass]="
+                    (btnType ? ' fd-button--' + btnType : '') +
+                    (glyph ? ' sap-icon--' + glyph : '') +
+                    (compact ? ' fd-button--compact' : '') +
+                    (this.disabled ? ' is-disabled' : '') +
+                    (toolbar ? ' fd-button--standard': '')
+                "
+        [attr.aria-expanded]="this.disabled ? false : isOpen"
+        [attr.aria-disabled]="this.disabled"
+        aria-haspopup="true"
+        [disabled]="disabled"
+    >
+        <ng-content></ng-content>
+    </button>
+</div>

--- a/library/src/lib/popover/popover-dropdown/popover-dropdown.component.spec.ts
+++ b/library/src/lib/popover/popover-dropdown/popover-dropdown.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { PopoverDropdownComponent } from './popover-dropdown.component';
+
+
+describe('PopoverControlComponent', () => {
+    let component: PopoverDropdownComponent;
+    let fixture: ComponentFixture<PopoverDropdownComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [PopoverDropdownComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(PopoverDropdownComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/library/src/lib/popover/popover-dropdown/popover-dropdown.component.ts
+++ b/library/src/lib/popover/popover-dropdown/popover-dropdown.component.ts
@@ -1,0 +1,66 @@
+import { Component, Host, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { PopoverComponent } from '../popover.component';
+/**
+ * A component used to enforce a certain layout for the popover. With additional styling
+ * ```html
+ * <fd-popover>
+ *     <fd-popover-control>
+ *         <fd-dropdown>Dropdown</fd-dropdown>
+ *     </fd-popover-control>
+ *     <fd-popover-body>Popover Body</fd-popover-body>
+ * </fd-popover>
+ * ```
+ */
+@Component({
+    selector: 'fd-dropdown',
+    host: {
+        class: 'fd-dropdown',
+    },
+    templateUrl: 'popover-dropdown.component.html',
+    encapsulation: ViewEncapsulation.None
+})
+export class PopoverDropdownComponent implements OnDestroy {
+    /** Whether the popover should have an arrow. */
+    @Input()
+    noArrow: boolean = true;
+
+    /** Whether the popover is disabled. */
+    @Input()
+    disabled: boolean = false;
+
+    /** The glyph to display. */
+    @Input()
+    glyph: string;
+
+    /** The btnType to display. */
+    @Input()
+    btnType: string = '';
+
+    /** Whether the dropdown is in compact format. */
+    @Input()
+    compact: boolean = false;
+
+    /** Whether the dropdown is in a toolbar. */
+    @Input()
+    toolbar: boolean = false;
+
+    /** Whether the dropdown is opened. */
+    @Input()
+    isOpen: boolean = false;
+
+    /** Whether the dropdown is opened */
+    isOpenChange$: Subscription;
+
+    constructor(
+        @Host() popoverComponent: PopoverComponent
+    ) {
+        if (popoverComponent && popoverComponent.isOpenChange) {
+            this.isOpenChange$ = popoverComponent.isOpenChange.subscribe(isOpen => this.isOpen = isOpen)
+        }
+    }
+
+    public ngOnDestroy(): void {
+        this.isOpenChange$ = null;
+    }
+}

--- a/library/src/lib/popover/popover.component.html
+++ b/library/src/lib/popover/popover.component.html
@@ -1,42 +1,4 @@
-<div *ngIf="isDropdown" class="fd-dropdown"
-     [ngClass]="{ 'fd-dropdown--compact': compact, 'fd-dropdown--toolbar': toolbar }">
-    <div #popoverDropdownContainer>
-        <div class="fd-popover__control">
-            <button
-                fd-button
-                class="fd-dropdown__control fd-button"
-                [ngClass]="
-                    (btnType ? ' fd-button--' + btnType : '') +
-                    (glyph ? ' sap-icon--' + glyph : '') +
-                    (compact ? ' fd-button--compact' : '') +
-                    (this.disabled ? ' is-disabled' : '') +
-                    (toolbar ? ' fd-button--standard': '')
-                "
-                [attr.aria-expanded]="this.disabled ? false : isOpen"
-                [attr.aria-disabled]="this.disabled"
-                aria-haspopup="true"
-                [fdPopover]="popoverDropdownBody"
-                [(isOpen)]="isOpen"
-                [noArrow]="noArrow"
-                [disabled]="disabled"
-                [triggers]="triggers"
-                [placement]="placement"
-                [focusTrapped]="focusTrapped"
-                (isOpenChange)="isOpenChange.emit($event)"
-                [options]="options"
-                [fillControl]="fillControl"
-                [closeOnOutsideClick]="closeOnOutsideClick"
-                [closeOnEscapeKey]="closeOnEscapeKey"
-                [appendTo]="(appendTo ? appendTo : popoverDropdownContainer)">
-                <ng-content></ng-content>
-            </button>
-        </div>
-        <ng-template #popoverDropdownBody>
-            <ng-container *ngTemplateOutlet="popoverBodyTpl"></ng-container>
-        </ng-template>
-    </div>
-</div>
-<div *ngIf="!isDropdown" #popoverContainer>
+<div #popoverContainer>
     <div class="fd-popover__control"
          [attr.aria-expanded]="this.disabled ? false : isOpen"
          [attr.aria-disabled]="this.disabled"

--- a/library/src/lib/popover/popover.component.ts
+++ b/library/src/lib/popover/popover.component.ts
@@ -58,25 +58,9 @@ export class PopoverComponent {
     @Input()
     placement: Placement;
 
-    /** Only to be used when the popover is used as a dropdown. The glyph to display. */
-    @Input()
-    glyph: string;
-
-    /** Only to be used when the popover is used as a dropdown. The btnType to display. */
-    @Input()
-    btnType: string = '';
-
     /** Whether the popover is open. Can be used through two-way binding. */
     @Input()
     isOpen: boolean = false;
-
-    /** Only to be used when the popover is used as a dropdown. Whether the dropdown is in compact format. */
-    @Input()
-    compact: boolean = false;
-
-    /** Only to be used when the popover is used as a dropdown. Whether the dropdown is in a toolbar. */
-    @Input()
-    toolbar: boolean = false;
 
     /** The Popper.js options to attach to this popover.
      * See the [Popper.js Documentation](https://popper.js.org/popper-documentation.html) for details. */

--- a/library/src/lib/popover/popover.module.ts
+++ b/library/src/lib/popover/popover.module.ts
@@ -6,11 +6,19 @@ import { PopoverControlComponent } from './popover-control/popover-control.compo
 import { PopoverBodyComponent } from './popover-body/popover-body.component';
 import { PopoverDirective } from './popover-directive/popover.directive';
 import { PopoverContainer } from './popover-directive/popover-container';
+import { PopoverDropdownComponent } from './popover-dropdown/popover-dropdown.component';
 
 @NgModule({
-    declarations: [PopoverComponent, PopoverControlComponent, PopoverBodyComponent, PopoverDirective, PopoverContainer],
+    declarations: [
+        PopoverComponent,
+        PopoverControlComponent,
+        PopoverBodyComponent,
+        PopoverDirective,
+        PopoverContainer,
+        PopoverDropdownComponent
+    ],
     imports: [CommonModule],
-    exports: [PopoverComponent, PopoverControlComponent, PopoverBodyComponent, PopoverDirective],
+    exports: [PopoverComponent, PopoverControlComponent, PopoverBodyComponent, PopoverDirective, PopoverDropdownComponent],
     entryComponents: [PopoverContainer]
 })
 export class PopoverModule {}

--- a/library/src/lib/time/time.component.ts
+++ b/library/src/lib/time/time.component.ts
@@ -50,10 +50,6 @@ export class TimeComponent implements OnChanges, ControlValueAccessor {
     time: TimeObject = { hour: 0, minute: 0, second: 0 };
 
     /** @hidden */
-    @Input()
-    isDateTimePicker: boolean = false;
-
-    /** @hidden */
     @Output()
     focusArrowLeft: EventEmitter<any> = new EventEmitter<any>();
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/771
#### Please provide a brief summary of this pull request.
I removed:
- isDropdown, instead of it I added it as new component to popover module
- Time isDateTimePicker input 
- Calendar isDateTimePicker input I changed name to make it more clear, keyboard logic is too complex to refactor.
#### If this is a new feature, have you updated the documentation?
Updated by itself.