### PR TITLE
fix: Fix alert derived class constructor bug

### DIFF
--- a/libs/core/src/lib/alert/alert.component.ts
+++ b/libs/core/src/lib/alert/alert.component.ts
@@ -27,7 +27,7 @@ let alertUniqueId: number = 0;
  * @deprecated
  * Alert component is depricated since version 0.16.0
  * Message Strip component should be used instead.
- * 
+ *
  * The component that represents an alert. It can be only be used inline.
  * If the AlertService is used, this component is auto-generated.
  */
@@ -114,16 +114,15 @@ export class AlertComponent extends AbstractFdNgxClass implements OnInit, AfterV
     childContent: Type<any> | TemplateRef<any> | string = undefined;
 
     /** @hidden */
-    // @ts-ignore
     constructor(private elRef: ElementRef,
                 private cdRef: ChangeDetectorRef,
                 private componentFactoryResolver: ComponentFactoryResolver,
                 private ngZone: NgZone,
                 @Optional() private alertConfig: AlertConfig,
                 @Optional() private alertRef: AlertRef) {
-        // @ts-ignore
-        this._setAlertConfig(alertConfig);
         super(elRef);
+        this._setAlertConfig(alertConfig);
+        this._setProperties();
     }
 
     /** @hidden */


### PR DESCRIPTION
### Please provide a brief summary of this pull request.
This PR changes call order in Alert component constructor, moving `super()` call to the top.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

