### PR TITLE
fix: Add support for focus/trigger on breadcrumb overflow indicator

### DIFF
--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -7,7 +7,7 @@
 
 <ng-content></ng-content>
 
-<fd-menu #menu [placement]="placement$ | async">
+<fd-menu #menu [placement]="placement$ | async" [compact]="compact">
     <li fd-menu-item *ngFor="let collapsedBreadcrumbItem of collapsedBreadcrumbItems">
         <a fd-menu-interactive [attr.href]="collapsedBreadcrumbItem.href"
            [routerLink]="collapsedBreadcrumbItem.routerLink">

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,5 +1,6 @@
 <fd-breadcrumb-item *ngIf="collapsedBreadcrumbItems.length" [fdMenuTrigger]="menu">
-    <a fd-breadcrumb-link>...
+    <a fd-breadcrumb-link tabindex="0" (keydown)="keyDownHandle($event)">
+        ...
         <fd-icon [glyph]="'slim-arrow-down'"></fd-icon>
     </a>
 </fd-breadcrumb-item>

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -95,9 +95,9 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
     /** @hidden */
     keyDownHandle(event: KeyboardEvent): void {
         if (KeyUtil.isKey(event, 'Enter') || KeyUtil.isKey(event, ' ')) {
+            this.popoverComponent.toggle();
             event.stopPropagation();
             event.preventDefault();
-            this.popoverComponent.toggle();
         }
     }
 

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -95,9 +95,8 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
 
     /** @hidden */
     keyDownHandle(event: KeyboardEvent): void {
-        if (KeyUtil.isKey(event, 'Enter') || KeyUtil.isKey(event, ' ')) {
+        if (KeyUtil.isKey(event, ['Enter', ' '])) {
             this.popoverComponent.toggle();
-            event.stopPropagation();
             event.preventDefault();
         }
     }

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -16,8 +16,8 @@ import {
 import { BreadcrumbItemDirective } from './breadcrumb-item.directive';
 import { RtlService } from '../utils/services/rtl.service';
 import { BehaviorSubject } from 'rxjs';
-import { PopoverComponent } from '../popover/popover.component';
 import { KeyUtil } from '../utils/public_api';
+import { MenuComponent } from '../menu/menu.component';
 
 /**
  * Breadcrumb parent wrapper directive. Must have breadcrumb item child directives.
@@ -43,13 +43,18 @@ import { KeyUtil } from '../utils/public_api';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BreadcrumbComponent implements AfterContentInit, OnInit {
+
+    /** Whenever links wrapped inside overflow should be displayed in compact mode  */
+    @Input()
+    compact: boolean = false;
+
     /** @hidden */
     @ContentChildren(forwardRef(() => BreadcrumbItemDirective))
     breadcrumbItems: QueryList<BreadcrumbItemDirective>;
 
     /** @hidden */
-    @ViewChild(PopoverComponent)
-    popoverComponent: PopoverComponent;
+    @ViewChild(MenuComponent)
+    menuComponent: MenuComponent;
 
     /** @hidden */
     collapsedBreadcrumbItems: Array<BreadcrumbItemDirective> = [];
@@ -96,7 +101,7 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
     /** @hidden */
     keyDownHandle(event: KeyboardEvent): void {
         if (KeyUtil.isKey(event, ['Enter', ' '])) {
-            this.popoverComponent.toggle();
+            this.menuComponent.toggle();
             event.preventDefault();
         }
     }

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -9,12 +9,14 @@ import {
     Input,
     OnInit,
     Optional,
-    QueryList,
+    QueryList, ViewChild,
     ViewEncapsulation
 } from '@angular/core';
 import { BreadcrumbItemDirective } from './breadcrumb-item.directive';
 import { RtlService } from '../utils/services/rtl.service';
 import { BehaviorSubject } from 'rxjs';
+import { PopoverComponent } from '../popover/popover.component';
+import { KeyUtil } from '../utils/public_api';
 
 /**
  * Breadcrumb parent wrapper directive. Must have breadcrumb item child directives.
@@ -43,6 +45,10 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
     /** @hidden */
     @ContentChildren(forwardRef(() => BreadcrumbItemDirective))
     breadcrumbItems: QueryList<BreadcrumbItemDirective>;
+
+    /** @hidden */
+    @ViewChild(PopoverComponent)
+    popoverComponent: PopoverComponent;
 
     /** @hidden */
     collapsedBreadcrumbItems: Array<BreadcrumbItemDirective> = [];
@@ -84,6 +90,15 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
             this.expandBreadcrumbs();
         }
         this.previousContainerWidth = this.containerBoundary;
+    }
+
+    /** @hidden */
+    keyDownHandle(event: KeyboardEvent): void {
+        if (KeyUtil.isKey(event, 'Enter') || KeyUtil.isKey(event, ' ')) {
+            event.stopPropagation();
+            event.preventDefault();
+            this.popoverComponent.toggle();
+        }
     }
 
     /** @hidden */

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -9,7 +9,8 @@ import {
     Input,
     OnInit,
     Optional,
-    QueryList, ViewChild,
+    QueryList,
+    ViewChild,
     ViewEncapsulation
 } from '@angular/core';
 import { BreadcrumbItemDirective } from './breadcrumb-item.directive';


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/2590
blocked by: https://github.com/SAP/fundamental-ngx/pull/2572
#### Please provide a brief summary of this pull request.
there is added way to focus on overflow breadcrumb and trigger popover from there.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

