### PR TITLE
fix: popover-placement-example fix for the control elements

### DIFF
--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-placement/popover-placement-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-placement/popover-placement-example.component.scss
@@ -1,1 +1,1 @@
-@import '../../../../../../../../../node_modules/fundamental-styles/dist/layout.css';
+@import '../../../../../../../../../node_modules/fundamental-styles/dist/fundamental-styles.css';


### PR DESCRIPTION
### Please provide a brief summary of this pull request.
The example for popover placement is broken. All control elements are situated together. 
The styling for `fd-col-#` is in `layout.css but it doesn't bring the styling to the component. We need to import the whole lib to make it work. 
Until we find the problem in Fundamental-styles we are going to use this solution.

Before:
<img width="1950" alt="Screen Shot 2019-11-06 at 9 44 53 AM" src="https://user-images.githubusercontent.com/39598672/68309122-f931f680-007b-11ea-8792-748df71d0deb.png">

After:
<img width="1875" alt="Screen Shot 2019-11-06 at 9 44 40 AM" src="https://user-images.githubusercontent.com/39598672/68309113-f505d900-007b-11ea-8eda-5ce77f992a3a.png">

Documentation checklist:
- [x] Documentation Examples
