### PR TITLE
fix: Combobox keep full width

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -75,7 +75,7 @@
     <ul
         fd-list
         [dropdownMode]="true"
-        class="fd-combobox-input-menu-overflow"
+        class="fd-combobox-custom-list fd-combobox-input-menu-overflow"
         [style.maxHeight]="!mobile && maxHeight"
         [hasMessage]="listMessages && listMessages.length > 0"
     >

--- a/libs/core/src/lib/combobox/combobox.component.scss
+++ b/libs/core/src/lib/combobox/combobox.component.scss
@@ -8,6 +8,10 @@
     .fd-combobox-shellbar-custom {
         display: inline-block;
     }
+
+    .fd-combobox-custom-list {
+        max-width: 100%;
+    }
 }
 
 .fd-combobox-input-menu-overflow {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
related to: https://github.com/SAP/fundamental-ngx/issues/2939
#### Please provide a brief summary of this pull request.
Right now combobox keeps full width, instead of 600px limits.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

