### PR TITLE
fix: downgrade rxjs

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -17,7 +17,7 @@
     "@angular/core": "^7.2.15",
     "@angular/forms": "^7.2.15",
     "@angular/animations": "^7.2.15",
-    "rxjs": "^6.5.2"
+    "rxjs": "^6.4.0"
   },
   "devDependencies": {
     "standard-version": "4.4.0",


### PR DESCRIPTION
For some reason the build errors with the latest merge. Not sure why but it seems like downgrading from 6.5.2 does the trick.