### PR TITLE
docs: space added for example's buttons

### DIFF
--- a/apps/docs/src/app/core/component-docs/button/examples/button-examples.component.scss
+++ b/apps/docs/src/app/core/component-docs/button/examples/button-examples.component.scss
@@ -1,3 +1,4 @@
 .fd-button {
     margin-right: 12px;
+    margin-bottom: 10px;
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Relates #2304
#### Please provide a brief summary of this pull request.
PR brins extra space arround example's buttons

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done