### PR TITLE
fix: removed extra space from first and last child

### DIFF
--- a/libs/core/src/lib/menu/menu.component.scss
+++ b/libs/core/src/lib/menu/menu.component.scss
@@ -34,8 +34,6 @@ $block: fd-menu;
     @include fd-ellipsis();
 
     position: relative;
-    padding-top: 4px;
-    padding-bottom: 4px;
     width: 100%;
     display: inline-block;
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#### Please provide a brief summary of this pull request.
PR removes extra space from first and last child of menu, but doing so, I introduced an issue from styles. We should wait with merging this until https://github.com/SAP/fundamental-styles/pull/895 will be merged.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

## After
![image](https://user-images.githubusercontent.com/10849982/82321142-ac3cbe80-99d4-11ea-802d-c6a38152229a.png)
