### PR TITLE
fix: remove 2nd ellipses when 3rd to last page is selected

### DIFF
--- a/libs/core/src/lib/pagination/pagination.service.spec.ts
+++ b/libs/core/src/lib/pagination/pagination.service.spec.ts
@@ -86,4 +86,16 @@ describe('PaginationService', () => {
         expect(pages[1]).toEqual(service.MORE);
         expect(pages[5]).toEqual(service.MORE);
     });
+
+    it('should not have two dots sections if second to last page is currentPage', () => {
+        const pagination: Pagination = {
+            totalItems: 150,
+            itemsPerPage: 2,
+            currentPage: 73
+        };
+        const pages = service.getPages(pagination);
+        expect(pages[1]).toEqual(service.MORE);
+        expect(pages[5]).not.toEqual(service.MORE);
+        expect(pages[5]).toEqual(75);
+    })
 });

--- a/libs/core/src/lib/pagination/pagination.service.ts
+++ b/libs/core/src/lib/pagination/pagination.service.ts
@@ -58,7 +58,7 @@ export class PaginationService {
                 for (let i = pagination.currentPage - buffer; i <= pagination.currentPage + buffer; i++) {
                     pages.push(i);
                 }
-                if (totalPages !== DISPLAY_NUM_PAGES + 1) {
+                if (totalPages !== DISPLAY_NUM_PAGES + 1 && pagination.currentPage !== totalPages - 2) {
                     pages.push(this.MORE);
                 }
                 pages.push(totalPages);


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#2012 

#### Please provide a brief summary of this pull request.

Do not add ellipses a second time when 3rd to last page is selected.

**Before:**
![Screen Shot 2020-02-19 at 2 05 52 PM](https://user-images.githubusercontent.com/2471874/74876517-0f10b200-5321-11ea-8c31-9cddf2ee8a67.png)

**After**
![Screen Shot 2020-02-19 at 2 06 04 PM](https://user-images.githubusercontent.com/2471874/74876522-120ba280-5321-11ea-9c1b-9b9850e81c5b.png)

