### PR TITLE
fix: Change icon to component, add tests

### DIFF
--- a/docs/app/documentation/component-docs/icon/examples/icon-example.component.html
+++ b/docs/app/documentation/component-docs/icon/examples/icon-example.component.html
@@ -1,6 +1,6 @@
 <div class="grid">
     <div *ngFor="let icon of icons">
-        <fd-icon [glyph]="icon" [size]="'l'"></fd-icon>
+        <fd-icon [size]="'l'" [glyph]="icon"></fd-icon>
         <span>{{ icon }}</span>
     </div>
 </div>

--- a/docs/app/documentation/component-docs/icon/examples/icon-example.component.ts
+++ b/docs/app/documentation/component-docs/icon/examples/icon-example.component.ts
@@ -6,6 +6,7 @@ import { Component } from '@angular/core';
     styleUrls: ['./icon-docs.component.scss']
 })
 export class IconExampleComponent {
+
     icons: any = [
         'accelerated',
         'accept',

--- a/docs/app/documentation/utilities/api-files.ts
+++ b/docs/app/documentation/utilities/api-files.ts
@@ -72,7 +72,7 @@ export const API_FILES = {
         'FormSetDirective'
     ],
     icon: [
-        'IconDirective'
+        'IconComponent'
     ],
     identifier: [
         'IdentifierDirective'

--- a/library/src/lib/icon/icon.component.spec.ts
+++ b/library/src/lib/icon/icon.component.spec.ts
@@ -1,0 +1,47 @@
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Component, ElementRef, ViewChild } from '@angular/core';
+
+import { IconModule } from './icon.module';
+import { IconComponent } from './icon.component';
+
+const ICON_NAME = 'add';
+const ICON_SIZE = 'l';
+
+@Component({
+    selector: 'fd-test-icon',
+    template: `
+        <fd-icon [glyph]="iconName" [size]="iconSize"></fd-icon>
+    `
+})
+class TestWrapperComponent {
+    readonly iconName = ICON_NAME;
+    readonly iconSize = ICON_SIZE;
+}
+
+describe('IconComponent', () => {
+    let component: TestWrapperComponent;
+    let fixture: ComponentFixture<TestWrapperComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestWrapperComponent],
+            imports: [IconModule]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestWrapperComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('Should Add icon class with glyph on input', () => {
+        const icon = fixture.debugElement.nativeElement.querySelector('fd-icon');
+        expect(icon.className).toContain('sap-icon--' + ICON_NAME);
+        expect(icon.className).toContain('sap-icon--' + ICON_SIZE);
+    });
+});

--- a/library/src/lib/icon/icon.component.spec.ts
+++ b/library/src/lib/icon/icon.component.spec.ts
@@ -1,5 +1,5 @@
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
 
 import { IconModule } from './icon.module';
 import { IconComponent } from './icon.component';

--- a/library/src/lib/icon/icon.component.ts
+++ b/library/src/lib/icon/icon.component.ts
@@ -14,15 +14,13 @@ const BASE_ICON_CLASS = 'sap-icon';
 const PREFIX_ICON_CLASS = BASE_ICON_CLASS + '--';
 
 /**
- * The Component that represents an icon.
+ * The component that represents an icon.
  *
  * ```html
  * <fd-icon [glyph]="cart-approval" [size]="'l'"></fd-icon>
  * ```
  */
 @Component({
-    // TODO to be discussed
-    // tslint:disable-next-line:directive-selector
     selector: 'fd-icon',
     template: ``,
     host: {
@@ -32,7 +30,9 @@ const PREFIX_ICON_CLASS = BASE_ICON_CLASS + '--';
 })
 export class IconComponent extends AbstractFdNgxClass {
 
-    /** The glyph name  */
+    /** The icon name to display. See the icon page for the list of icons
+     * here: https://sap.github.io/fundamental-ngx/icon
+     * */
     @Input() glyph;
 
     /** 

--- a/library/src/lib/icon/icon.component.ts
+++ b/library/src/lib/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, ElementRef, Inject } from '@angular/core';
+import { Directive, Input, ElementRef, Inject, AfterContentInit, AfterViewInit, Component } from '@angular/core';
 import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 
 /** 
@@ -14,22 +14,27 @@ const BASE_ICON_CLASS = 'sap-icon';
 const PREFIX_ICON_CLASS = BASE_ICON_CLASS + '--';
 
 /**
- * The directive that represents an icon. 
+ * The Component that represents an icon.
  *
  * ```html
  * <fd-icon [glyph]="cart-approval" [size]="'l'"></fd-icon>
- * ```
+ // * ```
+ // * Or
+ // * ```html
+ // * <fd-icon [size]="'l'">cart-approval</fd-icon>
+ // * ```
  */
-@Directive({
+@Component({
     // TODO to be discussed
     // tslint:disable-next-line:directive-selector
     selector: 'fd-icon',
+    template: ``,
     host: {
         role: 'presentation'
     }
 })
-export class IconDirective extends AbstractFdNgxClass {
-    
+export class IconComponent extends AbstractFdNgxClass {
+
     /** The glyph name */
     @Input() glyph;
 

--- a/library/src/lib/icon/icon.component.ts
+++ b/library/src/lib/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, ElementRef, Inject, AfterContentInit, AfterViewInit, Component } from '@angular/core';
+import { Component, ElementRef, Input, ViewEncapsulation } from '@angular/core';
 import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 
 /** 
@@ -31,11 +31,12 @@ const PREFIX_ICON_CLASS = BASE_ICON_CLASS + '--';
     template: ``,
     host: {
         role: 'presentation'
-    }
+    },
+    encapsulation: ViewEncapsulation.None
 })
 export class IconComponent extends AbstractFdNgxClass {
 
-    /** The glyph name */
+    /** The glyph name  */
     @Input() glyph;
 
     /** 

--- a/library/src/lib/icon/icon.component.ts
+++ b/library/src/lib/icon/icon.component.ts
@@ -18,11 +18,7 @@ const PREFIX_ICON_CLASS = BASE_ICON_CLASS + '--';
  *
  * ```html
  * <fd-icon [glyph]="cart-approval" [size]="'l'"></fd-icon>
- // * ```
- // * Or
- // * ```html
- // * <fd-icon [size]="'l'">cart-approval</fd-icon>
- // * ```
+ * ```
  */
 @Component({
     // TODO to be discussed

--- a/library/src/lib/icon/icon.module.ts
+++ b/library/src/lib/icon/icon.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { IconDirective } from './icon.directive';
+import { IconComponent } from './icon.component';
 
 @NgModule({
     imports: [CommonModule],
-    exports: [IconDirective],
-    declarations: [IconDirective]
+    exports: [IconComponent],
+    declarations: [IconComponent]
 })
 export class IconModule {}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes https://github.com/SAP/fundamental-ngx/issues/890
#### Please provide a brief summary of this pull request.
I changed icon directive to component and added some tests. Also tried to add support for adding icon name inside component brackets, but it's hard to deal with it on any changes. Other libraries got different system, where font-style interpretate whole words as a icons.
#### If this is a new feature, have you updated the documentation?
-