### PR TITLE
fix: add icons styles to dependant components

### DIFF
--- a/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.html
@@ -13,7 +13,7 @@
         NGX
     </span>
 </a>
-<div class="fd-docs--toolbar__lib">
+<div class="fd-shellbar fd-docs--toolbar__lib">
     <fd-product-menu [control]="isOnCore ? 'Core' : 'Platform'" [closePopoverOnSelect]="true" [items]="items">
     </fd-product-menu>
 </div>

--- a/libs/core/src/lib/action-bar/action-bar.component.scss
+++ b/libs/core/src/lib/action-bar/action-bar.component.scss
@@ -1,1 +1,2 @@
+@import "~fundamental-styles/dist/icon";
 @import "~fundamental-styles/dist/action-bar";

--- a/libs/core/src/lib/alert/alert.component.scss
+++ b/libs/core/src/lib/alert/alert.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 @import "~fundamental-styles/dist/alert";
 
 .fd-alert {

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.scss
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 @import '~fundamental-styles/dist/breadcrumb';
 
 .fd-breadcrumb {

--- a/libs/core/src/lib/button/button.component.scss
+++ b/libs/core/src/lib/button/button.component.scss
@@ -1,1 +1,2 @@
+@import "~fundamental-styles/dist/icon";
 @import "~fundamental-styles/dist/button";

--- a/libs/core/src/lib/calendar/calendar.component.scss
+++ b/libs/core/src/lib/calendar/calendar.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 @import '~fundamental-styles/dist/calendar';
 
 .fd-calendar__content {

--- a/libs/core/src/lib/date-picker/date-picker.component.scss
+++ b/libs/core/src/lib/date-picker/date-picker.component.scss
@@ -1,3 +1,5 @@
+@import "~fundamental-styles/dist/icon";
+
 .fd-date-picker-custom {
     display: inline-block;
 

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.scss
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.scss
@@ -1,3 +1,5 @@
+@import "~fundamental-styles/dist/icon";
+
 .fd-datetime-host {
     display: inline-block;
     width: 230px;

--- a/libs/core/src/lib/input-group/input-group.component.scss
+++ b/libs/core/src/lib/input-group/input-group.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 @import '~fundamental-styles/dist/input-group';
 
 fd-input-group {

--- a/libs/core/src/lib/input-group/input-group.component.scss
+++ b/libs/core/src/lib/input-group/input-group.component.scss
@@ -1,4 +1,6 @@
 @import "~fundamental-styles/dist/icon";
+@import "~fundamental-styles/dist/form-item";
+@import "~fundamental-styles/dist/input";
 @import '~fundamental-styles/dist/input-group';
 
 fd-input-group {

--- a/libs/core/src/lib/list/list.component.scss
+++ b/libs/core/src/lib/list/list.component.scss
@@ -1,1 +1,2 @@
+@import "~fundamental-styles/dist/icon";
 @import "~fundamental-styles/dist/list";

--- a/libs/core/src/lib/modal/modal.component.scss
+++ b/libs/core/src/lib/modal/modal.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 // @import "~fundamental-styles/dist/modal";
 
 //TODO evaluate whether this should go to fd-styles

--- a/libs/core/src/lib/pagination/pagination.component.scss
+++ b/libs/core/src/lib/pagination/pagination.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 @import "~fundamental-styles/dist/pagination";
 
 .fd-pagination-direction-override-display {

--- a/libs/core/src/lib/segmented-button/segmented-button.component.scss
+++ b/libs/core/src/lib/segmented-button/segmented-button.component.scss
@@ -1,2 +1,3 @@
+@import "~fundamental-styles/dist/icon";
 @import '~fundamental-styles/dist/segmented-button';
 @import '~fundamental-styles/dist/button';

--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 @import '../button/button.component.scss';
 
 .fd-select-custom {

--- a/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
+++ b/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
@@ -13,7 +13,7 @@
     >
         <fd-popover-control>
             <button
-                class="fd-button fd-button--transparet fd-button--menu fd-shellbar__button fd-shellbar__button--menu"
+                class="fd-button fd-button--transparent fd-button--menu fd-shellbar__button--menu"
             >
                 <span class="fd-shellbar__title">
                     {{ control }}

--- a/libs/core/src/lib/shellbar/shellbar.component.scss
+++ b/libs/core/src/lib/shellbar/shellbar.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 @import "~fundamental-styles/dist/shellbar";
 @import "~fundamental-styles/dist/counter";
 

--- a/libs/core/src/lib/split-button/split-button.component.scss
+++ b/libs/core/src/lib/split-button/split-button.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 @import '~fundamental-styles/dist/button-split';
 
 // temp fix, this should be added to styles

--- a/libs/core/src/lib/switch/switch.component.scss
+++ b/libs/core/src/lib/switch/switch.component.scss
@@ -1,3 +1,4 @@
+@import "~fundamental-styles/dist/icon";
 @import "~fundamental-styles/dist/switch";
 
 .fd-switch-custom {

--- a/libs/core/src/lib/tree/tree.component.scss
+++ b/libs/core/src/lib/tree/tree.component.scss
@@ -1,1 +1,2 @@
+@import "~fundamental-styles/dist/icon";
 @import "~fundamental-styles/dist/tree";


### PR DESCRIPTION
Bring `@import "~fundamental-styles/dist/icon";` to all components that rely on icons, such as Buttons, Input-Groups, etc.