### PR TITLE
adds custom styling for select control

### DIFF
--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -9,7 +9,7 @@
             <ng-container *ngTemplateOutlet="triggerTemplate; context: {$implicit: this}"></ng-container>
         </ng-container>
         <ng-container *ngIf="!triggerTemplate">
-            <button class="fd-dropdown__control fd-button fd-select-button-custom"
+            <button class="fd-button fd-select-button-custom"
                     aria-haspopup="true"
                     [ngClass]="{'fd-button--compact': compact}"
                     [attr.aria-expanded]="isOpen"

--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -12,18 +12,73 @@
     }
 
     .fd-select-button-custom {
+        padding-right: 0;
         display: flex;
-        align-items: flex-end;
         justify-content: space-between;
+        align-items: stretch;
+        width: 100%;
+        border-color: var(--sapUiFieldBorderColor, #89919a);
+        color: var(--sapUiFieldTextColor, #32363a);
+        border-radius: 0.125rem;
 
         &::after {
-            flex-shrink: 0;
+            font-family: 'SAP-icons';
+            content: '\e1e2';
+            color: var(--sapUiContentIconColor, #0854a0);
+            font-style: normal;
+            font-weight: normal;
+            font-size: 12px;
+            text-decoration: inherit;
+            text-transform: none;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            speak: none;
+            width: 36px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
         }
-    }
 
-    .fd-select-button-custom {
-        &::after {
-            margin-top: 0;
+        &:hover {
+            border-color: var(--sapUiFieldHoverBorderColor, #0854a0);
+            background-color: var(--sapUiFieldBackground, #ffffff);
+            color: var(--sapUiFieldTextColor, #32363a);
+
+            &::after {
+                background-color: var(--sapUiButtonLiteHoverBackground, #ebf5fe);
+            }
+        }
+
+        &:active,
+        &.is-active,
+        &[aria-expanded='true'] {
+            border-color: var(--sapUiFieldActiveBorderColor, #0854a0);
+
+            &::after {
+                color: var(--sapUiButtonActiveTextColor, #ffffff);
+                background-color: var(--sapButton_Lite_Active_Background, #0854a0);
+            }
+        }
+
+        [dir='rtl'] &,
+        &[dir='rtl'] {
+            padding-left: 0;
+            padding-right: 12px;
+        }
+
+        &[aria-disabled='true'],
+        &.is-disabled,
+        &:disabled {
+            cursor: not-allowed;
+            &:hover {
+                border-color: var(--sapUiFieldBorderColor, #89919a);
+                background-color: var(--sapUiFieldBackground, #ffffff);
+                color: var(--sapUiFieldTextColor, #32363a);
+
+                &::after {
+                    background-color: var(--sapUiFieldBackground, #ffffff);
+                }
+            }
         }
     }
 
@@ -31,6 +86,7 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow-x: hidden;
+        pointer-events: none;
     }
 
     .fd-select-popover-body-custom {


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
The control element of Select component depends on `fd-dropdown__control` class from Fundamental-styles for styling. Since Dropdown is not included in the Fundamental-styles dist folder we need to come up with a `temporary` solution and provide custom styling here in Fundamental-ngx. This `temporary` solution is necessary until we create a select control element in fund-styles and  use the styling from there. 