### PR TITLE
chore: disabled ivy on netlify till  angular 9

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -55,7 +55,8 @@
                             }]
                         },
                         "production-unoptimized": {
-                            "fileReplacements": [{
+                            "tsConfig":"apps/docs/tsconfig.netlify.json",
+			    "fileReplacements": [{
                                 "replace": "apps/docs/src/environments/environment.ts",
                                 "with": "apps/docs/src/environments/environment.prod.ts"
                             }],

--- a/angular.json
+++ b/angular.json
@@ -56,7 +56,7 @@
                         },
                         "production-unoptimized": {
                             "tsConfig":"apps/docs/tsconfig.netlify.json",
-			    "fileReplacements": [{
+			                      "fileReplacements": [{
                                 "replace": "apps/docs/src/environments/environment.ts",
                                 "with": "apps/docs/src/environments/environment.prod.ts"
                             }],

--- a/apps/docs/tsconfig.netlify.json
+++ b/apps/docs/tsconfig.netlify.json
@@ -1,0 +1,19 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
+        "outDir": "../../dist/out-tsc/apps/docs",
+        "types": [
+            "node"
+        ]
+    },
+    "exclude": [
+        "src/test.ts",
+        "**/*.spec.ts",
+        "**/*.stories.ts"
+    ],
+    "angularCompilerOptions": {
+        "enableIvy": false
+    },
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #1907

#### Please provide a brief summary of this pull request.

Ivy renderer has been disabled becaue it it throws error in IE 11
related to https://github.com/angular/angular/issues/30569

## Before:
![image](https://user-images.githubusercontent.com/10849982/74741590-63525e00-525d-11ea-9c19-da5ed7dd9837.png)

## After:
![image](https://user-images.githubusercontent.com/10849982/74741537-4ae24380-525d-11ea-8e4c-f7d01c39b75a.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
