### PR TITLE
fix: Removed hardcoded library name from module component

### DIFF
--- a/NEW_COMPONENT.md
+++ b/NEW_COMPONENT.md
@@ -90,7 +90,7 @@ In poster-header.component.html Copy/paste the code here:
 <description>
     <p>The poster shows an image</p>
 </description>
-<import module="PosterModule" path="fundamental-ngx"></import>
+<import module="PosterModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/NEW_PLATFORM_COMPONENT.md
+++ b/NEW_PLATFORM_COMPONENT.md
@@ -113,7 +113,7 @@ In poster-header.component.html Copy/paste the code here:
 <description>
     <p>The poster shows an image</p>
 </description>
-<import module="PosterModule" path="fundamental-ngx/platform"></import>
+<import module="PosterModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/action-bar/action-bar-header/action-bar-header.component.html
+++ b/apps/docs/src/app/core/component-docs/action-bar/action-bar-header/action-bar-header.component.html
@@ -1,8 +1,7 @@
 <header>Action Bar</header>
 <description>The Action Bar is located at the top of the page and is used for Page title and Main Actions for the page.
 </description>
-<import module="ActionBarModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ActionBarModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/alert/alert-header/alert-header.component.html
+++ b/apps/docs/src/app/core/component-docs/alert/alert-header/alert-header.component.html
@@ -1,7 +1,6 @@
 <header>Alert</header>
 <description>Alerts are used to display short messages that require user attention.</description>
-<import module="AlertModule"
-        path="@fundamental-ngx/core"></import>
+<import module="AlertModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/badge-label/badge-label-header/badge-label-header.component.html
+++ b/apps/docs/src/app/core/component-docs/badge-label/badge-label-header/badge-label-header.component.html
@@ -8,8 +8,7 @@
     <p> - Orange can be used for a warning status or to indicate that an action can be taken</p>
     <p> - Red indicates error status</p>
 </description>
-<import module="BadgeLabelModule"
-        path="@fundamental-ngx/core"></import>
+<import module="BadgeLabelModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/breadcrumb/breadcrumb-header/breadcrumb-header.component.html
+++ b/apps/docs/src/app/core/component-docs/breadcrumb/breadcrumb-header/breadcrumb-header.component.html
@@ -10,8 +10,7 @@
     <code>[attr.href]</code> attribute.
 
 </description>
-<import module="BreadcrumbModule"
-        path="@fundamental-ngx/core"></import>
+<import module="BreadcrumbModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/button-group/button-group-header/button-group-header.component.html
+++ b/apps/docs/src/app/core/component-docs/button-group/button-group-header/button-group-header.component.html
@@ -4,8 +4,7 @@
     <br /><br />
     Buttons in a button group can be navigated to via the tab key and pressed with the space bar or enter key.
 </description>
-<import module="ButtonGroupModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ButtonGroupModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/button/button-header/button-header.component.html
+++ b/apps/docs/src/app/core/component-docs/button/button-header/button-header.component.html
@@ -4,8 +4,7 @@
     <br /><br />
     Buttons can be navigated to via the tab key and pressed with the space bar or enter key.
 </description>
-<import module="ButtonModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ButtonModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/calendar/calendar-header/calendar-header.component.html
+++ b/apps/docs/src/app/core/component-docs/calendar/calendar-header/calendar-header.component.html
@@ -9,8 +9,7 @@
     into the day/month/year selection grid and use the arrow keys to navigate around the grid and make a selection with
     the space bar or enter key.
 </description>
-<import module="CalendarModule"
-        path="@fundamental-ngx/core"></import>
+<import module="CalendarModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/checkbox/checkbox-header/checkbox-header.component.html
+++ b/apps/docs/src/app/core/component-docs/checkbox/checkbox-header/checkbox-header.component.html
@@ -4,8 +4,7 @@
     disabled and also displayed in a row. <br />Checkboxes are keyboard navigable via the tab key and selected with
     the space bar.
 </description>
-<import module="FormModule"
-        path="@fundamental-ngx/core"></import>
+<import module="FormModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/combobox/combobox-header/combobox-header.component.html
+++ b/apps/docs/src/app/core/component-docs/combobox/combobox-header/combobox-header.component.html
@@ -3,8 +3,7 @@
     The combobox component is an opinionated composition of the input-group and popover components to
     accomplish the UI pattern of an autocomplete-like experience, also known as combobox input.
 </description>
-<import module="ComboboxModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ComboboxModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/date-picker/date-picker-header/date-picker-header.component.html
+++ b/apps/docs/src/app/core/component-docs/date-picker/date-picker-header/date-picker-header.component.html
@@ -6,8 +6,7 @@
     The date picker supports the same keyboard navigability as the calendar. The calendar can be opened by focusing the
     date picker input field and closed by focusing the calendar icon button and pressing enter or space.
 </description>
-<import module="DatePickerModule"
-        path="@fundamental-ngx/core"></import>
+<import module="DatePickerModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-header/datetime-picker-header.component.html
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-header/datetime-picker-header.component.html
@@ -9,8 +9,7 @@
     <br /><br />
     Fully compatible with Angular forms.
 </description>
-<import module="DatetimePickerModule"
-        path="@fundamental-ngx/core"></import>
+<import module="DatetimePickerModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/file-input/file-input-header/file-input-header.component.html
+++ b/apps/docs/src/app/core/component-docs/file-input/file-input-header/file-input-header.component.html
@@ -5,8 +5,7 @@
     The aim is to facilitate the use and styling of the native file input. The projected content can have a file dragged
     and dropped over.
 </description>
-<import module="FileInputModule"
-        path="@fundamental-ngx/core"></import>
+<import module="FileInputModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/icon/icon-header/icon-header.component.html
+++ b/apps/docs/src/app/core/component-docs/icon/icon-header/icon-header.component.html
@@ -2,8 +2,7 @@
 <description>Icons are used throughout the UI to save space, allow for visual clarity and focus, and for fun. Icons can
     be used adaptively
     if desired, but at this point they are used more as visual elements within other components.</description>
-<import module="IconModule"
-        path="@fundamental-ngx/core"></import>
+<import module="IconModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/identifier/identifier-header/identifier-header.component.html
+++ b/apps/docs/src/app/core/component-docs/identifier/identifier-header/identifier-header.component.html
@@ -1,7 +1,6 @@
 <header>Identifier</header>
 <description>Identifier is a way to visually present something using an icon or user initials.</description>
-<import module="IdentifierModule"
-        path="@fundamental-ngx/core"></import>
+<import module="IdentifierModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/image/image-header/image-header.component.html
+++ b/apps/docs/src/app/core/component-docs/image/image-header/image-header.component.html
@@ -1,7 +1,6 @@
 <header>Image</header>
 <description>When using images you can use our helpers classes to adjust the size and the shape.</description>
-<import module="ImageModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ImageModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/infinite-scroll/infinite-scroll-header/infinite-scroll-header.component.html
+++ b/apps/docs/src/app/core/component-docs/infinite-scroll/infinite-scroll-header/infinite-scroll-header.component.html
@@ -8,8 +8,7 @@
     directive is attached to. It then monitors the scrolling and emits an event when the inputted percentage value is
     reached.
 </description>
-<import module="InfiniteScrollModule"
-        path="@fundamental-ngx/core"></import>
+<import module="InfiniteScrollModule"></import>
 
 
 <fd-header-tabs></fd-header-tabs>

--- a/apps/docs/src/app/core/component-docs/inline-help/inline-help-header/inline-help-header.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/inline-help-header/inline-help-header.component.html
@@ -1,8 +1,7 @@
 <header>Inline Help</header>
 <description>Inline help is used to display help text in a popover, often inline with headers, body text and form
     labels. It also uses the fd-popover component and supports much of its functionality.</description>
-<import module="InlineHelpModule"
-        path="@fundamental-ngx/core"></import>
+<import module="InlineHelpModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/input-group/input-group-header/input-group-header.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/input-group-header/input-group-header.component.html
@@ -1,8 +1,7 @@
 <header>Input Group</header>
 <description>The Input groups component are form inputs with add-ons that allows the user to better understand the
     information been entered.</description>
-<import module="InputGroupModule"
-        path="@fundamental-ngx/core"></import>
+<import module="InputGroupModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/input/input-header/input-header.component.html
+++ b/apps/docs/src/app/core/component-docs/input/input-header/input-header.component.html
@@ -1,6 +1,5 @@
 <header>Input</header>
-<import module="FormModule"
-        path="@fundamental-ngx/core"></import>
+<import module="FormModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/layout-grid/layout-grid-docs-header/layout-grid-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/layout-grid/layout-grid-docs-header/layout-grid-docs-header.component.html
@@ -1,7 +1,6 @@
 <header>Layout Grid</header>
 <description>Use a layout grid to arrange components evenly in a grid layout.</description>
-<import module="LayoutGridModule"
-        path="@fundamental-ngx/core"></import>
+<import module="LayoutGridModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/list/list-header/list-header.component.html
+++ b/apps/docs/src/app/core/component-docs/list/list-header/list-header.component.html
@@ -6,8 +6,7 @@
     <code>[attr.href]</code> attributes. List action buttons and checkboxes can be navigated via the tab key. List
     checkboxes can be selected with the space bar.
 </description>
-<import module="ListModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ListModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/loading-spinner-docs/loading-spinner-header/loading-spinner-header.component.html
+++ b/apps/docs/src/app/core/component-docs/loading-spinner-docs/loading-spinner-header/loading-spinner-header.component.html
@@ -3,8 +3,7 @@
     A loading spinner informs the user of an ongoing operation. Only one busy indicator should be shown at a time. The
     <code>loading</code> input on the component is used to hide and show the element.
 </description>
-<import module="LoadingSpinnerModule"
-        path="@fundamental-ngx/core"></import>
+<import module="LoadingSpinnerModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/localization-editor/localization-editor-header/localization-editor-header.component.html
+++ b/apps/docs/src/app/core/component-docs/localization-editor/localization-editor-header/localization-editor-header.component.html
@@ -3,8 +3,7 @@
     The localization editor is used to translate text into a number of languages.
     It promotes spatial efficiency through the use of the popover component under the hood.
 </description>
-<import module="LocalizationEditorModule"
-        path="@fundamental-ngx/core"></import>
+<import module="LocalizationEditorModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-header/mega-menu-header.component.html
+++ b/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-header/mega-menu-header.component.html
@@ -3,8 +3,7 @@
     Mega Menu is extended menu component, which contains sub lists. The Mega Menu component provides fully keyboard
     support. Arrow Left and Arrow Right opens/closes sublist.
 </description>
-<import module="MegaMenuModule"
-        path="@fundamental-ngx/core"></import>
+<import module="MegaMenuModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/menu/menu-header/menu-header.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/menu-header/menu-header.component.html
@@ -3,8 +3,7 @@
     Menu item anchors will be keyboard navigable via the tab key provided they have <code>[routerLink]</code> or
     <code>[attr.href]</code> attributes.
 </description>
-<import module="MenuModule"
-        path="@fundamental-ngx/core"></import>
+<import module="MenuModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/modal/modal-docs-header/modal-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/modal/modal-docs-header/modal-docs-header.component.html
@@ -4,8 +4,7 @@
     simple information with a short form, to get confirmation or display contextual information
     that does not require a page.
 </description>
-<import module="ModalModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ModalModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/multi-input/multi-input-header/multi-input-header.component.html
+++ b/apps/docs/src/app/core/component-docs/multi-input/multi-input-header/multi-input-header.component.html
@@ -3,8 +3,7 @@
     Input field with multiple selection enabled. Should be used when a user can select between a limited number of
     pre-defined options with a filter-enabled context.
 </description>
-<import module="MultiInputModule"
-        path="@fundamental-ngx/core"></import>
+<import module="MultiInputModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/notification/notification-docs-header/notification-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/notification/notification-docs-header/notification-docs-header.component.html
@@ -4,8 +4,7 @@
     information,
     gives possibility to somehow answer to this information or gather more information, by redirecting to the action.
 </description>
-<import module="NotificationModule"
-        path="@fundamental-ngx/core"></import>
+<import module="NotificationModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/pagination/pagination-header/pagination-header.component.html
+++ b/apps/docs/src/app/core/component-docs/pagination/pagination-header/pagination-header.component.html
@@ -7,8 +7,7 @@
     Pages can be selected programmatically by calling the <code>goToPage(pageNumber)</code> function on the pagination
     component.
 </description>
-<import module="PaginationModule"
-        path="@fundamental-ngx/core"></import>
+<import module="PaginationModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/panel/panel-docs-header/panel-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/panel/panel-docs-header/panel-docs-header.component.html
@@ -1,7 +1,6 @@
 <header>Panel</header>
 <description>The Panel is a layout component that serves many formatting purposes.</description>
-<import module="PanelModule"
-        path="@fundamental-ngx/core"></import>
+<import module="PanelModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/popover-directive/popover-directive-header/popover-directive-header.component.html
+++ b/apps/docs/src/app/core/component-docs/popover-directive/popover-directive-header/popover-directive-header.component.html
@@ -9,8 +9,7 @@
         alternative.
     </p>
 </description>
-<import module="PopoverModule"
-        path="@fundamental-ngx/core"></import>
+<import module="PopoverModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/popover/popover-header/popover-header.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/popover-header/popover-header.component.html
@@ -16,8 +16,7 @@
         Fundamental-ngx popovers use <a href="https://popper.js.org/index.html">Popper.js.</a>
     </p>
 </description>
-<import module="PopoverModule"
-        path="@fundamental-ngx/core"></import>
+<import module="PopoverModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/product-switch/product-switch-docs-header/product-switch-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/product-switch/product-switch-docs-header/product-switch-docs-header.component.html
@@ -2,8 +2,7 @@
 <description>
     Product Switch provides a role based access to all products or LoBs. It shows only one level of navigation.
 </description>
-<import module="ProductSwitchModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ProductSwitchModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/radio/radio-header/radio-header.component.html
+++ b/apps/docs/src/app/core/component-docs/radio/radio-header/radio-header.component.html
@@ -3,8 +3,7 @@
     Radio buttons allow the user to see all options and select one. Generally, this is used when there are between 2-3
     options. This component can also be disabled and displayed in a row. <br />
     Keyboard support for radio button selection is handled via the arrow keys.</description>
-<import module="FormModule"
-        path="@fundamental-ngx/core"></import>
+<import module="FormModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/scroll-spy/scroll-spy-header/scroll-spy-header.component.html
+++ b/apps/docs/src/app/core/component-docs/scroll-spy/scroll-spy-header/scroll-spy-header.component.html
@@ -7,8 +7,7 @@
     The examples below make use of the id to determine what element is spied on, but many other approaches are also
     possible.
 </description>
-<import module="ScrollSpyModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ScrollSpyModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/select-native/select-native-header/select-native-header.component.html
+++ b/apps/docs/src/app/core/component-docs/select-native/select-native-header/select-native-header.component.html
@@ -2,8 +2,7 @@
 <description>The Select is native html component similar to a dropdown but is more commonly used within a form. It can
     also be set several states.
 </description>
-<import module="FormModule"
-        path="@fundamental-ngx/core"></import>
+<import module="FormModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/select/select-header/select-header.component.html
+++ b/apps/docs/src/app/core/component-docs/select/select-header/select-header.component.html
@@ -7,8 +7,7 @@
     <br /><br />
     To view the styled native select, visit the <a [routerLink]="'/form'">Form</a> page.
 </description>
-<import module="SelectModule"
-        path="@fundamental-ngx/core"></import>
+<import module="SelectModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs-header/shellbar-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs-header/shellbar-docs-header.component.html
@@ -6,8 +6,7 @@
 
     Before getting started, here are some things to know.
 </description>
-<import module="ShellbarModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ShellbarModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/side-navigation/side-navigation-header/side-navigation-header.component.html
+++ b/apps/docs/src/app/core/component-docs/side-navigation/side-navigation-header/side-navigation-header.component.html
@@ -5,8 +5,7 @@
     <code>[attr.href]</code> attributes. Sub-levels of tiered side navigation can be opened with the
     space bar or enter key.
 </description>
-<import module="SideNavigationModule"
-        path="@fundamental-ngx/core"></import>
+<import module="SideNavigationModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/split-button/split-button-header/split-button-header.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/split-button-header/split-button-header.component.html
@@ -5,8 +5,7 @@
     Buttons can be navigated to via the tab key and pressed with the space bar or enter key, also dropdown icon can be
     triggered by focusing on it by tab key and space or enter.
 </description>
-<import module="SplitButtonModule"
-        path="@fundamental-ngx/core"></import>
+<import module="SplitButtonModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/table/table-docs-header/table-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/table/table-docs-header/table-docs-header.component.html
@@ -4,8 +4,7 @@
     a set of item
     of the same type which data is divided on columns to facilitate the comparison between items.
 </description>
-<import module="TableModule"
-        path="@fundamental-ngx/core"></import>
+<import module="TableModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-header/tabs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-header/tabs-header.component.html
@@ -4,8 +4,7 @@
     <br /><br />
     Tabs can be navigated through via the tab key and selected with the enter key or space bar.
 </description>
-<import module="TabsModule"
-        path="@fundamental-ngx/core"></import>
+<import module="TabsModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/textarea/textarea-header/textarea-header.component.html
+++ b/apps/docs/src/app/core/component-docs/textarea/textarea-header/textarea-header.component.html
@@ -1,6 +1,5 @@
 <header>Textarea</header>
-<import module="FormModule"
-        path="@fundamental-ngx/core"></import>
+<import module="FormModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/tile/tile-docs-header/tile-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/tile/tile-docs-header/tile-docs-header.component.html
@@ -1,8 +1,7 @@
 <header>Tile</header>
 <description>A Tile component can be used to display information in a simple container format.
 </description>
-<import module="TileModule"
-        path="@fundamental-ngx/core"></import>
+<import module="TileModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/time-picker/time-picker-header/time-picker-header.component.html
+++ b/apps/docs/src/app/core/component-docs/time-picker/time-picker-header/time-picker-header.component.html
@@ -9,8 +9,7 @@
     The Time Picker component uses Time Component, for internationalization configuration, check
     <code>Internationalization</code> section in <code>Time</code> documentation
 </description>
-<import module="TimePickerModule"
-        path="@fundamental-ngx/core"></import>
+<import module="TimePickerModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/time/time-header/time-header.component.html
+++ b/apps/docs/src/app/core/component-docs/time/time-header/time-header.component.html
@@ -6,8 +6,7 @@
     <br /><br />
     Time component buttons are navigable via the tab key and can be pressed via the space bar or enter key.
 </description>
-<import module="TimeModule"
-        path="@fundamental-ngx/core"></import>
+<import module="TimeModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/toggle/toggle-header/toggle-header.component.html
+++ b/apps/docs/src/app/core/component-docs/toggle/toggle-header/toggle-header.component.html
@@ -4,8 +4,7 @@
     <br /><br />
     Once focused, it can be toggled using the spacebar or the enter key.
 </description>
-<import module="ToggleModule"
-        path="@fundamental-ngx/core"></import>
+<import module="ToggleModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/token/token-header/token-header.component.html
+++ b/apps/docs/src/app/core/component-docs/token/token-header/token-header.component.html
@@ -3,8 +3,7 @@
     A token is used to represent contextualizing information. They can be useful to show applied filters, selected
     values for form fields or object metadata.
 </description>
-<import module="TokenModule"
-        path="@fundamental-ngx/core"></import>
+<import module="TokenModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/tree/tree-header/tree-header.component.html
+++ b/apps/docs/src/app/core/component-docs/tree/tree-header/tree-header.component.html
@@ -3,8 +3,7 @@
     into the data in an simple way. Along with displaying the hierarchy information it can also contain other data in
     the
     same node as well.</description>
-<import module="TreeModule"
-        path="@fundamental-ngx/core"></import>
+<import module="TreeModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/documentation/core-helpers/import/import.component.ts
+++ b/apps/docs/src/app/documentation/core-helpers/import/import.component.ts
@@ -1,18 +1,35 @@
-import { Component, Input } from '@angular/core';
+import { Component, Inject, Input } from '@angular/core';
+import { Libraries } from '../../utilities/libraries';
 
 @Component({
     selector: 'import',
     template: `
-    <code>
-        <span style="color: rgb(0, 0, 136);">import</span> 
-        &#123; {{ module }} &#125;
-        <span style="color: rgb(0, 0, 136);">from </span>
-        <span style="color: rgb(0, 136, 0);">'{{ path }}'</span>;
-    </code>
-  `
+        <code>
+            <span style="color: rgb(0, 0, 136);">import</span>
+            &#123; {{ module }} &#125;
+            <span style="color: rgb(0, 0, 136);">from </span>
+            <span style="color: rgb(0, 136, 0);">'{{ library }}'</span>;
+        </code>
+    `
 })
 export class ImportComponent {
     @Input() module: string;
 
-    @Input() path: string;
+    library: string;
+
+    constructor(
+        @Inject('CURRENT_LIB') private currentLib: Libraries
+    ) {
+        switch (this.currentLib) {
+            case 'core' : {
+                this.library = '@fundamental-ngx/core';
+                break;
+            }
+
+            case 'platform': {
+                this.library = '@fundamental-ngx/platform';
+                break;
+            }
+        }
+    }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-button/platform-button-header/platform-button-header.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-button/platform-button-header/platform-button-header.component.html
@@ -4,7 +4,7 @@
     <br /><br />
     Buttons can be navigated to via the tab key and pressed with the space bar or enter key.
 </description>
-<import module="PlatformButtonModule" path="@fundamental-ngx/platform"></import>
+<import module="PlatformButtonModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2200,9 +2200,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.2.tgz",
-      "integrity": "sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+      "integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -3087,9 +3087,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
+      "version": "12.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
+      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -4432,9 +4432,9 @@
       }
     },
     "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -5783,9 +5783,9 @@
       "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
     },
     "core-js-compat": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.0.tgz",
-      "integrity": "sha512-pgQUcgT2+v9/yxHgMynYjNj7nmxLRXv3UC39rjCjDwpe63ev2rioQTju1PKLYUBbPCQQvZNWvQC8tBJd65q11g==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.1.tgz",
+      "integrity": "sha512-YdeJI26gLc0CQJ9asLE5obEgBz2I0+CIgnoTbS2T0d5IPQw/OCgCIFR527RmpduxjrB3gSEHoGOCTq9sigOyfw==",
       "dev": true,
       "requires": {
         "browserslist": "^4.7.2",
@@ -6717,9 +6717,9 @@
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -7423,9 +7423,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz",
-      "integrity": "sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
       "dev": true,
       "optional": true
     },
@@ -8463,9 +8463,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -8475,14 +8475,25 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
-          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^5.2.0"
+            "strip-ansi": "^6.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.0"
+              }
+            }
           }
         },
         "strip-ansi": {
@@ -8492,6 +8503,14 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            }
           }
         }
       }
@@ -13701,9 +13720,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
       "dev": true
     },
     "object-is": {
@@ -14412,9 +14431,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "prismjs": {
@@ -17291,9 +17310,9 @@
       "dev": true
     },
     "ts-node": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
-      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.0.tgz",
+      "integrity": "sha512-fbG32iZEupNV2E2Fd2m2yt1TdAwR3GTCrJQBHDevIiEBNy1A8kqnyl1fv7jmRmmbtcapFab2glZXHJvfD1ed0Q==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1532
#### Please provide a brief summary of this pull request.
There is added functionality, to detect library (core/platform). Right now it's not needed to hardocde the lib name.

#### Please check whether the PR fulfills the following requirements - **Internal Changes**
- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist - **Internal Changes**
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
