### PR TITLE
fix: Deprecate isDropdown flag on popover

### DIFF
--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -52,7 +52,9 @@ export class PopoverComponent {
     @HostBinding('class.fd-popover-custom--disabled')
     disabled: boolean = false;
 
-    /** Whether the popover should be treated as a dropdown. */
+    /** @deprecated
+     * Left for backward compatibility. It's going to be removed on 0.20.0
+     */
     @Input()
     isDropdown: boolean = false;
 

--- a/libs/core/src/lib/product-switch/product-switch/product-switch.component.html
+++ b/libs/core/src/lib/product-switch/product-switch/product-switch.component.html
@@ -7,7 +7,6 @@
         (isOpenChange)="openChanged($event)"
         [disabled]="disabled"
         [triggers]="triggers"
-        [isDropdown]="isDropdown"
         [focusTrapped]="false"
     >
         <fd-popover-control>

--- a/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
+++ b/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
@@ -5,7 +5,6 @@
         [closeOnOutsideClick]="closeOnOutsideClick"
         [(isOpen)]="isOpen"
         (isOpenChange)="openChanged($event)"
-        [isDropdown]="isDropdown"
         [triggers]="triggers"
         [focusTrapped]="false"
         [placement]="placement"

--- a/libs/core/src/lib/shellbar/user-menu/shellbar-user-menu.component.html
+++ b/libs/core/src/lib/shellbar/user-menu/shellbar-user-menu.component.html
@@ -9,7 +9,6 @@
             [placement]="placement"
             (isOpenChange)="openChanged($event)"
             [disabled]="disabled"
-            [isDropdown]="isDropdown"
             [focusTrapped]="false"
         >
             <fd-popover-control>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2593
#### Please provide a brief summary of this pull request.
There is deprecated isDropdown flag on popover

