### PR TITLE
fix: missing button restored, removed selected state from header

### DIFF
--- a/libs/core/src/lib/calendar/calendar-header/calendar-header.component.html
+++ b/libs/core/src/lib/calendar/calendar-header/calendar-header.component.html
@@ -20,7 +20,6 @@
                     [compact]="compact"
                     [fdType]="'transparent'"
                     [attr.aria-label]="calendarI18nLabels.monthSelectionLabel + ' ' + monthLabel"
-                    [attr.aria-selected]="isOnMonthView()"
                     (click)="processViewChange('month', $event)"
                     type="button"
                 >
@@ -33,7 +32,6 @@
                     [compact]="compact"
                     [fdType]="'transparent'"
                     [attr.aria-label]="calendarI18nLabels.yearSelectionLabel + ' ' + currentlyDisplayed.year"
-                    [attr.aria-selected]="isOnYearView()"
                     (click)="processViewChange('year', $event)"
                     type="button"
                 >
@@ -44,12 +42,10 @@
         <ng-container *ngIf="activeView === 'aggregatedYear' || activeView === 'year'">
             <div class="fd-calendar__action">
                 <button
-                    *ngIf="activeView === 'year'"
                     fd-button
                     [compact]="compact"
                     [fdType]="'transparent'"
                     [attr.aria-label]="calendarI18nLabels.yearSelectionLabel + ' ' + currentlyDisplayed.year"
-                    [attr.aria-selected]="isOnYearView()"
                     (click)="processViewChange('aggregatedYear', $event)"
                     type="button"
                 >


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #2393
#### Please provide a brief summary of this pull request.
PR removes slected state from header's buttons and restore missing button on year-range selection

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

## Before:
<img width="347" alt="Screen Shot 2020-04-21 at 5 21 10 PM" src="https://user-images.githubusercontent.com/4380815/79915188-84b5fe80-83f4-11ea-9bf3-96bad8af4fe7.png">
<img width="355" alt="Screen Shot 2020-04-21 at 5 20 46 PM" src="https://user-images.githubusercontent.com/4380815/79915189-854e9500-83f4-11ea-8afc-22c63df842c0.png">
<img width="348" alt="Screen Shot 2020-04-21 at 5 20 40 PM" src="https://user-images.githubusercontent.com/4380815/79915191-85e72b80-83f4-11ea-863d-0bdca64c332a.png">

## After:
<img width="291" alt="Screen Shot 2020-04-21 at 5 21 50 PM" src="https://user-images.githubusercontent.com/4380815/79915235-9d261900-83f4-11ea-82fd-895f12d270f8.png">
<img width="301" alt="Screen Shot 2020-04-21 at 5 21 41 PM" src="https://user-images.githubusercontent.com/4380815/79915236-9dbeaf80-83f4-11ea-9c57-832d449807d1.png">
<img width="277" alt="Screen Shot 2020-04-21 at 5 21 37 PM" src="https://user-images.githubusercontent.com/4380815/79915238-9e574600-83f4-11ea-8790-b8e793c8e113.png">
