### PR TITLE
fix: adds missing fd-alert--dismissible class

### DIFF
--- a/library/src/lib/alert/alert.component.ts
+++ b/library/src/lib/alert/alert.component.ts
@@ -206,6 +206,9 @@ export class AlertComponent extends AbstractFdNgxClass implements OnInit, AfterV
         if (this.type) {
             this._addClassToElement('fd-alert--' + this.type);
         }
+        if (this.dismissible) {
+            this._addClassToElement('fd-alert--dismissible');
+        }
     }
 
     private loadFromTemplate(template: TemplateRef<any>): void {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #1066 

#### Please provide a brief summary of this pull request.
We were not adding the `fd-alert--dismissible` class to the component which was causing the overlapping of the content of the alert with the dismissible button. 
`fd-alert--dismissible` class adds an additional `padding-right: 48px` which prevents the overlapping.

BEFORE:
<img width="753" alt="Screen Shot 2019-07-30 at 11 14 58 AM" src="https://user-images.githubusercontent.com/39598672/62141873-494e2f80-b2bb-11e9-99ea-2f27a5d98530.png">

AFTER:
<img width="789" alt="Screen Shot 2019-07-30 at 11 07 36 AM" src="https://user-images.githubusercontent.com/39598672/62141811-3176ab80-b2bb-11e9-8f9a-39bc0ea8cd7a.png">

