### PR TITLE
docs: Add example of dynamic height popover body

### DIFF
--- a/docs/app/documentation/component-docs/popover/examples/popover-dynamic/popover-dynamic-example.component.html
+++ b/docs/app/documentation/component-docs/popover/examples/popover-dynamic/popover-dynamic-example.component.html
@@ -1,0 +1,18 @@
+<fd-popover #popoverComponent [closeOnOutsideClick]="true" [focusTrapped]="true" placement="top"
+            [noArrow]="false" title="top">
+    <fd-popover-control>
+        <button fd-button [glyph]="'add'" class="fd-image--circle"></button>
+    </fd-popover-control>
+    <fd-popover-body>
+        <fd-side-nav *ngFor="let component of componentWithTasks">
+            <fd-side-nav-item>
+                <a fd-side-nav-link [hasSublist]="true" (onSubListOpenChange)="popoverComponent.updatePopover()">{{component.name}}</a>
+                <div fd-side-nav-sublist>
+                    <div fd-side-nav-subitem *ngFor="let task of component.tasks">
+                        <a fd-side-nav-sublink>{{task.name}}</a>
+                    </div>
+                </div>
+            </fd-side-nav-item>
+        </fd-side-nav>
+    </fd-popover-body>
+</fd-popover>

--- a/docs/app/documentation/component-docs/popover/examples/popover-dynamic/popover-dynamic-example.component.ts
+++ b/docs/app/documentation/component-docs/popover/examples/popover-dynamic/popover-dynamic-example.component.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'fd-popover-dynamic-example',
+    templateUrl: './popover-dynamic-example.component.html'
+})
+export class PopoverDynamicExampleComponent {
+
+    componentWithTasks = [
+        {
+            name: 'name 1',
+            tasks: [
+                {name: 'subName1'},
+                {name: 'subName2'},
+                {name: 'subName3'},
+            ]
+        },
+        {
+            name: 'name 2',
+            tasks: [
+                {name: 'subName1'},
+                {name: 'subName2'},
+                {name: 'subName3'},
+            ]
+        },
+        {
+            name: 'name 3',
+            tasks: [
+                {name: 'subName1'},
+                {name: 'subName2'},
+                {name: 'subName3'},
+            ]
+        },
+        {
+            name: 'name 4',
+            tasks: [
+                {name: 'subName1'},
+                {name: 'subName2'},
+                {name: 'subName3'},
+            ]
+        },
+        {
+            name: 'name 5',
+            tasks: [
+                {name: 'subName1'},
+                {name: 'subName2'},
+                {name: 'subName3'},
+            ]
+        },
+    ];
+
+}

--- a/docs/app/documentation/component-docs/popover/popover-docs.component.html
+++ b/docs/app/documentation/component-docs/popover/popover-docs.component.html
@@ -53,6 +53,19 @@
 
 <separator></separator>
 
+<h2>Dynamic Body Height</h2>
+<description>
+    In case of height change inside popover body, the position of popover is not automatically changed, mostly cause of
+    optimization reasons. To force change of the position, it is needed to call <code>updatePopover()</code> method inside
+    popover, as it is on example. There is used <code>SideNavigation</code> component.
+</description>
+<component-example [name]="'ex6'">
+    <fd-popover-dynamic-example></fd-popover-dynamic-example>
+</component-example>
+<code-example [exampleFiles]="popoverDynamicExample"></code-example>
+
+<separator></separator>
+
 <description>
     <p>
         Under the hood, the Popover component makes use of <code>PopoverDirective</code>.

--- a/docs/app/documentation/component-docs/popover/popover-docs.component.ts
+++ b/docs/app/documentation/component-docs/popover/popover-docs.component.ts
@@ -8,6 +8,8 @@ import * as popoverPlacementTsSrc from '!raw-loader!./examples/popover-placement
 import * as popoverModalHtmlSrc from '!raw-loader!./examples/popover-modal/popover-modal-example.component.html';
 import * as popoverModalTsSrc from '!raw-loader!./examples/popover-modal/popover-modal-example.component.ts';
 import * as popoverFillHSrc from '!raw-loader!./examples/popover-c-fill/popover-c-fill.component.html';
+import * as popoverDynamicHSrc from '!raw-loader!./examples/popover-dynamic/popover-dynamic-example.component.html';
+import * as popoverDynamicTSrc from '!raw-loader!./examples/popover-dynamic/popover-dynamic-example.component.ts';
 import { ExampleFile } from '../../core-helpers/code-example/example-file';
 
 @Component({
@@ -51,6 +53,17 @@ export class PopoverDocsComponent {
         {
             language: 'typescript',
             code: popoverModalTsSrc
+        }
+    ];
+
+    popoverDynamicExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: popoverDynamicHSrc,
+        },
+        {
+            language: 'typescript',
+            code: popoverDynamicTSrc
         }
     ];
 

--- a/docs/app/documentation/documentation.module.ts
+++ b/docs/app/documentation/documentation.module.ts
@@ -413,6 +413,7 @@ import {
 import { ComboboxSearchFunctionExampleComponent } from './component-docs/combobox/examples/combobox-search-function-example.component';
 import { CalendarI18nMomentExampleComponent } from './component-docs/calendar/examples/calendar--i18n-moment-example.component';
 import { SelectMaxHeightExampleComponent } from './component-docs/select/examples/select-height/select-max-height-example.component';
+import { PopoverDynamicExampleComponent } from './component-docs/popover/examples/popover-dynamic/popover-dynamic-example.component';
 
 @NgModule({
     declarations: [
@@ -585,6 +586,7 @@ import { SelectMaxHeightExampleComponent } from './component-docs/select/example
         PanelGridColumnSpanExampleComponent,
         PaginationExampleComponent,
         PopoverExampleComponent,
+        PopoverDynamicExampleComponent,
         PopoverPlacementExampleComponent,
         PopoverProgrammaticOpenExampleComponent,
         PopoverModalExampleComponent,


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1125
#### Please provide a brief summary of this pull request.
I added one example of `updatePopover()` method in popover, to refresh positioning of popover, when the height of body is changed.
#### If this is a new feature, have you updated the documentation?
There is one example