### PR TITLE
chore(build):Update path to the dist and improve readability of script

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -67,8 +67,7 @@ npm run build-deploy-library
 #
 ./ci-scripts/sync-version.sh
 
-
-cd "libs"
+cd "dist/libs"
 
 pwd
 for P in ${PACKAGES[@]};
@@ -79,6 +78,7 @@ do
     cd ..
 done
 
+cd ../../
 
 
 if [ ${args[0]} == "master" ]; then

--- a/ci-scripts/sync-version.sh
+++ b/ci-scripts/sync-version.sh
@@ -13,9 +13,10 @@ echo "Updating packages.json under dist/libs with version ${NEW_VERSION}"
 ANGULAR_VERSION=$(node -p "require('./package.json').dependencies['@angular/core']")
 RXJS_VERSION=$(node -p "require('./package.json').dependencies['rxjs']")
 
-cd ./dist/
+cd ./dist
 
 grep -rl 'VERSION_PLACEHOLDER' . | xargs  perl -p -i -e "s/VERSION_PLACEHOLDER/${NEW_VERSION}/g"
 grep -rl 'ANGULAR_VER_PLACEHOLDER' . | xargs  perl -p -i -e "s/ANGULAR_VER_PLACEHOLDER/${ANGULAR_VERSION}/g"
 grep -rl 'RXJS_VER_PLACEHOLDER' . | xargs  perl -p -i -e "s/RXJS_VER_PLACEHOLDER/${RXJS_VERSION}/g"
 
+cd ../


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.

This corrects path in the publish script relative to the root and improve readibility of the script. 

This shoudl fix up paths as current build failed that was caused by syncup that has cd dist but never jump out
