### PR TITLE
Fix panel expanded binding

### DIFF
--- a/libs/core/src/lib/panel/panel-expand/panel-expand.component.spec.ts
+++ b/libs/core/src/lib/panel/panel-expand/panel-expand.component.spec.ts
@@ -16,7 +16,6 @@ describe('PanelExpandComponent', () => {
 
     beforeEach(async(() => {
         const panelSpy = jasmine.createSpyObj('PanelService', ['updateExpanded']);
-        const mockExpandedObservable = new BehaviorSubject(false);
 
         TestBed.configureTestingModule({
             declarations: [PanelExpandComponent],
@@ -24,7 +23,7 @@ describe('PanelExpandComponent', () => {
         }).compileComponents();
 
         panelServiceSpy = TestBed.get(PanelService);
-        panelServiceSpy.expanded$ = mockExpandedObservable;
+        panelServiceSpy.expanded$ = new BehaviorSubject({isExpanded: false, isExpandTriggerClick: false});
     }));
 
     beforeEach(() => {
@@ -47,7 +46,7 @@ describe('PanelExpandComponent', () => {
     it('should call the Panel Service with the correct value', () => {
         button.nativeElement.click();
         fixture.detectChanges();
-        expect(panelServiceSpy.updateExpanded).toHaveBeenCalledWith(true);
+        expect(panelServiceSpy.updateExpanded).toHaveBeenCalledWith(true, true);
     });
 
     it('should expand the button when clicked', () => {

--- a/libs/core/src/lib/panel/panel-expand/panel-expand.component.ts
+++ b/libs/core/src/lib/panel/panel-expand/panel-expand.component.ts
@@ -71,6 +71,7 @@ export class PanelExpandComponent implements OnInit, OnDestroy {
         this._panelService.updateExpanded(this.expanded, true);
     }
 
+    /** @hidden */
     private _listenOnExpandedChange(): void {
         this._subscription = this._panelService.expanded$
             .pipe(filter(value => !value.isExpandTriggerClick))

--- a/libs/core/src/lib/panel/panel.component.spec.ts
+++ b/libs/core/src/lib/panel/panel.component.spec.ts
@@ -35,7 +35,6 @@ describe('PanelComponent', () => {
 
     beforeEach(async(() => {
         const panelSpy = jasmine.createSpyObj('PanelService', ['updateExpanded']);
-        const mockExpandedObservable = new BehaviorSubject(false);
 
         TestBed.configureTestingModule({
             declarations: [TestComponent],
@@ -44,7 +43,7 @@ describe('PanelComponent', () => {
         }).compileComponents();
 
         panelServiceSpy = TestBed.get(PanelService);
-        panelServiceSpy.expanded$ = mockExpandedObservable;
+        panelServiceSpy.expanded$ = new BehaviorSubject({isExpanded: false, isExpandTriggerClick: false});
     }));
 
     beforeEach(() => {

--- a/libs/core/src/lib/panel/panel.component.ts
+++ b/libs/core/src/lib/panel/panel.component.ts
@@ -3,17 +3,20 @@ import {
     ChangeDetectorRef,
     Component,
     ElementRef,
+    EventEmitter,
     HostBinding,
     Input,
     OnChanges,
     OnDestroy,
     OnInit,
+    Output,
     SimpleChanges,
     ViewEncapsulation
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { applyCssClass, CssClassBuilder } from '../utils/public_api';
 import { PanelService } from './panel.service';
+import { filter } from 'rxjs/operators';
 
 let panelUniqueId: number = 0;
 
@@ -50,8 +53,12 @@ export class PanelComponent implements CssClassBuilder, OnChanges, OnInit, OnDes
     id: string = 'fd-panel-' + panelUniqueId++;
 
     /** Whether the Panel Content is expanded */
-    @Input() 
+    @Input()
     expanded: boolean = false;
+
+    /** Emits event when expanded state has been changed */
+    @Output()
+    expandedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
     /** @hidden */
     private _subscription: Subscription;
@@ -66,18 +73,17 @@ export class PanelComponent implements CssClassBuilder, OnChanges, OnInit, OnDes
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
-        this._subscription = this._panelService.expanded$.subscribe((value) => {
-            this.expanded = value;
-            this._cdRef.detectChanges();
-        });
+        this._listenOnExpandedChange();
     }
 
     /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
-        this.buildComponentCssClass();
+        if (changes && changes.class) {
+            this.buildComponentCssClass();
+        }
 
         if (changes && changes.expanded) {
-            this._panelService.updateExpanded(this.expanded);
+            this._panelService.updateExpanded(this.expanded, false);
         }
     }
 
@@ -102,5 +108,15 @@ export class PanelComponent implements CssClassBuilder, OnChanges, OnInit, OnDes
     /** @hidden */
     elementRef(): ElementRef<any> {
         return this._elementRef;
+    }
+
+    private _listenOnExpandedChange(): void {
+        this._subscription = this._panelService.expanded$
+            .pipe(filter(value => value.isExpandTriggerClick))
+            .subscribe(value => {
+                this.expanded = value.isExpanded;
+                this.expandedChange.emit(this.expanded);
+                this._cdRef.detectChanges();
+            });
     }
 }

--- a/libs/core/src/lib/panel/panel.component.ts
+++ b/libs/core/src/lib/panel/panel.component.ts
@@ -78,9 +78,7 @@ export class PanelComponent implements CssClassBuilder, OnChanges, OnInit, OnDes
 
     /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
-        if (changes && changes.class) {
-            this.buildComponentCssClass();
-        }
+        this.buildComponentCssClass();
 
         if (changes && changes.expanded) {
             this._panelService.updateExpanded(this.expanded, false);
@@ -89,9 +87,7 @@ export class PanelComponent implements CssClassBuilder, OnChanges, OnInit, OnDes
 
     /** @hidden */
     ngOnDestroy(): void {
-        if (this._subscription) {
-            this._subscription.unsubscribe();
-        }
+        this._subscription.unsubscribe();
     }
 
     @applyCssClass
@@ -110,6 +106,7 @@ export class PanelComponent implements CssClassBuilder, OnChanges, OnInit, OnDes
         return this._elementRef;
     }
 
+    /** @hidden */
     private _listenOnExpandedChange(): void {
         this._subscription = this._panelService.expanded$
             .pipe(filter(value => value.isExpandTriggerClick))

--- a/libs/core/src/lib/panel/panel.service.ts
+++ b/libs/core/src/lib/panel/panel.service.ts
@@ -1,15 +1,17 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
+interface ExpandedChange {
+    isExpanded: boolean
+    isExpandTriggerClick: boolean
+}
+
 @Injectable()
 export class PanelService {
-    isExpanded: boolean = false;
-    expanded$: BehaviorSubject<boolean> = new BehaviorSubject(this.isExpanded);
+    expanded$ = new BehaviorSubject<ExpandedChange>({isExpanded: false, isExpandTriggerClick: false});
 
     /** Whether the Panel is expanded */
-    updateExpanded(value: boolean) {
-        value === this.isExpanded ? this.isExpanded = !value : this.isExpanded = value
-        
-        this.expanded$.next(this.isExpanded);
+    updateExpanded(isExpanded: boolean, byUser: boolean) {
+        this.expanded$.next({ isExpanded: isExpanded, isExpandTriggerClick: byUser });
     }
 }


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.

Current Panel implementation does not support `expanded` two-way binding and includes duplicate `expanded` state settings inside PanelComponent logic, for example within `PanelExpandComponent`:

 => `PanelExpand.click()`
 => `set expanded state`
 => `updateExpanded`
 => `updateExpandedListener`
 => `set expanded state`

The problem was there was no way to distinguish if the expanded event is coming from outside or inside of the components and it has been resolved with adding `isExpandTriggerClick` parameter to internal expand event.

I think it is a little bit over-complicated but I cannot find other quick solution.