### PR TITLE
fix: DatePickers add focus trap

### DIFF
--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -1,4 +1,4 @@
-<fd-popover [(isOpen)]="isOpen" [triggers]="[]" [placement]="placement" [closeOnEscapeKey]="true" [disabled]="disabled">
+<fd-popover [(isOpen)]="isOpen" [triggers]="[]" [placement]="placement" [closeOnEscapeKey]="true" [disabled]="disabled" [focusTrapped]="true">
     <fd-popover-control>
         <fd-input-group [compact]="compact" [state]="state" [disabled]="disabled">
             <input

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -3,6 +3,7 @@
         [(isOpen)]="isOpen"
         [closeOnOutsideClick]="false"
         [closeOnEscapeKey]="false"
+        [focusTrapped]="true"
         [triggers]="[]"
         [disabled]="disabled"
         [placement]="placement"


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Relates to: https://github.com/SAP/fundamental-ngx/issues/2334
#### Please provide a brief summary of this pull request.
Add focus trap to popover on datepicker and datetimepicker