### PR TITLE
docs: added an example to the fd-toggle docs (using reactive forms)

### DIFF
--- a/docs/app/documentation/component-docs/toggle/examples/toggle-form-example/toggle-forms-example.component.html
+++ b/docs/app/documentation/component-docs/toggle/examples/toggle-form-example/toggle-forms-example.component.html
@@ -1,0 +1,10 @@
+<form [formGroup]="customForm">
+    <fd-toggle formControlName="toggle1">Toggle 1</fd-toggle>
+    <fd-toggle formControlName="toggle2">Toggle 2</fd-toggle>
+    <fd-toggle formControlName="toggle3">Toggle 3</fd-toggle>
+</form>
+<br />
+
+Toggle 1: {{ customForm.controls.toggle1.value }} <br />
+Toggle 2: {{ customForm.controls.toggle2.value }} <br />
+Toggle 3: {{ customForm.controls.toggle3.value }}

--- a/docs/app/documentation/component-docs/toggle/examples/toggle-form-example/toggle-forms-example.component.ts
+++ b/docs/app/documentation/component-docs/toggle/examples/toggle-form-example/toggle-forms-example.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+
+@Component({
+    selector: 'fd-toggle-forms-example',
+    templateUrl: './toggle-forms-example.component.html'
+})
+export class ToggleFormsExampleComponent {
+    customForm = new FormGroup({
+        toggle1: new FormControl(false),
+        toggle2: new FormControl(false),
+        toggle3: new FormControl(false)
+    });
+};

--- a/docs/app/documentation/component-docs/toggle/toggle-docs.component.html
+++ b/docs/app/documentation/component-docs/toggle/toggle-docs.component.html
@@ -22,6 +22,16 @@
 <code-example [code]="toggleBindingHtml" [language]="'HTML'"></code-example>
 <code-example [code]="toggleBindingTs" [language]="'typescript'"></code-example>
 
+<separator></separator>
+<h2>Toggle used within Form</h2>
+<description>It is possible to use the fd-toggle component within Angular Reactive Forms</description>
+<component-example [name]="'ex4'">
+    <fd-toggle-forms-example></fd-toggle-forms-example>
+</component-example>
+<code-example [code]="toggleFormExampleHtml" [language]="'HTML'"></code-example>
+<code-example [code]="toggleFormExampleTs" [language]="'typescript'"></code-example>
+
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
-    <fd-toggle [disabled]="data.properties.disabled" [(ngModel)]="data.properties.checked" [size]="data.modifier.size">Example Toggle</fd-toggle>
+    <fd-toggle [disabled]="data.properties.disabled" [(ngModel)]="data.properties.checked" [size]="data.modifier.size">
+        Example Toggle</fd-toggle>
 </playground>

--- a/docs/app/documentation/component-docs/toggle/toggle-docs.component.ts
+++ b/docs/app/documentation/component-docs/toggle/toggle-docs.component.ts
@@ -5,6 +5,8 @@ import * as toggleBindingExampleHtml from '!raw-loader!./examples/toggle-binding
 import * as toggleBindingExampleTs from '!raw-loader!./examples/toggle-binding-example/toggle-binding-example.component.ts';
 import { Schema } from '../../../schema/models/schema.model';
 import { SchemaFactoryService } from '../../../schema/services/schema-factory/schema-factory.service';
+import * as toggleFormExampleHtmlSrc from '!raw-loader!./examples/toggle-form-example/toggle-forms-example.component.html';
+import * as toggleFormExampleTsSrc from '!raw-loader!./examples/toggle-form-example/toggle-forms-example.component.ts';
 
 @Component({
     selector: 'app-toggle',
@@ -54,6 +56,8 @@ export class ToggleDocsComponent {
     toggleDisableHtml = toggleDisableExample;
     toggleBindingHtml = toggleBindingExampleHtml;
     toggleBindingTs = toggleBindingExampleTs;
+    toggleFormExampleHtml = toggleFormExampleHtmlSrc;
+    toggleFormExampleTs = toggleFormExampleTsSrc;
 
     constructor(private schemaFactory: SchemaFactoryService) {
         this.schema = this.schemaFactory.getComponent('toggle');

--- a/docs/app/documentation/documentation.module.ts
+++ b/docs/app/documentation/documentation.module.ts
@@ -209,6 +209,7 @@ import { ToggleDocsComponent } from './component-docs/toggle/toggle-docs.compone
 import { ToggleSizesExampleComponent } from './component-docs/toggle/examples/toggle-sizes-example/toggle-sizes-example.component';
 import { DisabledToggleExampleComponent } from './component-docs/toggle/examples/disabled-toggle-example/disabled-toggle-example.component';
 import { ToggleBindingExampleComponent } from './component-docs/toggle/examples/toggle-binding-example/toggle-binding-example.component';
+import { ToggleFormsExampleComponent } from './component-docs/toggle/examples/toggle-form-example/toggle-forms-example.component';
 import { ListInfiniteScrollExampleComponent } from './component-docs/list/examples/list-infinite-scroll-example.component';
 import { DropdownInfiniteScrollExampleComponent } from './component-docs/dropdown/examples/dropdown-infinite-scroll-example.component';
 import { ModalInModalComponent } from './component-docs/modal/examples/stackable-modals/modal-in-modal.component';
@@ -527,6 +528,7 @@ export function highlightJsFactory() {
         ToggleSizesExampleComponent,
         DisabledToggleExampleComponent,
         ToggleBindingExampleComponent,
+        ToggleFormsExampleComponent,
         TokenDocsComponent,
         TokenExampleComponent,
         ToolbarComponent,


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#677 

#### Please provide a brief summary of this pull request.

Adds another example to the fd-toggle component in the documentation (using angular reactive forms)

#### If this is a new feature, have you updated the documentation?

Not necessary

