### PR TITLE
fix(core): expose Util package to platform

### DIFF
--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -1,4 +1,4 @@
-import {angularCliVersion} from '@nrwl/schematics/src/lib-versions';
+import { angularCliVersion } from '@nrwl/schematics/src/lib-versions';
 
 export * from './lib/fundamental-ngx-core.module';
 export * from './lib/action-bar/public_api';
@@ -43,4 +43,4 @@ export * from './lib/time-picker/public_api';
 export * from './lib/toggle/public_api';
 export * from './lib/token/public_api';
 export * from './lib/tree/public_api';
-
+export * from './lib/utils/pipes/pipe.module';

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -43,4 +43,3 @@ export * from './lib/time-picker/public_api';
 export * from './lib/toggle/public_api';
 export * from './lib/token/public_api';
 export * from './lib/tree/public_api';
-export * from './lib/utils/pipes/pipe.module';

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -1,4 +1,4 @@
-import { angularCliVersion } from '@nrwl/schematics/src/lib-versions';
+import {angularCliVersion} from '@nrwl/schematics/src/lib-versions';
 
 export * from './lib/fundamental-ngx-core.module';
 export * from './lib/action-bar/public_api';

--- a/libs/core/src/lib/fundamental-ngx-core.module.ts
+++ b/libs/core/src/lib/fundamental-ngx-core.module.ts
@@ -1,101 +1,101 @@
-import {NgModule} from '@angular/core';
-import {ActionBarModule} from './action-bar/action-bar.module';
-import {AlertModule} from './alert/alert.module';
-import {AlertService} from './alert/alert-service/alert.service';
-import {BadgeLabelModule} from './badge-label/badge-label.module';
-import {BreadcrumbModule} from './breadcrumb/breadcrumb.module';
-import {ButtonModule} from './button/button.module';
-import {ButtonGroupModule} from './button-group/button-group.module';
-import {CalendarModule} from './calendar/calendar.module';
-import {ComboboxModule} from './combobox/combobox.module';
-import {DatePickerModule} from './date-picker/date-picker.module';
-import {DatetimePickerModule} from './datetime-picker/datetime-picker.module';
-import {FileInputModule} from './file-input/file-input.module';
-import {FormModule} from './form/form.module';
-import {IconModule} from './icon/icon.module';
-import {IdentifierModule} from './identifier/identifier.module';
-import {ImageModule} from './image/image.module';
-import {InfiniteScrollModule} from './infinite-scroll/infinite-scroll.module';
-import {InlineHelpModule} from './inline-help/inline-help.module';
-import {InputGroupModule} from './input-group/input-group.module';
-import {ListModule} from './list/list.module';
-import {LoadingSpinnerModule} from './loading-spinner/loading-spinner.module';
-import {MenuModule} from './menu/menu.module';
-import {ModalModule} from './modal/modal.module';
-import {ModalService} from './modal/modal-service/modal.service';
-import {MultiInputModule} from './multi-input/multi-input.module';
-import {PaginationModule} from './pagination/pagination.module';
-import {PanelModule} from './panel/panel.module';
-import {PopoverModule} from './popover/popover.module';
-import {ScrollSpyModule} from './scroll-spy/scroll-spy.module';
-import {ShellbarModule} from './shellbar/shellbar.module';
-import {SideNavigationModule} from './side-navigation/side-navigation.module';
-import {SelectModule} from './select/select.module';
-import {SplitButtonModule} from './split-button/split-button.module';
-import {TableModule} from './table/table.module';
-import {TabsModule} from './tabs/tabs.module';
-import {TileModule} from './tile/tile.module';
-import {TreeModule} from './tree/tree.module';
-import {TimeModule} from './time/time.module';
-import {TimePickerModule} from './time-picker/time-picker.module';
-import {ToggleModule} from './toggle/toggle.module';
-import {TokenModule} from './token/token.module';
+import { NgModule } from '@angular/core';
+import { ActionBarModule } from './action-bar/action-bar.module';
+import { AlertModule } from './alert/alert.module';
+import { AlertService } from './alert/alert-service/alert.service';
+import { BadgeLabelModule } from './badge-label/badge-label.module';
+import { BreadcrumbModule } from './breadcrumb/breadcrumb.module';
+import { ButtonModule } from './button/button.module';
+import { ButtonGroupModule } from './button-group/button-group.module';
+import { CalendarModule } from './calendar/calendar.module';
+import { ComboboxModule } from './combobox/combobox.module';
+import { DatePickerModule } from './date-picker/date-picker.module';
+import { DatetimePickerModule } from './datetime-picker/datetime-picker.module';
+import { FileInputModule } from './file-input/file-input.module';
+import { FormModule } from './form/form.module';
+import { IconModule } from './icon/icon.module';
+import { IdentifierModule } from './identifier/identifier.module';
+import { ImageModule } from './image/image.module';
+import { InfiniteScrollModule } from './infinite-scroll/infinite-scroll.module';
+import { InlineHelpModule } from './inline-help/inline-help.module';
+import { InputGroupModule } from './input-group/input-group.module';
+import { ListModule } from './list/list.module';
+import { LoadingSpinnerModule } from './loading-spinner/loading-spinner.module';
+import { MenuModule } from './menu/menu.module';
+import { ModalModule } from './modal/modal.module';
+import { ModalService } from './modal/modal-service/modal.service';
+import { MultiInputModule } from './multi-input/multi-input.module';
+import { PaginationModule } from './pagination/pagination.module';
+import { PanelModule } from './panel/panel.module';
+import { PopoverModule } from './popover/popover.module';
+import { ScrollSpyModule } from './scroll-spy/scroll-spy.module';
+import { ShellbarModule } from './shellbar/shellbar.module';
+import { SideNavigationModule } from './side-navigation/side-navigation.module';
+import { SelectModule } from './select/select.module';
+import { SplitButtonModule } from './split-button/split-button.module';
+import { TableModule } from './table/table.module';
+import { TabsModule } from './tabs/tabs.module';
+import { TileModule } from './tile/tile.module';
+import { TreeModule } from './tree/tree.module';
+import { TimeModule } from './time/time.module';
+import { TimePickerModule } from './time-picker/time-picker.module';
+import { ToggleModule } from './toggle/toggle.module';
+import { TokenModule } from './token/token.module';
 
-import {CommonModule} from '@angular/common';
-import {FormsModule} from '@angular/forms';
-import {LocalizationEditorModule} from './localizator-editor/localization-editor.module';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { LocalizationEditorModule } from './localizator-editor/localization-editor.module';
 import { MegaMenuModule } from './mega-menu/mega-menu.module';
 import { LayoutGridModule } from './layout-grid/layout-grid.module';
+import { PipeModule } from './utils/pipes/pipe.module';
 
 @NgModule({
-  imports: [CommonModule, FormsModule],
-  exports: [
-    ActionBarModule,
-    AlertModule,
-    BadgeLabelModule,
-    BreadcrumbModule,
-    ButtonModule,
-    ButtonGroupModule,
-    CalendarModule,
-    ComboboxModule,
-    DatePickerModule,
-    DatetimePickerModule,
-    FileInputModule,
-    FormModule,
-    IconModule,
-    IdentifierModule,
-    ImageModule,
-    InlineHelpModule,
-    IdentifierModule,
-    InfiniteScrollModule,
-    InputGroupModule,
-    LayoutGridModule,
-    ListModule,
-    LoadingSpinnerModule,
-    LocalizationEditorModule,
-    MenuModule,
-    MegaMenuModule,
-    ModalModule,
-    MultiInputModule,
-    PaginationModule,
-    PanelModule,
-    PopoverModule,
-    ScrollSpyModule,
-    SelectModule,
-    ShellbarModule,
-    SideNavigationModule,
-    SplitButtonModule,
-    TableModule,
-    TabsModule,
-    TileModule,
-    TimeModule,
-    TimePickerModule,
-    ToggleModule,
-    TokenModule,
-    TreeModule,
-  ],
-  providers: [AlertService, ModalService],
+    imports: [CommonModule, FormsModule],
+    exports: [
+        ActionBarModule,
+        AlertModule,
+        BadgeLabelModule,
+        BreadcrumbModule,
+        ButtonModule,
+        ButtonGroupModule,
+        CalendarModule,
+        ComboboxModule,
+        DatePickerModule,
+        DatetimePickerModule,
+        FileInputModule,
+        FormModule,
+        IconModule,
+        IdentifierModule,
+        ImageModule,
+        InlineHelpModule,
+        IdentifierModule,
+        InfiniteScrollModule,
+        InputGroupModule,
+        LayoutGridModule,
+        ListModule,
+        LoadingSpinnerModule,
+        LocalizationEditorModule,
+        MenuModule,
+        MegaMenuModule,
+        ModalModule,
+        MultiInputModule,
+        PaginationModule,
+        PanelModule,
+        PopoverModule,
+        ScrollSpyModule,
+        SelectModule,
+        ShellbarModule,
+        SideNavigationModule,
+        SplitButtonModule,
+        TableModule,
+        TabsModule,
+        TileModule,
+        TimeModule,
+        TimePickerModule,
+        ToggleModule,
+        TokenModule,
+        TreeModule,
+        PipeModule
+    ],
+    providers: [AlertService, ModalService]
 })
-export class FundamentalNgxCoreModule {
-
-}
+export class FundamentalNgxCoreModule {}

--- a/libs/core/src/lib/fundamental-ngx-core.module.ts
+++ b/libs/core/src/lib/fundamental-ngx-core.module.ts
@@ -1,101 +1,101 @@
-import { NgModule } from '@angular/core';
-import { ActionBarModule } from './action-bar/action-bar.module';
-import { AlertModule } from './alert/alert.module';
-import { AlertService } from './alert/alert-service/alert.service';
-import { BadgeLabelModule } from './badge-label/badge-label.module';
-import { BreadcrumbModule } from './breadcrumb/breadcrumb.module';
-import { ButtonModule } from './button/button.module';
-import { ButtonGroupModule } from './button-group/button-group.module';
-import { CalendarModule } from './calendar/calendar.module';
-import { ComboboxModule } from './combobox/combobox.module';
-import { DatePickerModule } from './date-picker/date-picker.module';
-import { DatetimePickerModule } from './datetime-picker/datetime-picker.module';
-import { FileInputModule } from './file-input/file-input.module';
-import { FormModule } from './form/form.module';
-import { IconModule } from './icon/icon.module';
-import { IdentifierModule } from './identifier/identifier.module';
-import { ImageModule } from './image/image.module';
-import { InfiniteScrollModule } from './infinite-scroll/infinite-scroll.module';
-import { InlineHelpModule } from './inline-help/inline-help.module';
-import { InputGroupModule } from './input-group/input-group.module';
-import { ListModule } from './list/list.module';
-import { LoadingSpinnerModule } from './loading-spinner/loading-spinner.module';
-import { MenuModule } from './menu/menu.module';
-import { ModalModule } from './modal/modal.module';
-import { ModalService } from './modal/modal-service/modal.service';
-import { MultiInputModule } from './multi-input/multi-input.module';
-import { PaginationModule } from './pagination/pagination.module';
-import { PanelModule } from './panel/panel.module';
-import { PopoverModule } from './popover/popover.module';
-import { ScrollSpyModule } from './scroll-spy/scroll-spy.module';
-import { ShellbarModule } from './shellbar/shellbar.module';
-import { SideNavigationModule } from './side-navigation/side-navigation.module';
-import { SelectModule } from './select/select.module';
-import { SplitButtonModule } from './split-button/split-button.module';
-import { TableModule } from './table/table.module';
-import { TabsModule } from './tabs/tabs.module';
-import { TileModule } from './tile/tile.module';
-import { TreeModule } from './tree/tree.module';
-import { TimeModule } from './time/time.module';
-import { TimePickerModule } from './time-picker/time-picker.module';
-import { ToggleModule } from './toggle/toggle.module';
-import { TokenModule } from './token/token.module';
+import {NgModule} from '@angular/core';
+import {ActionBarModule} from './action-bar/action-bar.module';
+import {AlertModule} from './alert/alert.module';
+import {AlertService} from './alert/alert-service/alert.service';
+import {BadgeLabelModule} from './badge-label/badge-label.module';
+import {BreadcrumbModule} from './breadcrumb/breadcrumb.module';
+import {ButtonModule} from './button/button.module';
+import {ButtonGroupModule} from './button-group/button-group.module';
+import {CalendarModule} from './calendar/calendar.module';
+import {ComboboxModule} from './combobox/combobox.module';
+import {DatePickerModule} from './date-picker/date-picker.module';
+import {DatetimePickerModule} from './datetime-picker/datetime-picker.module';
+import {FileInputModule} from './file-input/file-input.module';
+import {FormModule} from './form/form.module';
+import {IconModule} from './icon/icon.module';
+import {IdentifierModule} from './identifier/identifier.module';
+import {ImageModule} from './image/image.module';
+import {InfiniteScrollModule} from './infinite-scroll/infinite-scroll.module';
+import {InlineHelpModule} from './inline-help/inline-help.module';
+import {InputGroupModule} from './input-group/input-group.module';
+import {ListModule} from './list/list.module';
+import {LoadingSpinnerModule} from './loading-spinner/loading-spinner.module';
+import {MenuModule} from './menu/menu.module';
+import {ModalModule} from './modal/modal.module';
+import {ModalService} from './modal/modal-service/modal.service';
+import {MultiInputModule} from './multi-input/multi-input.module';
+import {PaginationModule} from './pagination/pagination.module';
+import {PanelModule} from './panel/panel.module';
+import {PopoverModule} from './popover/popover.module';
+import {ScrollSpyModule} from './scroll-spy/scroll-spy.module';
+import {ShellbarModule} from './shellbar/shellbar.module';
+import {SideNavigationModule} from './side-navigation/side-navigation.module';
+import {SelectModule} from './select/select.module';
+import {SplitButtonModule} from './split-button/split-button.module';
+import {TableModule} from './table/table.module';
+import {TabsModule} from './tabs/tabs.module';
+import {TileModule} from './tile/tile.module';
+import {TreeModule} from './tree/tree.module';
+import {TimeModule} from './time/time.module';
+import {TimePickerModule} from './time-picker/time-picker.module';
+import {ToggleModule} from './toggle/toggle.module';
+import {TokenModule} from './token/token.module';
 
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { LocalizationEditorModule } from './localizator-editor/localization-editor.module';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {LocalizationEditorModule} from './localizator-editor/localization-editor.module';
 import { MegaMenuModule } from './mega-menu/mega-menu.module';
 import { LayoutGridModule } from './layout-grid/layout-grid.module';
-import { PipeModule } from './utils/pipes/pipe.module';
 
 @NgModule({
-    imports: [CommonModule, FormsModule],
-    exports: [
-        ActionBarModule,
-        AlertModule,
-        BadgeLabelModule,
-        BreadcrumbModule,
-        ButtonModule,
-        ButtonGroupModule,
-        CalendarModule,
-        ComboboxModule,
-        DatePickerModule,
-        DatetimePickerModule,
-        FileInputModule,
-        FormModule,
-        IconModule,
-        IdentifierModule,
-        ImageModule,
-        InlineHelpModule,
-        IdentifierModule,
-        InfiniteScrollModule,
-        InputGroupModule,
-        LayoutGridModule,
-        ListModule,
-        LoadingSpinnerModule,
-        LocalizationEditorModule,
-        MenuModule,
-        MegaMenuModule,
-        ModalModule,
-        MultiInputModule,
-        PaginationModule,
-        PanelModule,
-        PopoverModule,
-        ScrollSpyModule,
-        SelectModule,
-        ShellbarModule,
-        SideNavigationModule,
-        SplitButtonModule,
-        TableModule,
-        TabsModule,
-        TileModule,
-        TimeModule,
-        TimePickerModule,
-        ToggleModule,
-        TokenModule,
-        TreeModule,
-        PipeModule
-    ],
-    providers: [AlertService, ModalService]
+  imports: [CommonModule, FormsModule],
+  exports: [
+    ActionBarModule,
+    AlertModule,
+    BadgeLabelModule,
+    BreadcrumbModule,
+    ButtonModule,
+    ButtonGroupModule,
+    CalendarModule,
+    ComboboxModule,
+    DatePickerModule,
+    DatetimePickerModule,
+    FileInputModule,
+    FormModule,
+    IconModule,
+    IdentifierModule,
+    ImageModule,
+    InlineHelpModule,
+    IdentifierModule,
+    InfiniteScrollModule,
+    InputGroupModule,
+    LayoutGridModule,
+    ListModule,
+    LoadingSpinnerModule,
+    LocalizationEditorModule,
+    MenuModule,
+    MegaMenuModule,
+    ModalModule,
+    MultiInputModule,
+    PaginationModule,
+    PanelModule,
+    PopoverModule,
+    ScrollSpyModule,
+    SelectModule,
+    ShellbarModule,
+    SideNavigationModule,
+    SplitButtonModule,
+    TableModule,
+    TabsModule,
+    TileModule,
+    TimeModule,
+    TimePickerModule,
+    ToggleModule,
+    TokenModule,
+    TreeModule,
+  ],
+  providers: [AlertService, ModalService],
 })
-export class FundamentalNgxCoreModule {}
+export class FundamentalNgxCoreModule {
+
+}

--- a/libs/core/src/lib/utils/public_api.ts
+++ b/libs/core/src/lib/utils/public_api.ts
@@ -1,1 +1,2 @@
 export * from './directives/only-digits.directive';
+export * from './pipes/pipe.module';


### PR DESCRIPTION
need to extend the library for the UTIL package for the platform team to use the code instead of rewriting the same.
fixes: #1269

####Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/1269

#### Please provide a brief summary of this pull request.
need to extend the library for the UTIL package for the platform team to use the code instead of rewriting the same.

#### If this is a new feature, have you updated the documentation?
enhancement of existing feature
