### PR TITLE
fix: Support Calendar key navigation | IE11

### DIFF
--- a/libs/core/src/lib/calendar/calendar.service.ts
+++ b/libs/core/src/lib/calendar/calendar.service.ts
@@ -106,14 +106,16 @@ export class CalendarService {
      */
     onKeydownHandler(event: KeyboardEvent, index: number): void {
         const rtl: boolean = this._rtlService && this._rtlService.rtl.getValue();
-        
+
         switch (event.key) {
+            case 'Spacebar':
             case 'Enter':
             case ' ': {
                 event.preventDefault();
                 this.onKeySelect.next(index);
                 break;
             }
+            case 'Left':
             case 'ArrowLeft': {
                 event.preventDefault();
                 if (!rtl) {
@@ -123,6 +125,7 @@ export class CalendarService {
                 }
                 break;
             }
+            case 'Right':
             case 'ArrowRight': {
                 event.preventDefault();
                 if (!rtl) {
@@ -132,6 +135,7 @@ export class CalendarService {
                 }
                 break;
             }
+            case 'Up':
             case 'ArrowUp': {
                 event.preventDefault();
                 if (index <= this.colAmount - 1) {
@@ -141,6 +145,7 @@ export class CalendarService {
                 }
                 break;
             }
+            case 'Down':
             case 'ArrowDown': {
                 event.preventDefault();
                 if (index >= this.getId(this.rowAmount - 1, 0)) {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #2304

#### Please provide a brief summary of this pull request.
IE11 keyboard events keys have different naming. This PR adds support for IE11 key names.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

