### PR TITLE
fix: Stop propagating clicks from nested icon

### DIFF
--- a/libs/core/src/lib/nested-list/nested-item/nested-item.directive.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.directive.spec.ts
@@ -171,7 +171,7 @@ describe('NestedItemDirective', () => {
     it('Should react to events from icon child', () => {
         fixture.detectChanges();
         spyOn(nestedItemListDirective, 'toggle');
-        nestedItemListDirective.contentItem.nestedExpandIcon.onClick();
+        nestedItemListDirective.contentItem.nestedExpandIcon.onClick(new MouseEvent('click'));
         fixture.detectChanges();
         expect(nestedItemListDirective.toggle).toHaveBeenCalledWith();
     });
@@ -180,7 +180,7 @@ describe('NestedItemDirective', () => {
         fixture.detectChanges();
         itemService.popover.handleOpenChange(true);
         spyOn(nestedItemPopoverDirective, 'toggle');
-        nestedItemPopoverDirective.contentItem.nestedExpandIcon.onClick();
+        nestedItemPopoverDirective.contentItem.nestedExpandIcon.onClick(new MouseEvent('click'));
         fixture.detectChanges();
         expect(nestedItemPopoverDirective.toggle).toHaveBeenCalledWith();
     });

--- a/libs/core/src/lib/nested-list/nested-list-directives.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-list-directives.spec.ts
@@ -55,7 +55,7 @@ describe('NestedListDirectives', () => {
 
         spyOn((<any>expandIconElement)._itemService.toggle, 'next');
 
-        expandIconElement.onClick();
+        expandIconElement.onClick(new MouseEvent('click'));
 
         fixture.detectChanges();
 

--- a/libs/core/src/lib/nested-list/nested-list-directives.ts
+++ b/libs/core/src/lib/nested-list/nested-list-directives.ts
@@ -111,10 +111,11 @@ export class NestedListExpandIconDirective {
     ) {}
 
     /** Mouse event handler */
-    @HostListener('click')
-    onClick(): void {
+    @HostListener('click', ['$event'])
+    onClick(event: MouseEvent): void {
         this.expanded = !this.expanded;
         this._itemService.toggle.next(this.expanded);
+        event.stopPropagation();
     }
 
     /** Handler for focus events */


### PR DESCRIPTION
#### Please provide a link to the associated issue.
relates to: https://github.com/SAP/fundamental-ngx/issues/2674
#### Please provide a brief summary of this pull request.
Click event now is not propagated upper, so it doesn't provide selected flag change.