### PR TITLE
chore: Add new font imports to schematics

### DIFF
--- a/ci-scripts/sync-version.sh
+++ b/ci-scripts/sync-version.sh
@@ -15,6 +15,7 @@ CDK_VERSION=$(node -p "require('./package.json').dependencies['@angular/cdk']")
 POPPER_VERSION=$(node -p "require('./package.json').dependencies['popper.js']")
 FDSTYLES_VERSION=$(node -p "require('./package.json').dependencies['fundamental-styles']")
 FOCUSTRAP_VERSION=$(node -p "require('./package.json').dependencies['focus-trap']")
+THEMING_VERSION=$(node -p "require('./package.json').dependencies['@sap-theming/theming-base-content']")
 
 cd ./dist
 
@@ -25,5 +26,6 @@ grep -rl 'CDK_VER_PLACEHOLDER' . | xargs  perl -X -p -i -e "s/CDK_VER_PLACEHOLDE
 grep -rl 'POPPER_VER_PLACEHOLDER' . | xargs  perl -X -p -i -e "s/POPPER_VER_PLACEHOLDER/${POPPER_VERSION}/g"
 grep -rl 'FDSTYLES_VER_PLACEHOLDER' . | xargs  perl -X -p -i -e "s/FDSTYLES_VER_PLACEHOLDER/${FDSTYLES_VERSION}/g"
 grep -rl 'FOCUSTRAP_VER_PLACEHOLDER' . | xargs  perl -X -p -i -e "s/FOCUSTRAP_VER_PLACEHOLDER/${FOCUSTRAP_VERSION}/g"
+grep -rl 'THEMING_VER_PLACEHOLDER' . | xargs  perl -X -p -i -e "s/THEMING_VER_PLACEHOLDER/${THEMING_VERSION}/g"
 
 cd ../

--- a/libs/core/ng-package.json
+++ b/libs/core/ng-package.json
@@ -11,6 +11,6 @@
     "focus-trap",
     "popper.js",
     "fundamental-styles",
-    "@angular/cdk"
+    "@sap-theming/theming-base-content"
   ]
 }

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -22,6 +22,7 @@
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {
+    "@sap-theming/theming-base-content": "THEMING_VER_PLACEHOLDER",
     "focus-trap": "FOCUSTRAP_VER_PLACEHOLDER",
     "fundamental-styles": "FDSTYLES_VER_PLACEHOLDER",
     "popper.js": "POPPER_VER_PLACEHOLDER"

--- a/libs/core/schematics/ng-add/index.ts
+++ b/libs/core/schematics/ng-add/index.ts
@@ -125,8 +125,8 @@ function addFontsToStyles(options: any): Rule {
         if (options.styleFonts) {
 
             if (!stylesFileContent) {
-                throw new SchematicsException(`Unable to find styles.scss. Please manually configure your styles. 
-                For more info, visit https://fundamental-styles.netlify.com/getting-started.html`);
+                console.warn(`Unable to find styles.scss. Please manually configure your styles. For more info, visit https://fundamental-styles.netlify.com/getting-started.html`);
+                return tree;
             }
 
             try {
@@ -141,8 +141,8 @@ function addFontsToStyles(options: any): Rule {
                 }
 
             } catch (e) {
-                throw new SchematicsException(`Unable to find styles.scss. Please manually configure your styles. 
-                For more info, visit https://fundamental-styles.netlify.com/getting-started.html`);
+                console.warn(`Unable to find styles.scss. Please manually configure your styles. For more info, visit https://fundamental-styles.netlify.com/getting-started.html`);
+                return tree;
             }
         }
 

--- a/libs/core/schematics/ng-add/index.ts
+++ b/libs/core/schematics/ng-add/index.ts
@@ -7,19 +7,19 @@ import { getAppModulePath } from '@schematics/angular/utility/ng-ast-utils';
 import { getProject } from '@schematics/angular/utility/project';
 import { WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 
-import chalk from 'chalk';
 import { cdkVersion } from './versions';
+import { defaultFontStyle } from './styles';
 
 const browserAnimationsModuleName = 'BrowserAnimationsModule';
 const noopAnimationsModuleName = 'NoopAnimationsModule';
 const fdStylesIconPath = 'node_modules/fundamental-styles/dist/icon.css';
-const fdStylesFontsPath = 'node_modules/fundamental-styles/dist/fonts.css';
 
 export function ngAdd(options: any): Rule {
     return chain([
         addDependencies(),
         addAnimations(options),
         addStylePathToConfig(options),
+        addFontsToStyles(options),
         endInstallTask()
     ]);
 }
@@ -52,7 +52,7 @@ function addDependencies(): Rule {
 
         dependencies.forEach(dependency => {
             addPackageJsonDependency(tree, dependency);
-            console.log(chalk.green(`✅️ Added ${dependency.name} to ${dependency.type}.`));
+            console.log(`✅️ Added ${dependency.name} to ${dependency.type}.`);
         });
 
         return tree;
@@ -67,23 +67,23 @@ function addAnimations(options: any): Rule {
 
         if (options.animations) {
             if (hasModuleImport(tree, modulePath, noopAnimationsModuleName)) {
-                return console.warn(chalk.red(`Could not set up "${chalk.bold(browserAnimationsModuleName)}" ` +
-                    `because "${chalk.bold(noopAnimationsModuleName)}" is already imported. Please manually ` +
-                    `set up browser animations.`));
+                return console.warn(`Could not set up "${browserAnimationsModuleName}" ` +
+                    `because "${noopAnimationsModuleName}" is already imported. Please manually ` +
+                    `set up browser animations.`);
             }
             addImportToRootModule(tree, browserAnimationsModuleName,
                 '@angular/platform-browser/animations', modulePath);
-            console.log(chalk.green(`✅️ Added ${browserAnimationsModuleName} to root module.`));
+            console.log(`✅️ Added ${browserAnimationsModuleName} to root module.`);
         } else if (!hasModuleImport(tree, modulePath, browserAnimationsModuleName)) {
             addImportToRootModule(tree, noopAnimationsModuleName,
                 '@angular/platform-browser/animations', modulePath);
-            console.log(chalk.green(`✅️ Added ${noopAnimationsModuleName} to root module.`));
+            console.log(`✅️ Added ${noopAnimationsModuleName} to root module.`);
         }
         return tree;
     };
 }
 
-// Adds the style path to the angular.json.
+// Adds the icon style path to the angular.json.
 function addStylePathToConfig(options: any): Rule {
     return (tree: Tree) => {
         const angularConfigPath = '/angular.json';
@@ -97,20 +97,55 @@ function addStylePathToConfig(options: any): Rule {
             // tslint:disable-next-line:no-non-null-assertion
             let stylesArray = (workspaceJson!.projects[options.project]!.architect!.build!.options as any)['styles'];
 
-            if (!stylesArray.includes(fdStylesIconPath) || !stylesArray.includes(fdStylesFontsPath)) {
-                stylesArray = pushStylesToArray(stylesArray, fdStylesFontsPath);
+            if (!stylesArray.includes(fdStylesIconPath)) {
                 stylesArray = pushStylesToArray(stylesArray, fdStylesIconPath);
                 // tslint:disable-next-line:no-non-null-assertion
                 (workspaceJson!.projects[options.project]!.architect!.build!.options as any)['styles'] = stylesArray;
             } else {
-                console.log(chalk.green(`✅️ Found duplicate style path in angular.json. Skipping.`));
+                console.log(`✅️ Found duplicate style path in angular.json. Skipping.`);
                 return tree;
             }
         } catch (e) {
             throw new SchematicsException(`Unable to find angular.json project styles. Please manually configure your styles array.`);
         }
         tree.overwrite(angularConfigPath, JSON.stringify(workspaceJson, null, 2));
-        console.log(chalk.green(`✅️ Added fundamental-styles path to angular.json.`));
+        console.log(`✅️ Added fundamental-styles path to angular.json.`);
+        return tree;
+    };
+}
+
+// Adds the default fonts import into styles.scss
+function addFontsToStyles(options: any): Rule {
+    return (tree: Tree) => {
+        const stylesFilePath = '/src/styles.scss';
+        const stylesFileContent = tree.read('/src/styles.scss');
+        const defaultFontStyleString = defaultFontStyle;
+        const sapThemingImport: string = 'node_modules/@sap-theming/theming-base-content/content/Base/baseLib';
+
+        if (options.styleFonts) {
+
+            if (!stylesFileContent) {
+                throw new SchematicsException(`Unable to find styles.scss. Please manually configure your styles. 
+                For more info, visit https://fundamental-styles.netlify.com/getting-started.html`);
+            }
+
+            try {
+                let stylesFileString: string = stylesFileContent.toString();
+
+                if (!stylesFileString.includes(sapThemingImport)) {
+                    stylesFileString = defaultFontStyleString + stylesFileString;
+                    tree.overwrite(stylesFilePath, stylesFileString);
+                } else {
+                    console.log(`✅️ There are imports from @sap-theming in styles.scss already. Skipping`);
+                    return tree;
+                }
+
+            } catch (e) {
+                throw new SchematicsException(`Unable to find styles.scss. Please manually configure your styles. 
+                For more info, visit https://fundamental-styles.netlify.com/getting-started.html`);
+            }
+        }
+
         return tree;
     };
 }

--- a/libs/core/schematics/ng-add/schema.json
+++ b/libs/core/schematics/ng-add/schema.json
@@ -10,6 +10,12 @@
             "description": "Whether Angular browser animations should be set up.",
             "x-prompt": "Set up browser animations for Fundamental Library for Angular?"
         },
+        "styleFonts": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether default fonts from theming should be added to styles.scss.",
+            "x-prompt": "Add default font imports into styles.scss?"
+        },
         "project": {
             "type": "string",
             "description": "The name of the project.",

--- a/libs/core/schematics/ng-add/styles.ts
+++ b/libs/core/schematics/ng-add/styles.ts
@@ -1,0 +1,31 @@
+/** */
+export const defaultFontStyle = `
+@font-face {
+    font-family: '72';
+    src: url('node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_base_fiori/fonts/72-Regular-full.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: '72';
+    src: url('node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_base_fiori/fonts/72-Light.woff') format('woff');
+    font-weight: 300;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: '72';
+    src: url('node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_base_fiori/fonts/72-Bold.woff') format('woff');
+    font-weight: 700;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'SAP-icons';
+    src: url('node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_fiori_3/fonts/SAP-icons.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+
+`;

--- a/libs/core/tsconfig.lib.prod.json
+++ b/libs/core/tsconfig.lib.prod.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./tsconfig.lib.json",
+  "extends": "./tsconfig.lib.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -273,17 +273,6 @@
             }
           }
         },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "core-js": {
           "version": "3.6.4",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
@@ -1351,18 +1340,6 @@
         "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "@babel/parser": {
@@ -2211,17 +2188,6 @@
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "y18n": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
@@ -2509,17 +2475,6 @@
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "cosmiconfig": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
@@ -2680,17 +2635,6 @@
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
         },
         "cli-cursor": {
           "version": "2.1.0",
@@ -2869,17 +2813,6 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
         },
         "cli-cursor": {
           "version": "2.1.0",
@@ -3552,17 +3485,6 @@
         "tsconfig-paths-webpack-plugin": "^3.2.0"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "micromatch": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -4358,9 +4280,9 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/marked": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.7.3.tgz",
-      "integrity": "sha512-WXdEKuT3azHxLTThd5dwnpLt2Q9QiC8iKj09KZRtVqro3pX8hhY+GbD8FZOae6SBBEJ22yKJn3c7ejL0aucAcA=="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.7.4.tgz",
+      "integrity": "sha512-fdg0NO4qpuHWtZk6dASgsrBggY+8N4dWthl1bAQG9ceKUNKFjqpHaDKCAhRUI6y8vavG7hLSJ4YBwJtZyZEXqw=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -4478,9 +4400,9 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.5.tgz",
-      "integrity": "sha512-L7EbSkhSaWBpkl+PZAEAqZTqtTeIsq7s/oX/q0LNnxxJoRVKQE0T81XDVyaxjiiKQwiV2vhVeYRqxdRNqGOGJw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.0.tgz",
+      "integrity": "sha512-3ZcoyPYHVOCcLpnfZwD47KFLr8W/mpUcgjpf1M4Q78TMJIw7KMAHSjiCLJp1z3ZrBR9pTLbe191O0TldFK5zcw==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -5294,17 +5216,6 @@
             "electron-to-chromium": "^1.3.47"
           }
         },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "postcss": {
           "version": "6.0.23",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
@@ -5929,16 +5840,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -6520,55 +6421,13 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
-      "dev": true,
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "character-entities": {
@@ -6811,19 +6670,6 @@
         "@types/q": "^1.5.1",
         "chalk": "^2.4.1",
         "q": "^1.1.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "code-point-at": {
@@ -8787,9 +8633,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.403",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz",
-      "integrity": "sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw=="
+      "version": "1.3.404",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.404.tgz",
+      "integrity": "sha512-G7XYSpNXv/GhFLgjGyBJAs9LjLHBWhsvjf6VI/VbptG9KiABHSItETTgDe1LDjbHA5P/Rn2MMDKOvhewM+w2Cg=="
     },
     "element-resize-detector": {
       "version": "1.2.1",
@@ -9638,13 +9484,6 @@
         }
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
-    },
     "filename-reserved-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
@@ -9838,18 +9677,6 @@
         "semver": "^5.6.0",
         "tapable": "^1.0.0",
         "worker-rpc": "^0.1.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "form-data": {
@@ -12995,18 +12822,6 @@
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "requires": {
         "chalk": "^2.4.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "log4js": {
@@ -13760,13 +13575,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -17204,9 +17012,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.2.tgz",
-          "integrity": "sha512-Zo84u6o2PebMSK3zjJ6Zp5wi8VnQZnEaCP13Ul/lt1ANsLACxnJxq4EEm1PY94/por1Hm9+7xpIswdS5AkieMA==",
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.0.tgz",
+          "integrity": "sha512-uyvgU/igkrMgNHwLgXvlpD9jEADbJhB0+JXSywoO47JgJ6c16iau9F9cjtc/E5o0PoqRYTiTIAPRKaYe84z6eQ==",
           "dev": true
         }
       }
@@ -17229,9 +17037,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.2.tgz",
-          "integrity": "sha512-Zo84u6o2PebMSK3zjJ6Zp5wi8VnQZnEaCP13Ul/lt1ANsLACxnJxq4EEm1PY94/por1Hm9+7xpIswdS5AkieMA==",
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.0.tgz",
+          "integrity": "sha512-uyvgU/igkrMgNHwLgXvlpD9jEADbJhB0+JXSywoO47JgJ6c16iau9F9cjtc/E5o0PoqRYTiTIAPRKaYe84z6eQ==",
           "dev": true
         }
       }
@@ -17259,9 +17067,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.2.2.tgz",
-          "integrity": "sha512-Zo84u6o2PebMSK3zjJ6Zp5wi8VnQZnEaCP13Ul/lt1ANsLACxnJxq4EEm1PY94/por1Hm9+7xpIswdS5AkieMA==",
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.0.tgz",
+          "integrity": "sha512-uyvgU/igkrMgNHwLgXvlpD9jEADbJhB0+JXSywoO47JgJ6c16iau9F9cjtc/E5o0PoqRYTiTIAPRKaYe84z6eQ==",
           "dev": true
         }
       }
@@ -17322,19 +17130,6 @@
         "read-pkg": "^3.0.0",
         "shell-quote": "^1.6.1",
         "string.prototype.padend": "^3.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "npm-run-path": {
@@ -17636,18 +17431,6 @@
         "log-symbols": "^3.0.0",
         "strip-ansi": "^5.2.0",
         "wcwidth": "^1.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "original": {
@@ -18309,28 +18092,6 @@
         "supports-color": "^6.1.0"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -19683,17 +19444,6 @@
             "node-releases": "^1.1.29"
           }
         },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "chokidar": {
           "version": "2.1.8",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -19820,8 +19570,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -20612,9 +20360,9 @@
       "dev": true
     },
     "react-fast-compare": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.0.1.tgz",
+      "integrity": "sha512-C5vP0J644ofZGd54P8++O7AvrqMEbrGf8Ue0eAUJLJyw168dAX2aiYyX/zcY/eSNwO0IDjsKUaLE6n83D+TnEg==",
       "dev": true
     },
     "react-focus-lock": {
@@ -20632,15 +20380,15 @@
       }
     },
     "react-helmet-async": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.4.tgz",
-      "integrity": "sha512-KTGHE9sz8N7+fCkZ2a3vzXH9eIkiTNhL2NhKR7XzzQl3WsGlCHh76arauJUIiGdfhjeMp7DY7PkASAmYFXeJYg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.5.tgz",
+      "integrity": "sha512-nqGA5a1HRZsw1lzDn+bYuUN2FyHRiY+DgjRVhEOKVBDTrrqJCpCIOuY/IRHdobr+KD1gGTP0WabZsTrIHnFKJA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.3.4",
+        "@babel/runtime": "^7.9.2",
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
-        "react-fast-compare": "^2.0.4",
+        "react-fast-compare": "^3.0.1",
         "shallowequal": "^1.1.0"
       }
     },
@@ -22443,19 +22191,6 @@
       "dev": true,
       "requires": {
         "chalk": "^2.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "split": {
@@ -23190,19 +22925,6 @@
         "stable": "^0.1.8",
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "symbol-observable": {
@@ -23662,18 +23384,6 @@
         "loader-utils": "^1.0.2",
         "micromatch": "^3.1.4",
         "semver": "^5.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "ts-node": {
@@ -23724,18 +23434,6 @@
         "chalk": "^2.3.0",
         "enhanced-resolve": "^4.0.0",
         "tsconfig-paths": "^3.4.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
       }
     },
     "tslib": {
@@ -23769,17 +23467,6 @@
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
           "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
         }
       }
     },
@@ -23922,23 +23609,13 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
-      "integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.0.tgz",
+      "integrity": "sha512-j5wNQBWaql8gr06dOUrfaohHlscboQZ9B8sNsoK5o4sBjm7Ht9dxSbrMXyktQpA16Acaij8AcoozteaPYZON0g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
-        }
+        "commander": "~2.20.3"
       }
     },
     "ultron": {
@@ -24529,8 +24206,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -25471,8 +25146,6 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "@types/jasminewd2": "2.0.8",
     "angular-cli-ghpages": "0.6.2",
     "babel-loader": "8.1.0",
-    "chalk": "4.0.0",
     "codelyzer": "5.2.2",
     "coveralls": "3.0.11",
     "fs-extra": "9.0.0",


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/2304
#### Please provide a brief summary of this pull request.
There are new schematics added into ngx core library `ng add @fundamental-ngx/core`
- There is one additional question before instalation: `Add default font imports into styles.scss?`, which is yes by default
- Chalk package is removed, it caused some issues for schematics (It's package for changing colors of messages in console)

If there are some `@sap-theming` imports in styles, it's skipped
![image](https://user-images.githubusercontent.com/26483208/79214198-b0f8da80-7e4a-11ea-8ef4-6ad8392b3b2f.png)
If the styles.scss can't be found, it throws message:
![image](https://user-images.githubusercontent.com/26483208/79215424-c7ebfc80-7e4b-11ea-9efe-3199ca8e37f2.png)

Otherwise it's added
![image](https://user-images.githubusercontent.com/26483208/79214267-d554b700-7e4a-11ea-9d53-7fcf94d48502.png)



#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

