### PR TITLE
fix(platform:search-input): Fix vertical alignment of placeholder text

### DIFF
--- a/libs/platform/src/lib/components/search-input/search-input.component.scss
+++ b/libs/platform/src/lib/components/search-input/search-input.component.scss
@@ -34,6 +34,14 @@
         padding-left: 12px;
         border-color: #89919a;
         background: none;
+
+        &::placeholder {
+            line-height: 36px;
+        }
+
+        &.fd-input--compact::placeholder {
+            line-height: 28px;
+        }
     }
 
     ::ng-deep [type=search]+.fd-input-group__addon {
@@ -66,6 +74,14 @@
         ::ng-deep input[type="search"],
         ::ng-deep .fd-input {
             border-color: var(--fd-color-neutral-4, #89919a);
+
+            &::placeholder {
+                line-height: var(--fd-forms-height, 36px);
+            }
+
+            &.fd-input--compact::placeholder {
+                line-height: var(--fd-forms-height-compact, 28px);
+            }
         }
 
         ::ng-deep [type=search]+.fd-input-group__addon {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Fixes: #1461 

#### Please provide a brief summary of this pull request.
Adjust CSS rules for input field placeholder, so that the `height` and `line-height` are properly synced.

***BEFORE:***
<img width="243" alt="Screen Shot 2019-10-23 at 3 36 25 PM" src="https://user-images.githubusercontent.com/48103491/67439368-e6fb8700-f5aa-11e9-91e8-ff85d68233f9.png">


***AFTER:***
<img width="247" alt="Screen Shot 2019-10-23 at 3 35 48 PM" src="https://user-images.githubusercontent.com/48103491/67439332-d3502080-f5aa-11e9-9ba6-edbeab5321a4.png">


#### If this is a new feature, have you updated the documentation?

- [ ] `README.md`
- [ ] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [ ] Documentation Examples
