### PR TITLE
fix: Add difference between invalid dates

### DIFF
--- a/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
+++ b/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
@@ -696,22 +696,25 @@ export class CalendarDayViewComponent implements OnInit, OnChanges, OnDestroy {
             if (dates.start) {
                 /** Find start date and mark it as selected */
                 startDay = calendarList.find((_day) => CalendarService.datesEqual(_day.date, dates.start));
-                if (startDay && !startDay.blocked && !startDay.disabled) {
+                if (startDay && !startDay.blocked && !startDay.disabled && !this.disableRangeStartFunction(startDay.date)) {
                     startDay.selected = true;
                 }
             }
             if (dates.end) {
                 /** Find end date and mark it as selected */
                 endDay = calendarList.find((_day) => CalendarService.datesEqual(_day.date, dates.end));
-                if (endDay && !endDay.blocked && !endDay.disabled) {
+                if (endDay && !endDay.blocked && !endDay.disabled && !this.disableRangeEndFunction(endDay.date)) {
                     endDay.selected = true;
                 }
             }
 
-            /** Mark all days, which are between start and end date */
-            calendarList
-                .filter((_day) => (_day.selectedRange = CalendarService.isBetween(_day.date, dates)))
-                .forEach((_day) => (_day.selectedRange = true));
+            /** Verify if start day and end day is valid, otherwise don't put range selection */
+            if (endDay && endDay.selected && startDay && startDay.selected) {
+                /** Mark all days, which are between start and end date */
+                calendarList
+                    .filter((_day) => (_day.selectedRange = CalendarService.isBetween(_day.date, dates)))
+                    .forEach((_day) => (_day.selectedRange = true));
+            }
         }
 
         this.refreshTabIndex(calendarList);

--- a/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
+++ b/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
@@ -246,7 +246,7 @@ export class CalendarDayViewComponent implements OnInit, OnChanges, OnDestroy {
             event.preventDefault();
         }
         this.newFocusedDayIndex = null;
-        if (!day.disabled) {
+        if (!day.disabled && !day.blocked) {
             if (this.calType === 'single') {
                 /** Remove selections from other day and put selection to chosen day */
                 this.calendarDayList.forEach((_day) => (_day.selected = false));
@@ -671,7 +671,7 @@ export class CalendarDayViewComponent implements OnInit, OnChanges, OnDestroy {
     /** Change selection flag on days to false, besides the selected one */
     private _changeSelectedSingleDay(day: CalendarDay, calendar: CalendarDay[]): void {
         calendar.forEach((_day) => (_day.selected = false));
-        if (day) {
+        if (day && !day.blocked && !day.disabled) {
             day.selected = true;
         }
         this.refreshTabIndex(calendar);
@@ -696,14 +696,14 @@ export class CalendarDayViewComponent implements OnInit, OnChanges, OnDestroy {
             if (dates.start) {
                 /** Find start date and mark it as selected */
                 startDay = calendarList.find((_day) => CalendarService.datesEqual(_day.date, dates.start));
-                if (startDay) {
+                if (startDay && !startDay.blocked && !startDay.disabled) {
                     startDay.selected = true;
                 }
             }
             if (dates.end) {
                 /** Find end date and mark it as selected */
                 endDay = calendarList.find((_day) => CalendarService.datesEqual(_day.date, dates.end));
-                if (endDay) {
+                if (endDay && !endDay.blocked && !endDay.disabled) {
                     endDay.selected = true;
                 }
             }

--- a/libs/core/src/lib/calendar/calendar.service.ts
+++ b/libs/core/src/lib/calendar/calendar.service.ts
@@ -58,6 +58,8 @@ export class CalendarService {
     static datesEqual(date1: FdDate, date2: FdDate): boolean {
         if (!date1 || !date2) {
             return false;
+        } else if (!date1.toDateString() && !date2.toDateString()) {
+            return false;
         } else {
             return date1.toDateString() === date2.toDateString();
         }

--- a/libs/core/src/lib/date-picker/date-picker.component.spec.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.spec.ts
@@ -195,10 +195,9 @@ describe('DatePickerComponent', () => {
         expect(component.onChange).toHaveBeenCalledWith({ start: date2, end: date1 });
     });
 
-    it('Should handle single date blocked by disable function', () => {
+    it('Should handle single date blocked by disable function and set invalid', () => {
         spyOn(component.selectedDateChange, 'emit');
         spyOn(component, 'onChange');
-        const invalidDate = (<any>component)._invalidDate();
         component.disableFunction = (fdDate: FdDate) => true;
         const todayDate = FdDate.getToday();
         const date = new FdDate(2000, 10, 10);
@@ -208,15 +207,13 @@ describe('DatePickerComponent', () => {
         expect(component.isInvalidDateInput).toBe(true);
         expect(component.calendarComponent.currentlyDisplayed.month).toBe(todayDate.month);
         expect(component.calendarComponent.currentlyDisplayed.year).toBe(todayDate.year);
-        expect(component.selectedDateChange.emit).toHaveBeenCalledWith(invalidDate);
-        expect(component.onChange).toHaveBeenCalledWith(invalidDate);
+        expect(component.selectedDateChange.emit).toHaveBeenCalledWith(date);
+        expect(component.onChange).toHaveBeenCalledWith(date);
     });
 
-    it('Should handle both range dates blocked by disable function', () => {
+    it('Should handle both range dates blocked by disable function and set invalid', () => {
         spyOn(component.selectedRangeDateChange, 'emit');
         spyOn(component, 'onChange');
-        const invalidDate = (<any>component)._invalidDate();
-        const rangeDateInvalidObject: FdRangeDate = { start: invalidDate, end: invalidDate };
         component.type = 'range';
         component.disableRangeStartFunction = (fdDate: FdDate) => true;
         component.disableRangeEndFunction = (fdDate: FdDate) => true;
@@ -226,6 +223,7 @@ describe('DatePickerComponent', () => {
         const date2 = new FdDate(2000, 10, 10);
         const strDate1 = (<any>component)._formatDate(date1);
         const strDate2 = (<any>component)._formatDate(date2);
+        const rangeDateInvalidObject: FdRangeDate = { start: date2, end: date1 };
 
         component.dateStringUpdate(strDate1 + ' - ' + strDate2);
 
@@ -236,10 +234,9 @@ describe('DatePickerComponent', () => {
         expect(component.onChange).toHaveBeenCalledWith(rangeDateInvalidObject);
     });
 
-    it('Should handle end range date blocked by disable function', () => {
+    it('Should handle end range date blocked by disable function and set invalid', () => {
         spyOn(component.selectedRangeDateChange, 'emit');
         spyOn(component, 'onChange');
-        const invalidDate = (<any>component)._invalidDate();
         component.type = 'range';
         component.disableRangeEndFunction = (fdDate: FdDate) =>
             fdDate.getTimeStamp() > FdDate.getToday().getTimeStamp();
@@ -249,7 +246,7 @@ describe('DatePickerComponent', () => {
         const strDate1 = (<any>component)._formatDate(date1);
         const strDate2 = (<any>component)._formatDate(date2);
 
-        const rangeDateInvalidObject: FdRangeDate = { start: date1, end: invalidDate };
+        const rangeDateInvalidObject: FdRangeDate = { start: date1, end: date2 };
 
         component.dateStringUpdate(strDate1 + ' - ' + strDate2);
 

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -422,7 +422,7 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
         this.inputFieldDate = date;
         /** Case when there is single mode */
         if (this.type === 'single') {
-            let fdDate = this.dateAdapter.parse(date);
+            const fdDate = this.dateAdapter.parse(date);
 
             /** Check if dates are equal, if so, there is no need to make any changes */
             if (!CalendarService.datesEqual(fdDate, this.selectedDate)) {
@@ -432,6 +432,7 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
                 if (!this.isInvalidDateInput && date) {
                     this._refreshCurrentlyDisplayedCalendarDate(fdDate);
                 }
+
                 /**
                  * Date in model is changed no matter if the parsed date from string is valid or not.
                  */
@@ -520,10 +521,6 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
     /** Method that returns info if end date model given is valid */
     private _isFdDateValid(fdDate: FdDate): boolean {
         return fdDate && fdDate instanceof FdDate && fdDate.isDateValid();
-    }
-
-    private _invalidDate(): FdDate {
-        return this.dateAdapter.parse('InVaLiDDaTe');
     }
 
     /** @hidden */

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -431,9 +431,6 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
                 /** Check if date is valid, if it's not, there is no need to refresh calendar */
                 if (!this.isInvalidDateInput && date) {
                     this._refreshCurrentlyDisplayedCalendarDate(fdDate);
-                } else {
-                    /** Whether string is invalid, by passed block or disable functions there is forced Invalid Object, */
-                    fdDate = this._invalidDate();
                 }
                 /**
                  * Date in model is changed no matter if the parsed date from string is valid or not.
@@ -467,16 +464,6 @@ export class DatePickerComponent implements ControlValueAccessor, Validator {
                 }
 
                 this.isInvalidDateInput = !this._isRangeModelValid(selectedRangeDate);
-
-                /** If start date is invalid, because of format, block or disable function, there is invalidDate forced */
-                if (!this._isStartDateValid(selectedRangeDate.start)) {
-                    selectedRangeDate.start = this._invalidDate();
-                }
-
-                /** If end date is invalid, because of format, block or disable function, there is invalidDate forced */
-                if (!this._isEndDateValid(selectedRangeDate.end)) {
-                    selectedRangeDate.end = this._invalidDate();
-                }
 
                 /** Whole object is changed, even it's invalid */
                 this.selectedRangeDate = selectedRangeDate;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2769
fixes: https://github.com/SAP/fundamental-ngx/issues/2926
#### Please provide a brief summary of this pull request.
That change enables possibility to differentiate invalid dates and empty values. It is correct behaviour.
The model now is changed, when invalid date is passed by string.
Before:
![dateoldone](https://user-images.githubusercontent.com/26483208/88640819-aba06280-d0be-11ea-9487-fcbd8b3858e3.gif)

After:
![datepickernewvalidation](https://user-images.githubusercontent.com/26483208/88645545-83b3fd80-d0c4-11ea-917e-4f53d9b4d792.gif)



#### Range Date Picker
before:
![oldrange](https://user-images.githubusercontent.com/26483208/88798946-05c82300-d1a6-11ea-8f89-1a4c8c552d87.gif)

After:
![newrange](https://user-images.githubusercontent.com/26483208/88798958-0a8cd700-d1a6-11ea-83d7-4ea9e127f5fa.gif)



#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

