### PR TITLE
fix: Add Offset in pixels to scroll spy

### DIFF
--- a/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-offset/scroll-spy-offset-example.component.html
+++ b/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-offset/scroll-spy-offset-example.component.html
@@ -1,0 +1,12 @@
+<div class="header-container">
+    <div class="header-item" *ngFor="let item of items" [ngClass]="{'selected': selectedSpy === item.id}">
+        <span class="icon">
+            <fd-icon [glyph]="'arrow-right'" [size]="'xs'"></fd-icon>
+        </span>
+        {{item.name}}
+    </div>
+</div>
+
+<div class="list-container" fdScrollSpy [trackedTags]="['div']" [targetOffset]="100" (spyChange)="selectedSpy = $event.id">
+    <div class="item" *ngFor="let item of items" [id]="item.id">{{item.name}}</div>
+</div>

--- a/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-offset/scroll-spy-offset-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-offset/scroll-spy-offset-example.component.scss
@@ -1,0 +1,57 @@
+:host {
+    display: flex;
+    flex-direction: row;
+    height: 190px;
+    position: relative;
+}
+
+.item {
+    height: 40px;
+    display: flex;
+    align-items: center;
+
+    &:last-child {
+        height: 220px;
+        align-items: flex-start;
+        padding-top: 10px;
+    }
+}
+
+.list-container {
+    border: 1px dashed black;
+    overflow: auto;
+    flex-grow: 1;
+}
+
+.header-container {
+    flex-direction: column;
+    display: flex;
+    width: 140px;
+    .header-item {
+        display: inline-block;
+    }
+}
+
+.icon {
+    left: -4px;
+    opacity: 0;
+}
+
+.selected {
+    font-weight: bold;
+    .icon {
+        opacity: 1;
+    }
+}
+
+.middle-marker-container {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    height: 0;
+    width: calc(100% - 140px);
+    .marker {
+        height: 1px;
+        border: 0.5px dashed black;
+    }
+}

--- a/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-offset/scroll-spy-offset-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-offset/scroll-spy-offset-example.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'fd-scroll-spy-offset-example',
+  templateUrl: './scroll-spy-offset-example.component.html',
+  styleUrls: ['./scroll-spy-offset-example.component.scss']
+})
+export class ScrollSpyOffsetExampleComponent implements OnInit {
+
+    selectedSpy = 'element-2';
+    items: any[] = [];
+
+    ngOnInit() {
+        this.generateItems(9);
+    }
+
+    generateItems(count: number): void {
+        for (let i = 0; i < count; ++i) {
+            this.items.push({name: 'Element ' + i, id: 'element-' + i});
+        }
+    }
+
+}

--- a/apps/docs/src/app/core/component-docs/scroll-spy/scroll-spy-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/scroll-spy/scroll-spy-docs.component.html
@@ -24,3 +24,16 @@
     <fd-scroll-spy-custom-example></fd-scroll-spy-custom-example>
 </component-example>
 <code-example [exampleFiles]="scrollSpyCustom"></code-example>
+
+
+<fd-docs-section-title [id]="'customOffset'" [componentName]="'scroll-spy'">
+    Custom Offset Detection Threshold
+</fd-docs-section-title>
+<description>
+    The <code>targetOffset</code> property allows you to add the offset to the detection. The value is measured in pixels,
+    so for example if there is <code>[targetOffset]="100"</code>, the event will be fired for element, that is 100px below.
+</description>
+<component-example [name]="'ex2'">
+    <fd-scroll-spy-offset-example></fd-scroll-spy-offset-example>
+</component-example>
+<code-example [exampleFiles]="scrollSpyCustom"></code-example>

--- a/apps/docs/src/app/core/core-documentation.module.ts
+++ b/apps/docs/src/app/core/core-documentation.module.ts
@@ -398,6 +398,7 @@ import { NotificationComponentAsContentExampleComponent } from './component-docs
 import { NotificationAsObjectExampleComponent } from './component-docs/notification/examples/notification-as-object.component';
 import { NotificationOptionsExampleComponent } from './component-docs/notification/examples/notification-options/notification-options-example.component';
 import { NotificationContentComponent } from './component-docs/notification/examples/component-as-content/notification-content.component';
+import { ScrollSpyOffsetExampleComponent } from './component-docs/scroll-spy/examples/scroll-spy-custom-offset/scroll-spy-offset-example.component';
 
 
 @NgModule({
@@ -583,6 +584,7 @@ import { NotificationContentComponent } from './component-docs/notification/exam
         ScrollSpyDocsComponent,
         ScrollSpyExampleComponent,
         ScrollSpyCustomExampleComponent,
+        ScrollSpyOffsetExampleComponent,
         SelectNativeExampleComponent,
         SelectNativeFormGroupExampleComponent,
         SelectNativeInlineHelpExampleComponent,

--- a/apps/docs/src/app/documentation/documentation.module.ts
+++ b/apps/docs/src/app/documentation/documentation.module.ts
@@ -760,7 +760,7 @@ import { ShellbarAdvancedExampleComponent } from '../core/component-docs/shellba
         FundamentalNgxCoreModule,
         HttpClientModule,
         CdkTableModule,
-        DragDropModule
+        DragDropModule,
     ],
     providers: [CopyService, ApiDocsService]
 })

--- a/libs/core/src/lib/scroll-spy/scroll-spy.directive.ts
+++ b/libs/core/src/lib/scroll-spy/scroll-spy.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
 
 /**
- * A directive designed to help navigation elements determine the element currently in view of the user. 
+ * A directive designed to help navigation elements determine the element currently in view of the user.
  */
 @Directive({
     selector: '[fdScrollSpy]'
@@ -19,16 +19,23 @@ export class ScrollSpyDirective {
     @Input()
     public fireEmpty: boolean = false;
 
-    /** 
-     * A number that represent at what location in the container the event is fired. 
-     * 0.5 would fire the events in the middle of the container, 
+    /**
+     * A number that represent at what location in the container the event is fired.
+     * 0.5 would fire the events in the middle of the container,
      * 0 for the top and 1 for the bottom.
      */
     @Input()
     public targetPercent: number = 0;
 
-    /** 
-     * Event fired on the scroll element when a new item becomes activated by the scrollspy . 
+    /**
+     * Number that represents the offset in pixels for fired target. `100` value means that the event will be fired for
+     * target that is 100 pixels below the spy container.
+     */
+    @Input()
+    public targetOffset: number = 0;
+
+    /**
+     * Event fired on the scroll element when a new item becomes activated by the scrollspy .
      * The returned value is the HTMLElement itself.
      */
     @Output()
@@ -46,7 +53,7 @@ export class ScrollSpyDirective {
         let spiedTag: HTMLElement;
         const children = this.elRef.nativeElement.children;
         const targetScrollTop = event.target.scrollTop;
-        const targetOffsetTop = event.target.offsetTop;
+        const targetOffsetTop = event.target.offsetTop + this.targetOffset;
 
         for (let i = 0; i < children.length; i++) {
             const element: HTMLElement = children[i];


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1446
#### Please provide a brief summary of this pull request.
There is added one example and one new input to scrollspy with `targetOffset`, that is measured in px.
#### If this is a new feature, have you updated the documentation?
There is 1 new example
- [x] `README.md` - not needed
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples - Added
