### PR TITLE
fix: remove circular dependency on mobile modes

### DIFF
--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.spec.ts
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.spec.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from '@angular/core';
 import { DialogModule } from '../../dialog/dialog.module';
 import { MultiInputComponent } from '../multi-input.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MULTI_INPUT_COMPONENT } from '../multi-input.interface';
 
 describe('MultiInputMobileComponent', () => {
     let component: MultiInputMobileComponent;
@@ -33,7 +34,7 @@ describe('MultiInputMobileComponent', () => {
         TestBed.configureTestingModule({
             imports: [ DialogModule, BrowserAnimationsModule ],
             declarations: [MultiInputMobileComponent],
-            providers: [ DynamicComponentService, {provide: MultiInputComponent, useValue: mockedMultiInputComponent} ]
+            providers: [ DynamicComponentService, {provide: MULTI_INPUT_COMPONENT, useValue: mockedMultiInputComponent} ]
         })
             .compileComponents();
     }));

--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
@@ -2,7 +2,7 @@ import {
     AfterViewInit,
     ChangeDetectionStrategy,
     Component,
-    ElementRef,
+    ElementRef, Inject,
     isDevMode,
     OnDestroy,
     OnInit,
@@ -13,9 +13,9 @@ import {
 import { DialogService } from '../../dialog/dialog-service/dialog.service';
 import { DialogRef } from '../../dialog/dialog-utils/dialog-ref.class';
 import { MobileModeConfig } from '../../utils/interfaces/mobile-mode-config';
-import { MultiInputComponent } from '../multi-input.component';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { MULTI_INPUT_COMPONENT, MultiInputInterface } from '../multi-input.interface';
 
 @Component({
     selector: 'fd-multi-input-mobile',
@@ -53,7 +53,7 @@ export class MultiInputMobileComponent implements OnInit, AfterViewInit, OnDestr
 
     constructor(
         private _dialogService: DialogService,
-        private _multiInputComponent: MultiInputComponent,
+        @Inject(MULTI_INPUT_COMPONENT) private _multiInputComponent: MultiInputInterface,
         private _elementRef: ElementRef
     ) {}
 

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -7,6 +7,7 @@ import {
     EventEmitter,
     forwardRef,
     Inject,
+    Injector,
     Input,
     OnChanges,
     OnInit,
@@ -29,7 +30,8 @@ import { ListItemDirective } from '../list/list-item.directive';
 import { applyCssClass, CssClassBuilder, DynamicComponentService, KeyUtil } from '../utils/public_api';
 import { MultiInputMobileComponent } from './multi-input-mobile/multi-input-mobile.component';
 import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
-import { DIALOG_CONFIG, DialogConfig } from '../dialog/dialog-utils/dialog-config.class';
+import { DialogConfig, DIALOG_CONFIG } from '../dialog/dialog-utils/dialog-config.class';
+import { MULTI_INPUT_COMPONENT, MultiInputInterface } from './multi-input.interface';
 
 /**
  * Input field with multiple selection enabled. Should be used when a user can select between a
@@ -55,7 +57,7 @@ import { DIALOG_CONFIG, DialogConfig } from '../dialog/dialog-utils/dialog-confi
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChanges, AfterViewInit, CssClassBuilder {
+export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChanges, AfterViewInit, CssClassBuilder, MultiInputInterface {
 
     /** Placeholder for the input field. */
     @Input()
@@ -468,7 +470,7 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
             { listTemplate: this.listTemplate, controlTemplate: this.controlTemplate },
             MultiInputMobileComponent,
             { container: this._elementRef.nativeElement },
-            { services: [this] }
+            { injector: Injector.create([{ provide: MULTI_INPUT_COMPONENT, useValue: this }]) }
         );
     }
 

--- a/libs/core/src/lib/multi-input/multi-input.interface.ts
+++ b/libs/core/src/lib/multi-input/multi-input.interface.ts
@@ -9,9 +9,9 @@ export const MULTI_INPUT_COMPONENT = new InjectionToken<string[]>('MultiInputInt
  * MultiInputComponent <==> MultiInputMobileComponent
  */
 export interface MultiInputInterface {
-    selectAllItems: () => {};
-    dialogDismiss: (backup: any[]) => {};
-    dialogApprove: () => {};
+    selectAllItems: () => void;
+    dialogDismiss: (backup: any[]) => void;
+    dialogApprove: () => void;
     multiInputMobileConfig?: MobileModeConfig;
     selected: any[];
     openChange: EventEmitter<boolean>;

--- a/libs/core/src/lib/multi-input/multi-input.interface.ts
+++ b/libs/core/src/lib/multi-input/multi-input.interface.ts
@@ -1,0 +1,19 @@
+import { DialogConfig } from '../dialog/dialog-utils/dialog-config.class';
+import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
+import { EventEmitter, InjectionToken } from '@angular/core';
+
+export const MULTI_INPUT_COMPONENT = new InjectionToken<string[]>('MultiInputInterface');
+
+/**
+ * Multi Input Interface to have typing and avoid circular dependency between
+ * MultiInputComponent <==> MultiInputMobileComponent
+ */
+export interface MultiInputInterface {
+    selectAllItems: () => {};
+    dialogDismiss: (backup: any[]) => {};
+    dialogApprove: () => {};
+    multiInputMobileConfig?: MobileModeConfig;
+    selected: any[];
+    openChange: EventEmitter<boolean>;
+    dialogConfig: DialogConfig
+}

--- a/libs/core/src/lib/select/select-mobile/select-mobile/select-mobile.component.ts
+++ b/libs/core/src/lib/select/select-mobile/select-mobile/select-mobile.component.ts
@@ -1,10 +1,10 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Inject, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { DialogRef } from '../../../dialog/dialog-utils/dialog-ref.class';
 import { DialogService } from '../../../dialog/dialog-service/dialog.service';
-import { SelectComponent } from '../../select.component';
 import { Subscription } from 'rxjs';
 import { MobileModeConfig } from '../../../utils/interfaces/mobile-mode-config';
 import { OptionComponent } from '../../option/option.component';
+import { SELECT_COMPONENT, SelectInterface } from '../../select.interface';
 
 @Component({
     selector: 'fd-select-mobile',
@@ -30,7 +30,7 @@ export class SelectMobileComponent implements OnInit, AfterViewInit, OnDestroy {
     constructor(
         private _elementRef: ElementRef,
         private _dialogService: DialogService,
-        private _selectComponent: SelectComponent
+        @Inject(SELECT_COMPONENT) private _selectComponent: SelectInterface
     ) { }
 
     /** @hidden */

--- a/libs/core/src/lib/select/select.component.ts
+++ b/libs/core/src/lib/select/select.component.ts
@@ -10,6 +10,7 @@ import {
     forwardRef,
     HostListener,
     Inject,
+    Injector,
     Input,
     OnDestroy,
     OnInit,
@@ -33,6 +34,7 @@ import { DynamicComponentService } from '../utils/dynamic-component/dynamic-comp
 import { SelectMobileComponent } from './select-mobile/select-mobile/select-mobile.component';
 import { DIALOG_CONFIG, DialogConfig } from '../dialog/dialog-utils/dialog-config.class';
 import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
+import { SELECT_COMPONENT, SelectInterface } from './select.interface';
 
 let selectUniqueId: number = 0;
 
@@ -61,7 +63,7 @@ export interface OptionStatusChange {
         }
     ]
 })
-export class SelectComponent implements OnInit, AfterViewInit, AfterContentInit, OnDestroy, ControlValueAccessor {
+export class SelectComponent implements OnInit, AfterViewInit, AfterContentInit, OnDestroy, ControlValueAccessor, SelectInterface {
 
     /** Id of the control. */
     @Input()
@@ -559,7 +561,7 @@ export class SelectComponent implements OnInit, AfterViewInit, AfterContentInit,
                 this.selectOptionsListTemplate,
                 SelectMobileComponent,
                 { container: this._elementRef.nativeElement },
-                { services: [this] }
+                { injector: Injector.create([{ provide: SELECT_COMPONENT, useValue: this }]) }
             )
         }
     }

--- a/libs/core/src/lib/select/select.interface.ts
+++ b/libs/core/src/lib/select/select.interface.ts
@@ -1,0 +1,19 @@
+import { EventEmitter, InjectionToken } from '@angular/core';
+import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
+import { OptionComponent } from './option/option.component';
+import { OptionStatusChange } from './select.component';
+import { DialogConfig } from '../dialog/dialog-utils/dialog-config.class';
+
+export const SELECT_COMPONENT = new InjectionToken<string[]>('SelectInterface');
+/**
+ * Select Interface to have typing and avoid circular dependency between
+ * SelectComponent <==> SelectMobileComponent
+ */
+export interface SelectInterface {
+    mobileConfig: MobileModeConfig;
+    setSelectedOption: ({option, controlChange}: OptionStatusChange, forceMobileSelect?: boolean) => {};
+    close: () => {};
+    selected: OptionComponent;
+    dialogConfig: DialogConfig;
+    isOpenChange: EventEmitter<boolean>;
+}

--- a/libs/core/src/lib/select/select.interface.ts
+++ b/libs/core/src/lib/select/select.interface.ts
@@ -11,8 +11,8 @@ export const SELECT_COMPONENT = new InjectionToken<string[]>('SelectInterface');
  */
 export interface SelectInterface {
     mobileConfig: MobileModeConfig;
-    setSelectedOption: ({option, controlChange}: OptionStatusChange, forceMobileSelect?: boolean) => {};
-    close: () => {};
+    setSelectedOption: ({option, controlChange}: OptionStatusChange, forceMobileSelect?: boolean) => void;
+    close: () => void;
     selected: OptionComponent;
     dialogConfig: DialogConfig;
     isOpenChange: EventEmitter<boolean>;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
relates: https://github.com/SAP/fundamental-ngx/issues/2674
#### Please provide a brief summary of this pull request.
There are included interfaces of components that have mobile mode. Also the way how we provide themselves is changed, to break import of each others there is InjectionToken
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

