### PR TITLE
fix: Dialog with header has body with rounded top corners | IE11

### DIFF
--- a/libs/core/src/lib/dialog/dialog.component.scss
+++ b/libs/core/src/lib/dialog/dialog.component.scss
@@ -18,8 +18,8 @@
 
     &--with-header {
         .fd-dialog__body {
-            border-top-left-radius: initial;
-            border-top-right-radius: initial;
+            border-top-left-radius: 0px;
+            border-top-right-radius: 0px;
         }
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of #2304

#### Please provide a brief summary of this pull request.
IE11 cannot properly interpret `border-radius: initial` value.
Use `border-radius: 0px` instead of `border-radius: initial`.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

