### PR TITLE
fix: update busy indicator background

### DIFF
--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
@@ -33,7 +33,7 @@
         left: 0;
         right: 0;
         z-index: 1;
-        background-color: rgba(247, 247, 247, 0.72);
+        background-color: rgba(0,0,0,0.3);
 
         &--transparent {
             background-color: transparent;


### PR DESCRIPTION
update busy indicator background - it doesn't look to white in fiori 3 dark theme