### PR TITLE
fix: make inline help component using popover component

### DIFF
--- a/docs/app/documentation/component-docs/inline-help/examples/inline-help-example.component.html
+++ b/docs/app/documentation/component-docs/inline-help/examples/inline-help-example.component.html
@@ -1,19 +1,19 @@
-<span>Bottom Right (Default) </span>
+<span>Bottom Start (Default) </span>
 <fd-inline-help>
     Lorem ipsum dolor sit amet, consectetur adipiscing.
 </fd-inline-help>
 <br/>
-<span>Bottom Left </span>
-<fd-inline-help [position]="'bottom-left'">
+<span>Bottom End </span>
+<fd-inline-help [placement]="'bottom-start'">
     Lorem ipsum dolor sit amet, consectetur adipiscing.
 </fd-inline-help>
 <br/>
 <span>Right </span>
-<fd-inline-help [position]="'right'">
+<fd-inline-help [placement]="'right'">
     Lorem ipsum dolor sit amet, consectetur adipiscing.
 </fd-inline-help>
 <br/>
 <span>Left </span>
-<fd-inline-help [position]="'left'">
+<fd-inline-help [placement]="'left'">
     Lorem ipsum dolor sit amet, consectetur adipiscing.
 </fd-inline-help>

--- a/docs/app/documentation/component-docs/inline-help/examples/inline-help-examples.component.ts
+++ b/docs/app/documentation/component-docs/inline-help/examples/inline-help-examples.component.ts
@@ -5,3 +5,9 @@ import { Component } from '@angular/core';
     templateUrl: './inline-help-example.component.html'
 })
 export class InlineHelpExampleComponent {}
+
+@Component({
+    selector: 'fd-inline-help-trigger-example',
+    templateUrl: './inline-help-trigger-example.component.html'
+})
+export class InlineHelpTriggerExampleComponent {}

--- a/docs/app/documentation/component-docs/inline-help/examples/inline-help-trigger-example.component.html
+++ b/docs/app/documentation/component-docs/inline-help/examples/inline-help-trigger-example.component.html
@@ -1,0 +1,5 @@
+<span>Click on me! </span>
+<fd-inline-help [triggers]="['click']">
+    Lorem ipsum dolor sit amet, consectetur adipiscing.
+</fd-inline-help>
+<br/>

--- a/docs/app/documentation/component-docs/inline-help/inline-help-docs.component.html
+++ b/docs/app/documentation/component-docs/inline-help/inline-help-docs.component.html
@@ -8,10 +8,20 @@
 
 <separator></separator>
 
+<h2>Inline Help with changed trigger event</h2>
+<component-example [name]="'ex2'">
+  <p class="fd-centered-content">
+    <fd-inline-help-trigger-example></fd-inline-help-trigger-example>
+  </p>
+</component-example>
+<code-example [code]="inlineHelpTriggerHtml" [language]="'HTML'"></code-example>
+
+<separator></separator>
+
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
   <p class="fd-centered-content">
     <span>{{data.properties.label}} </span>
-    <fd-inline-help [position]="data.properties.position">
+    <fd-inline-help [placement]="data.properties.position">
       {{data.properties.helpText}}
     </fd-inline-help>
   </p>

--- a/docs/app/documentation/component-docs/inline-help/inline-help-docs.component.ts
+++ b/docs/app/documentation/component-docs/inline-help/inline-help-docs.component.ts
@@ -3,6 +3,8 @@ import { Schema } from '../../../schema/models/schema.model';
 import { SchemaFactoryService } from '../../../schema/services/schema-factory/schema-factory.service';
 
 import * as inlineHelpSrc from '!raw-loader!./examples/inline-help-example.component.html';
+import * as inlineHelpTriggerHtml from '!raw-loader!./examples/inline-help-trigger-example.component.html';
+import Popper from 'popper.js';
 
 @Component({
     selector: 'app-inline-help',
@@ -22,7 +24,7 @@ export class InlineHelpDocsComponent implements OnInit {
                     },
                     position: {
                         type: 'string',
-                        enum: ['default', 'bottom-left', 'right', 'left']
+                        enum: Array.from(Popper.placements)
                     }
                 }
             }
@@ -36,11 +38,12 @@ export class InlineHelpDocsComponent implements OnInit {
         properties: {
             label: 'Inline Help',
             helpText: 'Lorem ipsum dolor sit amet, consectetur adipiscing.',
-            position: 'default'
+            position: 'bottom-start'
         }
     };
 
     inlineHelpHtml = inlineHelpSrc;
+    inlineHelpTriggerHtml = inlineHelpTriggerHtml;
 
     constructor(private schemaFactory: SchemaFactoryService) {
         this.schema = this.schemaFactory.getComponent('inlineHelp');

--- a/docs/app/documentation/component-docs/inline-help/inline-help-header/inline-help-header.component.html
+++ b/docs/app/documentation/component-docs/inline-help/inline-help-header/inline-help-header.component.html
@@ -1,6 +1,6 @@
 <header>Inline Help</header>
 <description>Inline help is used to display help text in a popover, often inline with headers, body text and form
-    labels. Also it uses popover component</description>
+    labels. It also uses the fd-popover component and supports much of its functionality.</description>
 <import module="InlineHelpModule" path="fundamental-ngx"></import>
 
 <fd-header-tabs></fd-header-tabs>

--- a/docs/app/documentation/component-docs/inline-help/inline-help-header/inline-help-header.component.html
+++ b/docs/app/documentation/component-docs/inline-help/inline-help-header/inline-help-header.component.html
@@ -1,6 +1,6 @@
 <header>Inline Help</header>
 <description>Inline help is used to display help text in a popover, often inline with headers, body text and form
-    labels.</description>
+    labels. Also it uses popover component</description>
 <import module="InlineHelpModule" path="fundamental-ngx"></import>
 
 <fd-header-tabs></fd-header-tabs>

--- a/docs/app/documentation/documentation.module.ts
+++ b/docs/app/documentation/documentation.module.ts
@@ -129,7 +129,10 @@ import {
     ImageShapesExampleComponent,
     ImageSizesExampleComponent
 } from './component-docs/image/examples/image-examples.component';
-import { InlineHelpExampleComponent } from './component-docs/inline-help/examples/inline-help-examples.component';
+import {
+    InlineHelpExampleComponent,
+    InlineHelpTriggerExampleComponent
+} from './component-docs/inline-help/examples/inline-help-examples.component';
 import {
     InputGroupButtonExampleComponent,
     InputGroupIconExampleComponent,
@@ -439,6 +442,7 @@ import { HighlightModule } from 'ngx-highlightjs';
         InfiniteScrollDocsComponent,
         InfiniteScrollBasicExampleComponent,
         InlineHelpExampleComponent,
+        InlineHelpTriggerExampleComponent,
         InputGroupButtonExampleComponent,
         InputGroupIconExampleComponent,
         InputGroupNumberExampleComponent,

--- a/library/src/lib/badge-label/badge.directive.ts
+++ b/library/src/lib/badge-label/badge.directive.ts
@@ -6,6 +6,7 @@ import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
  * Colors, generally in combination with text, are used to easily highlight the state of an object.
  */
 @Directive({
+    // tslint:disable-next-line:directive-selector
     selector: '[fd-badge]'
 })
 export class BadgeDirective extends AbstractFdNgxClass {

--- a/library/src/lib/badge-label/label.directive.ts
+++ b/library/src/lib/badge-label/label.directive.ts
@@ -6,6 +6,7 @@ import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
  * Colors, generally in combination with text, are used to easily highlight the state of an object.
  */
 @Directive({
+    // tslint:disable-next-line:directive-selector
     selector: '[fd-label]'
 })
 export class LabelDirective extends AbstractFdNgxClass {

--- a/library/src/lib/inline-help/inline-help.component.html
+++ b/library/src/lib/inline-help/inline-help.component.html
@@ -1,3 +1,13 @@
-<span [ngClass]="(position ? 'fd-inline-help__content fd-inline-help__content--' + position : 'fd-inline-help__content fd-inline-help__content--bottom-right')">
-  <ng-content></ng-content>
-</span>
+<fd-popover [noArrow]="false"
+            [placement]="placement"
+            [triggers]="triggers"
+    >
+        <fd-popover-control>
+            <span class="fd-inline-help" role="alert"></span>
+        </fd-popover-control>
+        <fd-popover-body>
+            <span class="fd-inline-help__content">
+                <ng-content></ng-content>
+            </span>
+        </fd-popover-body>
+</fd-popover>

--- a/library/src/lib/inline-help/inline-help.component.scss
+++ b/library/src/lib/inline-help/inline-help.component.scss
@@ -11,6 +11,9 @@
     right: 0;
     border: none;
 
+    /** Follow color used in fd-inline-help class */
+    color: var(--fd-color-text-1);
+
     /** Do not show arrow */
     &:before, &:after {
         display: none;

--- a/library/src/lib/inline-help/inline-help.component.scss
+++ b/library/src/lib/inline-help/inline-help.component.scss
@@ -1,0 +1,18 @@
+.fd-inline-help__content {
+
+    /** Simulate always hovered */
+    visibility: visible;
+    opacity: 1;
+    overflow: visible;
+
+    /** Reset attributes provided already by popover */
+    position: relative;
+    top: 0;
+    right: 0;
+    border: none;
+
+    /** Do not show arrow */
+    &:before, &:after {
+        display: none;
+    }
+}

--- a/library/src/lib/inline-help/inline-help.component.spec.ts
+++ b/library/src/lib/inline-help/inline-help.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { InlineHelpComponent } from './inline-help.component';
+import { InlineHelpModule } from './inline-help.module';
 
 describe('InlineHelpComponent', () => {
     let component: InlineHelpComponent;
@@ -8,7 +9,7 @@ describe('InlineHelpComponent', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [InlineHelpComponent]
+            imports: [InlineHelpModule]
         }).compileComponents();
     }));
 

--- a/library/src/lib/inline-help/inline-help.component.ts
+++ b/library/src/lib/inline-help/inline-help.component.ts
@@ -1,6 +1,5 @@
-import { Component, ElementRef, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import { Component, Input, ViewEncapsulation } from '@angular/core';
 import { Placement } from 'popper.js';
-import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 /**
  * The component that represents an inline-help. 
  * Inline help is used to display help text in a popover, often inline with headers, body text and form labels.
@@ -17,7 +16,7 @@ import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
     encapsulation: ViewEncapsulation.None,
     styleUrls: ['inline-help.component.scss']
 })
-export class InlineHelpComponent implements OnChanges {
+export class InlineHelpComponent {
 
     /** The placement of the inline help component. It can be one of: top, top-start, top-end, bottom,
      *  bottom-start, bottom-end, right, right-start, right-end, left, left-start, left-end.
@@ -30,6 +29,4 @@ export class InlineHelpComponent implements OnChanges {
      *  Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp). */
     @Input()
     triggers: string[] = ['mouseenter', 'mouseleave'];
-
-    ngOnChanges(changes: SimpleChanges): void {}
 }

--- a/library/src/lib/inline-help/inline-help.component.ts
+++ b/library/src/lib/inline-help/inline-help.component.ts
@@ -1,10 +1,12 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import { Placement } from 'popper.js';
+import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 /**
  * The component that represents an inline-help. 
  * Inline help is used to display help text in a popover, often inline with headers, body text and form labels.
  *
  * ```html
- * <fd-inline-help [position]="'bottom-left'">
+ * <fd-inline-help [placement]="'bottom-left'">
  *      Lorem ipsum dolor sit amet, consectetur adipiscing.
  * </fd-inline-help>
  * ```
@@ -12,18 +14,22 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
 @Component({
     selector: 'fd-inline-help',
     templateUrl: './inline-help.component.html',
-    host: {
-        class: 'fd-inline-help',
-        role: 'alert'
-    },
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    styleUrls: ['inline-help.component.scss']
 })
-export class InlineHelpComponent {
-    /** 
-     * The position of the inline help component.
-     * Options include *bottom-right*, *bottom-left*, *bottom-center*, *right*, and *left*.
-     * The default position is *bottom right* 
+export class InlineHelpComponent implements OnChanges {
+
+    /** The placement of the inline help component. It can be one of: top, top-start, top-end, bottom,
+     *  bottom-start, bottom-end, right, right-start, right-end, left, left-start, left-end.
+     *   The default placement is *bottom start*
      */
     @Input()
-    position: string;
+    placement: Placement = 'bottom-start';
+
+    /** The trigger events that will open/close the inline help component.
+     *  Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp). */
+    @Input()
+    triggers: string[] = ['mouseenter', 'mouseleave'];
+
+    ngOnChanges(changes: SimpleChanges): void {}
 }

--- a/library/src/lib/inline-help/inline-help.module.ts
+++ b/library/src/lib/inline-help/inline-help.module.ts
@@ -2,9 +2,10 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { InlineHelpComponent } from './inline-help.component';
+import { PopoverModule } from '../popover';
 
 @NgModule({
-    imports: [CommonModule],
+    imports: [CommonModule, PopoverModule],
     exports: [InlineHelpComponent],
     declarations: [InlineHelpComponent]
 })


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes https://github.com/SAP/fundamental-ngx/issues/620
#### Please provide a brief summary of this pull request.
I made inline help component using popover component inside, the popover control contains only the help icon. I adde dalso possibility to change trigger event. Had to put some styles, cause popover for example already got some borders/positions. I added also some styles which simulates the fact that the inline help component is always hovered, cause right now popover is controlling view.
#### If this is a new feature, have you updated the documentation?
I added one example.