### PR TITLE
fix: (input group) Add type of input group and example

### DIFF
--- a/apps/docs/src/app/core/component-docs/input-group/examples/input-group-search-example/input-group-search-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/examples/input-group-search-example/input-group-search-example.component.html
@@ -8,4 +8,20 @@
     (addOnButtonClicked)="searchTerm = ''">
 </fd-input-group>
 <br/>
-<span>searchTerm: {{searchTerm}}</span>
+<span>Search term: {{searchTerm}}</span>
+
+<br/>
+<br/>
+<br/>
+
+<label fd-form-label>Search input with search type</label>
+<fd-input-group
+    [disabled]="false"
+    [(ngModel)]="searchTermSecond"
+    [glyph]="'search'"
+    [placeholder]="'Search'"
+    [button]="true"
+    [type]="'search'">
+</fd-input-group>
+<br/>
+<span>Search term: {{searchTermSecond}}</span>

--- a/apps/docs/src/app/core/component-docs/input-group/examples/input-group-search-example/input-group-search-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/input-group/examples/input-group-search-example/input-group-search-example.component.ts
@@ -7,5 +7,6 @@ import { Component } from '@angular/core';
 export class InputGroupSearchExampleComponent {
 
     searchTerm = 'Search Term';
+    searchTermSecond = 'Search Term';
 
 }

--- a/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.html
@@ -69,7 +69,7 @@
 </fd-docs-section-title>
 <description>
     This input group automatically shows a clear search button when the user has entered a value in the input.
-    In example there is changed type of input, inside <code>InputGroup</code>, by passing <code>[type]="'search'"</code>
+    The input type can be changed using <code>[type]="'search'"</code> inside the <code>InputGroup</code>.
 </description>
 <component-example>
     <fd-input-group-search-example></fd-input-group-search-example>

--- a/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.html
@@ -69,6 +69,7 @@
 </fd-docs-section-title>
 <description>
     This input group automatically shows a clear search button when the user has entered a value in the input.
+    In example there is changed type of input, inside <code>InputGroup</code>, by passing <code>[type]="'search'"</code>
 </description>
 <component-example>
     <fd-input-group-search-example></fd-input-group-search-example>

--- a/libs/core/src/lib/input-group/input-group.component.html
+++ b/libs/core/src/lib/input-group/input-group.component.html
@@ -53,7 +53,7 @@
            [class]="inShellbar ? 'fd-shellbar__input-group__input' : ''"
            fd-input-group-input
            [compact]="compact"
-           type="text"
+           [type]="type"
            *ngIf="!inputElement && !inputTemplate"
            placeholder="{{placeholder}}">
 </ng-template>

--- a/libs/core/src/lib/input-group/input-group.component.ts
+++ b/libs/core/src/lib/input-group/input-group.component.ts
@@ -86,6 +86,10 @@ export class InputGroupComponent implements ControlValueAccessor {
     @Input()
     buttonType: ButtonType;
 
+    /** The type of the input, used in Input Group. By default value is set to 'text' */
+    @Input()
+    type: string = 'text';
+
     /** Button options.  Options include 'emphasized' and 'light'. Leave empty for default.' */
     @Input()
     buttonOptions: ButtonOptions | ButtonOptions[] = 'light';


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2136
#### Please provide a brief summary of this pull request.
There is added way to add `type` of input inside input-group component. 
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

