### PR TITLE
docs: add depreciation alert for Mega Menu and Select Native

### DIFF
--- a/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-docs.module.ts
@@ -10,7 +10,7 @@ import {
     MegaMenuGroupExampleComponent,
     MegaMenuPositionExampleComponent
 } from './examples/mega-menu-examples.component';
-import { MegaMenuModule } from '@fundamental-ngx/core';
+import { MegaMenuModule, MessageStripModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -24,7 +24,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-    imports: [RouterModule.forChild(routes), SharedDocumentationModule, MegaMenuModule],
+    imports: [RouterModule.forChild(routes), SharedDocumentationModule, MegaMenuModule, MessageStripModule],
     exports: [RouterModule],
     declarations: [
         MegaMenuDocsComponent,

--- a/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-header/mega-menu-header.component.html
+++ b/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-header/mega-menu-header.component.html
@@ -1,4 +1,7 @@
 <header>Mega Menu</header>
+<fd-message-strip [type]="'warning'" [dismissible]="false">
+    DEPRECATED. Mega Menu is now depricated. Please refer to <a [routerLink]="'/core/menu'">Menu</a> component.
+</fd-message-strip>
 <description>
     Mega Menu is extended menu component, which contains sub lists. The Mega Menu component provides fully keyboard
     support. Arrow Left and Arrow Right opens/closes sublist.

--- a/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-header/mega-menu-header.component.html
+++ b/apps/docs/src/app/core/component-docs/mega-menu/mega-menu-header/mega-menu-header.component.html
@@ -1,6 +1,6 @@
 <header>Mega Menu</header>
 <fd-message-strip [type]="'warning'" [dismissible]="false">
-    DEPRECATED. Mega Menu is now depricated. Please refer to <a [routerLink]="'/core/menu'">Menu</a> component.
+    DEPRECATED. Mega Menu is now deprecated. Please refer to <a [routerLink]="'/core/menu'">Menu</a> component.
 </fd-message-strip>
 <description>
     Mega Menu is extended menu component, which contains sub lists. The Mega Menu component provides fully keyboard

--- a/apps/docs/src/app/core/component-docs/select-native/select-native-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/select-native/select-native-docs.module.ts
@@ -11,7 +11,7 @@ import {
 import { SelectNativeFormGroupExampleComponent } from './examples/select-native-form-group-example.component';
 import { SelectNativeHeaderComponent } from './select-native-header/select-native-header.component';
 import { SelectNativeDocsComponent } from './select-native-docs.component';
-import { FormModule } from '@fundamental-ngx/core';
+import { FormModule, MessageStripModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -25,7 +25,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-    imports: [RouterModule.forChild(routes), SharedDocumentationModule, FormModule],
+    imports: [RouterModule.forChild(routes), SharedDocumentationModule, FormModule, MessageStripModule],
     exports: [RouterModule],
     declarations: [
         SelectNativeDocsComponent,

--- a/apps/docs/src/app/core/component-docs/select-native/select-native-header/select-native-header.component.html
+++ b/apps/docs/src/app/core/component-docs/select-native/select-native-header/select-native-header.component.html
@@ -1,4 +1,7 @@
 <header>Select Native</header>
+<fd-message-strip [type]="'warning'" [dismissible]="false">
+    DEPRECATED. Select Native is now depricated. Please refer to <a [routerLink]="'/core/select'">Select</a> component.
+</fd-message-strip>
 <description
     >The Select is native html component similar to a dropdown but is more commonly used within a form. It can also be
     set several states.

--- a/apps/docs/src/app/core/component-docs/select-native/select-native-header/select-native-header.component.html
+++ b/apps/docs/src/app/core/component-docs/select-native/select-native-header/select-native-header.component.html
@@ -1,6 +1,6 @@
 <header>Select Native</header>
 <fd-message-strip [type]="'warning'" [dismissible]="false">
-    DEPRECATED. Select Native is now depricated. Please refer to <a [routerLink]="'/core/select'">Select</a> component.
+    DEPRECATED. Select Native is now deprecated. Please refer to <a [routerLink]="'/core/select'">Select</a> component.
 </fd-message-strip>
 <description
     >The Select is native html component similar to a dropdown but is more commonly used within a form. It can also be


### PR DESCRIPTION
#### Related issue
Part of https://github.com/SAP/fundamental-ngx/issues/2777

#### Please provide a brief summary of this pull request.
Mega Menu and Select Native are deprecated. An alert has been added to both components