### PR TITLE
fix: Center dialog on IE11

### DIFF
--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
@@ -10,8 +10,6 @@
             <fd-bar-element [fullWidth]="true">
                 <ng-content select="[fd-dialog-title]"></ng-content>
             </fd-bar-element>
-        </div>
-        <div fd-bar-right>
             <fd-bar-element>
                 <ng-content select="[fd-dialog-close-button]"></ng-content>
             </fd-bar-element>

--- a/libs/core/src/lib/dialog/dialog.component.ts
+++ b/libs/core/src/lib/dialog/dialog.component.ts
@@ -224,17 +224,21 @@ export class DialogComponent implements OnInit, AfterContentInit, AfterViewInit,
 
     /** @hidden Set Dialog styles from DialogConfig */
     private _setStyles(): void {
-        const position = this.dialogConfig.position || {};
         this.dialogWindow.nativeElement.style.width = this.dialogConfig.width;
         this.dialogWindow.nativeElement.style.height = this.dialogConfig.height;
         this.dialogWindow.nativeElement.style.minWidth = this.dialogConfig.minWidth;
         this.dialogWindow.nativeElement.style.minHeight = this.dialogConfig.minHeight;
         this.dialogWindow.nativeElement.style.maxWidth = this.dialogConfig.maxWidth;
         this.dialogWindow.nativeElement.style.maxHeight = this.dialogConfig.maxHeight;
-        this.dialogWindow.nativeElement.style.top = position.top;
-        this.dialogWindow.nativeElement.style.bottom = position.bottom;
-        this.dialogWindow.nativeElement.style.left = position.left;
-        this.dialogWindow.nativeElement.style.right = position.right;
+
+        if (this.dialogConfig.position) {
+            this.dialogWindow.nativeElement.style.top = this.dialogConfig.position.top;
+            this.dialogWindow.nativeElement.style.bottom = this.dialogConfig.position.bottom;
+            this.dialogWindow.nativeElement.style.left = this.dialogConfig.position.left;
+            this.dialogWindow.nativeElement.style.right = this.dialogConfig.position.right;
+        } else {
+            this.dialogWindow.nativeElement.style.position = 'relative';
+        }
     }
 
     /** @hidden Listen on window resize and adjust padding */


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of #2304

#### Please provide a brief summary of this pull request.
Dialog was off center on IE11 browser because of `flexbox` and `position: absolute` combination.

Solution: using `position: relative` by default, and `position: absolute` when dialog is customly positioned.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

