### PR TITLE
fix: add correct colour for Inverted Link, improve doc example

### DIFF
--- a/apps/docs/src/app/core/component-docs/link/examples/link-example.component.html
+++ b/apps/docs/src/app/core/component-docs/link/examples/link-example.component.html
@@ -3,8 +3,6 @@
 <br /><br />
 <a fd-link [disabled]="true" aria-disabled="true">Disabled Link</a>
 <br /><br />
-<a fd-link [routerLink]="['./']" fragment="inverted" [inverted]="true">Inverted Link</a>
-<br /><br />
 <a [routerLink]="['./']" fd-link>
     Icon Right Link
     <fd-icon [glyph]="arrowRight$ | async" [size]="'s'"></fd-icon>
@@ -14,3 +12,7 @@
     <fd-icon [glyph]="arrowLeft$ | async" [size]="'s'"></fd-icon>
     Icon Left Link
 </a>
+<br /><br />
+<div style="background-color:#314a5e;padding:10px">
+    <a fd-link [routerLink]="['./']" fragment="inverted" [inverted]="true">Inverted Link</a>
+</div>

--- a/libs/core/src/lib/link/link.component.scss
+++ b/libs/core/src/lib/link/link.component.scss
@@ -1,1 +1,6 @@
 @import '~fundamental-styles/dist/link';
+
+// Temporary solution until the next styles release
+.fd-link--inverted:hover {
+    color: var(--sapLink_InvertedColor, #d3e8fd);
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/2777

#### Please provide a brief summary of this pull request.
Inverted Link is supposed to be used in the Shell Header's Bar. The documentation has been updated to show this case.
On hover the colour of the link is not correct. A temporary fix has been added till we release and adapt the latest version of Fundamental-styles


