### PR TITLE
fix: Make properties DND IE11 compatible

### DIFF
--- a/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.spec.ts
@@ -6,11 +6,13 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @Component({
     template: `
-        <div #directiveElement fd-dnd-container>
-            <div cdkDrag>
-                <div></div>
-            </div>
-        </div>
+            <span>
+                <div #directiveElement fd-dnd-container>
+                    <div cdkDrag>
+                        <div></div>
+                    </div>
+                </div>
+            </span>
     `
 })
 class TestDndContainerComponent {
@@ -53,6 +55,7 @@ describe('DndContainerDirective', () => {
     it('should react to drag release', () => {
         spyOn(directive.released, 'emit');
         (directive as any).placeholderElement = document.createElement('div');
+        directive.element.nativeElement.appendChild((directive as any).placeholderElement);
         directive.onCdkDragReleased();
         expect((directive as any).placeholderElement).toBeFalsy();
         expect(directive.released.emit).toHaveBeenCalled();

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
@@ -108,7 +108,7 @@ export class DndContainerDirective implements AfterContentInit {
 
     /** @hidden */
     public removePlaceholder(): void {
-        if (this.placeholderElement) {
+        if (this.placeholderElement && this.placeholderElement.parentNode) {
             // IE11 workaround
             this.placeholderElement.parentNode.removeChild(this.placeholderElement);
             this.placeholderElement = null;
@@ -117,7 +117,7 @@ export class DndContainerDirective implements AfterContentInit {
 
     /** @hidden */
     public removeLine(): void {
-        if (this.lineElement) {
+        if (this.lineElement && this.lineElement.parentNode) {
             // IE11 workaround
             this.lineElement.parentNode.removeChild(this.lineElement);
             this.lineElement = null;

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
@@ -54,13 +54,13 @@ export class DndContainerDirective implements AfterContentInit {
         const position: LinkPosition = isBefore ? 'before' : 'after';
 
         /** Depending on the position, gets the left or right side of element */
-        const x = rect.x + (isBefore || listMode ? 0 : this.element.nativeElement.offsetWidth);
+        const x = rect.left + (isBefore || listMode ? 0 : this.element.nativeElement.offsetWidth);
 
         /** Vertically distance is counted by distance from top of the side + half of the element height */
         return {
             x: x,
             position: position,
-            y: rect.y + (this.element.nativeElement.offsetHeight / 2),
+            y: rect.top + (this.element.nativeElement.offsetHeight / 2),
             stickToPosition: this.stickInPlace
         };
     }
@@ -109,7 +109,8 @@ export class DndContainerDirective implements AfterContentInit {
     /** @hidden */
     public removePlaceholder(): void {
         if (this.placeholderElement) {
-            this.placeholderElement.remove();
+            // IE11 workaround
+            this.placeholderElement.parentNode.removeChild(this.placeholderElement);
             this.placeholderElement = null;
         }
     }
@@ -117,7 +118,8 @@ export class DndContainerDirective implements AfterContentInit {
     /** @hidden */
     public removeLine(): void {
         if (this.lineElement) {
-            this.lineElement.remove();
+            // IE11 workaround
+            this.lineElement.parentNode.removeChild(this.lineElement);
             this.lineElement = null;
         }
     }

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
@@ -108,8 +108,6 @@ export class DndListDirective implements AfterContentInit {
         const replacedItemIndex = this.closestLinkIndex;
         const draggedItem = this.items[draggedItemIndex];
 
-
-
         if (draggedItemIndex < replacedItemIndex) {
             for (let i = draggedItemIndex; i < replacedItemIndex; i++) {
                 this.items[i] = this.items[i + 1];

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
@@ -108,6 +108,8 @@ export class DndListDirective implements AfterContentInit {
         const replacedItemIndex = this.closestLinkIndex;
         const draggedItem = this.items[draggedItemIndex];
 
+
+
         if (draggedItemIndex < replacedItemIndex) {
             for (let i = draggedItemIndex; i < replacedItemIndex; i++) {
                 this.items[i] = this.items[i + 1];
@@ -165,15 +167,15 @@ export class DndListDirective implements AfterContentInit {
         const draggedElementBound = <DOMRect>draggedElement.nativeElement.getBoundingClientRect();
         const targetElementBound = <DOMRect>targetElement.nativeElement.getBoundingClientRect();
 
-        if (draggedElementBound.y - targetElementBound.y > VERTICAL_OFFSET) {
+        if (draggedElementBound.top - targetElementBound.top > VERTICAL_OFFSET) {
             /** If element is higher than the dragged element, it's for sure before */
             return true;
-        } else if (targetElementBound.y - draggedElementBound.y > VERTICAL_OFFSET) {
+        } else if (targetElementBound.top - draggedElementBound.top > VERTICAL_OFFSET) {
             /** If element is lower than the dragged element, it's for sure after */
             return false;
         } else {
             /** If elements are in same level, the horizontal position decides if it's before/after */
-            return draggedElementBound.x - targetElementBound.x > 0;
+            return draggedElementBound.left - targetElementBound.left > 0;
         }
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
One of https://github.com/SAP/fundamental-ngx/issues/2192
#### Please provide a brief summary of this pull request.
There are some native JS methods replaced, because of IE11 compatibility
`getBoundingClientRect().x/y` to `getBoundingClientRect().left/top` and
`element.remove()` to `element.parentNode.removeChild(element)`
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

