### PR TITLE
fix: add routerLink to sideNav Links, change example

### DIFF
--- a/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-condensed-object-example/side-navigation-condensed-object-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-condensed-object-example/side-navigation-condensed-object-example.component.ts
@@ -10,8 +10,10 @@ export class SideNavigationCondensedObjectExampleComponent {
     sideNavigationConfiguration: SideNavigationModel = {
         condensed: true,
         mainNavigation: {
-            headerTitle: 'Header Title 1',
             items: [
+                {
+                    headerTitle: 'Header Title 1'
+                },
                 {
                     link: {
                         icon: 'menu',
@@ -58,6 +60,9 @@ export class SideNavigationCondensedObjectExampleComponent {
                             }
                         ]
                     }
+                },
+                {
+                    headerTitle: 'Header Title'
                 },
                 {
                     link: {

--- a/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-object-example/side-navigation-object-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-object-example/side-navigation-object-example.component.ts
@@ -22,7 +22,8 @@ export class SideNavigationObjectExampleComponent {
                 {
                     link: {
                         icon: 'menu',
-                        title: 'Link 2'
+                        title: 'Link 2',
+                        routerLink: '#'
                     }
                 },
                 {
@@ -32,6 +33,7 @@ export class SideNavigationObjectExampleComponent {
                         title: 'Link 3',
                     },
                     list: {
+                        headerTitle: 'Header Title 2',
                         items: [
                             {
                                 link: {
@@ -70,6 +72,7 @@ export class SideNavigationObjectExampleComponent {
             ]
         },
         utilityNavigation: {
+            headerTitle: 'Header Title 3',
             textOnly: true,
             items: [
                 {

--- a/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-object-example/side-navigation-object-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-object-example/side-navigation-object-example.component.ts
@@ -10,14 +10,19 @@ export class SideNavigationObjectExampleComponent {
     sideNavigationConfiguration: SideNavigationModel = {
         condensed: false,
         mainNavigation: {
-            headerTitle: 'Header Title 1',
             items: [
+                {
+                    headerTitle: 'Header Title 1',
+                },
                 {
                     link: {
                         callback: () => this.callbackFunction('First Item'),
                         icon: 'menu',
                         title: 'Link 1'
                     }
+                },
+                {
+                    headerTitle: 'Header Title 2',
                 },
                 {
                     link: {
@@ -33,7 +38,6 @@ export class SideNavigationObjectExampleComponent {
                         title: 'Link 3',
                     },
                     list: {
-                        headerTitle: 'Header Title 2',
                         items: [
                             {
                                 link: {
@@ -72,9 +76,11 @@ export class SideNavigationObjectExampleComponent {
             ]
         },
         utilityNavigation: {
-            headerTitle: 'Header Title 3',
             textOnly: true,
             items: [
+                {
+                    headerTitle: 'Header Title 3',
+                },
                 {
                     link: {
                         title: 'Link 1'

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -17,6 +17,7 @@
     "@angular/core": "ANGULAR_VER_PLACEHOLDER",
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
     "@angular/animations": "ANGULAR_VER_PLACEHOLDER",
+    "@angular/router": "ANGULAR_VER_PLACEHOLDER",
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {

--- a/libs/core/src/lib/nested-list/nested-list-model.ts
+++ b/libs/core/src/lib/nested-list/nested-list-model.ts
@@ -1,5 +1,6 @@
 
 export interface NestedListItem {
+    headerTitle?: string,
     list?: NestedListModel;
     link?: NestedListLink;
     expanded?: boolean;
@@ -9,7 +10,6 @@ export interface NestedListItem {
 export interface NestedListModel {
     textOnly?: boolean;
     items: NestedListItem[];
-    headerTitle?: string
 }
 
 export interface NestedListLink {

--- a/libs/core/src/lib/nested-list/nested-list-model.ts
+++ b/libs/core/src/lib/nested-list/nested-list-model.ts
@@ -17,5 +17,6 @@ export interface NestedListLink {
     title: string;
     callback?: Function;
     href?: string;
+    routerLink?: string;
     selected?: boolean;
 }

--- a/libs/core/src/lib/nested-list/nested-list.module.ts
+++ b/libs/core/src/lib/nested-list/nested-list.module.ts
@@ -10,11 +10,13 @@ import { PopoverModule } from '../popover/popover.module';
 import { NestedListPopoverComponent } from './nested-list-popover/nested-list-popover.component';
 import { PreparedNestedListComponent } from './prepared-nested-list/prepared-nested-list.component';
 import { NestedListStateService } from './nested-list-state.service';
+import { RouterModule } from '@angular/router';
 
 @NgModule({
     imports: [
         CommonModule,
-        PopoverModule
+        PopoverModule,
+        RouterModule
     ],
     declarations: [
         NestedListDirective,

--- a/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.html
+++ b/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.html
@@ -1,34 +1,36 @@
 <ul fd-nested-list [textOnly]="list?.textOnly">
-    <li *ngIf="list.headerTitle" fd-nested-list-header>
-        {{list.headerTitle}}
-    </li>
-    <li *ngFor="let item of list?.items"
-        fd-nested-list-item
-        [(expanded)]="item.expanded">
+    <ng-container *ngFor="let item of list?.items">
+        <li *ngIf="item.headerTitle" fd-nested-list-header>
+            {{item.headerTitle}}
+        </li>
+        <li *ngIf="!item.headerTitle"
+            fd-nested-list-item
+            [(expanded)]="item.expanded">
 
-        <fd-nested-list-popover *ngIf="condensed && first && item.list">
-            <a fd-nested-list-link *ngIf="item.link"
-               [onClickCallback]="item.link.callback"
-               [selected]="item.link.selected"
-               [attr.href]="item.link.href ? item.link.href : null"
-               [routerLink]="item.link.routerLink ? item.link.routerLink : []">
-                <span fd-nested-list-icon *ngIf="item.link.icon" [glyph]="item.link.icon"></span>
-                <span fd-nested-list-title>{{item.link.title}}</span>
-            </a>
-            <fd-prepared-nested-list [first]="false" *ngIf="item.list" [list]="item.list"></fd-prepared-nested-list>
-        </fd-nested-list-popover>
+            <fd-nested-list-popover *ngIf="condensed && first && item.list">
+                <a fd-nested-list-link *ngIf="item.link"
+                   [onClickCallback]="item.link.callback"
+                   [selected]="item.link.selected"
+                   [attr.href]="item.link.href ? item.link.href : null"
+                   [routerLink]="item.link.routerLink ? item.link.routerLink : []">
+                    <span fd-nested-list-icon *ngIf="item.link.icon" [glyph]="item.link.icon"></span>
+                    <span fd-nested-list-title>{{item.link.title}}</span>
+                </a>
+                <fd-prepared-nested-list [first]="false" *ngIf="item.list" [list]="item.list"></fd-prepared-nested-list>
+            </fd-nested-list-popover>
 
-        <ng-container *ngIf="!condensed || !first || !item.list">
-            <a fd-nested-list-link *ngIf="item.link"
-               [onClickCallback]="item.link.callback"
-               [selected]="item.link.selected"
-               [attr.href]="item.link.href ? item.link.href : null"
-               [routerLink]="item.link.routerLink ? item.link.routerLink : []">
-                <span fd-nested-list-icon *ngIf="item.link.icon" [glyph]="item.link.icon"></span>
-                <span fd-nested-list-title>{{item.link.title}}</span>
-            </a>
-            <fd-prepared-nested-list [first]="false" *ngIf="item.list" [list]="item.list"></fd-prepared-nested-list>
-        </ng-container>
+            <ng-container *ngIf="!condensed || !first || !item.list">
+                <a fd-nested-list-link *ngIf="item.link"
+                   [onClickCallback]="item.link.callback"
+                   [selected]="item.link.selected"
+                   [attr.href]="item.link.href ? item.link.href : null"
+                   [routerLink]="item.link.routerLink ? item.link.routerLink : []">
+                    <span fd-nested-list-icon *ngIf="item.link.icon" [glyph]="item.link.icon"></span>
+                    <span fd-nested-list-title>{{item.link.title}}</span>
+                </a>
+                <fd-prepared-nested-list [first]="false" *ngIf="item.list" [list]="item.list"></fd-prepared-nested-list>
+            </ng-container>
 
-    </li>
+        </li>
+    </ng-container>
 </ul>

--- a/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.html
+++ b/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.html
@@ -10,7 +10,8 @@
             <a fd-nested-list-link *ngIf="item.link"
                [onClickCallback]="item.link.callback"
                [selected]="item.link.selected"
-               [attr.href]="item.link.href ? item.link.href : null">
+               [attr.href]="item.link.href ? item.link.href : null"
+               [routerLink]="item.link.routerLink ? item.link.routerLink : []">
                 <span fd-nested-list-icon *ngIf="item.link.icon" [glyph]="item.link.icon"></span>
                 <span fd-nested-list-title>{{item.link.title}}</span>
             </a>
@@ -21,7 +22,8 @@
             <a fd-nested-list-link *ngIf="item.link"
                [onClickCallback]="item.link.callback"
                [selected]="item.link.selected"
-               [attr.href]="item.link.href ? item.link.href : null">
+               [attr.href]="item.link.href ? item.link.href : null"
+               [routerLink]="item.link.routerLink ? item.link.routerLink : []">
                 <span fd-nested-list-icon *ngIf="item.link.icon" [glyph]="item.link.icon"></span>
                 <span fd-nested-list-title>{{item.link.title}}</span>
             </a>


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
There is added [routerLink] to links on object-generated side navigation. 
It required to add `@angular/router` to peerDependencies.

Also there is added header to sublist and footer.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
