### PR TITLE
fix: checkbox ie11 too fast click fix

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -15,6 +15,8 @@ import { compareObjects } from '../../utils/public_api';
 
 let checkboxUniqueId: number = 0;
 
+export type fdCheckboxTypes = 'checked' | 'unchecked' | 'indeterminate' | 'force-checked';
+
 @Component({
     selector: 'fd-checkbox',
     templateUrl: './checkbox.component.html',
@@ -85,7 +87,7 @@ export class CheckboxComponent implements ControlValueAccessor {
     /** Stores current checkbox value. */
     public checkboxValue: any;
     /** Stores current checkbox state. */
-    public checkboxState: 'checked' | 'unchecked' | 'indeterminate' | 'force-checked';
+    public checkboxState: fdCheckboxTypes;
     /** @hidden Reference to callback provided by FormControl.*/
     public onTouched = () => {};
     /** @hidden Reference to callback provided by FormControl.*/
@@ -137,7 +139,7 @@ export class CheckboxComponent implements ControlValueAccessor {
 
     /** @hidden Updates checkbox Indeterminate state on mouse click on IE11 */
     public checkByClick() {
-        this._nextValueEvent();
+        this._nextValueEvent(true);
     }
 
     /** @hidden Updates checkbox Indeterminate state on spacebar key on IE11 */
@@ -153,8 +155,8 @@ export class CheckboxComponent implements ControlValueAccessor {
      * - emits new control value
      * - updates control state based on new control value
      * */
-    public nextValue(): void {
-        switch (this.checkboxState) {
+    public nextValue(previousValue?: fdCheckboxTypes): void {
+        switch (previousValue || this.checkboxState) {
             case 'checked':
                 this.checkboxValue = this.values.falseValue;
                 break;
@@ -190,10 +192,14 @@ export class CheckboxComponent implements ControlValueAccessor {
     }
 
     /** @hidden */
-    private _nextValueEvent(): void {
+    private _nextValueEvent(triggeredByClick?: boolean): void {
         if (this._isIE() && this.checkboxState === 'indeterminate') {
             this.checkboxState = 'force-checked';
             this._detectChanges();
+            /** Prevents from keeping the old value */
+            if (triggeredByClick) {
+                this.nextValue('force-checked');
+            }
         }
     }
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
related to: https://github.com/SAP/fundamental-ngx/issues/2777
#### Please provide a brief summary of this pull request.
There is a prevention from keeping old value, by clicking too fast in ie11 on checkbox.
![checkbox321](https://user-images.githubusercontent.com/26483208/86353762-1305f680-bc68-11ea-9287-14de4243701c.gif)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

