### PR TITLE
fix: add fix for lists in popovers (IE11 related issues)

### DIFF
--- a/libs/core/src/lib/list/list.component.scss
+++ b/libs/core/src/lib/list/list.component.scss
@@ -199,8 +199,8 @@
 }
 .fd-list__title {
     -webkit-box-flex: 3;
-    -ms-flex: 3 3 10%;
-    flex: 3 3 10%;
+    -ms-flex: 3 3 auto;
+    flex: 3 3 auto;
     font-size: 1rem;
     font-size: var(--sapFontLargeSize,1rem)
 }
@@ -208,8 +208,8 @@
     font-size: .875rem;
     font-size: var(--sapFontSize,.875rem);
     -webkit-box-flex: 2;
-    -ms-flex: 2 2 10%;
-    flex: 2 2 10%;
+    -ms-flex: 2 2 auto;
+    flex: 2 2 auto;
     text-align: right;
     padding-left: 1rem
 }

--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -4,6 +4,11 @@
 fd-select {
     & > fd-popover {
         width: 100%;
+
+        &.fd-popover__body--dropdown {
+            width: auto;
+            display: block;
+        }
     }
 
     & ul[fd-list] {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #2777

#### Please provide a brief summary of this pull request.
This PR introduces a fix for collapsed lists used inside popover (IE11 issue).
The problems were:
- IE11 does not accept `flex-basis` values in percentage units
- IE11 does not support `width: max-content`

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x]  Documentation Examples
- [x] Stackblitz works for all examples

