### PR TITLE
docs: separate core modules

### DIFF
--- a/apps/docs/src/app/core/component-docs/action-bar/action-bar-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/action-bar/action-bar-docs.module.ts
@@ -12,6 +12,7 @@ import {RouterModule, Routes} from '@angular/router';
 import {ApiComponent} from '../../../documentation/core-helpers/api/api.component';
 import {API_FILES} from '../../api-files';
 import {SharedDocumentationModule} from '../../../documentation/shared-documentation.module';
+import { ActionBarModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +28,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ActionBarModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/alert/alert-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/alert/alert-docs.module.ts
@@ -10,6 +10,7 @@ import {AlertContentComponent} from './examples/alert-content.component';
 import {AlertInlineExampleComponent} from './examples/alert-inline-example.component';
 import {AlertWidthExampleComponent} from './examples/alert-width-example.component';
 import {AlertHeaderComponent} from './alert-header/alert-header.component';
+import { AlertModule, AlertService } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -25,7 +26,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        AlertModule
     ],
     exports: [RouterModule],
     declarations: [
@@ -39,6 +41,9 @@ const routes: Routes = [
     ],
     entryComponents: [
         AlertContentComponent
+    ],
+    providers: [
+        AlertService
     ]
 })
 export class AlertDocsModule {

--- a/apps/docs/src/app/core/component-docs/badge-label/badge-label-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/badge-label/badge-label-docs.module.ts
@@ -13,6 +13,7 @@ import {
     LabelIconStatusExampleComponent, LabelStatusColorsExampleComponent
 } from './examples/badge-label-examples.component';
 import {BadgeLabelHeaderComponent} from './badge-label-header/badge-label-header.component';
+import { BadgeLabelModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -28,7 +29,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        BadgeLabelModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/breadcrumb/breadcrumb-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/breadcrumb/breadcrumb-docs.module.ts
@@ -10,6 +10,7 @@ import {
 } from './examples/breadcrumb-examples.component';
 import {BreadcrumbHeaderComponent} from './breadcrumb-header/breadcrumb-header.component';
 import {BreadcrumbDocsComponent} from './breadcrumb-docs.component';
+import { BreadcrumbModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -25,7 +26,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        BreadcrumbModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/busy-indicator/busy-indicator-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/busy-indicator-docs.module.ts
@@ -7,6 +7,7 @@ import {BusyIndicatorHeaderComponent} from './busy-indicator-header/busy-indicat
 import {BusyIndicatorDocsComponent} from './busy-indicator-docs.component';
 import {BusyIndicatorBasicExampleComponent} from './examples/busy-indicator-basic-example.component';
 import {BusyIndicatorToggleExampleComponent} from './examples/busy-indicator-toggle-example.component';
+import { BusyIndicatorModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -22,7 +23,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        BusyIndicatorModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/button-group/button-group-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/button-group/button-group-docs.module.ts
@@ -7,6 +7,7 @@ import {ButtonGroupDocsComponent} from './button-group-docs.component';
 import {ButtonGroupHeaderComponent} from './button-group-header/button-group-header.component';
 import {ButtonGroupToggleExampleComponent} from './examples/button-group-toggle-example.component';
 import {ButtonGroupDefaultExampleComponent} from './examples/button-group-default-example.component';
+import { ButtonGroupModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -22,7 +23,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ButtonGroupModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/button/button-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/button/button-docs.module.ts
@@ -12,6 +12,7 @@ import {
     ButtonStateExampleComponent,
     ButtonTypesExampleComponent
 } from './examples/button-examples.component';
+import { ButtonModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +28,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ButtonModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/calendar/calendar-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/calendar/calendar-docs.module.ts
@@ -12,6 +12,7 @@ import {CalendarFormExamplesComponent} from './examples/calendar-form-example.co
 import {CalendarProgrammaticallyChangeExampleComponent} from './examples/calendar-programmatically-change-example.component';
 import {CalendarI18nExampleComponent} from './examples/calendar-i18n-example.component';
 import {CalendarI18nMomentExampleComponent} from './examples/calendar--i18n-moment-example.component';
+import { ButtonGroupModule, CalendarModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +28,9 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        CalendarModule,
+        ButtonGroupModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/checkbox/checkbox-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/checkbox/checkbox-docs.module.ts
@@ -11,6 +11,7 @@ import {CheckboxDefaultExampleComponent} from './examples/checkbox-default-examp
 import {CheckboxReactiveFormsExampleComponent} from './examples/checkbox-reactive-forms-example.component';
 import {CheckboxStatesExampleComponent} from './examples/checkbox-states-example.component';
 import {CheckboxTristateExampleComponent} from './examples/checkbox-tristate-example.component';
+import { CheckboxModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -26,7 +27,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        CheckboxModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/combobox/combobox-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/combobox/combobox-docs.module.ts
@@ -15,6 +15,7 @@ import {ComboboxFormsExampleComponent} from './examples/combobox-forms-example.c
 import {ComboboxDisabledExampleComponent} from './examples/combobox-disabled-example.component';
 import {ComboboxHeightExampleComponent} from './examples/combobox-height-example.component';
 import {ComboboxOpenControlExampleComponent} from './examples/combobox-open-control-example.component';
+import { ComboboxModule, FormModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -30,7 +31,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ComboboxModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.module.ts
@@ -17,6 +17,7 @@ import {DatePickerFormatExampleComponent} from './examples/date-picker-format-ex
 import {DatePickerComplexI18nExampleComponent} from './examples/date-picker-complex-i18n-example/date-picker-complex-i18n-example.component';
 import {DatePickerRangeDisabledExampleComponent} from './examples/date-picker-range-disabled-example/date-picker-range-disabled-example.component';
 import {DatePickerDisableFuncExampleComponent} from './examples/date-picker-disable-func-example/date-picker-disable-func-example.component';
+import { ButtonGroupModule, DatePickerModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -32,7 +33,9 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        DatePickerModule,
+        ButtonGroupModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.module.ts
@@ -13,6 +13,7 @@ import {DatetimeFormatExampleComponent} from './examples/datetime-format-example
 import {DatetimeFormExampleComponent} from './examples/datetime-form-example/datetime-form-example.component';
 import {DatetimePickerAllowNullExampleComponent} from './examples/datetime-allow-null-example/datetime-allow-null-example.component';
 import {DatetimeDisabledExampleComponent} from './examples/datetime-disabled-example/datetime-disabled-example.component';
+import { ButtonGroupModule, DatetimePickerModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -28,7 +29,9 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        DatetimePickerModule,
+        ButtonGroupModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/dropdown/dropdown-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/dropdown/dropdown-docs.module.ts
@@ -10,7 +10,7 @@ import {DropdownIconsExampleComponent} from './examples/dropdown-icons-example.c
 import {DropdownStateExampleComponent} from './examples/dropdown-state-example.component';
 import {DropdownInfiniteScrollExampleComponent} from './examples/dropdown-infinite-scroll-example.component';
 import {DropdownToolbarExampleComponent} from './examples/dropdown-toolbar-example.component';
-import { PopoverModule } from '@fundamental-ngx/core';
+import { InfiniteScrollModule, MenuModule, PopoverModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +27,9 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        PopoverModule
+        PopoverModule,
+        InfiniteScrollModule,
+        MenuModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/dropdown/dropdown-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/dropdown/dropdown-docs.module.ts
@@ -10,6 +10,7 @@ import {DropdownIconsExampleComponent} from './examples/dropdown-icons-example.c
 import {DropdownStateExampleComponent} from './examples/dropdown-state-example.component';
 import {DropdownInfiniteScrollExampleComponent} from './examples/dropdown-infinite-scroll-example.component';
 import {DropdownToolbarExampleComponent} from './examples/dropdown-toolbar-example.component';
+import { PopoverModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -25,7 +26,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        PopoverModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/file-input/file-input-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/file-input/file-input-docs.module.ts
@@ -9,6 +9,7 @@ import {FileInputExampleComponent} from './examples/file-input-example/file-inpu
 import {FileInputCustomExampleComponent} from './examples/file-input-custom-example/file-input-custom-example.component';
 import {FileInputDragDisabledExampleComponent} from './examples/file-input-drag-disabled-example/file-input-drag-disabled-example.component';
 import {FileInputMaxExampleComponent} from './examples/file-input-max-example/file-input-max-example.component';
+import { FileInputModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -24,7 +25,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        FileInputModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/icon/icon-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/icon/icon-docs.module.ts
@@ -6,6 +6,7 @@ import {API_FILES} from '../../api-files';
 import {IconHeaderComponent} from './icon-header/icon-header.component';
 import {IconDocsComponent} from './icon-docs.component';
 import {IconExampleComponent} from './examples/icon-example.component';
+import { IconModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -21,7 +22,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        IconModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/identifier/identifier-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/identifier/identifier-docs.module.ts
@@ -12,6 +12,7 @@ import {
     InitialsIdentifierExampleComponent,
     TransparentIdentifierExampleComponent
 } from './examples/identifier-examples.component';
+import { IdentifierModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +28,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        IdentifierModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/image/image-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/image/image-docs.module.ts
@@ -6,6 +6,7 @@ import {API_FILES} from '../../api-files';
 import {ImageHeaderComponent} from './image-header/image-header.component';
 import {ImageDocsComponent} from './image-docs.component';
 import {ImageShapesExampleComponent, ImageSizesExampleComponent} from './examples/image-examples.component';
+import { ImageModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -21,7 +22,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ImageModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/infinite-scroll/infinite-scroll-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/infinite-scroll/infinite-scroll-docs.module.ts
@@ -6,6 +6,7 @@ import {API_FILES} from '../../api-files';
 import {InfiniteScrollHeaderComponent} from './infinite-scroll-header/infinite-scroll-header.component';
 import {InfiniteScrollDocsComponent} from './infinite-scroll-docs.component';
 import {InfiniteScrollBasicExampleComponent} from './examples/infinite-scroll-basic-example/infinite-scroll-basic-example.component';
+import { InfiniteScrollModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -21,7 +22,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        InfiniteScrollModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.module.ts
@@ -10,6 +10,7 @@ import {
     InlineHelpStyledExampleComponent,
     InlineHelpTriggerExampleComponent
 } from './examples/inline-help-examples.component';
+import { InlineHelpModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -25,7 +26,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        InlineHelpModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/input-group/input-group-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/input-group/input-group-docs.module.ts
@@ -16,6 +16,7 @@ import {
 import {InputGroupStatesExampleComponent} from './examples/input-group-states-example/input-group-states-example.component';
 import {InputGroupSearchExampleComponent} from './examples/input-group-search-example/input-group-search-example.component';
 import {InputGroupNumberExampleComponent} from './examples/input-group-number-example/input-group-number-example.component';
+import { InputGroupModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -31,7 +32,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        InputGroupModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/input/input-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/input/input-docs.module.ts
@@ -11,6 +11,7 @@ import {
     InputInlineHelpExampleComponent,
     InputStateExampleComponent
 } from './examples/input-examples.component';
+import { FormModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -26,7 +27,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        FormModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/layout-grid/layout-grid-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/layout-grid/layout-grid-docs.module.ts
@@ -12,7 +12,7 @@ import {
     LayoutGridNoGapExampleComponent
 } from './examples/layout-grid-examples.component';
 import {LayoutGridDocsHeaderComponent} from './layout-grid-docs-header/layout-grid-docs-header.component';
-import { LayoutGridModule } from '@fundamental-ngx/core';
+import { LayoutGridModule, PanelModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -29,7 +29,8 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        LayoutGridModule
+        LayoutGridModule,
+        PanelModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/layout-grid/layout-grid-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/layout-grid/layout-grid-docs.module.ts
@@ -12,6 +12,7 @@ import {
     LayoutGridNoGapExampleComponent
 } from './examples/layout-grid-examples.component';
 import {LayoutGridDocsHeaderComponent} from './layout-grid-docs-header/layout-grid-docs-header.component';
+import { LayoutGridModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +28,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        LayoutGridModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/link/link-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/link/link-docs.module.ts
@@ -6,6 +6,7 @@ import {API_FILES} from '../../api-files';
 import {LinkHeaderComponent} from './link-header/link-header.component';
 import {LinkDocsComponent} from './link-docs.component';
 import {LinkExampleComponent} from './examples/link-example.component';
+import { LinkModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -21,7 +22,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        LinkModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/list/list-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/list/list-docs.module.ts
@@ -13,7 +13,7 @@ import {
     ListExampleComponent
 } from './examples/list-examples.component';
 import {ListCheckboxFormExampleComponent} from './examples/list-checkbox-form-example.component';
-import { ListModule } from '@fundamental-ngx/core';
+import { CheckboxModule, InfiniteScrollModule, ListModule, RadioModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -30,7 +30,10 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        ListModule
+        ListModule,
+        CheckboxModule,
+        RadioModule,
+        InfiniteScrollModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/list/list-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/list/list-docs.module.ts
@@ -13,6 +13,7 @@ import {
     ListExampleComponent
 } from './examples/list-examples.component';
 import {ListCheckboxFormExampleComponent} from './examples/list-checkbox-form-example.component';
+import { ListModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -28,7 +29,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ListModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/loading-spinner-docs/loading-spinner-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/loading-spinner-docs/loading-spinner-docs.module.ts
@@ -7,6 +7,7 @@ import {LoadingSpinnerHeaderComponent} from './loading-spinner-header/loading-sp
 import {LoadingSpinnerDocsComponent} from './loading-spinner-docs.component';
 import {LoadingSpinnerExampleComponent} from './examples/loading-spinner-example.component';
 import {LoadingSpinnerContainerExampleComponent} from './examples/loading-spinner-container-example.component';
+import { LoadingSpinnerModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -22,7 +23,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        LoadingSpinnerModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/localization-editor/localization-editor-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/localization-editor/localization-editor-docs.module.ts
@@ -9,6 +9,7 @@ import {LocalizationEditorExampleComponent} from './examples/localization-editor
 import {LocalizationEditorFormsExampleComponent} from './examples/localization-editor-forms-example.component';
 import {LocalizationEditorTextareaExampleComponent} from './examples/localization-editor-textarea-example.component';
 import {LocalizationEditorTemplateExampleComponent} from './examples/localization-editor-template-example.component';
+import { LocalizationEditorModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -24,7 +25,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        LocalizationEditorModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-docs.module.ts
@@ -10,6 +10,7 @@ import {
     MegaMenuGroupExampleComponent,
     MegaMenuPositionExampleComponent
 } from './examples/mega-menu-examples.component';
+import { MegaMenuModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -25,7 +26,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        MegaMenuModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/menu/menu-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/menu/menu-docs.module.ts
@@ -12,6 +12,7 @@ import {
 } from './examples/menu-examples.component';
 import {MenuAddonExampleComponent} from './examples/menu-addon-examples.component';
 import {MenuKeyboardSupportExampleComponent} from './examples/menu-keyboard-support-example.component';
+import { MenuModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +28,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        MenuModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/modal/modal-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/modal/modal-docs.module.ts
@@ -15,6 +15,7 @@ import {ModalPositionExampleComponent} from './examples/modal-position/modal-pos
 import {ModalFullscreenExampleComponent} from './examples/fullscreen-modal/modal-fullscreen-example.component';
 import {ModalOpenTemplateExampleComponent} from './examples/template-as-content/modal-open-template-example.component';
 import {ModalComponentAsContentExampleComponent} from './examples/component-as-content/modal-component-as-content-example.component';
+import { ModalModule, ModalService } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -30,7 +31,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ModalModule
     ],
     exports: [RouterModule],
     declarations: [
@@ -52,6 +54,9 @@ const routes: Routes = [
         ModalInModalComponent,
         ModalInModalFirstComponent,
         ModalInModalSecondComponent
+    ],
+    providers: [
+        ModalService
     ]
 })
 export class ModalDocsModule {

--- a/apps/docs/src/app/core/component-docs/multi-input/multi-input-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/multi-input/multi-input-docs.module.ts
@@ -10,6 +10,7 @@ import {MultiInputDisplaywithExampleComponent} from './examples/multi-input-disp
 import {MultiInputExampleComponent} from './examples/multi-input-example/multi-input-example.component';
 import {MultiInputFilterExampleComponent} from './examples/multi-input-filter-example/multi-input-filter-example.component';
 import {MultiInputFormExampleComponent} from './examples/multi-input-form-example/multi-input-form-example.component';
+import { MultiInputModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -25,7 +26,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        MultiInputModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/notification/notification-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/notification/notification-docs.module.ts
@@ -12,6 +12,7 @@ import {NotificationOptionsContentComponent} from './examples/notification-optio
 import {NotificationOptionsExampleComponent} from './examples/notification-options/notification-options-example.component';
 import {NotificationOpenTemplateExampleComponent} from './examples/template-as-content/notification-open-template-example.component';
 import {NotificationAsObjectExampleComponent} from './examples/notification-as-object.component';
+import { NotificationModule, NotificationService } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +28,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        NotificationModule
     ],
     exports: [RouterModule],
     declarations: [
@@ -44,6 +46,9 @@ const routes: Routes = [
     entryComponents: [
         NotificationContentComponent,
         NotificationOptionsContentComponent
+    ],
+    providers: [
+        NotificationService
     ]
 })
 export class NotificationDocsModule {

--- a/apps/docs/src/app/core/component-docs/notification/notification-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/notification/notification-docs.module.ts
@@ -12,7 +12,7 @@ import {NotificationOptionsContentComponent} from './examples/notification-optio
 import {NotificationOptionsExampleComponent} from './examples/notification-options/notification-options-example.component';
 import {NotificationOpenTemplateExampleComponent} from './examples/template-as-content/notification-open-template-example.component';
 import {NotificationAsObjectExampleComponent} from './examples/notification-as-object.component';
-import { NotificationModule, NotificationService } from '@fundamental-ngx/core';
+import { IdentifierModule, NotificationModule, NotificationService } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -29,7 +29,8 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        NotificationModule
+        NotificationModule,
+        IdentifierModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/pagination/pagination-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/pagination/pagination-docs.module.ts
@@ -6,6 +6,7 @@ import {API_FILES} from '../../api-files';
 import {PaginationHeaderComponent} from './pagination-header/pagination-header.component';
 import {PaginationDocsComponent} from './pagination-docs.component';
 import {PaginationExampleComponent} from './examples/pagination-example.component';
+import { PaginationModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -21,7 +22,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        PaginationModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/panel/panel-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/panel/panel-docs.module.ts
@@ -7,6 +7,7 @@ import {PanelDocsHeaderComponent} from './panel-docs-header/panel-docs-header.co
 import {PanelDocsComponent} from './panel-docs.component';
 import {PanelExampleComponent} from './examples/panel-examples.component';
 import {PanelEdgeBleedExampleComponent} from './examples/panel-edge-bleed-example.component';
+import { PanelModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -22,7 +23,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        PanelModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/panel/panel-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/panel/panel-docs.module.ts
@@ -7,7 +7,7 @@ import {PanelDocsHeaderComponent} from './panel-docs-header/panel-docs-header.co
 import {PanelDocsComponent} from './panel-docs.component';
 import {PanelExampleComponent} from './examples/panel-examples.component';
 import {PanelEdgeBleedExampleComponent} from './examples/panel-edge-bleed-example.component';
-import { PanelModule } from '@fundamental-ngx/core';
+import { PanelModule, TableModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -24,7 +24,8 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        PanelModule
+        PanelModule,
+        TableModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/popover-directive/popover-directive-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/popover-directive/popover-directive-docs.module.ts
@@ -9,6 +9,7 @@ import {PopoverDirectiveExampleComponent} from './examples/popover-directive-exa
 import {PopoverFillComponent} from './examples/popover-fill/popover-fill.component';
 import {PopoverProgrammaticComponent} from './examples/popover-programmatic/popover-programmatic.component';
 import {PopoverTriggersComponent} from './examples/popover-triggers/popover-triggers.component';
+import { PopoverModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -24,7 +25,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        PopoverModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/popover/popover-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/popover/popover-docs.module.ts
@@ -12,6 +12,7 @@ import {PopoverModalExampleComponent} from './examples/popover-modal/popover-mod
 import {PopoverPlacementExampleComponent} from './examples/popover-placement/popover-placement-example.component';
 import {PopoverProgrammaticOpenExampleComponent} from './examples/popover-programmatic/popover-programmatic-open-example.component';
 import {PopoverExampleComponent} from './examples/popover-simple/popover-example.component';
+import { PopoverModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +28,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        PopoverModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/popover/popover-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/popover/popover-docs.module.ts
@@ -12,7 +12,15 @@ import {PopoverModalExampleComponent} from './examples/popover-modal/popover-mod
 import {PopoverPlacementExampleComponent} from './examples/popover-placement/popover-placement-example.component';
 import {PopoverProgrammaticOpenExampleComponent} from './examples/popover-programmatic/popover-programmatic-open-example.component';
 import {PopoverExampleComponent} from './examples/popover-simple/popover-example.component';
-import { PopoverModule } from '@fundamental-ngx/core';
+import {
+    IdentifierModule,
+    ImageModule,
+    MenuModule,
+    ModalModule,
+    MultiInputModule,
+    PopoverModule,
+    SideNavigationModule
+} from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -29,7 +37,13 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        PopoverModule
+        PopoverModule,
+        ImageModule,
+        IdentifierModule,
+        SideNavigationModule,
+        MultiInputModule,
+        MenuModule,
+        ModalModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/product-switch/product-switch-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/product-switch/product-switch-docs.module.ts
@@ -8,6 +8,7 @@ import {ProductSwitchDndExampleComponent} from './examples/product-switch-dnd-ex
 import {ProductSwitchDocsHeaderComponent} from './product-switch-docs-header/product-switch-docs-header.component';
 import {ProductSwitchListComponent} from './examples/product-switch-list/product-switch-list-example.component';
 import {ProductSwitchDocsComponent} from './product-switch-docs.component';
+import { ProductSwitchModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -23,7 +24,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ProductSwitchModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/radio/radio-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/radio/radio-docs.module.ts
@@ -7,6 +7,7 @@ import {RadioHeaderComponent} from './radio-header/radio-header.component';
 import {RadioDocsComponent} from './radio-docs.component';
 import {RadioExamplesComponent} from './examples/radio-examples.component';
 import {RadioFormGroupExampleComponent} from './examples/radio-form-group-example.component';
+import { RadioModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -22,7 +23,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        RadioModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/scroll-spy/scroll-spy-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/scroll-spy/scroll-spy-docs.module.ts
@@ -8,6 +8,7 @@ import {ScrollSpyOffsetExampleComponent} from './examples/scroll-spy-custom-offs
 import {ScrollSpyExampleComponent} from './examples/scroll-spy-example/scroll-spy-example.component';
 import {ScrollSpyHeaderComponent} from './scroll-spy-header/scroll-spy-header.component';
 import {ScrollSpyDocsComponent} from './scroll-spy-docs.component';
+import { ScrollSpyModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -23,7 +24,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ScrollSpyModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/select-native/select-native-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/select-native/select-native-docs.module.ts
@@ -11,6 +11,7 @@ import {
 import {SelectNativeFormGroupExampleComponent} from './examples/select-native-form-group-example.component';
 import {SelectNativeHeaderComponent} from './select-native-header/select-native-header.component';
 import {SelectNativeDocsComponent} from './select-native-docs.component';
+import { FormModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -26,7 +27,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        FormModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/select/select-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/select/select-docs.module.ts
@@ -14,6 +14,7 @@ import {SelectCustomTriggerComponent} from './examples/select-custom-trigger/sel
 import {SelectMaxHeightExampleComponent} from './examples/select-height/select-max-height-example.component';
 import {SelectViewValueExampleComponent} from './examples/select-view-value-example/select-view-value-example.component';
 import {SelectProgrammaticExampleComponent} from './examples/select-programmatic-example/select-programmatic-example.component';
+import { SelectModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -29,7 +30,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        SelectModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.module.ts
@@ -9,6 +9,7 @@ import {ShellbarBasicExampleComponent} from './examples/shellbar-basic-example.c
 import {ShellbarSideNavExampleComponent} from './examples/shellbar-side-nav/shellbar-side-nav-example.component';
 import {ShellbarAdvancedExampleComponent} from './examples/shellbar-advanced/shellbar-advanced-example.component';
 import {ShellbarCollapsibleExampleComponent} from './examples/shellbar-collapsible-example.component';
+import { ShellbarModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -24,7 +25,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        ShellbarModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.module.ts
@@ -9,7 +9,7 @@ import {ShellbarBasicExampleComponent} from './examples/shellbar-basic-example.c
 import {ShellbarSideNavExampleComponent} from './examples/shellbar-side-nav/shellbar-side-nav-example.component';
 import {ShellbarAdvancedExampleComponent} from './examples/shellbar-advanced/shellbar-advanced-example.component';
 import {ShellbarCollapsibleExampleComponent} from './examples/shellbar-collapsible-example.component';
-import { ShellbarModule } from '@fundamental-ngx/core';
+import { ComboboxModule, IdentifierModule, ProductSwitchModule, ShellbarModule, SideNavigationModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -26,7 +26,11 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        ShellbarModule
+        ShellbarModule,
+        ComboboxModule,
+        SideNavigationModule,
+        IdentifierModule,
+        ProductSwitchModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.module.ts
@@ -9,7 +9,14 @@ import {ShellbarBasicExampleComponent} from './examples/shellbar-basic-example.c
 import {ShellbarSideNavExampleComponent} from './examples/shellbar-side-nav/shellbar-side-nav-example.component';
 import {ShellbarAdvancedExampleComponent} from './examples/shellbar-advanced/shellbar-advanced-example.component';
 import {ShellbarCollapsibleExampleComponent} from './examples/shellbar-collapsible-example.component';
-import { ComboboxModule, IdentifierModule, ProductSwitchModule, ShellbarModule, SideNavigationModule } from '@fundamental-ngx/core';
+import {
+    ComboboxModule,
+    IdentifierModule,
+    ProductSwitchModule,
+    ShellbarModule,
+    SideNavigationModule,
+    TileModule
+} from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -30,7 +37,8 @@ const routes: Routes = [
         ComboboxModule,
         SideNavigationModule,
         IdentifierModule,
-        ProductSwitchModule
+        ProductSwitchModule,
+        TileModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/side-navigation/side-navigation-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/side-navigation/side-navigation-docs.module.ts
@@ -17,6 +17,7 @@ import {SideNavigationObjectExampleComponent} from './examples/side-navigation-o
 import {SideNavigationMultipleSelectedExampleComponent} from './examples/side-navigation-multiple-selected-example/side-navigation-multiple-selected-example.component';
 import {SideNavigationCondensedObjectExampleComponent} from './examples/side-navigation-condensed-object-example/side-navigation-condensed-object-example.component';
 import {SideNavigationCondensedExampleComponent} from './examples/side-navigation-condensed-example/side-navigation-condensed-example.component';
+import { SideNavigationModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -32,7 +33,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        SideNavigationModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/split-button/split-button-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/split-button/split-button-docs.module.ts
@@ -10,6 +10,7 @@ import {ButtonSplitTemplateExampleComponent} from './examples/split-button-templ
 import {ButtonSplitProgrammaticalExampleComponent} from './examples/split-button-programmatical-example.component';
 import {ButtonSplitOptionsExampleComponent} from './examples/split-button-options-example.component';
 import {ButtonSplitTypesIconsComponent} from './examples/split-button-icons-example.component';
+import { SplitButtonModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -25,7 +26,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        SplitButtonModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/switch/switch-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/switch/switch-docs.module.ts
@@ -10,6 +10,7 @@ import {SwitchFormsExampleComponent} from './examples/switch-form-example/switch
 import {SwitchBindingExampleComponent} from './examples/switch-binding-example/switch-binding-example.component';
 import {SemanticSwitchExampleComponent} from './examples/semantic-switch-example/semantic-switch-example.component';
 import {DisabledSwitchExampleComponent} from './examples/disabled-switch-example/disabled-switch-example.component';
+import { SwitchModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -25,7 +26,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        SwitchModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/table/table-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/table/table-docs.module.ts
@@ -9,7 +9,7 @@ import {TableExampleComponent} from './examples/table-example.component';
 import {TableCdkExampleComponent} from './examples/table-cdk-example.component';
 import {TableResponsiveExampleComponent} from './examples/table-responsive-example.component';
 import {TableCheckboxesExampleComponent} from './examples/table-checkboxes-example.component';
-import { TableModule } from '@fundamental-ngx/core';
+import { CheckboxModule, TableModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -26,7 +26,8 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        TableModule
+        TableModule,
+        CheckboxModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/table/table-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/table/table-docs.module.ts
@@ -9,6 +9,7 @@ import {TableExampleComponent} from './examples/table-example.component';
 import {TableCdkExampleComponent} from './examples/table-cdk-example.component';
 import {TableResponsiveExampleComponent} from './examples/table-responsive-example.component';
 import {TableCheckboxesExampleComponent} from './examples/table-checkboxes-example.component';
+import { TableModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -24,7 +25,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        TableModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-docs.module.ts
@@ -44,7 +44,7 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        TabsModule
+        TabsModule,
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/tabs/tabs-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/tabs/tabs-docs.module.ts
@@ -19,6 +19,7 @@ import {TabIconOnlyExampleComponent} from './examples/tab-icon-only-example/tab-
 import {TabSelectionExampleComponent} from './examples/tab-selection-example.component';
 import {ComplexTitleExampleComponent} from './examples/complex-title-example/complex-title-example.component';
 import {TabsNavigationModeExampleComponent} from './examples/tab-navigation-mode-example-component';
+import { TabsModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -42,7 +43,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        TabsModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/textarea/textarea-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/textarea/textarea-docs.module.ts
@@ -11,6 +11,7 @@ import {
     TextareaStateExampleComponent
 } from './examples/textarea-examples.component';
 import {TextareaFormGroupExampleComponent} from './examples/textarea-form-group-example.component';
+import { FormModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -26,7 +27,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        FormModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/tile/tile-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/tile/tile-docs.module.ts
@@ -13,6 +13,7 @@ import {
     TileMediaExampleComponent,
     TileProductExampleComponent
 } from './examples/tile-examples.component';
+import { TileModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -28,7 +29,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        TileModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/tile/tile-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/tile/tile-docs.module.ts
@@ -13,7 +13,7 @@ import {
     TileMediaExampleComponent,
     TileProductExampleComponent
 } from './examples/tile-examples.component';
-import { TileModule } from '@fundamental-ngx/core';
+import { IdentifierModule, ImageModule, TileModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -30,7 +30,9 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        TileModule
+        TileModule,
+        IdentifierModule,
+        ImageModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/time-picker/time-picker-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/time-picker/time-picker-docs.module.ts
@@ -14,6 +14,7 @@ import {TimePickerOnlyHoursExampleComponent} from './examples/time-picker-only-h
 import {TimePickerNoSecondsExampleComponent} from './examples/time-picker-no-seconds-example.component';
 import {TimePickerAllowNullExampleComponent} from './examples/time-picker-allow-null-example.component';
 import {TimePickerOtherDelimiterExampleComponent} from './examples/time-picker-other-delimiter-example.component';
+import { TimePickerModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -29,7 +30,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        TimePickerModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/time/time-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/time/time-docs.module.ts
@@ -14,6 +14,7 @@ import {TimeExampleComponent} from './examples/time-example.component';
 import {TimeDisabledExampleComponent} from './examples/time-disabled-example.component';
 import {Time12ExampleComponent} from './examples/time-12-example.component';
 import {TimeTwoDigitsExampleComponent} from './examples/time-two-digits-example/time-two-digits-example.component';
+import { TimeModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -29,7 +30,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        TimeModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/token/token-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/token/token-docs.module.ts
@@ -11,6 +11,7 @@ import {TokenCompactExampleComponent} from './examples/token-compact-example/tok
 import {TokenSelectedExampleComponent} from './examples/token-selected-example/token-selected-example.component';
 import {TokenReadOnlyExampleComponent} from './examples/token-readonly-example/token-readonly-example.component';
 import {TokenizerCompactExampleComponent} from './examples/tokenizer-compact-example/tokenizer-compact-example.component';
+import { TokenModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -26,7 +27,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        TokenModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/tree/tree-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/tree/tree-docs.module.ts
@@ -6,6 +6,7 @@ import {API_FILES} from '../../api-files';
 import {TreeDocsComponent} from './tree-docs.component';
 import {TreeHeaderComponent} from './tree-header/tree-header.component';
 import {SimpleTreeExampleComponent} from './examples/simple-tree-example.component';
+import { TreeModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -21,7 +22,8 @@ const routes: Routes = [
 @NgModule({
     imports: [
         RouterModule.forChild(routes),
-        SharedDocumentationModule
+        SharedDocumentationModule,
+        TreeModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/documentation/shared-core-modules.ts
+++ b/apps/docs/src/app/documentation/shared-core-modules.ts
@@ -1,11 +1,25 @@
-import { ButtonModule, FormModule, IconModule, InputGroupModule, ShellbarModule, SwitchModule, TabsModule } from '@fundamental-ngx/core';
+import {
+    AlertModule,
+    ButtonModule,
+    FormModule,
+    IconModule,
+    InlineHelpModule,
+    InputGroupModule, MenuModule, PopoverModule,
+    ShellbarModule,
+    SwitchModule,
+    TabsModule
+} from '@fundamental-ngx/core';
 
 export const sharedCoreModules = [
+    AlertModule,
     ButtonModule,
     InputGroupModule,
     ShellbarModule,
     IconModule,
     TabsModule,
     SwitchModule,
-    FormModule
+    FormModule,
+    InlineHelpModule,
+    PopoverModule,
+    MenuModule
 ];

--- a/apps/docs/src/app/documentation/shared-core-modules.ts
+++ b/apps/docs/src/app/documentation/shared-core-modules.ts
@@ -1,0 +1,11 @@
+import { ButtonModule, FormModule, IconModule, InputGroupModule, ShellbarModule, SwitchModule, TabsModule } from '@fundamental-ngx/core';
+
+export const sharedCoreModules = [
+    ButtonModule,
+    InputGroupModule,
+    ShellbarModule,
+    IconModule,
+    TabsModule,
+    SwitchModule,
+    FormModule
+];

--- a/apps/docs/src/app/documentation/shared-documentation.module.ts
+++ b/apps/docs/src/app/documentation/shared-documentation.module.ts
@@ -32,6 +32,7 @@ import { ToolbarComponent } from './core-helpers/toolbar/toolbar.component';
 import { SectionsToolbarComponent } from './core-helpers/sections-toolbar/sections-toolbar.component';
 import { HeaderTabsComponent } from './core-helpers/header-tabs/header-tabs.component';
 import { ApiComponent } from './core-helpers/api/api.component';
+import { sharedCoreModules } from './shared-core-modules';
 
 @NgModule({
     declarations: [
@@ -53,8 +54,6 @@ import { ApiComponent } from './core-helpers/api/api.component';
     ],
 
     imports: [
-        FundamentalNgxCoreModule,
-        FundamentalNgxPlatformModule,
         MarkdownModule.forChild(),
         CommonModule,
         FormsModule,
@@ -63,12 +62,11 @@ import { ApiComponent } from './core-helpers/api/api.component';
         CdkTableModule,
         DragDropModule,
         SchemaModule.forRoot(COMPONENT_SCHEMAS),
-        RouterModule
+        RouterModule,
+        sharedCoreModules
     ],
     providers: [CopyService, ApiDocsService],
     exports: [
-        FundamentalNgxCoreModule,
-        FundamentalNgxPlatformModule,
         PlayGroundComponent,
         CodeExampleComponent,
         HeaderComponent,
@@ -90,7 +88,8 @@ import { ApiComponent } from './core-helpers/api/api.component';
         ToolbarComponent,
         SectionsToolbarComponent,
         HeaderTabsComponent,
-        ApiComponent
+        ApiComponent,
+        sharedCoreModules
     ]
 })
 export class SharedDocumentationModule { }

--- a/apps/docs/src/app/platform/platform-documentation.module.ts
+++ b/apps/docs/src/app/platform/platform-documentation.module.ts
@@ -30,14 +30,14 @@ import {PlatformActionBarDocsComponent} from '../platform/component-docs/platfor
 import { SchemaModule } from '../schema/schema.module';
 import { PLATFORM_COMPONENT_SCHEMAS } from './component-docs/schemas';
 
-import { 
+import {
     PlatformLinkStandardExampleComponent,
     PlatformLinkEmphasizedExampleComponent,
     PlatformLinkDisabledExampleComponent,
     PlatformLinkDisabledEmphasizedExampleComponent,
     PlatformLinkInvertedExampleComponent,
     PlatformLinkTruncatedExampleComponent,
-    PlatformLinkIconExampleComponent 
+    PlatformLinkIconExampleComponent
 } from './component-docs/platform-link/platform-link-examples/platform-link-examples.component';
 import { PlatformLinkHeaderComponent } from './component-docs/platform-link/platform-link-header/platform-link-header.component';
 import { PlatformLinkDocsComponent } from './component-docs/platform-link/platform-link-docs.component';
@@ -58,6 +58,8 @@ import { PlatformSelectTypesNoBorderExampleComponent } from './component-docs/pl
 import { PlatformSelectTypesSplitExampleComponent } from './component-docs/platform-select/platform-select-examples/platform-select-types-split-example.component';
 import { PlatformSelectTypesWithIconExampleComponent } from './component-docs/platform-select/platform-select-examples/platform-select-types-with-icon-example.component';
 import { StackblitzService } from '../documentation/core-helpers/stackblitz/stackblitz.service';
+import { FundamentalNgxCoreModule } from '@fundamental-ngx/core';
+import { FundamentalNgxPlatformModule } from '@fundamental-ngx/platform';
 
 @NgModule({
     declarations: [
@@ -106,6 +108,8 @@ import { StackblitzService } from '../documentation/core-helpers/stackblitz/stac
         PlatformSelectTypesWithIconExampleComponent
     ],
     imports: [
+        FundamentalNgxCoreModule,
+        FundamentalNgxPlatformModule,
         SharedDocumentationModule,
         SchemaModule.forRoot(PLATFORM_COMPONENT_SCHEMAS),
         MarkdownModule.forChild(),

--- a/libs/core/src/lib/form/form-control/form-control.component.scss
+++ b/libs/core/src/lib/form/form-control/form-control.component.scss
@@ -1,6 +1,4 @@
 @import "~fundamental-styles/dist/form-item";
 @import "~fundamental-styles/dist/input";
-@import "~fundamental-styles/dist/checkbox";
-@import "~fundamental-styles/dist/radio";
 @import "~fundamental-styles/dist/textarea";
 @import "~fundamental-styles/dist/form-select";


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#### Please provide a brief summary of this pull request.

So previously we had whole `FdCoreModule` imported into docs main module.
It wasn't really needed, whole `FdCoreModule` was loaded even on `home` page entry.
Right now, every lazy-loaded module has got additional import, for component that it needs.
So for example: `CalendarDocsModule` has impoted core `CalendarModule`.
`CoreDocumentationModule` diesn't have `FundamentalNgxCoreModule` imported anymore.
Only shared modules, such as `ButtonModule` or `FormModule`, which are used on docs site are imported to main module. 

### Comparison to current Master - Entering Home Site:
With Cache 

[Before]
![image](https://user-images.githubusercontent.com/26483208/74835896-99a3e200-531e-11ea-86a9-19a5e5031be4.png)


[After]
![image](https://user-images.githubusercontent.com/26483208/74835860-885ad580-531e-11ea-8ff5-4fcbd7a93e51.png)


Without Cache
[Before]
![image](https://user-images.githubusercontent.com/26483208/74836182-2d75ae00-531f-11ea-8c91-77bfed032f91.png)

[After]
![image](https://user-images.githubusercontent.com/26483208/74836194-32d2f880-531f-11ea-80e8-58007f7fc08f.png)

### Network Usage
[Before]
![image](https://user-images.githubusercontent.com/26483208/74836243-5007c700-531f-11ea-9898-e19bf5c167c0.png)

[After]
![image](https://user-images.githubusercontent.com/26483208/74836290-6d3c9580-531f-11ea-90a4-41923c21d21a.png)




#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

