### PR TITLE
fix: (core) Add stick to position option

### DIFF
--- a/apps/docs/src/app/core/component-docs/product-switch/examples/product-switch-dnd-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/product-switch/examples/product-switch-dnd-example.component.ts
@@ -12,6 +12,7 @@ export class ProductSwitchDndExampleComponent {
             title: 'Home',
             subtitle: 'Central Home',
             icon: 'home',
+            stickToPosition: true,
             disabledDragAndDrop: true
         },
         {

--- a/apps/docs/src/app/core/component-docs/product-switch/examples/product-switch-list/product-switch-list-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/product-switch/examples/product-switch-list/product-switch-list-example.component.ts
@@ -12,7 +12,9 @@ export class ProductSwitchListComponent {
         {
             title: 'Home',
             subtitle: 'Central Home',
-            icon: 'home'
+            icon: 'home',
+            stickToPosition: true,
+            disabledDragAndDrop: true
         },
         {
             title: 'Analytics Cloud',

--- a/apps/docs/src/app/core/component-docs/product-switch/examples/product-switch-small-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/product-switch/examples/product-switch-small-example.component.ts
@@ -11,7 +11,9 @@ export class ProductSwitchSmallExampleComponent {
         {
             title: 'Home',
             subtitle: 'Central Home',
-            icon: 'home'
+            icon: 'home',
+            stickToPosition: true,
+            disabledDragAndDrop: true
         },
         {
             title: 'Analytics Cloud',

--- a/apps/docs/src/app/core/component-docs/product-switch/product-switch-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/product-switch/product-switch-docs.component.html
@@ -4,7 +4,8 @@
 <description>
     Product switch with enabled <code>Drag And Drop</code>. The DnD functionality can be switched off by passing
     <code>[dragAndDropEnabled]="false"</code> to component. The event thrown on drop can be handled by binding to
-    <code>(productsChange)</code>.
+    <code>(productsChange)</code>. The element can stick to it's position, it can be achieved by passing
+    <code>stickToPosition: true</code> value to the interface object. Example of usage is in <code>Home</code> product.
 </description>
 <component-example [name]="'ex1'">
     <fd-product-switch-dnd-example></fd-product-switch-dnd-example>

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
@@ -9,6 +9,7 @@
         (itemsChange)="productSwitchItemsChangeHandle($event)">
         <li
             fd-dnd-container
+            [stickInPlace]="product.stickToPosition"
             *ngFor="let product of products">
             <div cdkDrag
                  [cdkDragDisabled]="product.disabledDragAndDrop || !dragAndDropEnabled"

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch.item.ts
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch.item.ts
@@ -20,4 +20,7 @@ export interface ProductSwitchItem {
 
     /** Whether user wants to disable drag and drop functionality from single element */
     disabledDragAndDrop?: boolean;
+
+    /** Whether this element should stick in one place, without changing position */
+    stickToPosition?: boolean;
 }

--- a/libs/core/src/lib/product-switch/product-switch/product-switch.component.ts
+++ b/libs/core/src/lib/product-switch/product-switch/product-switch.component.ts
@@ -1,6 +1,5 @@
-import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { PopoverComponent } from '../../popover/popover.component';
-import { ProductSwitchItem } from '../product-switch-body/product-switch.item';
 
 @Component({
     selector: 'fd-product-switch',

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
@@ -22,15 +22,6 @@ export class DndContainerDirective implements AfterContentInit {
     private placeholderElement: HTMLElement;
 
     private lineElement: HTMLElement;
-
-    /** @hidden */
-    @ContentChild(CdkDrag, { static: false })
-    cdkDrag: CdkDrag;
-
-    constructor(
-        public element: ElementRef,
-    ) {}
-
     /** Event thrown when the element is moved by 1px */
     @Output()
     readonly moved: EventEmitter<CdkDragMove> = new EventEmitter<CdkDragMove>();
@@ -42,6 +33,17 @@ export class DndContainerDirective implements AfterContentInit {
     /** Event thrown when the element is started to be dragged */
     @Output()
     readonly started: EventEmitter<void> = new EventEmitter<void>();
+
+    /** Whether this element should stick in one place, without changing position */
+    @Input() stickInPlace: boolean = false;
+
+    /** @hidden */
+    @ContentChild(CdkDrag, { static: false })
+    cdkDrag: CdkDrag;
+
+    constructor(
+        public element: ElementRef,
+    ) {}
 
     /** @hidden */
     public getElementChord(isBefore: boolean, listMode: boolean): ElementChord {
@@ -58,7 +60,8 @@ export class DndContainerDirective implements AfterContentInit {
         return {
             x: x,
             position: position,
-            y: rect.y + (this.element.nativeElement.offsetHeight / 2)
+            y: rect.y + (this.element.nativeElement.offsetHeight / 2),
+            stickToPosition: this.stickInPlace
         };
     }
 

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
@@ -117,4 +117,27 @@ describe('DndListDirective', () => {
 
         expect((directive as any).removeAllLines).toHaveBeenCalled();
     });
+
+    it ('should handle stickToPosition', () => {
+
+        spyOn((directive as any), 'generateLine');
+
+
+
+        const pointerPosition = { pointerPosition: { x: 230, y: 230 } };
+        (directive as any).closestLinkIndex = 1000;
+        (directive as any).closestLinkPosition = 'after';
+        (directive as any).draggedItemIndex = 3;
+
+        /** This is element tht should be ignored */
+        elementChords.push({ x: 235, y: 230, stickToPosition: true, position: 'after' });
+
+        (directive as any).elementChords = elementChords;
+
+        directive.onMove(<any>pointerPosition);
+
+        expect((directive as any).closestLinkIndex).toBe(2);
+        expect((directive as any).closestLinkPosition).toBe('before');
+        expect((directive as any).generateLine).toHaveBeenCalledWith(2, 'before');
+    })
 });


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1491
#### Please provide a brief summary of this pull request.
There is added one new option to product switch item which is called `stickToPosition`. Passing true value to this variable will disable element from changing it's position.  

- [x] `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
