### PR TITLE
fix: Remove max-width limits from dropdown

### DIFF
--- a/libs/core/src/lib/list/list.component.scss
+++ b/libs/core/src/lib/list/list.component.scss
@@ -523,3 +523,7 @@
     border-bottom-right-radius: .25rem;
     border-bottom-right-radius: var(--sapElement_BorderCornerRadius,.25rem)
 }
+
+.fd-list--dropdown {
+    max-width: 100%;
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
relates: https://github.com/SAP/fundamental-ngx/issues/2674
#### Please provide a brief summary of this pull request.
There is removed limit for max-width of dropdowns
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md