### PR TITLE
fix(platform:search-input): Supress emit or "searchSubmit" event when input text is empty

### DIFF
--- a/libs/platform/src/lib/components/search-input/search-input.component.spec.ts
+++ b/libs/platform/src/lib/components/search-input/search-input.component.spec.ts
@@ -74,6 +74,8 @@ describe('SearchInputComponent', () => {
         fixture = TestBed.createComponent(TestComponent);
         host = fixture.componentInstance;
         component = host.component;
+        host.inputValue = null;
+        host.submitValue = null;
         fixture.detectChanges();
     });
 
@@ -214,7 +216,7 @@ describe('SearchInputComponent', () => {
         textInput.triggerEventHandler('keyup', { key: 'a' });
         fixture.detectChanges();
 
-        expect(combobox.isOpen).toBeTruthy();
+        expect(combobox.open).toBeTruthy();
     });
 
     it('should emit an "inputChange" event when user types in the input field', () => {
@@ -295,6 +297,24 @@ describe('SearchInputComponent', () => {
         fixture.detectChanges();
 
         expect(host.submitValue).toEqual({ text: 'appl', category: null });
+    });
+
+    it('should not emit a "searchSubmit" event when user clicks keyboard enter in input field and the input field is null', () => {
+
+        // set type ahead list
+        host.placeholder = 'Search';
+        host.suggestions = [{ value: 'Apple' }, { value: 'Banana' }, { value: 'Carrot' }];
+        fixture.detectChanges();
+
+        const textInput = fixture.debugElement.query(By.css('input.fd-input'));
+
+        // simulate input entry
+        textInput.nativeElement.value = '';
+        textInput.nativeElement.dispatchEvent(new Event('input'));
+        textInput.triggerEventHandler('keydown', { code: 'Enter' });
+        fixture.detectChanges();
+
+        expect(host.submitValue).toBeNull();
     });
 
     it('should be able to be put into "isLoading" state', () => {

--- a/libs/platform/src/lib/components/search-input/search-input.component.ts
+++ b/libs/platform/src/lib/components/search-input/search-input.component.ts
@@ -182,7 +182,12 @@ export class SearchInputComponent implements OnInit, OnChanges, AfterViewInit {
             this.cancelSearch.emit();
         } else {
             // close dropdown
-            this.combobox.open = false;
+            this.combobox.isOpenChangeHandle(false);
+
+            // if there is no input text, don't emit event
+            if (!this.inputText) {
+                return;
+            }
 
             this.searchSubmit.emit({
                 text: this.inputText,


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Fixes: #1472

#### Please provide a brief summary of this pull request.
Added an if guard to suppress emit of "searchSubmit" event if the input text is empty.

#### If this is a new feature, have you updated the documentation?

- [ ] `README.md`
- [ ] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [ ] Documentation Examples
