### PR TITLE
fix: super call error when using NotificationComponent

### DIFF
--- a/libs/core/src/lib/notification/notification/notification.component.ts
+++ b/libs/core/src/lib/notification/notification/notification.component.ts
@@ -83,7 +83,6 @@ export class NotificationComponent extends AbstractFdNgxClass implements AfterVi
         @Optional() private notificationRef: NotificationRef
     ) {
         super(elRef);
-        // @ts-ignore
         this._setNotificationConfig(notificationConfig);
     }
 

--- a/libs/core/src/lib/notification/notification/notification.component.ts
+++ b/libs/core/src/lib/notification/notification/notification.component.ts
@@ -82,9 +82,9 @@ export class NotificationComponent extends AbstractFdNgxClass implements AfterVi
         @Optional() private notificationConfig: NotificationConfig,
         @Optional() private notificationRef: NotificationRef
     ) {
+        super(elRef);
         // @ts-ignore
         this._setNotificationConfig(notificationConfig);
-        super(elRef);
     }
 
     ngAfterViewInit(): void {


### PR DESCRIPTION
#### Please provide a link to the associated issue.

[#2755](https://github.com/SAP/fundamental-ngx/issues/2755)

#### Please provide a brief summary of this pull request.

Fix for super call in NotificationComponent
Moved it to the top of constructor

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

