### PR TITLE
docs: fix the broken Bar documentation

### DIFF
--- a/apps/docs/src/app/core/component-docs/bar/bar-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/bar/bar-docs.component.html
@@ -5,7 +5,7 @@
     The default mode of the Bar component is Desktop. For Tablet and Mobile use the Cosy mode by adding <code>[cosy]="true"</code> to <code>fd-bar</code>
 </description>
 
-<component-example [name]="'ex1'">
+<component-example>
     <fd-bar-default-example></fd-bar-default-example>
 </component-example>
 <code-example [exampleFiles]="barDefaultExample"></code-example>
@@ -17,7 +17,7 @@
 </fd-docs-section-title>
 <description></description>
 
-<component-example [name]="'ex2'">
+<component-example>
     <fd-bar-header-example></fd-bar-header-example>
 </component-example>
 <code-example [exampleFiles]="barHeaderExample"></code-example>
@@ -29,7 +29,7 @@
 </fd-docs-section-title>
 <description></description>
 
-<component-example [name]="'ex3'">
+<component-example>
     <fd-bar-subheader-example></fd-bar-subheader-example>
 </component-example>
 <code-example [exampleFiles]="barSubHeaderExample"></code-example>
@@ -43,7 +43,7 @@
     A bar element can take the whole width of the container by setting the <code>[fullWidth]</code> property to <code>true</code>. 
 </description>
 
-<component-example [name]="'ex4'">
+<component-example>
     <fd-bar-header-subheader-example></fd-bar-header-subheader-example>
 </component-example>
 <code-example [exampleFiles]="barHeaderSubHeaderExample"></code-example>
@@ -55,7 +55,7 @@
 </fd-docs-section-title>
 <description></description>
 
-<component-example [name]="'ex5'">
+<component-example>
     <fd-bar-footer-example></fd-bar-footer-example>
 </component-example>
 <code-example [exampleFiles]="barFooterExample"></code-example>
@@ -67,7 +67,7 @@
 </fd-docs-section-title>
 <description></description>
 
-<component-example [name]="'ex6'">
+<component-example>
     <fd-bar-floating-footer-example></fd-bar-floating-footer-example>
 </component-example>
 <code-example [exampleFiles]="barFloatingFooterExample"></code-example>
@@ -81,7 +81,7 @@
     To use the Bar component as a building block of a Page set the <code>[inPage]</code> property to <code>true</code>. For a Home Page use the <code>[inHomePage]</code> property.
 </description>
 
-<component-example [name]="'ex7'">
+<component-example>
     <fd-bar-page-example></fd-bar-page-example>
 </component-example>
 <code-example [exampleFiles]="barPageExample"></code-example>
@@ -95,8 +95,7 @@
     The left and right paddings of the Bar can be adjusted according to the width of the container with the <code>[size]</code> property. Available values are: <code>s</code>, <code>m_l</code> and <code>xl</code>
 </description>
 
-<component-example [name]="'ex8'">
+<component-example>
     <fd-bar-page-responsive-example></fd-bar-page-responsive-example>
 </component-example>
 <code-example [exampleFiles]="barPageResponsiveExample"></code-example>
-


### PR DESCRIPTION
Remove `name` property from `component-example` in Bar docs
