### PR TITLE
fix: Bring button styling to Panel and aria-controls attribute value

### DIFF
--- a/libs/core/src/lib/panel/panel.component.html
+++ b/libs/core/src/lib/panel/panel.component.html
@@ -1,11 +1,14 @@
  <div class="fd-panel__header">
     <div *ngIf="!fixed" class="fd-panel__expand">
-        <button 
-            class="fd-button fd-button--transparent fd-panel__button" 
-            [ngClass]="{ 'fd-button--compact': compact, 'is-expanded' : expanded }"
+        <button
+            fd-button
+            fdType="transparent"
+            class="fd-panel__button"
             [id]="expandId"
+            [compact]="compact"
+            [class.is-expanded]="expanded"
             [attr.aria-expanded]="expanded"
-            [attr.aria-controls]="expandId"
+            [attr.aria-controls]="panelContent?.id"
             [attr.aria-label]="expandAriaLabel"
             [attr.aria-labelledby]="expandAriaLabelledBy"
             (click)="toggleExpand()">

--- a/libs/core/src/lib/panel/panel.component.ts
+++ b/libs/core/src/lib/panel/panel.component.ts
@@ -9,9 +9,11 @@ import {
     OnChanges,
     OnInit,
     ViewEncapsulation,
-    Output
+    Output,
+    ContentChild
 } from '@angular/core';
 import { applyCssClass, CssClassBuilder } from '../utils/public_api';
+import { PanelContentDirective } from './panel-content/panel-content.directive';
 
 let panelUniqueId: number = 0;
 let panelExpandUniqueId: number = 0;
@@ -66,6 +68,10 @@ export class PanelComponent implements CssClassBuilder, OnChanges, OnInit {
     /** Output event triggered when the Expand button is clicked */
     @Output()
     expandedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+    /** Reference to panel content */
+    @ContentChild(PanelContentDirective)
+    panelContent: PanelContentDirective;
 
     /** @hidden */
     constructor(private _cdRef: ChangeDetectorRef, private _elementRef: ElementRef) {}

--- a/libs/core/src/lib/panel/panel.module.ts
+++ b/libs/core/src/lib/panel/panel.module.ts
@@ -4,15 +4,15 @@ import { CommonModule } from '@angular/common';
 import { PanelComponent } from './panel.component';
 import { PanelContentDirective } from './panel-content/panel-content.directive';
 import { PanelTitleDirective } from './panel-title/panel-title.directive';
+import { ButtonModule } from '../button/button.module';
 
 @NgModule({
     declarations: [
         PanelComponent,
         PanelContentDirective,
         PanelTitleDirective
-
     ],
-    imports: [CommonModule],
+    imports: [CommonModule, ButtonModule],
     exports: [
         PanelComponent,
         PanelContentDirective,


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes: #2904
Closes: #2893 

#### Please provide a brief summary of this pull request.
This PR:
- makes panel use `fd-button` component so proper stylesheets for button are loaded together with the Panel
- fixes `[attr.aria-controls]` attribute value

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples