### PR TITLE
docs: add note about es5/RtlService to readme

### DIFF
--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -64,6 +64,9 @@ For an existing Angular CLI application,
 
     _If you do not use the Angular CLI or if this command does not work for you, please see the [full installation guide](https://github.com/SAP/fundamental-ngx/wiki/Full-Installation-Guide)._
 
+1. **Edit your tsconfig.**
+   Edit the `target` in your `tsconfig.json` to `es5`. The library is incompatible with later versions.
+   
 1. **Import the modules you want to use.**
 
     To add the entire library, add the following import to your main application module.
@@ -97,6 +100,10 @@ For an existing Angular CLI application,
     })
     export class DemoModule { }
     ```
+   
+1. **Provide the RtlService.**
+   In your main application module, add `RtlService` to the list of providers. This service is needed to ensure proper right-to-left functionality for
+   users with their browser set to an RTL language.
 
 1. **Add the component to your HTML.**
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#2304 

Adding notes to the setup guide about es5 and RtlService being required.  Hopefully we can find workarounds for this