### PR TITLE
fix: Misaligned select icon | IE11

### DIFF
--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -39,7 +39,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            height: -webkit-fill-available;
+            height: auto;
         }
 
         &:hover {
@@ -92,7 +92,7 @@
             &::after {
                 border-left-style: solid;
                 border-left-width: 1px;
-                height: -webkit-fill-available;
+                height: auto;
                 border-color: var(--sapUiFieldBorderColor, #89919a);
             }
             &:hover {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #2304

#### Please provide a brief summary of this pull request.
Change icon `::after` element height from `fit-content` to `auto`

AFTER:
![image](https://user-images.githubusercontent.com/17496353/79206786-257a4c00-7e40-11ea-82d0-1e931095e96c.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

