### PR TITLE
docs: (popover) change dynamic popover example placement

### DIFF
--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dynamic/popover-dynamic-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dynamic/popover-dynamic-example.component.html
@@ -1,4 +1,4 @@
-<fd-popover #popoverComponent [closeOnOutsideClick]="true" [focusTrapped]="true" placement="top"
+<fd-popover #popoverComponent [closeOnOutsideClick]="true" [focusTrapped]="true"
             [noArrow]="false" title="top">
     <fd-popover-control>
         <button fd-button [glyph]="'add'" class="fd-image--circle"></button>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes: https://github.com/SAP/fundamental-ngx/issues/2061
#### Please provide a brief summary of this pull request.
There is changed placement on popover dynamic example, to prevent overflowing behind the page. 
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

