### PR TITLE
fix: Modal height example issues. Close icon fix.

### DIFF
--- a/apps/docs/src/app/core/component-docs/modal/examples/component-as-content/modal-component-as-content-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/modal/examples/component-as-content/modal-component-as-content-example.component.ts
@@ -24,7 +24,9 @@ export class ModalComponentAsContentExampleComponent {
                     'nearly one-third of the world\'s production of pineapples.',
                 thirdParagraph: 'The flesh and juice of the pineapple are used in cuisines around the world.'
             },
-            maxWidth: '300px'
+            maxWidth: '300px',
+            height: '300px',
+            maxHeight: '100vh'
         });
 
         // TODO Subscribe to result

--- a/apps/docs/src/app/core/component-docs/modal/examples/component-as-content/modal-content.component.ts
+++ b/apps/docs/src/app/core/component-docs/modal/examples/component-as-content/modal-content.component.ts
@@ -8,7 +8,7 @@ import { ModalRef } from '@fundamental-ngx/core';
             <h1 fd-modal-title>{{modalRef.data.title}}</h1>
             <button fd-modal-close-btn (click)="modalRef.dismiss('x')"></button>
         </fd-modal-header>
-        <fd-modal-body style="max-height: 100px;">
+        <fd-modal-body>
             <p>{{modalRef.data.firstParagraph}}</p>
             <p>{{modalRef.data.secondParagraph}}</p>
             <p>{{modalRef.data.thirdParagraph}}</p>

--- a/libs/core/src/lib/modal/modal-utils/modal-directives.ts
+++ b/libs/core/src/lib/modal/modal-utils/modal-directives.ts
@@ -34,10 +34,22 @@ export class ModalTitleDirective {
 export class ModalCloseButtonDirective {
 
     /** @hidden */
+    @HostBinding('attr.aria-label')
+    ariaLabel: string = 'close';
+
+    /** @hidden */
+    @HostBinding('class.sap-icon--decline')
+    sapIconDeclineClass: boolean = true;
+
+    /** @hidden */
+    @HostBinding('class.sap-icon--l')
+    sapIconLClass: boolean = true;
+
+    /** @hidden */
     @HostBinding('class.fd-button--light')
-    lightButton = true;
+    lightButtonClass: boolean = true;
 
     /** @hidden */
     @HostBinding('class.fd-modal__close')
-    modalClose = true;
+    modalCloseClass: boolean = true;
 }

--- a/libs/core/src/lib/modal/modal.component.scss
+++ b/libs/core/src/lib/modal/modal.component.scss
@@ -5,6 +5,7 @@
     max-width: none;
     z-index: 1000;
     position: absolute;
+    max-height: 100vh;
 
     &:focus {
         outline: none;
@@ -21,4 +22,8 @@
     max-width: inherit;
     display: flex;
     flex-direction: column;
+}
+
+.fd-modal__body {
+    max-height: none;
 }

--- a/libs/core/src/lib/modal/modal.component.ts
+++ b/libs/core/src/lib/modal/modal.component.ts
@@ -144,7 +144,7 @@ export class ModalComponent extends AbstractFdNgxClass implements OnInit, AfterV
         if (!elementRef) {
             return;
         }
-        this.HOST_COMPONENT_CLASS_LIST.forEach(className => elementRef.nativeElement.classList.add(className));
+        elementRef.nativeElement.classList.add(...this.HOST_COMPONENT_CLASS_LIST);
     }
 
     _setProperties(): void {

--- a/libs/core/src/lib/modal/modal.component.ts
+++ b/libs/core/src/lib/modal/modal.component.ts
@@ -44,6 +44,13 @@ import { ModalRef } from './modal-utils/modal-ref';
 })
 export class ModalComponent extends AbstractFdNgxClass implements OnInit, AfterViewInit, OnDestroy {
 
+    /** List of classes that will be added to component, when load from component option is picked. */
+    readonly HOST_COMPONENT_CLASS_LIST: string[] = [
+        'fd-modal__content--overrides',
+        'fd-modal__content',
+    ];
+
+
     @ViewChild('vc', { read: ViewContainerRef, static: false  })
     containerRef: ViewContainerRef;
 
@@ -122,6 +129,7 @@ export class ModalComponent extends AbstractFdNgxClass implements OnInit, AfterV
         this.containerRef.clear();
         const componentFactory = this.componentFactoryResolver.resolveComponentFactory(content);
         this.componentRef = this.containerRef.createComponent(componentFactory);
+        this.addClassesToComponent(this.componentRef.location);
     }
 
     private loadFromTemplate(content: TemplateRef<any>): void {
@@ -130,6 +138,13 @@ export class ModalComponent extends AbstractFdNgxClass implements OnInit, AfterV
             $implicit: this.modalRef
         };
         this.componentRef = this.containerRef.createEmbeddedView(content, context);
+    }
+
+    private addClassesToComponent(elementRef: ElementRef): void {
+        if (!elementRef) {
+            return;
+        }
+        this.HOST_COMPONENT_CLASS_LIST.forEach(className => elementRef.nativeElement.classList.add(className));
     }
 
     _setProperties(): void {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1474
#### Please provide a brief summary of this pull request.
I changed the way how there are added classes, when modal is generated `as component`. There is also fixed `max-height` value for whole modal. 
I added some classes to the icon element, following fundamental-styles. 
#### If this is a new feature, have you updated the documentation?
There is changed example a little bit, with height specified.

- [x] `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
