### PR TITLE
fix: change checkbox state update trigger

### DIFF
--- a/apps/docs/src/app/core/component-docs/checkbox/examples/checkbox-states-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/checkbox/examples/checkbox-states-example.component.ts
@@ -5,21 +5,28 @@ import {Component} from '@angular/core';
     template: `
         <div>
             States:
-            <fd-checkbox label="No state"></fd-checkbox>
-            <fd-checkbox state="information" label="Info state"></fd-checkbox>
-            <fd-checkbox state="valid" label="Valid state"></fd-checkbox>
-            <fd-checkbox state="warning" label="Warning state"></fd-checkbox>
-            <fd-checkbox state="invalid" label="Invalid state"></fd-checkbox>
+            <fd-checkbox [(ngModel)]="checkboxValue1" label="No state"></fd-checkbox>
+            <fd-checkbox [(ngModel)]="checkboxValue2" state="information" label="Info state"></fd-checkbox>
+            <fd-checkbox [(ngModel)]="checkboxValue3" state="valid" label="Valid state"></fd-checkbox>
+            <fd-checkbox [(ngModel)]="checkboxValue4" state="warning" label="Warning state"></fd-checkbox>
+            <fd-checkbox [(ngModel)]="checkboxValue5" state="invalid" label="Invalid state"></fd-checkbox>
         </div>
         <div>
             Disabled:
-            <fd-checkbox [disabled]="true" label="Disabled label"></fd-checkbox>
+            <fd-checkbox [(ngModel)]="checkboxValue6" [disabled]="true" label="Disabled label"></fd-checkbox>
         </div>
         <div>
             Compact:
-            <fd-checkbox [compact]="true" label="Compact label"></fd-checkbox>
+            <fd-checkbox [(ngModel)]="checkboxValue7" [compact]="true" label="Compact label"></fd-checkbox>
         </div>
     `,
 })
 export class CheckboxStatesExampleComponent {
+    public checkboxValue1 = false;
+    public checkboxValue2 = false;
+    public checkboxValue3 = false;
+    public checkboxValue4 = false;
+    public checkboxValue5 = false;
+    public checkboxValue6 = false;
+    public checkboxValue7 = false;
 }

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -9,9 +9,11 @@
     [indeterminate]="isIndeterminate"
     [class.fd-checkbox--compact]="compact"
     [ngClass]="(state ? 'is-' + state : '')"
-    (change)="nextValue()"
+    (keydown)="muteKey($event)"
+    (keyup)="checkByKey($event)"
 >
 <label class="fd-checkbox__label"
+       (click)="checkByClick($event)"
        [class.fd-checkbox__label--compact]="compact"
        [for]="inputId">
     {{label}}

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.spec.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.spec.ts
@@ -102,7 +102,6 @@ describe('CheckboxComponent', () => {
         expect(input.disabled).toBe(true);
         expect(hostComponent.value).toBe(false);
         expect(checkbox.checkboxValue).toBe(false);
-        expect(checkbox.nextValue).not.toHaveBeenCalled();
     });
 
     it('should be compact', async() => {

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -154,7 +154,7 @@ export class CheckboxComponent implements ControlValueAccessor {
     /** @hidden Updates checkbox state on spacebar key
      * and prevents from double check update from label-input binding */
     public checkByKey(event: KeyboardEvent): void {
-        if (event.keyCode === 32) {
+        if (this._isSpaceBarEvent(event)) {
             this.nextValue();
             event.preventDefault();
         }
@@ -162,9 +162,14 @@ export class CheckboxComponent implements ControlValueAccessor {
 
     /** @hidden Prevents from checkbox update based on label-input binding */
     public muteKey(event: KeyboardEvent): void {
-        if (event.keyCode === 32) {
+        if (this._isSpaceBarEvent(event)) {
             event.preventDefault();
         }
+    }
+
+    /** @hidden Determines event source based on key code */
+    private _isSpaceBarEvent(event: KeyboardEvent): boolean {
+        return event.keyCode === 32;
     }
 
     /** @hidden Based on current control value sets new control state. */

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -144,6 +144,29 @@ export class CheckboxComponent implements ControlValueAccessor {
         this._changeDetectorRef.detectChanges();
     }
 
+    /** @hidden Updates checkbox state on mouse click
+     * and prevents from double check update from label-input binding */
+    public checkByClick(event: Event) {
+        this.nextValue();
+        event.preventDefault();
+    }
+
+    /** @hidden Updates checkbox state on spacebar key
+     * and prevents from double check update from label-input binding */
+    public checkByKey(event: KeyboardEvent): void {
+        if (event.keyCode === 32) {
+            this.nextValue();
+            event.preventDefault();
+        }
+    }
+
+    /** @hidden Prevents from checkbox update based on label-input binding */
+    public muteKey(event: KeyboardEvent): void {
+        if (event.keyCode === 32) {
+            event.preventDefault();
+        }
+    }
+
     /** @hidden Based on current control value sets new control state. */
     private _setState(): void {
         if (this._compare(this.checkboxValue, this.values.trueValue)) {


### PR DESCRIPTION
#### Link to the associated issue.
#1811 

#### Brief summary of this pull request.
This PR fixes weird behavior of tristate checkbox in IE11, caused by IE11 not emitting change event on indeterminate state change. To fix this error I've changed the source triggering change of checkbox state from input `(change)` to label `(click)` and input `(keyup)` events.

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md