### PR TITLE
docs: remove duplicate section headings in the documentation

### DIFF
--- a/apps/docs/src/app/core/component-docs/file-input/file-input-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/file-input/file-input-docs.component.html
@@ -42,7 +42,6 @@
 <fd-docs-section-title [id]="'file-input-dropzone'" [componentName]="'file-input'">
     Dropzone File Input
 </fd-docs-section-title>
-<h2>Dropzone File Input</h2>
 <description
     >The component outputs events that make it very simple to style a dropzone depending on the current state. The
     example below also allows deals with duplicates, concatenating consecutive files into a list, and then displays them

--- a/apps/docs/src/app/core/component-docs/image/image-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/image/image-docs.component.html
@@ -25,7 +25,6 @@
 </description>
 <separator></separator>
 
-<h2>Extensibility</h2>
 <fd-docs-section-title [id]="'image-extensibility'" [componentName]="'image'">
     Extensibility
 </fd-docs-section-title>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of #2192 
#### Please provide a brief summary of this pull request.
Removed duplicate section heading from the documentation of Image and File Input
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
