### PR TITLE
fix: popover replace hardcoded background color #2468

### DIFF
--- a/libs/core/src/lib/popover/popover-directive/popover-container.scss
+++ b/libs/core/src/lib/popover/popover-directive/popover-container.scss
@@ -1,7 +1,8 @@
 .fd-popover-container-custom {
     z-index: 1000;
     transition: none;
-    background-color: white;
+    background-color: #fff;
+    background-color: var(--sapGroup_ContentBackground, #fff);
 
     &:focus {
         outline: none;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #2468 
fixes #2465 

#### Please provide a brief summary of this pull request.
use theming parameter for popover background color

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

BEFORE:
<img width="190" alt="Screen Shot 2020-05-14 at 9 52 32 PM" src="https://user-images.githubusercontent.com/4380815/82003037-5ca17000-962d-11ea-92f9-2ae7935dcfd8.png">

AFTER:
<img width="200" alt="Screen Shot 2020-05-14 at 9 52 49 PM" src="https://user-images.githubusercontent.com/4380815/82003044-61feba80-962d-11ea-863e-054b68f01b13.png">
