### PR TITLE
fix: seconds regexp, trigger timepicker on enter/focusout

### DIFF
--- a/libs/core/src/lib/time-picker/format/time-parser.ts
+++ b/libs/core/src/lib/time-picker/format/time-parser.ts
@@ -51,7 +51,7 @@ export class TimeFormatParserDefault extends TimeFormatParser {
         let regexp;
         if (!meridian) {
             if (displaySeconds) {
-                regexp = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9]|[0-9])(:[0-5][0-9]|[0-9])$/;
+                regexp = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9]|[0-9]):([0-5][0-9]|[0-9])$/;
             } else if (displayMinutes) {
                 regexp = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9]|[0-9])$/;
             } else {
@@ -70,7 +70,7 @@ export class TimeFormatParserDefault extends TimeFormatParser {
             }
         } else if (meridian) {
             if (displaySeconds) {
-                regexp = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9]|[0-9])(:[0-5][0-9]|[0-9]) [APap][mM]$/;
+                regexp = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9]|[0-9]):([0-5][0-9]|[0-9]) [APap][mM]$/;
             } else if (displayMinutes) {
                 regexp = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9]|[0-9]) [APap][mM]$/;
             } else {

--- a/libs/core/src/lib/time-picker/time-picker.component.html
+++ b/libs/core/src/lib/time-picker/time-picker.component.html
@@ -8,8 +8,10 @@
             [disabled]="disabled"
             [glyph]="'fob-watch'">
             <input [value]="getFormattedTime()"
+                   #inputElement
                    fd-input-group-input
-                   (keyup)="timeInputChanged($event.currentTarget.value)"
+                   (keyup.enter)="timeInputChanged($event.currentTarget.value)"
+                   (focusout)="timeInputChanged(inputElement.value)"
                    (focus)="onFocusHandler()"
                    (click)="inputGroupClicked($event)"
                    [disabled]="disabled"


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1505
#### Please provide a brief summary of this pull request.
There was some bugs in time picker input. Regexp for seconds didn't work properly and the `keyup` event sometimes refreshed value too early.
#### If this is a new feature, have you updated the documentation?
No changes in interface.
- [x] `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
