### PR TITLE
fix: Change addon place on multi input, remove doubled padding from dropdown list on multi input

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -14,9 +14,9 @@
     (keyup)="$event.stopPropagation()"
 />
 <label class="fd-checkbox__label"
+       #labelElement
        (click)="checkByClick()"
        [for]="inputId"
-       [class.fd-list__label]="checkboxInList"
        [class.fd-checkbox__label--compact]="compact">
     <ng-container *ngIf="label">
         {{ label }}

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -16,6 +16,7 @@
 <label class="fd-checkbox__label"
        (click)="checkByClick()"
        [for]="inputId"
+       [class.fd-list__label]="checkboxInList"
        [class.fd-checkbox__label--compact]="compact">
     <ng-container *ngIf="label">
         {{ label }}

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -66,6 +66,10 @@ export class CheckboxComponent implements ControlValueAccessor {
     @Input()
     tristateSelectable: boolean = true;
 
+    /** Whenever the checkbox is used inside list, it applies another class to label */
+    @Input()
+    checkboxInList: boolean = false;
+
     /** Sets values returned by control. */
     @Input('values')
     set _values(checkboxValues: FdCheckboxValues) {

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -31,11 +31,11 @@ let checkboxUniqueId: number = 0;
 })
 export class CheckboxComponent implements ControlValueAccessor {
     /** @hidden */
-    @ViewChild('inputLabel', { static: false })
+    @ViewChild('inputLabel')
     inputLabel: ElementRef;
 
     /** @hidden */
-    @ViewChild('labelElement', { static: false })
+    @ViewChild('labelElement')
     labelElement: ElementRef;
 
     /** Sets [id] property of input, binds input with input label using [for] property. */

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -32,7 +32,11 @@ let checkboxUniqueId: number = 0;
 export class CheckboxComponent implements ControlValueAccessor {
     /** @hidden */
     @ViewChild('inputLabel', { static: false })
+
     inputLabel: ElementRef;
+    /** @hidden */
+    @ViewChild('labelElement', { static: false })
+    labelElement: ElementRef;
 
     /** Sets [id] property of input, binds input with input label using [for] property. */
     @Input()
@@ -65,10 +69,6 @@ export class CheckboxComponent implements ControlValueAccessor {
     /** Allows to prevent user from manually selecting controls third state. */
     @Input()
     tristateSelectable: boolean = true;
-
-    /** Whenever the checkbox is used inside list, it applies another class to label */
-    @Input()
-    checkboxInList: boolean = false;
 
     /** Sets values returned by control. */
     @Input('values')

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -32,8 +32,8 @@ let checkboxUniqueId: number = 0;
 export class CheckboxComponent implements ControlValueAccessor {
     /** @hidden */
     @ViewChild('inputLabel', { static: false })
-
     inputLabel: ElementRef;
+
     /** @hidden */
     @ViewChild('labelElement', { static: false })
     labelElement: ElementRef;

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -86,7 +86,6 @@
             [selected]="selected.indexOf(value) !== -1"
         >
             <fd-checkbox
-                [checkboxInList]="true"
                 [ngModel]="selected ? selected.indexOf(value) !== -1 : false"
                 class="fd-multi-input-checkbox"
                 (keydown)="handleKeyDown($event, ind)"

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -36,8 +36,11 @@
         [button]="true"
         [compact]="compact"
         [disabled]="disabled"
+        [isExpanded]="open"
+        [isControl]="true"
+        [glyph]="glyph"
         (click)="openChangeHandle(!open || mobile)">
-        <fd-tokenizer [compact]="compact" [class]="'fd-multi-input-tokenizer-custom'" [glyph]="glyph">
+        <fd-tokenizer [compact]="compact" [class]="'fd-multi-input-tokenizer-custom'" >
             <fd-token
                 *ngFor="let token of selected"
                 [compact]="compact"
@@ -68,7 +71,7 @@
 <ng-template #list>
     <ul
         fd-list
-        class="fd-multi-input-menu-overflow"
+        class="fd-list--multi-input fd-multi-input-menu-overflow"
         *ngIf="displayedValues && displayedValues.length"
         [style.maxHeight]="!mobile ? maxHeight : 'auto'"
     >
@@ -80,6 +83,7 @@
             [selected]="selected.indexOf(value) !== -1"
         >
             <fd-checkbox
+                [checkboxInList]="true"
                 [ngModel]="selected ? selected.indexOf(value) !== -1 : false"
                 class="fd-multi-input-checkbox"
                 (keydown)="handleKeyDown($event, ind)"

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -36,11 +36,14 @@
         [button]="true"
         [compact]="compact"
         [disabled]="disabled"
-        [isExpanded]="open"
+        [isExpanded]="open && !mobile"
         [isControl]="true"
         [glyph]="glyph"
         (click)="openChangeHandle(!open || mobile)">
-        <fd-tokenizer [compact]="compact" [class]="'fd-multi-input-tokenizer-custom'" >
+        <fd-tokenizer [compact]="compact"
+                      class="fd-multi-input-tokenizer-custom"
+                      [class.fd-multi-input-tokenizer-custom--compact]="compact"
+        >
             <fd-token
                 *ngFor="let token of selected"
                 [compact]="compact"

--- a/libs/core/src/lib/multi-input/multi-input.component.scss
+++ b/libs/core/src/lib/multi-input/multi-input.component.scss
@@ -1,7 +1,7 @@
 //TODO evaluate whether this should be in fd-styles
 
 .fd-multi-input-tokenizer-custom {
-    width: 100%;
+    width: calc(100% - 2.25rem);
 }
 
 .fd-multi-input-input-group-custom {
@@ -13,6 +13,7 @@
 
     .fd-multi-input-item {
         cursor: pointer;
+        padding: 0;
     }
 
     .fd-multi-input-popover-size {

--- a/libs/core/src/lib/multi-input/multi-input.component.scss
+++ b/libs/core/src/lib/multi-input/multi-input.component.scss
@@ -2,6 +2,9 @@
 
 .fd-multi-input-tokenizer-custom {
     width: calc(100% - 2.25rem);
+    &--compact {
+        width: calc(100% - 2rem);
+    }
 }
 
 .fd-multi-input-input-group-custom {

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -9,7 +9,7 @@ import {
     Inject,
     Injector,
     Input,
-    OnChanges,
+    OnChanges, OnDestroy,
     OnInit,
     Optional,
     Output,
@@ -32,6 +32,8 @@ import { MultiInputMobileComponent } from './multi-input-mobile/multi-input-mobi
 import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
 import { DialogConfig, DIALOG_CONFIG } from '../dialog/dialog-utils/dialog-config.class';
 import { MULTI_INPUT_COMPONENT, MultiInputInterface } from './multi-input.interface';
+import { CheckboxComponent } from '../checkbox/checkbox/checkbox.component';
+import { Subscription } from 'rxjs';
 
 /**
  * Input field with multiple selection enabled. Should be used when a user can select between a
@@ -57,7 +59,14 @@ import { MULTI_INPUT_COMPONENT, MultiInputInterface } from './multi-input.interf
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChanges, AfterViewInit, CssClassBuilder, MultiInputInterface {
+export class MultiInputComponent implements
+    OnInit,
+    ControlValueAccessor,
+    OnChanges,
+    AfterViewInit,
+    CssClassBuilder,
+    MultiInputInterface,
+    OnDestroy {
 
     /** Placeholder for the input field. */
     @Input()
@@ -178,6 +187,9 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
     @ViewChild(PopoverComponent)
     popoverRef: PopoverComponent;
 
+    @ViewChildren(CheckboxComponent)
+    checkboxComponents: QueryList<CheckboxComponent>;
+
     /** @hidden */
     @ViewChild('control', { read: TemplateRef })
     controlTemplate: TemplateRef<any>;
@@ -201,6 +213,9 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
     focusTrap: FocusTrap;
 
     /** @hidden */
+    private _subscriptions = new Subscription();
+
+    /** @hidden */
     onChange: Function = () => {
     };
 
@@ -215,8 +230,7 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
         private _changeDetRef: ChangeDetectorRef,
         private _menuKeyboardService: MenuKeyboardService,
         private _dynamicComponentService: DynamicComponentService
-    ) {
-    }
+    ) {}
 
     /** @hidden */
     ngOnInit() {
@@ -247,6 +261,12 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
         if (this.mobile) {
             this._setUpMobileMode();
         }
+        this.setUpCheckboxSubscription();
+    }
+
+    /** @hidden */
+    ngOnDestroy(): void {
+        this._subscriptions.unsubscribe();
     }
 
     @applyCssClass
@@ -448,6 +468,20 @@ export class MultiInputComponent implements OnInit, ControlValueAccessor, OnChan
         } else {
             this.focusTrap.deactivate();
         }
+    }
+
+    /** @hidden */
+    private _applyClassToCheckboxes(): void {
+        this.checkboxComponents.forEach(
+            _checkbox => _checkbox.labelElement.nativeElement.classList.add('fd-list__label')
+        );
+    }
+
+    /** @hidden */
+    private setUpCheckboxSubscription(): void {
+        this._subscriptions.add(
+            this.checkboxComponents.changes.subscribe(() => this._applyClassToCheckboxes())
+        );
     }
 
     /** @hidden */

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -9,7 +9,8 @@ import {
     Inject,
     Injector,
     Input,
-    OnChanges, OnDestroy,
+    OnChanges,
+    OnDestroy,
     OnInit,
     Optional,
     Output,
@@ -187,6 +188,7 @@ export class MultiInputComponent implements
     @ViewChild(PopoverComponent)
     popoverRef: PopoverComponent;
 
+    /** @hidden */
     @ViewChildren(CheckboxComponent)
     checkboxComponents: QueryList<CheckboxComponent>;
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Related to: https://github.com/SAP/fundamental-ngx/issues/2674
#### Please provide a brief summary of this pull request.
There was addon button rendered in tokenizer, instead of input group.
Also the checkbox should now if it's used in list component, to apply paddings and change focus outline.
Before:
![image](https://user-images.githubusercontent.com/26483208/85037911-420b6b00-b186-11ea-957b-efafb6603556.png)

After:
![image](https://user-images.githubusercontent.com/26483208/85037849-2c964100-b186-11ea-9cb7-bd562313d6b8.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

