### PR TITLE
fix: Add popover update, when created

### DIFF
--- a/libs/core/src/lib/popover/popover-directive/popover.directive.ts
+++ b/libs/core/src/lib/popover/popover-directive/popover.directive.ts
@@ -281,6 +281,7 @@ export class PopoverDirective implements OnInit, OnDestroy, OnChanges {
         this.appRef.attachView(this.containerRef.hostView);
         const setupRef = this.containerRef.instance.isSetup.subscribe(() => {
             this.createPopper();
+            this.updatePopper();
             setupRef.unsubscribe();
         });
 


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
Issue is well reproduced [there](https://stackblitz.com/edit/angular-z4pvxw?file=src/app/popover-placement-example.component.html).
For some reason, popover is not updated, when it overflows the browser window.
There is forced update, on every open.

We should consider migrating to `@angular/cdk/overflow`
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

