### PR TITLE
fix: Change padding strategy on token component

### DIFF
--- a/libs/core/src/lib/token/token.component.scss
+++ b/libs/core/src/lib/token/token.component.scss
@@ -5,3 +5,15 @@
 .fd-token__disabled::after{
     cursor: not-allowed;
 }
+
+.fd-token {
+    padding-left: 0;
+    padding-right: 0;
+    &:after {
+        padding-right: 8px;
+    }
+}
+
+.fd-token-content {
+    padding-left: 8px;
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1300
#### Please provide a brief summary of this pull request.
I changed paddings on token component, it will prevent from closing on left side click.
