### PR TITLE
fix: (core:Alert) Add new button classes to alert component

### DIFF
--- a/libs/core/src/lib/alert/alert-service/alert.service.spec.ts
+++ b/libs/core/src/lib/alert/alert-service/alert.service.spec.ts
@@ -7,6 +7,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AlertContainerComponent } from '../alert-utils/alert-container.component';
 import { DynamicComponentService } from '../../utils/dynamic-component/dynamic-component.service';
 import { AlertRef } from '../alert-utils/alert-ref';
+import { ButtonModule } from '@fundamental-ngx/core';
 
 @Component({
     template: `        
@@ -21,7 +22,7 @@ class TemplateTestComponent {
 
 @NgModule({
     declarations: [AlertComponent, AlertContainerComponent, TemplateTestComponent],
-    imports: [CommonModule, BrowserModule],
+    imports: [CommonModule, BrowserModule, ButtonModule],
     providers: [AlertService, DynamicComponentService],
     entryComponents: [AlertComponent, AlertContainerComponent, TemplateTestComponent]
 })

--- a/libs/core/src/lib/alert/alert.component.html
+++ b/libs/core/src/lib/alert/alert.component.html
@@ -1,4 +1,7 @@
 <button class="fd-alert__close"
+        fd-button
+        [compact]="true"
+        [options]="'light'"
         *ngIf="dismissible"
         (click)="dismiss(undefined, true)"
         [attr.aria-controls]="id"

--- a/libs/core/src/lib/alert/alert.component.html
+++ b/libs/core/src/lib/alert/alert.component.html
@@ -7,5 +7,7 @@
         [attr.aria-controls]="id"
         [attr.aria-label]="dismissLabel">
 </button>
-<ng-container #container>{{message}}</ng-container>
-<ng-content></ng-content>
+<p class="fd-alert__text">
+    <ng-container #container>{{message}}</ng-container>
+    <ng-content></ng-content>
+</p>

--- a/libs/core/src/lib/alert/alert.component.scss
+++ b/libs/core/src/lib/alert/alert.component.scss
@@ -2,6 +2,7 @@
 
 .fd-alert {
     display: block;
+    line-height: 1rem;
 }
 
 
@@ -11,4 +12,10 @@
 
 .fd-has-display-none {
     display: none;
+}
+
+.fd-alert__close {
+    border-width: 1px;
+    border-style: solid;
+    border-color: transparent;
 }

--- a/libs/core/src/lib/alert/alert.component.scss
+++ b/libs/core/src/lib/alert/alert.component.scss
@@ -2,7 +2,6 @@
 
 .fd-alert {
     display: block;
-    line-height: 1rem;
 }
 
 

--- a/libs/core/src/lib/alert/alert.component.spec.ts
+++ b/libs/core/src/lib/alert/alert.component.spec.ts
@@ -8,6 +8,7 @@ import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { DynamicComponentService } from '../utils/dynamic-component/dynamic-component.service';
+import { ButtonModule } from '@fundamental-ngx/core';
 
 @Component({
     template: `        
@@ -22,7 +23,7 @@ class TemplateTestComponent {
 
 @NgModule({
     declarations: [AlertComponent, AlertContainerComponent, TemplateTestComponent],
-    imports: [CommonModule, BrowserModule, NoopAnimationsModule],
+    imports: [CommonModule, BrowserModule, NoopAnimationsModule, ButtonModule],
     providers: [AlertService, DynamicComponentService],
     entryComponents: [AlertComponent, AlertContainerComponent, TemplateTestComponent]
 })

--- a/libs/core/src/lib/alert/alert.module.ts
+++ b/libs/core/src/lib/alert/alert.module.ts
@@ -6,10 +6,11 @@ import { AlertComponent } from './alert.component';
 import { AlertService } from './alert-service/alert.service';
 import { AlertContainerComponent } from './alert-utils/alert-container.component';
 import { DynamicComponentService } from '../utils/dynamic-component/dynamic-component.service';
+import { ButtonModule } from '../button/button.module';
 
 @NgModule({
     declarations: [AlertComponent, AlertContainerComponent],
-    imports: [CommonModule, IconModule],
+    imports: [CommonModule, IconModule, ButtonModule],
     exports: [AlertComponent, AlertContainerComponent],
     entryComponents: [AlertContainerComponent, AlertComponent],
     providers: [AlertService, DynamicComponentService]


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1758
#### Please provide a brief summary of this pull request.
There was changes in `styles@0.4.0` about the close button on alert component. There are new classes added. 
Due to `AbstractFdxNgClass` usage, which changes the hierarchy of classes I had to add some additional styles, to make it look the same as on styles. 
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
