### PR TITLE
fix: add fix for Dialog header and footer in Mobile view

### DIFF
--- a/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.html
+++ b/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.html
@@ -1,4 +1,4 @@
-<footer fd-bar class="fd-dialog__footer" barDesign="footer" [cosy]="dialogConfig.mobile">
+<footer fd-bar class="fd-dialog__footer" barDesign="footer" [cosy]="cosy">
     <ng-container *ngTemplateOutlet="footerTemplate ? footerTemplate : defaultTemplate"></ng-container>
 
     <ng-template #defaultTemplate>

--- a/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.ts
+++ b/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.ts
@@ -16,19 +16,21 @@ import { DIALOG_CONFIG, DialogConfig } from '../dialog-utils/dialog-config.class
     templateUrl: './dialog-footer.component.html'
 })
 export class DialogFooterComponent implements AfterContentInit {
+    /** Whether the dialog footer should be displayed in mobile mode. */
+    cosy: boolean;
+
     /** @hidden */
     footerTemplate: TemplateRef<any>;
 
     /** @hidden */
     @ContentChildren(TemplateDirective) customTemplates: QueryList<TemplateDirective>;
 
-    constructor(@Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig) {
-        this.dialogConfig = this.dialogConfig || {};
-    }
+    constructor(@Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig) {}
 
     /** @hidden */
     ngAfterContentInit() {
         this._assignCustomTemplates();
+        this.cosy = this.dialogConfig ? this.dialogConfig.mobile : false;
     }
 
     /** @hidden Assign custom templates */

--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
@@ -1,6 +1,6 @@
 <header
     fd-bar
-    [cosy]="dialogConfig.mobile"
+    [cosy]="cosy"
     [class]="'fd-dialog__header'"
     [barDesign]="subHeaderTemplate ? 'header-with-subheader' : 'header'"
 >
@@ -20,6 +20,6 @@
     </ng-template>
 </header>
 
-<div fd-bar *ngIf="subHeaderTemplate" class="fd-dialog__subheader" barDesign="subheader" [cosy]="dialogConfig.mobile">
+<div fd-bar *ngIf="subHeaderTemplate" class="fd-dialog__subheader" barDesign="subheader" [cosy]="cosy">
     <ng-container *ngTemplateOutlet="subHeaderTemplate"></ng-container>
 </div>

--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.ts
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.ts
@@ -17,6 +17,9 @@ import { DIALOG_CONFIG, DialogConfig } from '../dialog-utils/dialog-config.class
     templateUrl: './dialog-header.component.html'
 })
 export class DialogHeaderComponent implements AfterContentInit {
+    /** Whether the dialog header/subheader should be displayed in mobile mode. */
+    cosy: boolean;
+
     /** @hidden */
     headerTemplate: TemplateRef<any>;
 
@@ -27,12 +30,12 @@ export class DialogHeaderComponent implements AfterContentInit {
     @ContentChildren(TemplateDirective) customTemplates: QueryList<TemplateDirective>;
 
     constructor(@Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig) {
-        this.dialogConfig = this.dialogConfig || {};
     }
 
     /** @hidden */
     ngAfterContentInit(): void {
         this._assignCustomTemplates();
+        this.cosy = this.dialogConfig ? this.dialogConfig.mobile : false;
     }
 
     /** @hidden Assign custom templates */


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/2674
#### Please provide a brief summary of this pull request.
The header, the subheader and the footer of the Dialog are using the Bar component. In Mobile view these elements should be in Cosy mode which was not the case, causing the input field to be cut. 

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md

Documentation checklist:
- [x] Documentation Examples

