### PR TITLE
docs: use link component in list example

### DIFF
--- a/apps/docs/src/app/core/component-docs/list/examples/list-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-example.component.html
@@ -1,9 +1,9 @@
 <ul fd-list>
     <li fd-list-item>
-        <a [routerLink]="['./']" fd-link>List item Link 1</a>
+        <a [href]="'#'" fd-link>List item Link 1</a>
     </li>
     <li fd-list-item>
-        <a [routerLink]="['./']" fd-link>List item Link 2</a>
+        <a [href]="'#'" fd-link>List item Link 2</a>
     </li>
     <li fd-list-item>List item 3</li>
     <li fd-list-item>List item 4</li>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-example.component.html
@@ -1,9 +1,9 @@
 <ul fd-list>
     <li fd-list-item>
-        <a [href]="'#'" fd-link>List item Link 1</a>
+        <a [href]="'#'" fd-link>List item with link 1</a>
     </li>
     <li fd-list-item>
-        <a [href]="'#'" fd-link>List item Link 2</a>
+        <a [href]="'#'" fd-link>List item with link 2</a>
     </li>
     <li fd-list-item>List item 3</li>
     <li fd-list-item>List item 4</li>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-example.component.html
@@ -1,10 +1,10 @@
 <ul fd-list>
     <li fd-list-item>
-        <a href="#">List item 1</a>
+        <a [routerLink]="['./']" fd-link>List item Link 1</a>
     </li>
-    <li fd-list-item>List item 2</li>
     <li fd-list-item>
-        <a href="#">List item 3</a>
+        <a [routerLink]="['./']" fd-link>List item Link 2</a>
     </li>
+    <li fd-list-item>List item 3</li>
     <li fd-list-item>List item 4</li>
 </ul>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
[defect hunting](https://github.com/SAP/fundamental-ngx/issues/1967)
#### Please provide a brief summary of this pull request.
Fix the link to be a fiori/fundamentals link for styling. It is completely normal that it is blue since it is a link but at least now if it has been visited or whatever, it will be attributed to a fundamental link and not a normal anchor tag. Changing the wording in the documentation will help clarify this to users
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

