### PR TITLE
fix: (core) add name property to switch component

### DIFF
--- a/libs/core/src/lib/switch/switch.component.html
+++ b/libs/core/src/lib/switch/switch.component.html
@@ -14,6 +14,7 @@
             type="checkbox"
             role="checkbox"
             [id]="innerInputId"
+            [name]="name"
             [disabled]="disabled"
             [attr.aria-checked]="checked"
             [attr.aria-label]="ariaLabel"

--- a/libs/core/src/lib/switch/switch.component.spec.ts
+++ b/libs/core/src/lib/switch/switch.component.spec.ts
@@ -44,6 +44,15 @@ describe('SwitchComponent', () => {
         expect(input.id).toBe(component.innerInputId);
     });
 
+    it('should accept custom name', () => {
+        const name = 'custom-name';
+        component.name = name;
+
+        detectChangesOnPush();
+
+        expect(input.getAttribute('ng-reflect-name')).toEqual(component.name);
+    });
+
     it('should auto-generate id', () => {
         expect(component.id).toBeTruthy();
     });

--- a/libs/core/src/lib/switch/switch.component.ts
+++ b/libs/core/src/lib/switch/switch.component.ts
@@ -51,7 +51,11 @@ export class SwitchComponent implements ControlValueAccessor {
 
     /** Id for the switch component. If omitted, a unique one is generated. */
     @Input()
-    id: string = 'fd-switch-' + switchUniqueId++;
+    id = `fd-switch-${switchUniqueId++}`;
+
+    /** Sets input name attribute. */
+    @Input()
+    name: string;
 
     /** Whether the switch is checked. */
     @Input()


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/2979
#### Please provide a brief summary of this pull request.
Added `name` property to the core Switch component