### PR TITLE
fix: (platform) Input Component and documentation code changes 

### DIFF
--- a/apps/docs/src/app/platform/api-files.ts
+++ b/apps/docs/src/app/platform/api-files.ts
@@ -10,6 +10,7 @@ export const API_FILES = {
     checkbox: ['CheckboxComponent'],
     checkboxGroup: ['CheckboxGroupComponent'],
     infoLabel: ['InfoLabelComponent'],
+    input: ['InputComponent'],
     link: ['LinkComponent'],
     menu: ['MenuComponent', 'MenuItemComponent', 'MenuTriggerDirective'],
     menuButton: ['MenuButtonComponent'],

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-docs.component.html
@@ -1,0 +1,27 @@
+<fd-docs-section-title [id]="'inputDef'" [componentName]="'Input'">
+    Input Types
+</fd-docs-section-title>
+<description>This example shows Input default implementaion. </description>
+<component-example>
+    <fd-platform-input-example></fd-platform-input-example>
+</component-example>
+<code-example [exampleFiles]="defaultInputType"></code-example>
+
+<fd-docs-section-title [id]="'inputValid'" [componentName]="'inputValidation'">
+    Input States With Messages Components And AriaLabelledBy Attribute.
+</fd-docs-section-title>
+<description>This example shows Input validation with Message implementaion. </description>
+<component-example>
+    <fdp-platform-input-reactive-form-validation-example></fdp-platform-input-reactive-form-validation-example>
+</component-example>
+<code-example [exampleFiles]="inputReactiveFormValidationInputType"></code-example>
+
+<fd-docs-section-title [id]="'inputValid'" [componentName]="'inputAutoComplete'">
+    Input States With Auto Complete Components And Aria Label Attribute.
+</fd-docs-section-title>
+<description>This example shows Input AutoComplete with Input implementaion. </description>
+<component-example>
+    <fdp-platform-input-auto-complete-form-validation-example>
+    </fdp-platform-input-auto-complete-form-validation-example>
+</component-example>
+<code-example [exampleFiles]="inputAutoCompleteFormValidationInputType"></code-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-docs.component.html
@@ -1,4 +1,4 @@
-<fd-docs-section-title [id]="'inputDef'" [componentName]="'Input'">
+<fd-docs-section-title [id]="'input-default'" [componentName]="'Input'">
     Input Types
 </fd-docs-section-title>
 <description>This example shows Input default implementaion. </description>
@@ -7,7 +7,7 @@
 </component-example>
 <code-example [exampleFiles]="defaultInputType"></code-example>
 
-<fd-docs-section-title [id]="'inputValid'" [componentName]="'inputValidation'">
+<fd-docs-section-title [id]="'input-reactive'" [componentName]="'inputValidation'">
     Input States With Messages Components And AriaLabelledBy Attribute.
 </fd-docs-section-title>
 <description>This example shows Input validation with Message implementaion. </description>
@@ -16,7 +16,7 @@
 </component-example>
 <code-example [exampleFiles]="inputReactiveFormValidationInputType"></code-example>
 
-<fd-docs-section-title [id]="'inputValid'" [componentName]="'inputAutoComplete'">
+<fd-docs-section-title [id]="'input-auto-complete'" [componentName]="'inputAutoComplete'">
     Input States With Auto Complete Components And Aria Label Attribute.
 </fd-docs-section-title>
 <description>This example shows Input AutoComplete with Input implementaion. </description>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-docs.component.ts
@@ -1,0 +1,57 @@
+import { Component } from '@angular/core';
+import * as platformInputDefaultTypesSrc from '!raw-loader!./platform-input-example/platform-input-example.component.html';
+import * as platformInputDefaultTypesTsSrc from '!raw-loader!./platform-input-example/platform-input-example.component.ts';
+
+import * as platformInputReactiveFormValidationTypesSrc from '!raw-loader!./platform-input-example/platform-input-reactive-validation-example.component.html';
+import * as platformInputReactiveFormValidationTypesTsSrc from '!raw-loader!./platform-input-example/platform-input-reactive-validation-example.component.ts';
+
+import * as platformInputAutoCompleteFormValidationTypesSrc from '!raw-loader!./platform-input-example/platform-input-auto-complete-validation-example.component.html';
+import * as platformInputAutoCompleteFormValidationTypesTsSrc from '!raw-loader!./platform-input-example/platform-input-auto-complete-validation-example.component.ts';
+import { ExampleFile } from '../../../../documentation/core-helpers/code-example/example-file';
+
+@Component({
+    selector: 'fd-platform-input-docs',
+    templateUrl: './platform-input-docs.component.html'
+})
+export class PlatformInputDocsComponent {
+    defaultInputType: ExampleFile[] = [
+        {
+            language: 'html',
+            code: platformInputDefaultTypesSrc,
+            fileName: 'platform-input-example'
+        },
+        {
+            language: 'typescript',
+            code: platformInputDefaultTypesTsSrc,
+            fileName: 'platform-input-example',
+            component: 'PlatformInputDefaultExampleComponent'
+        }
+    ];
+
+    inputReactiveFormValidationInputType: ExampleFile[] = [
+        {
+            language: 'html',
+            code: platformInputReactiveFormValidationTypesSrc,
+            fileName: 'platform-input-reactive-validation-example'
+        },
+        {
+            language: 'typescript',
+            code: platformInputReactiveFormValidationTypesTsSrc,
+            fileName: 'platform-input-reactive-validation-example',
+            component: 'PlatformInputReactiveValidationExampleComponent'
+        }
+    ];
+    inputAutoCompleteFormValidationInputType: ExampleFile[] = [
+        {
+            language: 'html',
+            code: platformInputAutoCompleteFormValidationTypesSrc,
+            fileName: 'platform-input-auto-complete-validation-example'
+        },
+        {
+            language: 'typescript',
+            code: platformInputAutoCompleteFormValidationTypesTsSrc,
+            fileName: 'platform-input-auto-complete-validation-example',
+            component: 'PlatformInputAutoCompleteValidationExampleComponent'
+        }
+    ];
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-docs.module.ts
@@ -1,0 +1,41 @@
+import { Routes, RouterModule } from '@angular/router';
+import { PlatformInputHeaderComponent } from './platform-input-header/platform-input-header.component';
+import { PlatformInputDocsComponent } from './platform-input-docs.component';
+import { NgModule } from '@angular/core';
+import { PlatformInputModule, FdpFormGroupModule, PlatformButtonModule } from '@fundamental-ngx/platform';
+import { PlatformInputExampleComponent } from './platform-input-example/platform-input-example.component';
+import { PlatformInputReactiveValidationExampleComponent } from './platform-input-example/platform-input-reactive-validation-example.component';
+import { PlatformInputAutoCompleteValidationExampleComponent } from './platform-input-example/platform-input-auto-complete-validation-example.component';
+import { ApiComponent } from '../../../../documentation/core-helpers/api/api.component';
+import { API_FILES } from '../../../api-files';
+import { SharedDocumentationModule } from '../../../../documentation/shared-documentation.module';
+
+const routes: Routes = [
+    {
+        path: '',
+        component: PlatformInputHeaderComponent,
+        children: [
+            { path: '', component: PlatformInputDocsComponent },
+            { path: 'api', component: ApiComponent, data: { content: API_FILES.input } }
+        ]
+    }
+];
+
+@NgModule({
+    imports: [
+        RouterModule.forChild(routes),
+        SharedDocumentationModule,
+        PlatformInputModule,
+        FdpFormGroupModule,
+        PlatformButtonModule
+    ],
+    exports: [RouterModule],
+    declarations: [
+        PlatformInputExampleComponent,
+        PlatformInputHeaderComponent,
+        PlatformInputDocsComponent,
+        PlatformInputReactiveValidationExampleComponent,
+        PlatformInputAutoCompleteValidationExampleComponent
+    ]
+})
+export class PlatformInputDocsModule {}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.html
@@ -3,8 +3,8 @@
         <fd-popover-control>
             <fdp-input
                 [type]="'text'"
-                id="form-input-7"
-                name="autoCompletTextInput"
+                [id]="'form-input-7'"
+                [name]="'autoCompletTextInput'"
                 [placeholder]="'Enter the sport name'"
                 [(ngModel)]="inputText"
                 (input)="onSearchChange()"

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.html
@@ -1,0 +1,35 @@
+<div>
+    <fd-popover class="fd-popover" [isOpen]="open">
+        <fd-popover-control>
+            <fdp-input
+                [type]="'text'"
+                id="form-input-7"
+                name="autoCompletTextInput"
+                [placeholder]="'Enter the sport name'"
+                [(ngModel)]="inputText"
+                (input)="onSearchChange()"
+                [ariaLabel]="'Input with Auto complete'"
+            >
+            </fdp-input>
+        </fd-popover-control>
+        <fd-popover-body *ngIf="options && options.length">
+            <ng-container [ngTemplateOutlet]="menuTemplate"> </ng-container>
+        </fd-popover-body>
+    </fd-popover>
+</div>
+<ng-template #menuTemplate>
+    <div *ngIf="!itemTemplate" class="fd-popover__body fd-popover__body--no-arrow">
+        <nav class="fd-menu">
+            <ul fd-menu-list class="fd-menu__list">
+                <li
+                    fd-menu-list-item
+                    class="fd-menu__item"
+                    *ngFor="let option of options"
+                    (click)="onItemClick(option)"
+                >
+                    {{ option }}
+                </li>
+            </ul>
+        </nav>
+    </div>
+</ng-template>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.scss
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.scss
@@ -1,0 +1,3 @@
+.fd-popover {
+    width: 100%;
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit, TemplateRef, Input } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+
+@Component({
+    selector: 'fdp-platform-input-auto-complete-form-validation-example',
+    templateUrl: './platform-input-auto-complete-validation-example.component.html',
+    styleUrls: ['./platform-input-auto-complete-validation-example.component.scss']
+})
+export class PlatformInputAutoCompleteValidationExampleComponent implements OnInit {
+    submitted = false;
+    inputText: string = '';
+    state = false;
+    options: string[];
+
+    public sportsData: string[] = [
+        'American Football',
+        'Badminton',
+        'Basketball',
+        'Cricket',
+        'Football',
+        'Golf',
+        'Hockey',
+        'Rugby',
+        'Snooker',
+        'Tennis'
+    ];
+
+    /** Whether the combobox is opened. */
+    @Input()
+    open: boolean = false;
+
+    /**
+     * The template with which to display the individual listed items.
+     * Use it by passing an ng-template with implicit content. See examples for more info.
+     */
+    @Input()
+    itemTemplate: TemplateRef<any>;
+
+    constructor(private fb: FormBuilder) {}
+
+    ngOnInit() {
+        this.options = this.sportsData;
+    }
+
+    filter(value: string): string[] {
+        const filterValue = value.toLowerCase();
+        return this.sportsData.filter((item: string) => item.toLowerCase().includes(filterValue));
+    }
+
+    onSearchChange() {
+        this.options = this.filter(this.inputText);
+        this.open = true;
+    }
+
+    onItemClick(clickedValue) {
+        this.inputText = clickedValue;
+        this.open = false;
+    }
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.ts
@@ -8,7 +8,7 @@ import { FormBuilder } from '@angular/forms';
 })
 export class PlatformInputAutoCompleteValidationExampleComponent implements OnInit {
     submitted = false;
-    inputText: string = '';
+    inputText: string;
     state = false;
     options: string[];
 
@@ -27,7 +27,7 @@ export class PlatformInputAutoCompleteValidationExampleComponent implements OnIn
 
     /** Whether the combobox is opened. */
     @Input()
-    open: boolean = false;
+    open: boolean;
 
     /**
      * The template with which to display the individual listed items.
@@ -38,7 +38,7 @@ export class PlatformInputAutoCompleteValidationExampleComponent implements OnIn
 
     constructor(private fb: FormBuilder) {}
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.options = this.sportsData;
     }
 
@@ -47,12 +47,12 @@ export class PlatformInputAutoCompleteValidationExampleComponent implements OnIn
         return this.sportsData.filter((item: string) => item.toLowerCase().includes(filterValue));
     }
 
-    onSearchChange() {
+    onSearchChange(): void {
         this.options = this.filter(this.inputText);
         this.open = true;
     }
 
-    onItemClick(clickedValue) {
+    onItemClick(clickedValue): void {
         this.inputText = clickedValue;
         this.open = false;
     }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-example.component.html
@@ -1,0 +1,70 @@
+<form #myForm="ngForm">
+    <fdp-form-group [formGroup]="formTypesGroupRegister">
+        <fdp-form-field
+            #ffl1
+            label="Default Input"
+            [id]="'input1'"
+            name="reactiveFormInput"
+            zone="“zLeft”"
+            rank="1"
+            [placeholder]="'Field placeholder text'"
+        >
+            <fdp-input [type]="'text'"> </fdp-input>
+        </fdp-form-field>
+        <fdp-form-field
+            #ffl1
+            label="Text Input"
+            [id]="'input2'"
+            name="reactiveFormInput"
+            zone="“zLeft”"
+            rank="1"
+            [placeholder]="'Field placeholder text'"
+        >
+            <fdp-input [type]="'text'"> </fdp-input>
+        </fdp-form-field>
+        <fdp-form-field
+            #ffl1
+            label="Number Text Box"
+            [id]="'input3'"
+            name="reactiveFormInput"
+            zone="“zLeft”"
+            rank="1"
+            [placeholder]="'Field placeholder text'"
+        >
+            <fdp-input [type]="'number'"></fdp-input>
+        </fdp-form-field>
+        <fdp-form-field
+            #ffl1
+            label="Compact Text Box"
+            [id]="'input4'"
+            name="compactTextBox"
+            zone="“zLeft”"
+            rank="1"
+            [placeholder]="'Field placeholder text'"
+        >
+            <fdp-input [type]="'text'" [contentDensity]="'compact'"></fdp-input>
+        </fdp-form-field>
+        <fdp-form-field
+            #ffl1
+            label="ReadOnly Text Box"
+            [id]="'input5'"
+            name="readOnlyInput"
+            zone="“zLeft”"
+            rank="1"
+            [placeholder]="'Field placeholder text'"
+        >
+            <fdp-input [type]="'text'" [readonly]="true"></fdp-input>
+        </fdp-form-field>
+        <fdp-form-field
+            #ffl1
+            label="Disabled Text Box"
+            [id]="'input6'"
+            name="disabledInput"
+            zone="“zLeft”"
+            rank="1"
+            [placeholder]="'Field placeholder text'"
+        >
+            <fdp-input [type]="'text'" [disabled]="true"></fdp-input>
+        </fdp-form-field>
+    </fdp-form-group>
+</form>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-example.component.html
@@ -2,69 +2,81 @@
     <fdp-form-group [formGroup]="formTypesGroupRegister">
         <fdp-form-field
             #ffl1
-            label="Default Input"
+            label="Default Input Field"
             [id]="'input1'"
             name="reactiveFormInput"
             zone="“zLeft”"
             rank="1"
             [placeholder]="'Field placeholder text'"
         >
-            <fdp-input [type]="'text'"> </fdp-input>
+            <fdp-input [name]="'input1'" [id]="'input1'" [type]="'text'"> </fdp-input>
         </fdp-form-field>
         <fdp-form-field
             #ffl1
-            label="Text Input"
+            label="Text Input Field"
             [id]="'input2'"
             name="reactiveFormInput"
             zone="“zLeft”"
             rank="1"
             [placeholder]="'Field placeholder text'"
         >
-            <fdp-input [type]="'text'"> </fdp-input>
+            <fdp-input [name]="'input2'" [id]="'input2'" [type]="'text'"> </fdp-input>
         </fdp-form-field>
         <fdp-form-field
             #ffl1
-            label="Number Text Box"
+            label="Number Input Field"
             [id]="'input3'"
             name="reactiveFormInput"
             zone="“zLeft”"
             rank="1"
             [placeholder]="'Field placeholder text'"
         >
-            <fdp-input [type]="'number'"></fdp-input>
+            <fdp-input [name]="'input3'" [id]="'input3'" [type]="'number'"></fdp-input>
         </fdp-form-field>
         <fdp-form-field
             #ffl1
-            label="Compact Text Box"
+            label="Compact Input Field"
             [id]="'input4'"
             name="compactTextBox"
             zone="“zLeft”"
             rank="1"
             [placeholder]="'Field placeholder text'"
         >
-            <fdp-input [type]="'text'" [contentDensity]="'compact'"></fdp-input>
+            <fdp-input [name]="'input4'" [id]="'input4'" [type]="'text'" [contentDensity]="'compact'"></fdp-input>
         </fdp-form-field>
         <fdp-form-field
             #ffl1
-            label="ReadOnly Text Box"
+            label="ReadOnly Input Field"
             [id]="'input5'"
             name="readOnlyInput"
             zone="“zLeft”"
             rank="1"
             [placeholder]="'Field placeholder text'"
         >
-            <fdp-input [type]="'text'" [readonly]="true"></fdp-input>
+            <fdp-input [name]="'input5'" [id]="'input5'" [type]="'text'" [readonly]="true"></fdp-input>
         </fdp-form-field>
         <fdp-form-field
             #ffl1
-            label="Disabled Text Box"
+            label="Disabled Input Field"
             [id]="'input6'"
             name="disabledInput"
             zone="“zLeft”"
             rank="1"
             [placeholder]="'Field placeholder text'"
         >
-            <fdp-input [type]="'text'" [disabled]="true"></fdp-input>
+            <fdp-input [name]="'input6'" [id]="'input6'" [type]="'text'" [disabled]="true"></fdp-input>
+        </fdp-form-field>
+        <fdp-form-field
+            #ffl1
+            label="Inline Help Input Field"
+            [id]="'input6'"
+            name="disabledInput"
+            zone="“zLeft”"
+            rank="1"
+            [placeholder]="'Field placeholder text'"
+            hint="Lorem ipsum dolor sit amet, consectetur adipiscing."
+        >
+            <fdp-input [name]="'input6'" [id]="'input6'" [type]="'text'"></fdp-input>
         </fdp-form-field>
     </fdp-form-group>
 </form>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-example.component.ts
@@ -1,10 +1,14 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 @Component({
     selector: 'fd-platform-input-example',
     templateUrl: './platform-input-example.component.html'
 })
-export class PlatformInputExampleComponent {
+export class PlatformInputExampleComponent implements OnInit {
     formTypesGroupRegister: FormGroup;
+
+    ngOnInit(): void {
+        this.formTypesGroupRegister = new FormGroup({});
+    }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-example.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+    selector: 'fd-platform-input-example',
+    templateUrl: './platform-input-example.component.html'
+})
+export class PlatformInputExampleComponent {
+    formTypesGroupRegister: FormGroup;
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-reactive-validation-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-reactive-validation-example.component.html
@@ -1,0 +1,25 @@
+<form #myForm="ngForm">
+    <fdp-form-group [formGroup]="formGroupRegister">
+        <fdp-form-field
+            #ffl1
+            label="My Favorite Colors"
+            [id]="'input9'"
+            name="reactiveFormInput"
+            zone="“zLeft”"
+            rank="1"
+            [placeholder]="'Field placeholder text'"
+            [required]="true"
+            hint="Pick one of your favorite color"
+        >
+            <fdp-input [formControl]="ffl1.formControl" [type]="'text'" [ariaLabelledBy]="'label'"> </fdp-input>
+        </fdp-form-field>
+        <fdp-form-field [id]="'button-1'" [rank]="10" zone="zRight">
+            <fdp-button [type]="'submit'" (click)="onSubmit()">Submit</fdp-button>
+        </fdp-form-field>
+        <ng-template #i18n let-errors>
+            <ng-container *ngIf="errors.required">
+                <span> Pellentesque metus lacus commodo eget justo ut rutrum varius nunc</span>
+            </ng-container>
+        </ng-template>
+    </fdp-form-group>
+</form>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-reactive-validation-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-reactive-validation-example.component.html
@@ -9,9 +9,15 @@
             rank="1"
             [placeholder]="'Field placeholder text'"
             [required]="true"
-            hint="Pick one of your favorite color"
         >
-            <fdp-input [formControl]="ffl1.formControl" [type]="'text'" [ariaLabelledBy]="'label'"> </fdp-input>
+            <fdp-input
+                [name]="'input6'"
+                [id]="'input6'"
+                [formControl]="ffl1.formControl"
+                [type]="'text'"
+                [ariaLabelledBy]="'label'"
+            >
+            </fdp-input>
         </fdp-form-field>
         <fdp-form-field [id]="'button-1'" [rank]="10" zone="zRight">
             <fdp-button [type]="'submit'" (click)="onSubmit()">Submit</fdp-button>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-reactive-validation-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-reactive-validation-example.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+
+@Component({
+    selector: 'fdp-platform-input-reactive-form-validation-example',
+    templateUrl: './platform-input-reactive-validation-example.component.html'
+})
+export class PlatformInputReactiveValidationExampleComponent implements OnInit {
+    formGroupRegister: FormGroup;
+    submitted = false;
+    validate = [Validators.requiredTrue];
+    constructor(private fb: FormBuilder) {}
+
+    ngOnInit() {
+        this.formGroupRegister = new FormGroup({});
+    }
+
+    hasError() {
+        return this.formGroupRegister.invalid && this.submitted;
+    }
+
+    onSubmit() {
+        // stop here if form is invalid
+        if (this.formGroupRegister.invalid) {
+            this.submitted = true;
+            return;
+        }
+
+        // display form values on success
+        alert('SUCCESS!! :-)\n\n' + JSON.stringify(this.formGroupRegister.value, null, 4));
+    }
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-reactive-validation-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-reactive-validation-example.component.ts
@@ -11,15 +11,15 @@ export class PlatformInputReactiveValidationExampleComponent implements OnInit {
     validate = [Validators.requiredTrue];
     constructor(private fb: FormBuilder) {}
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.formGroupRegister = new FormGroup({});
     }
 
-    hasError() {
+    hasError(): boolean {
         return this.formGroupRegister.invalid && this.submitted;
     }
 
-    onSubmit() {
+    onSubmit(): void {
         // stop here if form is invalid
         if (this.formGroupRegister.invalid) {
             this.submitted = true;

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-header/platform-input-header.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-header/platform-input-header.component.html
@@ -1,0 +1,17 @@
+<header>Input</header>
+<description>
+    <p>
+        The text input in Platform is the extension of the native Input component present in fundamental ngx-core. While
+        in fundamental ngx-core, it is a html native element, in Platform it is wrapped up as a angular @component with
+        developer's productivity in mind.
+    </p>
+    <ul>
+        <li>Text Input is introduced as component in the Platform.</li>
+        <li>Designed to work easily with Platform FormsGroup and FormField components.</li>
+        <li>aria-label and aria-labelledby has been introduced for accessibility support.</li>
+    </ul>
+</description>
+<import module="PlatformInputModule"></import>
+
+<fd-header-tabs></fd-header-tabs>
+<router-outlet></router-outlet>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-header/platform-input-header.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-header/platform-input-header.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'fd-platform-input-header',
+    templateUrl: './platform-input-header.component.html'
+})
+export class PlatformInputHeaderComponent {}

--- a/apps/docs/src/app/platform/documentation/platform-documentation.component.ts
+++ b/apps/docs/src/app/platform/documentation/platform-documentation.component.ts
@@ -21,6 +21,7 @@ export class PlatformDocumentationComponent extends DocumentationBaseComponent {
             { url: 'platform/checkbox', name: 'Checkbox' },
             { url: 'platform/checkbox-group', name: 'Checkbox Group' },
             { url: 'platform/info-label', name: 'Info Label' },
+            { url: 'platform/input', name: 'Input' },
             { url: 'platform/link', name: 'Link' },
             { url: 'platform/menu', name: 'Menu' },
             { url: 'platform/menu-button', name: 'Menu Button' },

--- a/apps/docs/src/app/platform/platform-documentation.module.ts
+++ b/apps/docs/src/app/platform/platform-documentation.module.ts
@@ -20,6 +20,9 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
         RouterModule.forChild(ROUTES),
         ScrollingModule
     ],
-    providers: [{ provide: 'CURRENT_LIB', useValue: 'platform' }, StackblitzService]
+    providers: [
+        { provide: 'CURRENT_LIB', useValue: 'platform' },
+        StackblitzService
+    ]
 })
 export class PlatformDocumentationModule {}

--- a/apps/docs/src/app/platform/platform-documentation.routes.ts
+++ b/apps/docs/src/app/platform/platform-documentation.routes.ts
@@ -106,10 +106,18 @@ export const ROUTES: Routes = [
                     )
             },
             {
-              path: 'switch',
-              loadChildren: () =>
-                import('./component-docs/platform-forms/switch/platform-switch-docs.module')
-                  .then(m => m.PlatformSwitchDocsModule)
+                path: 'switch',
+                loadChildren: () =>
+                    import('./component-docs/platform-forms/switch/platform-switch-docs.module').then(
+                        (m) => m.PlatformSwitchDocsModule
+                    )
+            },
+            {
+                path: 'input',
+                loadChildren: () =>
+                    import('./component-docs/platform-forms/platform-input/platform-input-docs.module').then(
+                        (m) => m.PlatformInputDocsModule
+                    )
             }
         ]
     }

--- a/libs/platform/src/lib/components/form/base.input.ts
+++ b/libs/platform/src/lib/components/form/base.input.ts
@@ -57,6 +57,20 @@ export abstract class BaseInput extends BaseComponent
     }
 
     /**
+	 * readOnly Value to Mark component read only
+	 */
+    @Input()
+    readonly: boolean;
+
+    /** Binds to control aria-labelledBy attribute */
+    @Input()
+    ariaLabelledBy: string = null;
+
+    /** Sets control aria-label attribute value */
+    @Input()
+    ariaLabel: string = null;
+
+    /**
      * Tell  the component if we are in editing mode.
      *
      */

--- a/libs/platform/src/lib/components/form/form-control.ts
+++ b/libs/platform/src/lib/components/form/form-control.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 import { NgControl } from '@angular/forms';
 
 export type ContentDensity = 'compact' | 'cozy';
-export type Status = 'error' | 'warning' | void;
+export type Status = 'success' | 'error' | 'warning' | 'default' | 'information';
 
 export abstract class FormFieldControl<T> {
     /**

--- a/libs/platform/src/lib/components/form/form-group/fdp-form.module.ts
+++ b/libs/platform/src/lib/components/form/form-group/fdp-form.module.ts
@@ -1,14 +1,19 @@
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { FormModule as FdFormModule, InlineHelpModule, PopoverModule } from '@fundamental-ngx/core';
+import { FormModule as FdFormModule,
+         InlineHelpModule, 
+         PopoverModule } from '@fundamental-ngx/core';
 import { FormGroupComponent } from './form-group.component';
 import { FormFieldComponent } from './form-field/form-field.component';
-import { InputMessageGroupWithTemplate } from '../input-message-group-with-template/input-message-group-with-template.component';
+import { 
+        InputMessageGroupWithTemplate 
+        } from '../input-message-group-with-template/input-message-group-with-template.component';
 
 @NgModule({
     declarations: [FormGroupComponent, FormFieldComponent, InputMessageGroupWithTemplate],
     imports: [CommonModule, FormsModule, ReactiveFormsModule, FdFormModule, InlineHelpModule, PopoverModule],
-    exports: [FormGroupComponent, FormFieldComponent]
+    exports: [FormGroupComponent, FormFieldComponent, InputMessageGroupWithTemplate]
+
 })
 export class FdpFormGroupModule {}

--- a/libs/platform/src/lib/components/form/form.spec.ts
+++ b/libs/platform/src/lib/components/form/form.spec.ts
@@ -2,7 +2,7 @@ import { Component, ViewChild, ElementRef } from '@angular/core';
 import { async, TestBed, ComponentFixture } from '@angular/core/testing';
 
 import { FdpFormGroupModule } from './form-group/fdp-form.module';
-import { FdpInputModule } from './input/fdp-input.module';
+import { PlatformInputModule } from './input/fdp-input.module';
 import { ReactiveFormsModule, FormGroup } from '@angular/forms';
 import { FormFieldComponent } from './form-group/form-field/form-field.component';
 import { FormGroupComponent } from '@fundamental-ngx/core';
@@ -88,7 +88,7 @@ describe('Simple Form', () => {
             imports: [
                 ReactiveFormsModule,
                 FdpFormGroupModule,
-                FdpInputModule,
+                PlatformInputModule,
             ],
             declarations: [SimpleFormTestComponent],
         }).compileComponents();
@@ -240,7 +240,7 @@ describe('Nested Form Groups', () => {
             imports: [
                 ReactiveFormsModule,
                 FdpFormGroupModule,
-                FdpInputModule,
+                PlatformInputModule,
             ],
             declarations: [NestedFormGroupsTestComponent],
         }).compileComponents();

--- a/libs/platform/src/lib/components/form/form.spec.ts
+++ b/libs/platform/src/lib/components/form/form.spec.ts
@@ -19,41 +19,49 @@ interface TestUser {
 
 @Component({
     template: `
-    <form [formGroup]="userFormGroup" (ngSubmit)="onSubmit()">
-        <fdp-form-group #userForm
-            [object]="user"
-            [formGroup]="userFormGroup"
-            [hintPlacement]="'right'"
-            [i18Strings]="i18n">
-            <fdp-form-field #firstName
-                id="firstName"
-                label="First Name"
-                hint="Enter your first name."
-                zone="zTop"
-                required=true>
-                <fdp-input [formControl]="firstName.formControl"></fdp-input>
-            </fdp-form-field>
-            <fdp-form-field #lastName
-                id="lastName"
-                label="Last Name"
-                hint="Enter your last name."
-                zone="zTop"
-                required=true>
-                <fdp-input [formControl]="lastName.formControl"></fdp-input>
-            </fdp-form-field>
-            <fdp-form-field #favoriteColor
-                id="favoriteColor"
-                label="Favorite Color"
-                hint="What is your favorite color?"
-                zone="zBottom">
-                <fdp-input [formControl]="favoriteColor.formControl"></fdp-input>
-            </fdp-form-field>
-            <ng-template #i18n let-errors>
-                <span *ngIf="errors && errors.required" class="error">This field is required.</span>
-            </ng-template>
-        </fdp-form-group>
-        <button type="submit" #submitButton>Submit</button>
-    </form>
+        <form [formGroup]="userFormGroup" (ngSubmit)="onSubmit()">
+            <fdp-form-group
+                #userForm
+                [object]="user"
+                [formGroup]="userFormGroup"
+                [hintPlacement]="'right'"
+                [i18Strings]="i18n"
+            >
+                <fdp-form-field
+                    #firstName
+                    id="firstName"
+                    label="First Name"
+                    hint="Enter your first name."
+                    zone="zTop"
+                    required="true"
+                >
+                    <fdp-input [formControl]="firstName.formControl"></fdp-input>
+                </fdp-form-field>
+                <fdp-form-field
+                    #lastName
+                    id="lastName"
+                    label="Last Name"
+                    hint="Enter your last name."
+                    zone="zTop"
+                    required="true"
+                >
+                    <fdp-input [formControl]="lastName.formControl"></fdp-input>
+                </fdp-form-field>
+                <fdp-form-field
+                    #favoriteColor
+                    id="favoriteColor"
+                    label="Favorite Color"
+                    hint="What is your favorite color?"
+                    zone="zBottom"
+                >
+                    <fdp-input [formControl]="favoriteColor.formControl"></fdp-input>
+                </fdp-form-field>
+                <ng-template #i18n let-errors>
+                    <span *ngIf="errors && errors.required" class="error">This field is required.</span>
+                </ng-template>
+            </fdp-form-group>
+            <button type="submit" #submitButton>Submit</button>
+        </form>
     `
 })
 class SimpleFormTestComponent {
@@ -69,7 +77,7 @@ class SimpleFormTestComponent {
     public user: TestUser = {
         firstName: 'Tom',
         lastName: 'Tiny',
-        favoriteColor: 'blue',
+        favoriteColor: 'blue'
     };
 
     public result: any = null;
@@ -85,12 +93,8 @@ describe('Simple Form', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [
-                ReactiveFormsModule,
-                FdpFormGroupModule,
-                PlatformInputModule,
-            ],
-            declarations: [SimpleFormTestComponent],
+            imports: [ReactiveFormsModule, FdpFormGroupModule, PlatformInputModule],
+            declarations: [SimpleFormTestComponent]
         }).compileComponents();
     }));
 
@@ -149,12 +153,10 @@ describe('Simple Form', () => {
         expect(host.result).toEqual({
             firstName: 'Tom',
             lastName: 'Tiny',
-            favoriteColor: 'blue',
+            favoriteColor: 'blue'
         });
     });
-
 });
-
 
 @Component({
     template: `
@@ -183,20 +185,46 @@ describe('Simple Form', () => {
                     label="Street">
                     <fdp-input [formControl]="street.formControl"></fdp-input>
                 </fdp-form-field>
-                <fdp-form-field #city
-                    id="city"
-                    label="City">
-                    <fdp-input [formControl]="city.formControl"></fdp-input>
+                <fdp-form-field #lastName id="lastName" label="Last Name">
+                    <fdp-input
+                        [name]="'input_test5'"
+                        [id]="'input_test5'"
+                        [formControl]="lastName.formControl"
+                    ></fdp-input>
                 </fdp-form-field>
-                <fdp-form-field #state
-                    id="state"
-                    label="State">
-                    <fdp-input [formControl]="state.formControl"></fdp-input>
+                <fdp-form-field #favoriteColor id="favoriteColor" label="Favorite Color">
+                    <fdp-input
+                        [name]="'input_test6'"
+                        [id]="'input_test6'"
+                        [formControl]="favoriteColor.formControl"
+                    ></fdp-input>
                 </fdp-form-field>
+                <fdp-form-group #addressGroup>
+                    <fdp-form-field #street id="street" label="Street">
+                        <fdp-input
+                            [name]="'input_test7'"
+                            [id]="'input_test7'"
+                            [formControl]="street.formControl"
+                        ></fdp-input>
+                    </fdp-form-field>
+                    <fdp-form-field #city id="city" label="City">
+                        <fdp-input
+                            [name]="'input_test8'"
+                            [id]="'input_test8'"
+                            [formControl]="city.formControl"
+                        ></fdp-input>
+                    </fdp-form-field>
+                    <fdp-form-field #state id="state" label="State">
+                        <fdp-input
+                            [name]="'input_test9'"
+                            [id]="'input_test9'"
+                            [formControl]="state.formControl"
+                        ></fdp-input>
+                    </fdp-form-field>
+                </fdp-form-group>
             </fdp-form-group>
-        </fdp-form-group>
-        <button type="submit" #submitButton>Submit</button>
-    </form>
+            <button type="submit" #submitButton>Submit</button>
+        </form>
     `
 })
 class NestedFormGroupsTestComponent {
@@ -228,7 +256,6 @@ class NestedFormGroupsTestComponent {
     onSubmit(): void {
         this.result = this.userFormGroup.value;
     }
-
 }
 
 describe('Nested Form Groups', () => {
@@ -237,12 +264,8 @@ describe('Nested Form Groups', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [
-                ReactiveFormsModule,
-                FdpFormGroupModule,
-                PlatformInputModule,
-            ],
-            declarations: [NestedFormGroupsTestComponent],
+            imports: [ReactiveFormsModule, FdpFormGroupModule, PlatformInputModule],
+            declarations: [NestedFormGroupsTestComponent]
         }).compileComponents();
     }));
 
@@ -282,5 +305,4 @@ describe('Nested Form Groups', () => {
             state: 'AK'
         });
     });
-
 });

--- a/libs/platform/src/lib/components/form/input/fdp-input.module.ts
+++ b/libs/platform/src/lib/components/form/input/fdp-input.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { CommonModule } from '@angular/common';
-import { FormModule as FdFormModule } from '@fundamental-ngx/core';
 import { InputComponent } from './input.component';
+import { CommonModule } from '@angular/common';
+import { FormModule } from '@fundamental-ngx/core';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
     declarations: [InputComponent],
-    imports: [CommonModule, FormsModule, ReactiveFormsModule, FdFormModule],
+    imports: [CommonModule, FormModule, FormsModule],
     exports: [InputComponent]
 })
-export class FdpInputModule {}
+export class PlatformInputModule {}

--- a/libs/platform/src/lib/components/form/input/input.component.html
+++ b/libs/platform/src/lib/components/form/input/input.component.html
@@ -12,7 +12,10 @@
     [attr.placeholder]="placeholder"
     [disabled]="disabled"
     [compact]="contentDensity == 'compact'"
-    [state]="status === 'error' ? 'invalid' : ''"
+    [state]="status"
+    [readOnly]="readonly"
     (blur)="_onFocusChanged(false)"
     (focus)="_onFocusChanged(true)"
+    [attr.aria-label]="ariaLabel"
+    [attr.aria-labelledby]="ariaLabelledBy"
 />

--- a/libs/platform/src/lib/components/form/input/input.component.ts
+++ b/libs/platform/src/lib/components/form/input/input.component.ts
@@ -30,9 +30,9 @@ import { FormFieldControl } from '../form-control';
 import { NgControl, NgForm } from '@angular/forms';
 import { BaseInput } from '../base.input';
 
-const VALID_INPUT_TYPES = ['text', 'number', 'email'];
+const VALID_INPUT_TYPES = ['text', 'number', 'email', 'password'];
 
-export type InputType = 'text' | 'number' | 'email';
+export type InputType = 'text' | 'number' | 'email' | 'password';
 
 /**
  * Input field implementation to be compliant with our FormGroup/FormField design and also to
@@ -49,6 +49,13 @@ export class InputComponent extends BaseInput implements OnInit, AfterViewInit {
     @Input()
     type: InputType = 'text';
 
+    state: Status = 'default';
+
+    /** @hidden */
+    @ViewChild('inputElement')
+    inputElement: ElementRef;
+
+    /** return the value in the text box */
     @Input()
     get value(): any {
         return super.getValue();
@@ -56,6 +63,11 @@ export class InputComponent extends BaseInput implements OnInit, AfterViewInit {
 
     set value(value: any) {
         super.setValue(value);
+    }
+
+    /** @hidden */
+    elementRef(): ElementRef<any> {
+        return this.inputElement;
     }
 
     constructor(
@@ -70,9 +82,5 @@ export class InputComponent extends BaseInput implements OnInit, AfterViewInit {
         if (!this.type || VALID_INPUT_TYPES.indexOf(this.type) === -1) {
             throw new Error(` Input type ${this.type} is not supported`);
         }
-    }
-
-    ngAfterViewInit(): void {
-        super.ngAfterViewInit();
     }
 }

--- a/libs/platform/src/lib/components/form/input/input.component.ts
+++ b/libs/platform/src/lib/components/form/input/input.component.ts
@@ -24,9 +24,11 @@ import {
     Input,
     OnInit,
     Optional,
-    Self
+    Self,
+    ViewChild,
+    ElementRef
 } from '@angular/core';
-import { FormFieldControl } from '../form-control';
+import { FormFieldControl, Status } from '../form-control';
 import { NgControl, NgForm } from '@angular/forms';
 import { BaseInput } from '../base.input';
 

--- a/libs/platform/src/lib/components/form/input/input.component.ts
+++ b/libs/platform/src/lib/components/form/input/input.component.ts
@@ -79,6 +79,7 @@ export class InputComponent extends BaseInput implements OnInit, AfterViewInit {
     }
 
     ngOnInit(): void {
+        super.ngOnInit();
         if (!this.type || VALID_INPUT_TYPES.indexOf(this.type) === -1) {
             throw new Error(` Input type ${this.type} is not supported`);
         }


### PR DESCRIPTION
#### Please provide a link to the associated issue.

 #https://github.com/SAP/fundamental-ngx/issues/2655

#### Please provide a brief summary of this pull request.

The text input is used to enter single of text. When empty, it can hold a placeholder similar to a select component. You can define the height and width of the text input and also determine specific behaviour when handling texts.

The Input has the same features and functionality as the Input component in Fundamental NGX: Core. As such, the Platform Input component will be a wrapper around the Core Input component and will provide identical bindings as Input. Additionally, since this is an input element, it needs to implement the FormFieldControl as described in the FormGroup Layout or extend existing BaseInputComponent.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

