### PR TITLE
chore(platform): Changing default selector prefix for "platform" project

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -33,12 +33,10 @@
                     },
                     "configurations": {
                         "production": {
-                            "fileReplacements": [
-                                {
-                                    "replace": "apps/docs/src/environments/environment.ts",
-                                    "with": "apps/docs/src/environments/environment.prod.ts"
-                                }
-                            ],
+                            "fileReplacements": [{
+                                "replace": "apps/docs/src/environments/environment.ts",
+                                "with": "apps/docs/src/environments/environment.prod.ts"
+                            }],
                             "optimization": true,
                             "outputHashing": "all",
                             "sourceMap": false,
@@ -48,13 +46,11 @@
                             "extractLicenses": true,
                             "vendorChunk": false,
                             "buildOptimizer": true,
-                            "budgets": [
-                                {
-                                    "type": "initial",
-                                    "maximumWarning": "2mb",
-                                    "maximumError": "5mb"
-                                }
-                            ]
+                            "budgets": [{
+                                "type": "initial",
+                                "maximumWarning": "2mb",
+                                "maximumError": "5mb"
+                            }]
                         },
                         "hmr": {
                             "optimization": true,
@@ -66,12 +62,10 @@
                             "extractLicenses": true,
                             "vendorChunk": false,
                             "buildOptimizer": true,
-                            "fileReplacements": [
-                                {
-                                    "replace": "apps/docs/src/environments/environment.ts",
-                                    "with": "apps/docs/src/environments/environment.prod.ts"
-                                }
-                            ]
+                            "fileReplacements": [{
+                                "replace": "apps/docs/src/environments/environment.ts",
+                                "with": "apps/docs/src/environments/environment.prod.ts"
+                            }]
                         }
                     }
                 },
@@ -184,7 +178,7 @@
             "root": "libs/platform",
             "sourceRoot": "libs/platform/src",
             "projectType": "library",
-            "prefix": "fundamental-ngx",
+            "prefix": "fdp",
             "architect": {
                 "build": {
                     "builder": "@angular-devkit/build-ng-packagr:build",

--- a/libs/platform/tslint.json
+++ b/libs/platform/tslint.json
@@ -2,6 +2,6 @@
     "extends": "../../tslint.json",
     "rules": {
         "directive-selector": [true, "attribute", "fundamentalNgx", "camelCase"],
-        "component-selector": [true, "element", "fundamental-ngx", "kebab-case"]
+        "component-selector": [true, "element", "fdp", "kebab-case"]
     }
 }

--- a/nx.json
+++ b/nx.json
@@ -18,7 +18,7 @@
             "tags": ["fd"]
         },
         "platform": {
-            "tags": ["fd"]
+            "tags": ["fdp"]
         }
     }
 }


### PR DESCRIPTION
Changing the default prefix to "fdp" for "platform".

#### Please provide a link to the associated issue.
Fixes #1258 

#### Please provide a brief summary of this pull request.
Changed configuration files to help enforce adding "fdp" prefix to all newly generated components for the `platform` library/project.

#### If this is a new feature, have you updated the documentation?
N/A
