### PR TITLE
fix: Add check before change detection, to prevent using destroyed view

### DIFF
--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -329,7 +329,7 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
     /** @hidden */
     setDisabledState(isDisabled: boolean): void {
         this.disabled = isDisabled;
-        this._changeDetectionRef.detectChanges();
+        this._detectChanges();
     }
 
     /**
@@ -377,7 +377,7 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
                 this.inputFieldDate = '';
             }
         }
-        this._changeDetectionRef.detectChanges();
+        this._detectChanges();
         this.isInvalidDateInput = !this.isModelValid();
     }
 
@@ -535,6 +535,16 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
             return customFormattedDate;
         } else {
             return this._datePipe.transform(fdDate.toDate(), this.format, null, this.locale);
+        }
+    }
+
+    /**
+     * @hidden
+     * Method that triggers change detection
+     */
+    private _detectChanges(): void {
+        if (!this._changeDetectionRef['destroyed']) {
+            this._changeDetectionRef.detectChanges();
         }
     }
 

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -322,7 +322,7 @@ export class DatetimePickerComponent implements OnInit, ControlValueAccessor, Va
     /** @hidden */
     setDisabledState(isDisabled: boolean): void {
         this.disabled = isDisabled;
-        this._changeDetRef.detectChanges();
+        this._detectChanges();
     }
 
     /**
@@ -340,7 +340,7 @@ export class DatetimePickerComponent implements OnInit, ControlValueAccessor, Va
             this._refreshCurrentlyDisplayedCalendarDate(this.date.date);
             this._setInput(this.date);
         }
-        this._changeDetRef.detectChanges();
+        this._detectChanges();
     }
 
     /**
@@ -434,7 +434,7 @@ export class DatetimePickerComponent implements OnInit, ControlValueAccessor, Va
 
     private _setInput(fdDateTime: FdDatetime): void {
         this.inputFieldDate = this._formatDateTime(fdDateTime);
-        this._changeDetRef.detectChanges();
+        this._detectChanges();
     }
 
     /** @hidden */
@@ -459,4 +459,13 @@ export class DatetimePickerComponent implements OnInit, ControlValueAccessor, Va
         }
     }
 
+    /**
+     * @hidden
+     * Method that triggers change detection
+     */
+    private _detectChanges(): void {
+        if (!this._changeDetRef['destroyed']) {
+            this._changeDetRef.detectChanges();
+        }
+    }
 }

--- a/libs/core/src/lib/radio/radio-button/radio-button.component.ts
+++ b/libs/core/src/lib/radio/radio-button/radio-button.component.ts
@@ -13,6 +13,7 @@ import { applyCssClass, CssClassBuilder } from '../../utils/public_api';
 
 export type stateType = 'valid' | 'invalid' | 'warning' | 'default' | 'information';
 let uniqueId = 0;
+
 @Component({
     selector: 'fd-radio-button',
     templateUrl: './radio-button.component.html',
@@ -120,10 +121,12 @@ export class RadioButtonComponent implements AfterViewInit, CssClassBuilder, Con
 
     // ControlValueAccessor implementation
     /** @hidden */
-    onChange: any = () => { };
+    onChange: any = () => {
+    };
 
     /** @hidden */
-    onTouched: any = () => { };
+    onTouched: any = () => {
+    };
 
     /** @hidden */
     registerOnChange(fn: (selected: any) => { void }): void {
@@ -138,13 +141,14 @@ export class RadioButtonComponent implements AfterViewInit, CssClassBuilder, Con
     /** @hidden */
     setDisabledState(isDisabled: boolean): void {
         this.disabled = isDisabled;
-        this.changeDetectionRef.detectChanges();
+        this._detectChanges();
     }
 
     /** @hidden */
     writeValue(value: any): void {
         this.valueChange(value);
     }
+
     // End implementation
 
     /** @hidden */
@@ -159,12 +163,13 @@ export class RadioButtonComponent implements AfterViewInit, CssClassBuilder, Con
 
         this._setNativeElementCheckedState();
 
-        this.changeDetectionRef.detectChanges();
+        this._detectChanges();
         this.onChange(value);
     }
 
     /** @hidden */
-    constructor(private changeDetectionRef: ChangeDetectorRef) { }
+    constructor(private changeDetectionRef: ChangeDetectorRef) {
+    }
 
     /** @hidden */
     ngAfterViewInit(): void {
@@ -212,6 +217,16 @@ export class RadioButtonComponent implements AfterViewInit, CssClassBuilder, Con
     private _setNativeElementCheckedState(): void {
         if (this.inputElement) {
             this.inputElement.nativeElement.checked = this.checked;
+        }
+    }
+
+    /**
+     * @hidden
+     * Method that triggers change detection
+     */
+    private _detectChanges(): void {
+        if (!this.changeDetectionRef['destroyed']) {
+            this.changeDetectionRef.detectChanges();
         }
     }
 }

--- a/libs/core/src/lib/switch/switch.component.ts
+++ b/libs/core/src/lib/switch/switch.component.ts
@@ -118,7 +118,7 @@ export class SwitchComponent implements ControlValueAccessor {
      */
     writeValue(value: any): void {
         this.checked = value;
-        this.changeDetectorRef.detectChanges();
+        this._detectChanges();
     }
 
     /**
@@ -143,7 +143,16 @@ export class SwitchComponent implements ControlValueAccessor {
      */
     setDisabledState(isDisabled: boolean): void {
         this.disabled = isDisabled;
-        this.changeDetectorRef.detectChanges();
+        this._detectChanges();
     }
 
+    /**
+     * @hidden
+     * Method that triggers change detection
+     */
+    private _detectChanges(): void {
+        if (!this.changeDetectorRef['destroyed']) {
+            this.changeDetectorRef.detectChanges();
+        }
+    }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
There are added statements on change detection for new other components.
This fix should only go for angular@8.X, because this for angular@9.X everything is working fine
#### Please provide a brief summary of this pull request.

#### Please check whether the PR fulfills the following requirements

- [ ] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [ ] tests for the changes that have been done

Documentation checklist:
- [ ] update `README.md`
- [ ] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [ ] Documentation Examples
- [ ] Stackblitz works for all examples

