### PR TITLE
fix: Datetime picker crash

### DIFF
--- a/library/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/library/src/lib/datetime-picker/datetime-picker.component.ts
@@ -372,6 +372,9 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
      */
     handleTimeChange(time: TimeObject): void {
         this.time = time;
+        if (!this.selectedDate || !this.selectedDate.isDateValid()) {
+            this.selectedDate = FdDate.getToday();
+        }
         this.date = new FdDatetime(this.selectedDate, this.time);
         this.isInvalidDateInput = !this.isModelValid();
         this.setInput(this.date);


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1201
#### Please provide a brief summary of this pull request.
Right now, when there is no date and time is picked, date is automatically changed to Today date.
