### PR TITLE
fix: input group number arrow's size fixed

### DIFF
--- a/libs/core/src/lib/input-group/input-group-number.component.html
+++ b/libs/core/src/lib/input-group/input-group-number.component.html
@@ -11,9 +11,8 @@
             fd-button
             [disabled]="disabled"
             [glyph]="'slim-arrow-up'"
-            [class]="'fd-button--half'"
+            [class]="'fd-button--half fd-input-group__button'"
             [fdType]="'transparent'"
-            class="fd-input-group__button"
             [attr.aria-label]="stepUpLabel"
             (click)="stepUpClicked()"
         ></button>
@@ -21,9 +20,8 @@
             fd-button
             [disabled]="disabled"
             [glyph]="'slim-arrow-down'"
-            [class]="'fd-button--half'"
+            [class]="'fd-button--half fd-input-group__button'"
             [fdType]="'transparent'"
-            class="fd-input-group__button"
             [attr.aria-label]="stepDownLabel"
             (click)="stepDownClicked()"
         ></button>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#2304
#### Please provide a brief summary of this pull request.
PR provides a fix for height of input group number arrows
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
