### PR TITLE
fix: Reset input on invalid date

### DIFF
--- a/library/src/lib/date-picker/date-picker.component.ts
+++ b/library/src/lib/date-picker/date-picker.component.ts
@@ -307,9 +307,11 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
              */
             selected = <FdDate>selected;
             this.selectedDate = selected;
-            this.inputFieldDate = this.dateAdapter.format(selected);
             if (this.isModelValid()) {
+                this.inputFieldDate = this.dateAdapter.format(selected);
                 this.calendarComponent.setCurrentlyDisplayed(this.selectedDate);
+            } else {
+                this.inputFieldDate = '';
             }
 
         } else {
@@ -326,6 +328,8 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
                     this.calendarComponent.setCurrentlyDisplayed(this.selectedRangeDate.start);
                     this.inputFieldDate = this.dateAdapter.format(selected.start) +
                         this.dateAdapter.rangeDelimiter + this.dateAdapter.format(selected.end);
+                } else {
+                    this.inputFieldDate = '';
                 }
             } else {
                 this.inputFieldDate = '';


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1213
#### Please provide a brief summary of this pull request.
So since now date picker reset input field, when the value passed by ValueController(ngModel, RectiveForms) is wrong. 
