### PR TITLE
fix: Added missing components to public apis, add utils public api. Add html exmaples

### DIFF
--- a/library/src/lib/action-bar/action-bar-header/action-bar-header.directive.ts
+++ b/library/src/lib/action-bar/action-bar-header/action-bar-header.directive.ts
@@ -1,5 +1,4 @@
-import { Component, Directive, ElementRef, ViewEncapsulation } from '@angular/core';
-import { AbstractFdNgxClass } from '../../utils/abstract-fd-ngx-class';
+import { Directive } from '@angular/core';
 
 /**
  * The action bar header, which contains the action bar's title and description components.

--- a/library/src/lib/calendar/calendar.component.ts
+++ b/library/src/lib/calendar/calendar.component.ts
@@ -35,6 +35,9 @@ export type DaysOfWeek = 1 | 2 | 3 | 4 | 5 | 6 | 7;
  *
  * Calendar component used for selecting dates, typically used by the DatePicker and DateTimePicker components.
  * Supports the Angular forms module, enabling form validity, ngModel, etc.
+ * ```html
+ * <fd-calendar></fd-calendar>
+ * ```
  */
 @Component({
     selector: 'fd-calendar',

--- a/library/src/lib/calendar/public_api.ts
+++ b/library/src/lib/calendar/public_api.ts
@@ -3,3 +3,4 @@ export * from './i18n/calendar-i18n';
 export * from './i18n/calendar-i18n-labels';
 export * from './models/fd-date';
 export * from './models/fd-range-date';
+export * from './calendar.component';

--- a/library/src/lib/combobox/combobox.component.ts
+++ b/library/src/lib/combobox/combobox.component.ts
@@ -26,6 +26,13 @@ import focusTrap, { FocusTrap } from 'focus-trap';
  * Allows users to filter through results and select a value.
  *
  * Supports Angular Forms.
+ * ```html
+ * <fd-combobox
+ *      [(ngModel)]="searchTerm"
+ *      [dropdownValues]="dropdownValues"
+ *      [placeholder]="'Type some text...'">
+ * </fd-combobox>
+ * ```
  */
 @Component({
     selector: 'fd-combobox',

--- a/library/src/lib/combobox/public_api.ts
+++ b/library/src/lib/combobox/public_api.ts
@@ -1,1 +1,2 @@
 export * from './combobox.module';
+export * from './combobox.component';

--- a/library/src/lib/date-picker/date-picker.component.ts
+++ b/library/src/lib/date-picker/date-picker.component.ts
@@ -15,6 +15,15 @@ import { CalendarComponent } from '../calendar/calendar.component';
 import { FdRangeDate } from '../calendar/models/fd-range-date';
 import { DateFormatParser } from './format/date-parser';
 
+/**
+ * The datetime picker component is an opinionated composition of the fd-popover and
+ * fd-calendar components to accomplish the UI pattern for picking a date.
+ *
+ * Supports Angular Forms.
+ * ```html
+ * <fd-date-picker [(ngModel)]="date"></fd-date-picker>
+ * ```
+ */
 @Component({
     selector: 'fd-date-picker',
     templateUrl: './date-picker.component.html',

--- a/library/src/lib/date-picker/public_api.ts
+++ b/library/src/lib/date-picker/public_api.ts
@@ -2,3 +2,4 @@ export * from './date-picker.module';
 export * from './format/date-parser';
 export * from '../calendar/models/fd-date';
 export * from '../calendar/models/fd-range-date';
+export * from './date-picker.component';

--- a/library/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/library/src/lib/datetime-picker/datetime-picker.component.ts
@@ -25,6 +25,10 @@ import { FdDatetime } from './models/fd-datetime';
 /**
  * The datetime picker component is an opinionated composition of the fd-popover,
  * fd-calendar and fd-time components to accomplish the UI pattern for picking a date and time.
+ * Supports Angular Forms.
+ * ```html
+ * <fd-date-time-picker [(ngModel)]="dateTime"></fd-date-time-picker>
+ * ```
  */
 @Component({
     selector: 'fd-datetime-picker',

--- a/library/src/lib/datetime-picker/public_api.ts
+++ b/library/src/lib/datetime-picker/public_api.ts
@@ -1,2 +1,3 @@
 export * from './datetime-picker.module';
+export * from './format/datetime-parser';
 export * from './models/fd-datetime';

--- a/library/src/lib/localizator-editor/localization-editor-item/localization-editor-item.component.ts
+++ b/library/src/lib/localizator-editor/localization-editor-item/localization-editor-item.component.ts
@@ -5,7 +5,6 @@ import {
     Input,
     OnChanges,
     OnInit,
-    SimpleChanges,
     TemplateRef,
     ViewEncapsulation
 } from '@angular/core';

--- a/library/src/lib/localizator-editor/public_api.ts
+++ b/library/src/lib/localizator-editor/public_api.ts
@@ -1,1 +1,4 @@
 export * from './localization-editor.module';
+export * from './localization-editor-item/localization-editor-item.component';
+export * from './localization-editor-main/localization-editor-main.component';
+export * from './localization-editor.directives';

--- a/library/src/lib/mega-menu/mega-menu-group/mega-menu-group.component.ts
+++ b/library/src/lib/mega-menu/mega-menu-group/mega-menu-group.component.ts
@@ -1,5 +1,27 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 
+/**
+ *  Component represents mega menu group, which contains list with menu items.
+ *  ```html
+ *  <fd-mega-menu-group>
+ *      <h3 fd-mega-menu-title>Title 1</h3>
+ *      <ul fd-mega-menu-list>
+ *          <fd-mega-menu-item>
+ *              <a fd-mega-menu-link>Item 0</a>
+ *              <li fd-mega-menu-subitem>
+ *                 <a fd-mega-menu-sublink>Sub Item 1</a>
+ *            </li>
+ *              <li fd-mega-menu-subitem>
+ *                <a fd-mega-menu-sublink>Sub Item 2</a>
+ *           </li>
+ *             <li fd-mega-menu-subitem>
+ *                  <a fd-mega-menu-sublink>Sub Item 3</a>
+ *             </li>
+ *          </fd-mega-menu-item>
+ *      </ul>
+ *  </fd-mega-menu-group>
+ *  ```
+ * */
 @Component({
     selector: 'fd-mega-menu-group',
     templateUrl: './mega-menu-group.component.html',

--- a/library/src/lib/mega-menu/mega-menu-item/mega-menu-item.component.ts
+++ b/library/src/lib/mega-menu/mega-menu-item/mega-menu-item.component.ts
@@ -23,6 +23,23 @@ import { DefaultMenuItem } from '../../menu/default-menu-item';
 
 export type MenuSubListPosition = 'left' | 'right';
 
+/**
+ *  Component represents mega menu item, which contains subitems and link.
+ *  ```html
+ *  <fd-mega-menu-item>
+ *      <a fd-mega-menu-link>Item 0</a>
+ *      <li fd-mega-menu-subitem>
+ *          <a fd-mega-menu-sublink>Sub Item 1</a>
+ *      </li>
+ *      <li fd-mega-menu-subitem>
+ *          <a fd-mega-menu-sublink>Sub Item 2</a>
+ *      </li>
+ *      <li fd-mega-menu-subitem>
+ *          <a fd-mega-menu-sublink>Sub Item 3</a>
+ *      </li>
+ *  </fd-mega-menu-item>
+ *  ```
+ * */
 @Component({
     selector: 'fd-mega-menu-item',
     templateUrl: './mega-menu-item.component.html',

--- a/library/src/lib/mega-menu/mega-menu-link/mega-menu-link.directive.ts
+++ b/library/src/lib/mega-menu/mega-menu-link/mega-menu-link.directive.ts
@@ -1,5 +1,11 @@
 import { Directive, ElementRef, HostBinding, Input } from '@angular/core';
 
+/**
+ *  Directive represents mega menu link.
+ *  ```html
+ * <a fd-mega-menu-link href="#">Link</a>
+ *  ```
+ * */
 @Directive({
     // tslint:disable-next-line:directive-selector
     selector: '[fd-mega-menu-link]',

--- a/library/src/lib/mega-menu/mega-menu-list/mega-menu-list.directive.ts
+++ b/library/src/lib/mega-menu/mega-menu-list/mega-menu-list.directive.ts
@@ -11,6 +11,25 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { MenuKeyboardService } from '../../menu/menu-keyboard.service';
 
+/**
+ *  Directive represents mega menu list, which contains items.
+ *  ```html
+ *  <ul fd-mega-menu-list>
+ *      <fd-mega-menu-item>
+ *          <a fd-mega-menu-link>Item 0</a>
+ *          <li fd-mega-menu-subitem>
+ *              <a fd-mega-menu-sublink>Sub Item 1</a>
+ *          </li>
+ *          <li fd-mega-menu-subitem>
+ *              <a fd-mega-menu-sublink>Sub Item 2</a>
+ *          </li>
+ *          <li fd-mega-menu-subitem>
+ *              <a fd-mega-menu-sublink>Sub Item 3</a>
+ *          </li>
+ *      </fd-mega-menu-item>
+ *  </ul>
+ *  ```
+ * */
 @Directive({
     // tslint:disable-next-line:directive-selector
     selector: '[fd-mega-menu-list]'

--- a/library/src/lib/mega-menu/mega-menu-subitem.directive.ts
+++ b/library/src/lib/mega-menu/mega-menu-subitem.directive.ts
@@ -2,6 +2,14 @@ import { ContentChild, Directive, EventEmitter, HostBinding, HostListener, Outpu
 import { DefaultMenuItem } from '../menu/default-menu-item';
 import { MegaMenuSublinkDirective } from './mega-menu-sublink.directive';
 
+/**
+ *  Directive represents mega menu subitem, which can contain sublink.
+ *  ```html
+ * <li fd-mega-menu-subitem>
+ *      <a fd-mega-menu-sublink>Sub Item 2</a>
+ * </li>
+ *  ```
+ * */
 @Directive({
     // tslint:disable-next-line:directive-selector
     selector: '[fd-mega-menu-subitem]'

--- a/library/src/lib/mega-menu/mega-menu-sublink.directive.ts
+++ b/library/src/lib/mega-menu/mega-menu-sublink.directive.ts
@@ -1,5 +1,11 @@
 import { Directive, ElementRef, HostBinding } from '@angular/core';
 
+/**
+ *  Directive represents mega menu sub link.
+ *  ```html
+ * <a fd-mega-menu-sublink href="#">Link</a>
+ *  ```
+ * */
 @Directive({
     // tslint:disable-next-line:directive-selector
     selector: '[fd-mega-menu-sublink]',

--- a/library/src/lib/mega-menu/mega-menu.component.ts
+++ b/library/src/lib/mega-menu/mega-menu.component.ts
@@ -1,5 +1,25 @@
 import { Component, ViewEncapsulation } from '@angular/core';
-
+/**
+ *  Component represents mega menu element, which contains list with menu items, links, sublists, subitems and sublinks..
+ *  ```html
+ *  <fd-mega-menu>
+ *      <ul fd-mega-menu-list>
+ *          <fd-mega-menu-item>
+ *              <a fd-mega-menu-link>Item 0</a>
+ *              <li fd-mega-menu-subitem>
+ *                 <a fd-mega-menu-sublink>Sub Item 1</a>
+ *            </li>
+ *              <li fd-mega-menu-subitem>
+ *                <a fd-mega-menu-sublink>Sub Item 2</a>
+ *           </li>
+ *             <li fd-mega-menu-subitem>
+ *                  <a fd-mega-menu-sublink>Sub Item 3</a>
+ *             </li>
+ *          </fd-mega-menu-item>
+ *      </ul>
+ *  </fd-mega-menu>
+ *  ```
+ * */
 @Component({
     selector: 'fd-mega-menu',
     templateUrl: './mega-menu.component.html',

--- a/library/src/lib/mega-menu/public_api.ts
+++ b/library/src/lib/mega-menu/public_api.ts
@@ -1,2 +1,5 @@
 export * from './mega-menu.module';
-export { MenuSubListPosition } from './mega-menu-item/mega-menu-item.component'
+export * from './mega-menu-item/mega-menu-item.component'
+export * from './mega-menu-link/mega-menu-link.directive'
+export * from './mega-menu-subitem.directive';
+export * from './mega-menu-sublink.directive';

--- a/library/src/lib/menu/menu-keyboard.service.ts
+++ b/library/src/lib/menu/menu-keyboard.service.ts
@@ -1,5 +1,4 @@
 import { Subject } from 'rxjs';
-import { MenuItemDirective } from './menu-item.directive';
 import { Output } from '@angular/core';
 import { DefaultMenuItem } from './default-menu-item';
 

--- a/library/src/lib/menu/public_api.ts
+++ b/library/src/lib/menu/public_api.ts
@@ -1,3 +1,6 @@
 export * from './menu.module';
 export * from './menu-item.directive';
 export * from './menu-keyboard.service';
+export * from './menu-item.directive';
+export * from './menu.component';
+export * from './default-menu-item';

--- a/library/src/lib/scroll-spy/public_api.ts
+++ b/library/src/lib/scroll-spy/public_api.ts
@@ -1,1 +1,2 @@
 export * from './scroll-spy.module';
+export * from './scroll-spy.directive';

--- a/library/src/lib/search-input/public_api.ts
+++ b/library/src/lib/search-input/public_api.ts
@@ -1,1 +1,2 @@
 export * from './search-input.module';
+export * from './search-input.component';

--- a/library/src/lib/select/public_api.ts
+++ b/library/src/lib/select/public_api.ts
@@ -1,1 +1,3 @@
 export * from './select.module';
+export * from './select.component';
+export * from './option/option.component'

--- a/library/src/lib/shellbar/public_api.ts
+++ b/library/src/lib/shellbar/public_api.ts
@@ -1,1 +1,4 @@
 export * from './shellbar.module';
+export * from './product-menu/product-menu.component';
+export * from './shellbar-actions/shellbar-actions.component';
+export * from './shellbar.component';

--- a/library/src/lib/side-navigation/public_api.ts
+++ b/library/src/lib/side-navigation/public_api.ts
@@ -1,1 +1,3 @@
 export * from './side-navigation.module';
+export * from './side-navigation-link/side-navigation-link.directive';
+export * from './side-navigation-sublist/side-navigation-sublist.directive';

--- a/library/src/lib/side-navigation/side-navigation-item/side-navigation-item.component.ts
+++ b/library/src/lib/side-navigation/side-navigation-item/side-navigation-item.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, AfterViewInit, Component, ContentChild, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { AfterContentInit, Component, ContentChild, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { SideNavigationLinkDirective } from '../side-navigation-link/side-navigation-link.directive';
 import { Subscription } from 'rxjs';
 import { SideNavigationSublistDirective } from '../side-navigation-sublist/side-navigation-sublist.directive';

--- a/library/src/lib/side-navigation/side-navigation-link/side-navigation-link.directive.ts
+++ b/library/src/lib/side-navigation/side-navigation-link/side-navigation-link.directive.ts
@@ -3,7 +3,7 @@ import {
     ElementRef,
     Output,
     EventEmitter,
-    Directive, HostListener, Inject, OnInit, HostBinding
+    Directive, HostListener, Inject, HostBinding
 } from '@angular/core';
 import { AbstractFdNgxClass } from '../../utils/abstract-fd-ngx-class';
 

--- a/library/src/lib/side-navigation/side-navigation-list/side-navigation-list.directive.ts
+++ b/library/src/lib/side-navigation/side-navigation-list/side-navigation-list.directive.ts
@@ -1,4 +1,4 @@
-import { Component, Directive, ViewEncapsulation } from '@angular/core';
+import { Directive } from '@angular/core';
 
 /**
  * The directive that represents a list group.

--- a/library/src/lib/side-navigation/side-navigation-subitem/side-navigation-subitem.directive.ts
+++ b/library/src/lib/side-navigation/side-navigation-subitem/side-navigation-subitem.directive.ts
@@ -1,4 +1,4 @@
-import { Component, Directive, ViewEncapsulation } from '@angular/core';
+import { Directive } from '@angular/core';
 
 /**
  * The component that represents a sub item.

--- a/library/src/lib/side-navigation/side-navigation-sublist/side-navigation-sublist.directive.ts
+++ b/library/src/lib/side-navigation/side-navigation-sublist/side-navigation-sublist.directive.ts
@@ -1,5 +1,4 @@
-import { Component, Directive, ElementRef, HostBinding, Inject, ViewEncapsulation } from '@angular/core';
-import { AbstractFdNgxClass } from '../../utils/abstract-fd-ngx-class';
+import { Directive, ElementRef } from '@angular/core';
 /**
  * The component that represents a navigation group.
  * ```html

--- a/library/src/lib/tabs/public_api.ts
+++ b/library/src/lib/tabs/public_api.ts
@@ -1,1 +1,3 @@
 export * from './tabs.module';
+export * from './tabs.service';
+export * from './tab-list.component';

--- a/library/src/lib/tile/public_api.ts
+++ b/library/src/lib/tile/public_api.ts
@@ -1,2 +1,3 @@
 export * from './tile.module';
-export * from './tile-grid/tile-grid.directive'
+export * from './tile-grid/tile-grid.directive';
+export * from './tile.component';

--- a/library/src/lib/time-picker/public_api.ts
+++ b/library/src/lib/time-picker/public_api.ts
@@ -1,1 +1,3 @@
 export * from './time-picker.module';
+export * from './time-picker.component';
+export * from './format/time-parser';

--- a/library/src/lib/time/public_api.ts
+++ b/library/src/lib/time/public_api.ts
@@ -2,3 +2,4 @@ export * from './time.module';
 export * from './i18n/time-i18n-labels';
 export * from './i18n/time-i18n';
 export * from './time-object';
+export * from './time.component';

--- a/library/src/lib/toggle/public_api.ts
+++ b/library/src/lib/toggle/public_api.ts
@@ -1,1 +1,3 @@
 export * from './toggle.module';
+export * from './toggle.component';
+

--- a/library/src/lib/token/public_api.ts
+++ b/library/src/lib/token/public_api.ts
@@ -1,1 +1,2 @@
 export * from './token.module';
+export * from './token.component';

--- a/library/src/lib/tree/public_api.ts
+++ b/library/src/lib/tree/public_api.ts
@@ -1,1 +1,3 @@
 export * from './tree.module';
+export * from './tree.component';
+export * from './tree-child.component';

--- a/library/src/lib/utils/directives/only-digits.directive.ts
+++ b/library/src/lib/utils/directives/only-digits.directive.ts
@@ -30,5 +30,4 @@ export class OnlyDigitsDirective {
             e.preventDefault();
         }
     }
-
 }

--- a/library/src/lib/utils/public_api.ts
+++ b/library/src/lib/utils/public_api.ts
@@ -1,0 +1,1 @@
+export * from './directives/only-digits.directive';

--- a/library/src/public_api.ts
+++ b/library/src/public_api.ts
@@ -36,6 +36,7 @@ export * from './lib/shellbar/public_api';
 export * from './lib/side-navigation/public_api';
 export * from './lib/select/public_api';
 export * from './lib/split-button/public_api';
+export * from './lib/utils/public_api';
 export * from './lib/table/public_api';
 export * from './lib/tabs/public_api';
 export * from './lib/tile/public_api';


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
During testing our library on other app, I encountered some issues, when wanted to change properties of components by `@ViewChild()`, because none of them was included to public_api files, so right now useful ones are injected into.
There was also some issues with AOT building, cause of `DefaultMenuItem` usage, so it had to be added to public_api either. 
There are included some html examples on API tab, because it was missing and I removed unused imports from code. 
#### If this is a new feature, have you updated the documentation?
Html examples on api tabs.