### PR TITLE
chore: edit mergeable

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -8,21 +8,21 @@ mergeable:
           regex: ^\[WIP\]
           message: This is work in progress. Do not merge yet.
         must_include:
-          regex: ^(feat|docs|chore|fix|test)(\(\w+\))?:.+$
+          regex: ^(feat|docs|chore|fix|test)(\(\w+\))?(:|\().+$
           message: Semantic release conventions must be followed.
       - do: description
         must_exclude:
           regex: \[ \]
           message: There are incomplete TODO task(s) unchecked.
       - do: approvals
-        min:
-          count: 2
-        or: 
+        or:
           - required:
-              reviewers: [ 'InnaAtanasova' ] 
+              reviewers: [ 'InnaAtanasova' ]
           - required:
-              reviewers: [ 'droshev' ]  
+              reviewers: [ 'droshev' ]
           - required:
-              reviewers: [ 'MattL75' ]  
+              reviewers: [ 'MattL75' ]
           - required:
-              reviewers: [ 'JKMarkowski' ]  
+              reviewers: [ 'JKMarkowski' ]
+          - min:
+              count: 2


### PR DESCRIPTION
Small edit to mergeable file to move `or` to the beginning so it doesn't require 2 approvals AND one of the listed reviewers.

Edited title regex to allow dependabot pr's to pass `chore(` versus `chore:`