### PR TITLE
fix: first day issues

### DIFF
--- a/docs/app/documentation/component-docs/date-picker/examples/date-picker-i18n-example.component.ts
+++ b/docs/app/documentation/component-docs/date-picker/examples/date-picker-i18n-example.component.ts
@@ -88,7 +88,7 @@ export class CustomI18nLabels extends CalendarI18nLabels {
             <button fd-button-grouped [size]="'xs'" (click)="setBulgarian()" [state]="isSelected('bg')">Bulgarian</button>
         </fd-button-group>
         <br>
-        <fd-date-picker [(ngModel)]="date" [startingDayOfWeek]="2"></fd-date-picker>
+        <fd-date-picker [(ngModel)]="date" [startingDayOfWeek]="1"></fd-date-picker>
         `,
 
     // Note that this can be provided in the root of your application.

--- a/library/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.spec.ts
+++ b/library/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.spec.ts
@@ -5,7 +5,7 @@ import { FdDate } from '../../models/fd-date';
 import { CalendarDay } from '../../models/calendar-day';
 import { CalendarService } from '../../calendar.service';
 
-describe('Calendar2DayViewComponent', () => {
+describe('CalendarDayViewComponent', () => {
     let component: CalendarDayViewComponent;
     let fixture: ComponentFixture<CalendarDayViewComponent>;
 

--- a/library/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
+++ b/library/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
@@ -16,8 +16,6 @@ import { CalendarType, DaysOfWeek } from '../../calendar.component';
 import { CalendarDay } from '../../models/calendar-day';
 import { CalendarService } from '../../calendar.service';
 import { FdRangeDate } from '../../models/fd-range-date';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 
 /** Component representing the day view of the calendar. */
 @Component({

--- a/library/src/lib/calendar/calendar.component.ts
+++ b/library/src/lib/calendar/calendar.component.ts
@@ -89,7 +89,7 @@ export class CalendarComponent implements OnInit, ControlValueAccessor, Validato
     @Input()
     public activeView: FdCalendarView = 'day';
 
-    /** The day of the week the calendar should start on. 0 represents Sunday, 1 is Monday, 2 is Tuesday, and so on. */
+    /** The day of the week the calendar should start on. 1 represents Sunday, 2 is Monday, 3 is Tuesday, and so on. */
     @Input()
     public startingDayOfWeek: DaysOfWeek = 1;
 

--- a/library/src/lib/date-picker/date-picker.component.ts
+++ b/library/src/lib/date-picker/date-picker.component.ts
@@ -6,7 +6,7 @@ import {
     Output, ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import { CalendarType, FdCalendarView } from '../calendar/calendar.component';
+import { CalendarType, DaysOfWeek, FdCalendarView } from '../calendar/calendar.component';
 import { AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator } from '@angular/forms';
 import { Placement } from 'popper.js';
 import { FdDate } from '../calendar/models/fd-date';
@@ -72,9 +72,9 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
     @Input()
     public selectedRangeDate: FdRangeDate = { start: null, end: null };
 
-    /** The day of the week the calendar should start on. 0 represents Sunday, 1 is Monday, 2 is Tuesday, and so on. */
+    /** The day of the week the calendar should start on. 1 represents Sunday, 2 is Monday, 3 is Tuesday, and so on. */
     @Input()
-    startingDayOfWeek: number = 0;
+    startingDayOfWeek: DaysOfWeek = 1;
 
     /** Whether to validate the date picker input. */
     @Input()


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1141
#### Please provide a brief summary of this pull request.
I made datepicker and calendar first day consistent, the bug was caused by the fact that on datepicker the sunday was marked as a 0 number and on calendar as a 1. Right now sunday is marked as 1 everywhere.
#### If this is a new feature, have you updated the documentation?
