### PR TITLE
feat: update form validation states and messages

### DIFF
--- a/apps/docs/src/app/core/component-docs/checkbox/checkbox-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/checkbox/checkbox-docs.component.html
@@ -86,7 +86,7 @@
     <ul>
         <li style="margin-bottom: .5rem;">
             Modifies visual appearance of checkbox <br>
-            <code>[state] = 'valid' | 'invalid' | 'information' | 'warning'</code>
+            <code>[state] = 'success' | 'error' | 'information' | 'warning'</code>
         </li>
         <li style="margin-bottom: .5rem;">
             Disables control <br>

--- a/apps/docs/src/app/core/component-docs/checkbox/examples/checkbox-states-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/checkbox/examples/checkbox-states-example.component.ts
@@ -7,9 +7,9 @@ import {Component} from '@angular/core';
             States:
             <fd-checkbox [(ngModel)]="checkboxValue1" label="No state"></fd-checkbox>
             <fd-checkbox [(ngModel)]="checkboxValue2" state="information" label="Info state"></fd-checkbox>
-            <fd-checkbox [(ngModel)]="checkboxValue3" state="valid" label="Valid state"></fd-checkbox>
+            <fd-checkbox [(ngModel)]="checkboxValue3" state="success" label="Success state"></fd-checkbox>
             <fd-checkbox [(ngModel)]="checkboxValue4" state="warning" label="Warning state"></fd-checkbox>
-            <fd-checkbox [(ngModel)]="checkboxValue5" state="invalid" label="Invalid state"></fd-checkbox>
+            <fd-checkbox [(ngModel)]="checkboxValue5" state="error" label="Error state"></fd-checkbox>
         </div>
         <div>
             Disabled:

--- a/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-allow-null-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-allow-null-example.component.ts
@@ -4,7 +4,7 @@ import { DatePickerComponent, FdDate } from '@fundamental-ngx/core';
 @Component({
     selector: 'fd-date-picker-allow-null-example',
     template: `
-        <fd-date-picker [allowNull]="false" [type]="'single'" [(ngModel)]="date" [state]="isInvalid() ? 'invalid' : 'valid'"></fd-date-picker>
+        <fd-date-picker [allowNull]="false" [type]="'single'" [(ngModel)]="date" [state]="isInvalid() ? 'error' : 'success'"></fd-date-picker>
         <br/>
         <div>Selected Date: {{date ? date.toDateString() : 'null'}}</div>`
 })

--- a/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-disable-func-example/date-picker-disable-func-example.component.html
+++ b/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-disable-func-example/date-picker-disable-func-example.component.html
@@ -4,11 +4,11 @@
             <label fd-form-label>Date Picker</label>
             <fd-date-picker
                 [disableFunction]="disableFunction"
-                [state]="isValid() ? 'valid' : 'invalid'"
+                [state]="isValid() ? 'success' : 'error'"
                 formControlName="date">
             </fd-date-picker>
-            <fd-form-message *ngIf="isValid()" [type]="'success'">This is valid DatePicker</fd-form-message>
-            <fd-form-message *ngIf="!isValid()" [type]="'error'">This is invalid DatePicker</fd-form-message>
+            <fd-form-message *ngIf="isValid()" [type]="'success'">This is valid(success) DatePicker</fd-form-message>
+            <fd-form-message *ngIf="!isValid()" [type]="'error'">This is invalid(error) DatePicker</fd-form-message>
         </div>
         <br/>
         Touched: {{customForm.controls.date.touched}}<br/>

--- a/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-form-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-form-example.component.ts
@@ -10,11 +10,11 @@ import { FdDate } from '@fundamental-ngx/core';
                 <div fd-form-item>
                     <label fd-form-label>Date Picker</label>
                     <fd-date-picker 
-                            [state]="isValid() ? 'valid' : 'invalid'" 
+                            [state]="isValid() ? 'success' : 'error'" 
                             formControlName="date">
                     </fd-date-picker>
-                    <fd-form-message *ngIf="isValid()" [type]="'success'">This is valid DatePicker</fd-form-message>
-                    <fd-form-message *ngIf="!isValid()" [type]="'error'">This is invalid DatePicker</fd-form-message>
+                    <fd-form-message *ngIf="isValid()" [type]="'success'">This is valid(success) DatePicker</fd-form-message>
+                    <fd-form-message *ngIf="!isValid()" [type]="'error'">This is invalid(error) DatePicker</fd-form-message>
                 </div>
                 <br/>
                 Touched: {{customForm.controls.date.touched}}<br/>

--- a/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-range-disabled-example/date-picker-range-disabled-example.component.html
+++ b/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-range-disabled-example/date-picker-range-disabled-example.component.html
@@ -3,7 +3,7 @@
         <fd-date-picker
             type="range"
             formControlName="dates"
-            [state]="isValid() ? 'valid' : 'invalid'"
+            [state]="isValid() ? 'success' : 'error'"
             [disableRangeEndFunction]="disabledEndFunction"
             [disableRangeStartFunction]="disabledStartFunction"
         ></fd-date-picker>

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-allow-null-example/datetime-allow-null-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-allow-null-example/datetime-allow-null-example.component.ts
@@ -4,7 +4,7 @@ import { DatetimePickerComponent, FdDatetime } from '@fundamental-ngx/core';
 @Component({
     selector: 'fd-date-time-picker-allow-null-example',
     template: `
-        <fd-datetime-picker [allowNull]="false" [(ngModel)]="selectedDay" [state]="isValid() ? 'invalid' : 'valid'"></fd-datetime-picker>
+        <fd-datetime-picker [allowNull]="false" [(ngModel)]="selectedDay" [state]="isValid() ? 'error' : 'success'"></fd-datetime-picker>
         <span style="padding-left: 20px;">Selected Date: {{selectedDay?.toLocaleDateString()}}</span>
     `
 })

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-form-example/datetime-form-example.component.html
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-form-example/datetime-form-example.component.html
@@ -3,7 +3,7 @@
     <div fd-form-item>
         <label fd-form-label>Valid Date Picker</label>
         <fd-datetime-picker
-            [state]="isValid() ? 'valid' : 'invalid'"
+            [state]="isValid() ? 'success' : 'error'"
             formControlName="date"
             [disableFunction]="blockFunction">
         </fd-datetime-picker>

--- a/apps/docs/src/app/core/component-docs/input-group/examples/input-group-states-example/input-group-states-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input-group/examples/input-group-states-example/input-group-states-example.component.html
@@ -1,12 +1,45 @@
-<label fd-form-label>Information</label>
-<fd-input-group [addOnText]="'Button'" [button]="true" [state]="'information'" [placeholder]="'Placeholder'"></fd-input-group>
+<div fd-form-item>
+    <label fd-form-label>Information</label>
+    <fd-form-input-message-group>
+        <fd-input-group fd-form-control [addOnText]="'Button'" [button]="true" [state]="'information'" [placeholder]="'Placeholder'"></fd-input-group>
+        <fd-form-message [type]="'information'">
+            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+        </fd-form-message>
+    </fd-form-input-message-group>
+</div>
+
 <br />
-<label fd-form-label>Success</label>
-<fd-input-group [addOnText]="'Button'" [button]="true" [state]="'valid'" [placeholder]="'Placeholder'"></fd-input-group>
+
+<div fd-form-item>
+    <label fd-form-label>Success</label>
+    <fd-form-input-message-group>
+        <fd-input-group fd-form-control [addOnText]="'Button'" [compact]="true" [button]="true" [state]="'success'" [placeholder]="'Placeholder'"></fd-input-group>
+        <fd-form-message [type]="'success'">
+            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+        </fd-form-message>
+    </fd-form-input-message-group>
+</div>
+
 <br />
-<label fd-form-label>Warning</label>
-<fd-input-group [addOnText]="'Button'" [button]="true" [state]="'warning'" [placeholder]="'Placeholder'"></fd-input-group>
+
+<div fd-form-item>
+    <label fd-form-label>Warning</label>
+    <fd-form-input-message-group>
+        <fd-input-group fd-form-control [addOnText]="'Button'" [button]="true" [state]="'warning'" [placeholder]="'Placeholder'"></fd-input-group>
+        <fd-form-message [type]="'warning'">
+            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+        </fd-form-message>
+    </fd-form-input-message-group>
+</div>
+
 <br />
-<label fd-form-label>Invalid</label>
-<fd-input-group [addOnText]="'Button'" [button]="true" [state]="'invalid'" [placeholder]="'Placeholder'"></fd-input-group>
-<br />
+
+<div fd-form-item>
+    <label fd-form-label>Error</label>
+    <fd-form-input-message-group>
+        <fd-input-group fd-form-control [addOnText]="'Button'" [button]="true" [state]="'error'" [placeholder]="'Placeholder'"></fd-input-group>
+        <fd-form-message [type]="'error'">
+            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+        </fd-form-message>
+    </fd-form-input-message-group>
+</div>

--- a/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/input-group/input-group-docs.component.ts
@@ -54,7 +54,7 @@ export class InputGroupDocsComponent {
                     },
                     state: {
                         type: 'string',
-                        enum: ['valid', 'invalid', 'information', 'warning']
+                        enum: ['success', 'error', 'information', 'warning']
                     },
                 }
             },

--- a/apps/docs/src/app/core/component-docs/input/examples/input-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input/examples/input-state-example.component.html
@@ -1,9 +1,9 @@
 <div fd-form-item>
     <label fd-form-label for="input-52">
-        Valid Input
+        Valid(Success) Input
     </label>
     <fd-form-input-message-group>
-        <input fd-form-control type="text" id="input-52" placeholder="Field placeholder text" [state]="'valid'"/>
+        <input fd-form-control type="text" id="input-52" placeholder="Field placeholder text" [state]="'success'"/>
         <fd-form-message [type]="'success'">
             Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
         </fd-form-message>
@@ -12,10 +12,10 @@
 
 <div fd-form-item>
     <label fd-form-label for="input-53">
-        Invalid Input - Message appears on hover
+        Invalid(Error) Input - Message appears on hover
     </label>
     <fd-form-input-message-group [triggers]="['mouseenter', 'mouseleave']">
-        <input fd-form-control type="text" id="input-53" placeholder="Field placeholder text" [state]="'invalid'"/>
+        <input fd-form-control type="text" id="input-53" placeholder="Field placeholder text" [state]="'error'"/>
         <fd-form-message [type]="'error'">
             Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
         </fd-form-message>

--- a/apps/docs/src/app/core/component-docs/multi-input/examples/multi-input-form-example/multi-input-form-example.component.html
+++ b/apps/docs/src/app/core/component-docs/multi-input/examples/multi-input-form-example/multi-input-form-example.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="customForm">
     <fieldset fd-fieldset>
         <div fd-form-item>
-            <label fd-form-label>Valid Localization Editor</label>
+            <label fd-form-label>Valid Multi Input</label>
             <fd-multi-input
                 [state]="isValid() ? 'success' : 'error'"
                 formControlName="selectedValues"
@@ -11,7 +11,7 @@
             </fd-multi-input>
         </div>
         <div fd-form-item>
-            <label fd-form-label>Disabled Localization Editor</label>
+            <label fd-form-label>Disabled Multi Input</label>
             <fd-multi-input
                 formControlName="disabledSelectedValues"
                 [dropdownValues]="['Apple', 'Banana', 'Pineapple', 'Tomato']"

--- a/apps/docs/src/app/core/component-docs/multi-input/examples/multi-input-form-example/multi-input-form-example.component.html
+++ b/apps/docs/src/app/core/component-docs/multi-input/examples/multi-input-form-example/multi-input-form-example.component.html
@@ -3,7 +3,7 @@
         <div fd-form-item>
             <label fd-form-label>Valid Localization Editor</label>
             <fd-multi-input
-                [state]="isValid() ? 'valid' : 'invalid'"
+                [state]="isValid() ? 'success' : 'error'"
                 formControlName="selectedValues"
                 [dropdownValues]="['Apple', 'Banana', 'Pineapple', 'Tomato']"
                 [placeholder]="'Search Here...'"

--- a/apps/docs/src/app/core/component-docs/radio/examples/radio-example.component.html
+++ b/apps/docs/src/app/core/component-docs/radio/examples/radio-example.component.html
@@ -87,11 +87,11 @@
             <fd-radio-button
                 id="radio-10"
                 name="radio-name-4"
-                [state]="'valid'"
+                [state]="'success'"
                 [value]="'val1'"
                 [(ngModel)]="optionFourVariable"
             >
-                Valid Option
+                Valid(Success) Option
             </fd-radio-button>
         </div>
         <div fd-form-item [isCheck]="true">
@@ -110,10 +110,10 @@
                 name="radio-name-4"
                 id="radio-12"
                 [value]="'val3'"
-                [state]="'invalid'"
+                [state]="'error'"
                 [(ngModel)]="optionFourVariable"
             >
-                Invalid Option
+                Invalid(Error) Option
             </fd-radio-button>
         </div>
         <div fd-form-item [isCheck]="true">
@@ -147,12 +147,12 @@
         <div fd-form-item [isCheck]="true">
             <fd-radio-button
                 name="radio-name-5"
-                [state]="'valid'"
+                [state]="'success'"
                 [value]="'val1'"
                 [compact]="true"
                 [(ngModel)]="optionFiveVariable"
             >
-                Valid Option
+                Valid(Success) Option
             </fd-radio-button>
         </div>
         <div fd-form-item [isCheck]="true">
@@ -170,11 +170,11 @@
             <fd-radio-button
                 name="radio-name-5"
                 [value]="'val3'"
-                [state]="'invalid'"
+                [state]="'error'"
                 [compact]="true"
                 [(ngModel)]="optionFiveVariable"
             >
-                Invalid Option
+                Invalid(Error) Option
             </fd-radio-button>
         </div>
         <div fd-form-item [isCheck]="true">
@@ -209,13 +209,13 @@
         <div fd-form-item [isCheck]="true">
             <fd-radio-button
                 name="radio-name-6"
-                [state]="'valid'"
+                [state]="'success'"
                 [value]="'val1'"
                 [compact]="true"
                 [disabled]="true"
                 [(ngModel)]="optionSixVariable"
             >
-                Valid Option
+                Valid(Success) Option
             </fd-radio-button>
         </div>
         <div fd-form-item [isCheck]="true">
@@ -234,12 +234,12 @@
             <fd-radio-button
                 name="radio-name-6"
                 [value]="'val3'"
-                [state]="'invalid'"
+                [state]="'error'"
                 [compact]="true"
                 [disabled]="true"
                 [(ngModel)]="optionSixVariable"
             >
-                Invalid Option
+                Invalid(Error) Option
             </fd-radio-button>
         </div>
         <div fd-form-item [isCheck]="true">

--- a/apps/docs/src/app/core/component-docs/select-native/examples/select-native-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/select-native/examples/select-native-state-example.component.html
@@ -11,9 +11,9 @@
 </div>
 <div fd-form-item>
     <label fd-form-label for="select-52">
-        Valid select
+        Valid(Success) select
     </label>
-    <select fd-form-control id="select-52" name="" [state]="'valid'">
+    <select fd-form-control id="select-52" name="" [state]="'success'">
         <option value="1">Duis malesuada odio volutpat elementum</option>
         <option value="2">Suspendisse ante ligula</option>
         <option value="3">Sed bibendum sapien at posuere interdum</option>
@@ -21,9 +21,9 @@
 </div>
 <div fd-form-item>
     <label fd-form-label for="select-53">
-        Invalid select
+        Invalid(Error) select
     </label>
-    <select fd-form-control id="select-53" name="" [state]="'invalid'">
+    <select fd-form-control id="select-53" name="" [state]="'error'">
         <option value="1">Duis malesuada odio volutpat elementum</option>
         <option value="2">Suspendisse ante ligula</option>
         <option value="3">Sed bibendum sapien at posuere interdum</option>

--- a/apps/docs/src/app/core/component-docs/textarea/examples/textarea-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/textarea/examples/textarea-state-example.component.html
@@ -1,9 +1,9 @@
 <div fd-form-item>
     <label fd-form-label for="input-52">
-        Valid Textarea
+        Valid(Success) Textarea
     </label>
     <fd-form-input-message-group>
-        <textarea fd-form-control id="textarea-52" placeholder="Field placeholder text" [state]="'valid'"></textarea>
+        <textarea fd-form-control id="textarea-52" placeholder="Field placeholder text" [state]="'success'"></textarea>
         <fd-form-message [type]="'success'"
             >Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
         </fd-form-message>
@@ -12,10 +12,10 @@
 
 <div fd-form-item>
     <label fd-form-label for="input-53">
-        Invalid Textarea
+        Invalid(Error) Textarea
     </label>
     <fd-form-input-message-group>
-        <textarea fd-form-control id="textarea-53" placeholder="Field placeholder text" [state]="'invalid'"></textarea>
+        <textarea fd-form-control id="textarea-53" placeholder="Field placeholder text" [state]="'error'"></textarea>
         <fd-form-message [type]="'error'"
             >Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
         </fd-form-message>
@@ -35,7 +35,7 @@
 
 <div fd-form-item>
     <label fd-form-label for="input-55">
-        Invalid Textarea
+        Information Textarea
     </label>
     <fd-form-input-message-group>
         <textarea
@@ -43,6 +43,7 @@
             id="textarea-55"
             placeholder="Field placeholder text"
             [state]="'information'"
+            [compact]="true"
         ></textarea>
         <fd-form-message [type]="'information'"
             >Pellentesque metus lacus commodo eget justo ut rutrum varius nunc

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.spec.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.spec.ts
@@ -72,12 +72,12 @@ describe('CheckboxComponent', () => {
     });
 
     it('should add state class', async () => {
-        checkbox.state = 'valid';
+        checkbox.state = 'success';
         fixture.detectChanges();
 
         await fixture.whenStable();
         const input = fixture.nativeElement.querySelector('input');
-        expect(input).toHaveClass('is-valid')
+        expect(input).toHaveClass('is-success')
     });
 
     it('should display input label', async () => {

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -38,7 +38,7 @@ export class CheckboxComponent implements ControlValueAccessor {
 
     /** State of control, changes visual appearance of control. */
     @Input()
-    state: 'valid' | 'invalid' | 'info' | 'warning';
+    state: 'success' | 'error' | 'info' | 'warning';
 
     /** Sets [name] property of input. */
     @Input()

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -105,7 +105,7 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.
+     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.  
      */
     @Input()
     state: FormStates;

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -105,7 +105,7 @@ export class ComboboxComponent implements ControlValueAccessor, OnInit, OnChange
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.  
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.  
      */
     @Input()
     state: FormStates;

--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -12,7 +12,7 @@
                 (ngModelChange)="handleInputChange($event)"
                 (click)="openCalendar()"
                 [compact]="compact"
-                [ngClass]="{ 'is-invalid': isInvalidDateInput && useValidation }"
+                [ngClass]="{ 'is-error': isInvalidDateInput && useValidation }"
             />
             <span fd-input-group-addon [button]="true" [compact]="compact">
                 <button

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -132,7 +132,7 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
     state: FormStates;

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -20,7 +20,7 @@
                     [placeholder]="placeholder"
                     (click)="openPopover()"
                     [compact]="compact"
-                    [ngClass]="{ 'is-invalid': isInvalidDateInput && useValidation }"
+                    [ngClass]="{ 'is-error': isInvalidDateInput && useValidation }"
                     [disabled]="disabled"
                 />
                 <span fd-input-group-addon [state]="state" [compact]="compact" [button]="true">

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -170,7 +170,7 @@ export class DatetimePickerComponent implements OnInit, ControlValueAccessor, Va
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
     state: FormStates;

--- a/libs/core/src/lib/form/form-control/form-control.directive.ts
+++ b/libs/core/src/lib/form/form-control/form-control.directive.ts
@@ -19,7 +19,7 @@ export class FormControlDirective extends AbstractFdNgxClass {
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
     state: FormStates;

--- a/libs/core/src/lib/form/form-control/form-states.ts
+++ b/libs/core/src/lib/form/form-control/form-states.ts
@@ -1,1 +1,1 @@
-export type FormStates = 'valid' | 'invalid' | 'warning' | 'information';
+export type FormStates = 'success' | 'error' | 'warning' | 'information';

--- a/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.html
+++ b/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.html
@@ -1,4 +1,4 @@
-<fd-popover class="fd-form-input-message-group"
+<fd-popover class="fd-form-input-message-group fd-popover--input-message-group"
             [placement]="placement$ | async"
             [triggers]="triggers"
             [fillControlMode]="fillControlMode"

--- a/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.scss
+++ b/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.scss
@@ -6,3 +6,9 @@
 .fd-popover-container-custom {
     border: none;
 }
+
+.fd-form-input-message-group {
+    .fd-input {
+        display: block;
+    }
+}

--- a/libs/core/src/lib/input-group/input-group-directives.ts
+++ b/libs/core/src/lib/input-group/input-group-directives.ts
@@ -65,7 +65,7 @@ export class InputGroupAddOnDirective extends AbstractFdNgxClass implements Afte
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
     state: FormStates;

--- a/libs/core/src/lib/input-group/input-group.component.ts
+++ b/libs/core/src/lib/input-group/input-group.component.ts
@@ -104,7 +104,7 @@ export class InputGroupComponent implements ControlValueAccessor {
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
     state: FormStates;

--- a/libs/core/src/lib/localizator-editor/localization-editor-main/localization-editor-main.component.ts
+++ b/libs/core/src/lib/localizator-editor/localization-editor-main/localization-editor-main.component.ts
@@ -26,7 +26,7 @@ export class LocalizationEditorMainComponent extends LocalizationEditorItemCompo
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
     state: FormStates;

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -129,7 +129,7 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
     state: FormStates;

--- a/libs/core/src/lib/radio/radio-button/radio-button.component.spec.ts
+++ b/libs/core/src/lib/radio/radio-button/radio-button.component.spec.ts
@@ -6,8 +6,8 @@ import { FormsModule } from '@angular/forms';
 
 @Component({
     template: `
-        <fd-radio-button #radio1 state="valid" [(ngModel)]="selectedValue" [value]="1" name="radio"></fd-radio-button>
-        <fd-radio-button #radio2 state="invalid" [(ngModel)]="selectedValue" [value]="2" name="radio"></fd-radio-button>
+        <fd-radio-button #radio1 state="success" [(ngModel)]="selectedValue" [value]="1" name="radio"></fd-radio-button>
+        <fd-radio-button #radio2 state="error" [(ngModel)]="selectedValue" [value]="2" name="radio"></fd-radio-button>
         <fd-radio-button
             #radio3
             [disabled]="true"
@@ -72,8 +72,8 @@ describe('RadioButtonComponent', () => {
         await wait(fixture);
 
         // value is accessed by [] because component doesn't have a getter for state by design
-        expect(component.radioButton1.state).toContain('valid');
-        expect(component.radioButton2.state).toContain('invalid');
+        expect(component.radioButton1.state).toContain('success');
+        expect(component.radioButton2.state).toContain('error');
     });
 
     it('should be disabled', async () => {

--- a/libs/core/src/lib/radio/radio-button/radio-button.component.ts
+++ b/libs/core/src/lib/radio/radio-button/radio-button.component.ts
@@ -12,7 +12,7 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { applyCssClass, CssClassBuilder } from '../../utils/public_api';
 
-export type stateType = 'valid' | 'invalid' | 'warning' | 'default' | 'information';
+export type stateType = 'success' | 'error' | 'warning' | 'default' | 'information';
 let uniqueId = 0;
 @Component({
     selector: 'fd-radio-button',
@@ -46,7 +46,7 @@ export class RadioButtonComponent implements OnChanges, OnInit, CssClassBuilder,
     compact: boolean;
 
     /** The field to set state of radio button using:
-     * 'valid' | 'invalid' | 'warning' | 'default' | 'information'
+     * 'success' | 'error' | 'warning' | 'default' | 'information'
      * by default value is set to 'default'
      */
     @Input()

--- a/libs/core/src/lib/time-picker/time-picker.component.html
+++ b/libs/core/src/lib/time-picker/time-picker.component.html
@@ -19,7 +19,7 @@
                    (click)="inputGroupClicked($event)"
                    [disabled]="disabled"
                    type="text"
-                   [ngClass]="{ 'is-invalid': isInvalidTimeInput && validate }"
+                   [ngClass]="{ 'is-error': isInvalidTimeInput && validate }"
                    class="fd-input"
                    [placeholder]="placeholder"
                    [attr.aria-label]="timePickerInputLabel">

--- a/libs/core/src/lib/time-picker/time-picker.component.ts
+++ b/libs/core/src/lib/time-picker/time-picker.component.ts
@@ -87,13 +87,13 @@ export class TimePickerComponent implements ControlValueAccessor, OnInit {
     @Input()
     timePickerInputLabel: string = 'Time picker input';
 
-    /** Whether a null input is considered valid. */
+    /** Whether a null input is considered valid(success). */
     @Input()
     allowNull: boolean = true;
 
     /**
      *  The state of the form control - applies css classes.
-     *  Can be `valid`, `invalid`, `warning`, `information` or blank for default.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
     state: FormStates;
@@ -111,7 +111,7 @@ export class TimePickerComponent implements ControlValueAccessor, OnInit {
      */
     @Input() keepTwoDigitsTime: boolean = false;
 
-    /** @hidden Whether the input time is valid. Internal use. */
+    /** @hidden Whether the input time is valid(success). Internal use. */
     isInvalidTimeInput: boolean = false;
 
     /** @hidden */

--- a/libs/core/src/lib/time/time.component.html
+++ b/libs/core/src/lib/time/time.component.html
@@ -16,7 +16,7 @@
         fd-only-digits
         [ngClass]="{
             'is-disabled': disabled,
-            'is-invalid': (displayedHour > 24 || displayedHour < 0) && validate
+            'is-error': (displayedHour > 24 || displayedHour < 0) && validate
         }"
         (ngModelChange)="displayedHourChanged($event)"
         (blur)="inputBlur('hour')"
@@ -57,7 +57,7 @@
         fd-only-digits
         (ngModelChange)="minuteModelChange($event)"
         (blur)="inputBlur('minute')"
-        [ngClass]="{ 'is-disabled': disabled, 'is-invalid': (time.minute > 59 || time.minute < 0) && validate }"
+        [ngClass]="{ 'is-disabled': disabled, 'is-error': (time.minute > 59 || time.minute < 0) && validate }"
         class="fd-input fd-time__input fd-input--no-number-spinner"
         type="number"
         placeholder="{{ timeI18n?.minutesPlaceholder }}"
@@ -94,7 +94,7 @@
         fd-only-digits
         (ngModelChange)="secondModelChange($event)"
         (blur)="inputBlur('second')"
-        [ngClass]="{ 'is-disabled': disabled, 'is-invalid': (time.second > 59 || time.second < 0) && validate }"
+        [ngClass]="{ 'is-disabled': disabled, 'is-error': (time.second > 59 || time.second < 0) && validate }"
         class="fd-input fd-time__input fd-input--no-number-spinner"
         type="number"
         placeholder="{{ timeI18n?.secondsPlaceholder }}"


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes #2071 
#### Please provide a brief summary of this pull request.
The validation states have beed changed in Fundamental-styles. `invalid` state is now `error` and `valid` state is now `success`. 
For form-messages an additional class was added to the markup to remove the border of the Popover body.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

