### PR TITLE
fix: Provide way to put placement to shellbar product menu

### DIFF
--- a/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.component.html
@@ -18,7 +18,9 @@
 <description>
     When a product has multiple links, the product links should collapse into an overflow menu on mobile screens. All
     actions, except for the user menu, should be collapsed. See the placement of the
-    <code>&lt;fd-shellbar-collapse></code> container below.
+    <code>&lt;fd-shellbar-collapse></code> container below. <br>
+    <code>ProductSwitchComponent</code> and <code>ProductMenuComponent</code> have properties straight from popover
+    component, so some customisation can be added, by passing inputs ex. <code>[position]="'bottom-end'"</code>.
 </description>
 <component-example>
     <fd-shellbar-collapsible-example></fd-shellbar-collapsible-example>

--- a/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
+++ b/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
@@ -8,7 +8,7 @@
         [isDropdown]="isDropdown"
         [triggers]="triggers"
         [focusTrapped]="false"
-        [placement]="'bottom-end'"
+        [placement]="placement"
     >
         <fd-popover-control>
             <button class="fd-button fd-button--transparent fd-button--menu fd-shellbar__button--menu">

--- a/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions.component.html
+++ b/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions.component.html
@@ -15,7 +15,7 @@
     <ng-container *ngIf="!userComponent">
         <fd-shellbar-user-menu
             (itemClicked)="triggerItems()"
-            [options]="{ placement: 'bottom-end' }"
+            [placement]="'bottom-end'"
             [focusTrapped]="false"
             [user]="user"
             [userMenu]="userMenu"

--- a/libs/core/src/lib/shellbar/user-menu/shellbar-user-menu.component.html
+++ b/libs/core/src/lib/shellbar/user-menu/shellbar-user-menu.component.html
@@ -6,7 +6,7 @@
             [closeOnOutsideClick]="closeOnOutsideClick"
             [(isOpen)]="isOpen"
             [triggers]="triggers"
-            [placement]="'bottom-end'"
+            [placement]="placement"
             (isOpenChange)="openChanged($event)"
             [disabled]="disabled"
             [isDropdown]="isDropdown"


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2608
#### Please provide a brief summary of this pull request.
Before placement that was passed to popover from shellbar menu item was hardcoded. There is introduced binding placement passed, with bottom-start by default.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

