### PR TITLE
docs: Correct version number for the docs app

### DIFF
--- a/apps/docs/src/environments/environment.hmr.ts
+++ b/apps/docs/src/environments/environment.hmr.ts
@@ -1,4 +1,4 @@
-import {version} from '../../../../libs/core/package.json';
+import {version} from '../../../../package.json';
 
 export const environment = {
     production: false,

--- a/apps/docs/src/environments/environment.prod.ts
+++ b/apps/docs/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
-import {version} from '../../../../libs/core/package.json';
+import {version} from '../../../../package.json';
 
 export const environment = {
     production: true,

--- a/apps/docs/src/environments/environment.ts
+++ b/apps/docs/src/environments/environment.ts
@@ -3,7 +3,7 @@
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
-import {version} from '../../../../libs/core/package.json';
+import {version} from '../../../../package.json';
 
 export const environment = {
     production: false,


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#1304 

#### Please provide a brief summary of this pull request.
There is not need to refer `../../libs/core/package.json'` as library
version does not hold the actual number, the root `package.json` does

