### PR TITLE
fix failing test due to jasmine type matching bug

### DIFF
--- a/libs/core/src/lib/date-picker/date-picker.component.spec.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.spec.ts
@@ -219,7 +219,7 @@ describe('DatePickerComponent', () => {
         spyOn(component.selectedRangeDateChange, 'emit');
         spyOn(component, 'onChange');
         const invalidDate = (<any>component)._invalidDate();
-        const rangeDateInvalidObject: FdRangeDate = { start: invalidDate, end: invalidDate };
+        const rangeDateInvalidObject = { start: invalidDate, end: invalidDate };
         component.type = 'range';
         component.disableRangeStartFunction = (fdDate: FdDate) => true;
         component.disableRangeEndFunction = (fdDate: FdDate) => true;
@@ -251,7 +251,7 @@ describe('DatePickerComponent', () => {
         const strDate1 = (<any>component)._formatDate(date1);
         const strDate2 = (<any>component)._formatDate(date2);
 
-        const rangeDateInvalidObject: FdRangeDate = { start: date1, end: invalidDate };
+        const rangeDateInvalidObject = { start: date1, end: invalidDate };
 
         component.dateStringUpdate(strDate1 + ' - ' + strDate2);
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#2304 

#### Please provide a brief summary of this pull request.

Unit tests failing on date range picker throwing the error "Argument of type 'FdRangeDate' is not assignable to parameter of type 'AsymmetricMatcher<any> | FdRangeDate'."