### PR TITLE
fix: Add focus trap to combobox

### DIFF
--- a/library/src/lib/combobox/combobox.component.html
+++ b/library/src/lib/combobox/combobox.component.html
@@ -1,7 +1,7 @@
 <fd-popover [isOpen]="isOpen"
             (isOpenChange)="isOpenChangeHandle($event)"
             [fillControlMode]="'at-least'"
-            [triggers]=""
+            [triggers]="triggers"
             [disabled]="disabled"
             class="fd-combobox-popover-custom"
             [ngClass]="{'fd-popover-body--display-none': displayedValues && !displayedValues.length}">

--- a/library/src/lib/combobox/combobox.component.html
+++ b/library/src/lib/combobox/combobox.component.html
@@ -1,5 +1,7 @@
-<fd-popover [(isOpen)]="isOpen"
+<fd-popover [isOpen]="isOpen"
+            (isOpenChange)="isOpenChangeHandle($event)"
             [fillControlMode]="'at-least'"
+            [triggers]=""
             [disabled]="disabled"
             class="fd-combobox-popover-custom"
             [ngClass]="{'fd-popover-body--display-none': displayedValues && !displayedValues.length}">
@@ -8,7 +10,7 @@
             <div class="fd-input-group fd-input-group--after" [ngClass]="{'fd-input-group--compact': compact}">
                 <input #searchInputElement type="text" class="fd-input" [ngClass]="{'fd-input--compact': compact}"
                        (keydown)="onInputKeydownHandler($event)"
-                       (keyup)="onInputKeyupHandler()"
+                       (keyup)="onInputKeyupHandler($event)"
                        [disabled]="disabled"
                        [(ngModel)]="inputText"
                        (ngModelChange)="handleSearchTermChange()"

--- a/library/src/lib/combobox/combobox.component.spec.ts
+++ b/library/src/lib/combobox/combobox.component.spec.ts
@@ -35,6 +35,14 @@ describe('ComboboxComponent', () => {
         ];
         component.searchFunction = () => {};
         fixture.detectChanges();
+
+        /** That's focus trap testing workaround */
+        component.focusTrap = {
+            activate: () => {},
+            deactivate: () => {},
+            pause: () => {},
+            unpause: () => {},
+        }
     });
 
     it('should create', () => {

--- a/library/src/lib/combobox/combobox.component.ts
+++ b/library/src/lib/combobox/combobox.component.ts
@@ -69,8 +69,8 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
     glyph: string = 'navigation-down-arrow';
 
     /**
-     *  The trigger events that will open/close the popover, when .
-     *
+     *  The trigger events that will open/close the options popover, by default it is click, so if user click on
+     *  input field, the popover with options will open or close
      *  Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp).
      */
     @Input()

--- a/library/src/lib/combobox/combobox.component.ts
+++ b/library/src/lib/combobox/combobox.component.ts
@@ -136,9 +136,10 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
     inputTextValue: string;
 
     /** @hidden */
-    private readonly onDestroy$: Subject<void> = new Subject<void>();
+    public focusTrap: FocusTrap;
 
-    private focusTrap: FocusTrap;
+    /** @hidden */
+    private readonly onDestroy$: Subject<void> = new Subject<void>();
 
     /** @hidden */
     onChange: any = () => { };
@@ -303,11 +304,15 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
 
 
     private setupFocusTrap(): void {
-        this.focusTrap = focusTrap(this.elRef.nativeElement, {
-            clickOutsideDeactivates: true,
-            returnFocusOnDeactivate: true,
-            escapeDeactivates: false
-        });
+        try {
+            this.focusTrap = focusTrap(this.elRef.nativeElement, {
+                clickOutsideDeactivates: true,
+                returnFocusOnDeactivate: true,
+                escapeDeactivates: false
+            });
+        } catch (e) {
+            console.warn('Unsuccessful attempting to focus trap the Combobox.');
+        }
     }
 
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1170
#### Please provide a brief summary of this pull request.
I added focus-tap library to combobox. Right now focus trap is activated, when the popover body is open. I also added triggers input, to combobox, which is passed to popover. It can be handy, when someone want's to change or remove events that open/close the popover body inside combobox.