### PR TITLE
fix: add type button to input group and select

### DIFF
--- a/libs/core/src/lib/input-group/input-group.component.html
+++ b/libs/core/src/lib/input-group/input-group.component.html
@@ -25,7 +25,8 @@
                     [options]="buttonOptions"
                     [glyph]="glyph"
                     [class]="inShellbar ? 'fd-shellbar__button' : ''"
-                    (click)="buttonClicked($event)">
+                    (click)="buttonClicked($event)"
+                    type="button">
                 <ng-container *ngIf="!glyph">{{addOnText}}</ng-container>
             </button>
         </span>

--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -22,6 +22,7 @@
                     'fd-button--noborder': selectType === 'noborder',
                     'fd-button--splitborder': selectType === 'splitborder'
                 }"
+                type="button"
             >
                 <fd-icon *ngIf="glyph" size="m" [glyph]="glyph" class="fd-template-icon icon-position"> </fd-icon>
                 <span class="fd-select-text-custom" [dir]="dir$ | async">{{ triggerValue }}</span>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #2083
#### Please provide a brief summary of this pull request.
Added the attribute type=`button` to input group and select so forms are not submitted when placed in them.
#### Please check whether the PR fulfills the following requirements

- [ x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

