### PR TITLE
chore: fundamental-styles migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 ## Description
 
-The `fundamental-ngx` library is a set of [Angular](https://angular.io/) components built using [SAP Fiori Fundamentals](https://sap.github.io/fundamental/).
+The `fundamental-ngx` library is a set of [Angular](https://angular.io/) components built using [SAP Fundamental Styles](https://sap.github.io/fundamental-styles/).
 
-The SAP Fiori Fundamentals library is a design system and HTML/CSS component library used to build modern product user experiences with the SAP look and feel.
+The SAP Fundamental Styles library is a design system and HTML/CSS component library used to build modern product user experiences with the SAP look and feel.
 
 ## API Reference
 
@@ -29,16 +29,16 @@ Prior knowledge of Angular is recommended.
 
 For an existing Angular application,
 
-1. **Install Fundamental-ngx and Fiori Fundamentals.**
+1. **Install Fundamental-ngx and Fundamental Styles.**
 
     ```
-    npm install --save fiori-fundamentals fundamental-ngx
+    npm install --save fundamental-styles fundamental-ngx
     ```
 
-2. **Include Fiori Fundamentals CSS in the `styles` array of the `angular.json` file.**
+2. **Include Fundamental Styles CSS in the `styles` array of the `angular.json` file.**
 
-    ```scss
-    "./node_modules/fiori-fundamentals/dist/fiori-fundamentals.min.css"
+    ```
+    "node_modules/fundamental-styles/dist/fundamental-styles.min.css"
     ```
 
     _Note the path may be different if your CLI configuration is not in the root of your project directory._

--- a/angular.json
+++ b/angular.json
@@ -22,7 +22,7 @@
                         ],
                         "styles": [
                             "docs/fd-typedoc/assets/css/main.scss",
-                            "node_modules/fiori-fundamentals/dist/fiori-fundamentals.css",
+                            "node_modules/fundamental-styles/dist/fundamental-styles.min.css",
                             "docs/styles.scss"
                         ],
                         "scripts": [

--- a/library/package.json
+++ b/library/package.json
@@ -16,7 +16,7 @@
     "@angular/core": "^7.2.7",
     "@angular/forms": "^7.2.7",
     "@angular/animations": "^7.2.7",
-    "fiori-fundamentals": "^1.4.3",
+    "fundamental-styles": "^0.1.0",
     "rxjs": "^6.4.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3990,11 +3990,6 @@
                 "locate-path": "^2.0.0"
             }
         },
-        "fiori-fundamentals": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/fiori-fundamentals/-/fiori-fundamentals-1.6.0.tgz",
-            "integrity": "sha512-ueTreQyyy3THjlmgu3v/MTE6WyPyjcATPSfe55MN+dBHlHKHrA/9K6nMueXoe+MmAvmiGI+weqbkPgGCU6lAhQ=="
-        },
         "flatted": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
@@ -4188,7 +4183,8 @@
                     "version": "2.1.1",
                     "resolved": false,
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -4212,13 +4208,15 @@
                     "version": "1.0.0",
                     "resolved": false,
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "resolved": false,
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -4233,19 +4231,22 @@
                     "version": "1.1.0",
                     "resolved": false,
                     "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": false,
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "resolved": false,
                     "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -4374,7 +4375,8 @@
                     "version": "2.0.3",
                     "resolved": false,
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -4388,6 +4390,7 @@
                     "resolved": false,
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -4404,6 +4407,7 @@
                     "resolved": false,
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -4526,7 +4530,8 @@
                     "version": "1.0.1",
                     "resolved": false,
                     "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -4540,6 +4545,7 @@
                     "resolved": false,
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -4676,6 +4682,7 @@
                     "resolved": false,
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -4697,6 +4704,7 @@
                     "resolved": false,
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -4729,7 +4737,8 @@
                     "version": "1.0.2",
                     "resolved": false,
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
@@ -4749,6 +4758,11 @@
                 "mkdirp": ">=0.5 0",
                 "rimraf": "2"
             }
+        },
+        "fundamental-styles": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.1.0.tgz",
+            "integrity": "sha512-nLC2ZMTmxhq4kvP4hypQkx7CnUlXfjYfE7KQJrX6D6zLpb1zAuIuwuEv/D2FEqDkir4T9/nYnYg+agW6T8Mt7Q=="
         },
         "gauge": {
             "version": "2.7.4",
@@ -8873,9 +8887,9 @@
                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
                 },
                 "fstream": {
-                    "version": "1.0.11",
-                    "resolved": false,
-                    "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+                    "version": "1.0.12",
+                    "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+                    "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
                     "requires": {
                         "graceful-fs": "^4.1.2",
                         "inherits": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "dist/fundamental-ngx/index.js",
+    "description": "SAP Fundamentals, implemented in Angular",
     "scripts": {
         "build": "ng build",
         "build-docs": "npm run compile-typedoc && npm run copy-docs && ng build --prod --base-href=\"/fundamental-ngx/\" ",
@@ -42,8 +43,8 @@
         "@types/node": "^12.0.8",
         "angular-highlight-js": "^2.0.1",
         "core-js": "^2.6.9",
-        "fiori-fundamentals": "^1.6.0",
         "focus-trap": "^5.0.1",
+        "fundamental-styles": "^0.1.0",
         "highlight.js": "^9.15.6",
         "ngx-highlightjs": "^3.0.3",
         "ngx-markdown": "^8.0.2",


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes #880 

#### Please provide a brief summary of this pull request.
Migrates our documentation to fundamental-styles and also adds the new repo to the peer dependencies of the lib. Note that fiori-fundamental is still compatible with fundamental-ngx, but that may eventually change so migrating now is encouraged.