### PR TITLE
fix: SideNav From object - selected and keyboard func

### DIFF
--- a/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.ts
+++ b/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.ts
@@ -1,7 +1,8 @@
-import { AfterViewInit, ChangeDetectorRef, Component, forwardRef, Input, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, forwardRef, Input, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { NestedListDirective } from '../nested-list/nested-list.directive';
 import { NestedListModel } from '../nested-list-model';
 import { NestedListStateService } from '../nested-list-state.service';
+import { NestedItemDirective } from '../nested-item/nested-item.directive';
 
 /**
  * Component for internal usage, allows to generate the nested list from defined object.
@@ -37,7 +38,21 @@ export class PreparedNestedListComponent implements AfterViewInit {
      * @hidden
      */
     @ViewChild(forwardRef(() => NestedListDirective), { static: false })
-    nestedListDirective: NestedListDirective;
+    _nestedListDirective: NestedListDirective;
+
+    /**
+     * @hidden
+     */
+    @ViewChildren(forwardRef(() => NestedItemDirective))
+    nestedListItems: QueryList<NestedItemDirective>;
+
+    /**
+     * In prepared nested list, nested items should be taken as reference of View, not Content.
+     * There is direct reference to these directives here.
+     */
+    get nestedListDirective(): NestedListDirective {
+        return Object.assign(this._nestedListDirective, { nestedItems: this.nestedListItems });
+    }
 
     /** @hidden */
     constructor (


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
There was some bugs with selected state and keyboard support, when there was created a SideNavigation from object.
Before:
![image](https://user-images.githubusercontent.com/26483208/71717889-db81d300-2e19-11ea-8b2e-5938c261530e.png)
After:
![image](https://user-images.githubusercontent.com/26483208/71717906-e89ec200-2e19-11ea-9194-a0d54a6bf712.png)
Screens are quite outdated (PR removing 2nd level icons are already included)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
