### PR TITLE
fix: change remove method in toolbar

### DIFF
--- a/libs/core/src/lib/toolbar/toolbar.component.ts
+++ b/libs/core/src/lib/toolbar/toolbar.component.ts
@@ -226,7 +226,8 @@ export class ToolbarComponent implements OnInit, AfterViewInit, OnDestroy, After
 
     /** @hidden */
     private _removeToolbarItemFromDOM(toolbarItem: ToolbarItemDirective): void {
-        toolbarItem.elementRef.nativeElement.remove();
+        // IE11 workaround element.remove() is not supported
+        toolbarItem.elementRef.nativeElement.parentNode.removeChild(toolbarItem.elementRef.nativeElement);
     }
 
     /** @hidden */


### PR DESCRIPTION
#### Please provide a link to the associated issue.
related to https://github.com/SAP/fundamental-ngx/issues/2777
#### Please provide a brief summary of this pull request.
`element.remove` method is not supported by ie11, so there is added workaround.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

