### PR TITLE
fix: Change select loader positioning to absolute center

### DIFF
--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -10,7 +10,7 @@
         <ng-container *ngIf="triggerTemplate">
             <ng-container *ngTemplateOutlet="triggerTemplate; context: {$implicit: this}"></ng-container>
         </ng-container>
-        <div *ngIf="!triggerTemplate" [ngClass]="{ loading: loading }">
+        <div *ngIf="!triggerTemplate">
             <button class="fd-select-button-custom fd-button"
                     aria-haspopup="true"
                     [attr.aria-expanded]="isOpen"

--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -127,10 +127,7 @@
 
 fd-busy-indicator {
     position: absolute;
-}
-
-.loading {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Part of #1967

#### Please provide a brief summary of this pull request.

Centering children with `position: absolute` using flex-box doesn't work on IE11.
Flex-box centering has been replaced with absolute centering.

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples