### PR TITLE
feat: (platform) Fixing Menu/SearchField styles after fundamental-style upgrade

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-search-field/platform-search-field-examples/platform-search-field-basic-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-search-field/platform-search-field-examples/platform-search-field-basic-example.component.html
@@ -1,10 +1,6 @@
 <h4>Cozy</h4>
-<fdp-search-field
-    [placeholder]="'Search'"
-    [suggestions]="suggestions"
-    (searchSubmit)="onSearchSubmit($event)"
-    (inputChange)="onInputChange($event)"
-></fdp-search-field>
+<fdp-search-field [placeholder]="'Search'" [suggestions]="suggestions" (searchSubmit)="onSearchSubmit($event)"
+    (inputChange)="onInputChange($event)"></fdp-search-field>
 <div class="result-block">
     <div class="result-field">
         <label>Input Change Text: </label><span>{{ inputText }}</span>
@@ -14,13 +10,8 @@
     </div>
 </div>
 <h4>Compact</h4>
-<fdp-search-field
-    [placeholder]="'Search'"
-    [suggestions]="suggestions"
-    [size]="'compact'"
-    (searchSubmit)="onCompactSearchSubmit($event)"
-    (inputChange)="onCompactInputChange($event)"
-></fdp-search-field>
+<fdp-search-field [placeholder]="'Search'" [suggestions]="suggestions" [contentDensity]="'compact'"
+    (searchSubmit)="onCompactSearchSubmit($event)" (inputChange)="onCompactInputChange($event)"></fdp-search-field>
 
 <div class="result-block">
     <div class="result-field">

--- a/apps/docs/src/app/platform/component-docs/platform-search-field/platform-search-field-examples/platform-search-field-categories-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-search-field/platform-search-field-examples/platform-search-field-categories-example.component.html
@@ -1,11 +1,6 @@
 <h4>Cozy</h4>
-<fdp-search-field
-    [placeholder]="'Search'"
-    [suggestions]="suggestions"
-    [categories]="categories"
-    (searchSubmit)="onSearchSubmit($event)"
-    (inputChange)="onInputChange($event)"
-></fdp-search-field>
+<fdp-search-field [placeholder]="'Search'" [suggestions]="suggestions" [categories]="categories"
+    (searchSubmit)="onSearchSubmit($event)" (inputChange)="onInputChange($event)"></fdp-search-field>
 <div class="result-block">
     <div class="result-field">
         <label>Input Change Text: </label><span>{{ inputText }}</span>
@@ -21,14 +16,9 @@
     </div>
 </div>
 <h4>Compact</h4>
-<fdp-search-field
-    [placeholder]="'Search'"
-    [suggestions]="suggestions"
-    [categories]="categories"
-    [size]="'compact'"
-    (searchSubmit)="onCompactSearchSubmit($event)"
-    (inputChange)="onCompactInputChange($event)"
-></fdp-search-field>
+<fdp-search-field [placeholder]="'Search'" [suggestions]="suggestions" [categories]="categories"
+    [contentDensity]="'compact'" (searchSubmit)="onCompactSearchSubmit($event)"
+    (inputChange)="onCompactInputChange($event)"></fdp-search-field>
 <div class="result-block">
     <div class="result-field">
         <label>Input Change Text: </label><span>{{ compactInputText }}</span>

--- a/apps/docs/src/app/platform/component-docs/platform-search-field/platform-search-field-header/platform-search-field-header.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-search-field/platform-search-field-header/platform-search-field-header.component.html
@@ -1,12 +1,11 @@
 <header>Search Field</header>
-<description
-    >The SearchField component is an interface used to initiate searches for an application. The SearchField allows the
+<description>The SearchField component is an interface used to initiate searches for an application. The SearchField
+    allows the
     user to type in keywords and initiate a search based on the keyword via a keyboard 'enter' or by clicking on the
     search icon button. The SearchField has the option of including a type ahead dropdown to assist users on their
-    keyword search.</description
->
+    keyword search.</description>
 
-<import module="SearchField"></import>
+<import module="PlatformSearchFieldModule"></import>
 
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/libs/platform/src/lib/components/button/button.component.scss
+++ b/libs/platform/src/lib/components/button/button.component.scss
@@ -1,0 +1,3 @@
+:host {
+    display: inline-block;
+}

--- a/libs/platform/src/lib/components/menu/menu-item.component.scss
+++ b/libs/platform/src/lib/components/menu/menu-item.component.scss
@@ -1,7 +1,10 @@
-:host.cascades-right {
+@import '~fundamental-styles/dist/menu';
+
+:host.cascades-right.trigger .fd-menu__title {
     padding-right: 2rem;
+
     /* render arrow for trigger */
-    &.trigger:after {
+    &:after {
         position: absolute;
         right: 0;
         width: 2rem;
@@ -14,10 +17,11 @@
     }
 }
 
-:host.cascades-left {
+:host.cascades-left.trigger .fd-menu__title {
     padding-left: 2rem;
+
     /* render arrow for trigger */
-    &.trigger:before {
+    &:before {
         position: absolute;
         left: 0;
         width: 2rem;

--- a/libs/platform/src/lib/components/menu/menu-item.component.ts
+++ b/libs/platform/src/lib/components/menu/menu-item.component.ts
@@ -27,7 +27,7 @@ export class MenuItemComponent implements OnDestroy, FocusableOption {
     // Track when menu item is hovered over
     public hovered: Subject<MenuItemComponent> = new Subject<MenuItemComponent>();
 
-    constructor(private elementRef: ElementRef) {}
+    constructor(private elementRef: ElementRef) { }
 
     // Add Fundamental-Styles class for menu item
     @HostBinding('class.fd-menu__item') menuItemClass = true;
@@ -40,7 +40,7 @@ export class MenuItemComponent implements OnDestroy, FocusableOption {
         return this.cascadeDirection === 'left';
     }
 
-    @HostBinding('attr.role') role = 'listitem';
+    @HostBinding('attr.role') role = 'menuitem';
     @HostBinding('attr.tabindex') tabindex = '-1';
 
     // Handle selection of item via keyboard 'Enter' or mouseclick

--- a/libs/platform/src/lib/components/menu/menu.component.scss
+++ b/libs/platform/src/lib/components/menu/menu.component.scss
@@ -1,3 +1,4 @@
+@import '~fundamental-styles/dist/menu';
 .fd-popover__body {
     position: static;
 }

--- a/libs/platform/src/lib/components/search-field/search-field.component.html
+++ b/libs/platform/src/lib/components/search-field/search-field.component.html
@@ -1,106 +1,63 @@
-<div
-    class="search-field"
-    [ngClass]="{
+<div class="search-field" [ngClass]="{
         'with-categories': showCategoryDropdown,
         'is-loading': isLoading,
         'hide-category-label': hideCategoryLabel
-    }"
->
-    <div
-        class="search-field--input-group fd-input-group"
-        [attr.aria-controls]="menuId"
-        [attr.aria-expanded]="showDropdown ? 'true' : 'false'"
-        aria-haspopup="true"
-        #inputGroup
-    >
-        <span
-            class="fd-input-group__addon fd-input-group__addon--button"
-            [ngClass]="{ 'fd-input-group__addon--compact': compact }"
-            *ngIf="showCategoryDropdown"
-        >
-            <button
-                class="search-field--category-button fd-input-group__button fd-button fd-button--menu"
-                [ngClass]="{ 'fd-button--compact': compact }"
-                [fdpMenuTriggerFor]="categoryMenu"
-            >
-                <span class="search-field--category-label" *ngIf="!hideCategoryLabel">{{
+    }">
+    <div #inputGroup class="fdp-search-field__input-group fd-input-group" [attr.aria-controls]="menuId"
+        [attr.aria-expanded]="showDropdown ? 'true' : 'false'" aria-haspopup="true">
+        <span class="fd-input-group__addon fd-input-group__addon--button"
+            [ngClass]="{ 'fd-input-group__addon--compact': contentDensity === 'compact' }" *ngIf="showCategoryDropdown">
+            <button class="fdp-search-field__category-button fd-input-group__button fd-button fd-button--menu"
+                [ngClass]="{ 'fd-button--compact': contentDensity === 'compact' }" [fdpMenuTriggerFor]="categoryMenu">
+                <span class="fdp-search-field__category-label" *ngIf="!hideCategoryLabel">{{
                     currentCategory ? currentCategory.label : categoryLabel
                 }}</span>
             </button>
         </span>
-        <input
-            #inputField
-            type="text"
-            placeholder="{{ placeholder }}"
-            class="search-field--input fd-input fd-input-group__input"
-            [attr.id]="inputId"
-            [attr.disabled]="disabled ? '' : null"
-            [ngClass]="{ 'fd-input--compact': compact }"
-            (keydown)="onKeydown($event)"
-            (keydown.enter)="onSearchSubmit()"
-            [(ngModel)]="inputText"
-            (ngModelChange)="onValueChange($event)"
-        />
-        <span
-            class="fd-input-group__addon fd-input-group__addon--button"
-            [ngClass]="{ 'fd-input-group__addon--compact': compact }"
-            *ngIf="inputText && inputText.length > 0"
-        >
+        <input #inputField type="search" [attr.placeholder]="placeholder"
+            class="fdp-search-field__input fd-input fd-input-group__input" [attr.id]="inputId"
+            [attr.disabled]="disabled ? '' : null" [ngClass]="{ 'fd-input--compact': contentDensity === 'compact' }"
+            (keydown)="onKeydown($event)" (keydown.enter)="onSearchSubmit()" [(ngModel)]="inputText"
+            (ngModelChange)="onValueChange($event)" />
+        <span class="fd-input-group__addon fd-input-group__addon--button"
+            [ngClass]="{ 'fd-input-group__addon--compact': contentDensity === 'compact' }"
+            *ngIf="inputText && inputText.length > 0">
             <button
-                class="search-field--clear fd-input-group__button fd-button fd-button--transparent sap-icon--decline"
-                [ngClass]="{ 'fd-button--compact': compact }"
-                (click)="clearTextInput()"
-            ></button>
+                class="fdp-search-field__clear fd-input-group__button fd-button fd-button--transparent sap-icon--decline"
+                [ngClass]="{ 'fd-button--compact': contentDensity === 'compact' }" (click)="clearTextInput()"></button>
         </span>
-        <span
-            class="fd-input-group__addon fd-input-group__addon--button"
-            [ngClass]="{ 'fd-input-group__addon--compact': compact }"
-            *ngIf="!isLoading"
-        >
+        <span class="fd-input-group__addon fd-input-group__addon--button"
+            [ngClass]="{ 'fd-input-group__addon--compact': contentDensity === 'compact' }" *ngIf="!isLoading">
             <button
-                class="search-field--submit fd-input-group__button fd-button fd-button--transparent sap-icon--search"
-                [attr.id]="submitId"
-                [attr.disabled]="disabled ? '' : null"
-                [ngClass]="{ 'fd-button--compact': compact }"
-                (click)="onSearchSubmit()"
-            ></button>
+                class="fdp-search-field__submit fd-input-group__button fd-button fd-button--transparent sap-icon--search"
+                [attr.id]="submitId" [attr.disabled]="disabled ? '' : null"
+                [ngClass]="{ 'fd-button--compact': contentDensity === 'compact' }" (click)="onSearchSubmit()"></button>
         </span>
-        <span
-            class="fd-input-group__addon fd-input-group__addon--button"
-            [ngClass]="{ 'fd-input-group__addon--compact': compact }"
-            *ngIf="isLoading"
-        >
+        <span class="fd-input-group__addon fd-input-group__addon--button"
+            [ngClass]="{ 'fd-input-group__addon--compact': contentDensity === 'compact' }" *ngIf="isLoading">
             <button
-                class="search-field--loading fd-input-group__button fd-button fd-button--transparent sap-icon--synchronize"
-                [ngClass]="{ 'fd-button--compact': compact }"
-                (click)="onSearchSubmit()"
-            ></button>
+                class="fdp-search-field__loading fd-input-group__button fd-button fd-button--transparent sap-icon--synchronize"
+                [ngClass]="{ 'fd-button--compact': contentDensity === 'compact' }" (click)="onSearchSubmit()"></button>
         </span>
     </div>
 </div>
 <ng-template #suggestionMenuTemplate>
-    <div
-        class="search-field--dropdown fd-popover__body fd-popover__body--no-arrow"
-        [attr.dir]="dir"
-        *ngIf="(dropdownValues$ | async | suggestionMatches: inputText)?.length > 0"
-    >
-        <nav class="fd-menu" tabindex="-1" role="menu" [attr.id]="menuId" (keydown)="onKeydown($event)">
-            <ul class="fd-menu__list">
-                <li
-                    fdpSearchFieldSuggestion
-                    class="search-field--suggestion-item fd-menu__item"
-                    *ngFor="let value of dropdownValues$ | async | suggestionMatches: inputText"
-                    (keydown.enter)="onItemClick(value)"
-                    (click)="onItemClick(value)"
-                    [innerHTML]="value | highlight: inputText:true"
-                ></li>
+    <div class="fdp-search-field__dropdown fd-popover__body fd-popover__body--no-arrow" [attr.dir]='dir'
+        *ngIf="(dropdownValues$ | async | suggestionMatches:inputText)?.length > 0">
+        <nav class="fd-menu" tabindex="-1" [ngClass]="{ 'fd-menu--compact': contentDensity === 'compact'}"
+            [attr.id]="menuId" (keydown)="onKeydown($event)">
+            <ul class="fd-menu__list" role="menu">
+                <li fdpSearchFieldSuggestion class="fdp-search-field__suggestion-item fd-menu__item"
+                    *ngFor="let value of dropdownValues$ | async | suggestionMatches:inputText"
+                    (keydown.enter)="onItemClick(value)" (click)="onItemClick(value)"
+                    [innerHTML]="value | highlight:inputText:true" role="menuitem">
+                </li>
             </ul>
         </nav>
     </div>
 </ng-template>
 
 <fdp-menu #categoryMenu>
-    <fdp-menu-item *ngFor="let category of categories" (itemSelect)="setCurrentCategory(category)"
-        >{{ category.label }}
+    <fdp-menu-item *ngFor="let category of categories" (itemSelect)="setCurrentCategory(category)">{{ category.label }}
     </fdp-menu-item>
 </fdp-menu>

--- a/libs/platform/src/lib/components/search-field/search-field.component.scss
+++ b/libs/platform/src/lib/components/search-field/search-field.component.scss
@@ -1,9 +1,46 @@
 @import '~fundamental-styles/dist/input';
+
+/* Remove clear "x" from search field for IE browsers */
+input[type=text]::-ms-clear {
+    display: none;
+    width: 0;
+    height: 0;
+}
+
+input[type=text]::-ms-reveal {
+    display: none;
+    width: 0;
+    height: 0;
+}
+
+/* Remove clear "x" from search field for Webkit browsers */
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+    display: none;
+}
+
 input.fd-input {
     border: none;
     border-width: 0;
 }
+
 .fd-popover__body {
     position: static;
     width: 100%;
+}
+
+.search-field--dropdown {
+    .fd-menu {
+        max-width: none;
+    }
+
+    .fd-menu__list {
+        max-width: none;
+    }
+
+    .fd-menu__item {
+        max-width: none;
+    }
 }

--- a/libs/platform/src/lib/components/search-field/search-field.component.spec.ts
+++ b/libs/platform/src/lib/components/search-field/search-field.component.spec.ts
@@ -67,7 +67,7 @@ function getDropdownItems(menu: Element): NodeList {
             [categories]="categories"
             [categoryLabel]="categoryLabel"
             [hideCategoryLabel]="hideCategoryLabel"
-            [size]="size"
+            [contentDensity]="contentDensity"
             [isLoading]="isLoading"
             [disabled]="disabled"
             (inputChange)="onInputChange($event)"
@@ -85,7 +85,7 @@ class TestComponent {
     public categories: ValueLabelItem[];
     public categoryLabel: string;
     public hideCategoryLabel = false;
-    public size: 'cozy' | 'compact';
+    public contentDensity: 'cozy' | 'compact';
     public isLoading = false;
     public disabled = false;
 
@@ -95,7 +95,7 @@ class TestComponent {
 
     @ViewChild('outsideButton') outsideButton: ElementRef<HTMLElement>;
 
-    constructor() {}
+    constructor() { }
 
     onInputChange($event) {
         this.inputValue = $event;
@@ -154,10 +154,10 @@ describe('SearchFieldComponent', () => {
         host.suggestions = [{ value: 'Apple' }, { value: 'Banana' }, { value: 'Carrot' }];
         fixture.detectChanges();
 
-        const input: ElementRef = fixture.debugElement.query(By.css('.search-field--input'));
+        const input: ElementRef = fixture.debugElement.query(By.css('.fdp-search-field__input'));
         expect(input.nativeElement.id).toContain('fdp-search-field-input-');
 
-        const submitButton: ElementRef = fixture.debugElement.query(By.css('.search-field--submit'));
+        const submitButton: ElementRef = fixture.debugElement.query(By.css('.fdp-search-field__submit'));
         expect(submitButton.nativeElement.id).toContain('fdp-search-field-submit-');
 
         // simulate keyboard entry
@@ -241,10 +241,10 @@ describe('SearchFieldComponent', () => {
         host.categoryLabel = 'Category';
         fixture.detectChanges();
 
-        const categoryButton = fixture.debugElement.queryAll(By.css('.search-field--category-button'));
+        const categoryButton = fixture.debugElement.queryAll(By.css('.fdp-search-field__category-button'));
         expect(categoryButton.length).toBe(1);
 
-        const categoryLabel = fixture.debugElement.query(By.css('.search-field--category-label'));
+        const categoryLabel = fixture.debugElement.query(By.css('.fdp-search-field__category-label'));
         expect(categoryLabel.nativeElement.textContent).toBe('Category');
     });
 
@@ -255,7 +255,7 @@ describe('SearchFieldComponent', () => {
         host.categoryLabel = 'Categoría';
         fixture.detectChanges();
 
-        const categoryLabel = fixture.debugElement.query(By.css('.search-field--category-label'));
+        const categoryLabel = fixture.debugElement.query(By.css('.fdp-search-field__category-label'));
         expect(categoryLabel.nativeElement.textContent).toBe('Categoría');
     });
 
@@ -267,7 +267,7 @@ describe('SearchFieldComponent', () => {
         host.hideCategoryLabel = true;
         fixture.detectChanges();
 
-        const categoryLabel = fixture.debugElement.queryAll(By.css('.search-field--category-label'));
+        const categoryLabel = fixture.debugElement.queryAll(By.css('.fdp-search-field__category-label'));
         expect(categoryLabel.length).toBe(0);
     });
 
@@ -289,7 +289,7 @@ describe('SearchFieldComponent', () => {
         fixture.detectChanges();
 
         // click on category button
-        const button = fixture.debugElement.query(By.css('.search-field--category-button'));
+        const button = fixture.debugElement.query(By.css('.fdp-search-field__category-button'));
         button.nativeElement.click();
         fixture.detectChanges();
 
@@ -300,7 +300,7 @@ describe('SearchFieldComponent', () => {
         fixture.detectChanges();
 
         expect(component.currentCategory).toEqual(CATEGORIES[2]);
-        let categoryLabel = fixture.debugElement.query(By.css('.search-field--category-label'));
+        let categoryLabel = fixture.debugElement.query(By.css('.fdp-search-field__category-label'));
         expect(categoryLabel.nativeElement.textContent).toBe(CATEGORIES[2].label);
         expect(host.inputValue.category).toBe(CATEGORIES[2].value);
 
@@ -315,7 +315,7 @@ describe('SearchFieldComponent', () => {
         fixture.detectChanges();
 
         expect(component.currentCategory).toEqual(CATEGORIES[1]);
-        categoryLabel = fixture.debugElement.query(By.css('.search-field--category-label'));
+        categoryLabel = fixture.debugElement.query(By.css('.fdp-search-field__category-label'));
         expect(categoryLabel.nativeElement.textContent).toBe(CATEGORIES[1].label);
         expect(host.inputValue.category).toBe(CATEGORIES[1].value);
     });
@@ -328,19 +328,19 @@ describe('SearchFieldComponent', () => {
 
         fixture.detectChanges();
         let inputField: ElementRef = fixture.debugElement.query(By.css('input.fd-input'));
-        let submitButton: ElementRef = fixture.debugElement.query(By.css('button.search-field--submit'));
-        let categoryButton: ElementRef = fixture.debugElement.query(By.css('button.search-field--category-button'));
+        let submitButton: ElementRef = fixture.debugElement.query(By.css('button.fdp-search-field__submit'));
+        let categoryButton: ElementRef = fixture.debugElement.query(By.css('button.fdp-search-field__category-button'));
         let compactAddons: ElementRef[] = fixture.debugElement.queryAll(By.css('.fd-input-group__addon--compact'));
         expect(inputField.nativeElement.classList.contains('fd-input--compact')).toBeFalsy();
         expect(submitButton.nativeElement.classList.contains('fd-button--compact')).toBeFalsy();
         expect(categoryButton.nativeElement.classList.contains('fd-button--compact')).toBeFalsy();
         expect(compactAddons.length).toBe(0);
-        host.size = 'compact';
+        host.contentDensity = 'compact';
         fixture.detectChanges();
 
         inputField = fixture.debugElement.query(By.css('input.fd-input'));
-        submitButton = fixture.debugElement.query(By.css('button.search-field--submit'));
-        categoryButton = fixture.debugElement.query(By.css('button.search-field--category-button'));
+        submitButton = fixture.debugElement.query(By.css('button.fdp-search-field__submit'));
+        categoryButton = fixture.debugElement.query(By.css('button.fdp-search-field__category-button'));
         compactAddons = fixture.debugElement.queryAll(By.css('.fd-input-group__addon--compact'));
         expect(inputField.nativeElement.classList.contains('fd-input--compact')).toBeTruthy();
         expect(submitButton.nativeElement.classList.contains('fd-button--compact')).toBeTruthy();
@@ -590,7 +590,7 @@ describe('SearchFieldComponent', () => {
         host.isLoading = true;
         fixture.detectChanges();
 
-        const cancelButton: ElementRef = fixture.debugElement.query(By.css('.search-field--loading'));
+        const cancelButton: ElementRef = fixture.debugElement.query(By.css('.fdp-search-field__loading'));
         cancelButton.nativeElement.click();
         fixture.detectChanges();
 
@@ -604,8 +604,8 @@ describe('SearchFieldComponent', () => {
         host.disabled = true;
         fixture.detectChanges();
 
-        const input: ElementRef = fixture.debugElement.query(By.css('input[type="text"]'));
-        const submitButton: ElementRef = fixture.debugElement.query(By.css('button.search-field--submit'));
+        const input: ElementRef = fixture.debugElement.query(By.css('input[type="search"]'));
+        const submitButton: ElementRef = fixture.debugElement.query(By.css('button.fdp-search-field__submit'));
         expect(input.nativeElement.attributes['disabled']).toBeTruthy();
         expect(submitButton.nativeElement.attributes['disabled']).toBeTruthy();
     });
@@ -616,7 +616,7 @@ describe('SearchFieldComponent', () => {
         host.suggestions = [{ value: 'Apple' }, { value: 'Banana' }, { value: 'Carrot' }];
         fixture.detectChanges();
 
-        const clearButton = fixture.debugElement.queryAll(By.css('button.search-field--clear'));
+        const clearButton = fixture.debugElement.queryAll(By.css('button.fdp-search-field__clear'));
         expect(clearButton.length).toBe(0);
     });
 
@@ -632,7 +632,7 @@ describe('SearchFieldComponent', () => {
         textInput.nativeElement.dispatchEvent(new Event('input'));
         fixture.detectChanges();
 
-        const clearButton = fixture.debugElement.queryAll(By.css('button.search-field--clear'));
+        const clearButton = fixture.debugElement.queryAll(By.css('button.fdp-search-field__clear'));
         expect(clearButton.length).toBe(1);
     });
 
@@ -648,7 +648,7 @@ describe('SearchFieldComponent', () => {
         textInput.nativeElement.dispatchEvent(new Event('input'));
         fixture.detectChanges();
 
-        const clearButton = fixture.debugElement.queryAll(By.css('button.search-field--clear'));
+        const clearButton = fixture.debugElement.queryAll(By.css('button.fdp-search-field__clear'));
         clearButton[0].nativeElement.click();
 
         // check input field
@@ -757,7 +757,7 @@ describe('SearchFieldComponent', () => {
             [categoryLabel]="categoryLabel"
             [hideCategoryLabel]="hideCategoryLabel"
             [dataSource]="dataSource"
-            [size]="size"
+            [contentDensity]="contentDensity"
             [isLoading]="isLoading"
             [disabled]="disabled"
             (inputChange)="onInputChange($event)"
@@ -774,7 +774,7 @@ class DataSourceTestComponent implements OnInit {
     public categories: ValueLabelItem[];
     public categoryLabel: string;
     public hideCategoryLabel = false;
-    public size: 'cozy' | 'compact';
+    public contentDensity: 'cozy' | 'compact';
     public isLoading = false;
     public disabled = false;
     public dataSource: SearchFieldDataSource<any>;
@@ -785,7 +785,7 @@ class DataSourceTestComponent implements OnInit {
 
     @ViewChild('outsideButton') outsideButton: ElementRef<HTMLElement>;
 
-    constructor() {}
+    constructor() { }
 
     ngOnInit() {
         this.dataSource = new SearchFieldDataSource(new SearchFieldDataProvider());
@@ -865,7 +865,7 @@ describe('SearchFieldComponent with DataSource', () => {
 
     it('should be able to filter data source by category', () => {
         // click on category button
-        const button = fixture.debugElement.query(By.css('.search-field--category-button'));
+        const button = fixture.debugElement.query(By.css('.fdp-search-field__category-button'));
         button.nativeElement.click();
         fixture.detectChanges();
 

--- a/libs/platform/src/lib/components/search-field/search-field.component.ts
+++ b/libs/platform/src/lib/components/search-field/search-field.component.ts
@@ -27,6 +27,7 @@ import { TemplatePortal } from '@angular/cdk/portal';
 import { FocusKeyManager, FocusableOption } from '@angular/cdk/a11y';
 import { RtlService } from '@fundamental-ngx/core';
 import { SearchFieldDataSource } from '../../domain/public_api';
+import { BaseComponent } from '../base';
 
 export interface SearchInput {
     text: string;
@@ -52,7 +53,7 @@ export interface ValueLabelItem {
     }
 })
 export class SearchFieldSuggestionDirective implements FocusableOption {
-    constructor(private element: ElementRef) {}
+    constructor(private element: ElementRef) { }
     focus() {
         this.element.nativeElement.focus();
     }
@@ -66,7 +67,7 @@ let searchFieldIdCount = 0;
     styleUrls: ['./search-field.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SearchFieldComponent implements OnInit, OnDestroy {
+export class SearchFieldComponent extends BaseComponent implements OnInit, OnDestroy {
     /**
      * Place holder text for search input field.
      */
@@ -117,17 +118,6 @@ export class SearchFieldComponent implements OnInit, OnDestroy {
      * Initial input text.
      */
     @Input() inputText: string;
-
-    /**
-     * Set size of search input component.
-     */
-    @Input()
-    get size(): 'cozy' | 'compact' {
-        return this.compact ? 'compact' : 'cozy';
-    }
-    set size(value: 'cozy' | 'compact') {
-        this.compact = value === 'compact';
-    }
 
     /**
      * List of categories.
@@ -230,9 +220,11 @@ export class SearchFieldComponent implements OnInit, OnDestroy {
     constructor(
         private _overlay: Overlay,
         private _viewContainerRef: ViewContainerRef,
-        private _cd: ChangeDetectorRef,
+        protected _cd: ChangeDetectorRef,
         private _rtl: RtlService
-    ) {}
+    ) {
+        super(_cd);
+    }
 
     ngOnInit() {
         const baseId = 'fdp-search-field';
@@ -398,7 +390,7 @@ export class SearchFieldComponent implements OnInit, OnDestroy {
         this.showDropdown = false;
     }
 
-    openCategoryMenu(): void {}
+    openCategoryMenu(): void { }
 
     clearTextInput(): void {
         this.inputText = '';


### PR DESCRIPTION


#### Please provide a link to the associated issue.
#2277 

#### Please provide a brief summary of this pull request.
The architecture of the Menu CSS styles in Fundamental-Styles 0.8.x has changed from previous versions, and as a result, has broken the display of the platform Menu and SearchField components.

This PR makes fixes to the Menu and SearchField components to account for the Menu style changes.

**Menu BEFORE:**
<img width="1188" alt="Screen Shot 2020-04-08 at 9 08 28 AM" src="https://user-images.githubusercontent.com/48103491/78807215-9ae5a880-7978-11ea-8277-962f2d0732b2.png">

**Menu AFTER:**
<img width="1185" alt="Screen Shot 2020-04-08 at 9 05 36 AM" src="https://user-images.githubusercontent.com/48103491/78807254-a507a700-7978-11ea-955c-2e4ac9f8226e.png">

**SearchField BEFORE:**
<img width="1156" alt="Screen Shot 2020-04-08 at 9 08 15 AM" src="https://user-images.githubusercontent.com/48103491/78807312-bbadfe00-7978-11ea-833d-27c4ec41a6f0.png">

**SearchField AFTER:**
<img width="1153" alt="Screen Shot 2020-04-08 at 9 06 05 AM" src="https://user-images.githubusercontent.com/48103491/78807326-c10b4880-7978-11ea-840a-40a59c6e967a.png">

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md


