### PR TITLE
fix: Restore absolute modal position, fix ie11

### DIFF
--- a/libs/core/src/lib/modal/modal-service/modal.service.spec.ts
+++ b/libs/core/src/lib/modal/modal-service/modal.service.spec.ts
@@ -43,7 +43,7 @@ describe('ModalService', () => {
     });
 
     it('should open modal from template', () => {
-        spyOn<any>(service, 'destroyModalComponent').and.callThrough();
+        spyOn<any>(service, '_destroyModalComponent').and.callThrough();
         expect(service['modals'].length).toBe(0);
 
         const fixtureElTmp = TestBed.createComponent(TemplateTestComponent).componentInstance.templateRef;
@@ -54,12 +54,12 @@ describe('ModalService', () => {
         expect(service['modals'][0].backdropRef).toBeTruthy();
 
         modalRef.dismiss();
-        expect((service as any).destroyModalComponent).toHaveBeenCalled();
+        expect((service as any)._destroyModalComponent).toHaveBeenCalled();
         expect(service['modals'].length).toBe(0);
     });
 
     it('should open modal from component', () => {
-        spyOn<any>(service, 'destroyModalComponent').and.callThrough();
+        spyOn<any>(service, '_destroyModalComponent').and.callThrough();
         expect(service['modals'].length).toBe(0);
 
         const modalRef: ModalRef = service.open(TemplateTestComponent);
@@ -69,12 +69,12 @@ describe('ModalService', () => {
         expect(service['modals'][0].backdropRef).toBeTruthy();
 
         modalRef.dismiss();
-        expect((service as any).destroyModalComponent).toHaveBeenCalled();
+        expect((service as any)._destroyModalComponent).toHaveBeenCalled();
         expect(service['modals'].length).toBe(0);
     });
 
     it('should support disabled backdrop', () => {
-        spyOn<any>(service, 'destroyModalComponent').and.callThrough();
+        spyOn<any>(service, '_destroyModalComponent').and.callThrough();
         expect(service['modals'].length).toBe(0);
 
         const modalRef: ModalRef = service.open(TemplateTestComponent, {hasBackdrop: false});
@@ -84,7 +84,7 @@ describe('ModalService', () => {
         expect(service['modals'][0].backdropRef).toBeFalsy();
 
         modalRef.dismiss();
-        expect((service as any).destroyModalComponent).toHaveBeenCalled();
+        expect((service as any)._destroyModalComponent).toHaveBeenCalled();
         expect(service['modals'].length).toBe(0);
     });
 

--- a/libs/core/src/lib/modal/modal-service/modal.service.ts
+++ b/libs/core/src/lib/modal/modal-service/modal.service.ts
@@ -153,14 +153,14 @@ export class ModalService {
         const isYPositionSet: boolean = !!(position.bottom || position.top);
 
         if (isYPositionSet) {
-            componentRef.location.nativeElement.style.top = 'initial';
-            componentRef.location.nativeElement.style.bottom = 'initial';
+            componentRef.location.nativeElement.style.top = 'auto';
+            componentRef.location.nativeElement.style.bottom = 'auto';
             componentRef.location.nativeElement.style.transform = 'translate(-50%, 0)';
         }
 
         if (isXPositionSet) {
-            componentRef.location.nativeElement.style.right = 'initial';
-            componentRef.location.nativeElement.style.left = 'initial';
+            componentRef.location.nativeElement.style.right = 'auto';
+            componentRef.location.nativeElement.style.left = 'auto';
             componentRef.location.nativeElement.style.transform = 'translate(0, -50%)';
         }
 

--- a/libs/core/src/lib/modal/modal-service/modal.service.ts
+++ b/libs/core/src/lib/modal/modal-service/modal.service.ts
@@ -25,7 +25,7 @@ export class ModalService {
 
     /** @hidden */
     constructor(
-        @Inject(DynamicComponentService) private dynamicComponentService: DynamicComponentService
+        @Inject(DynamicComponentService) private _dynamicComponentService: DynamicComponentService
     ) {}
 
     /**
@@ -41,7 +41,7 @@ export class ModalService {
      */
     public dismissAll(): void {
         this.modals.forEach(item => {
-            this.destroyModalComponent(item.modalRef);
+            this._destroyModalComponent(item.modalRef);
         });
     }
 
@@ -60,7 +60,7 @@ export class ModalService {
         service.data = modalConfig.data;
 
         // Create Container
-        const container: ComponentRef<ModalContainer> = this.dynamicComponentService.createDynamicComponent
+        const container: ComponentRef<ModalContainer> = this._dynamicComponentService.createDynamicComponent
             < ModalContainer > (contentType, ModalContainer, modalConfig)
         ;
 
@@ -75,21 +75,21 @@ export class ModalService {
         // Create Backdrop
         let backdrop: ComponentRef<ModalBackdrop>;
         if (modalConfig.hasBackdrop) {
-            backdrop = this.dynamicComponentService.createDynamicComponent<ModalBackdrop>
+            backdrop = this._dynamicComponentService.createDynamicComponent<ModalBackdrop>
                 (contentType, ModalBackdrop, modalConfig, [service])
             ;
         }
 
         // Create Component
-        const component = this.dynamicComponentService.createDynamicComponent
+        const component = this._dynamicComponentService.createDynamicComponent
             < ModalComponent > (contentType, ModalComponent, modalConfig, [service])
         ;
 
         // Sizing
-        this.setModalSize(component, modalConfig);
+        this._setModalSize(component, modalConfig);
 
         // Positioning
-        this.setModalPosition(component, modalConfig.position);
+        this._setModalPosition(component, modalConfig.position);
 
         this.modals.push({
             modalRef: component,
@@ -98,7 +98,7 @@ export class ModalService {
         });
 
         const defaultBehaviourOnClose = () => {
-            this.destroyModalComponent(component);
+            this._destroyModalComponent(component);
             refSub.unsubscribe();
         };
 
@@ -109,17 +109,17 @@ export class ModalService {
         return service;
     }
 
-    private destroyModalComponent(modal: ComponentRef<ModalComponent>): void {
+    private _destroyModalComponent(modal: ComponentRef<ModalComponent>): void {
 
         const arrayRef = this.modals.find((item) => item.modalRef === modal);
         const indexOf = this.modals.indexOf(arrayRef);
-        this.dynamicComponentService.destroyComponent(arrayRef.modalRef);
-        this.dynamicComponentService.destroyComponent(arrayRef.containerRef);
+        this._dynamicComponentService.destroyComponent(arrayRef.modalRef);
+        this._dynamicComponentService.destroyComponent(arrayRef.containerRef);
         arrayRef.containerRef.destroy();
         arrayRef.modalRef.destroy();
 
         if (arrayRef.backdropRef) {
-            this.dynamicComponentService.destroyComponent(arrayRef.backdropRef);
+            this._dynamicComponentService.destroyComponent(arrayRef.backdropRef);
             arrayRef.backdropRef.destroy();
         }
 
@@ -128,7 +128,7 @@ export class ModalService {
 
     }
 
-    private setModalSize(componentRef: ComponentRef<ModalComponent>, configObj: ModalConfig): void {
+    private _setModalSize(componentRef: ComponentRef<ModalComponent>, configObj: ModalConfig): void {
         componentRef.location.nativeElement.style.minWidth = configObj.minWidth;
         componentRef.location.nativeElement.style.minHeight = configObj.minHeight;
         componentRef.location.nativeElement.style.maxWidth = configObj.maxWidth;
@@ -137,12 +137,35 @@ export class ModalService {
         componentRef.location.nativeElement.style.height = configObj.height;
     }
 
-    private setModalPosition(componentRef: ComponentRef<ModalComponent>, position: ModalPosition): void {
+    private _setModalPosition(componentRef: ComponentRef<ModalComponent>, position: ModalPosition): void {
         if (position) {
+            this._removeCurrentPositionModifiers(componentRef, position);
             componentRef.location.nativeElement.style.top = position.top;
             componentRef.location.nativeElement.style.bottom = position.bottom;
             componentRef.location.nativeElement.style.right = position.right;
             componentRef.location.nativeElement.style.left = position.left;
+        }
+    }
+
+    private _removeCurrentPositionModifiers(componentRef: ComponentRef<ModalComponent>, position: ModalPosition): void {
+
+        const isXPositionSet: boolean = !!(position.right || position.left);
+        const isYPositionSet: boolean = !!(position.bottom || position.top);
+
+        if (isYPositionSet) {
+            componentRef.location.nativeElement.style.top = 'initial';
+            componentRef.location.nativeElement.style.bottom = 'initial';
+            componentRef.location.nativeElement.style.transform = 'translate(-50%, 0)';
+        }
+
+        if (isXPositionSet) {
+            componentRef.location.nativeElement.style.right = 'initial';
+            componentRef.location.nativeElement.style.left = 'initial';
+            componentRef.location.nativeElement.style.transform = 'translate(0, -50%)';
+        }
+
+        if (isXPositionSet && isYPositionSet) {
+            componentRef.location.nativeElement.style.transform = 'translate(0, 0)'
         }
     }
 }

--- a/libs/core/src/lib/modal/modal.component.scss
+++ b/libs/core/src/lib/modal/modal.component.scss
@@ -3,6 +3,11 @@
 //TODO evaluate whether this should go to fd-styles
 .fd-modal-custom {
     max-width: none;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    position: absolute;
+
     z-index: 1000;
     max-height: 100vh;
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2010
#### Please provide a brief summary of this pull request.
`Position: Absolute` is needed to keep placement feature. I'm centering 
#### Please check whether the PR fulfills the following requirements


Results:
IE11:
![image](https://user-images.githubusercontent.com/26483208/74927960-e51ac680-53d8-11ea-842b-2978b83fd60f.png)

All positions:
![image](https://user-images.githubusercontent.com/26483208/74929033-f95fc300-53da-11ea-90f4-0fa6e1570435.png)

Position on IE
![image](https://user-images.githubusercontent.com/26483208/74933151-b3f3c380-53e3-11ea-90b5-4f73fa2d6876.png)



- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

