### PR TITLE
feat(platform): Changing platform module name to "FundamentaNgxPlatformModule"

### DIFF
--- a/libs/platform/src/lib/platform.module.ts
+++ b/libs/platform/src/lib/platform.module.ts
@@ -8,5 +8,5 @@ import { FundamentalNgxCoreModule } from '@fundamental-ngx/core';
         FundamentalNgxCoreModule
     ]
 })
-export class PlatformModule {
+export class FundamentalNgxPlatformModule {
 }


### PR DESCRIPTION

#### Please provide a link to the associated issue.
Fixes #1273 

#### Please provide a brief summary of this pull request.
Changed the name of the platform module from `PlatformModule` to `FundamentalNgxPlatformModule`.

#### If this is a new feature, have you updated the documentation?
