### PR TITLE
fix: reverted changes, removed 'this' keyboard from function call

### DIFF
--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -21,7 +21,6 @@ export type ButtonType =
     | 'emphasized'
     | 'menu';
 export type ButtonOptions = 'light' | 'emphasized' | 'menu';
-let buttonUniqueId: number = 0;
 
 // TODO remove in 0.17.0
 function replaceLightWithTransparent(option: string): string {
@@ -33,7 +32,7 @@ export function getOptionCssClass(options: ButtonOptions | ButtonOptions[]): str
     if (Array.isArray(options)) {
         return options.map((option) => `fd-button--${this.replaceLightWithTransparent(option)}`).join(' ');
     }
-    return `fd-button--${this.replaceLightWithTransparent(options)}`;
+    return `fd-button--${replaceLightWithTransparent(options)}`;
 }
 
 /**
@@ -54,20 +53,8 @@ export function getOptionCssClass(options: ButtonOptions | ButtonOptions[]): str
     styleUrls: ['./button.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    host: {
-        '[attr.aria-labelledby]': 'ariaLabelledBy',
-        '[attr.aria-label]': 'ariaLabel',
-        'role': 'button',
-        '[attr.id]': 'id',
-        'title': 'title'
-    },
 })
 export class ButtonComponent implements OnChanges, CssClassBuilder, OnInit {
-
-    ariaLabelledBy: string = null;
-
-    ariaLabel: string = null;
-
     /** The property allows user to pass additional css classes
      */
     @Input()
@@ -106,10 +93,6 @@ export class ButtonComponent implements OnChanges, CssClassBuilder, OnInit {
      * Will be removed in 0.17.0.
      * Use 'fdType' instead.
      */
-
-    /** Id for the button component. If omitted, a unique one is generated. */
-    @Input()
-    id: string = 'fd-switch-' + buttonUniqueId++;
 
     @Input()
     public options(opt: ButtonOptions | ButtonOptions[]) {


### PR DESCRIPTION

#### Please provide a brief summary of this pull request.
Revert the changes in the button done in https://github.com/SAP/fundamental-ngx/pull/2204


#### Please check whether the PR fulfills the following requirements

Reverted changes made by other PR

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done