### PR TITLE
test: add side nav to storybook

### DIFF
--- a/src/stories/sidenav/fd-side-nav.stories.ts
+++ b/src/stories/sidenav/fd-side-nav.stories.ts
@@ -42,14 +42,12 @@ export const SideNavigation = () => ({
                             <span *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></span>
                             <span fd-nested-list-title>{{textValue1}}</span>
                         </a>
-                        <ul fd-nested-list [textOnly]="mainSubTextOnlyVar">
+                        <ul fd-nested-list [textOnly]="true">
                             <li fd-nested-list-item>
                                 <a fd-nested-list-link>
-                                    <span *ngIf="!mainSubTextOnlyVar" fd-nested-list-icon [glyph]="iconSecondary"></span>
                                     <span fd-nested-list-title>{{textValue1}}</span>
                                 </a>
                                 <a fd-nested-list-link>
-                                    <span *ngIf="!mainSubTextOnlyVar" fd-nested-list-icon [glyph]="iconSecondary"></span>
                                     <span fd-nested-list-title>{{textValue1}}</span>
                                 </a>
                             </li>
@@ -81,7 +79,6 @@ export const SideNavigation = () => ({
     props: {
         mainCompactVar: boolean('Main Secion in Compact Mode', false),
         mainTextOnlyVar: boolean('Main Section Text Only', false),
-        mainSubTextOnlyVar: boolean('Main Sub Section Text Only', false),
         utilityTextOnlyVar: boolean('Utility Section text only', false),
         utilityCompactVar: boolean('Utility Section in Compact Mode', false),
         textValue1: text('Text Value 1', 'Item 1'),

--- a/src/stories/sidenav/fd-side-nav.stories.ts
+++ b/src/stories/sidenav/fd-side-nav.stories.ts
@@ -1,0 +1,172 @@
+import { moduleMetadata } from '@storybook/angular';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
+import { SideNavigationComponent, SideNavigationModule } from 'libs/core/src/lib/side-navigation/public_api';
+
+
+export default {
+    title: 'Fd side-navigation',
+    component: SideNavigationComponent,
+    moduleMetadata: moduleMetadata,
+    decorators: [
+        withKnobs,
+        withA11y,
+        moduleMetadata({
+            imports: [SideNavigationModule],
+            declarations: []
+        })
+    ]
+};
+
+export const SideNavigation = () => ({
+    template:
+        `<fd-side-nav>
+            <div fd-side-nav-main>
+                <ul fd-nested-list 
+                        [compact]="mainCompactVar" 
+                        [textOnly]="mainTextOnlyVar">
+                    <li fd-nested-list-item>
+                        <a fd-nested-list-link>
+                            <span *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></span>
+                            <span fd-nested-list-title>{{textValue1}}</span>
+                        </a>
+                    </li>
+                    <li fd-nested-list-item>
+                        <a fd-nested-list-link>
+                            <span *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></span>
+                            <span fd-nested-list-title>{{textValue1}}</span>
+                        </a>
+                    </li>
+                    <li fd-nested-list-item>
+                        <a fd-nested-list-link>
+                            <span *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></span>
+                            <span fd-nested-list-title>{{textValue1}}</span>
+                        </a>
+                        <ul fd-nested-list [textOnly]="mainSubTextOnlyVar">
+                            <li fd-nested-list-item>
+                                <a fd-nested-list-link>
+                                    <span *ngIf="!mainSubTextOnlyVar" fd-nested-list-icon [glyph]="iconSecondary"></span>
+                                    <span fd-nested-list-title>{{textValue1}}</span>
+                                </a>
+                                <a fd-nested-list-link>
+                                    <span *ngIf="!mainSubTextOnlyVar" fd-nested-list-icon [glyph]="iconSecondary"></span>
+                                    <span fd-nested-list-title>{{textValue1}}</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        
+            <div fd-side-nav-utility>
+                <ul fd-nested-list 
+                        [compact]="utilityCompactVar" 
+                        [textOnly]="utilityTextOnlyVar">
+                    <li fd-nested-list-item>
+                        <a fd-nested-list-link>
+                            <span *ngIf="!utilityTextOnlyVar" fd-nested-list-icon [glyph]="iconUtility"></span>  
+                            <span fd-nested-list-title>{{textValue1}}</span>
+                        </a>
+                    </li>
+                    <li fd-nested-list-item>
+                        <a fd-nested-list-link>
+                            <span *ngIf="!utilityTextOnlyVar" fd-nested-list-icon [glyph]="iconUtility"></span>
+                            <span fd-nested-list-title>{{textValue1}}</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </fd-side-nav>
+    `,
+    props: {
+        mainCompactVar: boolean('Main Secion in Compact Mode', false),
+        mainTextOnlyVar: boolean('Main Section Text Only', false),
+        mainSubTextOnlyVar: boolean('Main Sub Section Text Only', false),
+        utilityTextOnlyVar: boolean('Utility Section text only', false),
+        utilityCompactVar: boolean('Utility Section in Compact Mode', false),
+        textValue1: text('Text Value 1', 'Item 1'),
+        icon: text('Icon Primary', 'menu'),
+        iconSecondary: text('Icon Secondary', 'menu'),
+        iconUtility: text('Icon Utility', 'menu')
+    }
+});
+
+export const SideNavigationCondensed = () => ({
+    template:
+        `<fd-side-nav [condensed]="true">
+        <div fd-side-nav-main>
+            <ul fd-nested-list [compact]="mainCompactVar">
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <span fd-nested-list-icon [glyph]="icon"></span>
+                    </a>
+                </li>
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <span fd-nested-list-icon [glyph]="icon"></span>
+                    </a>
+                </li>
+                <li fd-nested-list-item>
+                    <fd-nested-list-popover>
+                        <a fd-nested-list-link>
+                            <span fd-nested-list-icon [glyph]="icon"></span>
+                            <span fd-nested-list-title>{{textValue1}}</span>
+
+                        </a>
+                        <ul fd-nested-list>
+                            <li fd-nested-list-item>
+                                <a fd-nested-list-link>
+                                    <span fd-nested-list-title>{{textValue1}}</span>
+                                </a>
+                            </li>
+                            <li fd-nested-list-item>
+                                <a fd-nested-list-link>
+                                    <span fd-nested-list-title>{{textValue1}}</span>
+                                </a>
+                            </li>
+                            <li fd-nested-list-item>
+                                <a fd-nested-list-link>
+                                    <span fd-nested-list-title>{{textValue1}}</span>
+                                </a>
+                            </li>
+                            <li fd-nested-list-item>
+                                <a fd-nested-list-link>
+                                    <span fd-nested-list-title>{{textValue1}}</span>
+                                </a>
+                            </li>
+                        </ul>
+                    </fd-nested-list-popover>
+                </li>
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <span fd-nested-list-icon [glyph]="icon"></span>
+                        <span fd-nested-list-title>{{textValue1}}</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    
+        <div fd-side-nav-utility>
+            <ul fd-nested-list [compact]="utilityCompactVar">
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <span fd-nested-list-icon [glyph]="icon"></span>
+                    </a>
+                </li>
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <span fd-nested-list-icon [glyph]="icon"></span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </fd-side-nav>
+    `,
+    props: {
+        mainCompactVar: boolean('Main Secion in Compact Mode', false),
+        utilityCompactVar: boolean('Utility Section in Compact Mode', false),
+        textValue1: text('Text Value 1', 'Item 1'),
+        icon: text('Icon Primary', 'menu')
+
+    }
+});


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/1954

#### Please provide a brief summary of this pull request.
This pr will add side navigation to storybook. There are two different ones as condensed must be separate from regular. There is no knob for the condensed because the situation would not happen
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

