### PR TITLE
fix: remove rounded corners for the first element of Select component

### DIFF
--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -18,3 +18,7 @@
         max-width: inherit;
     }
 }
+
+.fd-popover__body > :first-child {
+    border-radius: 0;
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/2777

#### Please provide a brief summary of this pull request.
The first element of the Popover body had rounded corners. They have been removed. 

