### PR TITLE
fix: combobox search term change popover positioning bug

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.spec.ts
+++ b/libs/core/src/lib/combobox/combobox.component.spec.ts
@@ -6,6 +6,7 @@ import { FormsModule } from '@angular/forms';
 import { MenuModule } from '../menu/menu.module';
 import { PipeModule } from '../utils/pipes/pipe.module';
 import { InputGroupModule } from '../input-group/input-group.module';
+import { PopoverComponent } from '@fundamental-ngx/core';
 
 describe('ComboboxComponent', () => {
     let component: ComboboxComponent;
@@ -175,4 +176,16 @@ describe('ComboboxComponent', () => {
         component.writeValue({ value: 'value2', displayedValue: 'displayedValue2' });
         expect(component.inputTextValue).toBe('displayedValue2');
     });
+
+    it('should handleSearchTermChange', () => {
+        component.dropdownValues = ['value 1', 'value 2'];
+        component.inputText = 'input text';
+        spyOn(component, 'filterFn');
+        spyOn(component.popoverComponent, 'updatePopover');
+
+        component.handleSearchTermChange();
+
+        expect(component.filterFn).toHaveBeenCalledWith(component.dropdownValues, component.inputText);
+        expect(component.popoverComponent.updatePopover).toHaveBeenCalled();
+    })
 });

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -25,6 +25,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import focusTrap, { FocusTrap } from 'focus-trap';
 import { FormStates } from '../form/form-control/form-states';
+import { PopoverComponent } from '../popover/popover.component';
 
 /**
  * Allows users to filter through results and select a value.
@@ -179,6 +180,10 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
     comboboxMenuElement: ElementRef;
 
     /** @hidden */
+    @ViewChild(PopoverComponent, { static: false })
+    popoverComponent: PopoverComponent;
+
+    /** @hidden */
     displayedValues: any[] = [];
 
     /** @hidden */
@@ -312,6 +317,9 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
     /** @hidden */
     handleSearchTermChange(): void {
         this.displayedValues = this.filterFn(this.dropdownValues, this.inputText);
+        if (this.popoverComponent) {
+            this.popoverComponent.updatePopover();
+        }
     }
 
     /** @hidden */


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#2029 

#### Please provide a brief summary of this pull request.

If the search term changes and affects the length of the resulting list, the popover body could be positioned incorrectly.  This updates the popover whenever the search term changes.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

