### PR TITLE
docs: Links on Input docs component sections

### DIFF
--- a/docs/app/documentation/component-docs/input/examples/input-form-group-example.component.scss
+++ b/docs/app/documentation/component-docs/input/examples/input-form-group-example.component.scss
@@ -1,8 +1,3 @@
 input {
     margin-bottom: 10px;
 }
-
-.flex-form-set{
-    display: flex;
-    justify-content: space-between;
-}

--- a/docs/app/documentation/component-docs/input/input-docs.component.html
+++ b/docs/app/documentation/component-docs/input/input-docs.component.html
@@ -1,4 +1,9 @@
-<h2>Input</h2>
+<h2 id="input" class="docs-header-link">
+    <a class="docs-markdown-a" aria-describedby="input" href="/input#input">
+        <span class="sap-icon--chain-link"></span>
+    </a>
+        Input
+</h2>
 <component-example [name]="'ex1'">
     <fd-input-example></fd-input-example>
 </component-example>
@@ -6,7 +11,12 @@
 
 <separator></separator>
 
-<h2>Input Help elements</h2>
+<h2 id="input-help-elements" class="docs-header-link">
+    <a class="docs-markdown-a"aria-describedby="input-help-elements" href="/input#input-help-elements">
+        <span class="sap-icon--chain-link"></span>
+    </a>
+        Input Help elements
+</h2>
 <component-example [name]="'ex2'">
     <fd-input-inline-help-example></fd-input-inline-help-example>
 </component-example>
@@ -14,7 +24,12 @@
 
 <separator></separator>
 
-<h2>Input States</h2>
+<h2 id="input-states" class="docs-header-link">
+    <a class="docs-markdown-a" aria-describedby="input-states" href="/input#input-states">
+        <span class="sap-icon--chain-link"></span>
+    </a>
+        Input States
+</h2>
 <component-example [name]="'ex3'">
     <fd-input-state-example></fd-input-state-example>
 </component-example>
@@ -22,7 +37,12 @@
 
 <separator></separator>
 
-<h2>Input in Reactive Form</h2>
+<h2 id="reactive-form-input" class="docs-header-link">
+    <a class="docs-markdown-a" aria-describedby="reactive-form-input" href="/input#reactive-form-input">
+        <span class="sap-icon--chain-link"></span>
+    </a>
+    Input in Reactive Form
+</h2>
 <description>
     The input element, like several other native html elements, support Angular reactive forms. Using the input within
     the form element greatly simplifies input value access and validation.

--- a/docs/app/documentation/component-docs/input/input-docs.component.html
+++ b/docs/app/documentation/component-docs/input/input-docs.component.html
@@ -1,9 +1,6 @@
-<h2 id="input" class="docs-header-link">
-    <a class="docs-markdown-a" aria-describedby="input" href="/input#input">
-        <span class="sap-icon--chain-link"></span>
-    </a>
-        Input
-</h2>
+<fd-docs-section-title [id]="'input'" [componentName]="'input'">
+    Input
+</fd-docs-section-title>
 <component-example [name]="'ex1'">
     <fd-input-example></fd-input-example>
 </component-example>
@@ -11,12 +8,10 @@
 
 <separator></separator>
 
-<h2 id="input-help-elements" class="docs-header-link">
-    <a class="docs-markdown-a"aria-describedby="input-help-elements" href="/input#input-help-elements">
-        <span class="sap-icon--chain-link"></span>
-    </a>
-        Input Help elements
-</h2>
+
+<fd-docs-section-title [id]="'input-help-elements'" [componentName]="'input'">
+    Input Help Elements
+</fd-docs-section-title>
 <component-example [name]="'ex2'">
     <fd-input-inline-help-example></fd-input-inline-help-example>
 </component-example>
@@ -24,12 +19,10 @@
 
 <separator></separator>
 
-<h2 id="input-states" class="docs-header-link">
-    <a class="docs-markdown-a" aria-describedby="input-states" href="/input#input-states">
-        <span class="sap-icon--chain-link"></span>
-    </a>
-        Input States
-</h2>
+
+<fd-docs-section-title [id]="'input-states'" [componentName]="'input'">
+    Input States
+</fd-docs-section-title>
 <component-example [name]="'ex3'">
     <fd-input-state-example></fd-input-state-example>
 </component-example>
@@ -37,12 +30,9 @@
 
 <separator></separator>
 
-<h2 id="reactive-form-input" class="docs-header-link">
-    <a class="docs-markdown-a" aria-describedby="reactive-form-input" href="/input#reactive-form-input">
-        <span class="sap-icon--chain-link"></span>
-    </a>
-    Input in Reactive Form
-</h2>
+<fd-docs-section-title [id]="'reactive-form-input'" [componentName]="'input'">
+     Reactive Form Input
+</fd-docs-section-title>
 <description>
     The input element, like several other native html elements, support Angular reactive forms. Using the input within
     the form element greatly simplifies input value access and validation.

--- a/docs/app/documentation/core-helpers/docs-section-title/docs-section-title.component.scss
+++ b/docs/app/documentation/core-helpers/docs-section-title/docs-section-title.component.scss
@@ -1,0 +1,17 @@
+.docs-header-link {
+    position: relative;
+    display: inline-block;
+}
+
+.docs-header-link .docs-markdown-a {
+    visibility: hidden;
+    text-align: center;
+    text-decoration: none;
+    margin-left: -25px;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.docs-header-link:hover .docs-markdown-a {
+    visibility: visible;
+}

--- a/docs/app/documentation/core-helpers/docs-section-title/docs-section-title.component.ts
+++ b/docs/app/documentation/core-helpers/docs-section-title/docs-section-title.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'fd-docs-section-title',
+  template: `
+    <h2 [id]="id" class="docs-header-link"> 
+      <a class="docs-markdown-a" [attr.aria-describedby]="id" href="/{{componentName}}#{{id}}">
+          <span class="sap-icon--chain-link"></span>
+      </a>
+      <ng-content></ng-content>
+  </h2>
+`,
+  styleUrls: ['./docs-section-title.component.scss']
+})
+export class DocsSectionTitleComponent implements OnInit {
+
+  @Input() id: string = '';
+
+  @Input() componentName: string = '';
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/docs/app/documentation/documentation.module.ts
+++ b/docs/app/documentation/documentation.module.ts
@@ -402,6 +402,7 @@ import { RadioFormGroupExampleComponent } from './component-docs/radio/examples/
 import { RadioExamplesComponent } from './component-docs/radio/examples/radio-examples.component';
 import { RadioDocsComponent } from './component-docs/radio/radio-docs.component';
 import { RadioHeaderComponent } from './component-docs/radio/radio-header/radio-header.component';
+import { DocsSectionTitleComponent } from './core-helpers/docs-section-title/docs-section-title.component';
 import { ComboboxSearchFunctionExampleComponent } from './component-docs/combobox/examples/combobox-search-function-example.component';
 import { SelectMaxHeightExampleComponent } from './component-docs/select/examples/select-height/select-max-height-example.component';
 
@@ -735,7 +736,8 @@ import { SelectMaxHeightExampleComponent } from './component-docs/select/example
         SelectAddingExampleComponent,
         SelectFormsComponent,
         SelectViewValueExampleComponent,
-        SelectMaxHeightExampleComponent
+        SelectMaxHeightExampleComponent,
+        DocsSectionTitleComponent
     ],
     entryComponents: [ModalContentComponent, ModalInModalComponent, ModalInModalSecondComponent, AlertContentComponent],
     imports: [

--- a/docs/styles.scss
+++ b/docs/styles.scss
@@ -221,3 +221,33 @@ a:focus {
 .modal-no-backdrop-custom-shadow {
     box-shadow: 0 4px 20px 0 grey
 }
+
+
+//this is the style for the link
+// .docs-markdown-a {
+//     visibility: hidden;
+//     margin-left: -25px;
+// }
+
+// .docs-header-link:hover .docs-markdown-a {
+//     visibility: visible;
+// }
+
+
+.docs-header-link {
+    position: relative;
+    display: inline-block;
+}
+
+.docs-header-link .docs-markdown-a {
+    visibility: hidden;
+    text-align: center;
+    text-decoration: none;
+    margin-left: -25px;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.docs-header-link:hover .docs-markdown-a {
+    visibility: visible;
+}

--- a/docs/styles.scss
+++ b/docs/styles.scss
@@ -221,33 +221,3 @@ a:focus {
 .modal-no-backdrop-custom-shadow {
     box-shadow: 0 4px 20px 0 grey
 }
-
-
-//this is the style for the link
-// .docs-markdown-a {
-//     visibility: hidden;
-//     margin-left: -25px;
-// }
-
-// .docs-header-link:hover .docs-markdown-a {
-//     visibility: visible;
-// }
-
-
-.docs-header-link {
-    position: relative;
-    display: inline-block;
-}
-
-.docs-header-link .docs-markdown-a {
-    visibility: hidden;
-    text-align: center;
-    text-decoration: none;
-    margin-left: -25px;
-    display: inline-block;
-    vertical-align: middle;
-}
-
-.docs-header-link:hover .docs-markdown-a {
-    visibility: visible;
-}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#1182
#### Please provide a brief summary of this pull request.
Added link before header title for easy navigate. 
There is also new component named `fd-docs-section-title`, which is used to add titles before section, we should refactor whole docs page in future.
#### If this is a new feature, have you updated the documentation?
Only input group component updated so far.