### PR TITLE
fix: (cdk-overlay) Update z-index for overlay

### DIFF
--- a/libs/core/src/lib/dialog/dialog.component.scss
+++ b/libs/core/src/lib/dialog/dialog.component.scss
@@ -1,7 +1,7 @@
 @import '~fundamental-styles/dist/dialog';
 
 .fd-dialog {
-    z-index: 1000;
+    z-index: 999;
 }
 
 .fd-dialog__resize-handle {

--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -1,7 +1,6 @@
 @import '~fundamental-styles/dist/select';
 @import '~fundamental-styles/dist/popover';
 
-
 /**
     Reference to overlay panel which independent from select triggering element.
  */
@@ -17,4 +16,15 @@
     &.fd-list--dropdown {
         max-width: inherit;
     }
+}
+
+/**
+   Dirty hack to enforce z-index of CDK's overlay class to be higher then Dialog z-index
+ */
+.cdk-overlay-container,
+.cdk-global-overlay-wrapper,
+.cdk-overlay-pane,
+.cdk-overlay-backdrop,
+.cdk-overlay-connected-position-bounding-box {
+    z-index: 1001 !important;
 }

--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -17,14 +17,3 @@
         max-width: inherit;
     }
 }
-
-/**
-   Dirty hack to enforce z-index of CDK's overlay class to be higher then Dialog z-index
- */
-.cdk-overlay-container,
-.cdk-global-overlay-wrapper,
-.cdk-overlay-pane,
-.cdk-overlay-backdrop,
-.cdk-overlay-connected-position-bounding-box {
-    z-index: 1001 !important;
-}


### PR DESCRIPTION
This fix updates schematics to add overlay styles to the project as well as
forces z-index to 1001 for all overlay classes.

#### Please provide a link to the associated issue.
fixes: #2780
blocked by: #2813

#### Please provide a brief summary of this pull request.

This fix updates schematics to add overlay styles to the project as well as 
forces z-index to 1001 for all overlay classes.


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [ ] tests for the changes that have been done
- [ ] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [ ] update `README.md`
- [ ] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [ ] Documentation Examples
- [ ] Stackblitz works for all examples

