### PR TITLE
fix: Add option to close popover product menu in shellbar on choose

### DIFF
--- a/docs/app/documentation/component-docs/shellbar/examples/shellbar-collapsible-example.component.html
+++ b/docs/app/documentation/component-docs/shellbar/examples/shellbar-collapsible-example.component.html
@@ -5,6 +5,7 @@
            aria-label="SAP"></a>
     </fd-shellbar-logo>
     <fd-product-menu [control]="productMenuControl"
+                     [closePopoverOnSelect]="true"
                      [items]="productMenuItems">
     </fd-product-menu>
     <fd-shellbar-subtitle>

--- a/library/src/lib/shellbar/product-menu/product-menu.component.html
+++ b/library/src/lib/shellbar/product-menu/product-menu.component.html
@@ -12,7 +12,7 @@
         <fd-popover-body>
             <fd-menu>
                 <ul fd-menu-list>
-                    <li fd-menu-item *ngFor="let item of items" (click)="item.callback($event)">
+                    <li fd-menu-item *ngFor="let item of items" (click)="itemClicked(item, $event)">
                         {{item.name}}
                     </li>
                 </ul>

--- a/library/src/lib/shellbar/product-menu/product-menu.component.ts
+++ b/library/src/lib/shellbar/product-menu/product-menu.component.ts
@@ -1,4 +1,5 @@
-import { Component, HostListener, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, HostListener, Input, OnInit, QueryList, ViewChild, ViewEncapsulation } from '@angular/core';
+import { PopoverComponent } from '../../popover/popover.component';
 
 /**
  * The component that represents a product menu.
@@ -16,6 +17,10 @@ import { Component, HostListener, Input, OnInit, ViewEncapsulation } from '@angu
 })
 export class ProductMenuComponent implements OnInit {
 
+    /** @hidden */
+    @ViewChild(PopoverComponent)
+    popoverComponent: PopoverComponent;
+
     /** 
      * The control element to toggle the product menu,
      * represented by the name of the current application. 
@@ -30,6 +35,10 @@ export class ProductMenuComponent implements OnInit {
     /** @hidden */
     productMenuCollapsed: boolean = false;
 
+    /** When set to true, popover list will be closed after selecting the option */
+    @Input()
+    closePopoverOnSelect: boolean = false;
+
     /** @hidden */
     @HostListener('window:resize', [])
     onResize() {
@@ -40,6 +49,16 @@ export class ProductMenuComponent implements OnInit {
     /** @hidden */
     ngOnInit() {
         this.onResize();
+    }
+
+    /**
+     * @hidden
+     */
+    itemClicked(item: any, event: any): void {
+        if (this.closePopoverOnSelect) {
+            this.popoverComponent.close();
+        }
+        item.callback(event);
     }
 
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1146
#### Please provide a brief summary of this pull request.
I added option to automatically close popover on product menu component in shellbar, when item is chosen.
#### If this is a new feature, have you updated the documentation?
