### PR TITLE
fix: Add 0.8.1 Css to time component

### DIFF
--- a/libs/core/src/lib/time/time.component.scss
+++ b/libs/core/src/lib/time/time.component.scss
@@ -1,6 +1,87 @@
 @import '~fundamental-styles/dist/input';
-@import '~fundamental-styles/dist/time';
 
+@charset "UTF-8";
+.fd-time {
+    font-size: .875rem;
+    font-size: var(--sapFontSize,.875rem);
+    line-height: 1.42857;
+    color: #32363a;
+    color: var(--sapTextColor,#32363a);
+    font-family: "72", "72full", Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, "72", "72full", Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    width: 184px
+}
+.fd-time::after,
+.fd-time::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit
+}
+.fd-time__item {
+    font-size: .875rem;
+    font-size: var(--sapFontSize,.875rem);
+    line-height: 1.42857;
+    color: #32363a;
+    color: var(--sapTextColor,#32363a);
+    font-family: "72", "72full", Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, "72", "72full", Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    display: inline-block;
+    max-width: 40px;
+    text-align: center;
+    margin-right: 4px
+}
+.fd-time__item::after,
+.fd-time__item::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit
+}
+.fd-time__item:last-child {
+    margin-right: 0
+}
+.fd-time__item .fd-time__input {
+    margin: 8px 0;
+    padding-left: 8px;
+    padding-right: 8px;
+    text-align: center;
+    width: 100%
+}
+.fd-time__control {
+    font-size: .875rem;
+    font-size: var(--sapFontSize,.875rem);
+    line-height: 1.42857;
+    color: #32363a;
+    color: var(--sapTextColor,#32363a);
+    font-family: "72", "72full", Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, "72", "72full", Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0
+}
+.fd-time__control::after,
+.fd-time__control::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit
+}
 .fd-time__item {
     .fd-time__input {
         min-width: auto;


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
Since we have 0.9.0 styles on master, old time component is not compatible with new styles css.
There are included old styles.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

