### PR TITLE
fix: removes the pointer events from the span inside the control button

### DIFF
--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -31,6 +31,7 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow-x: hidden;
+        pointer-events: none;
     }
 
     .fd-select-popover-body-custom {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes [1236](https://github.com/SAP/fundamental-ngx/issues/1236)
