### PR TITLE
fix: add disabled state to tabs

### DIFF
--- a/apps/docs/src/app/core/component-docs/tabs/examples/tabs-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tabs-example.component.html
@@ -3,7 +3,7 @@
     <fd-tab [title]="'Link 1'">
         Content for tab 1
     </fd-tab>
-    <fd-tab [title]="'Link 2'">
+    <fd-tab [disabled]="true" [title]="'Link 2'">
         Content for tab 2
     </fd-tab>
     <fd-tab [title]="'Link 3'">
@@ -19,7 +19,7 @@
     <fd-tab [title]="'Success'" [tabState]="'success'">
         Content for tab 1
     </fd-tab>
-    <fd-tab [title]="'Error'" [tabState]="'error'">
+    <fd-tab [disabled]="true" [title]="'Error'" [tabState]="'error'">
         Content for tab 2
     </fd-tab>
     <fd-tab [title]="'Warning'" [tabState]="'warning'">
@@ -44,7 +44,7 @@
         </ng-template>
         Content for tab 1
     </fd-tab>
-    <fd-tab>
+    <fd-tab [disabled]="true">
         <ng-template fd-tab-title-template>
             <span fd-tab-tag>Link 2</span>
         </ng-template>
@@ -68,7 +68,7 @@
             <span fd-tab-tag>Link 1</span>
         </a>
     </div>
-    <div fd-tab-item>
+    <div fd-tab-item [disabled]="true">
         <a fd-tab-link [active]="rla2.isActive" [routerLink]="'tab2'" routerLinkActive #rla2="routerLinkActive">
             <span fd-tab-tag>Link 2</span>
         </a>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tabs-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tabs-example.component.html
@@ -3,7 +3,7 @@
     <fd-tab [title]="'Link 1'">
         Content for tab 1
     </fd-tab>
-    <fd-tab [disabled]="true" [title]="'Link 2'">
+    <fd-tab [title]="'Link 2'">
         Content for tab 2
     </fd-tab>
     <fd-tab [title]="'Link 3'">
@@ -19,7 +19,7 @@
     <fd-tab [title]="'Success'" [tabState]="'success'">
         Content for tab 1
     </fd-tab>
-    <fd-tab [disabled]="true" [title]="'Error'" [tabState]="'error'">
+    <fd-tab [title]="'Error'" [tabState]="'error'">
         Content for tab 2
     </fd-tab>
     <fd-tab [title]="'Warning'" [tabState]="'warning'">
@@ -44,7 +44,7 @@
         </ng-template>
         Content for tab 1
     </fd-tab>
-    <fd-tab [disabled]="true">
+    <fd-tab>
         <ng-template fd-tab-title-template>
             <span fd-tab-tag>Link 2</span>
         </ng-template>
@@ -68,7 +68,7 @@
             <span fd-tab-tag>Link 1</span>
         </a>
     </div>
-    <div fd-tab-item [disabled]="true">
+    <div fd-tab-item>
         <a fd-tab-link [active]="rla2.isActive" [routerLink]="'tab2'" routerLinkActive #rla2="routerLinkActive">
             <span fd-tab-tag>Link 2</span>
         </a>

--- a/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
+++ b/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
@@ -35,7 +35,7 @@ export class TabItemDirective implements CssClassBuilder, OnChanges, OnInit {
     @Input()
     header: boolean;
 
-    /** Disabled state for tab item, disabled by default */
+    /** Disabled state for tab item */
     @Input()
     @HostBinding('attr.aria-disabled')
     @HostBinding('class.is-disabled')

--- a/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
+++ b/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
@@ -35,7 +35,7 @@ export class TabItemDirective implements CssClassBuilder, OnChanges, OnInit {
     @Input()
     header: boolean;
 
-    /** TODO */
+    /** Disabled state for tab item, disabled by default */
     @Input()
     @HostBinding('attr.aria-disabled')
     @HostBinding('class.is-disabled')

--- a/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
+++ b/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
@@ -1,4 +1,4 @@
-import { ContentChild, Directive, ElementRef, Input, OnChanges, OnInit } from '@angular/core';
+import { ContentChild, Directive, ElementRef, HostBinding, Input, OnChanges, OnInit } from '@angular/core';
 import { TabLinkDirective } from '../tab-link/tab-link.directive';
 import { applyCssClass, CssClassBuilder } from '../../utils/public_api';
 
@@ -34,6 +34,12 @@ export class TabItemDirective implements CssClassBuilder, OnChanges, OnInit {
     /** This should be used only on `filterMode`. Flag should be enable for first item */
     @Input()
     header: boolean;
+
+    /** TODO */
+    @Input()
+    @HostBinding('attr.aria-disabled')
+    @HostBinding('class.is-disabled')
+    disabled: boolean = false;
 
     /** Defines if there will be added fd-tabs__item class. Enabled by default. */
     @Input()

--- a/libs/core/src/lib/tabs/tab-link/tab-link.directive.ts
+++ b/libs/core/src/lib/tabs/tab-link/tab-link.directive.ts
@@ -30,6 +30,7 @@ export class TabLinkDirective extends AbstractFdNgxClass {
      */
     @Input()
     @HostBinding('attr.aria-disabled')
+    @HostBinding('class.is-disabled')
     disabled: boolean;
 
     /** Event Emitted always when, any keyboard event is dispatched on this element */

--- a/libs/core/src/lib/tabs/tab-link/tab-link.directive.ts
+++ b/libs/core/src/lib/tabs/tab-link/tab-link.directive.ts
@@ -15,7 +15,8 @@ import { AbstractFdNgxClass } from '../../utils/abstract-fd-ngx-class';
     // tslint:disable-next-line:directive-selector
     selector: '[fd-tab-link]',
     host: {
-        role: 'tab'
+        role: 'tab',
+        tabindex: '0'
     }
 })
 export class TabLinkDirective extends AbstractFdNgxClass {

--- a/libs/core/src/lib/tabs/tab-list.component.html
+++ b/libs/core/src/lib/tabs/tab-list.component.html
@@ -14,7 +14,7 @@
                 [attr.aria-labelledby]="!tab.ariaLabel && tab.ariaLabelledBy ? tab.ariaLabelledBy : null"
                 [disabled]="tab.disabled"
                 (keydown)="tabHeaderKeyHandler(i, $event)"
-                (click)="tabHeaderClickHandler(i, tab.disabled)"
+                (click)="tabHeaderClickHandler(i)"
             >
                 <ng-container *ngIf="tab.titleTemplate">
                     <ng-container [fd-tab-load-title]="tab.titleTemplate"></ng-container>

--- a/libs/core/src/lib/tabs/tab-list.component.html
+++ b/libs/core/src/lib/tabs/tab-list.component.html
@@ -13,7 +13,7 @@
                 [attr.aria-label]="tab.ariaLabel || null"
                 [attr.aria-labelledby]="!tab.ariaLabel && tab.ariaLabelledBy ? tab.ariaLabelledBy : null"
                 [disabled]="tab.disabled"
-                (keydown)="tabHeaderKeyHandler(i, $event, tab.disabled)"
+                (keydown)="tabHeaderKeyHandler(i, $event)"
                 (click)="tabHeaderClickHandler(i, tab.disabled)"
             >
                 <ng-container *ngIf="tab.titleTemplate">

--- a/libs/core/src/lib/tabs/tab-list.component.html
+++ b/libs/core/src/lib/tabs/tab-list.component.html
@@ -7,14 +7,14 @@
         <li fd-tab-item [header]="tab.header" [tabItemState]="tab.tabState">
             <a
                 fd-tab-link
-                #tabLink
                 [active]="tab.expanded"
                 [attr.tabindex]="0"
                 [attr.aria-controls]="tab.id"
                 [attr.aria-label]="tab.ariaLabel || null"
                 [attr.aria-labelledby]="!tab.ariaLabel && tab.ariaLabelledBy ? tab.ariaLabelledBy : null"
-                (keydown)="tabHeaderKeyHandler(i, $event)"
-                (click)="tabHeaderClickHandler(i)"
+                [disabled]="tab.disabled"
+                (keydown)="tabHeaderKeyHandler(i, $event, tab.disabled)"
+                (click)="tabHeaderClickHandler(i, tab.disabled)"
             >
                 <ng-container *ngIf="tab.titleTemplate">
                     <ng-container [fd-tab-load-title]="tab.titleTemplate"></ng-container>

--- a/libs/core/src/lib/tabs/tab-list.component.scss
+++ b/libs/core/src/lib/tabs/tab-list.component.scss
@@ -3,3 +3,8 @@
 .fd-tabs-custom {
     display: block;
 }
+
+.is-disabled {
+    pointer-events: none;
+    opacity: 0.4;
+}

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -117,8 +117,8 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
     }
 
     /** @hidden */
-    tabHeaderClickHandler(tabIndex: number, disabled?: boolean): void {
-        if (this.selectedIndex !== tabIndex && !disabled) {
+    tabHeaderClickHandler(tabIndex: number): void {
+        if (tabIndex !== this.selectedIndex) {
             this.selectTab(tabIndex);
         }
     }
@@ -137,7 +137,7 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
         this._tabsService.tabSelected
             .pipe(
                 takeUntil(this._onDestroy$),
-                filter((index) => index !== this.selectedIndex)
+                filter(index => index !== this.selectedIndex)
             )
             .subscribe((index) => this.selectTab(index));
     }

--- a/libs/core/src/lib/tabs/tab-nav/tab-nav.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-nav/tab-nav.component.spec.ts
@@ -90,6 +90,20 @@ describe('TabNavDirective', () => {
         expect(component.selectTab).toHaveBeenCalledWith(3);
     }));
 
+    it('should handle disabled state', fakeAsync(() => {
+        fixture.componentInstance.tabNavDirective.ngAfterContentInit();
+
+        spyOn(component, 'selectTab').and.callThrough();
+
+        fixture.componentInstance.tabLink.keyDown.emit(<any>{ key: 'ArrowRight', preventDefault: () => {} });
+        fixture.componentInstance.tabLink.keyDown.emit(<any>{ key: 'Enter', preventDefault: () => {} });
+
+        tick(10);
+        fixture.detectChanges();
+
+        expect(component.selectTab).toHaveBeenCalledWith(3);
+    }));
+
     it('should call select tab on service event', fakeAsync(() => {
         component.ngAfterContentInit();
         component.selectTab(1);

--- a/libs/core/src/lib/tabs/tab-nav/tab-nav.component.ts
+++ b/libs/core/src/lib/tabs/tab-nav/tab-nav.component.ts
@@ -17,7 +17,7 @@ import { TabsService } from '../tabs.service';
 import { merge, Subject } from 'rxjs';
 import { TabModes, TabSizes } from '../tab-list.component';
 import { applyCssClass, CssClassBuilder } from '../../utils/public_api';
-import { takeUntil } from 'rxjs/operators';
+import { filter, takeUntil } from 'rxjs/operators';
 
 @Component({
     // tslint:disable-next-line:component-selector
@@ -134,7 +134,10 @@ export class TabNavComponent implements AfterContentInit, OnChanges, OnInit, OnD
 
     /** @hidden */
     private _listenOnTabSelect(): void {
-        this._tabsService.tabSelected.pipe(takeUntil(this._onDestroy$)).subscribe((index) => this.selectTab(index));
+        this._tabsService.tabSelected.pipe(
+            takeUntil(this._onDestroy$),
+            filter(index => !this.tabLinks[index].disabled)
+        ).subscribe(index => this.selectTab(index));
     }
 
     /**
@@ -161,7 +164,7 @@ export class TabNavComponent implements AfterContentInit, OnChanges, OnInit, OnD
                 this._tabsService.tabHeaderKeyHandler(
                     index,
                     event,
-                    this.tabLinks.map((link) => link.elementRef.nativeElement)
+                    this.tabLinks.map(link => link.elementRef.nativeElement)
                 )
             );
         });

--- a/libs/core/src/lib/tabs/tab-nav/tab-nav.component.ts
+++ b/libs/core/src/lib/tabs/tab-nav/tab-nav.component.ts
@@ -22,7 +22,7 @@ import { filter, takeUntil } from 'rxjs/operators';
 @Component({
     // tslint:disable-next-line:component-selector
     selector: '[fd-tab-nav]',
-    template: ` <ng-content></ng-content>`,
+    template: `<ng-content></ng-content>`,
     providers: [TabsService],
     styleUrls: ['./tab-nav.component.scss'],
     encapsulation: ViewEncapsulation.None,

--- a/libs/core/src/lib/tabs/tab/tab-panel.component.ts
+++ b/libs/core/src/lib/tabs/tab/tab-panel.component.ts
@@ -73,6 +73,10 @@ export class TabPanelComponent implements OnChanges {
     @Input()
     header: boolean = false;
 
+    /** TODO */
+    @Input()
+    disabled: boolean = false;
+
     /** Semantic type of the tab item */
     @Input()
     tabState: TabItemState;

--- a/libs/core/src/lib/tabs/tab/tab-panel.component.ts
+++ b/libs/core/src/lib/tabs/tab/tab-panel.component.ts
@@ -73,7 +73,7 @@ export class TabPanelComponent implements OnChanges {
     @Input()
     header: boolean = false;
 
-    /** Disabled state for tab item, disabled by default */
+    /** Disabled state for tab item */
     @Input()
     disabled: boolean = false;
 

--- a/libs/core/src/lib/tabs/tab/tab-panel.component.ts
+++ b/libs/core/src/lib/tabs/tab/tab-panel.component.ts
@@ -73,7 +73,7 @@ export class TabPanelComponent implements OnChanges {
     @Input()
     header: boolean = false;
 
-    /** TODO */
+    /** Disabled state for tab item, disabled by default */
     @Input()
     disabled: boolean = false;
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2651
#### Please provide a brief summary of this pull request.
There is added disabled state for tabs. It's not shown in examples, but property is opened to be changed by passing `[disabled]="true"`

![image](https://user-images.githubusercontent.com/26483208/86335889-615acb80-bc4f-11ea-8174-09b5c9a5c48e.png)
![tabs](https://user-images.githubusercontent.com/26483208/86336004-86e7d500-bc4f-11ea-8d6e-635d4bc5039e.gif)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

