### PR TITLE
fix: Add 3rd state support for Ie11

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -1,4 +1,5 @@
 <input
+    #inputLabel
     type="checkbox"
     class="fd-checkbox"
     [id]="inputId"
@@ -9,8 +10,11 @@
     [ngClass]="(state ? 'is-' + state : '')"
     [ngModel]="isChecked"
     (ngModelChange)="nextValue()"
+    (keydown)="checkByKey($event)"
+    (keyup)="$event.stopPropagation()"
 >
 <label class="fd-checkbox__label"
+       (click)="checkByClick()"
        [class.fd-checkbox__label--compact]="compact"
        [for]="inputId">
     {{label}}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2027
#### Please provide a brief summary of this pull request.

There is added some workaround for IE11 and third state for checkbox.
I had to put 4th state, which is supposed to force `(ngModelChange)` and finally set `checked` state. 
Also there was some issues during change detecting and `checked` property is added manually to input.

there is also method, that informs if the user uses IE11, to force `nextValue` call on `intederminate` state, when it's mouse clicked, or space key is dispatched.

![checkbox](https://user-images.githubusercontent.com/26483208/74956152-f9c18380-5405-11ea-947d-b95423a465cf.gif)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

