### PR TITLE
chore: keep messages from GitHub on CI script

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -46,7 +46,7 @@ else
    exit 1
 fi
 
-git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" $CURRENT_BRANCH > /dev/null 2>&1;
+git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" $CURRENT_BRANCH > /dev/null;
 npm run build-deploy-library
 
 cd dist/libs


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
There is something wrong with travis CI.
![image](https://user-images.githubusercontent.com/26483208/74842042-04a6e600-532a-11ea-9fb2-e0a43c0db1c5.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

