### PR TITLE
[WIP] fix: Add static mode to form message

### DIFF
--- a/libs/core/src/lib/form/form-message/form-message.component.html
+++ b/libs/core/src/lib/form/form-message/form-message.component.html
@@ -1,6 +1,7 @@
 <span
     class="fd-form-message"
-    [ngClass]="[type ? ' fd-form-message--' + type : '', compact ? ' fd-form-message--' + compact : '']"
+    [class.fd-form-message--static] = "static"
+    [ngClass]="[type ? ' fd-form-message--' + type : '']"
 >
     <ng-content></ng-content>
 </span>

--- a/libs/core/src/lib/form/form-message/form-message.component.ts
+++ b/libs/core/src/lib/form/form-message/form-message.component.ts
@@ -18,7 +18,7 @@ export class FormMessageComponent {
     @Input()
     type: MessageStates;
 
-    /** Whether to apply compact mode to the message. */
+    /** Whether to display the message in static mode. */
     @Input()
-    compact: boolean = false;
+    static: boolean = false;
 }


### PR DESCRIPTION
Closes #1970

#### Please provide a brief summary of this pull request.
This PR adds new inpit to `FormMessageComponent` component enabling to display it in static mode. Also `compact` mode has been removed because it is not supported by form-message styling.

#### Please check whether the PR fulfills the following requirements

- [ ] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [ ] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [ ] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [ ] Documentation Examples
- [x] Stackblitz works for all examples

