### PR TITLE
fix: remove spinners, add some place between inputs

### DIFF
--- a/libs/core/src/lib/time/time.component.html
+++ b/libs/core/src/lib/time/time.component.html
@@ -19,7 +19,7 @@
             }"
             (ngModelChange)="displayedHourChanged($event)"
             (blur)="inputBlur('hour')"
-            class="fd-input fd-time__input"
+            class="fd-input fd-time__input fd-input--no-number-spinner"
             type="number"
             placeholder="{{timeI18n?.hoursPlaceholder}}"
             [attr.aria-label]="timeI18nLabels?.hoursLabel"/>
@@ -54,7 +54,7 @@
             (ngModelChange)="minuteModelChange($event)"
             (blur)="inputBlur('minute')"
             [ngClass]="{'is-disabled': disabled, 'is-invalid': ((time.minute > 59 || time.minute < 0) && validate)}"
-            class="fd-input fd-time__input"
+            class="fd-input fd-time__input fd-input--no-number-spinner"
             type="number"
             placeholder="{{timeI18n?.minutesPlaceholder}}"
             [attr.aria-label]="timeI18nLabels?.minutesLabel"/>
@@ -88,7 +88,7 @@
             (ngModelChange)="secondModelChange($event)"
             (blur)="inputBlur('second')"
             [ngClass]="{'is-disabled': disabled, 'is-invalid': ((time.second > 59 || time.second < 0) && validate)}"
-            class="fd-input fd-time__input"
+            class="fd-input fd-time__input fd-input--no-number-spinner"
             type="number"
             placeholder="{{timeI18n?.secondsPlaceholder}}"
             (keydown)="!meridian && !spinners ? lastButtonKeydown($event) : ''"

--- a/libs/core/src/lib/time/time.component.scss
+++ b/libs/core/src/lib/time/time.component.scss
@@ -1,8 +1,8 @@
 @import "~fundamental-styles/dist/input";
 @import "~fundamental-styles/dist/time";
 
-input[type='number']::-webkit-inner-spin-button,
-input[type='number']::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
+.fd-time__item {
+    .fd-time__input {
+        min-width: auto;
+    }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/1811
#### Please provide a brief summary of this pull request.
I added prepared classes to `inputs` on time component.
Also there was `max-width` shadowed by `fd-input`, I added it on `ngx` level.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

