### PR TITLE
fix: added optional separator line to menu list items

### DIFF
--- a/docs/app/documentation/component-docs/menu/examples/menu-examples.component.ts
+++ b/docs/app/documentation/component-docs/menu/examples/menu-examples.component.ts
@@ -4,10 +4,16 @@ import { Component } from '@angular/core';
     selector: 'fd-menu-example',
     templateUrl: './menu-example.component.html'
 })
-export class MenuExampleComponent {}
+export class MenuExampleComponent { }
 
 @Component({
     selector: 'fd-menu-group-example',
     templateUrl: './menu-group-example.component.html'
 })
-export class MenuGroupExampleComponent {}
+export class MenuGroupExampleComponent { }
+
+@Component({
+    selector: 'fd-menu-separator-example',
+    templateUrl: './menu-separator-example.component.html'
+})
+export class MenuSeparatorExampleComponent { }

--- a/docs/app/documentation/component-docs/menu/examples/menu-separator-example.component.html
+++ b/docs/app/documentation/component-docs/menu/examples/menu-separator-example.component.html
@@ -1,0 +1,29 @@
+<fd-menu>
+    <ul fd-menu-list [separator]="true">
+        <li fd-menu-item>
+            Option 1
+        </li>
+        <li fd-menu-item>
+            Option 2
+        </li>
+        <li fd-menu-item>
+            Option 3
+        </li>
+    </ul>
+    <fd-menu-group>
+        <h1 fd-menu-title>
+            Group header
+        </h1>
+        <ul fd-menu-list [separator]="true">
+            <li>
+                <a fd-menu-item>Option 4</a>
+            </li>
+            <li>
+                <a fd-menu-item>Option 5</a>
+            </li>
+            <li>
+                <a fd-menu-item>Option 6</a>
+            </li>
+        </ul>
+    </fd-menu-group>
+</fd-menu>

--- a/docs/app/documentation/component-docs/menu/examples/menu-separator-example.component.html
+++ b/docs/app/documentation/component-docs/menu/examples/menu-separator-example.component.html
@@ -1,5 +1,5 @@
-<fd-menu>
-    <ul fd-menu-list [separator]="true">
+<fd-menu [separator]="true">
+    <ul fd-menu-list>
         <li fd-menu-item>
             Option 1
         </li>
@@ -14,7 +14,7 @@
         <h1 fd-menu-title>
             Group header
         </h1>
-        <ul fd-menu-list [separator]="true">
+        <ul fd-menu-list>
             <li>
                 <a fd-menu-item>Option 4</a>
             </li>

--- a/docs/app/documentation/component-docs/menu/menu-docs.component.html
+++ b/docs/app/documentation/component-docs/menu/menu-docs.component.html
@@ -14,6 +14,15 @@
 
 <separator></separator>
 
+<h2>Menu with Optional Separator</h2>
+<description>Each menu item can have an optional separator shown as a line beneath the item.</description>
+<component-example [name]="'ex4'">
+    <fd-menu-separator-example></fd-menu-separator-example>
+</component-example>
+<code-example [exampleFiles]="menuSeparator"></code-example>
+
+<separator></separator>
+
 <h2>Keyboard Support</h2>
 <description>
     Keyboard support can be added on every component which uses the <code>MenuComponent</code>. It simulates

--- a/docs/app/documentation/component-docs/menu/menu-docs.component.ts
+++ b/docs/app/documentation/component-docs/menu/menu-docs.component.ts
@@ -4,6 +4,8 @@ import * as menuSrc from '!raw-loader!./examples/menu-example.component.html';
 import * as menuGroupSrc from '!raw-loader!./examples/menu-group-example.component.html';
 import * as menuKeyboardSrcH from '!raw-loader!./examples/menu-keyboard-support-example.component.html';
 import * as menuKeyboardSrcT from '!raw-loader!./examples/menu-keyboard-support-example.component.ts';
+import * as menuSeparatorSrc from '!raw-loader!./examples/menu-separator-example.component.html';
+
 import { ExampleFile } from '../../core-helpers/code-example/example-file';
 
 @Component({
@@ -33,4 +35,8 @@ export class MenuDocsComponent {
         }
     ];
 
+    menuSeparator: ExampleFile[] = [{
+        language: 'html',
+        code: menuSeparatorSrc
+    }];
 }

--- a/docs/app/documentation/documentation.module.ts
+++ b/docs/app/documentation/documentation.module.ts
@@ -143,7 +143,8 @@ import { LoadingSpinnerExampleComponent } from './component-docs/loading-spinner
 import { LoadingSpinnerContainerExampleComponent } from './component-docs/loading-spinner-docs/examples/loading-spinner-container-example.component';
 import {
     MenuExampleComponent,
-    MenuGroupExampleComponent
+    MenuGroupExampleComponent,
+    MenuSeparatorExampleComponent
 } from './component-docs/menu/examples/menu-examples.component';
 import { ModalOpenTemplateExampleComponent } from './component-docs/modal/examples/template-as-content/modal-open-template-example.component';
 import { ModalContentComponent } from './component-docs/modal/examples/component-as-content/modal-content.component';
@@ -547,6 +548,7 @@ import { RadioHeaderComponent } from './component-docs/radio/radio-header/radio-
         ListSingleSelectExampleComponent,
         MenuExampleComponent,
         MenuGroupExampleComponent,
+        MenuSeparatorExampleComponent,
         MenuKeyboardSupportExampleComponent,
         ModalOpenTemplateExampleComponent,
         ModalContentComponent,

--- a/library/src/lib/menu/menu-list.directive.ts
+++ b/library/src/lib/menu/menu-list.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, HostBinding, ElementRef, Input } from '@angular/core';
+import { Directive, HostBinding } from '@angular/core';
 
 /**
  * The directive that represents a listing structure of the menu.

--- a/library/src/lib/menu/menu-list.directive.ts
+++ b/library/src/lib/menu/menu-list.directive.ts
@@ -1,5 +1,4 @@
 import { Directive, HostBinding, ElementRef, Input } from '@angular/core';
-import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 
 /**
  * The directive that represents a listing structure of the menu.
@@ -9,25 +8,8 @@ import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
     // tslint:disable-next-line:directive-selector
     selector: '[fd-menu-list]'
 })
-export class MenuListDirective extends AbstractFdNgxClass {
+export class MenuListDirective {
     /** @hidden */
     @HostBinding('class.fd-menu__list')
     fdMenuListClass: boolean = true;
-
-    /** The separator line for each menu item. When set to true at list level, it adds a separator below each menu item in the list. 
-     * False by default. Leave empty for default. */
-    @Input()
-    separator: boolean = false;
-
-    /** @hidden */
-    constructor(public itemEl: ElementRef) {
-        super(itemEl);
-    }
-    /** @hidden */
-    _setProperties(): void {
-        if (this.separator) {
-            this._addClassToElement('fd-menu__list-separator');
-        }
-    }
-
 }

--- a/library/src/lib/menu/menu-list.directive.ts
+++ b/library/src/lib/menu/menu-list.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, HostBinding } from '@angular/core';
+import { Directive, HostBinding, ElementRef, Input } from '@angular/core';
+import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 
 /**
  * The directive that represents a listing structure of the menu.
@@ -8,8 +9,25 @@ import { Directive, HostBinding } from '@angular/core';
     // tslint:disable-next-line:directive-selector
     selector: '[fd-menu-list]'
 })
-export class MenuListDirective {
+export class MenuListDirective extends AbstractFdNgxClass {
     /** @hidden */
     @HostBinding('class.fd-menu__list')
     fdMenuListClass: boolean = true;
+
+    /** The separator line for each menu item. When set to true at list level, it adds a separator below each menu item in the list. 
+     * False by default. Leave empty for default. */
+    @Input()
+    separator: boolean = false;
+
+    /** @hidden */
+    constructor(public itemEl: ElementRef) {
+        super(itemEl);
+    }
+    /** @hidden */
+    _setProperties(): void {
+        if (this.separator) {
+            this._addClassToElement('fd-menu__list-separator');
+        }
+    }
+
 }

--- a/library/src/lib/menu/menu.component.scss
+++ b/library/src/lib/menu/menu.component.scss
@@ -3,7 +3,3 @@
         outline: var(--fd-color-action-focus) dotted 1px;
     }
 }
-.fd-menu__list-separator > ul > li,
-.fd-menu__list-separator > fd-menu-group > ul > li{
-    border-bottom: 1px #EDEDED solid;
-}

--- a/library/src/lib/menu/menu.component.scss
+++ b/library/src/lib/menu/menu.component.scss
@@ -3,3 +3,6 @@
         outline: var(--fd-color-action-focus) dotted 1px;
     }
 }
+.fd-menu__list-separator > li{
+    border-bottom: 1px #EDEDED solid;
+}

--- a/library/src/lib/menu/menu.component.scss
+++ b/library/src/lib/menu/menu.component.scss
@@ -3,6 +3,7 @@
         outline: var(--fd-color-action-focus) dotted 1px;
     }
 }
-.fd-menu__list-separator > li{
+.fd-menu__list-separator > ul > li,
+.fd-menu__list-separator > fd-menu-group > ul > li{
     border-bottom: 1px #EDEDED solid;
 }

--- a/library/src/lib/menu/menu.component.ts
+++ b/library/src/lib/menu/menu.component.ts
@@ -1,10 +1,8 @@
 import {
     Component, HostBinding,
     ViewEncapsulation,
-    Input,
-    ElementRef
+    Input
 } from '@angular/core';
-import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 
 /**
  * The component that represents a menu.
@@ -15,24 +13,15 @@ import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
     encapsulation: ViewEncapsulation.None,
     styleUrls: ['menu.component.scss']
 })
-export class MenuComponent extends AbstractFdNgxClass {
+export class MenuComponent {
     /** @hidden */
     @HostBinding('class.fd-menu')
     fdMenuClass: boolean = true;
 
-    /** The separator line for each menu item. When set to true at list level, it adds a separator below each menu item in the list. 
+    /** The separator line for each menu item. When set to true, it adds a separator below each menu item in the list. 
      * False by default. Leave empty for default. */
     @Input()
+    @HostBinding('class.fd-menu__list--separated')
     separator: boolean = false;
 
-    /** @hidden */
-    constructor(public itemEl: ElementRef) {
-        super(itemEl);
-    }
-    /** @hidden */
-    _setProperties(): void {
-        if (this.separator) {
-            this._addClassToElement('fd-menu__list-separator');
-        }
-    }
 }

--- a/library/src/lib/menu/menu.component.ts
+++ b/library/src/lib/menu/menu.component.ts
@@ -1,7 +1,10 @@
 import {
     Component, HostBinding,
-    ViewEncapsulation
+    ViewEncapsulation,
+    Input,
+    ElementRef
 } from '@angular/core';
+import { AbstractFdNgxClass } from '../utils/abstract-fd-ngx-class';
 
 /**
  * The component that represents a menu.
@@ -12,9 +15,24 @@ import {
     encapsulation: ViewEncapsulation.None,
     styleUrls: ['menu.component.scss']
 })
-export class MenuComponent {
+export class MenuComponent extends AbstractFdNgxClass {
     /** @hidden */
     @HostBinding('class.fd-menu')
     fdMenuClass: boolean = true;
 
+    /** The separator line for each menu item. When set to true at list level, it adds a separator below each menu item in the list. 
+     * False by default. Leave empty for default. */
+    @Input()
+    separator: boolean = false;
+
+    /** @hidden */
+    constructor(public itemEl: ElementRef) {
+        super(itemEl);
+    }
+    /** @hidden */
+    _setProperties(): void {
+        if (this.separator) {
+            this._addClassToElement('fd-menu__list-separator');
+        }
+    }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#1133 
#### Please provide a brief summary of this pull request.
Added optional separator line to menu list items. On fd-menu tag, use **[separator] = "true"** to get the line separator on the list items.
#### If this is a new feature, have you updated the documentation?
Yes.