### PR TITLE
fix: add ariaLabel input to product-switch for button

### DIFF
--- a/libs/core/src/lib/product-switch/product-switch/product-switch.component.html
+++ b/libs/core/src/lib/product-switch/product-switch/product-switch.component.html
@@ -13,6 +13,7 @@
         <fd-popover-control>
             <button
                 fd-button
+                [attr.aria-label]="ariaLabel"
                 class="fd-shellbar__button fd-product-switch__control"
                 [glyph]="'grid'"
                 [fdType]="'transparent'"

--- a/libs/core/src/lib/product-switch/product-switch/product-switch.component.ts
+++ b/libs/core/src/lib/product-switch/product-switch/product-switch.component.ts
@@ -12,4 +12,9 @@ import {Placement} from 'popper.js';
 export class ProductSwitchComponent extends PopoverComponent {
     @Input () 
     placement: Placement = 'bottom-end'
+
+
+    /**Input to set the aria label */
+    @Input ()
+    ariaLabel: string = 'popover-button';
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#2476
#### Please provide a brief summary of this pull request.
This pr will add an aria label input on the product switch component so that the button doesn't give the component a11y issues
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

