### PR TITLE
docs: Fix allowed PR types in the contribution guidelines from doc to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ chore: Updated package.json
 
 ##### Type
 
-Type can have following values: `WIP|feat|chore|test|doc|fix`.
+c
 
 The `WIP` represent work in progress and it will not be merged, so please make sure to use one of 
 the specific format such as `feat|chore|test|doc|fix` if your PR needs to be merged with master 


### PR DESCRIPTION
## Please provide a brief summary of this pull request.
In the PR Types there was a wrong type for tge documentation. Changing it from `doc:xxx` to `docs:xxxx`


#### Please check whether the PR fulfills the following requirements

- [x ] the commit message follows the guideline:
