### PR TITLE
fix: improved focus on calendar

### DIFF
--- a/docs/app/documentation/component-docs/calendar/examples/calendar-single-example.component.ts
+++ b/docs/app/documentation/component-docs/calendar/examples/calendar-single-example.component.ts
@@ -12,7 +12,8 @@ import { FdDate } from '../../../../../../library/src/lib/calendar/models/fd-dat
 
         <button fd-button (click)="disableWednesday()">Disable Wednesday</button>
         <br/><br/>
-        <div>Selected Date: {{date.toDateString()}}</div>`
+        <div>Selected Date: {{date.toDateString()}}</div>
+    `
 })
 export class CalendarSingleExampleComponent {
 

--- a/library/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
+++ b/library/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
@@ -332,7 +332,7 @@ export class CalendarDayViewComponent implements OnInit, AfterViewChecked, OnCha
             if (!calendarRow) {
                 calendarRow = [];
             }
-            return calendarRow.concat(totalCalendarRows);
+            return totalCalendarRows.concat(calendarRow);
         });
     }
 

--- a/library/src/lib/calendar/calendar-views/calendar-year-view/calendar-year-view.component.html
+++ b/library/src/lib/calendar/calendar-views/calendar-year-view/calendar-year-view.component.html
@@ -7,7 +7,7 @@
                 'fd-calendar__item--current': (year == currentYear)
             }"
             [attr.id]="id + '-fd-year-' + i"
-            [attr.tabindex]="year === yearSelected ? 0 : -1"
+            [attr.tabindex]="year === activeYear ? 0 : -1"
             (keydown)="onKeydownYearHandler($event, i)"
             (click)="selectYear(year, $event)">
             <span role="button" class="fd-calendar__text">

--- a/library/src/lib/calendar/calendar-views/calendar-year-view/calendar-year-view.component.ts
+++ b/library/src/lib/calendar/calendar-views/calendar-year-view/calendar-year-view.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, ViewEncapsulation, Output, Input, EventEmitter, ElementRef, AfterViewChecked, OnDestroy } from '@angular/core';
 import { FdDate } from '../../models/fd-date';
 import { takeUntil } from 'rxjs/operators';
-import { CalendarI18n } from '../../i18n/calendar-i18n';
 import { CalendarService } from '../../calendar.service';
 import { Subject } from 'rxjs';
 
@@ -16,6 +15,11 @@ import { Subject } from 'rxjs';
     }
 })
 export class CalendarYearViewComponent implements AfterViewChecked, OnInit, OnDestroy {
+
+    /** @hidden
+     *  This variable is used to define which year should be possible to focus (tabindex = 0)
+     * */
+    activeYear: number;
 
     /** Parameter that stores the dozen of years that are currently being displayed. */
     calendarYearList: number[];
@@ -47,6 +51,10 @@ export class CalendarYearViewComponent implements AfterViewChecked, OnInit, OnDe
     /** Event fired when a year is selected. */
     @Output()
     readonly yearClicked: EventEmitter<number> = new EventEmitter<number>();
+
+    /** @hidden */
+    constructor(private eRef: ElementRef, private calendarService: CalendarService) {
+    }
 
     /** @hidden */
     ngAfterViewChecked(): void {
@@ -92,14 +100,19 @@ export class CalendarYearViewComponent implements AfterViewChecked, OnInit, OnDe
         this.onDestroy$.complete();
     }
 
-    /** @hidden */
-    constructor(private eRef: ElementRef, private calendarService: CalendarService) { }
-
-    /** @hidden */
-    private constructYearList(): void {
-        this.calendarYearList = [];
-        for (let x = 0; x < 12; x++) {
-            this.calendarYearList.push(this.firstYearInList + x);
+    /**
+     * Method that returns active cell, which means:
+     * if there is any selected year, return selected year
+     * if there is no selected year, but there is current year, return current year
+     * if there is no current year, or selected, return first one
+     */
+    private getActiveYear(): number {
+        if (this.calendarYearList.find(year => year === this.yearSelected)) {
+            return this.calendarYearList.find(year => year === this.yearSelected);
+        } else if (this.calendarYearList.find(year => year === this.currentYear)) {
+            return this.calendarYearList.find(year => year === this.currentYear);
+        } else {
+            return this.calendarYearList[0];
         }
     }
 
@@ -135,5 +148,14 @@ export class CalendarYearViewComponent implements AfterViewChecked, OnInit, OnDe
         }
         this.yearSelected = selectedYear;
         this.yearClicked.emit(this.yearSelected);
+    }
+
+    /** @hidden */
+    private constructYearList(): void {
+        this.calendarYearList = [];
+        for (let x = 0; x < 12; x++) {
+            this.calendarYearList.push(this.firstYearInList + x);
+        }
+        this.activeYear = this.getActiveYear();
     }
 }

--- a/library/src/lib/calendar/calendar-views/calendar-year-view/calendar-year-view.component.ts
+++ b/library/src/lib/calendar/calendar-views/calendar-year-view/calendar-year-view.component.ts
@@ -17,7 +17,7 @@ import { Subject } from 'rxjs';
 export class CalendarYearViewComponent implements AfterViewChecked, OnInit, OnDestroy {
 
     /** @hidden
-     *  This variable is used to define which year should be possible to focus (tabindex = 0)
+     *  This variable is used to define which year from calendarYearList should be focusable by tab key
      * */
     activeYear: number;
 
@@ -107,13 +107,17 @@ export class CalendarYearViewComponent implements AfterViewChecked, OnInit, OnDe
      * if there is no current year, or selected, return first one
      */
     private getActiveYear(): number {
-        if (this.calendarYearList.find(year => year === this.yearSelected)) {
-            return this.calendarYearList.find(year => year === this.yearSelected);
-        } else if (this.calendarYearList.find(year => year === this.currentYear)) {
-            return this.calendarYearList.find(year => year === this.currentYear);
-        } else {
-            return this.calendarYearList[0];
+        const selectedYear: number = this.calendarYearList.find(year => year === this.yearSelected);
+        if (selectedYear) {
+            return selectedYear;
         }
+
+        const currentYear: number = this.calendarYearList.find(year => year === this.currentYear);
+        if (currentYear) {
+            return currentYear;
+        }
+
+        return this.calendarYearList[0];
     }
 
     /** Method for handling the keyboard navigation. */
@@ -152,8 +156,9 @@ export class CalendarYearViewComponent implements AfterViewChecked, OnInit, OnDe
 
     /** @hidden */
     private constructYearList(): void {
+        const displayedYearsAmount: number = 12;
         this.calendarYearList = [];
-        for (let x = 0; x < 12; x++) {
+        for (let x = 0; x < displayedYearsAmount; ++x) {
             this.calendarYearList.push(this.firstYearInList + x);
         }
         this.activeYear = this.getActiveYear();

--- a/library/src/lib/calendar/calendar.component.scss
+++ b/library/src/lib/calendar/calendar.component.scss
@@ -5,7 +5,10 @@
     td, li {
         &:focus {
             outline: 0;
-            box-shadow: inset 0 0 0 2px var(--fd-color-neutral-3);
+            box-shadow: inset 0 0 2px 2px var(--fd-color-neutral-3);
+            &:after {
+                display: none;
+            }
         }
     }
 }

--- a/library/src/lib/calendar/calendar.component.ts
+++ b/library/src/lib/calendar/calendar.component.ts
@@ -1,4 +1,5 @@
 import {
+    ChangeDetectorRef,
     Component,
     EventEmitter,
     forwardRef,
@@ -186,7 +187,10 @@ export class CalendarComponent implements OnInit, ControlValueAccessor {
     };
 
     /** @hidden */
-    constructor(public calendarI18n: CalendarI18n) {}
+    constructor(
+        public calendarI18n: CalendarI18n,
+        private changeDetectorRef: ChangeDetectorRef
+    ) {}
 
     /** @hidden */
     ngOnInit(): void {
@@ -364,6 +368,8 @@ export class CalendarComponent implements OnInit, ControlValueAccessor {
         this.currentlyDisplayed = { month: month, year: this.currentlyDisplayed.year };
         this.activeView = 'day';
         this.activeViewChange.emit(this.activeView);
+        this.changeDetectorRef.detectChanges();
+        this.dayViewComponent.focusActiveDay();
     }
 
     /**
@@ -393,6 +399,8 @@ export class CalendarComponent implements OnInit, ControlValueAccessor {
     public selectedYear(yearSelected: number) {
         this.activeView = 'day';
         this.currentlyDisplayed.year = yearSelected;
+        this.changeDetectorRef.detectChanges();
+        this.dayViewComponent.focusActiveDay();
     }
 
 }

--- a/library/src/lib/calendar/calendar.service.ts
+++ b/library/src/lib/calendar/calendar.service.ts
@@ -111,7 +111,7 @@ export class CalendarService {
                 break;
             }
             case 'Tab': {
-                if (this.focusEscapeFunction) {
+                if (this.focusEscapeFunction && !event.shiftKey) {
                     event.preventDefault();
                     this.focusEscapeFunction();
                 }

--- a/library/src/lib/calendar/models/fd-date.ts
+++ b/library/src/lib/calendar/models/fd-date.ts
@@ -62,25 +62,27 @@ export class FdDate {
 
     /**
      * Get amount of milliseconds from 01.01.1970
-     * 0 is thrown when some some of properties (day,month,year) are not defined
+     * -1 is thrown when some some of properties (day,month,year) are not defined
      * */
     public getTimeStamp(): number {
         if (this.year && this.month && this.day) {
             return this.toDate().getTime();
         } else {
-            return 0;
+            return -1;
         }
     }
 
     /**
      * Get number of weekday ex. Sunday = 1, Monday = 2, Tuesday = 3 etc.
-     * 0 is thrown when some some of properties (day,month,year) are not defined
+     * -1 is thrown when some some of properties (day,month,year) are not defined
+     * Native javascript date getDay() function returns Sunday as 0, Monday as 1, etc, to it's needed to increment value
+     *
      * */
     public getDay(): number {
         if (this.year && this.month && this.day) {
-            return this.toDate().getDay() % 7 + 1;
+            return this.toDate().getDay() + 1;
         } else {
-            return 0;
+            return -1;
         }
     }
 

--- a/library/src/lib/calendar/models/fd-date.ts
+++ b/library/src/lib/calendar/models/fd-date.ts
@@ -62,16 +62,26 @@ export class FdDate {
 
     /**
      * Get amount of milliseconds from 01.01.1970
+     * 0 is thrown when some some of properties (day,month,year) are not defined
      * */
     public getTimeStamp(): number {
-        return this.toDate().getTime();
+        if (this.year && this.month && this.day) {
+            return this.toDate().getTime();
+        } else {
+            return 0;
+        }
     }
 
     /**
      * Get number of weekday ex. Sunday = 1, Monday = 2, Tuesday = 3 etc.
+     * 0 is thrown when some some of properties (day,month,year) are not defined
      * */
     public getDay(): number {
-        return this.toDate().getDay() % 7 + 1;
+        if (this.year && this.month && this.day) {
+            return this.toDate().getDay() % 7 + 1;
+        } else {
+            return 0;
+        }
     }
 
     /** Get next day */


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1068
#### Please provide a brief summary of this pull request.
Issues with focus has been fixed. 
Right now:
- Shift tab escapes the focus on all views (that's how it's supposed to be)
- Tab doesn't escape the focus, by default.
- After changing month/year the active(selected > today > first) day is focused
- When year list is switched (+/- 12), it's possible to focus on active(selected > today > first) year, by tab key.
- Also added some statements which will provide protection from `undefined is not an object/function` errors.