### PR TITLE
fix: modal center, restore missing entryComponent

### DIFF
--- a/apps/docs/src/app/core/components.ts
+++ b/apps/docs/src/app/core/components.ts
@@ -794,5 +794,6 @@ export const entryComponents = [
     ModalInModalComponent,
     ModalInModalSecondComponent,
     AlertContentComponent,
-    NotificationContentComponent
+    NotificationContentComponent,
+    ModalInModalFirstComponent
 ]

--- a/libs/core/src/lib/modal/modal.component.scss
+++ b/libs/core/src/lib/modal/modal.component.scss
@@ -4,7 +4,6 @@
 .fd-modal-custom {
     max-width: none;
     z-index: 1000;
-    position: absolute;
     max-height: 100vh;
 
     &:focus {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Detect Hunting
#### Please provide a brief summary of this pull request.
There was unnecessary `position: absolute` on `fd-modal-custom`. For IE11 it caused some problems with centering the modal inside `flex` container.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

