### PR TITLE
chore: Change FundamentalNgxModule to FundamentalNgxCoreModule in readme

### DIFF
--- a/apps/docs/src/assets/README.md
+++ b/apps/docs/src/assets/README.md
@@ -40,11 +40,11 @@ For an existing Angular CLI application,
     To add the entire library, add the following import to your main application module.
 
     ```javascript
-    import { FundamentalNgxModule } from '@fundamental-ngx/core';
+    import { FundamentalNgxCoreModule } from '@fundamental-ngx/core';
     
     @NgModule({
         ...
-        imports: [FundamentalNgxModule],
+        imports: [FundamentalNgxCoreModule],
     })
     export class DemoModule { }
     ```

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -63,11 +63,11 @@ For an existing Angular CLI application,
     To add the entire library, add the following import to your main application module.
 
     ```javascript
-    import { FundamentalNgxModule } from '@fundamental-ngx/core';
+    import { FundamentalNgxCoreModule } from '@fundamental-ngx/core';
 
     @NgModule({
         ...
-        imports: [FundamentalNgxModule],
+        imports: [FundamentalNgxCoreModule],
     })
     export class DemoModule { }
     ```


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
There are changed occurance of invalid `FundamentalNgxModule` name in README.
#### If this is a new feature, have you updated the documentation?
Yes
- [x] `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
