### PR TITLE
fix: Close time picker on another open click

### DIFF
--- a/library/src/lib/time-picker/time-picker.component.html
+++ b/library/src/lib/time-picker/time-picker.component.html
@@ -22,7 +22,7 @@
                    [attr.aria-label]="timePickerInputLabel">
             <span class="fd-input-group__addon fd-input-group__addon--button fd-input-group__addon--after">
           <button [disabled]="disabled" type="button"
-                  [ngClass]="{ 'fd-button--compact' : compact }" (click)="addOnButtonClicked($event)"
+                  [ngClass]="{ 'fd-button--compact' : compact }" (click)="addOnButtonClicked()"
                   class="fd-button--icon fd-button--light sap-icon--fob-watch"></button>
         </span>
         </div>

--- a/library/src/lib/time-picker/time-picker.component.spec.ts
+++ b/library/src/lib/time-picker/time-picker.component.spec.ts
@@ -193,8 +193,7 @@ describe('TimePickerComponent', () => {
         component.disabled = false;
         const event = { stopPropagation: function() {} };
         spyOn(event, 'stopPropagation').and.callThrough();
-        component.addOnButtonClicked(event);
-        expect(event.stopPropagation).toHaveBeenCalled();
+        component.addOnButtonClicked();
         expect(component.isOpen).toBe(true);
     });
 

--- a/library/src/lib/time-picker/time-picker.component.ts
+++ b/library/src/lib/time-picker/time-picker.component.ts
@@ -145,9 +145,8 @@ export class TimePickerComponent implements ControlValueAccessor, OnInit {
     }
 
     /** @hidden */
-    addOnButtonClicked($event) {
+    addOnButtonClicked() {
         if (!this.disabled) {
-            $event.stopPropagation();
             this.isOpen = !this.isOpen;
         }
     }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/913
#### Please provide a brief summary of this pull request.
I removed stopPropagation() for click event on time picker icon. 
#### If this is a new feature, have you updated the documentation?
-