### PR TITLE
fix: add fix for Dialog header template close button

### DIFF
--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
@@ -10,6 +10,8 @@
             <fd-bar-element [fullWidth]="true">
                 <ng-content select="[fd-dialog-title]"></ng-content>
             </fd-bar-element>
+        </div>
+        <div fd-bar-right>
             <fd-bar-element>
                 <ng-content select="[fd-dialog-close-button]"></ng-content>
             </fd-bar-element>


### PR DESCRIPTION
### Please provide a brief summary of this pull request.
The close button was placed inside `fd-bar-left` together with the title which had fullWidth prop set to true. The close button should be placed inside `fd-bar-right` div

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md


