### PR TITLE
fix: Close Dialog on Esc key | IE11

### DIFF
--- a/libs/core/src/lib/dialog/dialog.component.ts
+++ b/libs/core/src/lib/dialog/dialog.component.ts
@@ -125,7 +125,7 @@ export class DialogComponent implements OnInit, AfterContentInit, AfterViewInit,
     /** @hidden Listen and close dialog on Escape key */
     @HostListener('keyup', ['$event'])
     closeDialogEsc(event: KeyboardEvent): void {
-        if (this.dialogConfig.escKeyCloseable && event.key === 'Escape') {
+        if (this.dialogConfig.escKeyCloseable && (event.key === 'Escape' || event.key === 'Esc')) {
             this._dialogRef.dismiss('escape');
         }
     }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of #2304

#### Please provide a brief summary of this pull request.
IE11 standard has different naming of some of the keys. PR introduces support for "Escape" and "Esc" key code.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

