### PR TITLE
chore(build): Added public package for npm publish

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -47,7 +47,7 @@ for P in ${PACKAGES[@]};
 do
     echo publish "@fundamental-ngx/${P}"
     cd ${P}
-    $NPM_BIN  publish
+    $NPM_BIN  publish --access public
     cd ..
 done
 


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
For initial package 

You need to provide --access public to the initial publication to publish a scoped package because, as Linus points out, scoped packages are private and paid by default. The publish readme doesn't show any way to provide arbitrary commands to npm, so you'll likely have to do the first publish by hand, without lerna and with npm directly.


#### If this is a new feature, have you updated the documentation?