### PR TITLE
fix: add li to select component

### DIFF
--- a/apps/docs/src/app/core/component-docs/dialog/examples/component-based/dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/component-based/dialog-example.component.ts
@@ -15,6 +15,9 @@ import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
                         {{ fact }}
                     </li>
                 </ul>
+                <fd-select placeholder="Select an option" [(value)]="selectedValue1">
+                  <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+                </fd-select>
             </fd-dialog-body>
 
             <fd-dialog-footer>
@@ -47,4 +50,10 @@ import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
 })
 export class DialogExampleComponent {
     constructor(@Inject(DIALOG_REF) public dialogRef: DialogRef) {}
-}
+    options: string[] = ['Apple', 'Pineapple', 'Tomato', 'Strawberry'];
+    selectedValue1: string;
+    selectedValue2: string;
+    selectedValue3: string;
+    selectedValue4: string;
+    selectedValue5: string = this.options[0];
+  }

--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -100,7 +100,14 @@
             {{ stateMessage }}
         </li>
 
+<<<<<<< Updated upstream
         <ng-content></ng-content>
+=======
+        <li>
+          <ng-content></ng-content>
+        </li>
+
+>>>>>>> Stashed changes
     </ul>
 </ng-template>
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: #2780 
#### Please provide a brief summary of this pull request.
This pr adds the li tags around the ng-content of the select component to keep the list attached to the component
It also adds a select to the dialog component example to demonstrate how to add a select to the dialog along with the overflow
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

