### PR TITLE
fix: Allow outside click for modal

### DIFF
--- a/libs/core/src/lib/modal/modal.component.ts
+++ b/libs/core/src/lib/modal/modal.component.ts
@@ -108,7 +108,8 @@ export class ModalComponent extends AbstractFdNgxClass implements OnInit, AfterV
                 this.focusTrap = focusTrap(this.elRef.nativeElement, {
                     clickOutsideDeactivates: this.backdropClickCloseable && this.hasBackdrop,
                     escapeDeactivates: false,
-                    initialFocus: this.elRef.nativeElement
+                    initialFocus: this.elRef.nativeElement,
+                    allowOutsideClick: (event: MouseEvent) => true
                 });
                 this.focusTrap.activate();
             } catch (e) {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1869
#### Please provide a brief summary of this pull request.
In case of stacked modal, focusTrap library in first modal didn't allow to propagate mouse events on second modal
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

