### PR TITLE
fix: pagination layout and dot hover issues

### DIFF
--- a/libs/core/src/lib/pagination/pagination.component.html
+++ b/libs/core/src/lib/pagination/pagination.component.html
@@ -1,49 +1,51 @@
+<ng-container ngPreserveWhitespaces>
 <span class="fd-pagination__total" [ngClass]="customClasses" *ngIf="displayTotalItems && totalItems">
     {{ totalItems }} {{ displayText }}
 </span>
-<nav class="fd-pagination__nav" *ngIf="totalItems && totalItems >= itemsPerPage">
-    <a
-        class="fd-pagination__link fd-pagination__link--previous"
-        tabindex="0"
-        role="button"
-        [attr.aria-label]="previousLabel"
-        [attr.aria-disabled]="currentPage === 1 ? true : null"
-        (keypress)="onKeypressHandler(currentPage - 1, $event)"
-        (click)="goToPage(currentPage - 1)"
-    >
-    </a>
-    <div dir="ltr" class="fd-pagination-direction-override-display">
-        <ng-container *ngFor="let page of pages$ | async">
-            <a
-                class="fd-pagination__link"
-                tabindex="0"
-                role="button"
-                (keypress)="onKeypressHandler(page, $event)"
-                (click)="goToPage(page, $event)"
-                *ngIf="page !== -1; else more"
-                [attr.aria-selected]="currentPage === page"
-            >
-                {{ page }}
-            </a>
-        </ng-container>
-    </div>
-    <a
-        class="fd-pagination__link fd-pagination__link--next"
-        [attr.aria-label]="nextLabel"
-        tabindex="0"
-        role="button"
-        [attr.aria-disabled]="isLastPage$ | async"
-        (keypress)="onKeypressHandler(currentPage + 1, $event)"
-        (click)="goToPage(currentPage + 1)"
-    >
-    </a>
-</nav>
+    <nav class="fd-pagination__nav" *ngIf="totalItems && totalItems >= itemsPerPage">
+        <a
+            class="fd-pagination__link fd-pagination__link--previous"
+            tabindex="0"
+            role="button"
+            [attr.aria-label]="previousLabel"
+            [attr.aria-disabled]="currentPage === 1 ? true : null"
+            (keypress)="onKeypressHandler(currentPage - 1, $event)"
+            (click)="goToPage(currentPage - 1)"
+        >
+        </a>
+        <div dir="ltr" class="fd-pagination-direction-override-display">
+            <ng-container *ngFor="let page of pages$ | async">
+                <a
+                    class="fd-pagination__link"
+                    tabindex="0"
+                    role="button"
+                    (keypress)="onKeypressHandler(page, $event)"
+                    (click)="goToPage(page, $event)"
+                    *ngIf="page !== -1; else more"
+                    [attr.aria-selected]="currentPage === page"
+                >
+                    {{ page }}
+                </a>
+            </ng-container>
+        </div>
+        <a
+            class="fd-pagination__link fd-pagination__link--next"
+            [attr.aria-label]="nextLabel"
+            tabindex="0"
+            role="button"
+            [attr.aria-disabled]="isLastPage$ | async"
+            (keypress)="onKeypressHandler(currentPage + 1, $event)"
+            (click)="goToPage(currentPage + 1)"
+        >
+        </a>
+    </nav>
 
-<ng-template #more>
+    <ng-template #more>
     <span
-        class="fd-pagination__link fd-pagination__more"
+        class="fd-pagination__more"
         aria-hidden="true"
         aria-label="..."
         role="presentation"
     ></span>
-</ng-template>
+    </ng-template>
+</ng-container>


### PR DESCRIPTION
#### Please provide a link to the associated issue.

fixes #2736 

#### Please provide a brief summary of this pull request.

Angular was stripping whitespace from the pagination template, which inline-block needs to display the pagination numbers correctly.  Also removes the pagination link class from the ellipses.

Before:
![Screen Shot 2020-06-23 at 1 21 24 PM](https://user-images.githubusercontent.com/2471874/85468751-13b4d380-b56a-11ea-9a1c-164f9ca4731e.png)

After:
![Screen Shot 2020-06-23 at 3 55 54 PM](https://user-images.githubusercontent.com/2471874/85468763-17485a80-b56a-11ea-83f5-c11142db1517.png)