### PR TITLE
fix: remove circular dependency for Nested List 

### DIFF
--- a/apps/docs/src/app/core/api-files.ts
+++ b/apps/docs/src/app/core/api-files.ts
@@ -266,7 +266,8 @@ export const API_FILES = {
         'NestedListIconDirective',
         'NestedListItem',
         'NestedListModel',
-        'NestedListLink'
+        'NestedListLink',
+        'NestedItemService'
     ],
     splitButton: [
         'SplitButtonComponent',

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.directive.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.directive.spec.ts
@@ -76,7 +76,7 @@ describe('NestedItemDirective', () => {
         nestedItemListDirective = component.nestedItemListDirective;
         emptyItemDirective = component.emptyItemDirective;
         nestedItemPopoverDirective = component.nestedItemPopoverDirective;
-        itemService = (<any>nestedItemPopoverDirective).itemService;
+        itemService = (<any>nestedItemPopoverDirective)._itemService;
         fixture.detectChanges();
     });
 

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.directive.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.directive.spec.ts
@@ -5,6 +5,7 @@ import { NestedListModule } from '../nested-list.module';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NestedListKeyboardService } from '../nested-list-keyboard.service';
 import { NestedListStateService } from '../nested-list-state.service';
+import { NestedItemService } from './nested-item.service';
 
 @Component({
     template: `
@@ -57,6 +58,7 @@ describe('NestedItemDirective', () => {
     let nestedItemListDirective: NestedItemDirective;
     let emptyItemDirective: NestedItemDirective;
     let fixture: ComponentFixture<TestNestedContainerComponent>;
+    let itemService: NestedItemService;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -74,6 +76,7 @@ describe('NestedItemDirective', () => {
         nestedItemListDirective = component.nestedItemListDirective;
         emptyItemDirective = component.emptyItemDirective;
         nestedItemPopoverDirective = component.nestedItemPopoverDirective;
+        itemService = (<any>nestedItemPopoverDirective).itemService;
         fixture.detectChanges();
     });
 
@@ -84,7 +87,7 @@ describe('NestedItemDirective', () => {
 
     it('Item with popover should react to open change from popover', () => {
         spyOn(nestedItemPopoverDirective, 'triggerOpen');
-        nestedItemPopoverDirective.popoverItem.handleOpenChange(true);
+        itemService.popover.handleOpenChange(true);
         expect(nestedItemPopoverDirective.triggerOpen).toHaveBeenCalled();
     });
 
@@ -102,7 +105,7 @@ describe('NestedItemDirective', () => {
     });
 
     it('Item with popover, should pass reference to popover child', () => {
-        expect(nestedItemPopoverDirective.popoverItem.parentItemElement).toBe(nestedItemPopoverDirective);
+        expect(itemService.popover.parentItemElement).toBe(nestedItemPopoverDirective);
     });
 
     it('Item with list should have children', () => {

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
@@ -100,9 +100,6 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
         this.propagateOpenChange(this._expanded);
     }
 
-    ngOnDestroy(): void {
-    }
-
     /** Method that expand the item and propagate it to children */
     triggerOpen(): void {
         if (!this.expanded) {

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
@@ -4,22 +4,22 @@ import {
     Directive,
     ElementRef,
     EventEmitter,
-    forwardRef,
     HostBinding,
-    Input,
+    Input, OnDestroy,
     Output
 } from '@angular/core';
 import { NestedLinkDirective } from '../nested-link/nested-link.directive';
 import { NestedListKeyboardService } from '../nested-list-keyboard.service';
-import { NestedListPopoverComponent } from '../nested-list-popover/nested-list-popover.component';
 import { NestedItemInterface } from './nested-item.interface';
-import { NestedListDirective } from '../nested-list/nested-list.directive';
-import { PreparedNestedListComponent } from '../prepared-nested-list/prepared-nested-list.component';
+import { NestedItemService } from './nested-item.service';
 
 @Directive({
-    selector: '[fdNestedItem], [fd-nested-list-item]'
+    selector: '[fdNestedItem], [fd-nested-list-item]',
+    providers: [
+        NestedItemService
+    ]
 })
-export class NestedItemDirective implements AfterContentInit, NestedItemInterface {
+export class NestedItemDirective implements AfterContentInit, NestedItemInterface, OnDestroy {
 
     /** @hidden */
     @HostBinding('class.fd-nested-list__item')
@@ -32,33 +32,15 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
     @ContentChild(NestedLinkDirective)
     linkItem: NestedLinkDirective;
 
-    /** @hidden */
-    @ContentChild(NestedListPopoverComponent)
-    popoverItem: NestedListPopoverComponent;
-
-    /** @hidden */
-    @ContentChild(forwardRef(() => NestedListDirective))
-    nestedListItem: NestedListDirective;
-
-    /** @hidden */
-    @ContentChild(forwardRef(() => PreparedNestedListComponent))
-    preparedListComponent: PreparedNestedListComponent;
-
     /** Check if the item element has any child */
     public get hasChildren(): boolean {
-        return !!(this.nestedListItem || this.popoverItem || this.nestedListFromPreparedComponent);
+        return !!(this.itemService && this.itemService.list);
     }
 
     /** Get all of the children item elements */
     public get allChildrenItems(): NestedItemInterface[] {
-        if (this.nestedListItem && this.nestedListItem.nestedItems) {
-            /** Get elements from child list */
-            return this.nestedListItem.nestedItems.toArray();
-
-        } else if (this.nestedListFromPreparedComponent && this.nestedListFromPreparedComponent.nestedItems) {
-            /** Get elements from child prepared list  component */
-            return this.nestedListFromPreparedComponent.nestedItems.toArray();
-
+        if (this.itemService && this.itemService.list) {
+            return this.itemService.list._nestedItems.toArray()
         } else {
             return [];
         }
@@ -66,6 +48,7 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
 
     /** @hidden */
     constructor (
+        private itemService: NestedItemService,
         private elementRef: ElementRef,
         private keyboardService: NestedListKeyboardService
     ) {}
@@ -93,7 +76,6 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
 
     /** @hidden */
     ngAfterContentInit(): void {
-
         /** Propagate hasChildren property */
         if (this.hasChildren && this.linkItem) {
             this.linkItem.hasChildren = true;
@@ -110,13 +92,16 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
             );
         }
 
-        /** Pass this element to popover child item, to allow control `expanded` value */
-        if (this.popoverItem) {
-            this.popoverItem.parentItemElement = this;
+        // /** Pass this element to popover child item, to allow control `expanded` value */
+        if (this.itemService.popover) {
+            this.itemService.popover.parentItemElement = this;
         }
 
         /** Propagate initial open state to children */
         this.propagateOpenChange(this._expanded);
+    }
+
+    ngOnDestroy(): void {
     }
 
     /** Method that expand the item and propagate it to children */
@@ -166,28 +151,17 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
             this.linkItem.expanded = open;
         }
 
-        if (this.nestedListItem) {
-            this.nestedListItem.hidden = !open;
+        if (this.itemService.list) {
+            this.itemService.list.hidden = !open;
         }
 
-        if (this.nestedListFromPreparedComponent) {
-            this.nestedListFromPreparedComponent.hidden = !open;
-        }
-
-        if (this.popoverItem) {
-            this.popoverItem.open = open;
+        if (this.itemService.popover) {
+            this.itemService.popover.open = open;
         }
 
         /** Trigger event to provide keyboard support to new list of opened item element. */
         this.keyboardService.refresh$.next();
         this.expandedChange.emit(open);
-    }
-
-    /**
-     * @hidden
-     */
-    private get nestedListFromPreparedComponent(): NestedListDirective {
-        return this.preparedListComponent && this.preparedListComponent.nestedListDirective;
     }
 
 }

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
@@ -34,13 +34,13 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
 
     /** Check if the item element has any child */
     public get hasChildren(): boolean {
-        return !!(this.itemService && this.itemService.list);
+        return !!(this._itemService && this._itemService.list);
     }
 
     /** Get all of the children item elements */
     public get allChildrenItems(): NestedItemInterface[] {
-        if (this.itemService && this.itemService.list) {
-            return this.itemService.list._nestedItems.toArray()
+        if (this._itemService && this._itemService.list) {
+            return this._itemService.list.nestedItems.toArray()
         } else {
             return [];
         }
@@ -48,9 +48,8 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
 
     /** @hidden */
     constructor (
-        private itemService: NestedItemService,
-        private elementRef: ElementRef,
-        private keyboardService: NestedListKeyboardService
+        private _itemService: NestedItemService,
+        private _keyboardService: NestedListKeyboardService
     ) {}
 
     /** Whether item should be expanded */
@@ -93,8 +92,8 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
         }
 
         // /** Pass this element to popover child item, to allow control `expanded` value */
-        if (this.itemService.popover) {
-            this.itemService.popover.parentItemElement = this;
+        if (this._itemService.popover) {
+            this._itemService.popover.parentItemElement = this;
         }
 
         /** Propagate initial open state to children */
@@ -147,20 +146,23 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
     private propagateOpenChange(open: boolean): void {
         this._expanded = open;
 
+        /** Propagate to child link directive */
         if (this.linkItem) {
             this.linkItem.expanded = open;
         }
 
-        if (this.itemService.list) {
-            this.itemService.list.hidden = !open;
+        /** Propagate hidden flag to list component, that is passed from child */
+        if (this._itemService.list) {
+            this._itemService.list.hidden = !open;
         }
 
-        if (this.itemService.popover) {
-            this.itemService.popover.open = open;
+        /** Propagate open flag to popover list component, that is passed from child */
+        if (this._itemService.popover) {
+            this._itemService.popover.open = open;
         }
 
         /** Trigger event to provide keyboard support to new list of opened item element. */
-        this.keyboardService.refresh$.next();
+        this._keyboardService.refresh$.next();
         this.expandedChange.emit(open);
     }
 

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
@@ -19,7 +19,7 @@ import { NestedItemService } from './nested-item.service';
         NestedItemService
     ]
 })
-export class NestedItemDirective implements AfterContentInit, NestedItemInterface, OnDestroy {
+export class NestedItemDirective implements AfterContentInit, NestedItemInterface {
 
     /** @hidden */
     @HostBinding('class.fd-nested-list__item')

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.directive.ts
@@ -2,10 +2,9 @@ import {
     AfterContentInit,
     ContentChild,
     Directive,
-    ElementRef,
     EventEmitter,
     HostBinding,
-    Input, OnDestroy,
+    Input,
     Output
 } from '@angular/core';
 import { NestedLinkDirective } from '../nested-link/nested-link.directive';
@@ -91,7 +90,7 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
             );
         }
 
-        // /** Pass this element to popover child item, to allow control `expanded` value */
+        /** Pass this element to popover child item, to allow control `expanded` value */
         if (this._itemService.popover) {
             this._itemService.popover.parentItemElement = this;
         }
@@ -162,5 +161,4 @@ export class NestedItemDirective implements AfterContentInit, NestedItemInterfac
         this._keyboardService.refresh$.next();
         this.expandedChange.emit(open);
     }
-
 }

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.service.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.service.ts
@@ -1,7 +1,8 @@
 import { NestedListInterface } from '../nested-list/nested-list.interface';
 import { NestedListPopoverInterface } from '../nested-list-popover/nested-list-popover.interface';
 
+/** Contains references to popover or list nested components, that are placed as direct children of item component */
 export class NestedItemService {
-    public list: NestedListInterface;
-    public popover?: NestedListPopoverInterface;
+    list: NestedListInterface;
+    popover?: NestedListPopoverInterface;
 }

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.service.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.service.ts
@@ -1,0 +1,7 @@
+import { NestedListInterface } from '../nested-list/nested-list.interface';
+import { NestedListPopoverInterface } from '../nested-list-popover/nested-list-popover.interface';
+
+export class NestedItemService {
+    public list: NestedListInterface;
+    public popover?: NestedListPopoverInterface;
+}

--- a/libs/core/src/lib/nested-list/nested-link/nested-link.directive.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-link/nested-link.directive.spec.ts
@@ -52,9 +52,11 @@ describe('NestedLinkDirective', () => {
         directiveElement.expanded = true;
         fixture.detectChanges();
 
-        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('is-expanded')).toBeTruthy();
-        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('is-selected')).toBeTruthy();
-        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('has-child')).toBeTruthy();
+        const classList = (directiveElement as any)._elementRef.nativeElement.classList;
+
+        expect(classList.contains('is-expanded')).toBeTruthy();
+        expect(classList.contains('is-selected')).toBeTruthy();
+        expect(classList.contains('has-child')).toBeTruthy();
 
     });
 

--- a/libs/core/src/lib/nested-list/nested-link/nested-link.directive.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-link/nested-link.directive.spec.ts
@@ -52,9 +52,9 @@ describe('NestedLinkDirective', () => {
         directiveElement.expanded = true;
         fixture.detectChanges();
 
-        expect((directiveElement as any).elementRef.nativeElement.classList.contains('is-expanded')).toBeTruthy();
-        expect((directiveElement as any).elementRef.nativeElement.classList.contains('is-selected')).toBeTruthy();
-        expect((directiveElement as any).elementRef.nativeElement.classList.contains('has-child')).toBeTruthy();
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('is-expanded')).toBeTruthy();
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('is-selected')).toBeTruthy();
+        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('has-child')).toBeTruthy();
 
     });
 

--- a/libs/core/src/lib/nested-list/nested-link/nested-link.directive.ts
+++ b/libs/core/src/lib/nested-list/nested-link/nested-link.directive.ts
@@ -66,19 +66,19 @@ export class NestedLinkDirective implements OnInit {
 
     /** Set focus on the element. */
     focus(): void {
-        this.elementRef.nativeElement.focus();
+        this._elementRef.nativeElement.focus();
     }
 
     /** Dispatches the click event on the element */
     click(): void {
-        this.elementRef.nativeElement.click();
+        this._elementRef.nativeElement.click();
     }
 
     /** @hidden */
     constructor(
-        private renderer: Renderer2,
-        private elementRef: ElementRef,
-        public changeDetRef: ChangeDetectorRef
+        public changeDetRef: ChangeDetectorRef,
+        private _renderer: Renderer2,
+        private _elementRef: ElementRef
     ) {}
 
     /** @hidden */
@@ -86,12 +86,12 @@ export class NestedLinkDirective implements OnInit {
         /** Add event listeners on the element */
 
         /** Keyboard */
-        this.renderer.listen(this.elementRef.nativeElement, 'keydown', (event) =>
+        this._renderer.listen(this._elementRef.nativeElement, 'keydown', (event) =>
             this.keyboardTriggered.emit(event)
         );
 
         /** Mouse Click */
-        this.renderer.listen(this.elementRef.nativeElement, 'click', (event) => {
+        this._renderer.listen(this._elementRef.nativeElement, 'click', (event) => {
             if (this.onClickCallback) {
                 this.onClickCallback();
             }

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.spec.ts
@@ -23,9 +23,7 @@ class MockNestedItem {
 }
 
 interface MockNestedList {
-    nestedItems: {
-        toArray: () => MockNestedItem[]
-    };
+    nestedItems:  MockNestedItem[]
 }
 
 describe('NestedListKeyboardSupportService', () => {
@@ -53,9 +51,7 @@ describe('NestedListKeyboardSupportService', () => {
 
     beforeEach(() => {
         object = {
-            nestedItems: {
-                toArray: toArray
-            }
+            nestedItems: toArray()
         };
         service = new NestedListKeyboardService(new MenuKeyboardService());
 

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.spec.ts
@@ -23,7 +23,7 @@ class MockNestedItem {
 }
 
 interface MockNestedList {
-    nestedItems: {
+    _nestedItems: {
         toArray: () => MockNestedItem[]
     };
 }
@@ -53,7 +53,7 @@ describe('NestedListKeyboardSupportService', () => {
 
     beforeEach(() => {
         object = {
-            nestedItems: {
+            _nestedItems: {
                 toArray: toArray
             }
         };

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.spec.ts
@@ -23,7 +23,7 @@ class MockNestedItem {
 }
 
 interface MockNestedList {
-    _nestedItems: {
+    nestedItems: {
         toArray: () => MockNestedItem[]
     };
 }
@@ -53,7 +53,7 @@ describe('NestedListKeyboardSupportService', () => {
 
     beforeEach(() => {
         object = {
-            _nestedItems: {
+            nestedItems: {
                 toArray: toArray
             }
         };

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
@@ -41,7 +41,6 @@ export class NestedListKeyboardService {
 
         /** Gathering all of the items */
         lists.forEach(list => items.push(...this.getAllListItems(list)));
-
         /** Putting the keyboard support function to each of the items */
         items.forEach((item, index) => {
             item.keyboardTriggered
@@ -56,8 +55,8 @@ export class NestedListKeyboardService {
     private getAllListItems(list: NestedListInterface): NestedItemInterface[] {
 
         const _items: NestedItemInterface[] = [];
-        if (list && list.nestedItems) {
-            list.nestedItems.toArray().forEach(item => {
+        if (list && list._nestedItems && list._nestedItems.toArray()) {
+            list._nestedItems.toArray().forEach(item => {
                 _items.push(...this.getItems(item));
             });
         }
@@ -109,7 +108,6 @@ export class NestedListKeyboardService {
                 this.keyboardService.keyDownHandler(keyboardEvent, index, items);
             }
         }
-
     }
 
 }

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
@@ -55,8 +55,8 @@ export class NestedListKeyboardService {
     private getAllListItems(list: NestedListInterface): NestedItemInterface[] {
 
         const _items: NestedItemInterface[] = [];
-        if (list && list.nestedItems && list.nestedItems.toArray()) {
-            list.nestedItems.toArray().forEach(item => {
+        if (list && list.nestedItems && list.nestedItems.length > 0) {
+            list.nestedItems.forEach(item => {
                 _items.push(...this.getItems(item));
             });
         }

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
@@ -55,8 +55,8 @@ export class NestedListKeyboardService {
     private getAllListItems(list: NestedListInterface): NestedItemInterface[] {
 
         const _items: NestedItemInterface[] = [];
-        if (list && list._nestedItems && list._nestedItems.toArray()) {
-            list._nestedItems.toArray().forEach(item => {
+        if (list && list.nestedItems && list.nestedItems.toArray()) {
+            list.nestedItems.toArray().forEach(item => {
                 _items.push(...this.getItems(item));
             });
         }

--- a/libs/core/src/lib/nested-list/nested-list-popover/nested-list-popover.component.ts
+++ b/libs/core/src/lib/nested-list/nested-list-popover/nested-list-popover.component.ts
@@ -1,12 +1,14 @@
 import { Component, ContentChild, HostBinding, ViewChild, ViewEncapsulation, Optional } from '@angular/core';
 import { Observable, of } from 'rxjs';
 
-import { NestedItemDirective } from '../nested-item/nested-item.directive';
 import { NestedLinkDirective } from '../nested-link/nested-link.directive';
 import { NestedListKeyboardService } from '../nested-list-keyboard.service';
 import { PopoverComponent } from '../../popover/popover.component';
 import { RtlService } from '../../utils/public_api';
 import { map } from 'rxjs/operators';
+import { NestedItemInterface } from '../nested-item/nested-item.interface';
+import { NestedItemService } from '../nested-item/nested-item.service';
+import { NestedListPopoverInterface } from './nested-list-popover.interface';
 
 @Component({
     selector: 'fd-nested-list-popover',
@@ -14,7 +16,7 @@ import { map } from 'rxjs/operators';
     styleUrls: ['./nested-list-popover.component.scss'],
     encapsulation: ViewEncapsulation.None
 })
-export class NestedListPopoverComponent {
+export class NestedListPopoverComponent implements NestedListPopoverInterface {
     /** @hidden */
     placement$: Observable<string>;
 
@@ -34,7 +36,7 @@ export class NestedListPopoverComponent {
      * @hidden
      * Reference to parent item, to propagate open and close change from popover.
      */
-    parentItemElement: NestedItemDirective;
+    parentItemElement: NestedItemInterface;
 
     /**
      * @hidden
@@ -44,10 +46,14 @@ export class NestedListPopoverComponent {
     /** @hidden */
     constructor(
         private _keyboardNestService: NestedListKeyboardService,
+        @Optional() private _itemService: NestedItemService,
         @Optional() private _rtlService: RtlService
     ) {
         this._listenOnKeyboardRefresh();
         this._createRtlObservable();
+        if (this._itemService) {
+            this._itemService.popover = this;
+        }
     }
 
     /**

--- a/libs/core/src/lib/nested-list/nested-list-popover/nested-list-popover.interface.ts
+++ b/libs/core/src/lib/nested-list/nested-list-popover/nested-list-popover.interface.ts
@@ -1,5 +1,6 @@
 import { NestedItemInterface } from '../nested-item/nested-item.interface';
 
+/** Interface, to reduce amount of circular dependency warnings */
 export interface NestedListPopoverInterface {
     parentItemElement: NestedItemInterface;
     open: boolean;

--- a/libs/core/src/lib/nested-list/nested-list-popover/nested-list-popover.interface.ts
+++ b/libs/core/src/lib/nested-list/nested-list-popover/nested-list-popover.interface.ts
@@ -1,0 +1,7 @@
+import { NestedItemInterface } from '../nested-item/nested-item.interface';
+
+export interface NestedListPopoverInterface {
+    parentItemElement: NestedItemInterface;
+    open: boolean;
+    handleOpenChange: (boolean) => void;
+}

--- a/libs/core/src/lib/nested-list/nested-list/nested-list.directive.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-list/nested-list.directive.spec.ts
@@ -76,12 +76,12 @@ describe('NestedListDirective', () => {
     });
 
     it('Should add classes', () => {
-        expect((level1List as any).elementRef.nativeElement.classList.contains('fd-nested-list')).toBeTruthy();
-        expect((level1List as any).elementRef.nativeElement.classList.contains('fd-nested-list--text-only')).toBeTruthy();
-        expect((level1List as any).elementRef.nativeElement.classList.contains('fd-nested-list--compact')).toBeTruthy();
-        expect((level1List as any).elementRef.nativeElement.classList.contains('level-1')).toBeTruthy();
-        expect((level3List as any).elementRef.nativeElement.classList.contains('level-3')).toBeTruthy();
-        expect((level4List as any).elementRef.nativeElement.classList.contains('level-4')).toBeTruthy();
+        expect((level1List as any)._elementRef.nativeElement.classList.contains('fd-nested-list')).toBeTruthy();
+        expect((level1List as any)._elementRef.nativeElement.classList.contains('fd-nested-list--text-only')).toBeTruthy();
+        expect((level1List as any)._elementRef.nativeElement.classList.contains('fd-nested-list--compact')).toBeTruthy();
+        expect((level1List as any)._elementRef.nativeElement.classList.contains('level-1')).toBeTruthy();
+        expect((level3List as any)._elementRef.nativeElement.classList.contains('level-3')).toBeTruthy();
+        expect((level4List as any)._elementRef.nativeElement.classList.contains('level-4')).toBeTruthy();
     })
 
 

--- a/libs/core/src/lib/nested-list/nested-list/nested-list.directive.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-list/nested-list.directive.spec.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
-import { MenuKeyboardService, PopoverModule } from '@fundamental-ngx/core';
+import { MenuKeyboardService } from '@fundamental-ngx/core';
 import { NestedListModule } from '../nested-list.module';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NestedListKeyboardService } from '../nested-list-keyboard.service';

--- a/libs/core/src/lib/nested-list/nested-list/nested-list.directive.ts
+++ b/libs/core/src/lib/nested-list/nested-list/nested-list.directive.ts
@@ -9,11 +9,12 @@ import { NestedListStateService } from '../nested-list-state.service';
 import { NestedItemDirective } from '../nested-item/nested-item.directive';
 import { NestedItemService } from '../nested-item/nested-item.service';
 import { NestedListKeyboardService } from '../nested-list-keyboard.service';
+import { NestedListInterface } from './nested-list.interface';
 
 @Directive({
     selector: '[fdNestedList], [fd-nested-list]'
 })
-export class NestedListDirective implements AfterContentInit {
+export class NestedListDirective implements AfterContentInit, NestedListInterface {
 
     /** @hidden */
     @HostBinding('class.fd-nested-list')
@@ -35,7 +36,7 @@ export class NestedListDirective implements AfterContentInit {
      * but it's used by services and NestedItemDirective by itself,
      */
     @ContentChildren(forwardRef(() => NestedItemDirective))
-    _nestedItems: QueryList<NestedItemDirective>;
+    nestedItems: QueryList<NestedItemDirective>;
 
     /** @hidden */
     @HostBinding('attr.aria-hidden')
@@ -44,9 +45,9 @@ export class NestedListDirective implements AfterContentInit {
     /** @hidden */
     constructor(
         @Optional() private _nestedItemService: NestedItemService,
-        private nestedListStateService: NestedListStateService,
-        private nestedListKeyboardService: NestedListKeyboardService,
-        private elementRef: ElementRef
+        private _nestedListStateService: NestedListStateService,
+        private _nestedListKeyboardService: NestedListKeyboardService,
+        private _elementRef: ElementRef
     ) {
         if (this._nestedItemService) {
             this._nestedItemService.list = this;
@@ -57,17 +58,17 @@ export class NestedListDirective implements AfterContentInit {
     ngAfterContentInit(): void {
         let nestedLevel: number = this.getNestedLevel();
         /** If there is condensed mode, maximum 2nd level class of nest can be added */
-        if (this.nestedListStateService.condensed) {
+        if (this._nestedListStateService.condensed) {
             nestedLevel = Math.min(...[nestedLevel, 2]);
         }
-        this._nestedItems.changes.subscribe(() => this.nestedListKeyboardService.refresh$.next());
+        this.nestedItems.changes.subscribe(() => this._nestedListKeyboardService.refresh$.next());
         this.handleNestedLevel(nestedLevel);
     }
 
     /** @hidden */
     private handleNestedLevel(level: number): void {
         /** Adding class with the nested level */
-        this.elementRef.nativeElement.classList.add('level-' + level);
+        this._elementRef.nativeElement.classList.add('level-' + level);
     }
 
     /**
@@ -75,7 +76,7 @@ export class NestedListDirective implements AfterContentInit {
      * Method, that checks how deep is the list element
      */
     private getNestedLevel(): number {
-        let element = this.elementRef.nativeElement;
+        let element = this._elementRef.nativeElement;
         const parentElements = [];
 
         /** Method that gathers all of the parentNode elements of current NestedListDirective element */

--- a/libs/core/src/lib/nested-list/nested-list/nested-list.directive.ts
+++ b/libs/core/src/lib/nested-list/nested-list/nested-list.directive.ts
@@ -1,21 +1,19 @@
 import {
-    AfterContentInit,
-    ContentChildren,
+    AfterContentInit, ContentChildren,
     Directive,
-    ElementRef,
-    forwardRef,
+    ElementRef, forwardRef,
     HostBinding,
-    Input,
-    QueryList
+    Input, Optional, QueryList
 } from '@angular/core';
-import { NestedItemDirective } from '../nested-item/nested-item.directive';
-import { NestedListInterface } from './nested-list.interface';
 import { NestedListStateService } from '../nested-list-state.service';
+import { NestedItemDirective } from '../nested-item/nested-item.directive';
+import { NestedItemService } from '../nested-item/nested-item.service';
+import { NestedListKeyboardService } from '../nested-list-keyboard.service';
 
 @Directive({
     selector: '[fdNestedList], [fd-nested-list]'
 })
-export class NestedListDirective implements AfterContentInit, NestedListInterface {
+export class NestedListDirective implements AfterContentInit {
 
     /** @hidden */
     @HostBinding('class.fd-nested-list')
@@ -37,7 +35,7 @@ export class NestedListDirective implements AfterContentInit, NestedListInterfac
      * but it's used by services and NestedItemDirective by itself,
      */
     @ContentChildren(forwardRef(() => NestedItemDirective))
-    nestedItems: QueryList<NestedItemDirective>;
+    _nestedItems: QueryList<NestedItemDirective>;
 
     /** @hidden */
     @HostBinding('attr.aria-hidden')
@@ -45,9 +43,15 @@ export class NestedListDirective implements AfterContentInit, NestedListInterfac
 
     /** @hidden */
     constructor(
+        @Optional() private _nestedItemService: NestedItemService,
         private nestedListStateService: NestedListStateService,
+        private nestedListKeyboardService: NestedListKeyboardService,
         private elementRef: ElementRef
-    ) {}
+    ) {
+        if (this._nestedItemService) {
+            this._nestedItemService.list = this;
+        }
+    }
 
     /** @hidden */
     ngAfterContentInit(): void {
@@ -56,6 +60,7 @@ export class NestedListDirective implements AfterContentInit, NestedListInterfac
         if (this.nestedListStateService.condensed) {
             nestedLevel = Math.min(...[nestedLevel, 2]);
         }
+        this._nestedItems.changes.subscribe(() => this.nestedListKeyboardService.refresh$.next());
         this.handleNestedLevel(nestedLevel);
     }
 

--- a/libs/core/src/lib/nested-list/nested-list/nested-list.interface.ts
+++ b/libs/core/src/lib/nested-list/nested-list/nested-list.interface.ts
@@ -3,6 +3,6 @@ import { NestedItemInterface } from '../nested-item/nested-item.interface';
 
 /** Interface, to reduce amount of circular dependency warnings */
 export interface NestedListInterface {
-    _nestedItems: QueryList<NestedItemInterface>
+    nestedItems: QueryList<NestedItemInterface>
     hidden: boolean;
 }

--- a/libs/core/src/lib/nested-list/nested-list/nested-list.interface.ts
+++ b/libs/core/src/lib/nested-list/nested-list/nested-list.interface.ts
@@ -1,8 +1,8 @@
-import { NestedItemInterface } from '../nested-item/nested-item.interface';
 import { QueryList } from '@angular/core';
+import { NestedItemInterface } from '../nested-item/nested-item.interface';
 
 /** Interface, to reduce amount of circular dependency warnings */
 export interface NestedListInterface {
-    nestedItems: QueryList<NestedItemInterface>;
+    _nestedItems: QueryList<NestedItemInterface>
     hidden: boolean;
 }

--- a/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.ts
+++ b/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.ts
@@ -63,7 +63,6 @@ export class PreparedNestedListComponent implements AfterViewInit {
 
     /** @hidden */
     ngAfterViewInit(): void {
-        this._changeDetRef.markForCheck();
         this._changeDetRef.detectChanges();
 
         /** If any item above, pass list directive reference to it */

--- a/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.ts
+++ b/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.ts
@@ -1,8 +1,15 @@
-import { AfterViewInit, ChangeDetectorRef, Component, forwardRef, Input, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectorRef,
+    Component,
+    forwardRef,
+    Input,
+    Optional,
+    ViewChild
+} from '@angular/core';
 import { NestedListDirective } from '../nested-list/nested-list.directive';
 import { NestedListModel } from '../nested-list-model';
-import { NestedListStateService } from '../nested-list-state.service';
-import { NestedItemDirective } from '../nested-item/nested-item.directive';
+import { NestedItemService } from '../nested-item/nested-item.service';
 
 /**
  * Component for internal usage, allows to generate the nested list from defined object.
@@ -41,27 +48,27 @@ export class PreparedNestedListComponent implements AfterViewInit {
     _nestedListDirective: NestedListDirective;
 
     /**
-     * @hidden
-     */
-    @ViewChildren(forwardRef(() => NestedItemDirective))
-    nestedListItems: QueryList<NestedItemDirective>;
-
-    /**
      * In prepared nested list, nested items should be taken as reference of View, not Content.
      * There is direct reference to these directives here.
      */
     get nestedListDirective(): NestedListDirective {
-        return Object.assign(this._nestedListDirective, { nestedItems: this.nestedListItems });
+        return this._nestedListDirective;
     }
 
     /** @hidden */
     constructor (
-        private changeDetRef: ChangeDetectorRef
+        private changeDetRef: ChangeDetectorRef,
+        @Optional() private _nestedItemService: NestedItemService
     ) {}
 
     /** @hidden */
     ngAfterViewInit(): void {
         this.changeDetRef.markForCheck();
         this.changeDetRef.detectChanges();
+
+        /** TODO */
+        if (this._nestedItemService) {
+            this._nestedItemService.list = this.nestedListDirective
+        }
     }
 }

--- a/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.ts
+++ b/libs/core/src/lib/nested-list/prepared-nested-list/prepared-nested-list.component.ts
@@ -57,16 +57,16 @@ export class PreparedNestedListComponent implements AfterViewInit {
 
     /** @hidden */
     constructor (
-        private changeDetRef: ChangeDetectorRef,
+        private _changeDetRef: ChangeDetectorRef,
         @Optional() private _nestedItemService: NestedItemService
     ) {}
 
     /** @hidden */
     ngAfterViewInit(): void {
-        this.changeDetRef.markForCheck();
-        this.changeDetRef.detectChanges();
+        this._changeDetRef.markForCheck();
+        this._changeDetRef.detectChanges();
 
-        /** TODO */
+        /** If any item above, pass list directive reference to it */
         if (this._nestedItemService) {
             this._nestedItemService.list = this.nestedListDirective
         }

--- a/libs/core/src/lib/nested-list/public_api.ts
+++ b/libs/core/src/lib/nested-list/public_api.ts
@@ -1,5 +1,6 @@
 export * from './nested-list.module';
 export * from './nested-item/nested-item.directive';
+export * from './nested-item/nested-item.service';
 export * from './nested-link/nested-link.directive';
 export * from './nested-list/nested-list.directive';
 export * from './nested-list-directives';

--- a/libs/core/src/lib/utils/decorators/apply-css-class.decorator.ts
+++ b/libs/core/src/lib/utils/decorators/apply-css-class.decorator.ts
@@ -1,4 +1,6 @@
-import { ELEMENT_REF_EXCEPTION, getStringFromHashMap, uuidv4 } from '../public_api';
+import { ELEMENT_REF_EXCEPTION  } from '../interfaces/has-element-ref.interface';
+import { getStringFromHashMap } from '../functions/get-string-from-hashmap';
+import { uuidv4 } from '../functions/uuidv4-generator';
 
 /**
  * Method decorator to apply css class to a component through native element

--- a/libs/core/src/lib/utils/decorators/apply-css-style.decorator.ts
+++ b/libs/core/src/lib/utils/decorators/apply-css-style.decorator.ts
@@ -1,4 +1,5 @@
-import { Hash, ELEMENT_REF_EXCEPTION } from '../public_api';
+import { ELEMENT_REF_EXCEPTION  } from '../interfaces/has-element-ref.interface';
+import { Hash } from '../datatypes/hash.datatype';
 
 /**
  * Method decorator to apply css styles to a component through native element


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#### Please provide a brief summary of this pull request.
Those changes removed circular dependency warning/error and all of the issues, that comes with it.
Tested with The lib es6/ng9 lib.
We could achieve that, thanks to services and interfaces, which allowed to avoid circular imports.



#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

