### PR TITLE
docs: Remove main language input from popover

### DIFF
--- a/apps/docs/src/app/core/component-docs/localization-editor/examples/localization-editor-forms-example.component.html
+++ b/apps/docs/src/app/core/component-docs/localization-editor/examples/localization-editor-forms-example.component.html
@@ -10,20 +10,21 @@
                        type="text"
                        placeholder="EN">
             </fd-localization-editor-main>
-            <li fd-localization-editor-element *ngFor="let key of customFormKeys">
+            <li fd-localization-editor-element *ngFor="let key of otherLanguages">
                 <fd-localization-editor-item [label]="key | uppercase" [compact]="true">
                     <input fd-form-control
                            fd-localization-editor-input
-                           formControlName="{{key}}"
                            type="text"
                            [compact]="true"
-                           placeholder="{{key | uppercase}}">
+                           [formControlName]="key"
+                           [placeholder]="key | uppercase">
                 </fd-localization-editor-item>
             </li>
         </fd-localization-editor>
         <br/>
     </div>
 </form>
-<ng-container *ngFor="let key of customFormKeys">
-    <br/>{{key | uppercase}}: {{customForm.get(key).value}}
-</ng-container>
+
+<div *ngFor="let item of customForm.controls | keyvalue">
+    {{item.key | uppercase}}: {{item.value.value}}
+</div>

--- a/apps/docs/src/app/core/component-docs/localization-editor/examples/localization-editor-forms-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/localization-editor/examples/localization-editor-forms-example.component.ts
@@ -15,5 +15,5 @@ export class LocalizationEditorFormsExampleComponent {
         nl: new FormControl('')
     });
 
-    customFormKeys: string[] = ['en', 'de', 'pl', 'ca', 'nl'];
+    otherLanguages: string[] = ['de', 'pl', 'ca', 'nl'];
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #2032

#### Please provide a brief summary of this pull request.
This PR updates Localization editor documentation example by removing main language from form displayed in popover.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples