### PR TITLE
feat: Added maxHeight to select component

### DIFF
--- a/docs/app/documentation/component-docs/select/examples/select-height/select-max-height-example.component.html
+++ b/docs/app/documentation/component-docs/select/examples/select-height/select-max-height-example.component.html
@@ -1,0 +1,15 @@
+<p>Selected Value: {{selectValue}}</p>
+<fd-select [(value)]="selectValue"
+           [maxHeight]="'250px'"
+           placeholder="Select an option...">
+    <fd-option value="apple">Apple</fd-option>
+    <fd-option value="pineapple">Pineapple</fd-option>
+    <fd-option value="tomato">Tomato</fd-option>
+    <fd-option value="strawberry">Strawberry</fd-option>
+    <fd-option value="banana">Banana</fd-option>
+    <fd-option value="orange">Orange</fd-option>
+    <fd-option value="lemon">Lemon</fd-option>
+    <fd-option value="carrot">Carrot</fd-option>
+    <fd-option value="potato">Potato</fd-option>
+    <fd-option value="kiwi">Kiwi</fd-option>
+</fd-select>

--- a/docs/app/documentation/component-docs/select/examples/select-height/select-max-height-example.component.ts
+++ b/docs/app/documentation/component-docs/select/examples/select-height/select-max-height-example.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'fd-select-max-height-example',
+    templateUrl: './select-max-height-example.component.html',
+})
+export class SelectMaxHeightExampleComponent {
+    selectValue: string;
+}

--- a/docs/app/documentation/component-docs/select/examples/select-nested-options/select-nested-options.component.html
+++ b/docs/app/documentation/component-docs/select/examples/select-nested-options/select-nested-options.component.html
@@ -1,6 +1,6 @@
 <p>Selected Value: {{this.value}}</p>
-<fd-select [(value)]="value" placeholder="Select an option...">
-    <div style="max-height: 200px; overflow: auto;">
+<fd-select [(value)]="value" placeholder="Select an option..." >
+    <div>
         <div>
             <p class="fd-menu__title">
                 <fd-icon [glyph]="'arrow-right'"></fd-icon>

--- a/docs/app/documentation/component-docs/select/select-docs.component.html
+++ b/docs/app/documentation/component-docs/select/select-docs.component.html
@@ -26,6 +26,18 @@
 </component-example>
 <code-example [exampleFiles]="selectViewValue"></code-example>
 
+
+<separator></separator>
+<h2>Select Max Height</h2>
+<description>
+    The select component allows to define <code>[maxHeight]</code>. It can be useful when there are a lot of options,
+    the select body is be scrollable. By default maximum height of select body is 45% of browsers window inner height.
+</description>
+<component-example [name]="'ex4'">
+    <fd-select-max-height-example></fd-select-max-height-example>
+</component-example>
+<code-example [exampleFiles]="selectMaxHeight"></code-example>
+
 <separator></separator>
 <h2>Nested Options</h2>
 <description>
@@ -35,7 +47,7 @@
 
     Note that accessibility generally requires some text-content to be present in the actual option element.
 </description>
-<component-example [name]="'ex4'">
+<component-example [name]="'ex5'">
     <fd-select-nested-options></fd-select-nested-options>
 </component-example>
 <code-example [exampleFiles]="selectNested"></code-example>
@@ -46,7 +58,7 @@
     The default trigger can be replaced by providing a template reference to the appropriate input.
     Note that the top-level element must be tab-indexed for the keyboard support to function correctly.
 </description>
-<component-example [name]="'ex5'">
+<component-example [name]="'ex6'">
     <fd-select-custom-trigger></fd-select-custom-trigger>
 </component-example>
 <code-example [exampleFiles]="customTrigger"></code-example>
@@ -59,7 +71,7 @@
     will become undefined. This was implemented to prevent a user from keeping the active value of a previously
     removed option.
 </description>
-<component-example [name]="'ex6'">
+<component-example [name]="'ex7'">
     <fd-select-adding-example></fd-select-adding-example>
 </component-example>
 <code-example [exampleFiles]="selectAdding"></code-example>
@@ -69,7 +81,7 @@
 <description>
     The select component can be used inside Angular reactive forms.
 </description>
-<component-example [name]="'ex7'">
+<component-example [name]="'ex8'">
     <fd-select-forms></fd-select-forms>
 </component-example>
 <code-example [exampleFiles]="selectForm"></code-example>

--- a/docs/app/documentation/component-docs/select/select-docs.component.ts
+++ b/docs/app/documentation/component-docs/select/select-docs.component.ts
@@ -18,7 +18,7 @@ import * as selectFormSrcT from '!raw-loader!./examples/select-forms/select-form
 import * as selectViewValueH from '!raw-loader!./examples/select-view-value-example/select-view-value-example.component.html';
 import * as selectViewValueT from '!raw-loader!./examples/select-view-value-example/select-view-value-example.component.ts';
 
-import * as selectMaxHeightH from '!raw-loader!./examples/select-height/select-max-height-example.component.ts';
+import * as selectMaxHeightH from '!raw-loader!./examples/select-height/select-max-height-example.component.html';
 import { ExampleFile } from '../../core-helpers/code-example/example-file';
 
 @Component({

--- a/docs/app/documentation/component-docs/select/select-docs.component.ts
+++ b/docs/app/documentation/component-docs/select/select-docs.component.ts
@@ -17,6 +17,8 @@ import * as selectFormSrcT from '!raw-loader!./examples/select-forms/select-form
 
 import * as selectViewValueH from '!raw-loader!./examples/select-view-value-example/select-view-value-example.component.html';
 import * as selectViewValueT from '!raw-loader!./examples/select-view-value-example/select-view-value-example.component.ts';
+
+import * as selectMaxHeightH from '!raw-loader!./examples/select-height/select-max-height-example.component.ts';
 import { ExampleFile } from '../../core-helpers/code-example/example-file';
 
 @Component({
@@ -72,6 +74,13 @@ export class SelectDocsComponent {
             language: 'typescript',
             code: selectFormSrcT
         }
+    ];
+
+    selectMaxHeight: ExampleFile[] = [
+        {
+            language: 'html',
+            code: selectMaxHeightH,
+        },
     ];
 
     selectViewValue: ExampleFile[] = [

--- a/docs/app/documentation/documentation.module.ts
+++ b/docs/app/documentation/documentation.module.ts
@@ -402,6 +402,7 @@ import { RadioExamplesComponent } from './component-docs/radio/examples/radio-ex
 import { RadioDocsComponent } from './component-docs/radio/radio-docs.component';
 import { RadioHeaderComponent } from './component-docs/radio/radio-header/radio-header.component';
 import { ComboboxSearchFunctionExampleComponent } from './component-docs/combobox/examples/combobox-search-function-example.component';
+import { SelectMaxHeightExampleComponent } from './component-docs/select/examples/select-height/select-max-height-example.component';
 
 @NgModule({
     declarations: [
@@ -731,6 +732,7 @@ import { ComboboxSearchFunctionExampleComponent } from './component-docs/combobo
         SelectAddingExampleComponent,
         SelectFormsComponent,
         SelectViewValueExampleComponent,
+        SelectMaxHeightExampleComponent,
         InputGroupNumberFormExampleComponent
     ],
     entryComponents: [ModalContentComponent, ModalInModalComponent, ModalInModalSecondComponent, AlertContentComponent],

--- a/library/src/lib/select/select.component.html
+++ b/library/src/lib/select/select.component.html
@@ -1,5 +1,5 @@
 <fd-popover [(isOpen)]="isOpen"
-            (isOpenChange)="isOpenChange.emit($event)"
+            (isOpenChange)="isOpenChangeHandle($event)"
             [options]="popperOptions"
             [fillControlMode]="fillControlMode"
             [appendTo]="appendTo"
@@ -18,7 +18,9 @@
             </button>
         </ng-container>
     </fd-popover-control>
-    <fd-popover-body>
+    <fd-popover-body
+        class="fd-select-popover-body-custom"
+        [style.maxHeight]="maxHeight || (calculatedMaxHeight + 'px')">
         <ng-content></ng-content>
     </fd-popover-body>
 </fd-popover>

--- a/library/src/lib/select/select.component.scss
+++ b/library/src/lib/select/select.component.scss
@@ -32,4 +32,8 @@
         white-space: nowrap;
         overflow-x: hidden;
     }
+
+    .fd-select-popover-body-custom {
+        display: block;
+    }
 }

--- a/library/src/lib/select/select.component.ts
+++ b/library/src/lib/select/select.component.ts
@@ -65,6 +65,10 @@ export class SelectComponent implements OnChanges, AfterContentInit, OnDestroy, 
     @Input()
     compact: boolean = false;
 
+    /** Max height of the popover. Any overflowing elements will be accessible through scrolling. */
+    @Input()
+    maxHeight: string;
+
     /** Popper.js options of the popover. */
     @Input()
     popperOptions: PopperOptions = {
@@ -105,6 +109,9 @@ export class SelectComponent implements OnChanges, AfterContentInit, OnDestroy, 
     readonly valueChange: EventEmitter<any>
         = new EventEmitter<any>();
 
+    /** @hidden */
+    calculatedMaxHeight: number;
+
     /** Current selected option component reference. */
     private selected: OptionComponent;
 
@@ -127,6 +134,13 @@ export class SelectComponent implements OnChanges, AfterContentInit, OnDestroy, 
 
     /** @hidden */
     onTouched: Function = () => {};
+
+    /** @hidden */
+    isOpenChangeHandle(isOpen: boolean): void {
+        this.isOpen = isOpen;
+        this.isOpenChange.emit(isOpen);
+        this.resizeScrollHandler();
+    }
 
     /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
@@ -229,6 +243,12 @@ export class SelectComponent implements OnChanges, AfterContentInit, OnDestroy, 
                 break;
             }
         }
+    }
+
+    /** @hidden */
+    @HostListener('window:resize')
+    resizeScrollHandler() {
+        this.calculatedMaxHeight = window.innerHeight * 0.45;
     }
 
     /**


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/1166
#### Please provide a brief summary of this pull request.
I added `maxHeight` input on a select component and also the default `maxHeight`, to prevent popover body from hiding. 
#### If this is a new feature, have you updated the documentation?
Added 1 example of maxHeight usage