### PR TITLE
fix: Add Input id on calendar and popover to allow custom

### DIFF
--- a/library/src/lib/calendar/calendar.component.ts
+++ b/library/src/lib/calendar/calendar.component.ts
@@ -69,8 +69,6 @@ let calendarUniqueId: number = 0;
     encapsulation: ViewEncapsulation.None
 })
 export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, ControlValueAccessor, OnChanges {
-    /** @hidden id for the calendar */
-    id: string;
 
     /** @hidden The id of the newly focused day. Internal use. */
     newFocusedDayId: string;
@@ -85,6 +83,10 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, C
     /** @hidden Subject the calendar subscribes to when the date value from the datePicker component changes. Internal use. */
     @Input()
     dateFromDatePicker: Subject<any>;
+
+    /** Id of the calendar. If none is provided, one will be generated. */
+    @Input()
+    id = 'fd-calendar-' + calendarUniqueId++;
 
     /** The type of calendar, 'single' for single date selection or 'range' for a range of dates. */
     @Input()
@@ -1067,7 +1069,6 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewChecked, C
 
         this.constructCalendar();
         this.constructCalendarYearsList();
-        this.id = 'fd-calendar-' + calendarUniqueId++;
         if (this.month) {
             this.selectMonth(this.month);
         } else {

--- a/library/src/lib/popover/popover.component.ts
+++ b/library/src/lib/popover/popover.component.ts
@@ -112,7 +112,8 @@ export class PopoverComponent {
     @Output()
     isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-    /** @hidden */
+    /** Id of the popover. If none is provided, one will be generated. */
+    @Input()
     id: string = 'fd-popover-' + popoverUniqueId++;
 
     /**


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes https://github.com/SAP/fundamental-ngx/issues/947
#### Please provide a brief summary of this pull request.
I added id inputs for calendar and popover to allow user putting custom ids 
#### If this is a new feature, have you updated the documentation?
-