### PR TITLE
fix: add fix for tokenizer input overlapping tokenizer border

### DIFF
--- a/libs/core/src/lib/token/tokenizer.component.scss
+++ b/libs/core/src/lib/token/tokenizer.component.scss
@@ -3,6 +3,7 @@
 input {
     &.fd-input {
         &.fd-tokenizer__input {
+            background-color: transparent;
             margin-right: 1px; // needed to display the right side tokenizer outline
             border: none;
             outline: none;


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Minor issue from April 30 defect hunting.  Fixes this:
![Screen Shot 2020-07-08 at 4 12 52 PM](https://user-images.githubusercontent.com/2471874/86975614-ee14f600-c135-11ea-955a-505279bc8a08.png)

