### PR TITLE
fix(platform:search-input): Fixing SCSS after fundamental-styles upgrade

### DIFF
--- a/libs/platform/src/lib/components/search-input/search-input.component.scss
+++ b/libs/platform/src/lib/components/search-input/search-input.component.scss
@@ -7,7 +7,8 @@
         border-bottom-right-radius: 0px;
 
         &:disabled {
-            opacity: 1.0;
+            color: #89919a;
+            border-color: #89919a;
         }
 
         &::after {
@@ -18,6 +19,11 @@
     }
 
     @supports(--css: variables) {
+        ::ng-deep button.fd-dropdown__control:disabled {
+            color: var(--fd-color-neutral-4, #89919a);
+            border-color: var(--fd-color-neutral-4, #89919a);
+        }
+
         ::ng-deep button.fd-dropdown__control::after {
             color: var(--fd-color-action-1, #0a6ed1);
         }
@@ -28,20 +34,13 @@
 
     ::ng-deep input[type="search"],
     ::ng-deep .fd-input {
-        border-width: 1px;
-        border-style: solid;
-        padding-right: 12px;
-        padding-left: 12px;
-        border-color: #89919a;
-        background: none;
+        margin-top: 0px;
     }
 
-    ::ng-deep [type=search]+.fd-input-group__addon {
-        border-width: 1px;
-        border-left-width: 0px;
-        border-style: solid;
-        border-color: #89919a;
-        width: auto;
+    ::ng-deep .fd-input--compact {
+        margin-top: 0px;
+        margin-bottom: 0px;
+        height: var(--fd-forms-height-compact, 28px);
     }
 
     ::ng-deep input:disabled {
@@ -50,15 +49,6 @@
 
     ::ng-deep input[type="search"]::-webkit-search-cancel-button {
         -webkit-appearance: searchfield-cancel-button;
-    }
-
-    ::ng-deep .fd-input-group .fd-input-group__addon--button>* {
-        border-color: transparent;
-    }
-
-    ::ng-deep .fd-button--compact::before {
-        font-size: 14px;
-        line-height: 1.2;
     }
 
     @supports(--css: variables) {
@@ -100,15 +90,6 @@
 }
 
 ::ng-deep [dir="rtl"] .search-input {
-
-    & [type=search]+.fd-input-group__addon {
-        border-width: 1px;
-        border-left-width: 1px;
-        border-right-width: 0px;
-        border-style: solid;
-        border-color: #89919a;
-        width: auto;
-    }
 
     & .search-input__category-dropdown button {
         border-top-right-radius: 4px;
@@ -163,6 +144,10 @@
 
 .is-loading ::ng-deep .fd-button:before {
     animation: sap-icon-spin 2s infinite linear;
+}
+
+.is-loading ::ng-deep .fd-button {
+    margin-left: 0;
 }
 
 .is-loading ::ng-deep .fd-input-group__addon:hover .fd-button:before {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Fixes: #1657 

#### Please provide a brief summary of this pull request.
After upgrade of fundamental-styles, the SCSS for the Search Input component was broken. SCSS for Search Input is updated to fix the styles.

***BEFORE:***
<img width="1343" alt="Screen Shot 2019-11-22 at 10 20 08 AM" src="https://user-images.githubusercontent.com/48103491/69450306-b033a080-0d11-11ea-91c5-13e07d046b62.png">

***AFTER:***
<img width="1339" alt="Screen Shot 2019-11-22 at 10 10 34 AM" src="https://user-images.githubusercontent.com/48103491/69450188-7367a980-0d11-11ea-8ee6-ec4cd02be0c9.png">


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
