### PR TITLE
feat:change the way of showing selected items of multi-input selector

### DIFF
--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -52,7 +52,7 @@
             [disabled]=this.disabled
             (onCloseClick)="handleSelect(false, token)"
             class="fd-multi-input-token-spacing">
-        {{token | displayFnPipe:displayFn}}
+        <span [innerHtml]="token | displayFnPipe:displayFn"></span>
     </fd-token>
 </div>
 


### PR DESCRIPTION
as selections of multi-input is using innerHtml with which i can wrap a new line to my selections. Actually the display of selected items should have the same behavior of the selection items.

#### Please provide a link to the associated issue.
fixes #1233 
#### Please provide a brief summary of this pull request.
change the way of showing selected items made it following the same behavior of the selection items
#### If this is a new feature, have you updated the documentation?
