### PR TITLE
fix: Protractor no longer waits for Alert timeout to be resolved

### DIFF
--- a/library/src/lib/alert/alert.component.ts
+++ b/library/src/lib/alert/alert.component.ts
@@ -14,7 +14,7 @@ import {
     Optional,
     EmbeddedViewRef,
     Output,
-    EventEmitter, ViewEncapsulation, HostListener
+    EventEmitter, ViewEncapsulation, HostListener, NgZone
 } from '@angular/core';
 import { AlertRef } from './alert-utils/alert-ref';
 import { alertFadeNgIf } from './alert-utils/alert-animations';
@@ -111,6 +111,7 @@ export class AlertComponent extends AbstractFdNgxClass implements OnInit, AfterV
     constructor(private elRef: ElementRef,
                 private cdRef: ChangeDetectorRef,
                 private componentFactoryResolver: ComponentFactoryResolver,
+                private ngZone: NgZone,
                 @Optional() private alertRef: AlertRef) {
         super(elRef);
     }
@@ -172,20 +173,22 @@ export class AlertComponent extends AbstractFdNgxClass implements OnInit, AfterV
         }
 
         if (this.duration >= 0) {
-            setTimeout(() => {
-                if (this.mousePersist) {
-                    const wait = () => {
-                        if (this.mouseInAlert === true) {
-                            setTimeout(wait, 500);
-                        } else {
-                            this.dismiss();
-                        }
-                    };
-                    wait();
-                } else {
-                    this.dismiss();
-                }
-            }, this.duration);
+            this.ngZone.runOutsideAngular(() => {
+                setTimeout(() => {
+                    if (this.mousePersist) {
+                        const wait = () => {
+                            if (this.mouseInAlert === true) {
+                                setTimeout(wait, 500);
+                            } else {
+                                this.ngZone.run(() => this.dismiss());
+                            }
+                        };
+                        wait();
+                    } else {
+                        this.ngZone.run(() => this.dismiss());
+                    }
+                }, this.duration);
+            });
         }
     }
 


### PR DESCRIPTION
Protractor waits until an Alert disappears before proceeding to next line.

Example case:
inside e2e test
```     
showAlert({message: 'sample message', duration: 5000});
closeAlertByIndex(0);
```
Protractor will wait until "setTimeout" is resolved before calling next line "closeAlertByIndex(0)" which will result in error because the Close Button cannot be found.

According to docs

> Protractor will wait until the Angular Zone stabilizes. This means long running async operations will block your test from continuing. To work around this, run these tasks outside the Angular zone

I've tried the `browser.waitForAngularEnabled(false)` but it's not deterministic. Sometimes it works, sometimes it doesn't.

I've also tried to wrap `alertService.open()` method call into `this.ngZone.runOutsideAngular(() => {})`, but the issue still persists.
I believe it's because AlertService dynamically creates AlertComponent which then calls setTimeout in lifecycle hook.

I do wrap `this.dismiss()` call in ngZone.run(), because it emits via @Output() to the parent where Change Detection should be fired.

