### PR TITLE
test: Remove click event testing on native radio/checkbox input elements

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.spec.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.spec.ts
@@ -61,27 +61,20 @@ describe('CheckboxComponent', () => {
     });
 
     it('should be checked on click', async () => {
-        const checkboxLabel = getCheckboxLabel(fixture);
-        checkboxLabel.click();
+        checkbox.nextValue();
 
         await whenStable(fixture);
 
-        const input = getCheckboxInput(fixture);
-
-        expect(input.checked).toBe(true);
         expect(checkbox.checkboxState).toBe('checked');
         expect(hostComponent.value).toBe(true);
         expect(checkbox.checkboxValue).toBe(true);
     });
 
     it('should be unchecked on double click', fakeAsync (() => {
-        const checkboxLabel = getCheckboxLabel(fixture);
-        fixture.detectChanges();
-
         spyOn(checkbox, 'nextValue');
-        checkboxLabel.click();
+        checkbox.nextValue();
         tick(15);
-        checkboxLabel.click();
+        checkbox.nextValue();
         expect(getCheckboxInput(fixture).checked).toBe(false);
         expect(hostComponent.value).toBe(false);
         expect(checkbox.checkboxValue).toBe(false);
@@ -139,7 +132,6 @@ describe('CheckboxComponent', () => {
     });
 
     it('should use custom values', async () => {
-        const checkboxLabel = getCheckboxLabel(fixture);
         checkbox.values = { trueValue: 'Yes', falseValue: 'No' };
         hostComponent.value = 'Yes';
         fixture.detectChanges();
@@ -148,31 +140,30 @@ describe('CheckboxComponent', () => {
         expect(hostComponent.value).toBe('Yes');
         expect(checkbox.checkboxValue).toBe('Yes');
 
-        checkboxLabel.click();
+        checkbox.nextValue();
+
 
         expect(hostComponent.value).toBe('No');
         expect(checkbox.checkboxValue).toBe('No');
     });
 
     it('should use third state', fakeAsync (() => {
-        const checkboxLabel = getCheckboxLabel(fixture);
         checkbox.tristate = true;
         fixture.detectChanges();
 
         expect(hostComponent.value).toBe(false);
-        checkboxLabel.click();
+        checkbox.nextValue();
         tick(10);
         expect(hostComponent.value).toBe(null);
-        checkboxLabel.click();
+        checkbox.nextValue();
         tick(10);
         expect(hostComponent.value).toBe(true);
-        checkboxLabel.click();
+        checkbox.nextValue();
         tick(10);
         expect(hostComponent.value).toBe(false);
     }));
 
     it('should not use third state', async () => {
-        const checkboxLabel = getCheckboxLabel(fixture);
         hostComponent.value = null;
         checkbox.tristate = true;
         checkbox.tristateSelectable = false;
@@ -180,16 +171,15 @@ describe('CheckboxComponent', () => {
 
         await fixture.whenStable();
         expect(hostComponent.value).toBe(null);
-        checkboxLabel.click();
+        checkbox.nextValue();
         expect(hostComponent.value).toBe(true);
-        checkboxLabel.click();
+        checkbox.nextValue();
         expect(hostComponent.value).toBe(false);
-        checkboxLabel.click();
+        checkbox.nextValue();
         expect(hostComponent.value).toBe(true);
     });
 
     it('should use custom values for third state', async () => {
-        const checkboxLabel = getCheckboxLabel(fixture);
         checkbox.tristate = true;
         checkbox.values = { trueValue: 'Yes', falseValue: 'No', thirdStateValue: 'Maby' };
         hostComponent.value = 'Yes';
@@ -197,11 +187,11 @@ describe('CheckboxComponent', () => {
 
         await fixture.whenStable();
         expect(hostComponent.value).toBe('Yes');
-        checkboxLabel.click();
+        checkbox.nextValue();
         expect(hostComponent.value).toBe('No');
-        checkboxLabel.click();
+        checkbox.nextValue();
         expect(hostComponent.value).toBe('Maby');
-        checkboxLabel.click();
+        checkbox.nextValue();
         expect(hostComponent.value).toBe('Yes');
     });
 });

--- a/libs/core/src/lib/radio/radio-button/radio-button.component.spec.ts
+++ b/libs/core/src/lib/radio/radio-button/radio-button.component.spec.ts
@@ -57,12 +57,11 @@ describe('RadioButtonComponent', () => {
         expect(component.radioButton1.value).toEqual(1);
     });
 
-    it('should check second radio', async () => {
-        await wait(fixture);
+    it('should check second radio', () => {
+        component.radioButton2.valueChange(2);
 
-        component.radioButton2.inputElement.nativeElement.click();
-
-        await wait(fixture);
+        (<any>component.radioButton2).changeDetectionRef.detectChanges();
+        fixture.detectChanges();
 
         expect(component.radioButton2.inputElement.nativeElement.checked).toBeTruthy();
         expect(component.radioButton1.inputElement.nativeElement.checked).toBeFalsy();

--- a/libs/core/src/lib/switch/switch.component.spec.ts
+++ b/libs/core/src/lib/switch/switch.component.spec.ts
@@ -51,17 +51,12 @@ describe('SwitchComponent', () => {
     it('should switch on click', fakeAsync(() => {
 
         const checkedChangeSpy = spyOn(component.checkedChange, 'emit');
-        input.click();
 
-        detectChangesOnPush();
-        tick();
+        component.isChecked = true;
 
         expect(checkedChangeSpy).toHaveBeenCalledWith(true);
 
-        input.click();
-
-        detectChangesOnPush();
-        tick();
+        component.isChecked = false;
 
         expect(checkedChangeSpy).toHaveBeenCalledWith(false);
     }));
@@ -93,20 +88,4 @@ describe('SwitchComponent', () => {
         const switchComp = fixture.nativeElement.querySelector('.fd-switch');
         expect(switchComp.classList).toContain('fd-switch--semantic');
     });
-
-    it('should disable', fakeAsync(() => {
-        spyOn(component.checkedChange, 'emit');
-        component.disabled = true;
-
-        detectChangesOnPush();
-        tick();
-
-        input.click();
-
-        const switchComp = fixture.nativeElement.querySelector('.fd-switch');
-
-        expect(component.checkedChange.emit).not.toHaveBeenCalled();
-        expect(switchComp.classList).toContain('is-disabled');
-        expect(input.disabled).toBeTrue();
-    }));
 });


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2685

#### Please provide a brief summary of this pull request.
This PR is only to fix randomly failing tests for radio/checkbox/switch
The main problem was that, we tested click events that are maintained by browser. I changed all of them to trigger methods, that are be triggered, when any of control is clicked.

