### PR TITLE
fix: add locale to i18n example of datetime picker

### DIFF
--- a/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-complex-i18n-example/date-picker-complex-i18n-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-complex-i18n-example/date-picker-complex-i18n-example.component.ts
@@ -1,7 +1,7 @@
 import { Component, Injectable, ViewChild } from '@angular/core';
 import { CalendarI18n, DatePickerComponent, FdDate } from '@fundamental-ngx/core';
 
-import * as moment from 'moment';
+import moment from 'moment';
 import 'moment/locale/es';
 import 'moment/locale/en-gb';
 import 'moment/locale/de';

--- a/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.module.ts
@@ -13,7 +13,7 @@ import { DatetimeFormatExampleComponent } from './examples/datetime-format-examp
 import { DatetimeFormExampleComponent } from './examples/datetime-form-example/datetime-form-example.component';
 import { DatetimePickerAllowNullExampleComponent } from './examples/datetime-allow-null-example/datetime-allow-null-example.component';
 import { DatetimeDisabledExampleComponent } from './examples/datetime-disabled-example/datetime-disabled-example.component';
-import { SegmentedButtonModule, DatetimePickerModule } from '@fundamental-ngx/core';
+import { DatetimePickerModule, SelectModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -27,7 +27,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-    imports: [RouterModule.forChild(routes), SharedDocumentationModule, DatetimePickerModule, SegmentedButtonModule],
+    imports: [RouterModule.forChild(routes), SharedDocumentationModule, DatetimePickerModule, SelectModule],
     exports: [RouterModule],
     declarations: [
         DatetimeExampleComponent,

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
@@ -31,4 +31,4 @@
         </fd-form-message>
     </div>
 </fieldset>
-<fd-datetime-picker [placeholder]="placeholder" [meridian]="false"  [displaySeconds]="false" [format]="actualFormat" [locale]="actualLocale" [(ngModel)]="date"></fd-datetime-picker>
+<fd-datetime-picker [placeholder]="placeholder" [meridian]="meridian"  [displaySeconds]="false" [format]="actualFormat" [locale]="actualLocale" [(ngModel)]="date"></fd-datetime-picker>

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
@@ -1,13 +1,7 @@
 <label fd-form-label>Languages</label>
-<fd-segmented-button id="language" style="margin-bottom: 20px;">
-    <button fd-segmented-button [size]="'xs'" (click)="setLocale('en-gb')" [state]="isSelected('en-gb')">
-        English
-    </button>
-    <button fd-segmented-button [size]="'xs'" (click)="setLocale('fr')" [state]="isSelected('fr')">French</button>
-    <button fd-segmented-button [size]="'xs'" (click)="setLocale('de')" [state]="isSelected('de')">German</button>
-    <button fd-segmented-button [size]="'xs'" (click)="setLocale('bg')" [state]="isSelected('bg')">Bulgarian</button>
-    <button fd-segmented-button [size]="'xs'" (click)="setLocale('pl')" [state]="isSelected('pl')">Polish</button>
-</fd-segmented-button>
+<fd-select (valueChange)="setLocale($event)" placeholder="Select an option" [(value)]="selectedLocale">
+  <fd-option *ngFor="let option of ['en-ca','fr','de','bg','pl']" [value]="option">{{ option }}</fd-option>
+</fd-select>
 
 <br />
 <fieldset fd-fieldset>

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
@@ -1,28 +1,8 @@
 <label fd-form-label>Languages</label>
-<fd-select (valueChange)="setLocale($event)" placeholder="Select an option" [(value)]="selectedLocale">
-  <fd-option *ngFor="let option of ['en-ca','fr','de','bg','pl']" [value]="option">{{ option }}</fd-option>
-</fd-select>
+<div class="example">
+  <fd-select (valueChange)="setLocale($event)" placeholder="Select an option" [(value)]="selectedLocale">
+    <fd-option *ngFor="let option of ['en-ca','fr','de','bg','pl']" [value]="option">{{ option }}</fd-option>
+  </fd-select>
+</div>
 
-<br />
-<fieldset fd-fieldset>
-    <div fd-form-item>
-        <label fd-form-label for="docs-date-picker-format">Date Format</label>
-        <fd-input-group
-            id="docs-date-picker-format"
-            [placeholder]="'Date Format'"
-            [(ngModel)]="actualFormat"
-            class="docs-example-fd-form-group"
-            [button]="true"
-            (addOnButtonClicked)="refresh()"
-            [addOnText]="'Refresh'"
-        >
-        </fd-input-group>
-        <fd-form-message type="help">
-            Full list of formats can be found in
-            <a href="https://angular.io/api/common/DatePipe" target="_blank">
-                Official Angular Documentation
-            </a>
-        </fd-form-message>
-    </div>
-</fieldset>
 <fd-datetime-picker [placeholder]="placeholder" [meridian]="meridian"  [displaySeconds]="false" [format]="actualFormat" [locale]="actualLocale" [(ngModel)]="date"></fd-datetime-picker>

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.scss
@@ -3,6 +3,11 @@
     display: block;
 }
 
-fd-datetime-picker {
-    width: 100%;
+fd-select, fd-datetime-picker {
+  padding: 0.5rem;
+  padding-left: 0;
+  
+  .example {
+    width: 230px;
+  }
 }

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -1,7 +1,7 @@
-import { Component, Injectable, OnInit, ViewChild } from '@angular/core';
-import { CalendarI18n, DatetimePickerComponent, FdDate, FdDatetime } from '@fundamental-ngx/core';
+import { Component, Injectable, ViewChild } from '@angular/core';
+import { CalendarI18n, DatetimePickerComponent, FdDatetime } from '@fundamental-ngx/core';
 
-import * as moment from 'moment';
+import moment from 'moment';
 import 'moment/locale/es';
 import 'moment/locale/en-gb';
 import 'moment/locale/de';

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -12,11 +12,11 @@ import { registerLocaleData } from '@angular/common';
 import localeFrench from '@angular/common/locales/fr';
 import localePolish from '@angular/common/locales/pl';
 import localeBulgarian from '@angular/common/locales/bg';
-import localeGb from '@angular/common/locales/en-GB';
+import localeCa from '@angular/common/locales/en-CA';
 import localeDe from '@angular/common/locales/de';
 
 const placeholders = new Map([
-  ['en-gb', 'mm/dd/yyyy, hh:mm a'],
+  ['en-ca', 'mm/dd/yyyy, hh:mm a'],
   ['fr', 'dd/mm/yyyy  hh:mm'],
   ['bg', 'дд/мм/гг чч:мм'],
   ['de', 'dd.mm.yy, hh:mm'],
@@ -60,16 +60,18 @@ export class DatetimePickerComplexI18nExampleComponent {
         registerLocaleData(localeFrench, 'fr');
         registerLocaleData(localePolish, 'pl');
         registerLocaleData(localeBulgarian, 'bg');
-        registerLocaleData(localeGb, 'en-gb');
+        registerLocaleData(localeCa, 'en-ca');
         registerLocaleData(localeDe, 'de');
-        moment.locale('en-gb');
+        moment.locale('en-ca');
     }
 
-    meridian: boolean = false;
+    meridian: boolean = true;
 
     actualLocale: string = '';
 
-    actualFormat = 'short';
+    selectedLocale: string = 'en-ca';
+
+    actualFormat: string = 'mm/dd/yyyy, hh:mm a';
 
     actualMomentJsLang = '';
 

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -65,13 +65,13 @@ export class DatetimePickerComplexI18nExampleComponent {
         moment.locale('en-ca');
     }
 
-    meridian: boolean = true;
+    meridian = true;
 
-    actualLocale: string = '';
+    actualLocale = '';
 
-    selectedLocale: string = 'en-ca';
+    selectedLocale = 'en-ca';
 
-    actualFormat: string = 'mm/dd/yyyy, hh:mm a';
+    actualFormat = 'mm/dd/yyyy, hh:mm a';
 
     actualMomentJsLang = '';
 
@@ -95,8 +95,7 @@ export class DatetimePickerComplexI18nExampleComponent {
       if (moment().format('LT').includes('AM') || moment().format('LT').includes('PM')) {
         this.actualFormat = 'mm/dd/yyyy, hh:mm a';
         this.meridian = true;
-      }
-      else {
+      } else {
         this.actualFormat = 'mm/dd/yyyy, hh:mm';
         this.meridian = false;
       }

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -71,7 +71,7 @@ export class DatetimePickerComplexI18nExampleComponent {
 
     selectedLocale = 'en-ca';
 
-    actualFormat = 'mm/dd/yyyy, hh:mm a';
+    actualFormat = 'MM/dd/yyyy, h:mm a';
 
     actualMomentJsLang = '';
 
@@ -80,6 +80,7 @@ export class DatetimePickerComplexI18nExampleComponent {
     public date: FdDatetime = FdDatetime.getToday();
 
     public refresh(): void {
+      console.log(this.date);
         this.datetimePickerComponent.locale = this.actualLocale;
         this.datetimePickerComponent.format = this.actualFormat;
         this.placeholder = placeholders.get(this.actualLocale);
@@ -93,10 +94,10 @@ export class DatetimePickerComplexI18nExampleComponent {
       this.actualLocale = locale;
       moment.locale(locale);
       if (moment().format('LT').includes('AM') || moment().format('LT').includes('PM')) {
-        this.actualFormat = 'mm/dd/yyyy, hh:mm a';
+        this.actualFormat = 'MM/dd/yyyy, h:mm a';
         this.meridian = true;
       } else {
-        this.actualFormat = 'mm/dd/yyyy, hh:mm';
+        this.actualFormat = 'MM/dd/yyyy, H:mm';
         this.meridian = false;
       }
       this.refresh();

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -16,7 +16,7 @@ import localeGb from '@angular/common/locales/en-GB';
 import localeDe from '@angular/common/locales/de';
 
 const placeholders = new Map([
-  ['en-gb', 'mm/dd/yyyy, hh:mm'],
+  ['en-gb', 'mm/dd/yyyy, hh:mm a'],
   ['fr', 'dd/mm/yyyy  hh:mm'],
   ['bg', 'дд/мм/гг чч:мм'],
   ['de', 'dd.mm.yy, hh:mm'],
@@ -65,7 +65,9 @@ export class DatetimePickerComplexI18nExampleComponent {
         moment.locale('en-gb');
     }
 
-    actualLocale = '';
+    meridian: boolean = false;
+
+    actualLocale: string = '';
 
     actualFormat = 'short';
 
@@ -85,10 +87,18 @@ export class DatetimePickerComplexI18nExampleComponent {
     }
 
     public setLocale(locale: string): void {
-        this.actualMomentJsLang = locale;
-        this.actualLocale = locale;
-        moment.locale(locale);
-        this.refresh();
+      this.actualMomentJsLang = locale;
+      this.actualLocale = locale;
+      moment.locale(locale);
+      if (moment().format('LT').includes('AM') || moment().format('LT').includes('PM')) {
+        this.actualFormat = 'mm/dd/yyyy, hh:mm a';
+        this.meridian = true;
+      }
+      else {
+        this.actualFormat = 'mm/dd/yyyy, hh:mm';
+        this.meridian = false;
+      }
+      this.refresh();
     }
 
     public isSelected(momentJsLang: string): string {

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -80,7 +80,6 @@ export class DatetimePickerComplexI18nExampleComponent {
     public date: FdDatetime = FdDatetime.getToday();
 
     public refresh(): void {
-      console.log(this.date);
         this.datetimePickerComponent.locale = this.actualLocale;
         this.datetimePickerComponent.format = this.actualFormat;
         this.placeholder = placeholders.get(this.actualLocale);

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.spec.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.spec.ts
@@ -175,6 +175,7 @@ describe('DatetimePickerComponent', () => {
     });
 
     it('should stick to last valid, on invalid string.', () => {
+        component.meridian = false;
         const dateTime = new FdDatetime(FdDate.getToday(), { hour: 12, minute: 11, second: 10 });
         component.writeValue(dateTime);
         const invalidTime = { hour: 50, minute: 30, second: 20 };

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.spec.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.spec.ts
@@ -55,6 +55,7 @@ describe('DatetimePickerComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(DatetimePickerComponent);
         component = fixture.componentInstance;
+        component.ngOnInit();
         component.date = new FdDatetime(FdDate.getToday().nextDay(), FdDatetime.getToday().time);
         component.selectedDate = FdDate.getToday().nextDay();
         fixture.detectChanges();
@@ -180,6 +181,7 @@ describe('DatetimePickerComponent', () => {
         component.writeValue(dateTime);
         const invalidTime = { hour: 50, minute: 30, second: 20 };
         const invalidDate = new FdDatetime(dateTime.date, invalidTime);
+        fixture.detectChanges();
         component.handleInputChange(internalParser(invalidDate));
         expect(component.inputFieldDate).toEqual(internalParser(dateTime));
         expect(component.isInvalidDateInput).toBeTruthy();

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -522,6 +522,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
             )
             .subscribe(() => {
                 this.timeComponent.changeActive('hour');
+                this.timeComponent.refreshTime();
             });
     }
 

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -515,13 +515,14 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     private _activateTimeComponent(): void {
         this.popover.directiveRef.loaded
             .pipe(
-                filter(() => !this.timeComponent.activeView),
                 first(),
                 takeUntil(this._onDestroy$),
                 delay(0)
             )
             .subscribe(() => {
+              if (!this.timeComponent.activeView) {
                 this.timeComponent.changeActive('hour');
+              }
                 this.timeComponent.refreshTime();
             });
     }

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -84,7 +84,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
 
     /** Date Format displayed on input. See more options: https://angular.io/api/common/DatePipe */
     @Input()
-    format = 'MM/dd/yyyy, HH:mm:ss a';
+    format: string;
 
     /** Locale for date pipe. See more https://angular.io/guide/i18n */
     @Input()
@@ -281,6 +281,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
 
     /** @hidden */
     ngOnInit(): void {
+        this.format = this.meridian ? 'MM/dd/yyyy, h:mm:ss a' : 'MM/dd/yyyy, H:mm:ss';
         if (this.date && this.inputFieldDate !== null) {
             this.selectedDate = this.date.date;
             this.time = this.date.time;

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -79,12 +79,20 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     placement: Placement = 'bottom-start';
 
     /** Whether the time component should be meridian (am/pm). */
+    /** @hidden */
+    private _meridian;
+
+
+    /** Setter for the _meridian property. */
     @Input()
-    meridian = true;
+    set meridian (value) {
+      this.format = this._meridian ? 'MM/dd/yyyy, h:mm:ss a' : 'MM/dd/yyyy, H:mm:ss';
+      this._meridian = value;
+    };
 
     /** Date Format displayed on input. See more options: https://angular.io/api/common/DatePipe */
     @Input()
-    format: string;
+    format = 'MM/dd/yyyy, HH:mm:ss';
 
     /** Locale for date pipe. See more https://angular.io/guide/i18n */
     @Input()
@@ -261,7 +269,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
 
     /** @hidden */
     onTouched: any = () => {};
-
+  
     /**
      * Function used to disable certain dates in the calendar.
      * @param fdDate FdDate
@@ -281,11 +289,10 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
 
     /** @hidden */
     ngOnInit(): void {
-        this.format = this.meridian ? 'MM/dd/yyyy, h:mm:ss a' : 'MM/dd/yyyy, H:mm:ss';
-        if (this.date && this.inputFieldDate !== null) {
-            this.selectedDate = this.date.date;
-            this.time = this.date.time;
-        }
+      if (this.date && this.inputFieldDate !== null) {
+          this.selectedDate = this.date.date;
+          this.time = this.date.time;
+      }
     }
 
     /** @hidden */

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -84,7 +84,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
 
     /** Date Format displayed on input. See more options: https://angular.io/api/common/DatePipe */
     @Input()
-    format = 'MM/dd/yyyy, HH:mm:ss';
+    format = 'MM/dd/yyyy, HH:mm:ss a';
 
     /** Locale for date pipe. See more https://angular.io/guide/i18n */
     @Input()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
         "target": "es5",
         "typeRoots": ["node_modules/@types"],
         "lib": ["es2016", "dom"],
+        "esModuleInterop": true,
         "paths": {
             "@fundamental-ngx/core": ["dist/libs/core", "libs/core/src/index.ts"],
             "@fundamental-ngx/platform": ["libs/platform/src/index.ts"]


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/2825
#### Please provide a brief summary of this pull request.
This pr will show to users an example of how to apply moment.js locale support to the application with fd-date-time-picker
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

