### PR TITLE
docs: Replace Object.values by Object.keys in examples

### DIFF
--- a/apps/docs/src/app/core/component-docs/checkbox/examples/checkbox-reactive-forms-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/checkbox/examples/checkbox-reactive-forms-example.component.ts
@@ -49,7 +49,7 @@ export class CheckboxReactiveFormsExampleComponent implements OnInit {
 
     private setControlOnAgreementsChange(): void {
         this.registrationForm.get('agreements').valueChanges.pipe(
-            map(agreements => Object.values(agreements)),
+            map(agreements => this.getValuesFromObject(agreements)),
             map((agreementsValues: boolean[]) => {
                 const agreeAll = agreementsValues.reduce((overall, value) => value && overall, true);
                 const declineAll = agreementsValues.reduce((overall, value) => !value && overall, true);
@@ -62,6 +62,11 @@ export class CheckboxReactiveFormsExampleComponent implements OnInit {
                 }
             })
         ).subscribe(acceptAllValue => this.registrationForm.get('acceptAll').setValue(acceptAllValue, {emitEvent: false}))
+    }
+
+    // This is equivalent for `Object.values` not supported by IE11
+    private getValuesFromObject(obj: Object): any[] {
+        return Object.keys(obj).map(e => obj[e]);
     }
 }
 


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
There is removed `Object.values` method usage on examples, cause it's not supported by IE11
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

