### PR TITLE
fix: Bring IE11 support for tristate on checkbox

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -13,7 +13,10 @@
     (keydown)="checkByKey($event)"
     (keyup)="$event.stopPropagation()"
 />
-<label class="fd-checkbox__label" [for]="inputId" [class.fd-checkbox__label--compact]="compact">
+<label class="fd-checkbox__label"
+       (click)="checkByClick()"
+       [for]="inputId"
+       [class.fd-checkbox__label--compact]="compact">
     <ng-container *ngIf="label">
         {{ label }}
     </ng-container>

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -132,8 +132,8 @@ export class CheckboxComponent implements ControlValueAccessor {
     }
 
     /** @hidden Updates checkbox Indeterminate state on mouse click on IE11 */
-    public checkByClick(event: Event) {
-        this.nextValue();
+    public checkByClick() {
+        this._nextValueEvent();
     }
 
     /** @hidden Updates checkbox Indeterminate state on spacebar key on IE11 */


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Relates to https://github.com/SAP/fundamental-ngx/issues/2674
#### Descriptions
There are reverted some changes, which broken ie11 support for tristate mode on checkbox.