### PR TITLE
docs: made blocked date dynamic + add description + fix small typo

### DIFF
--- a/docs/app/documentation/component-docs/button/button-docs.component.html
+++ b/docs/app/documentation/component-docs/button/button-docs.component.html
@@ -45,7 +45,7 @@
 <separator></separator>	
 <h2>Button State</h2>	
 <description>	
-  'disabled' and 'selected' state can be achieved through native 'diasbled' / 'aria-disabled' and 'aria-selected' attributes.
+  'disabled' and 'selected' state can be achieved through native 'disabled' / 'aria-disabled' and 'aria-selected' attributes.
 </description>	
 <component-example [name]="'ex4'">	
   <fd-button-state-example></fd-button-state-example>	

--- a/docs/app/documentation/component-docs/calendar/calendar-docs.component.html
+++ b/docs/app/documentation/component-docs/calendar/calendar-docs.component.html
@@ -9,6 +9,9 @@
     Note that selecting a day (or range of days) in this manner will override any block/disable functions. The
     <code>disableFunction</code>
     and <code>blockFunction</code> inputs can be changed and the calendar will automatically update (see example).
+    <br /><br />
+    A disabled date or range of dates cannot be selected, usually applied to a large range of past or future dates. A blocked 
+    date or range of dates cannot be selected, usually applied to blackout or booked dates mixed in with available dates.
 </description>
 <component-example [name]="'ex1'">
     <fd-calendar-single-example></fd-calendar-single-example>

--- a/docs/app/documentation/component-docs/calendar/examples/calendar-single-example.component.ts
+++ b/docs/app/documentation/component-docs/calendar/examples/calendar-single-example.component.ts
@@ -19,20 +19,20 @@ export class CalendarSingleExampleComponent {
 
     date = FdDate.getToday();
 
-    myDisableFunction = function(d: FdDate): boolean {
+    myDisableFunction = function (d: FdDate): boolean {
         const day = d.getDay();
         return day === 6 || day === 7;
     };
 
     // Block days before/after any day
-    myBlockFunction = function(d: FdDate): boolean {
-        const firstDay = new FdDate(2019, 7, 21);
-        const lastDay = new FdDate(2019, 7, 30);
+    myBlockFunction = function (d: FdDate): boolean {
+        const firstDay = FdDate.getToday();
+        const lastDay = new FdDate(firstDay.year, firstDay.month, firstDay.day + 7);
         return d.getTimeStamp() > firstDay.getTimeStamp() && d.getTimeStamp() < lastDay.getTimeStamp();
     };
 
     disableWednesday() {
-        this.myDisableFunction = function(d: FdDate): boolean {
+        this.myDisableFunction = function (d: FdDate): boolean {
             const day = d.getDay();
             return day === 4;
         };


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes#1091
#### Please provide a brief summary of this pull request.

- Made blocked date on calendar match current month and year
- added a short description for disabled and blocked date 
- fixed small typo in button 