### PR TITLE
fix: create initial focus directive

### DIFF
--- a/apps/docs/src/app/core/component-docs/dialog/dialog-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/dialog-docs.component.html
@@ -14,7 +14,11 @@
         <li>Use <code>fd-dialog-footer-button</code> to wrap footer buttons and create space between them.</li>
         <li>
             Add <code>fd-dialog-decisive-button</code> to key dialog buttons like "Save" or "Cancel" to add proper
-            styles and initial focus.
+            styles.
+        </li>
+        <li>
+            By default after opening the Dialog first focusable element will be focused. To focus specific element after
+            opening the Dialog, use <code>fd-initial-focus</code> directive.
         </li>
     </ul>
 </description>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/component-based/dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/component-based/dialog-example.component.ts
@@ -35,6 +35,7 @@ import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
                         fd-button
                         fdType="transparent"
                         fd-dialog-decisive-button
+                        fd-initial-focus
                         [compact]="true"
                         (click)="this.dialogRef.dismiss('Cancel')"
                     >

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.html
@@ -27,6 +27,7 @@
             <fd-dialog-footer-button>
                 <button
                     fd-button
+                    fd-initial-focus
                     fdType="emphasized"
                     fd-dialog-decisive-button
                     [compact]="true"

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-complex/dialog-complex-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-complex/dialog-complex-example.component.html
@@ -20,6 +20,7 @@
                 <div fd-bar-middle>
                     <fd-bar-element [fullWidth]="true">
                         <fd-input-group
+                            fd-initial-focus
                             glyph="search"
                             placement="after"
                             placeholder="Search"

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
@@ -17,6 +17,7 @@
                 <button
                     fd-button
                     fdType="emphasized"
+                    fd-initial-focus
                     fd-dialog-decisive-button
                     [compact]="true"
                     (click)="dialog.close()"

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
@@ -11,7 +11,11 @@
 
         <fd-dialog-footer>
             <fd-dialog-footer-button>
-                <button fd-button fdType="emphasized" fd-dialog-decisive-button (click)="dialog.close()">
+                <button fd-button
+                        fdType="emphasized"
+                        fd-initial-focus
+                        fd-dialog-decisive-button
+                        (click)="dialog.close()">
                     Interesting
                 </button>
             </fd-dialog-footer-button>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-position/dialog-position-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-position/dialog-position-example.component.html
@@ -15,6 +15,7 @@
                 <button
                     fd-button
                     fdType="emphasized"
+                    fd-initial-focus
                     fd-dialog-decisive-button
                     [compact]="true"
                     (click)="dialog.close()"

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-state/dialog-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-state/dialog-state-example.component.html
@@ -13,6 +13,7 @@
                 <button
                     fd-button
                     fdType="emphasized"
+                    fd-initial-focus
                     fd-dialog-decisive-button
                     [compact]="true"
                     (click)="dialog.close()"

--- a/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
@@ -20,6 +20,7 @@ import { SecondDialogExampleComponent } from './second-dialog-example.component'
                     <button
                         fd-button
                         fdType="emphasized"
+                        fd-initial-focus
                         fd-dialog-decisive-button
                         [compact]="true"
                         (click)="openDialog()"

--- a/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
@@ -19,6 +19,7 @@ import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
                     <button
                         fd-button
                         fdType="emphasized"
+                        fd-initial-focus
                         fd-dialog-decisive-button
                         [compact]="true"
                         (click)="dialogRef.close()"

--- a/apps/docs/src/app/core/component-docs/dialog/examples/template-based/template-based-dialog-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/template-based/template-based-dialog-example.component.html
@@ -26,6 +26,7 @@
                 <button
                     fd-button
                     fdType="transparent"
+                    fd-initial-focus
                     fd-dialog-decisive-button
                     [compact]="true"
                     (click)="dialog.dismiss('Cancel')"

--- a/libs/core/src/lib/dialog/dialog.component.ts
+++ b/libs/core/src/lib/dialog/dialog.component.ts
@@ -129,7 +129,7 @@ export class DialogComponent implements OnInit, AfterViewInit, OnDestroy, CssCla
 
     /** @hidden */
     ngOnDestroy(): void {
-        this._deactivateFocus();
+        this._deactivateFocusTrap();
         this._subscriptions.unsubscribe();
     }
 
@@ -190,7 +190,6 @@ export class DialogComponent implements OnInit, AfterViewInit, OnDestroy, CssCla
             try {
                 this._focusTrap = focusTrap(this._elementRef.nativeElement, {
                     clickOutsideDeactivates: this.dialogConfig.backdropClickCloseable && this.dialogConfig.hasBackdrop,
-                    initialFocus: this._elementRef.nativeElement.querySelector('[fd-dialog-decisive-button]'),
                     escapeDeactivates: false,
                     allowOutsideClick: (event: MouseEvent) => true
                 });
@@ -202,7 +201,7 @@ export class DialogComponent implements OnInit, AfterViewInit, OnDestroy, CssCla
     }
 
     /** @hidden */
-    private _deactivateFocus(): void {
+    private _deactivateFocusTrap(): void {
         if (this._focusTrap) {
             this._focusTrap.deactivate();
         }

--- a/libs/core/src/lib/dialog/dialog.module.ts
+++ b/libs/core/src/lib/dialog/dialog.module.ts
@@ -23,6 +23,7 @@ import { TemplateModule } from '../utils/directives/template/template.module';
 import { BusyIndicatorModule } from '../busy-indicator/busy-indicator.module';
 import { DialogFooterButtonComponent } from './dialog-footer-button/dialog-footer-button.component';
 import { DefaultDialogComponent } from './default-dialog/default-dialog.component';
+import { InitialFocusDirective } from '../utils/directives/initial-focus/initial-focus.directive';
 
 @NgModule({
     declarations: [
@@ -35,7 +36,8 @@ import { DefaultDialogComponent } from './default-dialog/default-dialog.componen
         DialogCloseButtonDirective,
         DialogFooterButtonComponent,
         DialogDecisiveButtonDirective,
-        DefaultDialogComponent
+        DefaultDialogComponent,
+        InitialFocusDirective
     ],
     imports: [
         BarModule,
@@ -59,7 +61,8 @@ import { DefaultDialogComponent } from './default-dialog/default-dialog.componen
         DialogContainerComponent,
         DialogCloseButtonDirective,
         DialogFooterButtonComponent,
-        DialogDecisiveButtonDirective
+        DialogDecisiveButtonDirective,
+        InitialFocusDirective
     ],
     entryComponents: [DialogComponent, DialogContainerComponent, DefaultDialogComponent],
     providers: [DialogService, DynamicComponentService]

--- a/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.spec.ts
+++ b/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.spec.ts
@@ -1,0 +1,29 @@
+import { InitialFocusDirective } from './initial-focus.directive';
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+@Component({ template: '<button fd-initial-focus #elementToFocus></button>' })
+class TestComponent {
+    @ViewChild('elementToFocus') elementToFocus: ElementRef;
+}
+
+describe('InitialFocusDirective', () => {
+    let component: TestComponent;
+    let fixture: ComponentFixture<TestComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestComponent, InitialFocusDirective]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should focus element', () => {
+        expect(document.activeElement).toBe(component.elementToFocus.nativeElement);
+    });
+});

--- a/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.ts
+++ b/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.ts
@@ -1,0 +1,19 @@
+import { AfterViewInit, Directive, ElementRef } from '@angular/core';
+
+@Directive({
+    selector: '[fdInitialFocus], [fd-initial-focus]'
+})
+export class InitialFocusDirective implements AfterViewInit {
+
+    constructor(private _elementRef: ElementRef) {}
+
+    ngAfterViewInit(): void {
+        this._focus();
+    }
+
+    private _focus(): void {
+        if (this._elementRef.nativeElement && typeof this._elementRef.nativeElement.focus === 'function') {
+            this._elementRef.nativeElement.focus();
+        }
+    }
+}

--- a/libs/core/src/lib/utils/public_api.ts
+++ b/libs/core/src/lib/utils/public_api.ts
@@ -4,6 +4,7 @@ export * from './directives/only-digits/only-digits.directive';
 export * from './directives/resize/resize.directive';
 export * from './directives/resize/resize-handle.directive';
 export * from './directives/resize/resize.module';
+export * from './directives/initial-focus/initial-focus.directive';
 
 export * from './pipes/pipe.module';
 export * from './pipes/displayFn.pipe';

--- a/libs/core/src/lib/utils/tests/element-ref-mock.class.ts
+++ b/libs/core/src/lib/utils/tests/element-ref-mock.class.ts
@@ -1,0 +1,7 @@
+import { ElementRef } from '@angular/core';
+
+export class MockElementRef extends ElementRef {
+    constructor() {
+        super(null);
+    }
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes: #2765

#### Please provide a brief summary of this pull request.
Previously the Dialog was always focusing first `[fd-dialog-decisive-button]` and this behavior could not be changed.

This PR:
- Changes default Dialog focus behavior
- Introduces `[fd-initial-focus]` directive

Now by default the Dialog focuses first focusable element and user can change this behavior by placing `[fd-initial-focus]` on any element that should be focused first after opening the dialog.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

