### PR TITLE
docs: (core) Add dropdown deprecated, put dropdown example into popover

### DIFF
--- a/apps/docs/src/app/core/component-docs/dropdown/dropdown-header/dropdown-header.component.html
+++ b/apps/docs/src/app/core/component-docs/dropdown/dropdown-header/dropdown-header.component.html
@@ -1,4 +1,10 @@
 <header>Dropdown</header>
+
+<fd-alert [type]="'warning'">
+    DEPRECATED. The <code>fd-dropdown-control</code> is deprecated, we recommend to use
+    <a [routerLink]="'/core/popover'" [fragment]="'dropdown'">Menu Button</a> instead.
+</fd-alert>
+
 <description>The dropdown component is an opinionated composition of the “fd-popover” and “fd-menu” components with the
     use of a styled
     button. It allows users to make one selection from a list. It is more flexible than the normal Select. Generally, it

--- a/apps/docs/src/app/core/component-docs/dropdown/examples/dropdown-icons-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dropdown/examples/dropdown-icons-example.component.html
@@ -10,7 +10,6 @@
                     <a href="" fd-menu-item>{{option.name}}</a>
 
             </ul>
-
         </fd-menu>
     </fd-popover-body>
 </fd-popover>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.html
@@ -1,0 +1,42 @@
+<fd-popover placement="bottom-start">
+    <fd-popover-control>
+        <button fd-button [options]="'menu'">Dropdown Popover</button>
+    </fd-popover-control>
+    <fd-popover-body>
+        <fd-menu>
+            <ul fd-menu-list>
+                <li fd-menu-item *ngFor="let item of menu">
+                    {{item}}
+                </li>
+            </ul>
+        </fd-menu>
+    </fd-popover-body>
+</fd-popover>
+<fd-popover placement="bottom-start" [disabled]="true">
+    <fd-popover-control>
+        <button fd-button [disabled]="true" [options]="'menu'">Disabled Dropdown Popover</button>
+    </fd-popover-control>
+    <fd-popover-body>
+        <fd-menu>
+            <ul fd-menu-list>
+                <li fd-menu-item *ngFor="let item of menu">
+                    {{item}}
+                </li>
+            </ul>
+        </fd-menu>
+    </fd-popover-body>
+</fd-popover>
+<fd-popover placement="bottom-start">
+    <fd-popover-control>
+        <button fd-button [options]="'menu'" [glyph]="'filter'">Dropdown with icon</button>
+    </fd-popover-control>
+    <fd-popover-body>
+        <fd-menu>
+            <ul fd-menu-list>
+                <li fd-menu-item *ngFor="let item of menu">
+                    {{item}}
+                </li>
+            </ul>
+        </fd-menu>
+    </fd-popover-body>
+</fd-popover>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.scss
@@ -1,0 +1,3 @@
+fd-popover {
+    margin-right: 20px;
+}

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.ts
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'fd-popover-dropdown-example',
+  templateUrl: './popover-dropdown.component.html',
+  styleUrls: ['./popover-dropdown.component.scss']
+})
+export class PopoverDropdownComponent {
+
+    menu = [
+        'Option 1',
+        'Option 2',
+        'Option 3',
+    ];
+}

--- a/apps/docs/src/app/core/component-docs/popover/popover-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/popover-docs.component.html
@@ -83,6 +83,19 @@
 
 <separator></separator>
 
+<fd-docs-section-title [id]="'dropdown'" [componentName]="'popover'">
+    Dropdown Popover
+</fd-docs-section-title>
+<description>
+    Dropdown is a composition of basic <code>popover</code> and <code>button</code> with <code>[options]="'menu'"</code>.
+</description>
+<component-example [name]="'ex7'">
+    <fd-popover-dropdown-example></fd-popover-dropdown-example>
+</component-example>
+<code-example [exampleFiles]="dropdownPopover"></code-example>
+
+<separator></separator>
+
 <description>
     <p>
         Under the hood, the Popover component makes use of <code>PopoverDirective</code>. It abstracts some

--- a/apps/docs/src/app/core/component-docs/popover/popover-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/popover/popover-docs.component.ts
@@ -15,6 +15,9 @@ import * as popoverFillHSrc from '!raw-loader!./examples/popover-c-fill/popover-
 import * as popoverFillSrcTs from '!raw-loader!./examples/popover-c-fill/popover-c-fill.component.ts';
 import * as popoverDynamicHSrc from '!raw-loader!./examples/popover-dynamic/popover-dynamic-example.component.html';
 import * as popoverDynamicTSrc from '!raw-loader!./examples/popover-dynamic/popover-dynamic-example.component.ts';
+import * as dropdownPopoverHtml from '!raw-loader!./examples/popover-dropdown/popover-dropdown.component.html';
+import * as dropdownPopoverTs from '!raw-loader!./examples/popover-dropdown/popover-dropdown.component.ts';
+import * as dropdownPopoverScss from '!raw-loader!./examples/popover-dropdown/popover-dropdown.component.scss';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
 import { DocsSectionTitleComponent } from '../../../documentation/core-helpers/docs-section-title/docs-section-title.component';
 import { ActivatedRoute } from '@angular/router';
@@ -100,6 +103,33 @@ export class PopoverDocsComponent implements OnInit {
             fileName: 'popover-c-fill',
             typescriptFileCode: popoverFillSrcTs,
             component: 'PopoverCFillComponent'
+        }
+    ];
+
+    dropdownPopover: ExampleFile[] = [
+        {
+            language: 'html',
+            code: dropdownPopoverHtml,
+            fileName: 'popover-dropdown',
+            typescriptFileCode: dropdownPopoverTs,
+            component: 'PopoverDropdownComponent',
+            scssFileCode: dropdownPopoverScss
+        },
+        {
+            language: 'ts',
+            code: dropdownPopoverTs,
+            fileName: 'popover-dropdown',
+            typescriptFileCode: dropdownPopoverTs,
+            component: 'PopoverDropdownComponent',
+            scssFileCode: dropdownPopoverScss
+        },
+        {
+            language: 'scss',
+            code: dropdownPopoverScss,
+            fileName: 'popover-dropdown',
+            typescriptFileCode: dropdownPopoverTs,
+            component: 'PopoverDropdownComponent',
+            scssFileCode: dropdownPopoverScss
         }
     ];
 

--- a/apps/docs/src/app/core/core-documentation.module.ts
+++ b/apps/docs/src/app/core/core-documentation.module.ts
@@ -402,6 +402,7 @@ import { SideNavigationCondensedObjectExampleComponent } from './component-docs/
 import { SideNavigationMultipleSelectedExampleComponent } from './component-docs/side-navigation/examples/side-navigation-multiple-selected-example/side-navigation-multiple-selected-example.component';
 import { DatePickerComplexI18nExampleComponent } from './component-docs/date-picker/examples/date-picker-complex-i18n-example/date-picker-complex-i18n-example.component';
 import { DatetimePickerComplexI18nExampleComponent } from './component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component';
+import { PopoverDropdownComponent } from './component-docs/popover/examples/popover-dropdown/popover-dropdown.component';
 import { SelectTypesExampleComponent } from './component-docs/select/examples/select-types-example/select-types-example.component';
 
 
@@ -752,7 +753,8 @@ import { SelectTypesExampleComponent } from './component-docs/select/examples/se
         SideNavigationThreeLevelsExampleComponent,
         NotificationContentComponent,
         DatePickerComplexI18nExampleComponent,
-        DatetimePickerComplexI18nExampleComponent
+        DatetimePickerComplexI18nExampleComponent,
+        PopoverDropdownComponent
     ],
 
     entryComponents: [

--- a/libs/core/src/lib/popover/popover-dropdown/popover-dropdown.component.ts
+++ b/libs/core/src/lib/popover/popover-dropdown/popover-dropdown.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Host, Inject, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Host, Inject, Input, isDevMode, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { PopoverComponent } from '../popover.component';
 import { ButtonType } from '../../button/button.component';
@@ -48,5 +48,11 @@ export class PopoverDropdownComponent {
     /** Whether the dropdown is opened. */
     @Input()
     isOpen: boolean = false;
+
+    constructor() {
+        if (isDevMode()) {
+            console.warn('Popover Dropdown has been deprecated, it will be removed soon. Replace it by popover with menu button');
+        }
+    }
 
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1654
#### Please provide a brief summary of this pull request.
There is marked `dropdown-popover` as a deprecated, also there is added one section presenting popover composed with `button menu`  
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
