### PR TITLE
fix: add ButtonFocusable flag to input-group related components

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -8,8 +8,8 @@
             [ngClass]="{'fd-popover-body--display-none': displayedValues && !displayedValues.length}">
     <fd-popover-control>
         <div class="fd-combobox-control">
-            <fd-input-group [glyph]="glyph" [compact]="compact" [button]="true" [state]="state"
-                            (addOnButtonClicked)="onPrimaryButtonClick()" [buttonFocusable]="false">
+            <fd-input-group [glyph]="glyph"  [compact]="compact" [button]="true" [state]="state"
+                            (addOnButtonClicked)="onPrimaryButtonClick()" [buttonFocusable]="buttonFocusable">
                 <input #searchInputElement type="text"
                        fd-input-group-input
                        [compact]="compact"

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -153,6 +153,10 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
     @Input()
     displayFn: Function = this.defaultDisplay;
 
+    /** Whether AddOn Button should be focusable, set to false by default */
+    @Input()
+    buttonFocusable: boolean = false;
+
     /** Event emitted when an item is clicked. Use *$event* to retrieve it. */
     @Output()
     readonly itemClicked: EventEmitter<ComboboxItem> = new EventEmitter<ComboboxItem>();

--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -19,6 +19,7 @@
                    [ngClass]="{ 'is-invalid': isInvalidDateInput && useValidation }">
             <span fd-input-group-addon [button]="true" [compact]="compact">
                 <button fd-button
+                        [attr.tabindex]="buttonFocusable ? 0 : -1"
                         [glyph]="'calendar'"
                         [options]="'light'"
                         [compact]="compact"

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -137,6 +137,12 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
     @Input()
     state: FormStates;
 
+    /**
+     * Whether AddOn Button should be focusable, set to true by default
+     */
+    @Input()
+    buttonFocusable: boolean = true;
+
     /** Fired when a new date is selected. */
     @Output()
     public readonly selectedDateChange: EventEmitter<FdDate> = new EventEmitter<FdDate>();

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -24,6 +24,7 @@
                     <button [disabled]="disabled" fd-button [glyph]="'date-time'"
                             [options]="'light'"
                             [compact]="compact"
+                            [attr.tabindex]="buttonFocusable ? 0 : -1"
                             (click)="togglePopover()" [attr.aria-label]="displayDatetimeToggleLabel"
                             [attr.aria-expanded]="isOpen">
                     </button>

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -172,6 +172,12 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     @Input()
     state: FormStates;
 
+    /**
+     * Whether AddOn Button should be focusable, set to true by default
+     */
+    @Input()
+    buttonFocusable: boolean = true;
+
     /** Event thrown every time calendar active view is changed */
     @Output()
     public readonly activeViewChange: EventEmitter<FdCalendarView> = new EventEmitter<FdCalendarView>();

--- a/libs/core/src/lib/input-group/input-group.component.ts
+++ b/libs/core/src/lib/input-group/input-group.component.ts
@@ -76,7 +76,7 @@ export class InputGroupComponent implements ControlValueAccessor {
     @Input()
     addOnText: string;
 
-    /** Whether Button should be focusable */
+    /** Whether AddOn Button should be focusable */
     @Input()
     buttonFocusable: boolean = true;
 

--- a/libs/core/src/lib/localizator-editor/localization-editor-main/localization-editor-main.component.html
+++ b/libs/core/src/lib/localizator-editor/localization-editor-main/localization-editor-main.component.html
@@ -8,6 +8,7 @@
           [type]="type">
         <button class="fd-localization-editor__button"
                 fd-button aria-haspopup="true"
+                [attr.tabindex]="buttonFocusable ? 0 : -1"
                 [options]="'light'"
                 [compact]="compact"
                 [attr.aria-expanded]="expanded">

--- a/libs/core/src/lib/localizator-editor/localization-editor-main/localization-editor-main.component.ts
+++ b/libs/core/src/lib/localizator-editor/localization-editor-main/localization-editor-main.component.ts
@@ -30,4 +30,10 @@ export class LocalizationEditorMainComponent extends LocalizationEditorItemCompo
      */
     @Input()
     state: FormStates;
+
+    /**
+     * Whether AddOn Button should be focusable, set to true by default
+     */
+    @Input()
+    buttonFocusable: boolean = true;
 }

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -12,7 +12,7 @@
                  [attr.aria-expanded]="open">
                 <fd-input-group
                     [state]="state"
-                    [buttonFocusable]="false"
+                    [buttonFocusable]="buttonFocusable"
                     [disabled]="disabled"
                     [compact]="compact"
                     [button]="true"

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -134,6 +134,12 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
     @Input()
     state: FormStates;
 
+    /**
+     * Whether AddOn Button should be focusable, set to false by default
+     */
+    @Input()
+    buttonFocusable: boolean = false;
+
     /** Event emitted when the search term changes. Use *$event* to access the new term. */
     @Output()
     readonly searchTermChange: EventEmitter<string> = new EventEmitter<string>();

--- a/libs/core/src/lib/time-picker/time-picker.component.html
+++ b/libs/core/src/lib/time-picker/time-picker.component.html
@@ -7,6 +7,7 @@
             [button]="true"
             [state]="state"
             [disabled]="disabled"
+            [buttonFocusable]="buttonFocusable"
             [glyph]="'fob-watch'">
             <input [value]="getFormattedTime()"
                    [compact]="compact"

--- a/libs/core/src/lib/time-picker/time-picker.component.ts
+++ b/libs/core/src/lib/time-picker/time-picker.component.ts
@@ -98,6 +98,12 @@ export class TimePickerComponent implements ControlValueAccessor, OnInit {
     @Input()
     state: FormStates;
 
+    /**
+     * Whether AddOn Button should be focusable, set to true by default
+     */
+    @Input()
+    buttonFocusable: boolean = true;
+
     /** @hidden Whether the input time is valid. Internal use. */
     isInvalidTimeInput: boolean = false;
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1639
#### Please provide a brief summary of this pull request.
There is `buttonFocusable` flag in all of the `input-group` related components 
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
