### PR TITLE
Fix: (platform) stackblitz module not declared for PlatformDocumentationModule

### DIFF
--- a/apps/docs/src/app/platform/platform-documentation.module.ts
+++ b/apps/docs/src/app/platform/platform-documentation.module.ts
@@ -57,6 +57,7 @@ import { PlatformSelectTypesDefaultExampleComponent } from './component-docs/pla
 import { PlatformSelectTypesNoBorderExampleComponent } from './component-docs/platform-select/platform-select-examples/platform-select-types-noborder-example.component';
 import { PlatformSelectTypesSplitExampleComponent } from './component-docs/platform-select/platform-select-examples/platform-select-types-split-example.component';
 import { PlatformSelectTypesWithIconExampleComponent } from './component-docs/platform-select/platform-select-examples/platform-select-types-with-icon-example.component';
+import { StackblitzService } from '../documentation/core-helpers/stackblitz/stackblitz.service';
 
 @NgModule({
     declarations: [
@@ -110,6 +111,9 @@ import { PlatformSelectTypesWithIconExampleComponent } from './component-docs/pl
         MarkdownModule.forChild(),
         RouterModule.forChild(ROUTES)
     ],
-    providers: [{ provide: 'CURRENT_LIB', useValue: 'platform' }]
+    providers: [
+            { provide: 'CURRENT_LIB', useValue: 'platform' },
+            StackblitzService
+        ]
 })
 export class PlatformDocumentationModule {}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #2020
Closes #2009

#### Please provide a brief summary of this pull request.
Fix for importing and declaring StackblitzService inside PlatformDocumentationModule

### Before:
![image](https://user-images.githubusercontent.com/10849982/74931314-a63c3f00-53df-11ea-966c-ee40d57d6f0c.png)

### After:
![image](https://user-images.githubusercontent.com/10849982/74931278-93296f00-53df-11ea-8fa4-eea289d9a277.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] Stackblitz works for all examples

