### PR TITLE
fix side navigation link keyboard event issue (#1186)

### DIFF
--- a/library/src/lib/side-navigation/side-navigation-link/side-navigation-link.directive.ts
+++ b/library/src/lib/side-navigation/side-navigation-link/side-navigation-link.directive.ts
@@ -55,7 +55,7 @@ export class SideNavigationLinkDirective extends AbstractFdNgxClass {
     }
 
     /** @hidden */
-    @HostListener('keypress', ['$event.target'])
+    @HostListener('keypress', ['$event'])
     onKeypressHandler(event) {
         if (this.hasSublist && (event.code === 'Enter' || event.code === 'Space')) {
             event.preventDefault();


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#1186

#### Please provide a brief summary of this pull request.

Fixes the parameter passed to the `onKeypressHandler` function in the side navigation link directive to event, which will now correctly read the event data when pressing the enter key or space bar.
