### PR TITLE
docs: Add input group complex example

### DIFF
--- a/apps/docs/src/app/core/component-docs/input-group/examples/input-group-button-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/examples/input-group-button-example.component.html
@@ -7,7 +7,6 @@
     <div fd-form-item>
         <label fd-form-label>Right Aligned Text Button Add-on</label>
         <fd-input-group [button]="true" [placement]="'after'" [addOnText]="'Submit'" [placeholder]="'Amount'">
-
         </fd-input-group>
     </div>
 </div>

--- a/apps/docs/src/app/core/component-docs/input-group/examples/input-group-complex-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/examples/input-group-complex-example.component.html
@@ -1,0 +1,24 @@
+<fd-form-group>
+    <label fd-form-label>Input Group with complex button addon.</label>
+    <fd-input-group>
+        <input fd-input-group-input fd-form-control>
+        <span fd-input-group-addon [button]="true">
+            <button fd-button
+                    [glyph]="'calendar'"
+                    [options]="'light'">
+            </button>
+        </span>
+    </fd-input-group>
+</fd-form-group>
+<br />
+<fd-form-group>
+    <div fd-form-item>
+        <label fd-form-label>Input Group with complex span addon.</label>
+        <fd-input-group>
+            <input fd-input-group-input fd-form-control>
+            <span fd-input-group-addon>
+                Addon
+            </span>
+        </fd-input-group>
+    </div>
+</fd-form-group>

--- a/apps/docs/src/app/core/component-docs/input-group/examples/input-group-examples.component.ts
+++ b/apps/docs/src/app/core/component-docs/input-group/examples/input-group-examples.component.ts
@@ -43,3 +43,9 @@ export class InputGroupTextExampleComponent {}
     templateUrl: './input-group-text-compact-example.component.html'
 })
 export class InputGroupTextCompactExampleComponent {}
+
+@Component({
+    selector: 'fd-input-group-complex-example',
+    templateUrl: './input-group-complex-example.component.html'
+})
+export class InputGroupComplexExampleComponent {}

--- a/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.html
@@ -89,6 +89,19 @@
 
 <separator></separator>
 
+<fd-docs-section-title [id]="'complex'" [componentName]="'inputGroup'">
+    Input Group with complex templates.
+</fd-docs-section-title>
+<description>It is possible to use complex templates inside <code>Input Group</code> component. To achieve it you should
+    use <code>fd-input-group-input</code> for complex input template, or <code>fd-input-group-addon</code> for complex addon template
+</description>
+<component-example [name]="'ex8'">
+    <fd-input-group-complex-example></fd-input-group-complex-example>
+</component-example>
+<code-example [exampleFiles]="complexInput"></code-example>
+
+<separator></separator>
+
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
     <fd-input-group
         [addOnText]="data.properties.addOnText"

--- a/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.ts
@@ -10,9 +10,8 @@ import * as inputGroupTextSrc from '!raw-loader!./examples/input-group-text-exam
 import * as inputGroupTextCompactSrc from '!raw-loader!./examples/input-group-text-compact-example.component.html';
 import * as formInputTsSrc from '!raw-loader!./examples/input-group-form-example.component.ts';
 import * as formInputHtmlSrc from '!raw-loader!./examples/input-group-form-example.component.html';
+import * as complexInputHtml from '!raw-loader!./examples/input-group-complex-example.component.html';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
-import { DocsSectionTitleComponent } from '../../../documentation/core-helpers/docs-section-title/docs-section-title.component';
-import { ActivatedRoute } from '@angular/router';
 
 @Component({
     selector: 'app-input-group',
@@ -751,6 +750,13 @@ export class InputGroupDocsComponent implements OnInit {
         {
             language: 'typescript',
             code: formInputTsSrc
+        }
+    ];
+
+    complexInput: ExampleFile[] = [
+        {
+            language: 'html',
+            code: complexInputHtml
         }
     ];
 

--- a/apps/docs/src/app/core/core-documentation.module.ts
+++ b/apps/docs/src/app/core/core-documentation.module.ts
@@ -112,7 +112,7 @@ import {
     InputGroupNumberExampleComponent,
     InputGroupSearchExampleComponent,
     InputGroupTextExampleComponent,
-    InputGroupTextCompactExampleComponent
+    InputGroupTextCompactExampleComponent, InputGroupComplexExampleComponent
 } from '../core/component-docs/input-group/examples/input-group-examples.component';
 import {
     ListActionsExampleComponent,
@@ -516,6 +516,7 @@ import { CoreDocumentationComponent } from './documentation/core-documentation.c
         InputGroupTextExampleComponent,
         InputGroupTextCompactExampleComponent,
         InputGroupFormExampleComponent,
+        InputGroupComplexExampleComponent,
         InputFormGroupExampleComponent,
         InputInlineHelpExampleComponent,
         InputStateExampleComponent,


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
Due to self contained adoption, we added new way to build `input group` component. The examples are added in this PR. 
#### If this is a new feature, have you updated the documentation?
One new example of usage in `input group` component.
