### PR TITLE
fix: Remove hard coded background color from popover

### DIFF
--- a/libs/core/src/lib/popover/popover-directive/popover-container.scss
+++ b/libs/core/src/lib/popover/popover-directive/popover-container.scss
@@ -1,7 +1,6 @@
 .fd-popover-container-custom {
     z-index: 1000;
     transition: none;
-    background-color: white;
 
     &:focus {
         outline: none;


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
Closes #2468
Closes #2465

Before: 
![image](https://user-images.githubusercontent.com/26483208/82027414-8477ee80-9694-11ea-9a0d-db3b734a0295.png)

![image](https://user-images.githubusercontent.com/17496353/82034806-f6edcc00-969e-11ea-8d29-c84ac53bb6b0.png)

After:
![image](https://user-images.githubusercontent.com/26483208/82027399-7e820d80-9694-11ea-9e1b-6407ab77b600.png)

![image](https://user-images.githubusercontent.com/17496353/82034771-e9d0dd00-969e-11ea-90e9-c29a8bcc2cee.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

