### PR TITLE
fix: Breadcrumb '/' after last item

### DIFF
--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,12 +1,3 @@
-<fd-breadcrumb-item *ngIf="collapsedBreadcrumbItems.length" [fdMenuTrigger]="menu">
-    <a fd-breadcrumb-link tabindex="0" (keydown)="keyDownHandle($event)">
-        ...
-        <fd-icon [glyph]="'slim-arrow-down'"></fd-icon>
-    </a>
-</fd-breadcrumb-item>
-
-<ng-content></ng-content>
-
 <fd-menu #menu [placement]="placement$ | async" [compact]="compact">
     <li fd-menu-item *ngFor="let collapsedBreadcrumbItem of collapsedBreadcrumbItems">
         <a fd-menu-interactive [attr.href]="collapsedBreadcrumbItem.href"
@@ -15,3 +6,12 @@
         </a>
     </li>
 </fd-menu>
+
+<fd-breadcrumb-item *ngIf="collapsedBreadcrumbItems.length" [fdMenuTrigger]="menu">
+    <a fd-breadcrumb-link tabindex="0" (keydown)="keyDownHandle($event)">
+        ...
+        <fd-icon [glyph]="'slim-arrow-down'"></fd-icon>
+    </a>
+</fd-breadcrumb-item>
+
+<ng-content></ng-content>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #2777

#### Please provide a brief summary of this pull request.
`/` sign is added based on child order. In previous implementation the Menu component was always last child.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

