### PR TITLE
docs: fix the time-picker example title and removed messages from localization editor

### DIFF
--- a/apps/docs/src/app/core/component-docs/localization-editor/examples/localization-editor-forms-example.component.html
+++ b/apps/docs/src/app/core/component-docs/localization-editor/examples/localization-editor-forms-example.component.html
@@ -21,7 +21,6 @@
                 </fd-localization-editor-item>
             </li>
         </fd-localization-editor>
-        <fd-form-message [type]="'information'">More information</fd-form-message>
         <br/>
     </div>
 </form>

--- a/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-no-seconds-example.component.html
+++ b/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-no-seconds-example.component.html
@@ -1,4 +1,3 @@
-<fd-time-picker [displaySeconds]="false"
-                [(ngModel)]="timePickerNoSecondsObject"></fd-time-picker>
+<fd-time-picker [displaySeconds]="false" [(ngModel)]="timePickerNoSecondsObject"></fd-time-picker>
 <br />
-Selected Time: {{timePickerNoSecondsObject.hour}}h {{timePickerNoSecondsObject.minute}}m {{timePickerNoSecondsObject.second}}s
+Selected Time: {{timePickerNoSecondsObject.hour}}h {{timePickerNoSecondsObject.minute}}m

--- a/apps/docs/src/app/core/component-docs/time-picker/time-picker-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/time-picker/time-picker-docs.component.html
@@ -21,7 +21,7 @@
 <separator></separator>
 
 <fd-docs-section-title [id]="'timePickerWithoutSpinners'" [componentName]="'time'">
-    Time Picker Without Spinners
+    Time Picker Without Seconds
 </fd-docs-section-title>
 <description>Use <code>[displaySeconds]=false</code> to turn off seconds for the time picker.</description>
 <component-example [name]="'ex3'">
@@ -34,8 +34,7 @@
 <fd-docs-section-title [id]="'timePickerWithoutMinutesSeconds'" [componentName]="'time'">
     Time Picker Without Minutes and Seconds
 </fd-docs-section-title>
-<description
-    >Use <code>[displaySeconds]="false"</code>, <code>[displayMinutes]="false"</code> or
+<description>Use <code>[displaySeconds]="false"</code>, <code>[displayMinutes]="false"</code> or
     <code>[displayHours]="false"</code>
     to turn off seconds, minutes or hours for the time picker. At least one of them should be enabled.
 </description>
@@ -71,8 +70,8 @@
 <fd-docs-section-title [id]="'null'" [componentName]="'time'">
     Null Validity
 </fd-docs-section-title>
-<description
-    >Null input values are considered valid by default. Use <code>[allowNull]="false"</code> to make them invalid.
+<description>Null input values are considered valid by default. Use <code>[allowNull]="false"</code> to make them
+    invalid.
 </description>
 <component-example [name]="'ex7'">
     <fd-time-picker-allow-null-example></fd-time-picker-allow-null-example>


### PR DESCRIPTION

#### Please provide a link to the associated issue.
part of [1967](https://github.com/SAP/fundamental-ngx/issues/1967)
#### Please provide a brief summary of this pull request.
- fixed the typo in the Time Picker example
- removed the form message from the Localization editor example

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

