### PR TITLE
docs: Remove menu with checkbox example

### DIFF
--- a/apps/docs/src/app/core/component-docs/menu/examples/menu-addon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/examples/menu-addon-example.component.html
@@ -20,12 +20,6 @@
         </li>
         <li>
             <a href="" fd-menu-item>
-                <input type="checkbox" fd-menu-item-addon />
-                Option 4
-            </a>
-        </li>
-        <li>
-            <a href="" fd-menu-item>
                 <fd-icon fd-menu-item-addon [glyph]="'cart'"></fd-icon>
                 Option 5
             </a>


### PR DESCRIPTION
Menu items should not be combined with checkbox, this is List use-case.