### PR TITLE
fix: (core) Add popover new open shortcut, improve multi input keyboard support, fix visual menu focus

### DIFF
--- a/apps/docs/src/app/core/component-docs/multi-input/examples/multi-input-form-example/multi-input-form-example.component.html
+++ b/apps/docs/src/app/core/component-docs/multi-input/examples/multi-input-form-example/multi-input-form-example.component.html
@@ -12,7 +12,6 @@
             <fd-multi-input
                 formControlName="disabledSelectedValues"
                 [dropdownValues]="['Apple', 'Banana', 'Pineapple', 'Tomato']"
-                [disabled]="'true'"
                 [placeholder]="'Search Here...'"
             >
             </fd-multi-input>

--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -22,8 +22,7 @@
         </div>
     </fd-popover-control>
     <fd-popover-body *ngIf="displayedValues && displayedValues.length">
-        <fd-menu class="fd-combobox-input-menu-overflow"
-                 [style.maxHeight]="maxHeight">
+        <fd-menu class="fd-combobox-input-menu-overflow" [style.maxHeight]="maxHeight">
             <ng-content></ng-content>
             <ul fd-menu-list>
                 <li *ngFor="let term of displayedValues; let index = index;"

--- a/libs/core/src/lib/combobox/combobox.component.spec.ts
+++ b/libs/core/src/lib/combobox/combobox.component.spec.ts
@@ -53,15 +53,14 @@ describe('ComboboxComponent', () => {
         spyOn(component, 'searchFunction');
         const event = {
             code: 'Enter',
-            preventDefault: () => {
-            }
+            preventDefault: () => {}
         };
-        component.onInputKeydownHandler(event);
+        component.onInputKeydownHandler(<any>event);
         expect(component.searchFunction).toHaveBeenCalled();
         event.code = 'ArrowDown';
         spyOn(event, 'preventDefault');
         spyOn(component.menuItems.first, 'focus');
-        component.onInputKeydownHandler(event);
+        component.onInputKeydownHandler(<any>event);
         expect(event.preventDefault).toHaveBeenCalled();
         expect(component.menuItems.first.focus).toHaveBeenCalled();
     });

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -163,6 +163,10 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
     searchInputElement: ElementRef;
 
     /** @hidden */
+    @ViewChild('comboboxMenuElement', { static: false })
+    comboboxMenuElement: ElementRef;
+
+    /** @hidden */
     displayedValues: any[] = [];
 
     /** @hidden */
@@ -220,10 +224,13 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
     }
 
     /** @hidden */
-    onInputKeydownHandler(event) {
+    onInputKeydownHandler(event: KeyboardEvent) {
         if (event.code === 'Enter' && this.searchFunction) {
             this.searchFunction();
         } else if (event.code === 'ArrowDown') {
+            if (event.altKey) {
+                this.isOpenChangeHandle(true);
+            }
             event.preventDefault();
             if (this.menuItems && this.menuItems.first) {
                 this.menuItems.first.focus();
@@ -238,6 +245,7 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
             this.inputText.length &&
             event.code !== 'Escape' &&
             event.code !== 'Space' &&
+            event.code !== 'Tab' &&
             event.code !== 'Enter') {
             this.isOpenChangeHandle(true);
         }
@@ -310,7 +318,7 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
         this.open = isOpen;
         this.openChange.emit(this.open);
         this.onTouched();
-        if (open) {
+        if (this.open) {
             this.focusTrap.activate();
         } else {
             this.focusTrap.deactivate();

--- a/libs/core/src/lib/menu/menu.component.scss
+++ b/libs/core/src/lib/menu/menu.component.scss
@@ -1,7 +1,1 @@
 @import "~fundamental-styles/dist/menu";
-//TODO to be reviewed and if needed to be brought to fd-styles
-.fd-menu__item {
-    &:focus {
-        outline: var(--fd-color-action-focus) dotted 1px;
-    }
-}

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -2,6 +2,7 @@
     <fd-popover [(isOpen)]="isOpen"
                 [triggers]="[]"
                 [disabled]="disabled"
+                [closeOnOutsideClick]="true"
                 [fillControlMode]="fillControlMode"
                 class="fd-multi-input-popover-custom">
         <fd-popover-control>
@@ -9,18 +10,20 @@
                  [attr.aria-label]="multiInputBodyLabel"
                  [attr.aria-expanded]="isOpen">
                 <fd-input-group
+                    [buttonFocusable]="false"
                     [disabled]="disabled"
                     [compact]="compact"
                     [button]="true"
                     [glyph]="glyph"
                     (addOnButtonClicked)="isOpen = !isOpen">
                     <input type="text" class="fd-input" fd-input-group-input
+                           #searchInputElement
                            [ngClass]="{'fd-input--compact': compact}"
                            [placeholder]="placeholder"
                            [disabled]="disabled"
                            [(ngModel)]="searchTerm"
                            (ngModelChange)="handleSearchTermChange()"
-                           (keypress)="isOpen = true"
+                           (keydown)="handleInputKeydown($event)"
                            (click)="isOpen = !isOpen">
                 </fd-input-group>
             </div>
@@ -30,8 +33,8 @@
                      *ngIf="displayedValues && displayedValues.length"
                      [style.maxHeight]="maxHeight">
                 <ul fd-menu-list>
-                    <li *ngFor="let value of displayedValues">
-                        <label fd-menu-item>
+                    <li *ngFor="let value of displayedValues; let ind  = index">
+                        <label fd-menu-item (keydown)="handleKeyDown($event, ind)">
                             <input type="checkbox" class="fd-checkbox"
                                    [ngModel]="selected ? selected.indexOf(value) !== -1 : false"
                                    (ngModelChange)="handleSelect($event, value)">

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -1,5 +1,6 @@
 <div class="fd-multi-input-field">
-    <fd-popover [(isOpen)]="isOpen"
+    <fd-popover [isOpen]="open"
+                (isOpenChange)="openChangeHandle($event)"
                 [triggers]="[]"
                 [disabled]="disabled"
                 [closeOnOutsideClick]="true"
@@ -8,14 +9,14 @@
         <fd-popover-control>
             <div class="fd-combobox-control"
                  [attr.aria-label]="multiInputBodyLabel"
-                 [attr.aria-expanded]="isOpen">
+                 [attr.aria-expanded]="open">
                 <fd-input-group
                     [buttonFocusable]="false"
                     [disabled]="disabled"
                     [compact]="compact"
                     [button]="true"
                     [glyph]="glyph"
-                    (addOnButtonClicked)="isOpen = !isOpen">
+                    (addOnButtonClicked)="openChangeHandle(!open)">
                     <input type="text" class="fd-input" fd-input-group-input
                            #searchInputElement
                            [ngClass]="{'fd-input--compact': compact}"
@@ -24,11 +25,11 @@
                            [(ngModel)]="searchTerm"
                            (ngModelChange)="handleSearchTermChange()"
                            (keydown)="handleInputKeydown($event)"
-                           (click)="isOpen = !isOpen">
+                           (click)="openChangeHandle(!open)">
                 </fd-input-group>
             </div>
         </fd-popover-control>
-        <fd-popover-body [attr.aria-hidden]="!isOpen">
+        <fd-popover-body [attr.aria-hidden]="!open">
             <fd-menu class="fd-multi-input-menu-overflow"
                      *ngIf="displayedValues && displayedValues.length"
                      [style.maxHeight]="maxHeight">

--- a/libs/core/src/lib/multi-input/multi-input.component.spec.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.spec.ts
@@ -32,6 +32,10 @@ describe('MultiInputComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(MultiInputComponent);
         component = fixture.componentInstance;
+        component.dropdownValues = [
+            { value: 'value', displayedValue: 'displayedValue' },
+            { value: 'value2', displayedValue: 'displayedValue2' }
+        ];
         fixture.detectChanges();
     });
 
@@ -86,44 +90,33 @@ describe('MultiInputComponent', () => {
     it('should open/close popover on input click', () => {
         component.dropdownValues = ['test1', 'test2', 'foobar'];
         component.ngOnInit();
-        component.isOpen = false;
+        component.open = false;
 
         const inputElement = fixture.nativeElement.querySelector('.fd-input');
         inputElement.click();
         fixture.detectChanges();
-        expect(component.isOpen).toBe(true);
+        expect(component.open).toBe(true);
 
         inputElement.click();
         fixture.detectChanges();
 
-        expect(component.isOpen).toBe(false);
+        expect(component.open).toBe(false);
     });
 
     it('should open/close popover on button click', () => {
         component.dropdownValues = ['test1', 'test2', 'foobar'];
         component.ngOnInit();
-        component.isOpen = false;
+        component.open = false;
 
         const button = fixture.nativeElement.querySelector('button');
         button.click();
         fixture.detectChanges();
-        expect(component.isOpen).toBe(true);
+        expect(component.open).toBe(true);
 
         button.click();
         fixture.detectChanges();
 
-        expect(component.isOpen).toBe(false);
-    });
-
-    it('should close popover on document click', () => {
-        component.dropdownValues = ['test1', 'test2', 'foobar'];
-        component.ngOnInit();
-        component.isOpen = true;
-
-        document.dispatchEvent(new Event('click'));
-        fixture.detectChanges();
-
-        expect(component.isOpen).toBe(false);
+        expect(component.open).toBe(false);
     });
 
     it('should select values', () => {
@@ -132,7 +125,7 @@ describe('MultiInputComponent', () => {
         spyOn(component, 'handleSelect').and.callThrough();
         component.dropdownValues = ['test1', 'test2', 'foobar'];
         component.ngOnInit();
-        component.isOpen = true;
+        component.open = true;
         fixture.detectChanges();
 
         (component as any).changeDetRef.markForCheck();
@@ -148,7 +141,7 @@ describe('MultiInputComponent', () => {
         spyOn(component, 'handleSelect').and.callThrough();
         component.dropdownValues = ['test1', 'test2', 'foobar'];
         component.ngOnInit();
-        component.isOpen = true;
+        component.open = true;
         fixture.detectChanges();
 
         component.selected = ['test1'];
@@ -161,6 +154,31 @@ describe('MultiInputComponent', () => {
         fixture.detectChanges();
 
         expect(fixture.nativeElement.querySelector('fd-token')).toBeFalsy();
+    });
+
+    it('should handle onMenuKeydownHandler, arrow up on the first item', () => {
+        const event: any = {
+            code: 'ArrowUp',
+            preventDefault: () => {}
+        };
+        spyOn(event, 'preventDefault');
+        spyOn(component.searchInputElement.nativeElement, 'focus');
+        component.handleKeyDown(event, 0);
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(component.searchInputElement.nativeElement.focus).toHaveBeenCalled();
+    });
+
+    it('should handle onMenuKeydownHandler, arrow up', () => {
+        const event: any = {
+            code: 'ArrowUp',
+            preventDefault: () => {},
+            stopPropagation: () => {}
+        };
+        spyOn(component.menuItems.first, 'focus');
+        spyOn(event, 'preventDefault');
+        component.handleKeyDown(event, 1);
+        expect(event.preventDefault).toHaveBeenCalled();
+        expect(component.menuItems.first.focus).toHaveBeenCalled();
     });
 
 });

--- a/libs/core/src/lib/popover/popover-directive/popover.directive.spec.ts
+++ b/libs/core/src/lib/popover/popover-directive/popover.directive.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PopoverDirective } from './popover.directive';
-import { AfterViewInit, Component, NgModule, ViewChild } from '@angular/core';
+import { Component, NgModule, ViewChild } from '@angular/core';
 import { PopoverModule } from '../popover.module';
 
 @Component({

--- a/libs/core/src/lib/popover/popover-dropdown/popover-dropdown.component.html
+++ b/libs/core/src/lib/popover/popover-dropdown/popover-dropdown.component.html
@@ -9,7 +9,6 @@
         [attr.aria-expanded]="this.disabled ? false : isOpen"
         [attr.aria-disabled]="this.disabled"
         aria-haspopup="true"
-        [disabled]="disabled"
     >
         <ng-content></ng-content>
     </button>

--- a/libs/core/src/lib/popover/popover.component.html
+++ b/libs/core/src/lib/popover/popover.component.html
@@ -3,6 +3,7 @@
          [attr.aria-expanded]="this.disabled ? false : isOpen"
          [attr.aria-disabled]="this.disabled"
          aria-haspopup="true"
+         (keydown)="handleKeydown($event)"
          [fdPopover]="popoverBody"
          [(isOpen)]="isOpen"
          (isOpenChange)="openChanged($event)"

--- a/libs/core/src/lib/popover/popover.component.spec.ts
+++ b/libs/core/src/lib/popover/popover.component.spec.ts
@@ -44,4 +44,17 @@ describe('PopoverComponent', () => {
         component.toggle();
         expect(component.isOpen).toBe(true);
     });
+
+    it ('should support Alt + ArrowDown event', () => {
+        spyOn(component.isOpenChange, 'emit');
+
+        const event: any = {
+            code: 'ArrowDown',
+            altKey: true
+        };
+
+        component.handleKeydown(event);
+        expect(component.isOpen).toBe(true);
+        expect(component.isOpenChange.emit).toHaveBeenCalledWith(true);
+    })
 });

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -155,6 +155,13 @@ export class PopoverComponent {
         this.updateDropdownIsOpen(isOpen);
     }
 
+    /** Method that is called, when there is keydown event dispatched */
+    public handleKeydown(event: KeyboardEvent): void {
+        if (event.code === 'ArrowDown' && event.altKey) {
+            this.open();
+        }
+    }
+
 
     /** @hidden
      *  Function that allows us to control aria-expanded on dropdown child

--- a/libs/core/src/lib/tabs/tab/tab-panel.component.ts
+++ b/libs/core/src/lib/tabs/tab/tab-panel.component.ts
@@ -16,7 +16,7 @@ let tabPanelUniqueId: number = 0;
         '[attr.aria-expanded]': 'expanded ? true : null',
         '[class.is-expanded]': 'expanded'
     },
-    encapsulation: ViewEncapsulation.None,
+    encapsulation: ViewEncapsulation.None
 })
 export class TabPanelComponent {
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/911
#### Please provide a brief summary of this pull request.
I added `alt + ArrowDown` support for popovers components. Also I improved a little multi input keyboard support, Now it's possible to navigate by arrows. There was some leftover after fundamental-styles 0.2.0 adapation, which is remvoed.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
