### PR TITLE
fix: combobox input add way to hide new item

### DIFF
--- a/docs/app/documentation/component-docs/combobox-input/combobox-input-header/combobox-input-header.component.html
+++ b/docs/app/documentation/component-docs/combobox-input/combobox-input-header/combobox-input-header.component.html
@@ -1,8 +1,8 @@
 <header>Combobox Input</header>
 <description>
     The combobox input component is an opinionated composition of the "input-group" and "popover" components to
-    accomplish the UI pattern for a typical input dropdown, also known as combobox input. There is a way to hide last
-    + New item, by not observe the <code>(newItemClicked)</code> event.
+    accomplish the UI pattern for a typical input dropdown, also known as combobox input. There is a way to To hide the
+    <code>+ New Item</code>, simply stop listening to the <code>(newItemClicked)</code> event.
 </description>
 <import module="ComboboxInputModule" path="fundamental-ngx"></import>
 

--- a/docs/app/documentation/component-docs/combobox-input/combobox-input-header/combobox-input-header.component.html
+++ b/docs/app/documentation/component-docs/combobox-input/combobox-input-header/combobox-input-header.component.html
@@ -1,7 +1,8 @@
 <header>Combobox Input</header>
 <description>
     The combobox input component is an opinionated composition of the "input-group" and "popover" components to
-    accomplish the UI pattern for a typical input dropdown, also known as combobox input.
+    accomplish the UI pattern for a typical input dropdown, also known as combobox input. There is a way to hide last
+    + New item, by not observe the <code>(newItemClicked)</code> event.
 </description>
 <import module="ComboboxInputModule" path="fundamental-ngx"></import>
 

--- a/docs/app/documentation/component-docs/combobox-input/examples/combobox-input-example.component.html
+++ b/docs/app/documentation/component-docs/combobox-input/examples/combobox-input-example.component.html
@@ -13,9 +13,8 @@
 <br />
 <fd-combobox-input [(ngModel)]="comboboxInputValThree"
                    [dropdownValues]="dropdownValues"
-                   [placeholder]="'Search here...'"
-                   [compact]="true"
-                   (newItemClicked)="newItem()">
+                   [placeholder]="'Search here... (without add item option)'"
+                   [compact]="true">
 </fd-combobox-input>
 <br />
 <span>Selected 1: {{comboboxInputValOne}}</span>

--- a/library/src/lib/combobox-input/combobox-input.component.html
+++ b/library/src/lib/combobox-input/combobox-input.component.html
@@ -34,6 +34,7 @@
                     </li>
 
                     <li fd-menu-item
+                        *ngIf="shouldShowNewItem()"
                         (click)="this.newItemClicked.emit()"
                         (keydown)="newItemKeydownHandler($event)">
                         <a tabindex="0" class="fd-menu__item fd-menu__link">{{newItemText}}</a>

--- a/library/src/lib/combobox-input/combobox-input.component.ts
+++ b/library/src/lib/combobox-input/combobox-input.component.ts
@@ -34,8 +34,8 @@ export class ComboboxInputComponent extends SearchInputComponent {
     @HostBinding('class.fd-combobox-input')
     comboboxClass = true;
 
-    /** Event emitted when a new item is clicked. Also When there is no listener for this event, then the last item
-     *  from list 'new item' won't be added
+    /**  accomplish the UI pattern for a typical input dropdown, also known as combobox input. There is a way to hide
+     * + New item, simply stop listening to the (newItemClicked) event.
      * */
     @Output()
     newItemClicked: EventEmitter<void> = new EventEmitter<void>();

--- a/library/src/lib/combobox-input/combobox-input.component.ts
+++ b/library/src/lib/combobox-input/combobox-input.component.ts
@@ -34,7 +34,9 @@ export class ComboboxInputComponent extends SearchInputComponent {
     @HostBinding('class.fd-combobox-input')
     comboboxClass = true;
 
-    /** Event emitted when a new item is clicked. */
+    /** Event emitted when a new item is clicked. Also When there is no listener for this event, then the last item
+     *  from list 'new item' won't be added
+     * */
     @Output()
     newItemClicked: EventEmitter<void> = new EventEmitter<void>();
 
@@ -64,6 +66,11 @@ export class ComboboxInputComponent extends SearchInputComponent {
                 }
             });
         }
+    }
+
+    /** @hidden */
+    public shouldShowNewItem(): boolean {
+        return this.newItemClicked.observers.length > 0;
     }
 
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes https://github.com/SAP/fundamental-ngx/issues/965
#### Please provide a brief summary of this pull request.
I added the way to hide `new item` element by checking if there is any observers on `newItemClicked` event
#### If this is a new feature, have you updated the documentation?
I added example to documentation
