### PR TITLE
fix: missing input group number placeholder

### DIFF
--- a/apps/docs/src/app/core/component-docs/input-group/examples/input-group-form-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/examples/input-group-form-example.component.html
@@ -12,7 +12,7 @@
         </div>
         <div fd-form-item>
             <label fd-form-label>Quantity Spinner</label>
-            <fd-input-group-number  formControlName="number"></fd-input-group-number>
+            <fd-input-group-number formControlName="number" [placeholder]="'Amount'"></fd-input-group-number>
             Number Entered: {{ customForm.controls?.number?.value }}
         </div>
     </fieldset>

--- a/apps/docs/src/app/core/component-docs/input-group/examples/input-group-number-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/examples/input-group-number-example.component.html
@@ -1,4 +1,4 @@
 <label fd-form-label>Quantity Spinner</label>
-<fd-input-group-number [disabled]="false" [(ngModel)]="numberValue"></fd-input-group-number>
+<fd-input-group-number [disabled]="false" [(ngModel)]="numberValue" [placeholder]="'Amount'"></fd-input-group-number>
 <br/>
 <span>numberValue: {{numberValue}}</span>

--- a/apps/docs/src/app/core/component-docs/input-group/examples/input-group-number-example/input-group-number-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/examples/input-group-number-example/input-group-number-example.component.html
@@ -1,4 +1,4 @@
 <label fd-form-label>Quantity Spinner</label>
-<fd-input-group-number [disabled]="false" [(ngModel)]="numberValue"></fd-input-group-number>
+<fd-input-group-number [disabled]="false" [(ngModel)]="numberValue" [placeholder]="'Amount'"></fd-input-group-number>
 <br/>
 <span>numberValue: {{numberValue}}</span>

--- a/libs/core/src/lib/input-group/input-group-number.component.ts
+++ b/libs/core/src/lib/input-group/input-group-number.component.ts
@@ -30,7 +30,7 @@ export class InputGroupNumberComponent implements ControlValueAccessor {
 
     /** Placeholder for the input field. */
     @Input()
-    placeholder: string;
+    placeholder: string = '';
 
     /** Aria label for the 'step up' button. */
     @Input()


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#2106 

#### Please provide a brief summary of this pull request.

Fix bug where default placeholder for number input group would read 'undefined'