### PR TITLE
fix: checkbox for reverted

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -13,7 +13,7 @@
     (keydown)="checkByKey($event)"
     (keyup)="$event.stopPropagation()"
 />
-<label class="fd-checkbox__label" (click)="checkByClick($event)" [class.fd-checkbox__label--compact]="compact">
+<label class="fd-checkbox__label" [for]="inputId" [class.fd-checkbox__label--compact]="compact">
     {{ label }}
     <ng-container *ngIf="!label">
         <ng-content></ng-content>

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -133,7 +133,6 @@ export class CheckboxComponent implements ControlValueAccessor {
 
     /** @hidden Updates checkbox Indeterminate state on mouse click on IE11 */
     public checkByClick(event: Event) {
-        event.stopPropagation();
         this.nextValue();
     }
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#### Please provide a brief summary of this pull request.

PR reverts [for] property in the checkbox component. We have to wait for chrome fix