### PR TITLE
test: add link to storybook

### DIFF
--- a/src/stories/link/link.stories.ts
+++ b/src/stories/link/link.stories.ts
@@ -1,0 +1,39 @@
+import { moduleMetadata } from '@storybook/angular';
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs';
+import { withA11y } from '@storybook/addon-a11y';
+import { LinkComponent, LinkModule } from 'libs/core/src/lib/link/public_api';
+import { RouterModule } from '@angular/router';
+
+export default {
+    title: 'Fd link',
+    component: LinkComponent,
+    moduleMetadata: moduleMetadata,
+    decorators: [
+        withKnobs,
+        withA11y,
+        moduleMetadata({
+            imports: [LinkModule, RouterModule],
+            declarations: []
+        })
+    ]
+};
+
+export const Link = () => ({
+    template:
+        `<a fd-link
+        [href]="hrefVar"
+        [emphasized]="emphasizedVar"
+        [disabled]="disabledVar"
+        fragment="inverted"
+        [inverted]="invertedVar"
+        >{{textValue}}</a>`,
+    props: {
+        emphasizedVar: boolean('Emphasized', false),
+        disabledVar: boolean('Disabled', false),
+        invertedVar: boolean('Inverted', true),
+        textValue: text('Text Value', 'Standard Link'),
+        hrefVar: text('Link', '#'),
+
+    }
+});
+


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/1954

#### Please provide a brief summary of this pull request.
This pr will add link to storybook. It does not use routerLink because there is not router for it to connect to. The accessibility issue from the inverted is normal. No way to add a class because storybook cannot access those/

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

