### PR TITLE
fix: IE11 crash by avoiding argument-less calls to classList.add

### DIFF
--- a/libs/core/src/lib/popover/popover-directive/popover.directive.ts
+++ b/libs/core/src/lib/popover/popover-directive/popover.directive.ts
@@ -245,7 +245,7 @@ export class PopoverDirective implements OnInit, OnDestroy, OnChanges {
         this.containerRef.instance.noArrow = this.noArrow;
         this.containerRef.instance.closeOnEscapeKey = this.closeOnEscapeKey;
 
-        if (this.additionalClasses) {
+        if (this.additionalClasses.length > 0) {
             this.containerRef.location.nativeElement.classList.add(...this.additionalClasses);
         }
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/2252

And it's the same issue and the same solution as in https://github.com/mapbox/mapbox-gl-draw/issues/479

#### Please provide a brief summary of this pull request.
On click of Buttons of Components like Datepicker, Combobox, and so on this issue is triggered because IE11 cannot handle empty Arrays on a spread operator e.g. `...this.additionalClasses`. Second thing is that the Array should be queried by `.length > 0` otherwise the statement will be always true.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

