### PR TITLE
docs: added long string title truncation code example.

### DIFF
--- a/docs/app/documentation/component-docs/action-bar/action-bar-docs.component.html
+++ b/docs/app/documentation/component-docs/action-bar/action-bar-docs.component.html
@@ -11,7 +11,7 @@
 
 
 
-<h2>Action bar with long string as page title</h2>
+<h2>Action bar with long page title</h2>
 <description>
   Display a page title. If the page title is a long string, it must truncate and display ellipsis after it crosses the
   width of the title bar.

--- a/docs/app/documentation/component-docs/action-bar/action-bar-docs.component.html
+++ b/docs/app/documentation/component-docs/action-bar/action-bar-docs.component.html
@@ -1,6 +1,6 @@
 <h2>Action bar with back button, description and action buttons</h2>
 <description>
-    Standard action bar which will likely fit most use cases.
+  Standard action bar which will likely fit most use cases.
 </description>
 <component-example [name]="'ex1'">
   <fd-action-bar-back-example></fd-action-bar-back-example>
@@ -9,12 +9,29 @@
 
 <separator></separator>
 
-<h2>Action bar with main actions and no Back button</h2>
+
+
+<h2>Action bar with long string as page title</h2>
 <description>
-    Display main actions within the Action bar. This allows for users to find important page actions in a
-    consistent area no matter what page they are on within the application.
+  Display a page title. If the page title is a long string, it must truncate and display ellipsis after it crosses the
+  width of the title bar.
 </description>
 <component-example [name]="'ex2'">
+  <fd-action-bar-long-string-title-truncation-example></fd-action-bar-long-string-title-truncation-example>
+</component-example>
+<code-example [exampleFiles]="titleTruncationExample"></code-example>
+
+<separator></separator>
+
+
+
+
+<h2>Action bar with main actions and no Back button</h2>
+<description>
+  Display main actions within the Action bar. This allows for users to find important page actions in a
+  consistent area no matter what page they are on within the application.
+</description>
+<component-example [name]="'ex3'">
   <fd-action-bar-no-back-example></fd-action-bar-no-back-example>
 </component-example>
 <code-example [exampleFiles]="noBackButtonExample"></code-example>
@@ -23,11 +40,12 @@
 
 <h2>Several Main Actions in a Contextual Menu</h2>
 <description>
-    When there are several main actions for a page, consider displaying them under a contextual menu.
-    This allows the user to look in the same position they are used to but avoids cluttering the action bar with more than 3-4 actions.
-    This also works well for a responsive/adaptive application.
+  When there are several main actions for a page, consider displaying them under a contextual menu.
+  This allows the user to look in the same position they are used to but avoids cluttering the action bar with more than
+  3-4 actions.
+  This also works well for a responsive/adaptive application.
 </description>
-<component-example [name]="'ex3'">
+<component-example [name]="'ex4'">
   <fd-action-bar-contextual-menu-example></fd-action-bar-contextual-menu-example>
 </component-example>
 <code-example [exampleFiles]="actionsContextualMenuHtml"></code-example>
@@ -36,10 +54,9 @@
 
 <h2>Action bar mobile view</h2>
 <description>
-    The action bar has an alternate way of displaying which is much more appropriate for mobile users.
+  The action bar has an alternate way of displaying which is much more appropriate for mobile users.
 </description>
-<component-example [name]="'ex4'">
+<component-example [name]="'ex5'">
   <fd-action-bar-mobile-example></fd-action-bar-mobile-example>
 </component-example>
 <code-example [exampleFiles]="mobileViewHtml"></code-example>
-

--- a/docs/app/documentation/component-docs/action-bar/action-bar-docs.component.ts
+++ b/docs/app/documentation/component-docs/action-bar/action-bar-docs.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 
 import * as backButtonExample from '!raw-loader!./examples/action-bar-back-example.component.html';
+import * as titleTruncationExample from '!raw-loader!./examples/action-bar-long-string-title-truncation-example.component.html';
 import * as contextualMenuExample from '!raw-loader!./examples/action-bar-contextual-menu-example.component.html';
 import * as mobileExample from '!raw-loader!./examples/action-bar-mobile-example.component.html';
 import * as noBackButtonExample from '!raw-loader!./examples/action-bar-no-back-example.component.html';
@@ -17,6 +18,11 @@ export class ActionBarDocsComponent {
         language: 'html',
         code: backButtonExample
     }];
+
+    titleTruncationExample: ExampleFile[] = [{
+        language: 'html',
+        code: titleTruncationExample
+    }]
 
     noBackButtonExample: ExampleFile[] = [{
         language: 'html',

--- a/docs/app/documentation/component-docs/action-bar/examples/action-bar-examples.component.ts
+++ b/docs/app/documentation/component-docs/action-bar/examples/action-bar-examples.component.ts
@@ -4,22 +4,29 @@ import { Component } from '@angular/core';
     selector: 'fd-action-bar-back-example',
     templateUrl: './action-bar-back-example.component.html'
 })
-export class ActionBarBackExampleComponent {}
+export class ActionBarBackExampleComponent { }
+
+@Component({
+    selector: 'fd-action-bar-long-string-title-truncation-example',
+    templateUrl: './action-bar-long-string-title-truncation-example.component.html'
+})
+export class ActionBarLongStringTitleTruncationExampleComponent { }
 
 @Component({
     selector: 'fd-action-bar-contextual-menu-example',
     templateUrl: './action-bar-contextual-menu-example.component.html'
 })
-export class ActionBarContextualMenuExampleComponent {}
+export class ActionBarContextualMenuExampleComponent { }
 
 @Component({
     selector: 'fd-action-bar-mobile-example',
     templateUrl: './action-bar-mobile-example.component.html'
 })
-export class ActionBarMobileExampleComponent {}
+export class ActionBarMobileExampleComponent { }
 
 @Component({
     selector: 'fd-action-bar-no-back-example',
     templateUrl: './action-bar-no-back-example.component.html'
 })
-export class ActionBarNoBackExampleComponent {}
+export class ActionBarNoBackExampleComponent { }
+

--- a/docs/app/documentation/component-docs/action-bar/examples/action-bar-long-string-title-truncation-example.component.html
+++ b/docs/app/documentation/component-docs/action-bar/examples/action-bar-long-string-title-truncation-example.component.html
@@ -1,0 +1,14 @@
+<div fd-action-bar>
+    <div fd-action-bar-back>
+        <button aria-label="back" fd-button [fdType]="'light'" [compact]="true" [glyph]="'nav-back'"></button>
+    </div>
+    <div fd-action-bar-header>
+        <h3 fd-action-bar-title>Page Title Demo for very very very very very very very very very very long string
+            example</h3>
+        <div fd-action-bar-description>Action bar Description</div>
+    </div>
+    <div fd-action-bar-actions>
+        <button fd-button [fdType]="'primary'">Cancel</button>
+        <button fd-button [fdType]="'main'">Save</button>
+    </div>
+</div>

--- a/docs/app/documentation/documentation.module.ts
+++ b/docs/app/documentation/documentation.module.ts
@@ -60,9 +60,12 @@ import { SearchInputDocsComponent } from './component-docs/search-input/search-i
 // examples
 import {
     ActionBarBackExampleComponent,
+    ActionBarLongStringTitleTruncationExampleComponent,
     ActionBarContextualMenuExampleComponent,
     ActionBarNoBackExampleComponent,
-    ActionBarMobileExampleComponent
+    ActionBarMobileExampleComponent,
+
+
 } from './component-docs/action-bar/examples/action-bar-examples.component';
 import { AlertExampleComponent } from './component-docs/alert/examples/alert-example.component';
 import { AlertInlineExampleComponent } from './component-docs/alert/examples/alert-inline-example.component';
@@ -451,6 +454,7 @@ import { RadioHeaderComponent } from './component-docs/radio/radio-header/radio-
         ComponentExampleComponent,
         ExampleBackgroundComponent,
         ActionBarBackExampleComponent,
+        ActionBarLongStringTitleTruncationExampleComponent,
         ActionBarContextualMenuExampleComponent,
         ActionBarMobileExampleComponent,
         ActionBarNoBackExampleComponent,


### PR DESCRIPTION
https://github.com/SAP/fundamental-styles/issues/237

Added an example to demonstrate the truncation long string title in the action bar.

No
