### PR TITLE
fix: Fix sizing of mobile mode multi input, fix dialog components configuration passing

### DIFF
--- a/libs/core/src/lib/dialog/dialog.component.ts
+++ b/libs/core/src/lib/dialog/dialog.component.ts
@@ -67,7 +67,7 @@ export class DialogComponent implements OnInit, AfterViewInit, OnDestroy, CssCla
     @ContentChild(DialogHeaderComponent)
     set dialogHeaderConfig(component: DialogHeaderComponent) {
         if (component) {
-            component.dialogConfig = component.dialogConfig || this.dialogConfig;
+            component.dialogConfig = this.dialogConfig;
         }
     }
 
@@ -75,8 +75,8 @@ export class DialogComponent implements OnInit, AfterViewInit, OnDestroy, CssCla
     @ContentChild(DialogBodyComponent)
     set dialogBodyConfig(component: DialogBodyComponent) {
         if (component) {
-            component.dialogRef = component.dialogRef || this._dialogRef;
-            component.dialogConfig = component.dialogConfig || this.dialogConfig;
+            component.dialogRef = this._dialogRef;
+            component.dialogConfig = this.dialogConfig;
         }
     }
 
@@ -84,7 +84,7 @@ export class DialogComponent implements OnInit, AfterViewInit, OnDestroy, CssCla
     @ContentChild(DialogFooterComponent)
     set dialogFooterConfig(component: DialogFooterComponent) {
         if (component) {
-            component.dialogConfig = component.dialogConfig || this.dialogConfig;
+            component.dialogConfig = this.dialogConfig;
         }
     }
 

--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.html
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.html
@@ -8,7 +8,7 @@
             </button>
             <ng-template fdTemplate="subheader">
                 <div fd-bar-middle>
-                    <fd-bar-element [fullWidth]="true">
+                    <fd-bar-element class="custom-multi-input-mobile-control-element">
                         <ng-container *ngTemplateOutlet="childContent?.controlTemplate"></ng-container>
                     </fd-bar-element>
                     <fd-bar-element class="custom-multi-input-select-all-bar-element">

--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.scss
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.scss
@@ -2,3 +2,10 @@
 .custom-multi-input-select-all-bar-element {
     min-width: 2.25rem;
 }
+
+.custom-multi-input-mobile-control-element {
+    width: calc(100% - 2.25rem);
+    .fd-multi-input-input-group-custom {
+        width: 100%;
+    }
+}

--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
@@ -63,6 +63,8 @@ export class MultiInputMobileComponent implements OnInit, AfterViewInit, OnDestr
         if (this.multiInputConfig) {
             this._listenOnMultiInputOpenChange();
         }
+
+        console.log(this.multiInputConfig);
     }
 
     /** @hidden */
@@ -128,6 +130,7 @@ export class MultiInputMobileComponent implements OnInit, AfterViewInit, OnDestr
 
     /** @hidden */
     private _open(): void {
+        console.log(this._multiInputComponent.dialogConfig);
         this._dialogRef = this._dialogService.open(
             this.dialogTemplate,
             {

--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
@@ -63,8 +63,6 @@ export class MultiInputMobileComponent implements OnInit, AfterViewInit, OnDestr
         if (this.multiInputConfig) {
             this._listenOnMultiInputOpenChange();
         }
-
-        console.log(this.multiInputConfig);
     }
 
     /** @hidden */
@@ -130,7 +128,6 @@ export class MultiInputMobileComponent implements OnInit, AfterViewInit, OnDestr
 
     /** @hidden */
     private _open(): void {
-        console.log(this._multiInputComponent.dialogConfig);
         this._dialogRef = this._dialogService.open(
             this.dialogTemplate,
             {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Related to https://github.com/SAP/fundamental-ngx/issues/2674
#### Please provide a brief summary of this pull request.
There are 2 things changed
- Passing configuration objects to dialog components, like header/body/footer wasn't working well, so the cozy mode wasn't applied as well
- There is some weird issue with flex, so I had to hard code some styles in ngx. 
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist