### PR TITLE
fix: (platform) Create common base class for Platform components

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-content-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-content-example.component.html
@@ -5,7 +5,7 @@
         <fdp-radio-group
             [id]="'radio1'"
             [name]="'radio1'"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [value]="'Spring'"
             [isInline]="false"
             formControlName="example1"
@@ -17,7 +17,7 @@
     </fieldset>
     <fieldset fd-fieldset>
         <p>Example 2: Inline Cozy Radio Button Group</p>
-        <fdp-radio-group [id]="'myid'" [name]="'radio2'" [size]="'cozy'" [isInline]="true" formControlName="example2">
+        <fdp-radio-group [id]="'myid'" [name]="'radio2'" [contentDensity]="'cozy'" [isInline]="true" formControlName="example2">
             <fdp-radio-button *ngFor="let season of seasons" [value]="season">
                 {{ season }}
             </fdp-radio-button>
@@ -38,7 +38,7 @@
         <fdp-radio-group
             [id]="'radio1'"
             [name]="'radio1'"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [value]="'March'"
             [isInline]="false"
             formControlName="example4"
@@ -70,7 +70,7 @@
         <fdp-radio-group
             [name]="'radio4'"
             [value]="'Summer'"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [isInline]="true"
             [(ngModel)]="favoriteSeason"
         >
@@ -83,7 +83,7 @@
 
     <p>Example 5: Inline Compact Radio Button Group</p>
     <fieldset fd-fieldset>
-        <fdp-radio-group [name]="'radio5'" [size]="'cozy'" [isInline]="true" [(ngModel)]="favoriteSeason2">
+        <fdp-radio-group [name]="'radio5'" [contentDensity]="'cozy'" [isInline]="true" [(ngModel)]="favoriteSeason2">
             <fdp-radio-button *ngFor="let season of seasons" [value]="season">
                 {{ season }}
             </fdp-radio-button>
@@ -95,7 +95,7 @@
         <fdp-radio-group
             [id]="'radio1'"
             [name]="'radio1'"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [value]="'March'"
             [isInline]="false"
             [(ngModel)]="favoriteMonth"

--- a/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-disabled-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-disabled-example.component.html
@@ -5,7 +5,7 @@
         <fdp-radio-group
             [id]="'myid'"
             [name]="'radio1'"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [isInline]="true"
             formControlName="example1"
         >
@@ -22,7 +22,7 @@
             [name]="'radio2'"
             [list]="seasons"
             [isInline]="true"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [value]="'Winter'"
             [hasNoValue]="true"
             [noValueLabel]="'(No selection)'"
@@ -45,7 +45,7 @@
         <fdp-radio-group
             [id]="'myid'"
             [name]="'radio3'"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [disabled]="true"
             [isInline]="true"
             [(ngModel)]="favoriteSeason1"
@@ -63,7 +63,7 @@
             [name]="'radio4'"
             [list]="seasons"
             [isInline]="true"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [value]="'Winter'"
             [disabled]="true"
             [hasNoValue]="true"

--- a/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-list-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-list-example.component.html
@@ -7,7 +7,7 @@
             [name]="'radio1'"
             [list]="seasons"
             [isInline]="false"
-            [size]="'cozy'"
+            [contentDensity]="'cozy'"
             [value]="'Summer'"
             formControlName="example1"
         >
@@ -20,7 +20,7 @@
             [name]="'radio2'"
             [list]="seasons"
             [isInline]="true"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [hasNoValue]="true"
             [noValueLabel]="'(No Selection)'"
             formControlName="example2"
@@ -44,7 +44,7 @@
             [name]="'radio4'"
             [value]="'Summer'"
             [list]="seasons"
-            [size]="'cozy'"
+            [contentDensity]="'cozy'"
             [isInline]="true"
             [(ngModel)]="favoriteOption"
         >
@@ -55,7 +55,7 @@
         <fdp-radio-group
             [name]="'radio4'"
             [list]="seasons"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [isInline]="true"
             [(ngModel)]="favoriteOption2"
         >

--- a/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-list-items-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-list-items-example.component.html
@@ -11,11 +11,11 @@
         >
         </fdp-radio-group>
     </fieldset>
-    <p>Example 2: Radio Buttons Types in Compact Size</p>
+    <p>Example 2: Radio Buttons Types in Compact contentDensity</p>
     <fieldset fd-fieldset>
         <fdp-radio-group
             [name]="'radio2'"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [list]="items"
             [isInline]="true"
             formControlName="example2"
@@ -38,7 +38,7 @@
             [name]="'radio3'"
             [value]="'Option 2'"
             [list]="items"
-            [size]="'cozy'"
+            [contentDensity]="'cozy'"
             [isInline]="true"
             [(ngModel)]="favoriteOption"
         >
@@ -49,7 +49,7 @@
         <fdp-radio-group
             [name]="'radio4'"
             [list]="items"
-            [size]="'compact'"
+            [contentDensity]="'compact'"
             [isInline]="true"
             [(ngModel)]="favoriteOption2"
         >

--- a/libs/platform/src/lib/components/base.ts
+++ b/libs/platform/src/lib/components/base.ts
@@ -1,0 +1,38 @@
+import { Input, ChangeDetectorRef } from '@angular/core';
+import { InputSize } from './form/form-control';
+
+let randomId = 0;
+
+/**
+ * This class contains common properties used across components. 
+ * this can be extended to reduce the code duplication across components.
+ * @hidden for form related Base , see BaseInput.
+ */
+export class BaseComponent {
+    protected defaultId: string = `fdp-id-${randomId++}`;
+    protected _disabled: boolean;
+
+    @Input()
+    id: string = this.defaultId;
+
+    @Input()
+    name: string;
+
+    @Input()
+    placeholder: string;
+
+    @Input()
+    contentDensity: InputSize = 'cozy';
+
+    @Input()
+    get disabled(): boolean {
+        return this._disabled;
+    }
+
+    set disabled(disabled: boolean) {
+        this._disabled = disabled;
+    }
+
+    constructor(protected _cd: ChangeDetectorRef) {}
+
+}

--- a/libs/platform/src/lib/components/base.ts
+++ b/libs/platform/src/lib/components/base.ts
@@ -1,29 +1,34 @@
 import { Input, ChangeDetectorRef } from '@angular/core';
-import { InputSize } from './form/form-control';
+import { ContentDensity } from './form/form-control';
 
 let randomId = 0;
 
 /**
- * This class contains common properties used across components. 
+ * This class contains common properties used across components.
  * this can be extended to reduce the code duplication across components.
  * @hidden for form related Base , see BaseInput.
  */
-export class BaseComponent {
+export abstract class BaseComponent {
     protected defaultId: string = `fdp-id-${randomId++}`;
     protected _disabled: boolean;
 
+    /** id for the Element */
     @Input()
     id: string = this.defaultId;
 
+    /** name for the element */
     @Input()
     name: string;
 
+    /** content Density of element. cozy | compact */
     @Input()
-    placeholder: string;
+    contentDensity: ContentDensity = 'cozy';
 
+    /** width of the element */
     @Input()
-    contentDensity: InputSize = 'cozy';
+    width: string;
 
+    /** disabled status of the element */
     @Input()
     get disabled(): boolean {
         return this._disabled;
@@ -34,5 +39,4 @@ export class BaseComponent {
     }
 
     constructor(protected _cd: ChangeDetectorRef) {}
-
 }

--- a/libs/platform/src/lib/components/form/base.input.ts
+++ b/libs/platform/src/lib/components/form/base.input.ts
@@ -41,6 +41,9 @@ export abstract class BaseInput extends BaseComponent implements FormFieldContro
     protected _destroyed = new Subject<void>();
 
     @Input()
+    placeholder: string;
+
+    @Input()
     get disabled(): boolean {
         if (this.ngControl && this.ngControl.disabled !== null) {
             return this.ngControl.disabled;

--- a/libs/platform/src/lib/components/form/base.input.ts
+++ b/libs/platform/src/lib/components/form/base.input.ts
@@ -12,7 +12,8 @@ import {
     SimpleChanges,
     ViewChild
 } from '@angular/core';
-import { FormFieldControl, InputSize, Status } from './form-control';
+import { FormFieldControl, Status } from './form-control';
+import { BaseComponent } from '../base';
 import { ControlValueAccessor, FormControl, NgControl, NgForm } from '@angular/forms';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Subject } from 'rxjs';
@@ -30,7 +31,7 @@ let randomId = 0;
  * Usually try to fire stateChange only for things that can change dynamically in runtime. We don't expect
  * that e.g. placeholder will change after component is created
  */
-export abstract class BaseInput implements FormFieldControl<any>, ControlValueAccessor,
+export abstract class BaseInput extends BaseComponent implements FormFieldControl<any>, ControlValueAccessor,
     OnInit, OnChanges, DoCheck, AfterViewInit, OnDestroy {
 
     protected defaultId: string = `fdp-input-id-${randomId++}`;
@@ -38,18 +39,6 @@ export abstract class BaseInput implements FormFieldControl<any>, ControlValueAc
     protected _value: any;
     protected _editable: boolean = true;
     protected _destroyed = new Subject<void>();
-
-    @Input()
-    id: string = this.defaultId;
-
-    @Input()
-    name: string;
-
-    @Input()
-    placeholder: string;
-
-    @Input()
-    size: InputSize = 'cozy';
 
     @Input()
     get disabled(): boolean {
@@ -129,7 +118,7 @@ export abstract class BaseInput implements FormFieldControl<any>, ControlValueAc
     constructor(protected _cd: ChangeDetectorRef,
                 @Optional() @Self() public ngControl: NgControl,
                 @Optional() @Self() public ngForm: NgForm) {
-
+        super(_cd);
         if (this.ngControl) {
             this.ngControl.valueAccessor = this;
         }

--- a/libs/platform/src/lib/components/form/combo-box/combo-box.component.html
+++ b/libs/platform/src/lib/components/form/combo-box/combo-box.component.html
@@ -2,7 +2,7 @@
              [dropdownValues]="_suggestions"
              [communicateByObject]="elementTypeIsObject"
              [disabled]="disabled"
-             [compact]="size === 'compact'"
+             [compact]="contentDensity === 'compact'"
              [inShellbar]="inShellbar"
              [placeholder]="placeholder"
              [maxHeight]="maxHeight"

--- a/libs/platform/src/lib/components/form/form-control.ts
+++ b/libs/platform/src/lib/components/form/form-control.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 import { NgControl } from '@angular/forms';
 
-export type InputSize = 'compact' | 'cozy';
+export type ContentDensity = 'compact' | 'cozy';
 export type Status = 'error' | 'warning' | void;
 
 export abstract class FormFieldControl<T> {
@@ -30,7 +30,7 @@ export abstract class FormFieldControl<T> {
     /**
      *  Components works in two sizes compact or cozy
      */
-    contentDensity: InputSize;
+    contentDensity: ContentDensity;
     /**
      *
      * Form Field listen for all the changes happening inside the input

--- a/libs/platform/src/lib/components/form/form-control.ts
+++ b/libs/platform/src/lib/components/form/form-control.ts
@@ -30,7 +30,7 @@ export abstract class FormFieldControl<T> {
     /**
      *  Components works in two sizes compact or cozy
      */
-    size: InputSize;
+    contentDensity: InputSize;
     /**
      *
      * Form Field listen for all the changes happening inside the input

--- a/libs/platform/src/lib/components/form/input/input.component.html
+++ b/libs/platform/src/lib/components/form/input/input.component.html
@@ -9,7 +9,7 @@
        [attr.type]="type"
        [attr.placeholder]="placeholder"
        [disabled]="disabled"
-       [compact]="size == 'compact'"
+       [compact]="contentDensity == 'compact'"
        [state]="status === 'error' ? 'invalid' : '' "
        (blur)="_onFocusChanged(false)"
        (focus)="_onFocusChanged(true)"

--- a/libs/platform/src/lib/components/form/radio-group/radio-group.component.html
+++ b/libs/platform/src/lib/components/form/radio-group/radio-group.component.html
@@ -8,7 +8,7 @@
                         context: {
                             name: name,
                             value: radio.value,
-                            size: size,
+                            contentDensity: contentDensity,
                             disabled: disabled || radio.disabled
                         }
                     "
@@ -27,7 +27,7 @@
             <fdp-radio-button
                 [name]="name"
                 [value]="'None'"
-                [size]="size"
+                [contentDensity]="contentDensity"
                 [disabled]="disabled"
                 [forceRender]="true"
                 (click)="selected($event)"
@@ -41,7 +41,7 @@
             <fdp-radio-button
                 [name]="name"
                 [value]="item.value ? item.value : item"
-                [size]="size"
+                [contentDensity]="contentDensity"
                 [disabled]="item.disabled ? item.disabled : disabled"
                 [forceRender]="true"
                 (click)="selected($event)"

--- a/libs/platform/src/lib/components/form/radio-group/radio-group.component.spec.ts
+++ b/libs/platform/src/lib/components/form/radio-group/radio-group.component.spec.ts
@@ -14,7 +14,7 @@ import { FormModule, RadioModule } from '@fundamental-ngx/core';
                 <fdp-radio-group
                     [id]="'radio1'"
                     [name]="'radio1'"
-                    [size]="'compact'"
+                    [contentDensity]="'compact'"
                     [value]="'Spring'"
                     [isInline]="false"
                     formControlName="example1"

--- a/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
+++ b/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
@@ -172,7 +172,7 @@ export class RadioGroupComponent extends CollectionBaseInput implements AfterVie
     private _setProperties(button: RadioButtonComponent) {
         if (button) {
             button.name = this.name;
-            button.size = this.size;
+            button.contentDensity = this.contentDensity;
             button.status = this.status;
             button.disabled = button.disabled ? button.disabled : this._disabled;
         }

--- a/libs/platform/src/lib/components/form/radio-group/radio/radio.component.html
+++ b/libs/platform/src/lib/components/form/radio-group/radio/radio.component.html
@@ -4,7 +4,7 @@
         [name]="name"
         [value]="value"
         [state]="state"
-        [compact]="size === 'compact'"
+        [compact]="contentDensity === 'compact'"
         [disabled]="disabled"
         (click)="onClick($event)"
     >

--- a/libs/platform/src/lib/components/form/radio-group/radio/radio.component.spec.ts
+++ b/libs/platform/src/lib/components/form/radio-group/radio/radio.component.spec.ts
@@ -47,7 +47,7 @@ describe('RadioButtonComponent', () => {
         component.id = 'id1';
         component.name = 'radio1';
         component.value = 'radio1';
-        component.size = 'compact';
+        component.contentDensity = 'compact';
         component.disabled = true;
 
         // forceRendere must be true for component creation
@@ -71,7 +71,7 @@ describe('RadioButtonComponent', () => {
         component.id = 'id1';
         component.name = 'radio1';
         component.value = 'radio1';
-        component.size = 'compact';
+        component.contentDensity = 'compact';
         component.disabled = true;
 
         // forceRendere must be true for component creation


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/2368

#### Please provide a brief summary of this pull request.
In Platform we have multiple components with some common properties eg. id, name, placeholder etc. these can be moved to a common class and can be extended by all components being developed or to be developed. This PR includes base class and changes to existing components to extend this base class.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] Documentation Examples
- [x] Stackblitz works for all examples

