### PR TITLE
docs: Change example of blur/focus on input state

### DIFF
--- a/apps/docs/src/app/core/component-docs/input/examples/input-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input/examples/input-state-example.component.html
@@ -26,7 +26,7 @@
     <label fd-form-label for="input-54">
         Warning Input - Example of message triggered only on focus/blur
     </label>
-    <fd-form-input-message-group [closeOnEscapeKey]="false" [closeOnOutsideClick]="false" [triggers]="['focus', 'blur']">
+    <fd-form-input-message-group [closeOnEscapeKey]="false" [closeOnOutsideClick]="false" [triggers]="['focusin', 'focusout']">
         <input fd-form-control type="text" id="input-54" placeholder="Field placeholder text" [state]="'warning'" />
         <fd-form-message [type]="'warning'">
             Pellentesque metus lacus commodo eget justo ut rutrum varius nunc


### PR DESCRIPTION
#### Please provide a link to the associated issue.
related to: https://github.com/SAP/fundamental-ngx/issues/2939
#### Please provide a brief summary of this pull request.
`focus` and `blur` are not event thrown natively by html elements. It has been changed to `focusin` and `focusout`
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

