### PR TITLE
docs: replaces the occurrence of fd-form__label class with fd-form-label directive

### DIFF
--- a/apps/docs/src/app/documentation/component-docs/input-group/examples/input-group-button-example.component.html
+++ b/apps/docs/src/app/documentation/component-docs/input-group/examples/input-group-button-example.component.html
@@ -1,4 +1,4 @@
-<label class="fd-form__label">Left Aligned Icon Button Add-on</label>
+<label fd-form-label>Left Aligned Icon Button Add-on</label>
 <fd-input-group [button]="true" [placement]="'before'" [glyph]="'accelerated'" [placeholder]="'Amount'">
 
 </fd-input-group>

--- a/apps/docs/src/app/documentation/component-docs/input-group/examples/input-group-icon-example.component.html
+++ b/apps/docs/src/app/documentation/component-docs/input-group/examples/input-group-icon-example.component.html
@@ -1,4 +1,4 @@
-<label class="fd-form__label">Left Aligned Icon Add-on</label>
+<label fd-form-label>Left Aligned Icon Add-on</label>
 <fd-input-group [placement]="'before'" [glyph]="'accelerated'" [placeholder]="'Amount'">
 
 </fd-input-group>

--- a/apps/docs/src/app/documentation/component-docs/input-group/examples/input-group-text-compact-example.component.html
+++ b/apps/docs/src/app/documentation/component-docs/input-group/examples/input-group-text-compact-example.component.html
@@ -1,4 +1,4 @@
-<label class="fd-form__label">Compact size</label>
+<label fd-form-label>Compact size</label>
 <fd-input-group [placement]="'before'" [addOnText]="'$'" [placeholder]="'Amount'" [compact]='true'>
 
 </fd-input-group>

--- a/apps/docs/src/app/documentation/component-docs/input-group/examples/input-group-text-example.component.html
+++ b/apps/docs/src/app/documentation/component-docs/input-group/examples/input-group-text-example.component.html
@@ -1,4 +1,4 @@
-<label class="fd-form__label">Left Aligned Text Add-on</label>
+<label fd-form-label>Left Aligned Text Add-on</label>
 <fd-input-group [placement]="'before'" [addOnText]="'$'" [placeholder]="'Amount'">
 
 </fd-input-group>

--- a/libs/core/src/lib/list/list-checkbox.component.html
+++ b/libs/core/src/lib/list/list-checkbox.component.html
@@ -1,5 +1,5 @@
 <div class="fd-form__item fd-form__item--check">
-    <label class="fd-form__label"
+    <label fd-form-label
            [htmlFor]="this.id">
         <input class="fd-form__control"
                type="checkbox"

--- a/libs/core/src/lib/toggle/toggle.component.html
+++ b/libs/core/src/lib/toggle/toggle.component.html
@@ -1,4 +1,4 @@
-<label class="fd-form__label" [attr.for]="innerInputId">
+<label fd-form-label [attr.for]="innerInputId">
     <span class="fd-toggle fd-form__control" [ngClass]="(this.size ? ('fd-toggle--' + this.size) : '')">
         <input #input
                type="checkbox"


### PR DESCRIPTION
closes #1191 
#### Please provide a link to the associated issue.
[#1191 ](https://github.com/SAP/fundamental-ngx/issues/1191)

#### Please provide a brief summary of this pull request.
In some examples in the documentation the labels were using `class="fd-form__label"` instead of the directive  `fd-form-label`. 