### PR TITLE
fix: fixed-width breadcrumb containers not collapsing overflowing breadcrumbs

### DIFF
--- a/apps/docs/src/app/core/component-docs/breadcrumb/breadcrumb-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/breadcrumb/breadcrumb-docs.component.html
@@ -21,7 +21,8 @@
 <description>
     The breadcrumb will automatically refer to its parent element to know whether to show breadcrumbs or to collapse them
     into the overflow menu. You can provide an HTMLElement to the [containerElement] input to set your own container
-    element.
+    element. Note that the responsiveness feature will not function properly if the containerElement or parent element
+    have a set fixed width.
 </description>
 <component-example>
     <fd-breadcrumb-responsive-example></fd-breadcrumb-responsive-example>

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -42,7 +42,7 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
     /** @hidden */
     collapsedBreadcrumbItems: Array<BreadcrumbItemDirective> = [];
 
-    /** @hidden */
+    /** @hidden used to compare to the current width to know whether to collapse or expand breadcrumbs */
     previousContainerWidth: number;
 
     /** @hidden */
@@ -65,7 +65,10 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
         if (this.containerElement) {
             this.containerBoundary = this.containerElement.getBoundingClientRect().width;
         }
-        // if the screen is getting smaller
+        /*
+            if this is the first load and there is no previousContainerWidth,
+            or the container boundary is smaller than the previousContainerWidth
+         */
         if (!this.previousContainerWidth || this.containerBoundary < this.previousContainerWidth) {
             // and the breadcrumbs extend past the window
             if (this.elementRef.nativeElement.getBoundingClientRect().width > this.containerBoundary) {

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -66,7 +66,7 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
             this.containerBoundary = this.containerElement.getBoundingClientRect().width;
         }
         // if the screen is getting smaller
-        if (this.containerBoundary < this.previousContainerWidth) {
+        if (!this.previousContainerWidth || this.containerBoundary < this.previousContainerWidth) {
             // and the breadcrumbs extend past the window
             if (this.elementRef.nativeElement.getBoundingClientRect().width > this.containerBoundary) {
                 this.collapseBreadcrumbs();
@@ -139,7 +139,6 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
 
     /** @hidden */
     ngAfterContentInit(): void {
-        this.previousContainerWidth = this.containerBoundary;
         this.onResize();
     }
 


### PR DESCRIPTION
Also explain that the responsive behavior will not work if the container has a fixed width.

#### Please provide a link to the associated issue.

#2160 

Before: 
![Screen Shot 2020-03-19 at 11 52 17 AM](https://user-images.githubusercontent.com/2471874/77098583-34541700-69d8-11ea-9fee-7f953a8de31d.png)

After:
![Screen Shot 2020-03-19 at 11 52 51 AM](https://user-images.githubusercontent.com/2471874/77098589-38803480-69d8-11ea-83ba-9775d72af618.png)
