### PR TITLE
fix: bug where error occasionally thrown due to missing check

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -50,7 +50,7 @@
             [dropdownMode]="true"
             class="fd-combobox-input-menu-overflow"
             [style.maxHeight]="maxHeight"
-            [hasMessage]="listMessages.length > 0"
+            [hasMessage]="listMessages && listMessages.length > 0"
         >
             <ng-content></ng-content>
             <ng-container *ngIf="groupFn">


### PR DESCRIPTION
fixes #2831 where combobox raises exception when used with *ngIf inside of reactive form