### PR TITLE
feat: adjust Tabs to newest 0.5.0 fundamental-styles structure

### DIFF
--- a/apps/docs/src/app/core/api-files.ts
+++ b/apps/docs/src/app/core/api-files.ts
@@ -260,11 +260,22 @@ export const API_FILES = {
         'ColumnSortableDirective'
     ],
     tabs: [
-        'TabPanelComponent',
         'TabListComponent',
+        'TabPanelComponent',
         'TabTitleDirective',
+        'TabLoadTitleDirective',
+        'TabNavComponent',
         'TabLinkDirective',
-        'TabNavComponent'
+        'TabItemDirective',
+        'TabTagDirective',
+        'TabIconDirective',
+        'TabCountDirective',
+        'TabLabelDirective',
+        'TabProcessDirective',
+        'TabHeaderDirective',
+        'TabCounterHeaderDirective',
+        'TabProcessIconDirective',
+        'TabSeparator'
     ],
     tile: [
         'ProductTileComponent',

--- a/apps/docs/src/app/core/component-docs/badge-label/badge-label-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/badge-label/badge-label-docs.component.html
@@ -5,7 +5,7 @@
     <fd-badge-default-example></fd-badge-default-example>
 </component-example>
 <code-example [exampleFiles]="defaultBadgeHtmlType"></code-example>
-
+<label fd-form-label>Simple Tabs Built by Passing Title Parameter</label>
 <separator></separator>
 
 <fd-docs-section-title [id]="'pill'" [componentName]="'badgeLabel'">

--- a/apps/docs/src/app/core/component-docs/tabs/examples/complex-title-example/complex-title-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/complex-title-example/complex-title-example.component.html
@@ -1,23 +1,77 @@
 <fd-tab-list>
     <fd-tab>
-        <ng-template fd-tab-title>
-            <fd-icon [glyph]="'delete'"></fd-icon>
-            <span style="margin-left: 12px;">Delete</span>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-tag>Link 1</span>
         </ng-template>
         Content for tab 1
     </fd-tab>
     <fd-tab>
-        <ng-template fd-tab-title>
-            <fd-icon [glyph]="'edit'"></fd-icon>
-            <span style="margin-left: 12px;">Edit</span>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-tag>Link 2</span>
         </ng-template>
         Content for tab 2
     </fd-tab>
-    <fd-tab [title]="'Tab 3'">
-        <ng-template fd-tab-title>
-            <fd-icon [glyph]="'search'"></fd-icon>
-            <span style="margin-left: 12px;">Search</span>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-tag>Link 3</span>
         </ng-template>
         Content for tab 3
     </fd-tab>
 </fd-tab-list>
+
+<fd-tab-list>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <p fd-tab-count>12</p>
+            <span fd-tab-tag>Link 1</span>
+        </ng-template>
+        Content for tab 1
+    </fd-tab>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <p fd-tab-count>13</p>
+            <span fd-tab-tag>Link 2</span>
+        </ng-template>
+        Content for tab 2
+    </fd-tab>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <p fd-tab-count>14</p>
+            <span fd-tab-tag>Link 3</span>
+        </ng-template>
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+
+<fd-tab-list [mode]="'filter'">
+    <fd-tab [header]="true">
+        <ng-template fd-tab-title-template>
+            <span fd-tab-header>
+                <span fd-tab-counter-header>100</span>
+                <span fd-tab-label>Description</span>
+            </span>
+        </ng-template>
+        Content for tab 1
+    </fd-tab>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'edit'">
+                <p fd-tab-count>35</p>
+            </span>
+            <span fd-tab-label>Description</span>
+        </ng-template>
+        Content for tab 2
+    </fd-tab>
+    <fd-tab [title]="'Tab 3'">
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'edit'">
+                <p fd-tab-count>35</p>
+            </span>
+            <span fd-tab-label>Description</span>
+        </ng-template>
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-counter/tab-counter.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-counter/tab-counter.component.html
@@ -45,14 +45,14 @@
         </ng-template>
         Content for tab 1
     </fd-tab>
-    <fd-tab [title]="'Link 2'">
+    <fd-tab>
         <ng-template fd-tab-title-template>
             <p fd-tab-count>12</p>
             <span fd-tab-tag>Link 2</span>
         </ng-template>
         Content for tab 2
     </fd-tab>
-    <fd-tab [title]="'Link 3'">
+    <fd-tab>
         <ng-template fd-tab-title-template>
             <p fd-tab-count>13</p>
             <span fd-tab-tag>Link 3</span>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-counter/tab-counter.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-counter/tab-counter.component.html
@@ -1,12 +1,12 @@
-<label fd-form-label>Simple Tabs Built by Passing Title Parameter</label>
+<label fd-form-label>Tabs With Counter Built by Passing Title Parameter</label>
 <fd-tab-list>
-    <fd-tab [title]="'Link 1'">
+    <fd-tab [title]="'Link 1'" [count]="'11'">
         Content for tab 1
     </fd-tab>
-    <fd-tab [title]="'Link 2'">
+    <fd-tab [title]="'Link 2'" [count]="'12'">
         Content for tab 2
     </fd-tab>
-    <fd-tab [title]="'Link 3'">
+    <fd-tab [title]="'Link 3'" [count]="'13'">
         Content for tab 3
     </fd-tab>
 </fd-tab-list>
@@ -16,19 +16,19 @@
 
 <label fd-form-label>Semantic Tabs Built by Passing Title Parameter</label>
 <fd-tab-list>
-    <fd-tab [title]="'Success'" [tabState]="'success'">
+    <fd-tab [title]="'Success'" [count]="'11'" [tabState]="'success'">
         Content for tab 1
     </fd-tab>
-    <fd-tab [title]="'Error'" [tabState]="'error'">
+    <fd-tab [title]="'Error'" [count]="'12'" [tabState]="'error'">
         Content for tab 2
     </fd-tab>
-    <fd-tab [title]="'Warning'" [tabState]="'warning'">
+    <fd-tab [title]="'Warning'" [count]="'13'" [tabState]="'warning'">
         Content for tab 3
     </fd-tab>
-    <fd-tab [title]="'Information'" [tabState]="'information'">
+    <fd-tab [title]="'Information'" [count]="'14'" [tabState]="'information'">
         Content for tab 4
     </fd-tab>
-    <fd-tab [title]="'Neutral'" [tabState]="'neutral'">
+    <fd-tab [title]="'Neutral'" [count]="'15'" [tabState]="'neutral'">
         Content for tab 5
     </fd-tab>
 </fd-tab-list>
@@ -36,22 +36,25 @@
 <br/>
 <br/>
 
-<label fd-form-label>Simple Tabs Built by Defining Template</label>
+<label fd-form-label>Tabs With Counter Built by Defining Template</label>
 <fd-tab-list>
     <fd-tab>
         <ng-template fd-tab-title-template>
+            <p fd-tab-count>11</p>
             <span fd-tab-tag>Link 1</span>
         </ng-template>
         Content for tab 1
     </fd-tab>
     <fd-tab [title]="'Link 2'">
         <ng-template fd-tab-title-template>
+            <p fd-tab-count>12</p>
             <span fd-tab-tag>Link 2</span>
         </ng-template>
         Content for tab 2
     </fd-tab>
     <fd-tab [title]="'Link 3'">
         <ng-template fd-tab-title-template>
+            <p fd-tab-count>13</p>
             <span fd-tab-tag>Link 3</span>
         </ng-template>
         Content for tab 3
@@ -61,7 +64,7 @@
 <br/>
 <br/>
 
-<label fd-form-label>Simple Tabs Built by defining own template and with routerLink</label>
+<label fd-form-label>Tabs With Counter Built by defining own template and with routerLink</label>
 <nav fd-tab-nav>
     <div fd-tab-item>
         <a fd-tab-link
@@ -69,6 +72,7 @@
            [routerLink]="'tab1'"
            routerLinkActive
            #rla1="routerLinkActive">
+            <p fd-tab-count>11</p>
             <span fd-tab-tag>Link 1</span>
         </a>
     </div>
@@ -78,6 +82,7 @@
            [routerLink]="'tab2'"
            routerLinkActive
            #rla2="routerLinkActive">
+            <p fd-tab-count>12</p>
             <span fd-tab-tag>Link 2</span>
         </a>
     </div>
@@ -87,6 +92,7 @@
            [routerLink]="'tab3'"
            routerLinkActive
            #rla3="routerLinkActive">
+            <p fd-tab-count>13</p>
             <span fd-tab-tag>Link 3</span>
         </a>
     </div>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-counter/tab-counter.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-counter/tab-counter.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'fd-tab-counter-example',
+  templateUrl: './tab-counter.component.html',
+  styleUrls: ['./tab-counter.component.scss']
+})
+export class TabCounterComponent {}

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-counter/tab-counter.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-counter/tab-counter.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'fd-tab-counter-example',
-  templateUrl: './tab-counter.component.html',
-  styleUrls: ['./tab-counter.component.scss']
+  templateUrl: './tab-counter.component.html'
 })
 export class TabCounterComponent {}

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-filter-example/tab-filter-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-filter-example/tab-filter-example.component.html
@@ -1,0 +1,108 @@
+<label fd-form-label>Filter Tabs Built by passing parameters</label>
+<fd-tab-list [mode]="'filter'">
+    <fd-tab [header]="true" [count]="'100'" [title]="'items'">
+        Content for tab 1
+    </fd-tab>
+    <fd-tab [glyph]="'cart'" [count]="'12'" [title]="'Title 1'">
+        Content for tab 2
+    </fd-tab>
+    <fd-tab [glyph]="'menu'" [count]="'13'" [title]="'Title 2'">
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+<br/>
+<br/>
+
+<label fd-form-label>Compact Filter Tabs Built by passing parameters</label>
+<fd-tab-list [mode]="'filter'" [compact]="true">
+    <fd-tab [header]="true" [count]="'100'" [title]="'items'">
+        Content for tab 1
+    </fd-tab>
+    <fd-tab [glyph]="'cart'" [count]="'12'" [title]="'Title 1'">
+        Content for tab 2
+    </fd-tab>
+    <fd-tab [glyph]="'menu'" [count]="'13'" [title]="'Title 2'">
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+<br/>
+<br/>
+
+<label fd-form-label>Filter Tabs Built by defining own template</label>
+<fd-tab-list [mode]="'filter'">
+    <fd-tab [header]="true">
+        <ng-template fd-tab-title-template>
+            <span fd-tab-header>
+                <span fd-tab-counter-header>100</span>
+                <span fd-tab-label>items</span>
+            </span>
+        </ng-template>
+        Content for tab 1
+    </fd-tab>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'edit'">
+                <p fd-tab-count>11</p>
+            </span>
+            <span fd-tab-label>Title 1</span>
+        </ng-template>
+        Content for tab 2
+    </fd-tab>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'menu'">
+                <p fd-tab-count>12</p>
+            </span>
+            <span fd-tab-label>Title 2</span>
+        </ng-template>
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+<br/>
+<br/>
+
+<label fd-form-label>Filter Tabs Built by defining own template with routerLink</label>
+<nav fd-tab-nav [mode]="'filter'">
+    <div fd-tab-item [header]="true">
+        <a fd-tab-link
+           [active]="rla1.isActive"
+           [routerLink]="'tab1'"
+           routerLinkActive
+           #rla1="routerLinkActive">
+            <span fd-tab-header>
+                <span fd-tab-counter-header>100</span>
+                <span fd-tab-label>items</span>
+            </span>
+        </a>
+    </div>
+    <div fd-tab-separator></div>
+    <div fd-tab-item>
+        <a fd-tab-link
+           [active]="rla2.isActive"
+           [routerLink]="'tab2'"
+           routerLinkActive
+           #rla2="routerLinkActive">
+            <span fd-tab-icon [icon]="'edit'">
+                <p fd-tab-count>11</p>
+            </span>
+            <span fd-tab-label>Title 1</span>
+        </a>
+    </div>
+    <div fd-tab-item>
+        <a fd-tab-link
+           [active]="rla3.isActive"
+           [routerLink]="'tab3'"
+           routerLinkActive
+           #rla3="routerLinkActive">
+            <span fd-tab-icon [icon]="'menu'">
+                <p fd-tab-count>12</p>
+            </span>
+            <span fd-tab-label>Title 2</span>
+        </a>
+    </div>
+</nav>
+
+<router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-filter-example/tab-filter-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-filter-example/tab-filter-example.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'fd-tab-filter-example',
+  templateUrl: './tab-filter-example.component.html',
+  styleUrls: ['./tab-filter-example.component.scss']
+})
+export class TabFilterExampleComponent {}

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-filter-example/tab-filter-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-filter-example/tab-filter-example.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'fd-tab-filter-example',
-  templateUrl: './tab-filter-example.component.html',
-  styleUrls: ['./tab-filter-example.component.scss']
+  templateUrl: './tab-filter-example.component.html'
 })
 export class TabFilterExampleComponent {}

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-icon-only-example/tab-icon-only-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-icon-only-example/tab-icon-only-example.component.html
@@ -1,0 +1,104 @@
+<label fd-form-label>Icon Only Tabs Built by passing parameters</label>
+<fd-tab-list [mode]="'icon-only'">
+    <fd-tab [glyph]="'menu'" [count]="'40'">
+        Content for tab 1
+    </fd-tab>
+    <fd-tab [glyph]="'cart'" [count]="'17'">
+        Content for tab 2
+    </fd-tab>
+    <fd-tab [glyph]="'edit'" [count]="'12'">
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+<br/>
+<br/>
+
+
+<label fd-form-label>Compact Icon Only Tabs Built by passing parameters</label>
+<fd-tab-list [mode]="'icon-only'" [compact]="true">
+    <fd-tab [glyph]="'menu'" [count]="'40'">
+        Content for tab 1
+    </fd-tab>
+    <fd-tab [glyph]="'cart'" [count]="'17'">
+        Content for tab 2
+    </fd-tab>
+    <fd-tab [glyph]="'edit'" [count]="'12'">
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+
+<br/>
+<br/>
+
+
+<label fd-form-label>Icon Only Tabs Built by defining own template</label>
+<fd-tab-list [mode]="'icon-only'">
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'menu'">
+                <p fd-tab-count>11</p>
+            </span>
+        </ng-template>
+        Content for tab 1
+    </fd-tab>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'cart'">
+                <p fd-tab-count>12</p>
+            </span>
+        </ng-template>
+        Content for tab 2
+    </fd-tab>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'delete'">
+                <p fd-tab-count>13</p>
+            </span>
+        </ng-template>
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+<br/>
+<br/>
+
+<label fd-form-label>Icon Only Tabs Built by defining own template with routerLink</label>
+<nav fd-tab-nav [mode]="'icon-only'">
+    <div fd-tab-item>
+        <a fd-tab-link
+           [active]="rla1.isActive"
+           [routerLink]="'tab1'"
+           routerLinkActive
+           #rla1="routerLinkActive">
+            <span fd-tab-icon [icon]="'delete'">
+                <p fd-tab-count>11</p>
+            </span>
+        </a>
+    </div>
+    <div fd-tab-item>
+        <a fd-tab-link
+           [active]="rla2.isActive"
+           [routerLink]="'tab2'"
+           routerLinkActive
+           #rla2="routerLinkActive">
+            <span fd-tab-icon [icon]="'cart'">
+                <p fd-tab-count>12</p>
+            </span>
+        </a>
+    </div>
+    <div fd-tab-item>
+        <a fd-tab-link
+           [active]="rla3.isActive"
+           [routerLink]="'tab3'"
+           routerLinkActive
+           #rla3="routerLinkActive">
+            <span fd-tab-icon [icon]="'delete'">
+                <p fd-tab-count>13</p>
+            </span>
+        </a>
+    </div>
+</nav>
+
+<router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-icon-only-example/tab-icon-only-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-icon-only-example/tab-icon-only-example.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'fd-tab-icon-only-example',
+  templateUrl: './tab-icon-only-example.component.html',
+  styleUrls: ['./tab-icon-only-example.component.scss']
+})
+export class TabIconOnlyExampleComponent {}

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-icon-only-example/tab-icon-only-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-icon-only-example/tab-icon-only-example.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'fd-tab-icon-only-example',
-  templateUrl: './tab-icon-only-example.component.html',
-  styleUrls: ['./tab-icon-only-example.component.scss']
+  templateUrl: './tab-icon-only-example.component.html'
 })
 export class TabIconOnlyExampleComponent {}

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-process-example/tab-process-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-process-example/tab-process-example.component.html
@@ -1,0 +1,115 @@
+<label fd-form-label>Icon Process Tabs Built by passing properties</label>
+<fd-tab-list [mode]="'process'">
+    <fd-tab [glyph]="'edit'" [count]="'11 of 100 items'" [title]="'Title 1'">
+        Content for tab 1
+    </fd-tab>
+    <fd-tab [glyph]="'cart'" [count]="'12 of 100 items'" [title]="'Title 2'">
+        Content for tab 2
+    </fd-tab>
+    <fd-tab [glyph]="'menu'" [count]="'13 of 100 items'" [title]="'Title 3'">
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+<br/>
+<br/>
+
+<label fd-form-label>Compact Process Tabs Built by passing properties</label>
+<fd-tab-list [mode]="'process'" [compact]="true">
+    <fd-tab [glyph]="'edit'" [count]="'11 of 100 items'" [title]="'Title 1'">
+        Content for tab 1
+    </fd-tab>
+    <fd-tab [glyph]="'cart'" [count]="'12 of 100 items'" [title]="'Title 2'">
+        Content for tab 2
+    </fd-tab>
+    <fd-tab [glyph]="'menu'" [count]="'13 of 100 items'" [title]="'Title 3'">
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+<br/>
+<br/>
+
+<label fd-form-label>Process Tabs Built by defining own template</label>
+<fd-tab-list [mode]="'process'">
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'menu'"></span>
+            <div fd-tab-process>
+                <span fd-tab-label>11 of 100</span>
+                <span fd-tab-label>Title 1</span>
+            </div>
+        </ng-template>
+        Content for tab 1
+    </fd-tab>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'edit'"></span>
+            <div fd-tab-process>
+                <span fd-tab-label>12 of 100</span>
+                <span fd-tab-label>Title 2</span>
+            </div>
+        </ng-template>
+        Content for tab 2
+    </fd-tab>
+    <fd-tab>
+        <ng-template fd-tab-title-template>
+            <span fd-tab-icon [icon]="'search'"></span>
+            <div fd-tab-process>
+                <span fd-tab-label>13 of 100</span>
+                <span fd-tab-label>Title 3</span>
+            </div>
+        </ng-template>
+        Content for tab 3
+    </fd-tab>
+</fd-tab-list>
+
+<br/>
+<br/>
+
+<label fd-form-label>Process Tabs Built by defining own template with routerLink</label>
+<nav fd-tab-nav [mode]="'process'">
+    <div fd-tab-item>
+        <a fd-tab-link
+           [active]="rla1.isActive"
+           [routerLink]="['tab1', {outlets: {aux: 'process'}}]"
+           routerLinkActive
+           #rla1="routerLinkActive">
+            <span fd-tab-icon [icon]="'menu'"></span>
+            <div fd-tab-process>
+                <span fd-tab-label>11 of 100</span>
+                <span fd-tab-label>Title 1</span>
+            </div>
+        </a>
+        <div fd-tab-process-icon></div>
+    </div>
+    <div fd-tab-item>
+        <a fd-tab-link
+           [active]="rla2.isActive"
+           [routerLink]="['tab2', {outlets: {aux: 'process'}}]"
+           routerLinkActive
+           #rla2="routerLinkActive">
+            <span fd-tab-icon [icon]="'edit'"></span>
+            <div fd-tab-process>
+                <span fd-tab-label>12 of 100</span>
+                <span fd-tab-label>Title 2</span>
+            </div>
+        </a>
+        <div fd-tab-process-icon></div>
+    </div>
+    <div fd-tab-item>
+        <a fd-tab-link
+           [active]="rla3.isActive"
+           [routerLink]="['tab3', {outlets: {aux: 'process'}}]"
+           routerLinkActive
+           #rla3="routerLinkActive">
+            <span fd-tab-icon [icon]="'search'"></span>
+            <div fd-tab-process>
+                <span fd-tab-label>13 of 100</span>
+                <span fd-tab-label>Title 3</span>
+            </div>
+        </a>
+    </div>
+</nav>
+
+<router-outlet name="process"></router-outlet>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-process-example/tab-process-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-process-example/tab-process-example.component.html
@@ -72,7 +72,7 @@
     <div fd-tab-item>
         <a fd-tab-link
            [active]="rla1.isActive"
-           [routerLink]="['tab1', {outlets: {aux: 'process'}}]"
+           [routerLink]="'tab1'"
            routerLinkActive
            #rla1="routerLinkActive">
             <span fd-tab-icon [icon]="'menu'"></span>
@@ -86,7 +86,7 @@
     <div fd-tab-item>
         <a fd-tab-link
            [active]="rla2.isActive"
-           [routerLink]="['tab2', {outlets: {aux: 'process'}}]"
+           [routerLink]="'tab2'"
            routerLinkActive
            #rla2="routerLinkActive">
             <span fd-tab-icon [icon]="'edit'"></span>
@@ -100,7 +100,7 @@
     <div fd-tab-item>
         <a fd-tab-link
            [active]="rla3.isActive"
-           [routerLink]="['tab3', {outlets: {aux: 'process'}}]"
+           [routerLink]="'tab3'"
            routerLinkActive
            #rla3="routerLinkActive">
             <span fd-tab-icon [icon]="'search'"></span>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-process-example/tab-process-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-process-example/tab-process-example.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'fd-tab-process-example',
+  templateUrl: './tab-process-example.component.html',
+  styleUrls: ['./tab-process-example.component.scss']
+})
+export class TabProcessExampleComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-process-example/tab-process-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-process-example/tab-process-example.component.ts
@@ -1,15 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'fd-tab-process-example',
   templateUrl: './tab-process-example.component.html',
-  styleUrls: ['./tab-process-example.component.scss']
 })
-export class TabProcessExampleComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-}
+export class TabProcessExampleComponent {}

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-selection-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-selection-example.component.html
@@ -5,7 +5,7 @@
     <fd-tab [title]="'Tab 2'">
         Tab 2
     </fd-tab>
-    <fd-tab [title]="'Tab 3'" [disabled]="true">
+    <fd-tab [title]="'Tab 3'">
         Tab 3
     </fd-tab>
 </fd-tab-list>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tabs-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tabs-example.component.html
@@ -44,13 +44,13 @@
         </ng-template>
         Content for tab 1
     </fd-tab>
-    <fd-tab [title]="'Link 2'">
+    <fd-tab>
         <ng-template fd-tab-title-template>
             <span fd-tab-tag>Link 2</span>
         </ng-template>
         Content for tab 2
     </fd-tab>
-    <fd-tab [title]="'Link 3'">
+    <fd-tab>
         <ng-template fd-tab-title-template>
             <span fd-tab-tag>Link 3</span>
         </ng-template>

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.html
@@ -24,7 +24,7 @@
 <component-example [name]="'ex2'">
     <fd-tab-counter-example></fd-tab-counter-example>
 </component-example>
-<code-example [exampleFiles]="counterTab"></code-example>
+<code-example [exampleFiles]="tabCounter"></code-example>
 
 <separator></separator>
 
@@ -39,7 +39,7 @@
 <component-example [name]="'ex3'">
     <fd-tab-icon-only-example></fd-tab-icon-only-example>
 </component-example>
-<code-example [exampleFiles]="iconOnly"></code-example>
+<code-example [exampleFiles]="tabIcon"></code-example>
 
 <separator></separator>
 
@@ -54,7 +54,7 @@
 <component-example [name]="'ex4'">
     <fd-tab-process-example></fd-tab-process-example>
 </component-example>
-<code-example [exampleFiles]="processMode"></code-example>
+<code-example [exampleFiles]="tabProcess"></code-example>
 
 <separator></separator>
 
@@ -69,7 +69,7 @@
 <component-example [name]="'ex5'">
     <fd-tab-filter-example></fd-tab-filter-example>
 </component-example>
-<code-example [exampleFiles]="filterMode"></code-example>
+<code-example [exampleFiles]="tabFilter"></code-example>
 
 <separator></separator>
 

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.html
@@ -1,10 +1,75 @@
 <fd-docs-section-title [id]="'simple'" [componentName]="'tabs'">
     Simple Tabs
 </fd-docs-section-title>
+<description>
+    Simple tabs can be built by setting specified properties to <code>fd-tab</code>. There is way to define
+    own templates, or use it with <code>[routerLink]</code>.
+    There is no <code>compact</code> mode on inline tabs.
+</description>
 <component-example [name]="'ex1'">
     <fd-tabs-example></fd-tabs-example>
 </component-example>
 <code-example [exampleFiles]="tabExample"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title [id]="'counter'" [componentName]="'tabs'">
+    Tabs with Counter
+</fd-docs-section-title>
+<description>
+    Tabs with counter can be built by setting specified properties to <code>fd-tab</code>. There is way to define
+    own templates, or use it with <code>[routerLink]</code>.
+    There is no <code>compact</code> mode on inline tabs with counter.
+</description>
+<component-example [name]="'ex2'">
+    <fd-tab-counter-example></fd-tab-counter-example>
+</component-example>
+<code-example [exampleFiles]="counterTab"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title [id]="'iconOnlyMode'" [componentName]="'tabs'">
+    Icon Only Mode
+</fd-docs-section-title>
+<description>
+    The Icon Only mode can be used, by adding <code>[mode]="'icon-only'"</code>. It requires different structure usage.
+    Tabs in Icon Only mode can be built by setting specified properties to <code>fd-tab</code>. There is way to define
+    own templates, or use it with <code>[routerLink]</code>.
+</description>
+<component-example [name]="'ex3'">
+    <fd-tab-icon-only-example></fd-tab-icon-only-example>
+</component-example>
+<code-example [exampleFiles]="iconOnly"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title [id]="'processMode'" [componentName]="'tabs'">
+    Process Mode
+</fd-docs-section-title>
+<description>
+    The Process Mode can be used by adding <code>[mode]="'process'"</code>. As on icons it has different structure than
+    tab any other mode. It can be built by setting properties, defining own template, or using it with
+    <code>[routerLink]</code>.
+</description>
+<component-example [name]="'ex4'">
+    <fd-tab-process-example></fd-tab-process-example>
+</component-example>
+<code-example [exampleFiles]="processMode"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title [id]="'filterMode'" [componentName]="'tabs'">
+    Filter Mode
+</fd-docs-section-title>
+<description>
+    The Process Mode can be used by adding <code>[mode]="'process'"</code>. As on icons it has different structure than
+    tab any other mode. It can be built by setting properties, defining own template, or using it with
+    <code>[routerLink]</code>.
+</description>
+<component-example [name]="'ex5'">
+    <fd-tab-filter-example></fd-tab-filter-example>
+</component-example>
+<code-example [exampleFiles]="filterMode"></code-example>
 
 <separator></separator>
 
@@ -16,37 +81,10 @@
     maintaining a flag. The second method requires setting a template reference variable and then calling the
     <code>selectTab(index)</code> method.
 </description>
-<component-example [name]="'ex2'">
+<component-example [name]="'ex6'">
     <fd-tab-selection-example></fd-tab-selection-example>
 </component-example>
 <code-example [exampleFiles]="tabSelection"></code-example>
-
-<separator></separator>
-
-<fd-docs-section-title [id]="'complexTabTitles'" [componentName]="'tabs'">
-    Complex Tab Titles
-</fd-docs-section-title>
-<description>
-    Use an ng-template with the <code>fd-tab-title</code> directive to access heavily customizable tab titles.
-</description>
-<component-example [name]="'ex3'">
-    <fd-complex-title-example></fd-complex-title-example>
-</component-example>
-<code-example [exampleFiles]="complexHeader"></code-example>
-
-<separator></separator>
-
-<fd-docs-section-title [id]="'tabNavigationMode'" [componentName]="'tabs'">
-    Tab Navigation Mode
-</fd-docs-section-title>
-<description>
-    It is possible to use the tabs in navigation mode. While there is no option to provide some content in this mode, it
-    does allow the use of a <code>router-outlet</code> with <code>[routerLink]</code> or <code>[href]</code> attributes.
-</description>
-<component-example [name]="'ex4'">
-    <fd-tabs-navigation-mode-example></fd-tabs-navigation-mode-example>
-</component-example>
-<code-example [exampleFiles]="navigationTab"></code-example>
 
 <separator></separator>
 
@@ -56,21 +94,28 @@
 <description>
     The tab component is very flexible, and supports dynamically adding or removing tabs.
 </description>
-<component-example [name]="'ex5'">
+<component-example [name]="'ex7'">
     <fd-adding-tab-example></fd-adding-tab-example>
 </component-example>
 <code-example [exampleFiles]="addingTab"></code-example>
 
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
-    <fd-tab-list>
-        <fd-tab [title]="data.properties.items.label" [disabled]="data.state.disabled">
-            {{ data.properties.panels.content }}
+    <fd-tab-list [mode]="data.properties.items.mode" [compact]="data.properties.items.compact">
+        <fd-tab [header]="data.properties.items.mode === 'filter'"
+                [title]="data.properties.item1.title"
+                [glyph]="data.properties.item1.icon"
+                [count]="data.properties.item1.counter">
+            {{ data.properties.item1.content }}
         </fd-tab>
-        <fd-tab [title]="data.properties.items.label2" [disabled]="data.state.disabled2">
-            {{ data.properties.panels.content2 }}
+        <fd-tab [title]="data.properties.item2.title2"
+                [glyph]="data.properties.item2.icon2"
+                [count]="data.properties.item2.counter2">
+            {{ data.properties.item2.content2 }}
         </fd-tab>
-        <fd-tab [title]="data.properties.items.label3" [disabled]="data.state.disabled3">
-            {{ data.properties.panels.content3 }}
+        <fd-tab [title]="data.properties.item3.title3"
+                [glyph]="data.properties.item3.icon3"
+                [count]="data.properties.item3.counter3">
+            {{ data.properties.item3.content3 }}
         </fd-tab>
     </fd-tab-list>
 </playground>

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.html
@@ -62,9 +62,10 @@
     Filter Mode
 </fd-docs-section-title>
 <description>
-    The Process Mode can be used by adding <code>[mode]="'process'"</code>. As on icons it has different structure than
+    The Filter Mode can be used by adding <code>[mode]="'filter'"</code>. It has different structure than
     tab any other mode. It can be built by setting properties, defining own template, or using it with
-    <code>[routerLink]</code>.
+    <code>[routerLink]</code>. To make filter Mode Tabs looks properly, it's mandatory to add <code>[header]="true"</code>
+    property to first tab item, or in case of custom template use different structure, as it is shown in example.
 </description>
 <component-example [name]="'ex5'">
     <fd-tab-filter-example></fd-tab-filter-example>

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.ts
@@ -19,9 +19,7 @@ import * as tabAddT from '!raw-loader!./examples/adding-tab-example/adding-tab-e
 import * as tabAddS from '!raw-loader!./examples/adding-tab-example/adding-tab-example.component.scss';
 import * as complexTabH from '!raw-loader!./examples/complex-title-example/complex-title-example.component.html';
 import * as complexTabHTsCode from '!raw-loader!./examples/complex-title-example/complex-title-example.component.ts';
-import * as navigationTab from '!raw-loader!./examples/tabs-navigation-mode-example.component.html';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
-import * as navigationTabTsCode from '!raw-loader!./examples/tab-navigation-mode-example-component.ts';
 import { Icons } from '../../../documentation/utilities/icons';
 
 @Component({

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.ts
@@ -144,17 +144,6 @@ export class TabsDocsComponent implements OnInit {
         }
     ];
 
-    counterTab: ExampleFile[] = [
-        {
-            language: 'html',
-            component: 'ComplexTitleExampleComponent',
-            code: complexTabH,
-            fileName: 'complex-title-example',
-            secondFile: 'complex-title-example',
-            typescriptFileCode: complexTabHTsCode
-        }
-    ];
-
     tabCounter: ExampleFile[] = [
         {
             language: 'html',

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.ts
@@ -16,6 +16,7 @@ import { ExampleFile } from '../../../documentation/core-helpers/code-example/ex
 import { DocsSectionTitleComponent } from '../../../documentation/core-helpers/docs-section-title/docs-section-title.component';
 import * as navigationTabTsCode from '!raw-loader!./examples/tab-navigation-mode-example-component.ts';
 import { ActivatedRoute } from '@angular/router';
+import { Icons } from '../../../documentation/utilities/icons';
 
 @Component({
     selector: 'app-tabs',
@@ -30,44 +31,68 @@ export class TabsDocsComponent implements OnInit {
                     items: {
                         type: 'object',
                         properties: {
-                            label: {
-                                type: 'string'
+                            mode: {
+                                type: 'string',
+                                enum: ['', 'icon-only', 'filter', 'process']
                             },
-                            label2: {
-                                type: 'string'
-                            },
-                            label3: {
-                                type: 'string'
+                            compact: {
+                                type: 'boolean'
                             }
                         }
                     },
-                    panels: {
+                    item1: {
                         type: 'object',
                         properties: {
+                            title: {
+                                type: 'string'
+                            },
+                            counter: {
+                                type: 'string'
+                            },
                             content: {
+                                type: 'string'
+                            },
+                            icon: {
+                                type: 'string',
+                                enum: Icons
+                            }
+                        }
+                    },
+                    item2: {
+                        type: 'object',
+                        properties: {
+                            title2: {
+                                type: 'string'
+                            },
+                            counter2: {
                                 type: 'string'
                             },
                             content2: {
                                 type: 'string'
                             },
-                            content3: {
-                                type: 'string'
+                            icon2: {
+                                type: 'string',
+                                enum: Icons
                             }
                         }
-                    }
-                }
-            },
-            state: {
-                type: 'object',
-                properties: {
-                    disabled: {
-                        type: 'boolean'
                     },
-                    disabled2: {
-                        type: 'boolean'
-                    },
-                    disabled3: {
-                        type: 'boolean'
+                    item3: {
+                        type: 'object',
+                        properties: {
+                            title3: {
+                                type: 'string'
+                            },
+                            counter3: {
+                                type: 'string'
+                            },
+                            content3: {
+                                type: 'string'
+                            },
+                            icon3: {
+                                type: 'string',
+                                enum: Icons
+                            }
+                        }
                     }
                 }
             }
@@ -80,19 +105,28 @@ export class TabsDocsComponent implements OnInit {
     data: any = {
         properties: {
             items: {
-                label: 'Link',
-                label2: 'Selected',
-                label3: 'Disabled'
+                mode: '',
+                compact: false
             },
-            panels: {
-                content: 'Content Link',
-                content2: 'Content Selected',
-                content3: 'Content Disabled'
-            }
+            item1: {
+                title: 'Title1',
+                counter: '1',
+                content: 'Content 1',
+                icon: 'menu'
+            },
+            item2: {
+                title2: 'Title2',
+                counter2: '2',
+                content2: 'Content 2',
+                icon2: 'menu'
+            },
+            item3: {
+                title3: 'Title3',
+                counter3: '3',
+                content3: 'Content 3',
+                icon3: 'menu'
+            },
         },
-        state: {
-            disabled3: 'true'
-        }
     };
 
     tabExample: ExampleFile[] = [

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-docs.component.ts
@@ -3,6 +3,14 @@ import { Schema } from '../../../schema/models/schema.model';
 import { SchemaFactoryService } from '../../../schema/services/schema-factory/schema-factory.service';
 
 import * as tabSrc from '!raw-loader!./examples/tabs-example.component.html';
+import * as tabCounter from '!raw-loader!./examples/tab-counter/tab-counter.component.html';
+import * as tabCounterTs from '!raw-loader!./examples/tab-counter/tab-counter.component.ts';
+import * as tabProcess from '!raw-loader!./examples/tab-process-example/tab-process-example.component.html';
+import * as tabProcessTs from '!raw-loader!./examples/tab-process-example/tab-process-example.component.ts';
+import * as tabIcon from '!raw-loader!./examples/tab-icon-only-example/tab-icon-only-example.component.html';
+import * as tabIconTs from '!raw-loader!./examples/tab-icon-only-example/tab-icon-only-example.component.ts';
+import * as tabFilter from '!raw-loader!./examples/tab-filter-example/tab-filter-example.component.html';
+import * as tabFilterTs from '!raw-loader!./examples/tab-filter-example/tab-filter-example.component.ts';
 import * as tabsTsCode from '!raw-loader!./examples/tabs-examples-component.ts';
 import * as tabSelectionSrc from '!raw-loader!./examples/tab-selection-example.component.html';
 import * as tabSelectionScss from '!raw-loader!./examples/tab-selection-example.component.scss';
@@ -13,9 +21,7 @@ import * as complexTabH from '!raw-loader!./examples/complex-title-example/compl
 import * as complexTabHTsCode from '!raw-loader!./examples/complex-title-example/complex-title-example.component.ts';
 import * as navigationTab from '!raw-loader!./examples/tabs-navigation-mode-example.component.html';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
-import { DocsSectionTitleComponent } from '../../../documentation/core-helpers/docs-section-title/docs-section-title.component';
 import * as navigationTabTsCode from '!raw-loader!./examples/tab-navigation-mode-example-component.ts';
-import { ActivatedRoute } from '@angular/router';
 import { Icons } from '../../../documentation/utilities/icons';
 
 @Component({
@@ -140,7 +146,7 @@ export class TabsDocsComponent implements OnInit {
         }
     ];
 
-    complexHeader: ExampleFile[] = [
+    counterTab: ExampleFile[] = [
         {
             language: 'html',
             component: 'ComplexTitleExampleComponent',
@@ -151,14 +157,47 @@ export class TabsDocsComponent implements OnInit {
         }
     ];
 
-    navigationTab: ExampleFile[] = [
+    tabCounter: ExampleFile[] = [
         {
             language: 'html',
-            component: 'TabsNavigationModeExampleComponent',
-            code: navigationTab,
-            fileName: 'tabs-navigation-mode-example',
-            secondFile: 'tabs-navigation-mode-example',
-            typescriptFileCode: navigationTabTsCode
+            component: 'TabCounterComponent',
+            code: tabCounter,
+            fileName: 'fd-tab-counter-example',
+            secondFile: 'fd-tab-counter-example',
+            typescriptFileCode: tabCounterTs
+        }
+    ];
+
+    tabProcess: ExampleFile[] = [
+        {
+            language: 'html',
+            component: 'TabProcessExampleComponent',
+            code: tabProcess,
+            fileName: 'fd-tab-process-example',
+            secondFile: 'fd-tab-process-example',
+            typescriptFileCode: tabProcessTs
+        }
+    ];
+
+    tabIcon: ExampleFile[] = [
+        {
+            language: 'html',
+            component: 'TabIconExampleComponent',
+            code: tabIcon,
+            fileName: 'fd-tab-icon-example',
+            secondFile: 'fd-tab-icon-example',
+            typescriptFileCode: tabIconTs
+        }
+    ];
+
+    tabFilter: ExampleFile[] = [
+        {
+            language: 'html',
+            component: 'TabFilterExampleComponent',
+            code: tabFilter,
+            fileName: 'fd-tab-filter-example',
+            secondFile: 'fd-tab-filter-example',
+            typescriptFileCode: tabFilterTs
         }
     ];
 

--- a/apps/docs/src/app/core/components.ts
+++ b/apps/docs/src/app/core/components.ts
@@ -404,6 +404,8 @@ import { TabSelectionExampleComponent } from './component-docs/tabs/examples/tab
 import { LinkExampleComponent } from './component-docs/link/examples/link-example.component';
 import { LinkDocsComponent } from './component-docs/link/link-docs.component';
 import { LinkHeaderComponent } from './component-docs/link/link-header/link-header.component';
+import { TabIconOnlyExampleComponent } from './component-docs/tabs/examples/tab-icon-only-example/tab-icon-only-example.component';
+import { TabProcessExampleComponent } from './component-docs/tabs/examples/tab-process-example/tab-process-example.component';
 
 export const declarations = [
     ActionBarDocsComponent,
@@ -489,6 +491,7 @@ export const declarations = [
     CalendarFormExamplesComponent,
     CalendarProgrammaticallyChangeExampleComponent,
     checkboxExampleComponents,
+    TabIconOnlyExampleComponent,
     DatePickerRangeExampleComponent,
     DatePickerSingleExampleComponent,
     DatePickerAllowNullExampleComponent,
@@ -761,6 +764,8 @@ export const declarations = [
     InputGroupStatesExampleComponent,
     DatePickerRangeDisabledExampleComponent,
     DatePickerDisableFuncExampleComponent,
+    TimeTwoDigitsExampleComponent,
+    TabProcessExampleComponent,
     TimeTwoDigitsExampleComponent,
     LinkExampleComponent,
     LinkDocsComponent,

--- a/apps/docs/src/app/core/components.ts
+++ b/apps/docs/src/app/core/components.ts
@@ -406,6 +406,8 @@ import { LinkDocsComponent } from './component-docs/link/link-docs.component';
 import { LinkHeaderComponent } from './component-docs/link/link-header/link-header.component';
 import { TabIconOnlyExampleComponent } from './component-docs/tabs/examples/tab-icon-only-example/tab-icon-only-example.component';
 import { TabProcessExampleComponent } from './component-docs/tabs/examples/tab-process-example/tab-process-example.component';
+import { TabFilterExampleComponent } from './component-docs/tabs/examples/tab-filter-example/tab-filter-example.component';
+import { TabCounterComponent } from './component-docs/tabs/examples/tab-counter/tab-counter.component';
 
 export const declarations = [
     ActionBarDocsComponent,
@@ -765,6 +767,9 @@ export const declarations = [
     DatePickerRangeDisabledExampleComponent,
     DatePickerDisableFuncExampleComponent,
     TimeTwoDigitsExampleComponent,
+    TabProcessExampleComponent,
+    TabFilterExampleComponent,
+    TabCounterComponent,
     TabProcessExampleComponent,
     TimeTwoDigitsExampleComponent,
     LinkExampleComponent,

--- a/apps/docs/src/app/core/core-documentation.module.ts
+++ b/apps/docs/src/app/core/core-documentation.module.ts
@@ -5,14 +5,10 @@ import { MarkdownModule } from 'ngx-markdown';
 import { ROUTES } from './core-documentation.routes';
 import { declarations, entryComponents } from './components';
 import { SharedDocumentationModule } from '../documentation/shared-documentation.module';
-import { TabFilterExampleComponent } from './component-docs/tabs/examples/tab-filter-example/tab-filter-example.component';
-import { TabCounterComponent } from './component-docs/tabs/examples/tab-counter/tab-counter.component';
 
 @NgModule({
     declarations: [
         declarations,
-        TabFilterExampleComponent,
-        TabCounterComponent,
     ],
 
     entryComponents: entryComponents,

--- a/apps/docs/src/app/core/core-documentation.module.ts
+++ b/apps/docs/src/app/core/core-documentation.module.ts
@@ -5,9 +5,15 @@ import { MarkdownModule } from 'ngx-markdown';
 import { ROUTES } from './core-documentation.routes';
 import { declarations, entryComponents } from './components';
 import { SharedDocumentationModule } from '../documentation/shared-documentation.module';
+import { TabFilterExampleComponent } from './component-docs/tabs/examples/tab-filter-example/tab-filter-example.component';
+import { TabCounterComponent } from './component-docs/tabs/examples/tab-counter/tab-counter.component';
 
 @NgModule({
-    declarations: declarations,
+    declarations: [
+        declarations,
+        TabFilterExampleComponent,
+        TabCounterComponent,
+    ],
 
     entryComponents: entryComponents,
     imports: [

--- a/apps/docs/src/app/documentation/core-helpers/code-example/code-example.component.scss
+++ b/apps/docs/src/app/documentation/core-helpers/code-example/code-example.component.scss
@@ -22,13 +22,6 @@
     width: 100%;
 }
 
-.fd-tabs__item {
-    padding: 0;
-    .fd-tabs__link {
-        padding: 16px;
-    }
-}
-
 code-example {
     ul.fd-tabs {
         margin-bottom: 0;

--- a/apps/docs/src/app/documentation/core-helpers/header-tabs/header-tabs.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/header-tabs/header-tabs.component.html
@@ -6,7 +6,7 @@
            [routerLink]="'./'"
            routerLinkActive
            #rla1="routerLinkActive">
-            Examples
+            <span fd-tab-tag>Examples</span>
         </a>
     </li>
     <li fd-tab-item>
@@ -15,7 +15,7 @@
            [routerLink]="'./api'"
            routerLinkActive
            #rla2="routerLinkActive">
-            API
+            <span fd-tab-tag>API</span>
         </a>
     </li>
 </ul>

--- a/apps/docs/src/app/schema/models/schema.model.ts
+++ b/apps/docs/src/app/schema/models/schema.model.ts
@@ -15,6 +15,6 @@ export interface Property {
     id?: string;
     type: string;
     items?: Property;
-    enum?: [any];
+    enum?: any[];
     properties?: Properties;
 }

--- a/apps/docs/src/styles.scss
+++ b/apps/docs/src/styles.scss
@@ -107,7 +107,6 @@ pre {
     ul {
         list-style: none;
         margin-left: 0;
-        padding-left: 0;
 
         a:hover {
             text-decoration: none;

--- a/libs/core/src/lib/alert/alert-service/alert.service.spec.ts
+++ b/libs/core/src/lib/alert/alert-service/alert.service.spec.ts
@@ -7,7 +7,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AlertContainerComponent } from '../alert-utils/alert-container.component';
 import { DynamicComponentService } from '../../utils/dynamic-component/dynamic-component.service';
 import { AlertRef } from '../alert-utils/alert-ref';
-import { ButtonModule } from '@fundamental-ngx/core';
+import { ButtonModule } from '../../button/button.module';
 
 @Component({
     template: `        

--- a/libs/core/src/lib/alert/alert.component.spec.ts
+++ b/libs/core/src/lib/alert/alert.component.spec.ts
@@ -8,7 +8,7 @@ import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { DynamicComponentService } from '../utils/dynamic-component/dynamic-component.service';
-import { ButtonModule } from '@fundamental-ngx/core';
+import { ButtonModule } from '../button/button.module';
 
 @Component({
     template: `        

--- a/libs/core/src/lib/popover/popover-body/popover-body-directives/popover-body-footer.directive.spec.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body-directives/popover-body-footer.directive.spec.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { PopoverModule } from '@fundamental-ngx/core';
+import { PopoverModule } from '../../popover.module';
 
 @Component({
     template: `

--- a/libs/core/src/lib/popover/popover-body/popover-body-directives/popover-body-header.directive.spec.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body-directives/popover-body-header.directive.spec.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { PopoverModule } from '@fundamental-ngx/core';
+import { PopoverModule } from '../../popover.module';
 
 @Component({
     template: `

--- a/libs/core/src/lib/popover/popover-body/popover-body-directives/popover-body-subheader.directive.spec.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body-directives/popover-body-subheader.directive.spec.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { PopoverModule } from '@fundamental-ngx/core';
+import { PopoverModule } from '../../popover.module';
 
 @Component({
     template: `

--- a/libs/core/src/lib/tabs/tab-item/tab-item.directive.spec.ts
+++ b/libs/core/src/lib/tabs/tab-item/tab-item.directive.spec.ts
@@ -1,8 +1,62 @@
 import { TabItemDirective } from './tab-item.directive';
+import { Component, ViewChild } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+@Component({
+    template: `
+        <li fd-tab-item #directiveElement>
+        </li>
+    `
+})
+class TestNestedContainerComponent {
+
+    @ViewChild('directiveElement', { static: true, read: TabItemDirective })
+    directiveElement: TabItemDirective;
+
+}
 
 describe('TabItemDirective', () => {
-  it('should create an instance', () => {
-    const directive = new TabItemDirective();
-    expect(directive).toBeTruthy();
-  });
-});
+    let component: TestNestedContainerComponent;
+    let directiveElement: TabItemDirective;
+    let fixture: ComponentFixture<TestNestedContainerComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestNestedContainerComponent, TabItemDirective],
+        })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestNestedContainerComponent);
+        component = fixture.componentInstance;
+        directiveElement = component.directiveElement;
+        fixture.detectChanges();
+    });
+
+
+    it('Should have good classes', () => {
+        directiveElement.header = true;
+        directiveElement.tabItemState = 'success';
+        directiveElement.buildComponentCssClass();
+        fixture.detectChanges();
+
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('fd-tabs__item')).toBeTruthy();
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('fd-tabs__item--header')).toBeTruthy();
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('fd-tabs__item--success')).toBeTruthy();
+
+    });
+
+
+    it('Should have good classes', () => {
+        directiveElement.header = false;
+        directiveElement.tabItemState = null;
+        directiveElement.buildComponentCssClass();
+        fixture.detectChanges();
+
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('fd-tabs__item')).toBeTruthy();
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('fd-tabs__item--header')).toBeFalsy();
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('fd-tabs__item--success')).toBeFalsy();
+
+    });
+})

--- a/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
+++ b/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
@@ -26,7 +26,8 @@ export type TabItemState = 'success' | 'error' | 'warning' | 'information' | 'ne
 export class TabItemDirective implements CssClassBuilder, OnInit {
 
     /** @hidden */
-    @ContentChild(TabLinkDirective, { static: false }) linkItem: TabLinkDirective;
+    @ContentChild(TabLinkDirective, { static: false })
+    linkItem: TabLinkDirective;
 
     private _class: string = '';
     @Input()

--- a/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
+++ b/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
@@ -1,5 +1,10 @@
-import { ContentChild, Directive } from '@angular/core';
+import { ContentChild, Directive, ElementRef, Input, OnInit } from '@angular/core';
 import { TabLinkDirective } from '../tab-link/tab-link.directive';
+import { applyCssClass, CssClassBuilder } from '../../utils/public_api';
+
+
+export type TabItemState = 'success' | 'error' | 'warning' | 'information' | 'neutral'
+
 /**
  * Tab Item is optional wrapper for Tab link
  *
@@ -18,8 +23,73 @@ import { TabLinkDirective } from '../tab-link/tab-link.directive';
         'class': 'fd-tabs__item'
     }
 })
-export class TabItemDirective {
+export class TabItemDirective implements CssClassBuilder, OnInit {
 
     /** @hidden */
     @ContentChild(TabLinkDirective, { static: false }) linkItem: TabLinkDirective;
+
+    private _class: string = '';
+    @Input()
+    set class(userClass: string) {
+        this._class = userClass;
+        this.buildComponentCssClass();
+    } // user's custom classes
+
+    /** Semantic type of the tab item */
+    private _tabItemState: TabItemState;
+    @Input()
+    set tabItemState(tabItemState: TabItemState) {
+        this._tabItemState = tabItemState;
+        this.buildComponentCssClass();
+    }
+
+    /** This should be used only on `filterMode`. Flag should be enable for first item */
+    private _header: boolean;
+    @Input()
+    set header(header: boolean) {
+        this._header = header;
+        this.buildComponentCssClass();
+    }
+
+    get header(): boolean {
+        return this._header;
+    }
+
+    /** Defines if there will be added fd-tabs__item class. Enabled by default. */
+    @Input()
+    fdTabItemClass: boolean = true;
+
+    /** @hidden */
+    constructor(
+        private _elementRef: ElementRef
+    ) {}
+
+    /** @hidden
+     * Function runs when component is initialized
+     * function should build component css class
+     */
+    ngOnInit(): void {
+        this.buildComponentCssClass();
+    }
+
+    @applyCssClass
+    /** CssClassBuilder interface implementation
+     * function must return single string
+     * function is responsible for order which css classes are applied
+     */
+    buildComponentCssClass(): string {
+        return [
+            this.fdTabItemClass ? 'fd-tabs__item' : '',
+            this._header ? 'fd-tabs__item--header' : '',
+            this._tabItemState ? `fd-tabs__item--${this._tabItemState}` : '',
+            this._class
+        ].filter(x => x !== '').join(' ');
+    }
+
+    /** HasElementRef interface implementation
+     * function used by applyCssClass and applyCssStyle decorators
+     */
+    elementRef(): ElementRef<any> {
+        return this._elementRef;
+    }
 }

--- a/libs/core/src/lib/tabs/tab-link/tab-link.directive.ts
+++ b/libs/core/src/lib/tabs/tab-link/tab-link.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostBinding, Input } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
 import { AbstractFdNgxClass } from '../../utils/abstract-fd-ngx-class';
 
 /**
@@ -33,6 +33,10 @@ export class TabLinkDirective extends AbstractFdNgxClass {
     @HostBinding('attr.aria-disabled')
     disabled: boolean;
 
+    /** Event Emitted always when, any keyboard event is dispatched on this element */
+    @Output()
+    readonly keyDown: EventEmitter<KeyboardEvent> = new EventEmitter<KeyboardEvent>();
+
     /** @hidden */
     _setProperties() {
         this._addClassToElement('fd-tabs__link');
@@ -44,6 +48,12 @@ export class TabLinkDirective extends AbstractFdNgxClass {
     /** @hidden */
     constructor(public elementRef: ElementRef) {
         super(elementRef);
+    }
+
+    /** @hidden */
+    @HostListener('keydown', ['$event'])
+    onKeyDown(e: KeyboardEvent) {
+        this.keyDown.emit(e);
     }
 
 }

--- a/libs/core/src/lib/tabs/tab-list.component.html
+++ b/libs/core/src/lib/tabs/tab-list.component.html
@@ -7,8 +7,8 @@
         <li fd-tab-item
             [header]="tab.header"
             [tabItemState]="tab.tabState">
-            <a #tabLink
-               fd-tab-link
+            <a fd-tab-link
+               #tabLink
                [active]="tab.expanded"
                [attr.tabindex]="0"
                [attr.aria-controls]="tab.id"

--- a/libs/core/src/lib/tabs/tab-list.component.html
+++ b/libs/core/src/lib/tabs/tab-list.component.html
@@ -1,24 +1,66 @@
 <ul class="fd-tabs"
+    [ngClass]="
+        (compact ? 'fd-tabs--compact ' : '') + (mode ? ( 'fd-tabs--' + mode ) : '') + (' fd-tabs--' + size)
+    "
     role="tablist">
-    <li fd-tab-item
-        *ngFor="let tab of panelTabs.toArray(); let i = index;">
-        <a #tabLink
-           fd-tab-link
-           [disabled]="tab.disabled"
-           [active]="tab.expanded"
-           [attr.tabindex]="tab.disabled ? -1 : 0"
-           [attr.aria-controls]="tab.id"
-           [attr.aria-label]="tab.ariaLabel || null"
-           [attr.aria-labelledby]="(!tab.ariaLabel && tab.ariaLabelledBy) ? tab.ariaLabelledBy : null"
-           (keydown)="tabHeaderKeyHandler(i, $event)"
-           (click)="tabHeaderClickHandler(i)">
+    <ng-container *ngFor="let tab of panelTabs.toArray(); let i = index;">
+        <li fd-tab-item
+            [header]="tab.header"
+            [tabItemState]="tab.tabState">
+            <a #tabLink
+               fd-tab-link
+               [active]="tab.expanded"
+               [attr.tabindex]="0"
+               [attr.aria-controls]="tab.id"
+               [attr.aria-label]="tab.ariaLabel || null"
+               [attr.aria-labelledby]="(!tab.ariaLabel && tab.ariaLabelledBy) ? tab.ariaLabelledBy : null"
+               (keydown)="tabHeaderKeyHandler(i, $event)"
+               (click)="tabHeaderClickHandler(i)">
 
-            <ng-container *ngIf="tab.titleTemplate">
-                <ng-container [fd-tab-load-title]="tab.titleTemplate"></ng-container>
-            </ng-container>
-            <ng-container *ngIf="!tab.titleTemplate">{{ tab.title }}</ng-container>
-        </a>
-    </li>
+                <ng-container *ngIf="tab.titleTemplate">
+                    <ng-container [fd-tab-load-title]="tab.titleTemplate"></ng-container>
+                </ng-container>
+
+                <ng-container *ngIf="!tab.titleTemplate" [ngSwitch]="mode">
+
+                    <ng-container *ngSwitchCase="'filter'">
+                        <span fd-tab-header *ngIf="tab.header">
+                            <span fd-tab-counter-header *ngIf="tab.count">{{tab.count}}</span>
+                            <span fd-tab-label *ngIf="tab.title">{{tab.title}}</span>
+                        </span>
+                        <ng-container *ngIf="!tab.header">
+                            <span fd-tab-icon [icon]="tab.glyph">
+                                <p fd-tab-count>{{tab.count}}</p>
+                            </span>
+                            <span fd-tab-label>{{tab.title}}</span>
+                        </ng-container>
+                    </ng-container>
+
+                    <ng-container *ngSwitchCase="'icon-only'">
+                        <span fd-tab-icon [icon]="tab.glyph">
+                            <p fd-tab-count>{{tab.count}}</p>
+                        </span>
+                    </ng-container>
+
+                    <ng-container *ngSwitchCase="'process'">
+                        <span fd-tab-icon *ngIf="tab.glyph" [icon]="tab.glyph"></span>
+                        <div fd-tab-process>
+                            <span fd-tab-label *ngIf="tab.count">{{tab.count}}</span>
+                            <span fd-tab-label *ngIf="tab.title">{{tab.title}}</span>
+                        </div>
+                    </ng-container>
+
+                    <ng-container *ngSwitchDefault>
+                        <p fd-tab-count *ngIf="tab.count">{{tab.count}}</p>
+                        <span fd-tab-tag>{{tab.title}}</span>
+                    </ng-container>
+                </ng-container>
+            </a>
+            <div fd-tab-process-icon *ngIf="mode === 'process' && i !== panelTabs.length - 1"></div>
+        </li>
+
+        <div *ngIf="tab.header" fd-tab-separator></div>
+    </ng-container>
 </ul>
 <ng-content select="fd-tab"></ng-content>
 <ng-content></ng-content>

--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -50,9 +50,10 @@ describe('TabListComponent', () => {
         expect(component.tabLinks.length).toBe(4);
     });
 
-    it('should handle tab select', () => {
+    it('should handle tab select', fakeAsync(() => {
         component.ngAfterViewInit();
-        component.selectedIndexChange.subscribe(id => expect(id).toBe(1));
         component.selectTab(1);
-    });
+        tick(1);
+        expect(component.selectedIndex).toBe(1);
+    }));
 });

--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -16,12 +16,14 @@ import { TabsModule } from './tabs.module';
     <fd-tab [title]="'Link'" id="tab3">
       Content Link Two
     </fd-tab>
-    <fd-tab [title]="'Disabled'" id="tab4">
+    <fd-tab [title]="'Disabled'" id="tab4" *ngIf="disabled">
       Disabled
     </fd-tab>
   </fd-tab-list>`
 })
-class TestWrapperComponent {}
+class TestWrapperComponent {
+    disabled: boolean = true;
+}
 
 describe('TabListComponent', () => {
     let component: TabListComponent;
@@ -49,4 +51,13 @@ describe('TabListComponent', () => {
         expect(component.selectedIndex).toBe(0);
         expect(component.tabLinks.length).toBe(4);
     });
+
+    it('should select tab', fakeAsync(() => {
+        component.ngAfterViewInit();
+        component.selectTab(3);
+
+        tick(10);
+        fixture.detectChanges();
+        expect(component.selectedIndex).toBe(3);
+    }));
 });

--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -16,13 +16,13 @@ import { TabsModule } from './tabs.module';
     <fd-tab [title]="'Link'" id="tab3">
       Content Link Two
     </fd-tab>
-    <fd-tab [title]="'Disabled'" id="tab4" *ngIf="disabled">
+    <fd-tab [title]="'Disabled'" id="tab4" *ngIf="showDisabled">
       Disabled
     </fd-tab>
   </fd-tab-list>`
 })
 class TestWrapperComponent {
-    disabled: boolean = true;
+    showDisabled: boolean = true;
 }
 
 describe('TabListComponent', () => {
@@ -59,5 +59,21 @@ describe('TabListComponent', () => {
         tick(10);
         fixture.detectChanges();
         expect(component.selectedIndex).toBe(3);
+    }));
+
+    it('should call reset tab', fakeAsync(() => {
+        spyOn((component as any), '_resetTabHook').and.callThrough();
+        component.ngAfterViewInit();
+        component.selectTab(3);
+
+        tick(10);
+        fixture.detectChanges();
+
+        fixture.componentInstance.showDisabled = false;
+        fixture.detectChanges();
+        tick(10);
+        fixture.detectChanges();
+        expect((component as any)._resetTabHook).toHaveBeenCalled();
+
     }));
 });

--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -10,13 +10,13 @@ import { TabsModule } from './tabs.module';
     <fd-tab [title]="'Link'" id="tab1">
       Content Link
     </fd-tab>
-    <fd-tab [title]="'Selected'" [disabled]="false" id="tab2">
+    <fd-tab [title]="'Selected'" id="tab2">
       Content Selected
     </fd-tab>
-    <fd-tab [title]="'Link'" [disabled]="false" id="tab3">
+    <fd-tab [title]="'Link'" id="tab3">
       Content Link Two
     </fd-tab>
-    <fd-tab [title]="'Disabled'" [disabled]="true" id="tab4">
+    <fd-tab [title]="'Disabled'" id="tab4">
       Disabled
     </fd-tab>
   </fd-tab-list>`

--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -49,11 +49,4 @@ describe('TabListComponent', () => {
         expect(component.selectedIndex).toBe(0);
         expect(component.tabLinks.length).toBe(4);
     });
-
-    it('should handle tab select', fakeAsync(() => {
-        component.ngAfterViewInit();
-        component.selectTab(1);
-        tick(1);
-        expect(component.selectedIndex).toBe(1);
-    }));
 });

--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -55,10 +55,4 @@ describe('TabListComponent', () => {
         component.selectedIndexChange.subscribe(id => expect(id).toBe(1));
         component.selectTab(1);
     });
-
-    it('should not select disabled tabs', () => {
-        component.ngAfterContentInit();
-        component.selectedIndexChange.subscribe(id => expect(id).toBe(0));
-        component.selectTab(3);
-    });
 });

--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -45,13 +45,13 @@ describe('TabListComponent', () => {
     });
 
     it('should handle ngAfterContentInit', () => {
-        component.ngAfterContentInit();
+        component.ngAfterViewInit();
         expect(component.selectedIndex).toBe(0);
         expect(component.tabLinks.length).toBe(4);
     });
 
     it('should handle tab select', () => {
-        component.ngAfterContentInit();
+        component.ngAfterViewInit();
         component.selectedIndexChange.subscribe(id => expect(id).toBe(1));
         component.selectTab(1);
     });

--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -76,4 +76,53 @@ describe('TabListComponent', () => {
         expect((component as any)._resetTabHook).toHaveBeenCalled();
 
     }));
+
+    it('should not call reset tab', fakeAsync(() => {
+        spyOn((component as any), '_resetTabHook').and.callThrough();
+        component.ngAfterViewInit();
+        component.selectTab(2);
+
+        tick(10);
+        fixture.detectChanges();
+
+        fixture.componentInstance.showDisabled = false;
+        fixture.detectChanges();
+        tick(10);
+        fixture.detectChanges();
+        expect((component as any)._resetTabHook).not.toHaveBeenCalled();
+
+    }));
+
+    it('should not select out of range tab', fakeAsync(() => {
+        component.ngAfterViewInit();
+        component.selectTab(1);
+
+        tick(10);
+        fixture.detectChanges();
+        expect(component.selectedIndex).toBe(1);
+
+        component.selectTab(7);
+
+        tick(10);
+        fixture.detectChanges();
+        expect(component.selectedIndex).toBe(1);
+    }));
+
+    it('should call select tab on service event', fakeAsync(() => {
+        component.ngAfterViewInit();
+        component.selectTab(1);
+
+        tick(10);
+        fixture.detectChanges();
+        expect(component.selectedIndex).toBe(1);
+
+        spyOn((component as any), 'selectTab').and.callThrough();
+
+        (component as any)._tabsService.tabSelected.next(2);
+
+        tick(10);
+        fixture.detectChanges();
+        expect(component.selectTab).toHaveBeenCalledWith(2);
+        expect(component.selectedIndex).toBe(2);
+    }));
 });

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -47,7 +47,7 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
     tabLinks: QueryList<ElementRef>;
 
     /** An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */
-    private readonly onDestroy$: Subject<void> = new Subject<void>();
+    private readonly _onDestroy$: Subject<void> = new Subject<void>();
 
     /** Index of the selected tab panel. */
     @Input()
@@ -72,10 +72,6 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
     @Output()
     selectedIndexChange = new EventEmitter<number>();
 
-    private _tabsSubscription: Subscription;
-    private _tabSelectSubscription: Subscription;
-    private _tabsPropertySubscription: Subscription;
-
     constructor(
         private _tabsService: TabsService,
         private _changeRef: ChangeDetectorRef
@@ -85,32 +81,32 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
     ngAfterViewInit(): void {
         this.selectTab(this.selectedIndex);
 
-        this._tabSelectSubscription = this._tabsService.tabSelected
+        this._tabsService.tabSelected
             .pipe(
-                takeUntil(this.onDestroy$),
+                takeUntil(this._onDestroy$),
                 filter(index => index !== this.selectedIndex)
             )
             .subscribe(index => this.selectTab(index))
         ;
 
-        this._tabsSubscription = this.panelTabs.changes
+        this.panelTabs.changes
             .pipe(
-                takeUntil(this.onDestroy$),
+                takeUntil(this._onDestroy$),
                 filter(() => !this._isIndexInRange(this.selectedIndex) || this._isAnyTabExpanded())
             )
             .subscribe(() => this._resetTabHook())
         ;
 
-        this._tabsPropertySubscription = merge(this._tabsService.tabPanelPropertyChanged, this.panelTabs.changes)
-            .pipe(takeUntil(this.onDestroy$))
+        merge(this._tabsService.tabPanelPropertyChanged, this.panelTabs.changes)
+            .pipe(takeUntil(this._onDestroy$))
             .subscribe(() => this._changeRef.detectChanges())
         ;
     }
 
     /** @hidden */
     ngOnDestroy(): void {
-        this.onDestroy$.next();
-        this.onDestroy$.complete();
+        this._onDestroy$.next();
+        this._onDestroy$.complete();
     }
 
     /** @hidden */

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -80,27 +80,9 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
     /** @hidden */
     ngAfterViewInit(): void {
         this.selectTab(this.selectedIndex);
-
-        this._tabsService.tabSelected
-            .pipe(
-                takeUntil(this._onDestroy$),
-                filter(index => index !== this.selectedIndex)
-            )
-            .subscribe(index => this.selectTab(index))
-        ;
-
-        this.panelTabs.changes
-            .pipe(
-                takeUntil(this._onDestroy$),
-                filter(() => !this._isIndexInRange(this.selectedIndex) || this._isAnyTabExpanded())
-            )
-            .subscribe(() => this._resetTabHook())
-        ;
-
-        merge(this._tabsService.tabPanelPropertyChanged, this.panelTabs.changes)
-            .pipe(takeUntil(this._onDestroy$))
-            .subscribe(() => this._changeRef.detectChanges())
-        ;
+        this._listenOnTabSelect();
+        this._listenOnContentQueryListChange();
+        this._listenOnPropertiesChange();
     }
 
     /** @hidden */
@@ -143,6 +125,40 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
     /** @hidden */
     tabHeaderKeyHandler(index: number, event: any): void {
         this._tabsService.tabHeaderKeyHandler(index, event, this.tabLinks.map(tab => tab.nativeElement));
+    }
+
+    /** @hidden */
+    private _listenOnTabSelect(): void {
+        this._tabsService.tabSelected
+            .pipe(
+                takeUntil(this._onDestroy$),
+                filter(index => index !== this.selectedIndex)
+            )
+            .subscribe(index => this.selectTab(index))
+        ;
+    }
+
+    /**
+     * @hidden
+     * Every time any of query is changed, ex. tab is removed or added
+     * reference to keydown subscriptions handler is renewed
+     */
+    private _listenOnContentQueryListChange(): void {
+        this.panelTabs.changes
+            .pipe(
+                takeUntil(this._onDestroy$),
+                filter(() => !this._isIndexInRange(this.selectedIndex) || this._isAnyTabExpanded())
+            )
+            .subscribe(() => this._resetTabHook())
+        ;
+    }
+
+    /** @hidden */
+    private _listenOnPropertiesChange(): void {
+        merge(this._tabsService.tabPanelPropertyChanged, this.panelTabs.changes)
+            .pipe(takeUntil(this._onDestroy$))
+            .subscribe(() => this._changeRef.detectChanges())
+        ;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -17,6 +17,10 @@ import { TabPanelComponent } from './tab/tab-panel.component';
 import { Subscription } from 'rxjs';
 import { TabsService } from './tabs.service';
 
+export type TabModes = 'icon-only' | 'process' | 'filter'
+
+export type TabSizes = 's' | 'm' | 'l' | 'xl' | 'xxl';
+
 /**
  * Represents a list of tab-panels.
  */
@@ -43,6 +47,21 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
     /** Index of the selected tab panel. */
     @Input()
     selectedIndex: number = 0;
+
+    /** Whether user wants to use tab component in compact mode */
+    @Input()
+    compact: boolean = false;
+
+    /** TODO */
+    @Input()
+    size: TabSizes = 'm';
+
+    /**
+     * Whether user wants to use tab component in certain mode. Modes available:
+     * 'icon-only' | 'process' | 'filter'
+     */
+    @Input()
+    mode: TabModes;
 
     /** Event emitted when the selected panel changes. */
     @Output()
@@ -94,7 +113,7 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
      * @param tabIndex Index of the tab to select.
      */
     selectTab(tabIndex: number): void {
-       if (this.isIndexInRange() && this.isTargetTabEnabled(tabIndex)) {
+       if (this.isIndexInRange()) {
             this.panelTabs.forEach((tab, index) => {
                 tab.expanded = index === tabIndex;
             });
@@ -117,10 +136,6 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
 
     private isIndexInRange(): boolean {
         return this.panelTabs && this.panelTabs.length > 0 && this.selectedIndex < this.panelTabs.length;
-    }
-
-    private isTargetTabEnabled(index: number): boolean {
-        return !this.panelTabs.toArray()[index].disabled;
     }
 
     private isTabContentEmpty(): boolean {

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -52,7 +52,7 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
     @Input()
     compact: boolean = false;
 
-    /** TODO */
+    /** Size of tab, it's mostly about adding spacing on tab container, available sizes 's' | 'm' | 'l' | 'xl' | 'xxl' */
     @Input()
     size: TabSizes = 'm';
 
@@ -71,8 +71,10 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
     private _tabSelectSubscription: Subscription;
 
     constructor(
-        private tabsService: TabsService
-    ) {}
+        private _tabsService: TabsService,
+        private _changeRef: ChangeDetectorRef
+    ) {
+    }
 
     /** @hidden */
     ngAfterContentInit(): void {
@@ -80,15 +82,15 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
             this.selectTab(this.selectedIndex);
         });
 
-        this._tabSelectSubscription = this.tabsService.tabSelected.subscribe(index => {
+        this._tabSelectSubscription = this._tabsService.tabSelected.subscribe(index => {
             if (index !== this.selectedIndex) {
                 this.selectTab(index);
             }
         });
 
         this._tabsSubscription = this.panelTabs.changes.subscribe(() => {
-            if (!this.isIndexInRange() || this.isTabContentEmpty()) {
-                this.resetTabHook();
+            if (!this._isIndexInRange() || this._isTabContentEmpty()) {
+                this._resetTabHook();
             }
         });
     }
@@ -113,11 +115,12 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
      * @param tabIndex Index of the tab to select.
      */
     selectTab(tabIndex: number): void {
-       if (this.isIndexInRange()) {
+        if (this._isIndexInRange()) {
             this.panelTabs.forEach((tab, index) => {
                 tab.expanded = index === tabIndex;
             });
             this.selectedIndex = tabIndex;
+            this._changeRef.detectChanges();
             this.selectedIndexChange.emit(tabIndex);
         }
     }
@@ -131,14 +134,14 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
 
     /** @hidden */
     tabHeaderKeyHandler(index: number, event: any): void {
-        this.tabsService.tabHeaderKeyHandler(index, event, this.tabLinks.map(tab => tab.nativeElement));
+        this._tabsService.tabHeaderKeyHandler(index, event, this.tabLinks.map(tab => tab.nativeElement));
     }
 
-    private isIndexInRange(): boolean {
+    private _isIndexInRange(): boolean {
         return this.panelTabs && this.panelTabs.length > 0 && this.selectedIndex < this.panelTabs.length;
     }
 
-    private isTabContentEmpty(): boolean {
+    private _isTabContentEmpty(): boolean {
         let result = true;
         this.panelTabs.forEach(tab => {
             if (tab.expanded) {
@@ -148,7 +151,7 @@ export class TabListComponent implements AfterContentInit, OnChanges, OnDestroy 
         return result;
     }
 
-    private resetTabHook(): void {
+    private _resetTabHook(): void {
         this.selectedIndex = 0;
         setTimeout(() => {
             this.selectTab(this.selectedIndex);

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -149,14 +149,17 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
         this._tabsService.tabHeaderKeyHandler(index, event, this.tabLinks.map(tab => tab.nativeElement));
     }
 
+    /** @hidden */
     private _isIndexInRange(index: number): boolean {
         return this.panelTabs && this.panelTabs.length > 0 && index < this.panelTabs.length;
     }
 
+    /** @hidden */
     private _isAnyTabExpanded(): boolean {
         return !this.panelTabs.some(tab => tab.expanded);
     }
 
+    /** @hidden */
     private _resetTabHook(): void {
         this.selectTab(0);
     }

--- a/libs/core/src/lib/tabs/tab-nav/tab-nav.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-nav/tab-nav.component.spec.ts
@@ -1,7 +1,8 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Component, ViewChild } from '@angular/core';
 import { TabsModule } from '../tabs.module';
 import { TabNavComponent } from './tab-nav.component';
+import { TabLinkDirective } from '../tab-link/tab-link.directive';
 
 
 @Component({
@@ -16,11 +17,17 @@ import { TabNavComponent } from './tab-nav.component';
             </div>
             <div fd-tab-item>
                 <a fd-tab-link
+                   #fdTabLink
                    [active]="false">
                     Link
                 </a>
             </div>
             <a fd-tab-link
+               [active]="false">
+                Link
+            </a>
+            <a fd-tab-link
+               *ngIf="showLastTab"
                [active]="false">
                 Link
             </a>
@@ -30,6 +37,12 @@ import { TabNavComponent } from './tab-nav.component';
 class TestNavWrapperComponent {
     @ViewChild(TabNavComponent, { static: false })
     tabNavDirective: TabNavComponent;
+
+    @ViewChild('fdTabLink', { static: false, read: TabLinkDirective })
+    tabLink: TabLinkDirective;
+
+    showLastTab: boolean = true;
+
 }
 
 describe('TabNavDirective', () => {
@@ -55,6 +68,48 @@ describe('TabNavDirective', () => {
 
     it('should handle ngAfterContentInit', () => {
         fixture.componentInstance.tabNavDirective.ngAfterContentInit();
-        expect(fixture.componentInstance.tabNavDirective.tabLinks.length).toBe(3);
+        expect(fixture.componentInstance.tabNavDirective.tabLinks.length).toBe(4);
     });
+
+    it('should react on query list change', fakeAsync(() => {
+        fixture.componentInstance.tabNavDirective.ngAfterContentInit();
+
+        spyOn((component as any), '_refreshSubscription').and.callThrough();
+
+        fixture.componentInstance.showLastTab = false;
+
+        tick(10);
+        fixture.detectChanges();
+
+        expect((component as any)._refreshSubscription).toHaveBeenCalled();
+    }));
+
+    it('should react on keydown', fakeAsync(() => {
+        fixture.componentInstance.tabNavDirective.ngAfterContentInit();
+
+        spyOn(component, 'selectTab').and.callThrough();
+
+        fixture.componentInstance.tabLink.keyDown.emit(<any>{ key: 'ArrowRight', preventDefault: () => {} });
+        fixture.componentInstance.tabLink.keyDown.emit(<any>{ key: 'Enter', preventDefault: () => {} });
+
+        tick(10);
+        fixture.detectChanges();
+
+        expect(component.selectTab).toHaveBeenCalledWith(3);
+    }));
+
+    it('should call select tab on service event', fakeAsync(() => {
+        component.ngAfterContentInit();
+        component.selectTab(1);
+
+        tick(10);
+        fixture.detectChanges();
+        spyOn((component as any), 'selectTab').and.callThrough();
+
+        (component as any)._tabsService.tabSelected.next(2);
+
+        tick(10);
+        fixture.detectChanges();
+        expect(component.selectTab).toHaveBeenCalledWith(2);
+    }));
 });

--- a/libs/core/src/lib/tabs/tab-nav/tab-nav.component.ts
+++ b/libs/core/src/lib/tabs/tab-nav/tab-nav.component.ts
@@ -16,32 +16,6 @@ import { Subscription } from 'rxjs';
 import { TabModes, TabSizes } from '../tab-list.component';
 import { applyCssClass, CssClassBuilder } from '../../utils/public_api';
 
-
-/**
- * Tab Nav for only navigation mode when you want for example use router-outlet
- *
- * ```html
- *<nav fd-tab-nav>
- *  <div fd-tab-item>
- *      <a fd-tab-link
- *      [active]="true">
- *          Link
- *      </a>
- *  </div>
- *  <div fd-tab-item>
- *      <a fd-tab-link
- *      [active]="false">
- *          Link
- *      </a>
- *  </div>
- *  <a fd-tab-link
- *  [active]="false">
- *      Link
- *  </a>
- * </nav>
- * ```
- */
-
 @Component({
     // tslint:disable-next-line:component-selector
     selector: '[fd-tab-nav]',
@@ -78,7 +52,7 @@ export class TabNavComponent implements AfterContentInit, OnDestroy, CssClassBui
     }
 
     private _size: TabSizes = 'm';
-    /***/
+    /** Size of tab, it's mostly about adding spacing on tab container, available sizes 's' | 'm' | 'l' | 'xl' | 'xxl' */
     @Input()
     set size(size: TabSizes) {
         this._size = size;

--- a/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
+++ b/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
@@ -1,4 +1,5 @@
-import { Directive, EmbeddedViewRef, Input, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Directive, ElementRef, EmbeddedViewRef, HostBinding, Input, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
+import { applyCssClass, CssClassBuilder } from '../../utils/public_api';
 
 /**
  * Directive used to identify the template which will populate the tab header.
@@ -16,10 +17,9 @@ import { Directive, EmbeddedViewRef, Input, OnInit, TemplateRef, ViewContainerRe
 @Directive({
     // TODO to be discussed
     // tslint:disable-next-line:directive-selector
-    selector: '[fd-tab-title]'
+    selector: '[fd-tab-title-template]'
 })
-export class TabTitleDirective {
-}
+export class TabTitleDirective {}
 
 /**
  * Not for external use. Portal to render the complex title template.
@@ -41,4 +41,155 @@ export class TabLoadTitleDirective implements OnInit {
         this.viewRef.clear();
         this.contentRef = this.viewRef.createEmbeddedView(this.content);
     }
+}
+
+
+/**
+ * Directive for counter element, available in most of modes on `tab` component
+ */
+@Directive({
+    // TODO to be discussed
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-tab-count]'
+})
+export class TabCountDirective {
+    /** @hidden */
+    @HostBinding('class.fd-tabs__count')
+    fdTabsCountClass: boolean = true;
+}
+
+
+/**
+ * Directive for icon element, available in most of modes on `tab` component
+ */
+@Directive({
+    // TODO to be discussed
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-tab-icon]'
+})
+export class TabIconDirective implements CssClassBuilder, OnInit {
+    private _class: string = '';
+    @Input() set class(userClass: string) {
+        this._class = userClass;
+        this.buildComponentCssClass();
+    } // user's custom classes
+
+    /** Defines if there will be added fd-tabs-icon class. Enabled by default. */
+    fdTabIconClass: boolean = true;
+
+    /**
+     * The icon to include inside the element
+     * See the icon page for the list of icons.
+     */
+    private _icon: string;
+    @Input() set icon(icon: string) {
+        this._icon = icon;
+        this.buildComponentCssClass();
+    };
+
+    /** @hidden */
+    constructor(
+        private _elementRef: ElementRef
+    ) {}
+
+    /** @hidden
+     * Function runs when component is initialized
+     * function should build component css class
+     * function should build css style
+     */
+    ngOnInit(): void {
+        this.buildComponentCssClass();
+    }
+
+    @applyCssClass
+    /** CssClassBuilder interface implementation
+     * function must return single string
+     * function is responsible for order which css classes are applied
+     */
+    buildComponentCssClass(): string {
+        return [
+            this.fdTabIconClass ? 'fd-tabs__icon' : '',
+            this._icon ? `sap-icon--${this._icon}` : '',
+            this._class
+        ].filter(x => x !== '').join(' ');
+    }
+
+    /** HasElementRef interface implementation
+     * function used by applyCssClass and applyCssStyle decorators
+     */
+    elementRef(): ElementRef<any> {
+        return this._elementRef;
+    }
+}
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-tab-tag]',
+    host: {
+        'class': 'fd-tabs__tag'
+    }
+})
+export class TabTagDirective {
+}
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-tab-label]',
+    host: {
+        'class': 'fd-tabs__label'
+    }
+})
+export class TabLabelDirective {
+}
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-tab-process]',
+    host: {
+        'class': 'fd-tabs__process'
+    }
+})
+export class TabProcessDirective {
+}
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-tab-header]',
+    host: {
+        'class': 'fd-tabs__header'
+    }
+})
+export class TabHeaderDirective {
+}
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-tab-counter-header]',
+    host: {
+        'class': 'fd-tabs__counter-header'
+    }
+})
+export class TabCounterHeaderDirective {
+}
+
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-tab-process-icon]',
+    host: {
+        'class': 'fd-tabs__process-icon'
+    }
+})
+export class TabProcessIconDirective {
+}
+
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-tab-separator]',
+    host: {
+        'class': 'fd-tabs__separator'
+    }
+})
+export class TabSeparator {
 }

--- a/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
+++ b/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
@@ -35,11 +35,11 @@ export class TabLoadTitleDirective implements OnInit {
 
     private contentRef: EmbeddedViewRef<any>;
 
-    constructor(private viewRef: ViewContainerRef) {}
+    constructor(private _viewRef: ViewContainerRef) {}
 
     ngOnInit(): void {
-        this.viewRef.clear();
-        this.contentRef = this.viewRef.createEmbeddedView(this.content);
+        this._viewRef.clear();
+        this.contentRef = this._viewRef.createEmbeddedView(this.content);
     }
 }
 
@@ -191,5 +191,5 @@ export class TabProcessIconDirective {
         'class': 'fd-tabs__separator'
     }
 })
-export class TabSeparator {
+export class TabSeparatorDirective {
 }

--- a/libs/core/src/lib/tabs/tab-utils/tab-icon.directive.spec.ts
+++ b/libs/core/src/lib/tabs/tab-utils/tab-icon.directive.spec.ts
@@ -1,0 +1,59 @@
+import { Component, ViewChild } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TabIconDirective } from './tab-directives';
+
+@Component({
+    template: `
+        <li fd-tab-icon #directiveElement>
+        </li>
+    `
+})
+class TestNestedContainerComponent {
+
+    @ViewChild('directiveElement', { static: true, read: TabIconDirective })
+    directiveElement: TabIconDirective;
+
+}
+
+describe('TabIconDirective', () => {
+    let component: TestNestedContainerComponent;
+    let directiveElement: TabIconDirective;
+    let fixture: ComponentFixture<TestNestedContainerComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestNestedContainerComponent, TabIconDirective],
+        })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestNestedContainerComponent);
+        component = fixture.componentInstance;
+        directiveElement = component.directiveElement;
+        fixture.detectChanges();
+    });
+
+
+    it('Should have good classes', () => {
+        directiveElement.icon = 'menu';
+        directiveElement.buildComponentCssClass();
+        fixture.detectChanges();
+
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('fd-tabs__icon')).toBeTruthy();
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('sap-icon--menu')).toBeTruthy();
+    });
+
+    it('Should be able to change icon', () => {
+
+
+        directiveElement.icon = 'edit';
+        directiveElement.buildComponentCssClass();
+        fixture.detectChanges();
+
+
+        directiveElement.icon = 'menu';
+        directiveElement.buildComponentCssClass();
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('sap-icon--menu')).toBeTruthy();
+    });
+})

--- a/libs/core/src/lib/tabs/tab/tab-panel.component.ts
+++ b/libs/core/src/lib/tabs/tab/tab-panel.component.ts
@@ -1,6 +1,17 @@
-import { Component, ContentChild, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    ContentChild,
+    Input,
+    OnChanges, Optional,
+    TemplateRef,
+    ViewEncapsulation
+} from '@angular/core';
 import { TabTitleDirective } from '../tab-utils/tab-directives';
 import { TabItemState } from '../tab-item/tab-item.directive';
+import { TabsService } from '../tabs.service';
 
 let tabPanelUniqueId: number = 0;
 
@@ -17,9 +28,10 @@ let tabPanelUniqueId: number = 0;
         '[attr.aria-expanded]': 'expanded ? true : null',
         '[class.is-expanded]': 'expanded'
     },
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TabPanelComponent {
+export class TabPanelComponent implements OnChanges {
 
     /** @hidden */
     @ContentChild(TabTitleDirective, { read: TemplateRef, static: false })
@@ -29,8 +41,10 @@ export class TabPanelComponent {
     @Input()
     id: string = 'fd-tab-panel' + tabPanelUniqueId++;
 
-    /** @hidden */
-    expanded = false;
+    /** @hidden
+     * Flag to inform if body for this tab should be displayed
+     */
+    expanded: boolean = false;
 
     /** @hidden */
     index: number;
@@ -59,7 +73,30 @@ export class TabPanelComponent {
     @Input()
     header: boolean = false;
 
-    /** */
+    /** Semantic type of the tab item */
     @Input()
-    tabState: TabItemState
+    tabState: TabItemState;
+
+    /** @hidden */
+    constructor(
+        private _changeDetRef: ChangeDetectorRef,
+        @Optional() private _tabsService: TabsService
+    ) {}
+
+    /** @hidden
+     * Thanks to OnPush change strategy detection on tab-list parent component,
+     * every change of any property should be reported.
+     */
+    public ngOnChanges(): void {
+        if (this._tabsService) {
+            this._tabsService.tabPanelPropertyChanged.next();
+        }
+    }
+
+    /** @hidden
+     * Method to change the state of expanded flag */
+    triggerExpandedPanel(expanded: boolean): void {
+        this.expanded = expanded;
+        this._changeDetRef.detectChanges();
+    }
 }

--- a/libs/core/src/lib/tabs/tab/tab-panel.component.ts
+++ b/libs/core/src/lib/tabs/tab/tab-panel.component.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component, ContentChild, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, ContentChild, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { TabTitleDirective } from '../tab-utils/tab-directives';
+import { TabItemState } from '../tab-item/tab-item.directive';
 
 let tabPanelUniqueId: number = 0;
 
@@ -24,22 +25,6 @@ export class TabPanelComponent {
     @ContentChild(TabTitleDirective, { read: TemplateRef, static: false })
     titleTemplate: TemplateRef<any>;
 
-    /** The title of the tab header. */
-    @Input()
-    title: string;
-
-    /** Aria-label of the tab. Also applied to the tab header. */
-    @Input()
-    ariaLabel: string;
-
-    /** Id of the element that labels the tab. Also applied to the tab header. */
-    @Input()
-    ariaLabelledBy: string;
-
-    /** Whether the tab is disabled. */
-    @Input()
-    disabled: boolean;
-
     /** Id of the tab. If none is provided, one will be generated. */
     @Input()
     id: string = 'fd-tab-panel' + tabPanelUniqueId++;
@@ -49,4 +34,32 @@ export class TabPanelComponent {
 
     /** @hidden */
     index: number;
+
+    /** Aria-label of the tab. Also applied to the tab header. */
+    @Input()
+    ariaLabel: string;
+
+    /** Id of the element that labels the tab. Also applied to the tab header. */
+    @Input()
+    ariaLabelledBy: string;
+
+    /** The title of tab, depending on mode used, it will be placed in different position */
+    @Input()
+    title: string;
+
+    /** The count of tab, depending on mode used, it will be placed in different position */
+    @Input()
+    count: string;
+
+    /** Glyph icon, it can be used only on  */
+    @Input()
+    glyph: string;
+
+    /** Glyph icon, it can be used only on  */
+    @Input()
+    header: boolean = false;
+
+    /** */
+    @Input()
+    tabState: TabItemState
 }

--- a/libs/core/src/lib/tabs/tabs.module.ts
+++ b/libs/core/src/lib/tabs/tabs.module.ts
@@ -4,7 +4,14 @@ import { CommonModule } from '@angular/common';
 import { TabPanelComponent } from './tab/tab-panel.component';
 import { TabListComponent } from './tab-list.component';
 
-import { TabLoadTitleDirective, TabTitleDirective } from './tab-utils/tab-directives';
+import {
+    TabCountDirective,
+    TabCounterHeaderDirective, TabHeaderDirective,
+    TabIconDirective, TabLabelDirective,
+    TabLoadTitleDirective, TabProcessDirective, TabProcessIconDirective, TabSeparator,
+    TabTagDirective,
+    TabTitleDirective
+} from './tab-utils/tab-directives';
 import { TabNavComponent } from './tab-nav/tab-nav.component';
 import { TabLinkDirective } from './tab-link/tab-link.directive';
 import { TabItemDirective } from './tab-item/tab-item.directive';
@@ -17,7 +24,16 @@ import { TabItemDirective } from './tab-item/tab-item.directive';
         TabLoadTitleDirective,
         TabNavComponent,
         TabLinkDirective,
-        TabItemDirective
+        TabItemDirective,
+        TabTagDirective,
+        TabIconDirective,
+        TabCountDirective,
+        TabLabelDirective,
+        TabProcessDirective,
+        TabHeaderDirective,
+        TabCounterHeaderDirective,
+        TabProcessIconDirective,
+        TabSeparator
     ],
     imports: [
         CommonModule
@@ -29,7 +45,16 @@ import { TabItemDirective } from './tab-item/tab-item.directive';
         TabLoadTitleDirective,
         TabNavComponent,
         TabItemDirective,
-        TabLinkDirective
+        TabLinkDirective,
+        TabTagDirective,
+        TabIconDirective,
+        TabCountDirective,
+        TabLabelDirective,
+        TabProcessDirective,
+        TabHeaderDirective,
+        TabCounterHeaderDirective,
+        TabProcessIconDirective,
+        TabSeparator
     ]
 })
 export class TabsModule {}

--- a/libs/core/src/lib/tabs/tabs.module.ts
+++ b/libs/core/src/lib/tabs/tabs.module.ts
@@ -8,7 +8,7 @@ import {
     TabCountDirective,
     TabCounterHeaderDirective, TabHeaderDirective,
     TabIconDirective, TabLabelDirective,
-    TabLoadTitleDirective, TabProcessDirective, TabProcessIconDirective, TabSeparator,
+    TabLoadTitleDirective, TabProcessDirective, TabProcessIconDirective, TabSeparatorDirective,
     TabTagDirective,
     TabTitleDirective
 } from './tab-utils/tab-directives';
@@ -33,7 +33,7 @@ import { TabItemDirective } from './tab-item/tab-item.directive';
         TabHeaderDirective,
         TabCounterHeaderDirective,
         TabProcessIconDirective,
-        TabSeparator
+        TabSeparatorDirective
     ],
     imports: [
         CommonModule
@@ -54,7 +54,7 @@ import { TabItemDirective } from './tab-item/tab-item.directive';
         TabHeaderDirective,
         TabCounterHeaderDirective,
         TabProcessIconDirective,
-        TabSeparator
+        TabSeparatorDirective
     ]
 })
 export class TabsModule {}

--- a/libs/core/src/lib/tabs/tabs.service.ts
+++ b/libs/core/src/lib/tabs/tabs.service.ts
@@ -17,17 +17,17 @@ export class TabsService {
         switch (event.key) {
             case ('ArrowLeft'): {
                 if (index - 1 >= 0) {
-                    this.getTabLinkFromIndex(index - 1, elements).focus();
+                    this._getTabLinkFromIndex(index - 1, elements).focus();
                 } else {
-                    this.getTabLinkFromIndex(elements.length - 1, elements).focus();
+                    this._getTabLinkFromIndex(elements.length - 1, elements).focus();
                 }
                 break;
             }
             case ('ArrowRight'): {
                 if (index + 1 < elements.length) {
-                    this.getTabLinkFromIndex(index + 1, elements).focus();
+                    this._getTabLinkFromIndex(index + 1, elements).focus();
                 } else {
-                    this.getTabLinkFromIndex(0, elements).focus();
+                    this._getTabLinkFromIndex(0, elements).focus();
                 }
                 break;
             }
@@ -43,7 +43,7 @@ export class TabsService {
     }
 
     /** @hidden */
-    private getTabLinkFromIndex(index: number, elements: HTMLElement[]): HTMLElement {
+    private _getTabLinkFromIndex(index: number, elements: HTMLElement[]): HTMLElement {
         return elements[index];
     }
 }

--- a/libs/core/src/lib/tabs/tabs.service.ts
+++ b/libs/core/src/lib/tabs/tabs.service.ts
@@ -7,7 +7,10 @@ import { Subject } from 'rxjs';
 export class TabsService {
 
     /** Event is thrown always when tab is selected by keyboard actions */
-    public tabSelected = new Subject<number>();
+    readonly tabSelected: Subject<number> = new Subject<number>();
+
+    /** Event is thrown always, when some property is changed */
+    readonly tabPanelPropertyChanged: Subject<void> = new Subject<void>();
 
     /** @hidden */
     tabHeaderKeyHandler(index: number, event: any, elements: HTMLElement[]): void {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/1844
#### Please provide a brief summary of this pull request.
0.5.0 styles tabs adaptation, it came with a lot of new tab modes
`Added 3 new modes for tab component process, filter, icon-only, which can be enabled by passing [mode]="name of mode into fd-tab-list or fd-tab-nav.`
Also there is new compact mode.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

