### PR TITLE
fix: adds the correct class for fd-menu-list

### DIFF
--- a/library/src/lib/menu/menu-list.directive.ts
+++ b/library/src/lib/menu/menu-list.directive.ts
@@ -10,6 +10,6 @@ import { Directive, HostBinding } from '@angular/core';
 })
 export class MenuListDirective {
     /** @hidden */
-    @HostBinding('class.fd-menu_list')
+    @HostBinding('class.fd-menu__list')
     fdMenuListClass: boolean = true;
 }


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.

fd-menu-list directive was attaching to the host `fd-menu_list` class. The correct class from Fundamental-styles is `fd-menu__list`.