### PR TITLE
fix: (core) Change event.code to event.key

### DIFF
--- a/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.spec.ts
+++ b/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.spec.ts
@@ -119,7 +119,7 @@ describe('CalendarDayViewComponent', () => {
         component.focusElement(component.newFocusedDayId);
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowDown', preventDefault: () => {
+            key: 'ArrowDown', preventDefault: () => {
             }
         };
         component.onKeydownDayHandler(event, focusFirstCell, { x: 2, y: 2 });
@@ -136,7 +136,7 @@ describe('CalendarDayViewComponent', () => {
         component.focusElement(component.newFocusedDayId);
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowUp', preventDefault: () => {
+            key: 'ArrowUp', preventDefault: () => {
             }
         };
         component.onKeydownDayHandler(event, focusFirstCell, { x: 2, y: 2 });
@@ -153,7 +153,7 @@ describe('CalendarDayViewComponent', () => {
         component.focusElement(component.newFocusedDayId);
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowLeft', preventDefault: () => {
+            key: 'ArrowLeft', preventDefault: () => {
             }
         };
         component.onKeydownDayHandler(event, focusFirstCell, { x: 2, y: 2 });
@@ -170,7 +170,7 @@ describe('CalendarDayViewComponent', () => {
         component.focusElement(component.newFocusedDayId);
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowRight', preventDefault: () => {
+            key: 'ArrowRight', preventDefault: () => {
             }
         };
         component.onKeydownDayHandler(event, focusFirstCell, { x: 2, y: 2 });
@@ -188,7 +188,7 @@ describe('CalendarDayViewComponent', () => {
         component.focusElement(component.newFocusedDayId);
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowDown', preventDefault: () => {
+            key: 'ArrowDown', preventDefault: () => {
             }
         };
         component.onKeydownDayHandler(event, focusFirstCell, { x: 2, y: component.dayViewGrid.length - 1 });
@@ -206,7 +206,7 @@ describe('CalendarDayViewComponent', () => {
         component.focusElement(component.newFocusedDayId);
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowUp', preventDefault: () => {
+            key: 'ArrowUp', preventDefault: () => {
             }
         };
         component.onKeydownDayHandler(event, focusFirstCell, { x: 0, y: 0 });
@@ -224,7 +224,7 @@ describe('CalendarDayViewComponent', () => {
         component.focusElement(component.newFocusedDayId);
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowRight', preventDefault: () => {
+            key: 'ArrowRight', preventDefault: () => {
             }
         };
         component.onKeydownDayHandler(event, focusFirstCell,
@@ -244,7 +244,7 @@ describe('CalendarDayViewComponent', () => {
         component.focusElement(component.newFocusedDayId);
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowLeft', preventDefault: () => {
+            key: 'ArrowLeft', preventDefault: () => {
             }
         };
         component.onKeydownDayHandler(event, focusFirstCell, { x: 0, y: 0 });

--- a/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
+++ b/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
@@ -240,14 +240,14 @@ export class CalendarDayViewComponent implements OnInit, OnChanges, OnDestroy {
      * @param grid with specified column and row as a x and y
      */
     onKeydownDayHandler(event, cell: CalendarDay, grid: { x: number, y: number }): void {
-        if (event.code === 'Tab' && !event.shiftKey) {
+        if (event.key === 'Tab' && !event.shiftKey) {
             if (this.focusEscapeFunction) {
                 event.preventDefault();
                 this.focusEscapeFunction();
             }
         } else {
-            switch (event.code) {
-                case ('Space'):
+            switch (event.key) {
+                case (' '):
                 case ('Enter'): {
                     event.preventDefault();
                     this.selectDate(cell);

--- a/libs/core/src/lib/calendar/calendar-views/calendar-month-view/calendar-month-view.component.spec.ts
+++ b/libs/core/src/lib/calendar/calendar-views/calendar-month-view/calendar-month-view.component.spec.ts
@@ -58,7 +58,7 @@ describe('CalendarMonthViewComponent', () => {
     it('Should focus the month below with ArrowDown', () => {
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowDown', preventDefault: () => {}
+            key: 'ArrowDown', preventDefault: () => {}
         };
         component.onKeydownMonthHandler(event, testMonth);
         expect(focusSpy).toHaveBeenCalledWith('#test-fd-month-9');
@@ -67,7 +67,7 @@ describe('CalendarMonthViewComponent', () => {
     it('Should focus the month above with ArrowUp', () => {
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowUp', preventDefault: () => {}
+            key: 'ArrowUp', preventDefault: () => {}
         };
         component.onKeydownMonthHandler(event, testMonth);
         expect(focusSpy).toHaveBeenCalledWith('#test-fd-month-1');
@@ -76,7 +76,7 @@ describe('CalendarMonthViewComponent', () => {
     it('Should focus the month to the left with ArrowLeft', () => {
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowLeft', preventDefault: () => {}
+            key: 'ArrowLeft', preventDefault: () => {}
         };
         component.onKeydownMonthHandler(event, testMonth);
         expect(focusSpy).toHaveBeenCalledWith('#test-fd-month-4');
@@ -85,7 +85,7 @@ describe('CalendarMonthViewComponent', () => {
     it('Should focus the month to the right with ArrowRight', () => {
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowRight', preventDefault: () => {}
+            key: 'ArrowRight', preventDefault: () => {}
         };
         component.onKeydownMonthHandler(event, testMonth);
         expect(focusSpy).toHaveBeenCalledWith('#test-fd-month-6');
@@ -93,7 +93,7 @@ describe('CalendarMonthViewComponent', () => {
 
     it('Should select a month with Enter', () => {
         const event = {
-            code: 'Enter', preventDefault: () => {}
+            key: 'Enter', preventDefault: () => {}
         };
         component.onKeydownMonthHandler(event, testMonth);
         expect(component.monthSelected).toEqual(6);
@@ -102,7 +102,7 @@ describe('CalendarMonthViewComponent', () => {
     it('Should select a month with Space', () => {
 
         const event = {
-            code: 'Space', preventDefault: () => {}
+            key: ' ', preventDefault: () => {}
         };
         component.onKeydownMonthHandler(event, testMonth);
         expect(component.monthSelected).toEqual(6);

--- a/libs/core/src/lib/calendar/calendar-views/calendar-year-view/calendar-year-view.component.spec.ts
+++ b/libs/core/src/lib/calendar/calendar-views/calendar-year-view/calendar-year-view.component.spec.ts
@@ -29,7 +29,7 @@ describe('Calendar2YearViewComponent', () => {
     it('Should focus on the year below when on ArrowDown', () => {
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowDown', preventDefault: () => {}
+            key: 'ArrowDown', preventDefault: () => {}
         };
         component.id = 'fd-calendar-0';
         component.onKeydownYearHandler(event, 6);
@@ -39,7 +39,7 @@ describe('Calendar2YearViewComponent', () => {
     it('Should focus on the year below when on ArrowUp', () => {
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowUp', preventDefault: () => {}
+            key: 'ArrowUp', preventDefault: () => {}
         };
         component.id = 'fd-calendar-0';
         component.onKeydownYearHandler(event, 6);
@@ -49,7 +49,7 @@ describe('Calendar2YearViewComponent', () => {
     it('Should focus on the year below when on ArrowRight', () => {
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowRight', preventDefault: () => {}
+            key: 'ArrowRight', preventDefault: () => {}
         };
         component.id = 'fd-calendar-0';
         component.onKeydownYearHandler(event, 6);
@@ -59,7 +59,7 @@ describe('Calendar2YearViewComponent', () => {
     it('Should focus on the year below when on ArrowLeft', () => {
         const focusSpy = spyOn(component, 'focusElement');
         const event = {
-            code: 'ArrowLeft', preventDefault: () => {}
+            key: 'ArrowLeft', preventDefault: () => {}
         };
         component.id = 'fd-calendar-0';
         component.onKeydownYearHandler(event, 6);
@@ -67,9 +67,9 @@ describe('Calendar2YearViewComponent', () => {
     });
 
     it('Should select the year when Enter key is clicked', () => {
-        let event: { code: string; preventDefault: () => void };
+        let event: { key: string; preventDefault: () => void };
         event = {
-            code: 'Enter', preventDefault: () => {}
+            key: 'Enter', preventDefault: () => {}
         };
         component.onKeydownYearHandler(event, 6);
         expect(component.yearSelected).toEqual(2025);
@@ -77,7 +77,7 @@ describe('Calendar2YearViewComponent', () => {
 
     it('Should select the year when Space key is clicked', () => {
         const event = {
-            code: 'Space', preventDefault: () => {}
+            key: ' ', preventDefault: () => {}
         };
         component.onKeydownYearHandler(event, 6);
         expect(component.yearSelected).toEqual(2025);

--- a/libs/core/src/lib/calendar/calendar.service.spec.ts
+++ b/libs/core/src/lib/calendar/calendar.service.spec.ts
@@ -80,14 +80,14 @@ describe('CalendarService', () => {
 
     it('Keydown handler should handle enter key', () => {
         spyOn(service.onKeySelect, 'next');
-        const keyboardEvent: any = { code: 'Enter', preventDefault: () => {} };
+        const keyboardEvent: any = { key: 'Enter', preventDefault: () => {} };
         service.onKeydownHandler(keyboardEvent, 10);
         expect(service.onKeySelect.next).toHaveBeenCalledWith(10);
     });
 
     it('Keydown handler should handle space key', () => {
         spyOn(service.onKeySelect, 'next');
-        const keyboardEvent: any = { code: 'Space', preventDefault: () => {} };
+        const keyboardEvent: any = { key: ' ', preventDefault: () => {} };
         service.onKeydownHandler(keyboardEvent, 10);
         expect(service.onKeySelect.next).toHaveBeenCalledWith(10);
     });
@@ -95,7 +95,7 @@ describe('CalendarService', () => {
     it('Keydown handler should end of list approach', () => {
         spyOn(service.onListEndApproach, 'next');
         spyOn(service.onFocusIdChange, 'next');
-        const keyboardEvent: any = { code: 'ArrowDown', preventDefault: () => {} };
+        const keyboardEvent: any = { key: 'ArrowDown', preventDefault: () => {} };
         service.onKeydownHandler(keyboardEvent, 10);
         expect(service.onListEndApproach.next).toHaveBeenCalled();
         expect(service.onFocusIdChange.next).toHaveBeenCalledWith(2);
@@ -104,7 +104,7 @@ describe('CalendarService', () => {
     it('Keydown handler should start of list approach', () => {
         spyOn(service.onListStartApproach, 'next');
         spyOn(service.onFocusIdChange, 'next');
-        const keyboardEvent: any = { code: 'ArrowUp', preventDefault: () => {} };
+        const keyboardEvent: any = { key: 'ArrowUp', preventDefault: () => {} };
         service.onKeydownHandler(keyboardEvent, 2);
         expect(service.onListStartApproach.next).toHaveBeenCalled();
         expect(service.onFocusIdChange.next).toHaveBeenCalledWith(10);

--- a/libs/core/src/lib/calendar/calendar.service.ts
+++ b/libs/core/src/lib/calendar/calendar.service.ts
@@ -63,9 +63,9 @@ export class CalendarService {
      * @param index which is number (0 - 11)
      */
     public onKeydownHandler(event: KeyboardEvent, index: number): void {
-        switch (event.code) {
+        switch (event.key) {
             case 'Enter':
-            case 'Space': {
+            case ' ': {
                 event.preventDefault();
                 this.onKeySelect.next(index);
                 break;

--- a/libs/core/src/lib/combobox/combobox.component.spec.ts
+++ b/libs/core/src/lib/combobox/combobox.component.spec.ts
@@ -52,12 +52,12 @@ describe('ComboboxComponent', () => {
     it('should call searchFunction onInputKeydownHandler', () => {
         spyOn(component, 'searchFunction');
         const event = {
-            code: 'Enter',
+            key: 'Enter',
             preventDefault: () => {}
         };
         component.onInputKeydownHandler(<any>event);
         expect(component.searchFunction).toHaveBeenCalled();
-        event.code = 'ArrowDown';
+        event.key = 'ArrowDown';
         spyOn(event, 'preventDefault');
         spyOn(component.menuItems.first, 'focus');
         component.onInputKeydownHandler(<any>event);
@@ -70,7 +70,7 @@ describe('ComboboxComponent', () => {
             return item.displayedValue;
         };
         const event: any = {
-            code: 'Enter',
+            key: 'Enter',
             preventDefault: () => {}
         };
         spyOn(component, 'onChange');
@@ -78,7 +78,7 @@ describe('ComboboxComponent', () => {
         expect(component.onChange).toHaveBeenCalledWith(component.dropdownValues[0].displayedValue);
         spyOn(event, 'preventDefault');
         spyOn(component.menuItems.toArray()[1], 'focus');
-        event.code = 'ArrowDown';
+        event.key = 'ArrowDown';
         component.onMenuKeydownHandler(event, 0);
         expect(event.preventDefault).toHaveBeenCalled();
         expect(component.menuItems.toArray()[1].focus).toHaveBeenCalled();
@@ -86,12 +86,12 @@ describe('ComboboxComponent', () => {
 
     it('should handle onMenuKeydownHandler, arrow up', () => {
         const event: any = {
-            code: 'ArrowUp',
+            key: 'ArrowUp',
             preventDefault: () => {}
         };
         spyOn(component.menuItems.first, 'focus');
         spyOn(event, 'preventDefault');
-        event.code = 'ArrowUp';
+        event.key = 'ArrowUp';
         component.onMenuKeydownHandler(event, 1);
         expect(event.preventDefault).toHaveBeenCalled();
         expect(component.menuItems.first.focus).toHaveBeenCalled();
@@ -99,13 +99,13 @@ describe('ComboboxComponent', () => {
 
     it('should handle onMenuKeydownHandler, arrow up on the first item', () => {
         const event: any = {
-            code: 'ArrowUp',
+            key: 'ArrowUp',
             preventDefault: () => {
             }
         };
         spyOn(event, 'preventDefault');
         spyOn(component.searchInputElement.nativeElement, 'focus');
-        event.code = 'ArrowUp';
+        event.key = 'ArrowUp';
         component.onMenuKeydownHandler(event, 0);
         expect(event.preventDefault).toHaveBeenCalled();
         expect(component.searchInputElement.nativeElement.focus).toHaveBeenCalled();

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -225,9 +225,9 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
 
     /** @hidden */
     onInputKeydownHandler(event: KeyboardEvent) {
-        if (event.code === 'Enter' && this.searchFunction) {
+        if (event.key === 'Enter' && this.searchFunction) {
             this.searchFunction();
-        } else if (event.code === 'ArrowDown') {
+        } else if (event.key === 'ArrowDown') {
             if (event.altKey) {
                 this.isOpenChangeHandle(true);
             }
@@ -243,10 +243,10 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
         if (this.openOnKeyboardEvent &&
             this.inputText &&
             this.inputText.length &&
-            event.code !== 'Escape' &&
-            event.code !== 'Space' &&
-            event.code !== 'Tab' &&
-            event.code !== 'Enter') {
+            event.key !== 'Escape' &&
+            event.key !== ' ' &&
+            event.key !== 'Tab' &&
+            event.key !== 'Enter') {
             this.isOpenChangeHandle(true);
         }
     }

--- a/libs/core/src/lib/mega-menu/mega-menu-item/mega-menu-item.component.spec.ts
+++ b/libs/core/src/lib/mega-menu/mega-menu-item/mega-menu-item.component.spec.ts
@@ -49,7 +49,7 @@ describe('MegaMenuItemComponent', () => {
     it('should open sublist and focus first sub element', () => {
         spyOn(component, 'openSubList');
         spyOn(component.subItems.first, 'focus');
-        const event: any = {code: 'ArrowRight', preventDefault: () => {}};
+        const event: any = {key: 'ArrowRight', preventDefault: () => {}};
         component.handleKeyboardEvent(event);
         expect(component.openSubList).toHaveBeenCalled();
         expect(component.subItems.first.focus).toHaveBeenCalled();
@@ -58,7 +58,7 @@ describe('MegaMenuItemComponent', () => {
     it('should close sublist and focus parent element', () => {
         spyOn(component, 'closeSubList');
         spyOn(component.link, 'focus');
-        const event: any = {code: 'ArrowLeft', preventDefault: () => {}};
+        const event: any = {key: 'ArrowLeft', preventDefault: () => {}};
         component.handleKeyboardEvent(event);
         expect(component.closeSubList).toHaveBeenCalled();
         expect(component.link.focus).toHaveBeenCalled();
@@ -67,7 +67,7 @@ describe('MegaMenuItemComponent', () => {
     it('should open sublist and focus first sub element', () => {
         spyOn(component, 'openSubList');
         spyOn(component.subItems.first, 'focus');
-        const event: any = {code: 'Enter', preventDefault: () => {}};
+        const event: any = {key: 'Enter', preventDefault: () => {}};
         component.handleKeyboardEvent(event);
         expect(component.openSubList).toHaveBeenCalled();
         expect(component.subItems.first.focus).toHaveBeenCalled();
@@ -76,7 +76,7 @@ describe('MegaMenuItemComponent', () => {
     it('should open sublist and focus first sub element', () => {
         spyOn(component, 'openSubList');
         spyOn(component.subItems.first, 'focus');
-        const event: any = {code: 'Space', preventDefault: () => {}};
+        const event: any = {key: ' ', preventDefault: () => {}};
         component.handleKeyboardEvent(event);
         expect(component.openSubList).toHaveBeenCalled();
         expect(component.subItems.first.focus).toHaveBeenCalled();
@@ -84,20 +84,20 @@ describe('MegaMenuItemComponent', () => {
 
     it('should throw arrow up event', () => {
         spyOn(component.keyDown, 'emit');
-        const event: any = {code: 'ArrowUp', preventDefault: () => {}};
+        const event: any = {key: 'ArrowUp', preventDefault: () => {}};
         component.handleKeyboardEvent(event);
         expect(component.keyDown.emit).toHaveBeenCalledWith(event);
     });
 
     it('should not propagate event on specified arrow down event', () => {
-        const event: any = {code: 'ArrowDown', stopPropagation: () => {}, preventDefault: () => {}};
+        const event: any = {key: 'ArrowDown', stopPropagation: () => {}, preventDefault: () => {}};
         spyOn(event, 'stopPropagation');
         component.handleSubListKeyDown(event, 0);
         expect(event.stopPropagation).toHaveBeenCalled();
     });
 
     it('should not propagate event on specified arrow up event', () => {
-        const event: any = {code: 'ArrowUp', stopPropagation: () => {}, preventDefault: () => {}};
+        const event: any = {key: 'ArrowUp', stopPropagation: () => {}, preventDefault: () => {}};
         spyOn(event, 'stopPropagation');
         component.handleSubListKeyDown(event, 0);
         expect(event.stopPropagation).toHaveBeenCalled();

--- a/libs/core/src/lib/mega-menu/mega-menu-item/mega-menu-item.component.ts
+++ b/libs/core/src/lib/mega-menu/mega-menu-item/mega-menu-item.component.ts
@@ -98,14 +98,14 @@ export class MegaMenuItemComponent implements AfterContentInit, OnDestroy, Defau
     /** @hidden */
     @HostListener('keydown', ['$event'])
     handleKeyboardEvent(event: KeyboardEvent): void {
-        switch (event.code) {
+        switch (event.key) {
             case ('ArrowLeft'): {
                 this.closeSubList();
                 this.link.focus();
                 break;
             }
             case ('ArrowRight'):
-            case ('Space'):
+            case (' '):
             case ('Enter'): {
                 this.openSubList();
                 this.changeDetectionRef.detectChanges();
@@ -180,7 +180,7 @@ export class MegaMenuItemComponent implements AfterContentInit, OnDestroy, Defau
      */
     handleSubListKeyDown(event: KeyboardEvent, index: number): void {
         this.menuKeyboardService.keyDownHandler(event, index, this.subItems.toArray());
-        if (event.code === 'ArrowDown' || event.code === 'ArrowUp') {
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
             event.stopPropagation();
         }
     }

--- a/libs/core/src/lib/menu/menu-keyboard.service.ts
+++ b/libs/core/src/lib/menu/menu-keyboard.service.ts
@@ -30,7 +30,7 @@ export class MenuKeyboardService {
             return;
         }
 
-        switch (event.code) {
+        switch (event.key) {
             case ('ArrowDown'): {
                 if (menuItems.length > index + 1) {
                     menuItems[index + 1].focus();
@@ -57,7 +57,7 @@ export class MenuKeyboardService {
                 event.preventDefault();
                 break;
             }
-            case ('Space'): {
+            case (' '): {
                 if (menuItems[index]) {
                     menuItems[index].click();
                     event.preventDefault();

--- a/libs/core/src/lib/menu/menu.component.spec.ts
+++ b/libs/core/src/lib/menu/menu.component.spec.ts
@@ -82,7 +82,7 @@ describe('MenuComponent', () => {
     it('should focus second element', () => {
         const list = elements.map(element => element.nativeElement);
         spyOn(list[1], 'focus');
-        const event: any = { code: 'ArrowDown', preventDefault: () => { } };
+        const event: any = { key: 'ArrowDown', preventDefault: () => { } };
         service.keyDownHandler(event, 0, items.toArray());
         expect(list[1].focus).toHaveBeenCalled();
     });
@@ -90,7 +90,7 @@ describe('MenuComponent', () => {
     it('Should use default function and select last element, when encounter a beginning and arrow up', () => {
         const list = elements.map(element => element.nativeElement);
         spyOn(list[3], 'focus');
-        const event: any = { code: 'ArrowUp', preventDefault: () => { } };
+        const event: any = { key: 'ArrowUp', preventDefault: () => { } };
         service.keyDownHandler(event, 0, items.toArray());
         expect(list[3].focus).toHaveBeenCalled();
     });
@@ -99,7 +99,7 @@ describe('MenuComponent', () => {
         const _elementOutOfScope = elementOutOfScope.nativeElement;
         service.focusEscapeAfterList = () => { _elementOutOfScope.focus(); };
         spyOn(_elementOutOfScope, 'focus');
-        const event: any = { code: 'ArrowDown', preventDefault: () => { } };
+        const event: any = { key: 'ArrowDown', preventDefault: () => { } };
         service.keyDownHandler(event, 3, items.toArray());
         expect(_elementOutOfScope.focus).toHaveBeenCalled();
     });
@@ -108,7 +108,7 @@ describe('MenuComponent', () => {
         const _elementOutOfScope = elementOutOfScope.nativeElement;
         service.focusEscapeBeforeList = () => { _elementOutOfScope.focus(); };
         spyOn(_elementOutOfScope, 'focus');
-        const event: any = { code: 'ArrowUp', preventDefault: () => { } };
+        const event: any = { key: 'ArrowUp', preventDefault: () => { } };
         service.keyDownHandler(event, 0, items.toArray());
         expect(_elementOutOfScope.focus).toHaveBeenCalled();
     });

--- a/libs/core/src/lib/multi-input/multi-input.component.spec.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.spec.ts
@@ -158,7 +158,7 @@ describe('MultiInputComponent', () => {
 
     it('should handle onMenuKeydownHandler, arrow up on the first item', () => {
         const event: any = {
-            code: 'ArrowUp',
+            key: 'ArrowUp',
             preventDefault: () => {}
         };
         spyOn(event, 'preventDefault');
@@ -170,7 +170,7 @@ describe('MultiInputComponent', () => {
 
     it('should handle onMenuKeydownHandler, arrow up', () => {
         const event: any = {
-            code: 'ArrowUp',
+            key: 'ArrowUp',
             preventDefault: () => {},
             stopPropagation: () => {}
         };

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -249,7 +249,7 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
 
     /** @hidden */
     public handleInputKeydown(event: KeyboardEvent): void {
-        if (event.code === 'ArrowDown') {
+        if (event.key === 'ArrowDown') {
             if (event.altKey) {
                 this.openChangeHandle(true)
             }

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.spec.ts
@@ -74,7 +74,7 @@ describe('NestedListKeyboardSupportService', () => {
 
         spyOn(items[1], 'focus').and.callThrough();
 
-        const keyboardEvent: any = { preventDefault: () => {}, code: 'ArrowRight' };
+        const keyboardEvent: any = { preventDefault: () => {}, key: 'ArrowRight' };
 
         (<any>service).handleKeyDown(keyboardEvent, 0, items);
 
@@ -93,7 +93,7 @@ describe('NestedListKeyboardSupportService', () => {
 
         spyOn(items[1], 'focus').and.callThrough();
 
-        const keyboardEvent: any = { preventDefault: () => {}, code: 'ArrowRight' };
+        const keyboardEvent: any = { preventDefault: () => {}, key: 'ArrowRight' };
 
         (<any>service).handleKeyDown(keyboardEvent, 0, items);
 
@@ -113,7 +113,7 @@ describe('NestedListKeyboardSupportService', () => {
 
         spyOn(items[9], 'focus').and.callThrough();
 
-        const keyboardEvent: any = { preventDefault: () => {}, code: 'ArrowLeft' };
+        const keyboardEvent: any = { preventDefault: () => {}, key: 'ArrowLeft' };
 
         (<any>service).handleKeyDown(keyboardEvent, 0, items);
 
@@ -131,7 +131,7 @@ describe('NestedListKeyboardSupportService', () => {
 
         spyOn(items[items.length - 1], 'focus').and.callThrough();
 
-        const keyboardEvent: any = { preventDefault: () => {}, code: 'ArrowLeft' };
+        const keyboardEvent: any = { preventDefault: () => {}, key: 'ArrowLeft' };
 
         (<any>service).handleKeyDown(keyboardEvent, 0, items);
 
@@ -148,7 +148,7 @@ describe('NestedListKeyboardSupportService', () => {
 
         spyOn(items[0], 'focus').and.callThrough();
 
-        const keyboardEvent: any = { preventDefault: () => {}, code: 'ArrowRight' };
+        const keyboardEvent: any = { preventDefault: () => {}, key: 'ArrowRight' };
 
         (<any>service).handleKeyDown(keyboardEvent, items.length - 1, items);
 

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
@@ -76,7 +76,7 @@ export class NestedListKeyboardService {
 
         const item: NestedItemInterface = items[index];
 
-        switch (keyboardEvent.code) {
+        switch (keyboardEvent.key) {
             case ('ArrowRight'): {
                 if (!item.expanded && item.hasChildren) {
                     item.triggerOpen();

--- a/libs/core/src/lib/pagination/pagination.component.spec.ts
+++ b/libs/core/src/lib/pagination/pagination.component.spec.ts
@@ -31,7 +31,7 @@ describe('Pagination Test', () => {
 
     it('should handle keypress', () => {
         const keyboardEvent = new KeyboardEvent('keypress', {
-            code: 'Enter'
+            key: 'Enter'
         });
         spyOn(keyboardEvent, 'preventDefault');
         spyOn(component, 'goToPage');

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -105,7 +105,7 @@ export class PaginationComponent implements OnChanges {
      * @param $event The keyboard event.
      */
     onKeypressHandler(page: number, $event: KeyboardEvent) {
-        if ($event.code === 'Space' || $event.code === 'Enter') {
+        if ($event.key === ' ' || $event.key === 'Enter') {
             $event.preventDefault();
             this.goToPage(page);
         }

--- a/libs/core/src/lib/popover/popover.component.spec.ts
+++ b/libs/core/src/lib/popover/popover.component.spec.ts
@@ -49,7 +49,7 @@ describe('PopoverComponent', () => {
         spyOn(component.isOpenChange, 'emit');
 
         const event: any = {
-            code: 'ArrowDown',
+            key: 'ArrowDown',
             altKey: true
         };
 

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -157,7 +157,7 @@ export class PopoverComponent {
 
     /** Method that is called, when there is keydown event dispatched */
     public handleKeydown(event: KeyboardEvent): void {
-        if (event.code === 'ArrowDown' && event.altKey) {
+        if (event.key === 'ArrowDown' && event.altKey) {
             this.open();
         }
     }

--- a/libs/core/src/lib/select/select.component.ts
+++ b/libs/core/src/lib/select/select.component.ts
@@ -248,7 +248,7 @@ export class SelectComponent implements OnChanges, AfterContentInit, OnDestroy, 
     /** @hidden */
     @HostListener('keydown', ['$event'])
     keydownHandler(event: KeyboardEvent): void {
-        switch (event.code) {
+        switch (event.key) {
             case ('ArrowUp'): {
                 event.preventDefault();
                 this.decrementFocused();

--- a/libs/core/src/lib/tabs/tabs.service.spec.ts
+++ b/libs/core/src/lib/tabs/tabs.service.spec.ts
@@ -42,33 +42,33 @@ describe('TabsService', () => {
     it('should handle focus', () => {
         const elements = anchors.map(anchor => anchor.nativeElement);
         spyOn(elements[1], 'focus');
-        service.tabHeaderKeyHandler(0, {code: 'ArrowRight'}, elements);
+        service.tabHeaderKeyHandler(0, {key: 'ArrowRight'}, elements);
         expect(elements[1].focus).toHaveBeenCalled();
     });
 
     it('should handle focus on first element, when reached last', () => {
         const elements = anchors.map(anchor => anchor.nativeElement);
         spyOn(elements[0], 'focus');
-        service.tabHeaderKeyHandler(2, {code: 'ArrowRight'}, elements);
+        service.tabHeaderKeyHandler(2, {key: 'ArrowRight'}, elements);
         expect(elements[0].focus).toHaveBeenCalled();
     });
 
     it('should handle focus on last element, when reached before first', () => {
         const elements = anchors.map(anchor => anchor.nativeElement);
         spyOn(elements[2], 'focus');
-        service.tabHeaderKeyHandler(0, {code: 'ArrowLeft'}, elements);
+        service.tabHeaderKeyHandler(0, {key: 'ArrowLeft'}, elements);
         expect(elements[2].focus).toHaveBeenCalled();
     });
 
     it('should handle select on first element', () => {
         const elements = anchors.map(anchor => anchor.nativeElement);
         service.tabSelected.subscribe(index => expect(index).toBe(0));
-        service.tabHeaderKeyHandler(0, {code: 'Enter'}, elements);
+        service.tabHeaderKeyHandler(0, {key: 'Enter'}, elements);
     });
 
     it('should handle select when space click on first element', () => {
         const elements = anchors.map(anchor => anchor.nativeElement);
         service.tabSelected.subscribe(index => expect(index).toBe(1));
-        service.tabHeaderKeyHandler(1, {code: 'Space', preventDefault: () => {}}, elements);
+        service.tabHeaderKeyHandler(1, {key: ' ', preventDefault: () => {}}, elements);
     });
 });

--- a/libs/core/src/lib/tabs/tabs.service.ts
+++ b/libs/core/src/lib/tabs/tabs.service.ts
@@ -11,7 +11,7 @@ export class TabsService {
 
     /** @hidden */
     tabHeaderKeyHandler(index: number, event: any, elements: HTMLElement[]): void {
-        switch (event.code) {
+        switch (event.key) {
             case ('ArrowLeft'): {
                 if (index - 1 >= 0) {
                     this.getTabLinkFromIndex(index - 1, elements).focus();
@@ -28,7 +28,7 @@ export class TabsService {
                 }
                 break;
             }
-            case ('Space'): {
+            case (' '): {
                 event.preventDefault();
                 this.tabSelected.next(index);
                 break;

--- a/libs/core/src/lib/time/time.component.ts
+++ b/libs/core/src/lib/time/time.component.ts
@@ -370,7 +370,7 @@ export class TimeComponent implements OnChanges, ControlValueAccessor {
      * Handles last button keyboard events
      */
     lastButtonKeydown(event: KeyboardEvent): void {
-        if (event.code === 'Tab' && !event.shiftKey) {
+        if (event.key === 'Tab' && !event.shiftKey) {
             event.preventDefault();
             this.focusArrowLeft.emit();
         }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1621
#### Please provide a brief summary of this pull request.
There is changed usage of detecting keyboard events. Before `event.code` was null on IE11 and Microsoft Edge. `event.key` is fully supported by all of the browsers.
![image](https://user-images.githubusercontent.com/26483208/69420672-68b41100-0d1f-11ea-92e4-0aa9a349cde2.png)

#### Please check whether the PR fulfills the following requirements

**Internal change, so no need to put anything in the docs**
- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
