### PR TITLE
fix: Add styling options to inline help component

### DIFF
--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-examples.component.ts
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-examples.component.ts
@@ -11,3 +11,9 @@ export class InlineHelpExampleComponent {}
     templateUrl: './inline-help-trigger-example.component.html'
 })
 export class InlineHelpTriggerExampleComponent {}
+
+@Component({
+    selector: 'fd-inline-help-styled-example',
+    templateUrl: './inline-help-styled-example.component.html'
+})
+export class InlineHelpStyledExampleComponent {}

--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-styled-example.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-styled-example.component.html
@@ -1,0 +1,10 @@
+<span>Inline help with modified control element </span>
+<fd-inline-help [inlineHelpIconStyle]="{'margin-left': '50px'}">
+    Lorem ipsum dolor sit amet, consectetur adipiscing.
+</fd-inline-help>
+<br/>
+<span>Inline help with styled content </span>
+<fd-inline-help [inlineHelpContentStyle]="{'width': '250px', 'min-width': '250px', 'overflow': 'hidden', 'text-overflow': 'ellipsis'}">
+    Lorem ipsum dolor sit amet, consectetur adipiscing.
+</fd-inline-help>
+<br/>

--- a/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.component.html
@@ -11,7 +11,7 @@
 <separator></separator>
 
 <fd-docs-section-title [id]="'inline-help-triggerEvent'" [componentName]="'inlineHelp'">
-    Inline Help with Changed Trigger Cvent
+    Inline Help with Changed Trigger Event
 </fd-docs-section-title>
 <component-example [name]="'ex2'">
     <p class="fd-centered-content">

--- a/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.component.html
@@ -11,7 +11,7 @@
 <separator></separator>
 
 <fd-docs-section-title [id]="'inline-help-triggerEvent'" [componentName]="'inlineHelp'">
-    Inline Help with changed trigger event
+    Inline Help with Changed Trigger Cvent
 </fd-docs-section-title>
 <component-example [name]="'ex2'">
     <p class="fd-centered-content">
@@ -19,6 +19,23 @@
     </p>
 </component-example>
 <code-example [exampleFiles]="inlineHelpTrigger"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title [id]="'inline-help-styled'" [componentName]="'inlineHelp'">
+    Inline Help with Styled Elements.
+</fd-docs-section-title>
+<description>
+    Inline Help component content can be modified by passing <code>[inlineHelpContentStyle]={{"{'width': '250px'}"}}</code>
+    and icon can be modified by passing <code>[inlineHelpIconStyle]={{"{'margin-left': '20px'}"}}</code>. Structure of the object
+    passed to this component is the same as <code>[ngStyle]</code>.
+</description>
+<component-example [name]="'ex3'">
+    <p class="fd-centered-content">
+        <fd-inline-help-styled-example></fd-inline-help-styled-example>
+    </p>
+</component-example>
+<code-example [exampleFiles]="inlineHelpStyles"></code-example>
 
 <separator></separator>
 

--- a/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.component.ts
@@ -73,7 +73,11 @@ export class InlineHelpDocsComponent implements OnInit {
     inlineHelpStyles: ExampleFile[] = [
         {
             language: 'html',
-            code: inlineHelpStylesHtml
+            code: inlineHelpStylesHtml,
+            fileName: 'inline-help-styled-example',
+            secondFile: 'inline-help-examples',
+            typescriptFileCode: inlineHelpTsCode,
+            component: 'InlineHelpStyledExampleComponent'
         }
     ];
 

--- a/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChildren, ElementRef, QueryList, AfterViewInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Schema } from '../../../schema/models/schema.model';
 import { SchemaFactoryService } from '../../../schema/services/schema-factory/schema-factory.service';
 
@@ -6,10 +6,9 @@ import * as inlineHelpSrc from '!raw-loader!./examples/inline-help-example.compo
 import * as inlineHelpTriggerHtml from '!raw-loader!./examples/inline-help-trigger-example.component.html';
 import * as inlineHelpTsCode from '!raw-loader!./examples/inline-help-examples.component.ts';
 import * as inlineHelpScssCode from '!raw-loader!./examples/inline-help-example.component.scss';
+import * as inlineHelpStylesHtml from '!raw-loader!./examples/inline-help-styled-example.component.html';
 import Popper from 'popper.js';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
-import { DocsSectionTitleComponent } from '../../../documentation/core-helpers/docs-section-title/docs-section-title.component';
-import { ActivatedRoute } from '@angular/router';
 
 @Component({
     selector: 'app-inline-help',
@@ -67,6 +66,14 @@ export class InlineHelpDocsComponent implements OnInit {
             secondFile: 'inline-help-examples',
             typescriptFileCode: inlineHelpTsCode,
             component: 'InlineHelpTriggerExampleComponent'
+        }
+    ];
+
+
+    inlineHelpStyles: ExampleFile[] = [
+        {
+            language: 'html',
+            code: inlineHelpStylesHtml
         }
     ];
 

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-modal/popover-modal-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-modal/popover-modal-example.component.html
@@ -9,7 +9,7 @@
     </fd-modal-header>
     <fd-modal-body style="max-height: 200px">
         <div style="height: 500px;">
-            <fd-popover [noArrow]="false" placement="bottom">
+            <fd-popover [noArrow]="false" [placement]="'bottom'">
                 <fd-popover-control>
                     <button fd-button>Click me!</button>
                 </fd-popover-control>

--- a/apps/docs/src/app/core/core-documentation.module.ts
+++ b/apps/docs/src/app/core/core-documentation.module.ts
@@ -103,7 +103,7 @@ import {
     ImageSizesExampleComponent
 } from '../core/component-docs/image/examples/image-examples.component';
 import {
-    InlineHelpExampleComponent,
+    InlineHelpExampleComponent, InlineHelpStyledExampleComponent,
     InlineHelpTriggerExampleComponent
 } from '../core/component-docs/inline-help/examples/inline-help-examples.component';
 import {
@@ -519,6 +519,7 @@ import { NotificationContentComponent } from './component-docs/notification/exam
         InfiniteScrollBasicExampleComponent,
         InlineHelpExampleComponent,
         InlineHelpTriggerExampleComponent,
+        InlineHelpStyledExampleComponent,
         InputGroupButtonExampleComponent,
         InputGroupIconExampleComponent,
         InputGroupNumberExampleComponent,

--- a/libs/core/src/lib/inline-help/inline-help.component.html
+++ b/libs/core/src/lib/inline-help/inline-help.component.html
@@ -1,12 +1,11 @@
 <fd-popover [noArrow]="false"
             [placement]="placement"
-            [triggers]="triggers"
-    >
+            [triggers]="triggers">
         <fd-popover-control>
-            <span class="fd-inline-help" role="alert"></span>
+            <span class="fd-inline-help" [ngStyle]="inlineHelpIconStyle" role="alert"></span>
         </fd-popover-control>
         <fd-popover-body>
-            <span class="fd-inline-help__content">
+            <span class="fd-inline-help__content" [ngStyle]="inlineHelpContentStyle">
                 <ng-content></ng-content>
             </span>
         </fd-popover-body>

--- a/libs/core/src/lib/inline-help/inline-help.component.ts
+++ b/libs/core/src/lib/inline-help/inline-help.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, ViewEncapsulation } from '@angular/core';
 import { Placement } from 'popper.js';
 /**
- * The component that represents an inline-help. 
+ * The component that represents an inline-help.
  * Inline help is used to display help text in a popover, often inline with headers, body text and form labels.
  *
  * ```html
@@ -29,4 +29,15 @@ export class InlineHelpComponent {
      *  Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp). */
     @Input()
     triggers: string[] = ['mouseenter', 'mouseleave'];
+
+    /**
+     * The inline help style has same type as popular [ngStyle] directive. Value will be passed to `control` element
+     * */
+    @Input()
+    inlineHelpIconStyle: {[key: string]: any} | {[key: string]: any}[];
+
+    /** The inline help style has same type as popular [ngStyle] directive. Value will be passed to content element */
+    @Input()
+    inlineHelpContentStyle: {[key: string]: any} | {[key: string]: any}[];
+
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1415
#### Please provide a brief summary of this pull request.
Made possible to add the dynamically styling of the elements inside `inline help` component.
#### If this is a new feature, have you updated the documentation?
There is 1 new example of documentation
- [x] `README.md` - **Not needed**
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes) - **Added**
- [x] Documentation Examples - **One example added**
