### PR TITLE
fix: add fix for input compact mode

### DIFF
--- a/apps/docs/src/app/core/component-docs/input/examples/input-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input/examples/input-example.component.html
@@ -3,7 +3,7 @@
     <input fd-form-control type="text" id="input-1" placeholder="Field placeholder text">
 </div>
 <div fd-form-item>
-    <label fd-form-label [required]="true" for="input-2">Required Input</label>
+    <label fd-form-label [required]="true" for="input-2">Required Input:</label>
     <input fd-form-control type="text" id="input-2" placeholder="Field placeholder text" aria-required="true">
 </div>
 <div fd-form-item>
@@ -13,5 +13,5 @@
 <div fd-form-item>
     <label fd-form-label for="input-4">Compact</label>
     <input fd-form-control [compact]="true" type="password" id="input-4" placeholder="Field placeholder text"
-           aria-required="true">
+        aria-required="true">
 </div>

--- a/apps/docs/src/app/core/component-docs/textarea/examples/textarea-example.component.html
+++ b/apps/docs/src/app/core/component-docs/textarea/examples/textarea-example.component.html
@@ -3,7 +3,7 @@
     <textarea fd-form-control id="textarea-1" placeholder="Field placeholder text"></textarea>
 </div>
 <div fd-form-item>
-    <label fd-form-label [required]="true" for="textarea-2">Required textarea</label>
+    <label fd-form-label [required]="true" for="textarea-2">Required textarea:</label>
     <textarea fd-form-control id="textarea-2" placeholder="Field placeholder text" aria-required="true"></textarea>
 </div>
 <div fd-form-item>

--- a/libs/core/src/lib/form/form-control/form-control.directive.ts
+++ b/libs/core/src/lib/form/form-control/form-control.directive.ts
@@ -74,7 +74,7 @@ export class FormControlDirective extends AbstractFdNgxClass {
     private _addControlClass(className: string): void {
         this._addClassToElement(className);
         if (this.compact) {
-            this._addClassToElement('${className}--compact`');
+            this._addClassToElement(className + '--compact');
         }
     }
 }


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
- Input compact mode was broken
- in the documentation added : in the label of required inputs
- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

