### PR TITLE
feat: added option in combobox to return whole object; added forms example

### DIFF
--- a/docs/app/documentation/component-docs/combobox/combobox-docs.component.html
+++ b/docs/app/documentation/component-docs/combobox/combobox-docs.component.html
@@ -73,6 +73,7 @@
 </component-example>
 <code-example [exampleFiles]="comboboxDisabledExample"></code-example>
 
+
 <separator></separator>
 <h2>Custom Height Example</h2>
 <description>
@@ -83,3 +84,19 @@
     <fd-combobox-height-example></fd-combobox-height-example>
 </component-example>
 <code-example [exampleFiles]="comboboxHeightExample"></code-example>
+
+<separator></separator>
+<h2>Reactive Form</h2>
+<description>
+    The Combobox component may also be used within Angular Reactive Forms.
+</description>
+<description>
+    Also in combobox can be used <code>[communicateByObject]</code>. Enabling this option changes the way the component
+    communicates with the outside. When combobox communicates by objects, writing in text input doesn't change binded
+    value, until it matches one of displayed dropdown options. Also on this mode, combobox on communication uses model
+    with same type as it's passed to <code>[dropdownValues]</code>
+</description>
+<component-example [name]="'ex6'">
+    <fd-combobox-forms-example></fd-combobox-forms-example>
+</component-example>
+<code-example [exampleFiles]="comboboxFormExample"></code-example>

--- a/docs/app/documentation/component-docs/combobox/combobox-docs.component.ts
+++ b/docs/app/documentation/component-docs/combobox/combobox-docs.component.ts
@@ -12,6 +12,8 @@ import * as comboboxTemplateH from '!raw-loader!./examples/combobox-template-exa
 import * as comboboxTemplateT from '!raw-loader!./examples/combobox-template-example.component.ts';
 import * as comboboxDisabledTemplateH from '!raw-loader!./examples/combobox-disabled-example.component.html';
 import * as comboboxDisabledTemplateT from '!raw-loader!./examples/combobox-disabled-example.component.ts';
+import * as comboboxFormT from '!raw-loader!./examples/combobox-forms-example.component.ts';
+import * as comboboxFormH from '!raw-loader!./examples/combobox-forms-example.component.html';
 import * as comboboxHeightHtml from '!raw-loader!./examples/combobox-height-example.component.html';
 import * as comboboxHeightTs from '!raw-loader!./examples/combobox-height-example.component.ts';
 import * as comboboxSeaTs from '!raw-loader!./examples/combobox-search-function-example.component.ts';
@@ -109,6 +111,17 @@ export class ComboboxDocsComponent {
         {
             language: 'typescript',
             code: comboboxHeightTs
+        }
+    ];
+
+    comboboxFormExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: comboboxFormH
+        },
+        {
+            language: 'typescript',
+            code: comboboxFormT
         }
     ];
 

--- a/docs/app/documentation/component-docs/combobox/examples/combobox-forms-example.component.html
+++ b/docs/app/documentation/component-docs/combobox/examples/combobox-forms-example.component.html
@@ -1,0 +1,29 @@
+<form [formGroup]="customForm">
+    Combobox with communication via Objects
+    <fd-combobox [dropdownValues]="dropdownValues"
+                 [placeholder]="'Type some text...'"
+                 [displayFn]="myDisplayFunction"
+                 [communicateByObject]="true"
+                 formControlName="itemOnDropdownMode">
+    </fd-combobox>
+</form><br/>
+
+Touched: {{customForm.controls.itemOnDropdownMode.touched}}<br/>
+Dirty: {{customForm.controls.itemOnDropdownMode.dirty}}<br/>
+Json Value: {{customForm.controls.itemOnDropdownMode.value | json}}
+<br/><br/>
+
+<form [formGroup]="customForm">
+    Combobox with communication via displayed value
+    <fd-combobox [dropdownValues]="dropdownValues"
+                 [placeholder]="'Type some text...'"
+                 [displayFn]="myDisplayFunction"
+                 formControlName="item">
+    </fd-combobox>
+</form><br/>
+
+Touched: {{customForm.controls.item.touched}}<br/>
+Dirty: {{customForm.controls.item.dirty}}<br/>
+Json Value: {{customForm.controls.item.value | json}}
+
+

--- a/docs/app/documentation/component-docs/combobox/examples/combobox-forms-example.component.ts
+++ b/docs/app/documentation/component-docs/combobox/examples/combobox-forms-example.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+
+interface ComboboxItem {
+    displayedValue: string,
+    value: string
+}
+
+@Component({
+    selector: 'fd-combobox-forms-example',
+    templateUrl: 'combobox-forms-example.component.html'
+})
+export class ComboboxFormsExampleComponent {
+
+
+    customForm = new FormGroup({
+        item: new FormControl(null),
+        itemOnDropdownMode: new FormControl(null)
+    });
+
+    dropdownValues: ComboboxItem[] = [
+        {displayedValue: 'Apple', value: 'AppleValue'},
+        {displayedValue: 'Banana', value: 'BananaValue'},
+        {displayedValue: 'Kiwi', value: 'AppleValue'},
+        {displayedValue: 'Strawberry', value: 'AppleValue'},
+        {displayedValue: 'Tomato', value: 'AppleValue'},
+    ];
+
+    myDisplayFunction = (item: ComboboxItem): string => {
+        if (item) {
+            return item.displayedValue;
+        }
+    }
+}

--- a/docs/app/documentation/documentation.module.ts
+++ b/docs/app/documentation/documentation.module.ts
@@ -370,6 +370,8 @@ import { ComboboxHeightExampleComponent } from './component-docs/combobox/exampl
 import { ComboboxDisabledExampleComponent } from './component-docs/combobox/examples/combobox-disabled-example.component';
 import { CalendarProgrammaticallyChangeExampleComponent } from './component-docs/calendar/examples/calendar-programmatically-change-example.component';
 import { SelectViewValueExampleComponent } from './component-docs/select/examples/select-view-value-example/select-view-value-example.component';
+import { ComboboxFormsExampleComponent } from './component-docs/combobox/examples/combobox-forms-example.component';
+import { InputGroupNumberFormExampleComponent } from './component-docs/input-group/examples/input-group-number-form-example.component';
 
 import { InputFormGroupExampleComponent } from './component-docs/input/examples/input-form-group-example.component';
 import {
@@ -647,6 +649,7 @@ import { SelectMaxHeightExampleComponent } from './component-docs/select/example
         ComboboxSearchFunctionExampleComponent,
         ComboboxExampleComponent,
         ComboboxTemplateExampleComponent,
+        ComboboxFormsExampleComponent,
         ComboboxDisabledExampleComponent,
         ComboboxHeightExampleComponent,
         LoadingSpinnerDocsComponent,

--- a/docs/app/documentation/documentation.module.ts
+++ b/docs/app/documentation/documentation.module.ts
@@ -371,7 +371,6 @@ import { ComboboxDisabledExampleComponent } from './component-docs/combobox/exam
 import { CalendarProgrammaticallyChangeExampleComponent } from './component-docs/calendar/examples/calendar-programmatically-change-example.component';
 import { SelectViewValueExampleComponent } from './component-docs/select/examples/select-view-value-example/select-view-value-example.component';
 import { ComboboxFormsExampleComponent } from './component-docs/combobox/examples/combobox-forms-example.component';
-import { InputGroupNumberFormExampleComponent } from './component-docs/input-group/examples/input-group-number-form-example.component';
 
 import { InputFormGroupExampleComponent } from './component-docs/input/examples/input-form-group-example.component';
 import {

--- a/library/src/lib/combobox/combobox.component.spec.ts
+++ b/library/src/lib/combobox/combobox.component.spec.ts
@@ -30,10 +30,11 @@ describe('ComboboxComponent', () => {
         fixture = TestBed.createComponent(ComboboxComponent);
         component = fixture.componentInstance;
         component.dropdownValues = [
-            'Apple',
-            'Banana'
+            { value: 'value', displayedValue: 'displayedValue' },
+            { value: 'value2', displayedValue: 'displayedValue2' }
         ];
-        component.searchFunction = () => {};
+        component.searchFunction = () => {
+        };
         fixture.detectChanges();
 
         /** That's focus trap testing workaround */
@@ -53,7 +54,8 @@ describe('ComboboxComponent', () => {
         spyOn(component, 'searchFunction');
         const event = {
             code: 'Enter',
-            preventDefault: () => {}
+            preventDefault: () => {
+            }
         };
         component.onInputKeydownHandler(event);
         expect(component.searchFunction).toHaveBeenCalled();
@@ -66,16 +68,16 @@ describe('ComboboxComponent', () => {
     });
 
     it('should fire selected event onMenuKeydownHandler, arrow down', () => {
-        component.inputText = 'test';
+        component.displayFn = (item: any): string => {
+            return item.displayedValue;
+        };
         const event: any = {
             code: 'Enter',
             preventDefault: () => {}
         };
-        const term = 'test';
-        component.dropdownValues = [term];
-        spyOn(component.itemClicked, 'emit');
+        spyOn(component, 'onChange');
         component.onMenuKeydownHandler(event, 0);
-        expect(component.itemClicked.emit).toHaveBeenCalled();
+        expect(component.onChange).toHaveBeenCalledWith(component.dropdownValues[0].displayedValue);
         spyOn(event, 'preventDefault');
         spyOn(component.menuItems.toArray()[1], 'focus');
         event.code = 'ArrowDown';
@@ -100,7 +102,8 @@ describe('ComboboxComponent', () => {
     it('should handle onMenuKeydownHandler, arrow up on the first item', () => {
         const event: any = {
             code: 'ArrowUp',
-            preventDefault: () => {}
+            preventDefault: () => {
+            }
         };
         spyOn(event, 'preventDefault');
         spyOn(component.searchInputElement.nativeElement, 'focus');
@@ -118,10 +121,48 @@ describe('ComboboxComponent', () => {
         expect(component.onTouched).toHaveBeenCalled();
     });
 
+    it('should write value not on dropdown mode', () => {
+        component.writeValue('someValue');
+        expect(component.inputText).toBe('someValue');
+    });
+
     it('should registerOnChange and registerOnTouched', () => {
         component.registerOnChange('function');
         component.registerOnTouched('function');
         expect(component.onChange).toBe('function');
         expect(component.onTouched).toBe('function');
+    });
+
+    it('should handle input entry on dropdown mode', () => {
+        spyOn(component, 'onChange');
+        component.communicateByObject = true;
+        component.displayFn = (item: any): string => {
+            return item.displayedValue;
+        };
+        component.inputText = 'displayedValue2';
+        expect(component.onChange).toHaveBeenCalledWith({ value: 'value2', displayedValue: 'displayedValue2' });
+    });
+
+    it('should handle wrong input entry on dropdown mode', () => {
+        spyOn(component, 'onChange');
+        component.communicateByObject = true;
+        component.displayFn = (item: any): string => {
+            if (item) {
+                return item.displayedValue;
+            } else {
+                return '';
+            }
+        };
+        component.inputText = 'otherDisplayedValue';
+        expect(component.onChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should handle write value from outside on dropdown mode', () => {
+        component.communicateByObject = true;
+        component.displayFn = (item: any): string => {
+            return item.displayedValue;
+        };
+        component.writeValue({ value: 'value2', displayedValue: 'displayedValue2' });
+        expect(component.inputTextValue).toBe('displayedValue2');
     });
 });


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1075
#### Please provide a brief summary of this pull request.
I added dropdown mode to combobox component, thanks to it component can communicate with the outside not only by strings, but with whole objects that are passed as a options.  
#### If this is a new feature, have you updated the documentation?
I added new example with reactive forms and usages of 2 combobox components, to compare enabled and disabled dropdown mode.
