### PR TITLE
chore: update release script

### DIFF
--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -12,7 +12,7 @@ archive=$(echo $git_branch | grep -cE "^archive\-v\d+$")
 [[ "$master" = "0" && "$archive" = "0" ]] && echo -e "\n\t${ERROR}Sorry, this branch cannot be released.${NOCOLOR}\n\tReleases can only be published from 'master' and 'archive-v#' branches.\n\n" && exit 0
 
 # make sure the current branch is a release candidate
-rcVersion=$(grep '\"version\":' libs/core/package.json | grep -c "\-rc.")
+rcVersion=$(grep '\"version\":' package.json | grep -c "\-rc.")
 [ "$rcVersion" = "0" ] && echo -e "\n\t${ERROR}Sorry, this branch is not a release candidate.${NOCOLOR}\n\tIn order to publish a release, the package must be an 'rc' version.\n\n" && exit 0
 
 # make sure the branch is clean


### PR DESCRIPTION
At the moment if we try to release it check `package.json` in `/libs/core` which doesn't have any `rc-`. It gives an error:
```
Sorry, this branch is not a release candidate.
	In order to publish a release, the package must be an 'rc' version.
```
