### PR TITLE
docs: fix sidebar squashing, add icons to shared module

### DIFF
--- a/apps/docs/src/app/documentation/core-helpers/sections-toolbar/sections-toolbar.component.scss
+++ b/apps/docs/src/app/documentation/core-helpers/sections-toolbar/sections-toolbar.component.scss
@@ -15,6 +15,7 @@
     flex-wrap: nowrap;
     white-space: nowrap;
     overflow: hidden;
+    flex-grow: 1;
 }
 
 .fd-docs-sidebar-content {

--- a/apps/docs/src/app/documentation/shared-core-modules.ts
+++ b/apps/docs/src/app/documentation/shared-core-modules.ts
@@ -13,6 +13,7 @@ import {
 export const sharedCoreModules = [
     AlertModule,
     ButtonModule,
+    IconModule,
     InputGroupModule,
     ShellbarModule,
     IconModule,


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
Latest Docs Issues:
Sidebar - collapse, when not fullfiled.
Menu Icon - Added module to shared modules.
Before:
![image](https://user-images.githubusercontent.com/26483208/79472778-8ce0f900-8004-11ea-86cc-0d90cc584390.png)

After: 
IE11:
![image](https://user-images.githubusercontent.com/26483208/79472711-776bcf00-8004-11ea-8eb7-1dbebe36c66d.png)
Opera:
![image](https://user-images.githubusercontent.com/26483208/79472746-83579100-8004-11ea-8a21-4762a8dc02d1.png)
#### Please check whether the PR fulfills the following requirements


- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

