### PR TITLE
fix: loading spinner aria-hidden issue

### DIFF
--- a/libs/core/src/lib/loading-spinner/loading-spinner.component.html
+++ b/libs/core/src/lib/loading-spinner/loading-spinner.component.html
@@ -1,3 +1,3 @@
-<div class="fd-spinner" [attr.aria-hidden]="!loading" [attr.aria-label]="loadingLabel">
+<div class="fd-spinner" *ngIf="loading" [attr.aria-label]="loadingLabel">
     <div class="fd-spinner__body"></div>
 </div>


### PR DESCRIPTION
Currently `aria-hidden`  behaves inconsistently across browsers.  [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute)

Solution (temporary) - replace `aria-hidden="true"` with ngIf

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
