### PR TITLE
fix: adds missing class for Action Bar description, updates the tests, updates the documentation

### DIFF
--- a/docs/app/documentation/component-docs/action-bar/examples/action-bar-back-example.component.html
+++ b/docs/app/documentation/component-docs/action-bar/examples/action-bar-back-example.component.html
@@ -7,7 +7,7 @@
         <div fd-action-bar-description>Action bar Description</div>
     </div>
     <div fd-action-bar-actions>
-        <button fd-button [fdType]="'primary'">Cancel</button>
         <button fd-button [fdType]="'main'">Save</button>
+        <button fd-button [fdType]="'light'">Cancel</button>
     </div>
 </div>

--- a/docs/app/documentation/component-docs/action-bar/examples/action-bar-long-string-title-truncation-example.component.html
+++ b/docs/app/documentation/component-docs/action-bar/examples/action-bar-long-string-title-truncation-example.component.html
@@ -3,12 +3,11 @@
         <button aria-label="back" fd-button [fdType]="'light'" [compact]="true" [glyph]="'nav-back'"></button>
     </div>
     <div fd-action-bar-header>
-        <h3 fd-action-bar-title>Page Title Demo for very very very very very very very very very very long string
-            example</h3>
-        <div fd-action-bar-description>Action bar Description</div>
+        <h3 fd-action-bar-title>Page Title Demo for very very very very very very very very very very very very very very very very very very very long text</h3>
+        <div fd-action-bar-description>Action bar Description with a very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long text</div>
     </div>
     <div fd-action-bar-actions>
-        <button fd-button [fdType]="'primary'">Cancel</button>
         <button fd-button [fdType]="'main'">Save</button>
+        <button fd-button [fdType]="'light'">Cancel</button>
     </div>
 </div>

--- a/docs/app/documentation/component-docs/action-bar/examples/action-bar-no-back-example.component.html
+++ b/docs/app/documentation/component-docs/action-bar/examples/action-bar-no-back-example.component.html
@@ -4,7 +4,7 @@
         <div fd-action-bar-description>Action bar Description</div>
     </div>
     <div fd-action-bar-actions>
-        <button fd-button [fdType]="'primary'">Cancel</button>
         <button fd-button [fdType]="'main'">Save</button>
+        <button fd-button [fdType]="'light'">Cancel</button>
     </div>
 </div>

--- a/library/src/lib/action-bar/action-bar-description/action-bar-description.directive.spec.ts
+++ b/library/src/lib/action-bar/action-bar-description/action-bar-description.directive.spec.ts
@@ -32,4 +32,8 @@ describe('ActionBarDescription', () => {
     it('should create', () => {
         expect(component).toBeTruthy();
     });
+
+    it('should assign class', () => {
+        expect(component.ref.nativeElement.className).toBe('fd-action-bar__description');
+    });
 });

--- a/library/src/lib/action-bar/action-bar-description/action-bar-description.directive.ts
+++ b/library/src/lib/action-bar/action-bar-description/action-bar-description.directive.ts
@@ -13,6 +13,9 @@ import { Directive } from '@angular/core';
  */
 @Directive({
     // tslint:disable-next-line:directive-selector
-    selector: '[fd-action-bar-description]'
+    selector: '[fd-action-bar-description]',
+    host: {
+        class: 'fd-action-bar__description'
+    }
 })
-export class ActionBarDescriptionDirective {}
+export class ActionBarDescriptionDirective { }


### PR DESCRIPTION
fixes #1126 

#### Please provide a link to the associated issue.
[#1126 ](https://github.com/SAP/fundamental-ngx/issues/1126)

#### Please provide a brief summary of this pull request.
- `action-bar-description` directive was not attaching the `fd-action-bar__description` class to the host element. 
- updated the test for this directive
- updated the `Action bar with long page title` example in the documentation with a very long description text
- updated the placement of the actions in the documentation to follow the design guidelines (`Cancel` btn should be of type `light` and after the main action) 
