### PR TITLE
fix: fix typo meni -> menu

### DIFF
--- a/apps/docs/src/app/core/component-docs/menu/menu-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/menu-docs.component.html
@@ -12,7 +12,7 @@
     Menu with Addon
 </fd-docs-section-title>
 <description
-    >This is an additional container that can be used for an icon or checkbox before the meni item text. This can be
+    >This is an additional container that can be used for an icon or checkbox before the menu item text. This can be
     achieved with the directives <code>fd-menu-item-addon</code> and <code>fd-menu-addon</code>
 </description>
 <component-example [name]="'ex10'">


### PR DESCRIPTION
It's just a small typo correction in a template of the documentation app. I haven't seen an issue for it. 