### PR TITLE
fix: Date Time Picker tests parser

### DIFF
--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.spec.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.spec.ts
@@ -16,13 +16,17 @@ describe('DatetimePickerComponent', () => {
     let component: DatetimePickerComponent;
     let fixture: ComponentFixture<DatetimePickerComponent>;
 
+    const takeAtLeastTwoDigits = (digit: number): string => {
+        return digit < 10 ? '0' + digit : String(digit);
+    };
+
     const internalParser = (date: FdDatetime): string => {
-        return date.month + '/' +
-            date.day + '/' +
+        return takeAtLeastTwoDigits(date.month) + '/' +
+            takeAtLeastTwoDigits(date.day) + '/' +
             date.year + ', ' +
-            date.hour + ':' +
-            date.minute + ':' +
-            date.second
+            takeAtLeastTwoDigits(date.hour) + ':' +
+            takeAtLeastTwoDigits(date.minute) + ':' +
+            takeAtLeastTwoDigits(date.second)
         ;
     };
 


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
There was some bug in parser function no tests inside DateTimePicker, it didn't force to have 2 digits, when sec/min/hour/day/month was less than 10.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
