### PR TITLE
fix: enable :empty selector on checkbox

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -14,7 +14,9 @@
     (keyup)="$event.stopPropagation()"
 />
 <label class="fd-checkbox__label" [for]="inputId" [class.fd-checkbox__label--compact]="compact">
-    {{ label }}
+    <ng-container *ngIf="label">
+        {{ label }}
+    </ng-container>
     <ng-container *ngIf="!label">
         <ng-content></ng-content>
     </ng-container>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
related to https://github.com/SAP/fundamental-ngx/issues/2602
#### Please provide a brief summary of this pull request.
There is a workaround for possibility to make use `:empty` state
Before:
![image](https://user-images.githubusercontent.com/26483208/83632053-dbd7f300-a59e-11ea-9b0b-7f0cab82a334.png)

After:
![image](https://user-images.githubusercontent.com/26483208/83632028-cbc01380-a59e-11ea-89b9-bf16e7c75f09.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

