### PR TITLE
fix: fd-tree throwing error when used without header

### DIFF
--- a/library/src/lib/tree/tree.component.ts
+++ b/library/src/lib/tree/tree.component.ts
@@ -64,11 +64,25 @@ export class TreeComponent implements OnInit, AfterContentInit {
     }
 
     handleEmptyTrailingCells(row) {
-        if (row && row.rowData && row.rowData.length && typeof row.rowData[0] !== 'object') {
+        if (
+            row &&
+            row.rowData &&
+            row.rowData.length &&
+            typeof row.rowData[0] !== 'object' &&
+            this.headers &&
+            this.headers.length
+        ) {
             while (row.rowData.length < this.headers.length) {
                 row.rowData.push('');
             }
-        } else if (row && row.rowData && row.rowData.length && typeof row.rowData[0] === 'object') {
+        } else if (
+            row &&
+            row.rowData &&
+            row.rowData.length &&
+            typeof row.rowData[0] === 'object' &&
+            this.headers &&
+            this.headers.length
+        ) {
             while (row.rowData.length < this.headers.length) {
                 row.rowData.push({
                     displayText: ''


### PR DESCRIPTION
#### Please provide a link to the associated issue.
No issue, found the issue while using fd-tree.

#### Please provide a brief summary of this pull request.
When using the `<fd-tree>` without a `[header]` this part of the code throws errors because `this.header` is undefined, practically making `[header]` a mandatory attribute even if you do not need headers (currently you need to provide an empty array).

#### If this is a new feature, have you updated the documentation?
As a side note the documentation for <fd-tree> I could not find on https://sap.github.io/fundamental-ngx/home.