### PR TITLE
fix: form message group example

### DIFF
--- a/apps/docs/src/app/core/api-files.ts
+++ b/apps/docs/src/app/core/api-files.ts
@@ -50,6 +50,7 @@ export const API_FILES = {
         'FormSetDirective',
         'FormInputMessageGroupComponent'
     ],
+    formMessage: ['FormInputMessageGroupComponent'],
     globalConfig: [
     ],
     icon: ['IconComponent'],

--- a/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.html
+++ b/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.html
@@ -1,0 +1,63 @@
+<div fd-form-item class="fd-custom-form-item-message">
+    <label fd-form-label for="input-message">
+        Message With Input
+    </label>
+    <fd-form-input-message-group>
+        <input fd-form-control type="text" id="input-message" placeholder="Field placeholder text" [state]="'information'" />
+        <fd-form-message [type]="'information'">
+            This Message is triggered by click event
+        </fd-form-message>
+    </fd-form-input-message-group>
+</div>
+
+<div fd-form-item class="fd-custom-form-item-message">
+    <label fd-form-label for="picker-message">
+        Message With Picker - Changed Programmatically
+        <button fd-button (click)="open = !open" style="width: 200px">Switch Visibility of Message </button>
+    </label>
+    <fd-form-input-message-group
+        [placement]="'bottom-start'"
+        [(isOpen)]="open"
+        [triggers]="[]"
+        [closeOnOutsideClick]="false"
+        [closeOnEscapeKey]="false">
+        <fd-date-picker id="picker-message" [state]="'information'" [placement]="'top'"></fd-date-picker>
+        <fd-form-message [type]="'information'">
+            This message is controlled by <code>open</code> variable.
+        </fd-form-message>
+    </fd-form-input-message-group>
+</div>
+
+<div fd-form-item class="fd-custom-form-item-message">
+    <label fd-form-label for="group-message">
+        Message With InputGroup - Hover
+    </label>
+    <fd-form-input-message-group
+        [placement]="'bottom'"
+        [triggers]="['mouseenter', 'mouseleave']"
+        [closeOnOutsideClick]="false"
+        [closeOnEscapeKey]="false">
+        <fd-input-group id="group-message" [glyph]="'world'" [state]="'information'" [button]="true"></fd-input-group>
+        <fd-form-message [type]="'information'">
+            This message is triggered only by hover on InputGroup
+        </fd-form-message>
+    </fd-form-input-message-group>
+</div>
+
+<div fd-form-item class="fd-custom-form-item-message">
+    <label fd-form-label for="textarea-message">
+        Message With Textarea - Try to focus
+    </label>
+    <fd-form-input-message-group
+        [triggers]="['focusin', 'focusout']"
+        [placement]="'bottom'"
+        [closeOnOutsideClick]="false"
+        [closeOnEscapeKey]="false">
+        <textarea fd-form-control id="textarea-message" [state]="'information'"></textarea>
+        <fd-form-message [type]="'information'">
+            This message is triggered only by focus/blur inside textarea, also placement is changed
+        </fd-form-message>
+    </fd-form-input-message-group>
+</div>
+
+

--- a/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.html
+++ b/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.html
@@ -15,17 +15,21 @@
         Message With Picker - Changed Programmatically
         <button fd-button (click)="open = !open" style="width: 200px">Switch Message Visibility</button>
     </label>
-    <fd-form-input-message-group
+    <fd-popover
         [placement]="'bottom-start'"
         [(isOpen)]="open"
         [triggers]="[]"
         [closeOnOutsideClick]="false"
         [closeOnEscapeKey]="false">
-        <fd-date-picker id="picker-message" [state]="'information'" [placement]="'top'"></fd-date-picker>
-        <fd-form-message [type]="'information'">
-            This message is controlled by <code>open</code> variable.
-        </fd-form-message>
-    </fd-form-input-message-group>
+        <fd-popover-control>
+            <fd-date-picker id="picker-message" [state]="'information'" [placement]="'top'"></fd-date-picker>
+        </fd-popover-control>
+        <fd-popover-body>
+            <fd-form-message [type]="'information'">
+                This message is controlled by <code>open</code> variable.
+            </fd-form-message>
+        </fd-popover-body>
+    </fd-popover>
 </div>
 
 <div fd-form-item class="fd-custom-form-item-message">

--- a/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.html
+++ b/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.html
@@ -5,7 +5,7 @@
     <fd-form-input-message-group>
         <input fd-form-control type="text" id="input-message" placeholder="Field placeholder text" [state]="'information'" />
         <fd-form-message [type]="'information'">
-            This Message is triggered by click event
+            This message is triggered by a click event.
         </fd-form-message>
     </fd-form-input-message-group>
 </div>
@@ -13,7 +13,7 @@
 <div fd-form-item class="fd-custom-form-item-message">
     <label fd-form-label for="picker-message">
         Message With Picker - Changed Programmatically
-        <button fd-button (click)="open = !open" style="width: 200px">Switch Visibility of Message </button>
+        <button fd-button (click)="open = !open" style="width: 200px">Switch Message Visibility</button>
     </label>
     <fd-form-input-message-group
         [placement]="'bottom-start'"
@@ -39,7 +39,7 @@
         [closeOnEscapeKey]="false">
         <fd-input-group id="group-message" [glyph]="'world'" [state]="'information'" [button]="true"></fd-input-group>
         <fd-form-message [type]="'information'">
-            This message is triggered only by hover on InputGroup
+            This message is only triggered by hovering over the InputGroup.
         </fd-form-message>
     </fd-form-input-message-group>
 </div>
@@ -55,7 +55,7 @@
         [closeOnEscapeKey]="false">
         <textarea fd-form-control id="textarea-message" [state]="'information'"></textarea>
         <fd-form-message [type]="'information'">
-            This message is triggered only by focus/blur inside textarea, also placement is changed
+            This message is only triggered by focusing inside the textarea. The message box placement is also changed.
         </fd-form-message>
     </fd-form-input-message-group>
 </div>

--- a/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.html
+++ b/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.html
@@ -11,18 +11,22 @@
 </div>
 
 <div fd-form-item class="fd-custom-form-item-message">
-    <label fd-form-label for="picker-message">
-        Message With Picker - Changed Programmatically
-        <button fd-button (click)="open = !open" style="width: 200px">Switch Message Visibility</button>
+    <label fd-form-label for="group-message-2">
+        Message With InputGroup - Changed Programmatically
     </label>
     <fd-popover
-        [placement]="'bottom-start'"
+        [placement]="'bottom'"
         [(isOpen)]="open"
         [triggers]="[]"
         [closeOnOutsideClick]="false"
         [closeOnEscapeKey]="false">
         <fd-popover-control>
-            <fd-date-picker id="picker-message" [state]="'information'" [placement]="'top'"></fd-date-picker>
+            <fd-input-group id="group-message-2"
+                            [state]="'information'"
+                            [button]="true"
+                            [addOnText]="'Toggle Message'"
+                            (addOnButtonClicked)="open = !open">
+            </fd-input-group>
         </fd-popover-control>
         <fd-popover-body>
             <fd-form-message [type]="'information'">

--- a/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.ts
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
     styles: [
             `
             .fd-custom-form-item-message {
-                margin-bottom: 30px !important;
+                margin-bottom: 40px !important;
             }
         `
     ]

--- a/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/form-message/examples/form-message-example.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'fd-form-message-example',
+    templateUrl: './form-message-example.component.html',
+    styles: [
+            `
+            .fd-custom-form-item-message {
+                margin-bottom: 30px !important;
+            }
+        `
+    ]
+})
+export class FormMessageExampleComponent {
+
+    open: boolean = false;
+
+    options: string[] = ['Apple', 'Pineapple', 'Tomato', 'Strawberry'];
+}

--- a/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.html
@@ -1,0 +1,10 @@
+<fd-docs-section-title [id]="'default'" [componentName]="'form-message'">
+    Form Message
+</fd-docs-section-title>
+<description>
+    Form message component can be used
+</description>
+<component-example>
+    <fd-form-message-example></fd-form-message-example>
+</component-example>
+<code-example [exampleFiles]="formMessageExample"></code-example>

--- a/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.html
@@ -1,8 +1,19 @@
 <fd-docs-section-title [id]="'default'" [componentName]="'form-message'">
-    Form Message
+    Form Message Input Group
 </fd-docs-section-title>
 <description>
-    Form message component can be used
+    <code>FormInputMessageGroupComponent</code> has built in popover component. Almost all of the properties are taken
+    from popover. It should contain control element, which is supposed to be one of forms component and
+    <code>FormMessageComponent</code> inside.
+    <ul>
+        <li>Input</li>
+        <li>Textarea</li>
+        <li>Input Group</li>
+        <li>Date Picker</li>
+        <li>Date Time Picker</li>
+        <li>Time Picker</li>
+    </ul>
+
 </description>
 <component-example>
     <fd-form-message-example></fd-form-message-example>

--- a/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.html
@@ -2,9 +2,9 @@
     Form Message Input Group
 </fd-docs-section-title>
 <description>
-    <code>FormInputMessageGroupComponent</code> has built in popover component. Almost all of the properties are taken
-    from popover. It should contain control element, which is supposed to be one of forms component and
-    <code>FormMessageComponent</code> inside.
+    The Form Input Message Group has a built-in popover component which uses most of the <code>popover</code> properties. 
+    <br>
+    At a minimum, it should contain a control element and a <code>FormMessage</code>. The suggested elements to use with this component are:
     <ul>
         <li>Input</li>
         <li>Textarea</li>

--- a/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.html
@@ -9,9 +9,6 @@
         <li>Input</li>
         <li>Textarea</li>
         <li>Input Group</li>
-        <li>Date Picker</li>
-        <li>Date Time Picker</li>
-        <li>Time Picker</li>
     </ul>
 
 </description>

--- a/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/form-message/form-message-docs.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import * as formMessageHtml from '!raw-loader!./examples/form-message-example.component.html';
+import * as formMessageTs from '!raw-loader!./examples/form-message-example.component.ts';
+import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
+
+@Component({
+    selector: 'app-input',
+    templateUrl: './form-message-docs.component.html'
+})
+export class FormMessageDocsComponent {
+    formMessageExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: formMessageHtml,
+            fileName: 'form-message-example'
+        },
+        {
+            language: 'typescript',
+            code: formMessageTs,
+            fileName: 'form-message-example',
+            component: 'FormMessageExampleComponent'
+        }
+    ];
+}

--- a/apps/docs/src/app/core/component-docs/form-message/form-message-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/form-message/form-message-docs.module.ts
@@ -1,0 +1,33 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ApiComponent } from '../../../documentation/core-helpers/api/api.component';
+import { SharedDocumentationModule } from '../../../documentation/shared-documentation.module';
+import { API_FILES } from '../../api-files';
+import { FormMessageHeaderComponent } from './form-message-header/form-message-header.component';
+import { FormMessageDocsComponent } from './form-message-docs.component';
+import {
+    FormMessageExampleComponent,
+} from './examples/form-message-example.component';
+import { DatePickerModule, FormModule } from '@fundamental-ngx/core';
+
+const routes: Routes = [
+    {
+        path: '',
+        component: FormMessageHeaderComponent,
+        children: [
+            { path: '', component: FormMessageDocsComponent },
+            { path: 'api', component: ApiComponent, data: { content: API_FILES.form } }
+        ]
+    }
+];
+
+@NgModule({
+    imports: [RouterModule.forChild(routes), SharedDocumentationModule, FormModule, DatePickerModule],
+    exports: [RouterModule],
+    declarations: [
+        FormMessageDocsComponent,
+        FormMessageHeaderComponent,
+        FormMessageExampleComponent,
+    ]
+})
+export class FormMessageDocsModule {}

--- a/apps/docs/src/app/core/component-docs/form-message/form-message-header/form-message-header.component.html
+++ b/apps/docs/src/app/core/component-docs/form-message/form-message-header/form-message-header.component.html
@@ -1,0 +1,5 @@
+<header>Form Message</header>
+<import module="FormModule"></import>
+
+<fd-header-tabs></fd-header-tabs>
+<router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/form-message/form-message-header/form-message-header.component.ts
+++ b/apps/docs/src/app/core/component-docs/form-message/form-message-header/form-message-header.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-select-header',
+    templateUrl: './form-message-header.component.html'
+})
+export class FormMessageHeaderComponent {}

--- a/apps/docs/src/app/core/component-docs/input/examples/input-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input/examples/input-state-example.component.html
@@ -24,9 +24,9 @@
 
 <div fd-form-item>
     <label fd-form-label for="input-54">
-        Warning Input
+        Warning Input - Example of message triggered only on focus/blur
     </label>
-    <fd-form-input-message-group>
+    <fd-form-input-message-group [closeOnEscapeKey]="false" [closeOnOutsideClick]="false" [triggers]="['focus', 'blur']">
         <input fd-form-control type="text" id="input-54" placeholder="Field placeholder text" [state]="'warning'" />
         <fd-form-message [type]="'warning'">
             Pellentesque metus lacus commodo eget justo ut rutrum varius nunc

--- a/apps/docs/src/app/core/core-documentation.routes.ts
+++ b/apps/docs/src/app/core/core-documentation.routes.ts
@@ -93,6 +93,11 @@ export const ROUTES: Routes = [
                     import('./component-docs/file-input/file-input-docs.module').then((m) => m.FileInputDocsModule)
             },
             {
+                path: 'form-message',
+                loadChildren: () =>
+                    import('./component-docs/form-message/form-message-docs.module').then((m) => m.FormMessageDocsModule)
+            },
+            {
                 path: 'global-config',
                 loadChildren: () =>
                     import('./component-docs/global-config/global-config-docs.module').then((m) => m.GlobalConfigDocsModule)

--- a/apps/docs/src/app/core/documentation/core-documentation.component.ts
+++ b/apps/docs/src/app/core/documentation/core-documentation.component.ts
@@ -33,6 +33,7 @@ export class CoreDocumentationComponent extends DocumentationBaseComponent {
             { url: 'core/dialog', name: 'Dialog' },
             { url: 'core/dropdown', name: 'Dropdown' },
             { url: 'core/icon', name: 'Icon' },
+            { url: 'core/form-message', name: 'Form Message' },
             { url: 'core/identifier', name: 'Identifier' },
             { url: 'core/image', name: 'Image' },
             { url: 'core/info-label', name: 'Info Label' },

--- a/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.html
+++ b/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.html
@@ -1,7 +1,9 @@
 <fd-popover
     class="fd-form-input-message-group fd-popover--input-message-group"
-    [placement]="placement$ | async"
+    [placement]="placement"
     [triggers]="triggers"
+    [noArrow]="noArrow"
+    [closeOnEscapeKey]="closeOnEscapeKey"
     [fillControlMode]="fillControlMode"
     [closeOnOutsideClick]="closeOnOutsideClick"
     [isOpen]="isOpen"
@@ -9,7 +11,7 @@
     [addContainerClass]="'fd-popover-container-custom--message'"
 >
     <fd-popover-control>
-        <ng-content select="[fd-form-control]"></ng-content>
+        <ng-content></ng-content>
     </fd-popover-control>
     <fd-popover-body>
         <ng-content select="fd-form-message"></ng-content>

--- a/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.ts
+++ b/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.ts
@@ -3,15 +3,11 @@ import {
     Component,
     EventEmitter,
     Input,
-    Optional,
     Output,
     ViewEncapsulation
 } from '@angular/core';
 import { PopoverFillMode } from '../../popover/popover-directive/popover.directive';
-import { RtlService } from '../../utils/services/rtl.service';
-import { Observable, of } from 'rxjs';
 import { Placement } from 'popper.js';
-import { map } from 'rxjs/operators';
 
 @Component({
     selector: 'fd-form-input-message-group',
@@ -44,6 +40,19 @@ export class FormInputMessageGroupComponent {
     @Input()
     fillControlMode: PopoverFillMode;
 
+    /** Whether the popover should have an arrow. */
+    @Input()
+    noArrow: boolean = true;
+
+    /** Whether the popover should close when the escape key is pressed. */
+    @Input()
+    closeOnEscapeKey: boolean = true;
+
+    /** The placement of the popover. It can be one of: top, top-start, top-end, bottom,
+     *  bottom-start, bottom-end, right, right-start, right-end, left, left-start, left-end. */
+    @Input()
+    placement: Placement = 'bottom-start';
+
     /** Whether the message is open. Can be used through two-way binding. */
     @Input()
     isOpen: boolean = false;
@@ -52,24 +61,10 @@ export class FormInputMessageGroupComponent {
     @Output()
     isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-    /** @hidden */
-    public placement$: Observable<Placement>;
-
-    constructor(@Optional() private _rtlService: RtlService) {
-        this._createRtlObservable();
-    }
-
     /**
      * Function is called every time message changes isOpen attribute
      */
     public openChanged(isOpen: boolean) {
         this.isOpenChange.emit(isOpen);
-    }
-
-    /** @hidden */
-    private _createRtlObservable(): void {
-        this.placement$ = this._rtlService
-            ? this._rtlService.rtl.pipe(map((isRtl) => (isRtl ? 'bottom-end' : 'bottom-start')))
-            : of('bottom-start');
     }
 }

--- a/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.html
+++ b/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.html
@@ -2,9 +2,10 @@
     (isOpenChange)="openChanged($event)"
     [addContainerClass]="'fd-popover-container-custom--message'"
     [closeOnOutsideClick]="closeOnOutsideClick"
+    [closeOnEscapeKey]="closeOnEscapeKey"
     [fillControlMode]="fillControlMode"
     [isOpen]="isOpen"
-    [placement]="placement$ | async"
+    [placement]="placement"
     [triggers]="['input', 'click']"
     class="fd-form-input-message-group fd-popover--input-message-group"
 >

--- a/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.ts
+++ b/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.ts
@@ -27,8 +27,4 @@ export class InputMessageGroupWithTemplate extends FormInputMessageGroupComponen
      */
     @ContentChild('triggerItem', { static: false })
     triggerItemTemplate: TemplateRef<any>;
-
-    constructor(@Optional() private _rtl: RtlService) {
-        super(_rtl);
-    }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2133
#### Please provide a brief summary of this pull request.
I introduced new documentation page with form message group component.
There are some examples with various form components.
Also form message group component has been extended, now it renderes `<ng-content>` as control element.
I added 2 new inputs and removed RTL support, which is already inside popover.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

