### PR TITLE
fix: only handle input change on keyup.enter or blur for datepicker/dateti…

### DIFF
--- a/docs/app/documentation/component-docs/date-picker/date-picker-docs.component.html
+++ b/docs/app/documentation/component-docs/date-picker/date-picker-docs.component.html
@@ -9,6 +9,10 @@
 <description>
   The default format for the input is MM/DD/YYYY. See the 'Formatting' section for details on how to change this.
 </description>
+<description>
+    The value for the input only changes the model on blur or an enter/return keystroke.  Submitting a partially correct input - such as "1/1/20"
+    will automatically set the date to "1/1/2020".
+</description>
 <component-example [name]="'ex1'">
   <fd-date-picker-single-example></fd-date-picker-single-example>
 </component-example>

--- a/docs/app/documentation/component-docs/datetime-picker/datetime-picker-docs.component.html
+++ b/docs/app/documentation/component-docs/datetime-picker/datetime-picker-docs.component.html
@@ -4,6 +4,10 @@
     The alternative is to use the date input combined with the dateChange output.
     There is also added <code>[position]</code> attribute which allows us to decide where popup should be shown
 </description>
+<description>
+    The value for the input only changes the model on blur or an enter/return keystroke.  Submitting a partially correct input - such as "1/1/20"
+    will automatically set the date to "1/1/2020".
+</description>
 <component-example [name]="'ex1'">
     <app-datetime-example></app-datetime-example>
 </component-example>

--- a/library/src/lib/date-picker/date-picker.component.html
+++ b/library/src/lib/date-picker/date-picker.component.html
@@ -9,7 +9,8 @@
                    [attr.aria-label]="dateInputLabel"
                    [value]="inputFieldDate"
                    [placeholder]="placeholder"
-                   (keyup)="getInputValue(datePicker.value)"
+                   (keyup.enter)="getInputValue(datePicker.value)"
+                   (blur)="getInputValue(datePicker.value)"
                    (click)="openCalendar(datePicker.value)"
                    [ngClass]="{ 'fd-input--compact': compact, 'is-invalid': isInvalidDateInput && validate }">
             <span class="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button">

--- a/library/src/lib/datetime-picker/datetime-picker.component.html
+++ b/library/src/lib/datetime-picker/datetime-picker.component.html
@@ -11,7 +11,8 @@
                        [attr.aria-label]="datetimeInputLabel"
                        [(ngModel)]="inputFieldDate"
                        [placeholder]="placeholder"
-                       (keyup)="inputValueChange(inputFieldDate)"
+                       (keyup.enter)="inputValueChange(inputFieldDate)"
+                       (blur)="inputValueChange(inputFieldDate)"
                        (click)="openPopover(inputFieldDate)"
                        [ngClass]="{ 'fd-input--compact': compact, 'is-invalid': isInvalidDateInput && validate }"
                        [disabled]="disabled">


### PR DESCRIPTION
…mepicker

fixes #967 

Easy fix for this issue.  I started working on a more complex fix, where we trigger validation checks at each keystroke (for the red outline) but not attempt to update the model until the user presses enter or blurs the input - this would require separating the validation and model updating logic.  However after reading a lot of UX stuff on stackoverflow, it sounds like it is best to handle validation only on submit or blur.

Another thing is if the user just enters "1" in the input and presses enter or blurs, the date input will automatically set the selected date to 1/1/2001, if the user sets the input to "1/1/20" in the input the date will be set to 1/1/2020... is this something we want?  I could also work on having the date input check if the formatting of the input matches the dateAdapter format function