### PR TITLE
fix: Add default button type to buttons

### DIFF
--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -5,7 +5,7 @@ import {
     Input,
     ViewEncapsulation,
     OnChanges,
-    OnInit
+    OnInit, HostBinding
 } from '@angular/core';
 import { applyCssClass, CssClassBuilder } from '../utils/public_api';
 
@@ -55,6 +55,14 @@ export function getOptionCssClass(options: ButtonOptions | ButtonOptions[]): str
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ButtonComponent implements OnChanges, CssClassBuilder, OnInit {
+
+    /**
+     * Native type of button element
+     */
+    @Input()
+    @HostBinding('attr.type')
+    type: string = 'button';
+
     /** The property allows user to pass additional css classes
      */
     @Input()


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2507
#### Please provide a brief summary of this pull request.
There is default button type for button component. Sometimes buttons are treated as `type="submit"` by default, what causes form submission.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

