### PR TITLE
docs: Deprecate Loading Spinner and Status Indicator

### DIFF
--- a/apps/docs/src/app/core/component-docs/alert/alert-header/alert-header.component.html
+++ b/apps/docs/src/app/core/component-docs/alert/alert-header/alert-header.component.html
@@ -1,5 +1,5 @@
 <header>Alert</header>
-<fd-message-strip [type]="'warning'">
+<fd-message-strip [type]="'warning'" [dismissible]="false">
     DEPRECATED. Alert does not exist as a Fiori 3 component so it has been deprecated. The inline version successor of the alert is <a [routerLink]="'/core/message-strip'">Message Strip</a> component. There is no overlay version of Alert in Fiori 3.
 </fd-message-strip>
 <description>Alerts are used to display short messages that require user attention.</description>

--- a/apps/docs/src/app/core/component-docs/badge-label/badge-label-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/badge-label/badge-label-docs.module.ts
@@ -13,7 +13,7 @@ import {
     LabelIconStatusExampleComponent, LabelStatusColorsExampleComponent
 } from './examples/badge-label-examples.component';
 import {BadgeLabelHeaderComponent} from './badge-label-header/badge-label-header.component';
-import { BadgeLabelModule } from '@fundamental-ngx/core';
+import { BadgeLabelModule, MessageStripModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -30,6 +30,7 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
+        MessageStripModule,
         BadgeLabelModule
     ],
     exports: [RouterModule],

--- a/apps/docs/src/app/core/component-docs/badge-label/badge-label-header/badge-label-header.component.html
+++ b/apps/docs/src/app/core/component-docs/badge-label/badge-label-header/badge-label-header.component.html
@@ -1,4 +1,9 @@
 <header>Status Indicators</header>
+<fd-message-strip [type]="'warning'" [dismissible]="false">
+    DEPRECATED. Status Indicator does not exist as a Fiori 3 component so it has been deprecated.
+    The successors of the Status Indicator are <a [routerLink]="'/core/object-status'">Object Status</a> and <a
+    [routerLink]="'/core/info-label'">Info Label</a>.
+</fd-message-strip>
 <description>
     <p>Badges and labels are used to indicate status. Colors, generally in combination with text, are used to easily
         highlight

--- a/apps/docs/src/app/core/component-docs/dropdown/dropdown-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/dropdown/dropdown-docs.module.ts
@@ -10,7 +10,7 @@ import {DropdownIconsExampleComponent} from './examples/dropdown-icons-example.c
 import {DropdownStateExampleComponent} from './examples/dropdown-state-example.component';
 import {DropdownInfiniteScrollExampleComponent} from './examples/dropdown-infinite-scroll-example.component';
 import {DropdownToolbarExampleComponent} from './examples/dropdown-toolbar-example.component';
-import { InfiniteScrollModule, MenuModule, PopoverModule } from '@fundamental-ngx/core';
+import { InfiniteScrollModule, MenuModule, MessageStripModule, PopoverModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -29,6 +29,7 @@ const routes: Routes = [
         SharedDocumentationModule,
         PopoverModule,
         InfiniteScrollModule,
+        MessageStripModule,
         MenuModule
     ],
     exports: [RouterModule],

--- a/apps/docs/src/app/core/component-docs/dropdown/dropdown-header/dropdown-header.component.html
+++ b/apps/docs/src/app/core/component-docs/dropdown/dropdown-header/dropdown-header.component.html
@@ -1,9 +1,9 @@
 <header>Dropdown</header>
 
-<fd-alert [type]="'warning'" [dismissible]="false">
-    DEPRECATED. The <code>fd-dropdown-control</code> is deprecated, we recommend to use
+<fd-message-strip [type]="'warning'" [dismissible]="false">
+    DEPRECATED. Dropdown component has been deprecated, we recommend to use
     <a [routerLink]="'/core/popover'" [fragment]="'dropdown'">Menu Button</a> instead.
-</fd-alert>
+</fd-message-strip>
 
 <description>The dropdown component is an opinionated composition of the “fd-popover” and “fd-menu” components with the
     use of a styled

--- a/apps/docs/src/app/core/component-docs/dropdown/dropdown-header/dropdown-header.component.html
+++ b/apps/docs/src/app/core/component-docs/dropdown/dropdown-header/dropdown-header.component.html
@@ -1,6 +1,6 @@
 <header>Dropdown</header>
 
-<fd-alert [type]="'warning'">
+<fd-alert [type]="'warning'" [dismissible]="false">
     DEPRECATED. The <code>fd-dropdown-control</code> is deprecated, we recommend to use
     <a [routerLink]="'/core/popover'" [fragment]="'dropdown'">Menu Button</a> instead.
 </fd-alert>

--- a/apps/docs/src/app/core/component-docs/loading-spinner-docs/loading-spinner-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/loading-spinner-docs/loading-spinner-docs.module.ts
@@ -7,7 +7,7 @@ import {LoadingSpinnerHeaderComponent} from './loading-spinner-header/loading-sp
 import {LoadingSpinnerDocsComponent} from './loading-spinner-docs.component';
 import {LoadingSpinnerExampleComponent} from './examples/loading-spinner-example.component';
 import {LoadingSpinnerContainerExampleComponent} from './examples/loading-spinner-container-example.component';
-import { LoadingSpinnerModule } from '@fundamental-ngx/core';
+import { LoadingSpinnerModule, MessageStripModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -24,7 +24,8 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        LoadingSpinnerModule
+        LoadingSpinnerModule,
+        MessageStripModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/core/component-docs/loading-spinner-docs/loading-spinner-header/loading-spinner-header.component.html
+++ b/apps/docs/src/app/core/component-docs/loading-spinner-docs/loading-spinner-header/loading-spinner-header.component.html
@@ -1,4 +1,8 @@
 <header>Loading Spinner</header>
+<fd-message-strip [type]="'warning'" [dismissible]="false">
+    DEPRECATED. Loading Spinner does not exist as a Fiori 3 component so it has been deprecated.
+    The successor of the Loading Spinner is <a [routerLink]="'/core/busy-indicator'">Busy Indicator</a> component.
+</fd-message-strip>
 <description>
     A loading spinner informs the user of an ongoing operation. Only one busy indicator should be shown at a time. The
     <code>loading</code> input on the component is used to hide and show the element.

--- a/libs/core/src/lib/badge-label/badge-label.module.ts
+++ b/libs/core/src/lib/badge-label/badge-label.module.ts
@@ -4,7 +4,11 @@ import { CommonModule } from '@angular/common';
 import { BadgeComponent } from './badge-label/badge.component';
 import { LabelComponent } from './label/label.component';
 import { StatusLabelComponent } from './status-label/status-label.component';
-
+/**
+ * @deprecated
+ * BadgeLabelModule is deprecated.
+ * Consult docs for better alternative.
+ */
 @NgModule({
     imports: [CommonModule],
     exports: [BadgeComponent, LabelComponent, StatusLabelComponent],

--- a/libs/core/src/lib/badge-label/badge-label/badge.component.ts
+++ b/libs/core/src/lib/badge-label/badge-label/badge.component.ts
@@ -3,6 +3,10 @@ import { AbstractFdNgxClass } from '../../utils/abstract-fd-ngx-class';
 import { BadgeStatus, BadgeModifier } from '../label/label.component';
 
 /**
+ * @deprecated
+ * BadgeComponent is deprecated.
+ * Consult docs for better alternative.
+ *
  * Badge component, used to indicate status.
  * Colors, generally in combination with text, are used to easily highlight the state of an object.
  */

--- a/libs/core/src/lib/badge-label/label/label.component.ts
+++ b/libs/core/src/lib/badge-label/label/label.component.ts
@@ -6,6 +6,10 @@ export type BadgeModifier = 'pill' | 'filled';
 export type BadgeIconStatus = 'available' | 'away' | 'busy' | 'offline';
 
 /**
+ * @deprecated
+ * LabelComponent is deprecated.
+ * Consult docs for better alternative.
+ *
  * Label component, used to indicate status, without any background or border
  * Colors, generally in combination with text, are used to easily highlight the state of an object.
  */

--- a/libs/core/src/lib/badge-label/status-label/status-label.component.ts
+++ b/libs/core/src/lib/badge-label/status-label/status-label.component.ts
@@ -3,6 +3,10 @@ import { AbstractFdNgxClass } from '../../utils/abstract-fd-ngx-class';
 import { BadgeStatus, BadgeIconStatus } from '../label/label.component';
 
 /**
+ * @deprecated
+ * StatusLabelComponent is deprecated.
+ * Consult docs for better alternative.
+ *
  * Status Label component with some default icons based on status input used to indicate status.
  * Icons are used to easily highlight the state of an object.
  */

--- a/libs/core/src/lib/loading-spinner/loading-spinner.component.ts
+++ b/libs/core/src/lib/loading-spinner/loading-spinner.component.ts
@@ -1,8 +1,11 @@
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 
 /**
- * The component that represents a loading spinner.
+ * @deprecated
+ * LoadingSpinnerComponent is deprecated.
+ * Consult docs for better alternative.
  *
+ * The component that represents a loading spinner.
  * ```html
  * <fd-loading-spinner [loading]="true"></fd-loading-spinner>
  * ```

--- a/libs/core/src/lib/loading-spinner/loading-spinner.module.ts
+++ b/libs/core/src/lib/loading-spinner/loading-spinner.module.ts
@@ -2,6 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LoadingSpinnerComponent } from './loading-spinner.component';
 
+/**
+ * @deprecated
+ * LoadingSpinnerModule is deprecated.
+ * Consult docs for better alternative.
+ */
 @NgModule({
     declarations: [LoadingSpinnerComponent],
     exports: [LoadingSpinnerComponent],

--- a/libs/core/src/lib/popover/popover-dropdown/popover-dropdown.component.ts
+++ b/libs/core/src/lib/popover/popover-dropdown/popover-dropdown.component.ts
@@ -3,6 +3,10 @@ import { Subscription } from 'rxjs';
 import { PopoverComponent } from '../popover.component';
 import { ButtonType } from '../../button/button.component';
 /**
+ * @deprecated
+ * PopoverDropdownComponent is deprecated
+ * Consult docs for better alternative
+ *
  * A component used to enforce a certain layout for the popover. With additional styling
  * ```html
  * <fd-popover>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #2334

#### Please provide a brief summary of this pull request.
This PR:
- deprecates Loading Spinner and Status Indicator components
- sets Message Strip components used for marking other components as deprecated as undismissable.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

