### PR TITLE
fix: Make combobox dropdown trigger unfocusable

### DIFF
--- a/library/src/lib/combobox/combobox.component.html
+++ b/library/src/lib/combobox/combobox.component.html
@@ -15,6 +15,7 @@
                        placeholder="{{placeholder}}">
                 <span class="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button">
                     <button fd-button
+                            tabindex="-1"
                             type="button"
                             [fdType]="'light'"
                             [glyph]="glyph"


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/912
#### Please provide a brief summary of this pull request.
I put tabindex to -1, to prevent from focusing on combobox dropdown icon.
