### PR TITLE
fix: combobox IE11 focus/blur crashing 

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -42,7 +42,7 @@
         [buttonFocusable]="buttonFocusable"
         [disabled]="disabled || readOnly"
         [isControl]="true"
-        (addOnButtonClicked)="onPrimaryButtonClick($event)"
+        (addOnButtonClicked)="onPrimaryButtonClick()"
         [isExpanded]="!mobile && open && displayedValues.length"
         [attr.aria-readonly]="readOnly"
         (click)="mobile && isOpenChangeHandle(true)">

--- a/libs/core/src/lib/combobox/combobox.component.spec.ts
+++ b/libs/core/src/lib/combobox/combobox.component.spec.ts
@@ -199,7 +199,7 @@ describe('ComboboxComponent', () => {
         spyOn(component, 'searchFn');
         spyOn(component, 'isOpenChangeHandle');
         component.open = false;
-        component.onPrimaryButtonClick(new MouseEvent('click'));
+        component.onPrimaryButtonClick();
         expect(component.searchFn).toHaveBeenCalled();
         expect(component.isOpenChangeHandle).toHaveBeenCalledWith(true);
     });
@@ -248,7 +248,7 @@ describe('ComboboxComponent', () => {
         component.inputText = 'displayedValue2';
         (<any>component)._refreshDisplayedValues();
         expect(component.displayedValues.length).toBe(1);
-        component.onPrimaryButtonClick(<any>{ stopPropagation: () => {}, preventDefault: () => {} });
+        component.onPrimaryButtonClick();
         expect(component.displayedValues.length).toBe(2);
     });
 

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -421,7 +421,6 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
             this.searchFn();
         }
         event.preventDefault();
-        event.stopPropagation();
         this._resetDisplayedValues();
         this.isOpenChangeHandle(!this.open);
         this.searchInputElement.nativeElement.focus();

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -317,7 +317,6 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
             if (this.searchFn) {
                 this.searchFn();
             }
-            this._moveCursorToInputEnd();
         } else if (KeyUtil.isKey(event, 'ArrowDown')) {
             if (event.altKey) {
                 this._resetDisplayedValues();
@@ -472,7 +471,6 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
                 forceClose: false
             });
         }
-        this._moveCursorToInputEnd();
     }
 
     /** Method that picks other value moved from current one by offset, called only when combobox is closed */
@@ -590,12 +588,6 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
     /** @hidden */
     private _hasDisplayedValues(): boolean {
         return this.open && this.displayedValues && this.displayedValues.length > 0;
-    }
-
-    /** @hidden */
-    private _moveCursorToInputEnd(): void {
-        const value = this.searchInputElement.nativeElement.value;
-        this.searchInputElement.nativeElement.setSelectionRange(value.length, value.length);
     }
 
     /** @hidden */

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -410,7 +410,7 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
     }
 
     /** @hidden */
-    onPrimaryButtonClick(event: MouseEvent): void {
+    onPrimaryButtonClick(): void {
         // Prevent primary button click behaviour on mobiles
         if (this.mobile) {
             return;
@@ -419,7 +419,6 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
         if (this.searchFn) {
             this.searchFn();
         }
-        event.preventDefault();
         this._resetDisplayedValues();
         this.isOpenChangeHandle(!this.open);
         this.searchInputElement.nativeElement.focus();
@@ -456,8 +455,10 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
 
     /** Method that handles complete event from auto complete directive, setting the new value, and closing popover */
     handleAutoComplete(event: AutoCompleteEvent): void {
-        this.inputText = event.term;
-        this.handleSearchTermChange();
+        if (this.inputText !== event.term) {
+            this.inputText = event.term;
+            this.handleSearchTermChange();
+        }
         if (event.forceClose) {
             this.isOpenChangeHandle(false);
         }
@@ -567,8 +568,8 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
         try {
             this.focusTrap = focusTrap(this._elementRef.nativeElement, {
                 clickOutsideDeactivates: true,
-                returnFocusOnDeactivate: true,
-                escapeDeactivates: false
+                escapeDeactivates: false,
+                initialFocus: this._elementRef.nativeElement
             });
         } catch (e) {
             console.warn('Unsuccessful attempting to focus trap the Combobox.');


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Related to: https://github.com/SAP/fundamental-ngx/issues/2939
#### Please provide a brief summary of this pull request.
Now, after closing combobox, another opened will be closed as well. It will fix IE11 crashing issue
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

