### PR TITLE
fix: pagination RTL idea

### DIFF
--- a/libs/core/src/lib/pagination/pagination-reverse.pipe.ts
+++ b/libs/core/src/lib/pagination/pagination-reverse.pipe.ts
@@ -1,9 +1,0 @@
-import { Pipe, PipeTransform } from '@angular/core';
-
-
-@Pipe({ name: 'paginationReverse' })
-export class PaginationReversePipe implements PipeTransform {
-    transform(value) {
-        return value.slice().reverse();
-    }
-}

--- a/libs/core/src/lib/pagination/pagination-reverse.pipe.ts
+++ b/libs/core/src/lib/pagination/pagination-reverse.pipe.ts
@@ -1,0 +1,9 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+
+@Pipe({ name: 'paginationReverse' })
+export class PaginationReversePipe implements PipeTransform {
+    transform(value) {
+        return value.slice().reverse();
+    }
+}

--- a/libs/core/src/lib/pagination/pagination.component.html
+++ b/libs/core/src/lib/pagination/pagination.component.html
@@ -1,6 +1,6 @@
-<span class="fd-pagination__total" [ngClass]="customClasses" *ngIf="displayTotalItems && totalItems"
-    >{{ totalItems }} {{ displayText }}</span
->
+<span class="fd-pagination__total" [ngClass]="customClasses" *ngIf="displayTotalItems && totalItems">
+    {{ totalItems }} {{ displayText }}
+</span>
 <nav class="fd-pagination__nav" *ngIf="totalItems && totalItems >= itemsPerPage">
     <a
         class="fd-pagination__link fd-pagination__link--previous"
@@ -9,8 +9,7 @@
         [attr.aria-label]="previousLabel"
         [attr.aria-disabled]="currentPage === 1 ? true : null"
         (keypress)="onKeypressHandler(currentPage - 1, $event)"
-        (click)="goToPage(currentPage - 1)"
-    >
+        (click)="goToPage(currentPage - 1)">
     </a>
     <div dir="ltr" class="fd-pagination-direction-override-display">
         <ng-container *ngFor="let page of pages$ | async">
@@ -21,9 +20,9 @@
                 (keypress)="onKeypressHandler(page, $event)"
                 (click)="goToPage(page, $event)"
                 *ngIf="page !== -1; else more"
-                [attr.aria-selected]="currentPage === page"
-                >{{ page }}</a
-            >
+                [attr.aria-selected]="currentPage === page">
+                    {{ page }}
+            </a>
         </ng-container>
     </div>
     <a
@@ -33,8 +32,7 @@
         role="button"
         [attr.aria-disabled]="isLastPage$ | async"
         (keypress)="onKeypressHandler(currentPage + 1, $event)"
-        (click)="goToPage(currentPage + 1)"
-    >
+        (click)="goToPage(currentPage + 1)">
     </a>
 </nav>
 

--- a/libs/core/src/lib/pagination/pagination.component.html
+++ b/libs/core/src/lib/pagination/pagination.component.html
@@ -1,4 +1,5 @@
-<span class="fd-pagination__total" *ngIf="displayTotalItems && totalItems">{{ totalItems }} {{displayText}}</span>
+<span class="fd-pagination__total" [ngClass]="{'fd-pagination__total--rtl': rtl$.getValue() === true}"
+      *ngIf="displayTotalItems && totalItems">{{ totalItems }} {{displayText}}</span>
 <nav class="fd-pagination__nav" *ngIf="totalItems && totalItems >= itemsPerPage">
     <a class="fd-pagination__link fd-pagination__link--previous"
        tabindex="0"
@@ -8,21 +9,30 @@
        (keypress)="onKeypressHandler(currentPage - 1, $event)"
        (click)="goToPage(currentPage - 1)">
     </a>
-    <ng-container *ngFor="let page of pages">
-        <a class="fd-pagination__link"
-           tabindex="0"
-           role="button"
-           (keypress)="onKeypressHandler(page, $event)"
-           (click)="goToPage(page, $event)"
-           *ngIf="page !== -1; else more"
-           [attr.aria-selected]="currentPage === page">{{page}}</a>
-        <ng-template #more>
-            <span class="fd-pagination__link fd-pagination__link--more"
-                  aria-hidden="true"
-                  aria-label="..."
-                  role="presentation"></span>
-        </ng-template>
-    </ng-container>
+    <div dir="ltr" class="fd-pagination-direction-override-display">
+        <ng-container *ngIf="rtl$.getValue() === false">
+            <ng-container *ngFor="let page of pages">
+                <a class="fd-pagination__link"
+                   tabindex="0"
+                   role="button"
+                   (keypress)="onKeypressHandler(page, $event)"
+                   (click)="goToPage(page, $event)"
+                   *ngIf="page !== -1; else more"
+                   [attr.aria-selected]="currentPage === page">{{page}}</a>
+            </ng-container>
+        </ng-container>
+        <ng-container *ngIf="rtl$.getValue() === true">
+            <ng-container *ngFor="let page of pages.slice().reverse()">
+                <a class="fd-pagination__link"
+                   tabindex="0"
+                   role="button"
+                   (keypress)="onKeypressHandler(page, $event)"
+                   (click)="goToPage(page, $event)"
+                   *ngIf="page !== -1; else more"
+                   [attr.aria-selected]="currentPage === page">{{page}}</a>
+            </ng-container>
+        </ng-container>
+    </div>
     <a class="fd-pagination__link fd-pagination__link--next"
        [attr.aria-label]="nextLabel"
        tabindex="0"
@@ -32,3 +42,10 @@
        (click)="goToPage(currentPage + 1)">
     </a>
 </nav>
+
+<ng-template #more>
+    <span class="fd-pagination__link fd-pagination__link--more"
+          aria-hidden="true"
+          aria-label="..."
+          role="presentation"></span>
+</ng-template>

--- a/libs/core/src/lib/pagination/pagination.component.html
+++ b/libs/core/src/lib/pagination/pagination.component.html
@@ -1,38 +1,48 @@
-<span class="fd-pagination__total" [ngClass]="{'fd-pagination__total--rtl': rtl$.getValue() === true}"
-      *ngIf="displayTotalItems && totalItems">{{ totalItems }} {{displayText}}</span>
+<span class="fd-pagination__total" [ngClass]="customClasses" *ngIf="displayTotalItems && totalItems"
+    >{{ totalItems }} {{ displayText }}</span
+>
 <nav class="fd-pagination__nav" *ngIf="totalItems && totalItems >= itemsPerPage">
-    <a class="fd-pagination__link fd-pagination__link--previous"
-       tabindex="0"
-       role="button"
-       [attr.aria-label]="previousLabel"
-       [attr.aria-disabled]="currentPage === 1 ? true : null"
-       (keypress)="onKeypressHandler(currentPage - 1, $event)"
-       (click)="goToPage(currentPage - 1)">
+    <a
+        class="fd-pagination__link fd-pagination__link--previous"
+        tabindex="0"
+        role="button"
+        [attr.aria-label]="previousLabel"
+        [attr.aria-disabled]="currentPage === 1 ? true : null"
+        (keypress)="onKeypressHandler(currentPage - 1, $event)"
+        (click)="goToPage(currentPage - 1)"
+    >
     </a>
     <div dir="ltr" class="fd-pagination-direction-override-display">
-        <ng-container *ngFor="let page of (rtl$.getValue() === true ? (pages | paginationReverse) : pages)">
-            <a class="fd-pagination__link"
-               tabindex="0"
-               role="button"
-               (keypress)="onKeypressHandler(page, $event)"
-               (click)="goToPage(page, $event)"
-               *ngIf="page !== -1; else more"
-               [attr.aria-selected]="currentPage === page">{{page}}</a>
+        <ng-container *ngFor="let page of pages$ | async">
+            <a
+                class="fd-pagination__link"
+                tabindex="0"
+                role="button"
+                (keypress)="onKeypressHandler(page, $event)"
+                (click)="goToPage(page, $event)"
+                *ngIf="page !== -1; else more"
+                [attr.aria-selected]="currentPage === page"
+                >{{ page }}</a
+            >
         </ng-container>
     </div>
-    <a class="fd-pagination__link fd-pagination__link--next"
-       [attr.aria-label]="nextLabel"
-       tabindex="0"
-       role="button"
-       [attr.aria-disabled]="isLastPage()"
-       (keypress)="onKeypressHandler(currentPage + 1, $event)"
-       (click)="goToPage(currentPage + 1)">
+    <a
+        class="fd-pagination__link fd-pagination__link--next"
+        [attr.aria-label]="nextLabel"
+        tabindex="0"
+        role="button"
+        [attr.aria-disabled]="isLastPage$ | async"
+        (keypress)="onKeypressHandler(currentPage + 1, $event)"
+        (click)="goToPage(currentPage + 1)"
+    >
     </a>
 </nav>
 
 <ng-template #more>
-    <span class="fd-pagination__link fd-pagination__link--more"
-          aria-hidden="true"
-          aria-label="..."
-          role="presentation"></span>
+    <span
+        class="fd-pagination__link fd-pagination__link--more"
+        aria-hidden="true"
+        aria-label="..."
+        role="presentation"
+    ></span>
 </ng-template>

--- a/libs/core/src/lib/pagination/pagination.component.html
+++ b/libs/core/src/lib/pagination/pagination.component.html
@@ -10,27 +10,14 @@
        (click)="goToPage(currentPage - 1)">
     </a>
     <div dir="ltr" class="fd-pagination-direction-override-display">
-        <ng-container *ngIf="rtl$.getValue() === false">
-            <ng-container *ngFor="let page of pages">
-                <a class="fd-pagination__link"
-                   tabindex="0"
-                   role="button"
-                   (keypress)="onKeypressHandler(page, $event)"
-                   (click)="goToPage(page, $event)"
-                   *ngIf="page !== -1; else more"
-                   [attr.aria-selected]="currentPage === page">{{page}}</a>
-            </ng-container>
-        </ng-container>
-        <ng-container *ngIf="rtl$.getValue() === true">
-            <ng-container *ngFor="let page of pages.slice().reverse()">
-                <a class="fd-pagination__link"
-                   tabindex="0"
-                   role="button"
-                   (keypress)="onKeypressHandler(page, $event)"
-                   (click)="goToPage(page, $event)"
-                   *ngIf="page !== -1; else more"
-                   [attr.aria-selected]="currentPage === page">{{page}}</a>
-            </ng-container>
+        <ng-container *ngFor="let page of (rtl$.getValue() === true ? (pages | paginationReverse) : pages)">
+            <a class="fd-pagination__link"
+               tabindex="0"
+               role="button"
+               (keypress)="onKeypressHandler(page, $event)"
+               (click)="goToPage(page, $event)"
+               *ngIf="page !== -1; else more"
+               [attr.aria-selected]="currentPage === page">{{page}}</a>
         </ng-container>
     </div>
     <a class="fd-pagination__link fd-pagination__link--next"

--- a/libs/core/src/lib/pagination/pagination.component.scss
+++ b/libs/core/src/lib/pagination/pagination.component.scss
@@ -1,1 +1,10 @@
 @import "~fundamental-styles/dist/pagination";
+
+.fd-pagination-direction-override-display {
+    display: inline-block;
+}
+
+.fd-pagination__total--rtl {
+    margin-right: 0;
+    margin-left: 8px;
+}

--- a/libs/core/src/lib/pagination/pagination.component.spec.ts
+++ b/libs/core/src/lib/pagination/pagination.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { PaginationComponent } from './pagination.component';
 import { PaginationService } from './pagination.service';
-import { PaginationReversePipe } from './pagination-reverse.pipe';
 
 describe('Pagination Test', () => {
     let component: PaginationComponent;
@@ -12,7 +11,7 @@ describe('Pagination Test', () => {
         const paginationSpy = jasmine.createSpyObj('PaginationService', ['getTotalPages', 'getPages']);
 
         TestBed.configureTestingModule({
-            declarations: [PaginationComponent, PaginationReversePipe],
+            declarations: [PaginationComponent],
             providers: [
                 { provide: PaginationService, useValue: paginationSpy }
             ]
@@ -56,7 +55,7 @@ describe('Pagination Test', () => {
     it('should get the pagination object for the service', () => {
         const retVal = component.getPaginationObject();
 
-        expect(retVal).toEqual({totalItems: 3, currentPage: 1, itemsPerPage: 2});
+        expect(retVal).toEqual({ totalItems: 3, currentPage: 1, itemsPerPage: 2 });
     });
 
 });

--- a/libs/core/src/lib/pagination/pagination.component.spec.ts
+++ b/libs/core/src/lib/pagination/pagination.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { PaginationComponent } from './pagination.component';
 import { PaginationService } from './pagination.service';
+import { PaginationReversePipe } from './pagination-reverse.pipe';
 
 describe('Pagination Test', () => {
     let component: PaginationComponent;
@@ -11,7 +12,7 @@ describe('Pagination Test', () => {
         const paginationSpy = jasmine.createSpyObj('PaginationService', ['getTotalPages', 'getPages']);
 
         TestBed.configureTestingModule({
-            declarations: [PaginationComponent],
+            declarations: [PaginationComponent, PaginationReversePipe],
             providers: [
                 { provide: PaginationService, useValue: paginationSpy }
             ]

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -1,14 +1,16 @@
 import {
-    ChangeDetectionStrategy,
+    ChangeDetectionStrategy, ChangeDetectorRef,
     Component,
     EventEmitter,
     Input,
-    OnChanges,
+    OnChanges, OnInit, Optional,
     Output,
     SimpleChanges,
     ViewEncapsulation
 } from '@angular/core';
 import { PaginationService } from './pagination.service';
+import { RtlService } from '@fundamental-ngx/core';
+import { BehaviorSubject } from 'rxjs';
 
 /**
  * The component that is used to provide navigation between paged information.
@@ -36,7 +38,7 @@ import { PaginationService } from './pagination.service';
     styleUrls: ['./pagination.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PaginationComponent implements OnChanges {
+export class PaginationComponent implements OnChanges, OnInit {
     /** Represents the total number of items. */
     @Input()
     totalItems: number;
@@ -76,7 +78,11 @@ export class PaginationComponent implements OnChanges {
     pages: number[];
 
     /** @hidden */
-    constructor(private paginationService: PaginationService) {}
+    rtl$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+    /** @hidden */
+    constructor(private paginationService: PaginationService, @Optional() private rtlService: RtlService,
+                private changeDetectionRef: ChangeDetectorRef) {}
 
     /** @hidden */
     ngOnChanges(changes: SimpleChanges) {
@@ -89,6 +95,17 @@ export class PaginationComponent implements OnChanges {
             this.currentPage = 1;
         } else if (this.currentPage > totalPages) {
             this.currentPage = totalPages;
+        }
+    }
+
+    /** @hidden */
+    ngOnInit(): void {
+        if (this.rtlService) {
+            this.rtlService.rtl.subscribe(value => {
+                this.rtl$.next(value);
+                this.pages = this.paginationService.getPages(this.getPaginationObject());
+                this.changeDetectionRef.detectChanges();
+            })
         }
     }
 

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -1,17 +1,19 @@
 import {
-    ChangeDetectionStrategy, ChangeDetectorRef,
+    ChangeDetectionStrategy,
     Component,
     EventEmitter,
     Input,
-    OnChanges, OnInit, Optional,
+    OnChanges,
+    OnInit,
+    Optional,
     Output,
     SimpleChanges,
     ViewEncapsulation
 } from '@angular/core';
 import { PaginationService } from './pagination.service';
 import { RtlService } from '../utils/services/rtl.service';
-import { BehaviorSubject, Observable, from } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
+import { Pagination } from './pagination.model';
 
 /**
  * The component that is used to provide navigation between paged information.
@@ -86,7 +88,7 @@ export class PaginationComponent implements OnChanges, OnInit {
     /** @hidden */
     pages$: BehaviorSubject<number[]> = new BehaviorSubject([]);
 
-    isLastPage$: BehaviorSubject<boolean> = new BehaviorSubject(this.isLastPage)
+    isLastPage$: BehaviorSubject<boolean> = new BehaviorSubject(this._isLastPage);
 
     /** @hidden */
     constructor(private paginationService: PaginationService, @Optional() private rtlService: RtlService) { }
@@ -97,7 +99,7 @@ export class PaginationComponent implements OnChanges, OnInit {
             this.currentPage = changes.currentPage.currentValue;
         }
 
-        this.refreshPages();
+        this._refreshPages();
 
         const totalPages = this.paginationService.getTotalPages(this.getPaginationObject());
         if (!this.currentPage || this.currentPage < 1) {
@@ -106,7 +108,7 @@ export class PaginationComponent implements OnChanges, OnInit {
             this.currentPage = totalPages;
         }
 
-        this.isLastPage$.next(this.isLastPage);
+        this.isLastPage$.next(this._isLastPage);
     }
 
     /** @hidden */
@@ -114,7 +116,7 @@ export class PaginationComponent implements OnChanges, OnInit {
         if (this.rtlService) {
             this.rtlService.rtl.subscribe(value => {
                 this.rtl = value;
-                this.refreshPages();
+                this._refreshPages();
             })
         }
     }
@@ -144,7 +146,7 @@ export class PaginationComponent implements OnChanges, OnInit {
             return;
         }
 
-        this.refreshPages();
+        this._refreshPages();
 
         this.pageChangeStart.emit(page);
     }
@@ -153,7 +155,7 @@ export class PaginationComponent implements OnChanges, OnInit {
      * Retrieves an object that represents
      * the total number of items, the current page, and the number of items per page.
      */
-    getPaginationObject() {
+    getPaginationObject(): Pagination {
         return {
             totalItems: this.totalItems,
             currentPage: this.currentPage,
@@ -162,14 +164,14 @@ export class PaginationComponent implements OnChanges, OnInit {
     }
 
     /** @hidden */
-    private refreshPages() {
+    private _refreshPages(): void {
         let pages = this.paginationService.getPages(this.getPaginationObject());
         pages = this.rtl ? pages.slice().reverse() : pages;
         this.pages$.next(pages);
     }
 
     /** @hidden */
-    private get isLastPage(): boolean {
+    private get _isLastPage(): boolean {
         return this.currentPage === this.paginationService.getTotalPages(this.getPaginationObject());
     }
 }

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -161,12 +161,14 @@ export class PaginationComponent implements OnChanges, OnInit {
         };
     }
 
+    /** @hidden */
     private refreshPages() {
         let pages = this.paginationService.getPages(this.getPaginationObject());
         pages = this.rtl ? pages.slice().reverse() : pages;
         this.pages$.next(pages);
     }
 
+    /** @hidden */
     private get isLastPage(): boolean {
         return this.currentPage === this.paginationService.getTotalPages(this.getPaginationObject());
     }

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -171,4 +171,3 @@ export class PaginationComponent implements OnChanges, OnInit {
         return this.currentPage === this.paginationService.getTotalPages(this.getPaginationObject());
     }
 }
-

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -157,3 +157,4 @@ export class PaginationComponent implements OnChanges, OnInit {
         return retVal;
     }
 }
+

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -9,7 +9,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { PaginationService } from './pagination.service';
-import { RtlService } from '@fundamental-ngx/core';
+import { RtlService } from '../utils/services/rtl.service';
 import { BehaviorSubject } from 'rxjs';
 
 /**

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -153,7 +153,7 @@ export class PaginationComponent implements OnChanges, OnInit {
      * Retrieves an object that represents
      * the total number of items, the current page, and the number of items per page.
      */
-    private getPaginationObject() {
+    getPaginationObject() {
         return {
             totalItems: this.totalItems,
             currentPage: this.currentPage,

--- a/libs/core/src/lib/pagination/pagination.module.ts
+++ b/libs/core/src/lib/pagination/pagination.module.ts
@@ -5,11 +5,12 @@ import { PaginationComponent } from './pagination.component';
 import { ButtonModule } from '../button/button.module';
 import { IconModule } from '../icon/icon.module';
 import { PaginationService } from './pagination.service';
+import { PaginationReversePipe } from './pagination-reverse.pipe';
 
 @NgModule({
-    declarations: [PaginationComponent],
+    declarations: [PaginationComponent, PaginationReversePipe],
     imports: [CommonModule, ButtonModule, IconModule],
     providers: [PaginationService],
-    exports: [PaginationComponent]
+    exports: [PaginationComponent, PaginationReversePipe]
 })
 export class PaginationModule {}

--- a/libs/core/src/lib/pagination/pagination.module.ts
+++ b/libs/core/src/lib/pagination/pagination.module.ts
@@ -5,12 +5,11 @@ import { PaginationComponent } from './pagination.component';
 import { ButtonModule } from '../button/button.module';
 import { IconModule } from '../icon/icon.module';
 import { PaginationService } from './pagination.service';
-import { PaginationReversePipe } from './pagination-reverse.pipe';
 
 @NgModule({
-    declarations: [PaginationComponent, PaginationReversePipe],
+    declarations: [PaginationComponent],
     imports: [CommonModule, ButtonModule, IconModule],
     providers: [PaginationService],
-    exports: [PaginationComponent, PaginationReversePipe]
+    exports: [PaginationComponent]
 })
-export class PaginationModule {}
+export class PaginationModule { }

--- a/src/stories/pagination/fd-pagination.stories.ts
+++ b/src/stories/pagination/fd-pagination.stories.ts
@@ -1,0 +1,33 @@
+import { moduleMetadata } from '@storybook/angular';
+import { withKnobs, number } from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
+
+import { PaginationComponent, PaginationModule } from 'libs/core/src/lib/pagination/public_api';
+
+export default {
+    title: 'Fd pagination',
+    component: PaginationComponent,
+    moduleMetadata: moduleMetadata,
+    decorators: [
+        withKnobs,
+        withA11y,
+        moduleMetadata({
+            imports: [PaginationModule],
+            declarations: []
+        })
+    ]
+};
+
+export const Pagination = () => ({
+    template:
+        `
+        <fd-pagination [totalItems]="totalItems"
+                       [itemsPerPage]="itemsPerPage"
+                       [currentPage]="currentPage"></fd-pagination>
+  `,
+    props: {
+        totalItems: number('totalItems', 50),
+        itemsPerPage: number('itemsPerPage', 10),
+        currentPage: number('currentPage', 3)
+    }
+});

--- a/src/stories/pagination/fd-pagination.stories.ts
+++ b/src/stories/pagination/fd-pagination.stories.ts
@@ -21,13 +21,16 @@ export default {
 export const Pagination = () => ({
     template:
         `
-        <fd-pagination [totalItems]="totalItems"
+        <fd-pagination [totalItems]="totalItems" (pageChangeStart)="newPageClicked($event)" 
                        [itemsPerPage]="itemsPerPage"
                        [currentPage]="currentPage"></fd-pagination>
   `,
     props: {
         totalItems: number('totalItems', 50),
         itemsPerPage: number('itemsPerPage', 10),
-        currentPage: number('currentPage', 3)
+        currentPage: number('currentPage', 3),
+        newPageClicked: (event: number) => {
+            alert('Page ' + event + ' clicked!');
+        }
     }
 });


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Closes #1967 

#### Please provide a brief summary of this pull request.

Simply using `dir="rtl"` won't flip the array of numbers presented in the `*ngFor`.  Here I'm using the RtlService and forcing `dir="ltr"` and reversing the array using a pipe.  This feels code-smelly so I'd love to get some other opinions

### Before:
![image](https://user-images.githubusercontent.com/10849982/74834701-3fa21d00-531c-11ea-9971-d847e26200df.png)

### After:
![firefox](https://user-images.githubusercontent.com/10849982/74834235-51cf8b80-531b-11ea-99a8-27b573591000.png)

![ie11](https://user-images.githubusercontent.com/10849982/74834783-63656300-531c-11ea-9bb7-6671a78f098c.png)

