### PR TITLE
chore: package downgraded to fix IE 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12270,7 +12270,8 @@
     "marked": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "dev": true
     },
     "material-colors": {
       "version": "1.2.6",
@@ -13038,14 +13039,22 @@
       }
     },
     "ngx-markdown": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-9.0.0.tgz",
-      "integrity": "sha512-wcXMxA4Skgk9SzhfDRjihap/Kjq17jmMQiE/Ccp0bNibGaDgS5DbZiPBlMNLkp669UvjY9wVuxE4NuDtmQHS9w==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/ngx-markdown/-/ngx-markdown-8.2.2.tgz",
+      "integrity": "sha512-wo2M2LIiLsuLqvmpeKwk8CDiT0qkxMdyNyCeypwJRcrfkzb6qjWEycA8i9VBBXwFze+8rS2BZn1YXrdezGi/3w==",
       "requires": {
-        "@types/marked": "^0.7.2",
+        "@types/marked": "^0.7.0",
         "katex": "^0.11.0",
-        "marked": "^0.8.0",
-        "prismjs": "^1.16.0"
+        "marked": "^0.7.0",
+        "prismjs": "^1.16.0",
+        "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+          "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+        }
       }
     },
     "nice-try": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "intl": "^1.2.5",
     "jasminewd2": "^2.0.6",
     "moment": "^2.24.0",
-    "ngx-markdown": "9.0.0",
+    "ngx-markdown": "8.2.2",
     "npm": "^6.14.3",
     "popper.js": "^1.16.1",
     "raw-loader": "^4.0.0",


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #2300 
Relates [ngx-markdown#210](https://github.com/jfcere/ngx-markdown/issues/210) [markedjs#1630](https://github.com/markedjs/marked/issues/1630)
#### Please provide a brief summary of this pull request.
Ngx-markdown depends on package called `marked` which recent version has issues on IE11.
Although PR fixes displaying documentation on IE11 it brings `npm ls` error again.
We have to wait with `ngx-markdown` upgrade till the fix is provided
