### PR TITLE
fix: focus over loading Busy Indicators on IE11

### DIFF
--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.html
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.html
@@ -20,6 +20,6 @@
          [class.fd-busy-indicator__overlay--transparent]="!busyIndicator?.previousElementSibling">
     </div>
 
-    <div #fakeFocusElement tabindex="0" aria-hidden="true" (focus)="fakeElementFocusHandler($event)"></div>
+    <div #fakeFocusElement tabindex="0" aria-hidden="true" (focusin)="fakeElementFocusHandler($event)"></div>
 
 </ng-container>

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
@@ -16,14 +16,9 @@
         position: relative;
 
         &:focus {
-            outline: none;
-
-            .fd-busy-indicator__overlay {
-                outline-offset: 0;
-                outline-width: var(--sapContent_FocusWidth, 0.0625rem);
-                outline-color: var(--sapContent_FocusColor, #000);
-                outline-style: var(--sapContent_FocusStyle, dotted);
-            }
+            outline-width: var(--sapContent_FocusWidth, 0.0625rem);
+            outline-color: var(--sapContent_FocusColor, #000);
+            outline-style: var(--sapContent_FocusStyle, dotted);
         }
 
         &--inline {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#2674

#### Please provide a brief summary of this pull request.
This PR changes focus event from `focus` to `focusin` because IE11 does not fully support `focus` event and moves visual focus to main Busy Indicator container.

![busy-indicator-focus](https://user-images.githubusercontent.com/17496353/84895418-92a99800-b0a2-11ea-90f4-23e1340a2e84.gif)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

