### PR TITLE
feat: refactor DND directive

### DIFF
--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
@@ -9,7 +9,7 @@
         fd-dnd-list
         class="fd-product-switch__list"
         [items]="products"
-        [listMode]="isListMode()"
+        [gridMode]="!isListMode()"
         (itemsChange)="productSwitchItemsChangeHandle($event)"
     >
         <li fd-dnd-item

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
@@ -18,7 +18,7 @@
             class="fd-product-switch__item"
             [ngClass]="{ selected: product.selected }"
             (click)="itemClick(product, $event)"
-            [dndDisabled]="product.disabledDragAndDrop || !dragAndDropEnabled"
+            [draggable]="!product.disabledDragAndDrop && dragAndDropEnabled"
             [stickInPlace]="product.stickToPosition">
             <div class="fd-product-switch__icon" [ngClass]="product.icon ? 'sap-icon--' + product.icon : ''">
                 <img *ngIf="product.image" [src]="product.image"/>

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
@@ -10,7 +10,7 @@
         class="fd-product-switch__list"
         [items]="products"
         [gridMode]="!isListMode()"
-        (itemsChange)="productSwitchItemsChangeHandle($event)"
+        (itemDropped)="productSwitchItemsChangeHandle($event)"
     >
         <li fd-dnd-item
             *ngFor="let product of products"

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
@@ -18,7 +18,7 @@
             class="fd-product-switch__item"
             [ngClass]="{ selected: product.selected }"
             (click)="itemClick(product, $event)"
-            [disabled]="product.disabledDragAndDrop || !dragAndDropEnabled"
+            [dndDisabled]="product.disabledDragAndDrop || !dragAndDropEnabled"
             [stickInPlace]="product.stickToPosition">
             <div class="fd-product-switch__icon" [ngClass]="product.icon ? 'sap-icon--' + product.icon : ''">
                 <img *ngIf="product.image" [src]="product.image"/>

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
@@ -12,22 +12,20 @@
         [listMode]="isListMode()"
         (itemsChange)="productSwitchItemsChangeHandle($event)"
     >
-        <li fd-dnd-container [stickInPlace]="product.stickToPosition" *ngFor="let product of products">
-            <div
-                cdkDrag
-                [cdkDragDisabled]="product.disabledDragAndDrop || !dragAndDropEnabled"
-                tabindex="0"
-                class="fd-product-switch__item fd-product-switch__fullfill"
-                [ngClass]="{ selected: product.selected }"
-                (click)="itemClick(product, $event)"
-            >
-                <div class="fd-product-switch__icon" [ngClass]="product.icon ? 'sap-icon--' + product.icon : ''">
-                    <img *ngIf="product.image" [src]="product.image" />
-                </div>
-                <div class="fd-product-switch__text">
-                    <div class="fd-product-switch__title">{{ product.title }}</div>
-                    <div class="fd-product-switch__subtitle">{{ product.subtitle }}</div>
-                </div>
+        <li fd-dnd-item
+            *ngFor="let product of products"
+            tabindex="0"
+            class="fd-product-switch__item"
+            [ngClass]="{ selected: product.selected }"
+            (click)="itemClick(product, $event)"
+            [disabled]="product.disabledDragAndDrop || !dragAndDropEnabled"
+            [stickInPlace]="product.stickToPosition">
+            <div class="fd-product-switch__icon" [ngClass]="product.icon ? 'sap-icon--' + product.icon : ''">
+                <img *ngIf="product.image" [src]="product.image"/>
+            </div>
+            <div class="fd-product-switch__text">
+                <div class="fd-product-switch__title">{{ product.title }}</div>
+                <div class="fd-product-switch__subtitle">{{ product.subtitle }}</div>
             </div>
         </li>
     </ul>

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.scss
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.scss
@@ -26,7 +26,7 @@
         }
     }
 
-    .fd-dnd-container {
+    .fd-dnd-item {
         position: relative;
 
         &.fd-dnd-on-drag {

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.scss
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.scss
@@ -1,162 +1,170 @@
 @import '~fundamental-styles/dist/product-switch';
 
-.cdk-drag-dragging {
-    z-index: 15;
-    background-color: #fff;
-    background-color: var(--sapList_Background, #fff);
-    opacity: 0.8;
-    transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
-    box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-}
-
-.fd-product-switch__item.cdk-drag-dragging {
-    outline: none;
-    cursor: grabbing;
-    box-shadow: 0 0 0 0.0625rem rgba(0, 0, 0, 0.15), 0 0.625rem 1.875rem 0 rgba(0, 0, 0, 0.3);
-}
-
-.fd-product-switch__body--mobile {
-    .fd-product-switch__item.cdk-drag-dragging {
-        outline: none;
-        box-shadow: 0 0 0 0.0625rem rgba(0, 0, 0, 0.15), 0 0.625rem 1.875rem 0 rgba(0, 0, 0, 0.3);
+    .fd-product-switch__list {
+        position: relative;
     }
-}
 
-.fd-dnd-placeholder {
-    top: 0;
-    left: 0;
-    position: absolute;
-    opacity: 0.3;
-    z-index: -1;
-}
-
-.fd-dnd-container {
-    position: relative;
-    padding: 0;
-    &.fd-dnd-on-drag {
+    .cdk-drag-dragging {
+        z-index: 15;
         background-color: #fff;
         background-color: var(--sapList_Background, #fff);
-        z-index: 15;
-        .fd-product-switch__item {
-            .fd-product-switch__title {
-                &:before,
-                &:after {
-                    background-color: #fff;
-                    background-color: var(--sapList_Background, #fff);
+        opacity: 0.8;
+        transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
+        box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
+    }
+
+    .fd-product-switch__item.cdk-drag-dragging {
+        outline: none;
+        cursor: grabbing;
+        box-shadow: 0 0 0 0.0625rem rgba(0, 0, 0, 0.15), 0 0.625rem 1.875rem 0 rgba(0, 0, 0, 0.3);
+    }
+
+    .fd-product-switch__body--mobile {
+        .fd-product-switch__item.cdk-drag-dragging {
+            outline: none;
+            box-shadow: 0 0 0 0.0625rem rgba(0, 0, 0, 0.15), 0 0.625rem 1.875rem 0 rgba(0, 0, 0, 0.3);
+        }
+    }
+
+    .fd-dnd-placeholder {
+        top: 0;
+        left: 0;
+        position: absolute;
+        opacity: 0.3;
+        z-index: -1;
+    }
+
+    .fd-dnd-container {
+        position: relative;
+
+        &.fd-dnd-on-drag {
+            background-color: #fff;
+            background-color: var(--sapList_Background, #fff);
+            z-index: 15;
+
+            .fd-product-switch__item {
+                .fd-product-switch__title {
+                    &:before,
+                    &:after {
+                        background-color: #fff;
+                        background-color: var(--sapList_Background, #fff);
+                    }
                 }
             }
-        }
-        .fd-product-switch__item:active .fd-product-switch__icon {
-            color:#0854A0;
-            color: var(--sapContent_IconColor, #0854A0);
-        }
 
-        .fd-product-switch__item:active .fd-product-switch__title {
-            color:#32363A;
-            color: var(--sapGroup_TitleTextColor, #32363A);
-        }
+            .fd-product-switch__item:active .fd-product-switch__icon {
+                color: #0854A0;
+                color: var(--sapContent_IconColor, #0854A0);
+            }
 
-        .fd-product-switch__item:active .fd-product-switch__subtitle {
-            color:#6A6D70;
-            color: var(--sapContent_LabelColor, #6A6D70);
-        }
+            .fd-product-switch__item:active .fd-product-switch__title {
+                color: #32363A;
+                color: var(--sapGroup_TitleTextColor, #32363A);
+            }
 
-        &.selected {
-            background-color: #fff;
-            background-color: var(--sapList_Background, #fff);
-        }
+            .fd-product-switch__item:active .fd-product-switch__subtitle {
+                color: #6A6D70;
+                color: var(--sapContent_LabelColor, #6A6D70);
+            }
 
-        .fd-product-switch__item:active {
-            background-color: #fff;
-            background-color: var(--sapList_Background, #fff);
+            &.selected {
+                background-color: #fff;
+                background-color: var(--sapList_Background, #fff);
+            }
+
+            .fd-product-switch__item:active {
+                background-color: #fff;
+                background-color: var(--sapList_Background, #fff);
+            }
         }
     }
-}
 
-.fd-product-switch__fullfill {
-    width: 500px;
-}
-
-.fd-product-switch__body--mobile {
     .fd-product-switch__fullfill {
-        width: 100%;
+        width: 500px;
     }
-}
 
-[dir='rtl'] {
     .fd-product-switch__body--mobile {
-        .fd-product-switch__title,
-        .fd-product-switch__subtitle {
-            text-align: right;
+        .fd-product-switch__fullfill {
+            width: 100%;
         }
     }
-}
 
-.drop-area__line {
-    z-index: 9999;
-    position: absolute;
-    background: #0854A0;
-    background:var(--sapContent_DragAndDropActiveColor, #0854A0);
-
-    &--vertical {
-        top: 0;
-        height: calc(100% - 0.5rem);
-        width: 2px;
-
-        &.after {
-            right: 0.2rem;
-        }
-
-        &.before {
-            left: -0.3rem;
-        }
-
-        &:before {
-            background-color: #fff;
-            background-color: var(--sapList_Background, #fff);
-            content: '';
-            position: absolute;
-            left: -0.2rem;
-            top: -0.5rem;
-            border-radius: 50%;
-            width: 0.5rem;
-            height: 0.5rem;
-            border-width: 0.125rem;
-            border-style: solid;
-            border-color: #0854A0;
-            border-color:var(--sapContent_DragAndDropActiveColor, #0854A0);
+    [dir='rtl'] {
+        .fd-product-switch__body--mobile {
+            .fd-product-switch__title,
+            .fd-product-switch__subtitle {
+                text-align: right;
+            }
         }
     }
-    &--horizontal {
-        left: 0;
-        width: 100%;
-        height: 2px;
-        &.before {
+
+    .drop-area__line {
+        z-index: 9999;
+        position: absolute;
+        background: #0854A0;
+        background: var(--sapContent_DragAndDropActiveColor, #0854A0);
+
+        &--vertical {
             top: 0;
+            height: calc(100% - 0.5rem);
+            width: 2px;
+
+            &.after {
+                right: 0.2rem;
+            }
+
+            &.before {
+                left: -0.3rem;
+            }
+
+            &:before {
+                background-color: #fff;
+                background-color: var(--sapList_Background, #fff);
+                content: '';
+                position: absolute;
+                left: -0.2rem;
+                top: -0.5rem;
+                border-radius: 50%;
+                width: 0.5rem;
+                height: 0.5rem;
+                border-width: 0.125rem;
+                border-style: solid;
+                border-color: #0854A0;
+                border-color: var(--sapContent_DragAndDropActiveColor, #0854A0);
+            }
         }
 
-        &.after {
-            bottom: 0;
-        }
+        &--horizontal {
+            left: 0;
+            width: 100%;
+            height: 2px;
 
-        &:before {
-            background-color: #fff;
-            background-color: var(--sapList_Background, #fff);
-            content: '';
-            position: absolute;
-            left: -0;
-            top: -0.2rem;
-            border-radius: 50%;
-            width: 0.5rem;
-            height: 0.5rem;
-            border-width: 0.125rem;
-            border-style: solid;
-            border-color: #0854A0;
-            border-color:var(--sapContent_DragAndDropActiveColor, #0854A0);
+            &.before {
+                top: 0;
+            }
+
+            &.after {
+                bottom: 0;
+            }
+
+            &:before {
+                background-color: #fff;
+                background-color: var(--sapList_Background, #fff);
+                content: '';
+                position: absolute;
+                left: -0;
+                top: -0.2rem;
+                border-radius: 50%;
+                width: 0.5rem;
+                height: 0.5rem;
+                border-width: 0.125rem;
+                border-style: solid;
+                border-color: #0854A0;
+                border-color: var(--sapContent_DragAndDropActiveColor, #0854A0);
+            }
         }
     }
-}
 
-.fd-product-switch__list > li {
-    list-style-type: none;
-}
+    .fd-product-switch__list > li {
+        list-style-type: none;
+    }

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.scss
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.scss
@@ -1,148 +1,148 @@
 @import '~fundamental-styles/dist/product-switch';
 
-    .fd-product-switch__list {
-        position: relative;
-    }
+.fd-product-switch__list {
+    position: relative;
+}
 
-    .cdk-drag-dragging {
-        z-index: 15;
-        background-color: #fff;
-        background-color: var(--sapList_Background, #fff);
-        opacity: 0.8;
-        transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
-        box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
-    }
+.cdk-drag-dragging {
+    z-index: 15;
+    background-color: #fff;
+    background-color: var(--sapList_Background, #fff);
+    opacity: 0.8;
+    transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
+    box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
+}
 
+.fd-product-switch__item.cdk-drag-dragging {
+    outline: none;
+    cursor: grabbing;
+    box-shadow: 0 0 0 0.0625rem rgba(0, 0, 0, 0.15), 0 0.625rem 1.875rem 0 rgba(0, 0, 0, 0.3);
+}
+
+.fd-product-switch__body--mobile {
     .fd-product-switch__item.cdk-drag-dragging {
         outline: none;
-        cursor: grabbing;
         box-shadow: 0 0 0 0.0625rem rgba(0, 0, 0, 0.15), 0 0.625rem 1.875rem 0 rgba(0, 0, 0, 0.3);
     }
+}
 
-    .fd-product-switch__body--mobile {
-        .fd-product-switch__item.cdk-drag-dragging {
-            outline: none;
-            box-shadow: 0 0 0 0.0625rem rgba(0, 0, 0, 0.15), 0 0.625rem 1.875rem 0 rgba(0, 0, 0, 0.3);
-        }
-    }
+.fd-dnd-item {
+    position: relative;
 
-    .fd-dnd-item {
-        position: relative;
+    &.fd-dnd-on-drag {
+        background-color: #fff;
+        background-color: var(--sapList_Background, #fff);
+        z-index: 15;
 
-        &.fd-dnd-on-drag {
-            background-color: #fff;
-            background-color: var(--sapList_Background, #fff);
-            z-index: 15;
-
-            &.fd-product-switch__item {
-                .fd-product-switch__title {
-                    &:before,
-                    &:after {
-                        background-color: #fff;
-                        background-color: var(--sapList_Background, #fff);
-                    }
-                }
-
-                .fd-product-switch__icon {
-                    color: #0854A0;
-                    color: var(--sapContent_IconColor, #0854A0);
-                }
-
-                .fd-product-switch__title {
-                    color: #32363A;
-                    color: var(--sapGroup_TitleTextColor, #32363A);
-                }
-
-                .fd-product-switch__subtitle {
-                    color: #6A6D70;
-                    color: var(--sapContent_LabelColor, #6A6D70);
-                }
-
-                &:active {
+        &.fd-product-switch__item {
+            .fd-product-switch__title {
+                &:before,
+                &:after {
                     background-color: #fff;
                     background-color: var(--sapList_Background, #fff);
                 }
             }
 
-            &.selected {
-                background-color: #fff;
-                background-color: var(--sapList_Background, #fff);
+            .fd-product-switch__icon {
+                color: #0854A0;
+                color: var(--sapContent_IconColor, #0854A0);
             }
-        }
-    }
 
-    [dir='rtl'] {
-        .fd-product-switch__body--mobile {
-            .fd-product-switch__title,
+            .fd-product-switch__title {
+                color: #32363A;
+                color: var(--sapGroup_TitleTextColor, #32363A);
+            }
+
             .fd-product-switch__subtitle {
-                text-align: right;
+                color: #6A6D70;
+                color: var(--sapContent_LabelColor, #6A6D70);
             }
+
+            &:active {
+                background-color: #fff;
+                background-color: var(--sapList_Background, #fff);
+            }
+        }
+
+        &.selected {
+            background-color: #fff;
+            background-color: var(--sapList_Background, #fff);
+        }
+    }
+}
+
+[dir='rtl'] {
+    .fd-product-switch__body--mobile {
+        .fd-product-switch__title,
+        .fd-product-switch__subtitle {
+            text-align: right;
+        }
+    }
+}
+
+.drop-area__line {
+    z-index: 9999;
+    position: absolute;
+    background: #0854A0;
+    background: var(--sapContent_DragAndDropActiveColor, #0854A0);
+
+    &--vertical {
+        top: 0;
+        height: calc(100% - 0.5rem);
+        width: 2px;
+
+        &.after {
+            right: 0.2rem;
+        }
+
+        &.before {
+            left: -0.3rem;
+        }
+
+        &:before {
+            background-color: #fff;
+            background-color: var(--sapList_Background, #fff);
+            content: '';
+            position: absolute;
+            left: -0.2rem;
+            top: -0.5rem;
+            border-radius: 50%;
+            width: 0.5rem;
+            height: 0.5rem;
+            border-width: 0.125rem;
+            border-style: solid;
+            border-color: #0854A0;
+            border-color: var(--sapContent_DragAndDropActiveColor, #0854A0);
         }
     }
 
-    .drop-area__line {
-        z-index: 9999;
-        position: absolute;
-        background: #0854A0;
-        background: var(--sapContent_DragAndDropActiveColor, #0854A0);
+    &--horizontal {
+        left: 0;
+        width: 100%;
+        height: 2px;
 
-        &--vertical {
+        &.before {
             top: 0;
-            height: calc(100% - 0.5rem);
-            width: 2px;
-
-            &.after {
-                right: 0.2rem;
-            }
-
-            &.before {
-                left: -0.3rem;
-            }
-
-            &:before {
-                background-color: #fff;
-                background-color: var(--sapList_Background, #fff);
-                content: '';
-                position: absolute;
-                left: -0.2rem;
-                top: -0.5rem;
-                border-radius: 50%;
-                width: 0.5rem;
-                height: 0.5rem;
-                border-width: 0.125rem;
-                border-style: solid;
-                border-color: #0854A0;
-                border-color: var(--sapContent_DragAndDropActiveColor, #0854A0);
-            }
         }
 
-        &--horizontal {
-            left: 0;
-            width: 100%;
-            height: 2px;
+        &.after {
+            bottom: 0;
+        }
 
-            &.before {
-                top: 0;
-            }
-
-            &.after {
-                bottom: 0;
-            }
-
-            &:before {
-                background-color: #fff;
-                background-color: var(--sapList_Background, #fff);
-                content: '';
-                position: absolute;
-                left: -0;
-                top: -0.2rem;
-                border-radius: 50%;
-                width: 0.5rem;
-                height: 0.5rem;
-                border-width: 0.125rem;
-                border-style: solid;
-                border-color: #0854A0;
-                border-color: var(--sapContent_DragAndDropActiveColor, #0854A0);
-            }
+        &:before {
+            background-color: #fff;
+            background-color: var(--sapList_Background, #fff);
+            content: '';
+            position: absolute;
+            left: -0;
+            top: -0.2rem;
+            border-radius: 50%;
+            width: 0.5rem;
+            height: 0.5rem;
+            border-width: 0.125rem;
+            border-style: solid;
+            border-color: #0854A0;
+            border-color: var(--sapContent_DragAndDropActiveColor, #0854A0);
         }
     }
+}

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.scss
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.scss
@@ -26,14 +26,6 @@
         }
     }
 
-    .fd-dnd-placeholder {
-        top: 0;
-        left: 0;
-        position: absolute;
-        opacity: 0.3;
-        z-index: -1;
-    }
-
     .fd-dnd-container {
         position: relative;
 
@@ -42,7 +34,7 @@
             background-color: var(--sapList_Background, #fff);
             z-index: 15;
 
-            .fd-product-switch__item {
+            &.fd-product-switch__item {
                 .fd-product-switch__title {
                     &:before,
                     &:after {
@@ -50,42 +42,32 @@
                         background-color: var(--sapList_Background, #fff);
                     }
                 }
-            }
 
-            .fd-product-switch__item:active .fd-product-switch__icon {
-                color: #0854A0;
-                color: var(--sapContent_IconColor, #0854A0);
-            }
+                .fd-product-switch__icon {
+                    color: #0854A0;
+                    color: var(--sapContent_IconColor, #0854A0);
+                }
 
-            .fd-product-switch__item:active .fd-product-switch__title {
-                color: #32363A;
-                color: var(--sapGroup_TitleTextColor, #32363A);
-            }
+                .fd-product-switch__title {
+                    color: #32363A;
+                    color: var(--sapGroup_TitleTextColor, #32363A);
+                }
 
-            .fd-product-switch__item:active .fd-product-switch__subtitle {
-                color: #6A6D70;
-                color: var(--sapContent_LabelColor, #6A6D70);
+                .fd-product-switch__subtitle {
+                    color: #6A6D70;
+                    color: var(--sapContent_LabelColor, #6A6D70);
+                }
+
+                &:active {
+                    background-color: #fff;
+                    background-color: var(--sapList_Background, #fff);
+                }
             }
 
             &.selected {
                 background-color: #fff;
                 background-color: var(--sapList_Background, #fff);
             }
-
-            .fd-product-switch__item:active {
-                background-color: #fff;
-                background-color: var(--sapList_Background, #fff);
-            }
-        }
-    }
-
-    .fd-product-switch__fullfill {
-        width: 500px;
-    }
-
-    .fd-product-switch__body--mobile {
-        .fd-product-switch__fullfill {
-            width: 100%;
         }
     }
 
@@ -163,8 +145,4 @@
                 border-color: var(--sapContent_DragAndDropActiveColor, #0854A0);
             }
         }
-    }
-
-    .fd-product-switch__list > li {
-        list-style-type: none;
     }

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.ts
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.ts
@@ -9,6 +9,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { ProductSwitchItem } from './product-switch.item';
+import { FdDropEvent } from '../../utils/drag-and-drop/dnd-list/dnd-list.directive';
 
 @Component({
     selector: 'fd-product-switch-body',
@@ -59,9 +60,9 @@ export class ProductSwitchBodyComponent implements OnInit {
     }
 
     /** Method called on products change */
-    productSwitchItemsChangeHandle(items: any[]): void {
-        this.productsChange.emit(items);
-        this.products = items;
+    productSwitchItemsChangeHandle(dropEvent: FdDropEvent<ProductSwitchItem>): void {
+        this.productsChange.emit(dropEvent.items);
+        this.products = dropEvent.items;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/product-switch/public_api.ts
+++ b/libs/core/src/lib/product-switch/public_api.ts
@@ -3,5 +3,5 @@ export * from './product-switch/product-switch.component';
 export * from './product-switch-body/product-switch.item';
 export * from './product-switch-body/product-switch-body.component';
 export * from '../utils/drag-and-drop/drag-and-drop.module';
-export * from '../utils/drag-and-drop/dnd-container/dnd-container.directive';
+export * from '../utils/drag-and-drop/dnd-item/dnd-item.directive';
 export * from '../utils/drag-and-drop/dnd-list/dnd-list.directive';

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.spec.ts
@@ -7,7 +7,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 @Component({
     template: `
         <span>
-            <div #directiveElement fd-dnd-container>
+            <div #directiveElement fd-dnd-item>
                 <div cdkDrag>
                     <div></div>
                 </div>

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
@@ -33,12 +33,14 @@ export class DndContainerDirective implements AfterContentInit {
     readonly started: EventEmitter<void> = new EventEmitter<void>();
 
     /** Whether this element should stick in one place, without changing position */
-    @Input() stickInPlace: boolean = false;
+    @Input()
+    stickInPlace = false;
+
+    /**  */
+    @Input()
+    disabled = false;
 
     /** */
-    @Input()
-    disabled: boolean = false;
-
     private _dragRef: DragRef;
 
     constructor(public element: ElementRef, private _dragDrop: DragDrop) {}
@@ -64,16 +66,9 @@ export class DndContainerDirective implements AfterContentInit {
 
     /** @hidden */
     public ngAfterContentInit(): void {
-        this._dragRef = this._dragDrop.createDrag(this.element);
-        this._dragRef.moved.subscribe((event: any) => {
-            this.onCdkMove(event);
-        });
-        this._dragRef.released.subscribe(() => {
-            this.onCdkDragReleased();
-        });
-        this._dragRef.started.subscribe(() => {
-            this.onCdkDragStart();
-        });
+        if (!this.disabled) {
+            this._setCDKDrag();
+        }
     }
 
     /** @hidden */
@@ -139,7 +134,6 @@ export class DndContainerDirective implements AfterContentInit {
     public createReplaceIndicator(): void {
         this.replaceIndicator = document.createElement('DIV');
         this.replaceIndicator.classList.add('fd-replace-indicator');
-        this.replaceIndicator.classList.add('fd-replace-indicator');
         this.element.nativeElement.appendChild(this.replaceIndicator);
     }
 
@@ -186,8 +180,11 @@ export class DndContainerDirective implements AfterContentInit {
         this.placeholderElement.style.top = offset.y + 'px';
         this.placeholderElement.style.left = offset.x + 'px';
         this.placeholderElement.style.position = 'absolute';
-        this.placeholderElement.style.width = this.element.nativeElement.offsetWidth;
-        this.placeholderElement.style.height = this.element.nativeElement.offsetHeight;
+        this.placeholderElement.style.zIndex = '0';
+        this.placeholderElement.style.opacity = '0.3';
+
+        this.placeholderElement.style.width = this.element.nativeElement.offsetWidth + 'px';
+        this.placeholderElement.style.height = this.element.nativeElement.offsetHeight + 'px';
     }
 
     private _getOffsetToParent(element: any): { x: number, y: number } {
@@ -201,5 +198,18 @@ export class DndContainerDirective implements AfterContentInit {
             y: Math.abs(element.getBoundingClientRect().top - parentTop)
         }
 
+    }
+
+    private _setCDKDrag(): void {
+        this._dragRef = this._dragDrop.createDrag(this.element);
+        this._dragRef.moved.subscribe((event: any) => {
+            this.onCdkMove(event);
+        });
+        this._dragRef.released.subscribe(() => {
+            this.onCdkDragReleased();
+        });
+        this._dragRef.started.subscribe(() => {
+            this.onCdkDragStart();
+        });
     }
 }

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-container/dnd-container.directive.ts
@@ -6,7 +6,7 @@ import { ElementChord, LinkPosition } from '../dnd-list/dnd-list.directive';
     // tslint:disable-next-line:directive-selector
     selector: '[fd-dnd-item]',
     host: {
-        class: 'fd-dnd-container'
+        class: 'fd-dnd-item'
     },
     providers: [
         DragDrop
@@ -22,25 +22,27 @@ export class DndContainerDirective implements AfterContentInit {
     private replaceIndicator: HTMLElement;
     /** Event thrown when the element is moved by 1px */
     @Output()
-    readonly moved: EventEmitter<CdkDragMove> = new EventEmitter<CdkDragMove>();
+    readonly moved = new EventEmitter<CdkDragMove>();
 
     /** Event thrown when the element is released */
     @Output()
-    readonly released: EventEmitter<void> = new EventEmitter<void>();
+    readonly released = new EventEmitter<void>();
 
     /** Event thrown when the element is started to be dragged */
     @Output()
-    readonly started: EventEmitter<void> = new EventEmitter<void>();
+    readonly started = new EventEmitter<void>();
 
     /** Whether this element should stick in one place, without changing position */
     @Input()
     stickInPlace = false;
 
-    /**  */
+    /** Defines if element is disabled from drag and drop */
     @Input()
-    disabled = false;
+    dndDisabled = false;
 
-    /** */
+    /** @hidden
+     * Drag reference, object created from DND CDK Service
+     */
     private _dragRef: DragRef;
 
     constructor(public element: ElementRef, private _dragDrop: DragDrop) {}
@@ -66,43 +68,37 @@ export class DndContainerDirective implements AfterContentInit {
 
     /** @hidden */
     public ngAfterContentInit(): void {
-        if (!this.disabled) {
+        if (!this.dndDisabled) {
             this._setCDKDrag();
         }
     }
 
     /** @hidden */
     public onCdkMove(cdkMovedEvent: CdkDragMove): void {
-        if (!this.disabled) {
-            this.moved.emit(cdkMovedEvent);
-        }
+        this.moved.emit(cdkMovedEvent);
     }
 
     /** @hidden */
     public onCdkDragReleased(): void {
-        if (!this.disabled) {
-            /** Remove class which is added, when element is dragged */
-            this.element.nativeElement.classList.remove(this.CLASS_WHEN_ELEMENT_DRAGGED);
-            this.released.emit();
+        /** Remove class which is added, when element is dragged */
+        this.element.nativeElement.classList.remove(this.CLASS_WHEN_ELEMENT_DRAGGED);
+        this.released.emit();
 
-            /** Resets the position of element. */
-            this._dragRef.reset();
+        /** Resets the position of element. */
+        this._dragRef.reset();
 
-            /** Removes placeholder element */
-            this.removePlaceholder();
-        }
+        /** Removes placeholder element */
+        this.removePlaceholder();
     }
 
     /** @hidden */
     public onCdkDragStart(): void {
-        if (!this.disabled) {
-            /** Adds class */
-            this.element.nativeElement.classList.add(this.CLASS_WHEN_ELEMENT_DRAGGED);
-            if (!this.placeholderElement) {
-                this.createPlaceHolder();
-            }
-            this.started.emit();
+        /** Adds class */
+        this.element.nativeElement.classList.add(this.CLASS_WHEN_ELEMENT_DRAGGED);
+        if (!this.placeholderElement) {
+            this.createPlaceHolder();
         }
+        this.started.emit();
     }
 
     /** @hidden */
@@ -174,6 +170,7 @@ export class DndContainerDirective implements AfterContentInit {
         this.element.nativeElement.after(clone);
     }
 
+    /** @hidden */
     private _setPlaceholderStyles(): void {
         const offset = this._getOffsetToParent(this.element.nativeElement);
 
@@ -187,6 +184,7 @@ export class DndContainerDirective implements AfterContentInit {
         this.placeholderElement.style.height = this.element.nativeElement.offsetHeight + 'px';
     }
 
+    /** @hidden */
     private _getOffsetToParent(element: any): { x: number, y: number } {
         const parentElement = element.parentElement;
 
@@ -200,6 +198,7 @@ export class DndContainerDirective implements AfterContentInit {
 
     }
 
+    /** @hidden */
     private _setCDKDrag(): void {
         this._dragRef = this._dragDrop.createDrag(this.element);
         this._dragRef.moved.subscribe((event: any) => {

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.spec.ts
@@ -45,25 +45,25 @@ describe('DndItemDirective', () => {
 
     it('should react to start drag', () => {
         spyOn(directive.started, 'emit');
-        expect((directive as any).placeholderElement).toBeFalsy();
+        expect((directive as any)._placeholderElement).toBeFalsy();
         directive.onCdkDragStart();
-        expect((directive as any).placeholderElement).not.toBeFalsy();
+        expect((directive as any)._placeholderElement).not.toBeFalsy();
         expect(directive.started.emit).toHaveBeenCalled();
     });
 
     it('should react to drag release', () => {
         spyOn(directive.released, 'emit');
-        (directive as any).placeholderElement = document.createElement('div');
-        directive.element.nativeElement.appendChild((directive as any).placeholderElement);
+        (directive as any)._placeholderElement = document.createElement('div');
+        directive.element.nativeElement.appendChild((directive as any)._placeholderElement);
         directive.onCdkDragReleased();
-        expect((directive as any).placeholderElement).toBeFalsy();
+        expect((directive as any)._placeholderElement).toBeFalsy();
         expect(directive.released.emit).toHaveBeenCalled();
     });
 
     it('should create proper horizontal line', () => {
         directive.createLine('before', true);
-        expect((directive as any).lineElement).not.toBeFalsy();
-        const classes: string[] = (directive as any).lineElement.classList;
+        expect((directive as any)._lineElement).not.toBeFalsy();
+        const classes: string[] = (directive as any)._lineElement.classList;
         expect(classes).toContain('drop-area__line');
         expect(classes).toContain('drop-area__line--horizontal');
         expect(classes).toContain('before');
@@ -71,8 +71,8 @@ describe('DndItemDirective', () => {
 
     it('should create proper vertical line', () => {
         directive.createLine('before', false);
-        expect((directive as any).lineElement).not.toBeFalsy();
-        const classes: string[] = (directive as any).lineElement.classList;
+        expect((directive as any)._lineElement).not.toBeFalsy();
+        const classes: string[] = (directive as any)._lineElement.classList;
         expect(classes).toContain('drop-area__line');
         expect(classes).toContain('drop-area__line--vertical');
         expect(classes).toContain('before');

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { DndContainerDirective } from './dnd-container.directive';
+import { DndItemDirective } from './dnd-item.directive';
 import { Component, ViewChild } from '@angular/core';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 
@@ -16,19 +16,19 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     `
 })
 class TestDndContainerComponent {
-    @ViewChild('directiveElement', { static: true, read: DndContainerDirective })
-    directive: DndContainerDirective;
+    @ViewChild('directiveElement', { static: true, read: DndItemDirective })
+    directive: DndItemDirective;
 }
 
-describe('DndContainerDirective', () => {
+describe('DndItemDirective', () => {
     let component: TestDndContainerComponent;
-    let directive: DndContainerDirective;
+    let directive: DndItemDirective;
     let fixture: ComponentFixture<TestDndContainerComponent>;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [DragDropModule],
-            declarations: [TestDndContainerComponent, DndContainerDirective]
+            declarations: [TestDndContainerComponent, DndItemDirective]
         }).compileComponents();
     }));
 

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.spec.ts
@@ -61,7 +61,7 @@ describe('DndItemDirective', () => {
     });
 
     it('should create proper horizontal line', () => {
-        directive.createLine('before', true);
+        directive.createLine('before', false);
         expect((directive as any)._lineElement).not.toBeFalsy();
         const classes: string[] = (directive as any)._lineElement.classList;
         expect(classes).toContain('drop-area__line');
@@ -70,7 +70,7 @@ describe('DndItemDirective', () => {
     });
 
     it('should create proper vertical line', () => {
-        directive.createLine('before', false);
+        directive.createLine('before', true);
         expect((directive as any)._lineElement).not.toBeFalsy();
         const classes: string[] = (directive as any)._lineElement.classList;
         expect(classes).toContain('drop-area__line');

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
@@ -1,5 +1,5 @@
 import { AfterContentInit, Directive, ElementRef, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
-import { CdkDragMove, DragDrop, DragRef } from '@angular/cdk/drag-drop';
+import { DragDrop, DragRef } from '@angular/cdk/drag-drop';
 import { ElementChord, LinkPosition } from '../dnd-list/dnd-list.directive';
 import { Subscription } from 'rxjs';
 

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
@@ -63,7 +63,9 @@ export class DndItemDirective implements AfterContentInit, OnDestroy {
     /** @hidden */
     private _subscriptions = new Subscription();
 
-    /** @hidden */
+    /** @hidden
+     * Element that indicates position of dragged element. It's ghost copy of dragged element.
+     */
     private _placeholderElement: HTMLElement;
 
     /** @hidden */

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
@@ -3,6 +3,11 @@ import { CdkDragMove, DragDrop, DragRef } from '@angular/cdk/drag-drop';
 import { ElementChord, LinkPosition } from '../dnd-list/dnd-list.directive';
 import { Subscription } from 'rxjs';
 
+export interface ElementPosition {
+    x: number;
+    y: number;
+}
+
 @Directive({
     // tslint:disable-next-line:directive-selector
     selector: '[fd-dnd-item]',
@@ -16,7 +21,7 @@ import { Subscription } from 'rxjs';
 export class DndItemDirective implements AfterContentInit, OnDestroy {
     /** Event thrown when the element is moved by 1px */
     @Output()
-    readonly moved = new EventEmitter<CdkDragMove>();
+    readonly moved = new EventEmitter<ElementPosition>();
 
     /** Event thrown when the element is released */
     @Output()
@@ -82,8 +87,8 @@ export class DndItemDirective implements AfterContentInit, OnDestroy {
     }
 
     /** @hidden */
-    onCdkMove(cdkMovedEvent: CdkDragMove): void {
-        this.moved.emit(cdkMovedEvent);
+    onCdkMove(position: ElementPosition): void {
+        this.moved.emit(position);
     }
 
     /** @hidden */
@@ -212,7 +217,7 @@ export class DndItemDirective implements AfterContentInit, OnDestroy {
     private _setCDKDrag(): void {
         this._dragRef = this._dragDrop.createDrag(this.element);
         this._subscriptions.add(
-            this._dragRef.moved.subscribe((event: any) => this.onCdkMove(event))
+            this._dragRef.moved.subscribe(event => this.onCdkMove(event.pointerPosition))
         );
         this._subscriptions.add(
             this._dragRef.released.subscribe(() => this.onCdkDragReleased())

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
@@ -13,13 +13,6 @@ import { ElementChord, LinkPosition } from '../dnd-list/dnd-list.directive';
     ]
 })
 export class DndItemDirective implements AfterContentInit {
-    /** Class added to element, when it's dragged. */
-    readonly CLASS_WHEN_ELEMENT_DRAGGED: string = 'fd-dnd-on-drag';
-
-    private placeholderElement: HTMLElement;
-
-    private lineElement: HTMLElement;
-    private replaceIndicator: HTMLElement;
     /** Event thrown when the element is moved by 1px */
     @Output()
     readonly moved = new EventEmitter<CdkDragMove>();
@@ -40,10 +33,17 @@ export class DndItemDirective implements AfterContentInit {
     @Input()
     dndDisabled = false;
 
+    /** Class added to element, when it's dragged. */
+    readonly CLASS_WHEN_ELEMENT_DRAGGED: string = 'fd-dnd-on-drag';
+
     /** @hidden
      * Drag reference, object created from DND CDK Service
      */
     private _dragRef: DragRef;
+
+    private _placeholderElement: HTMLElement;
+    private _lineElement: HTMLElement;
+    private _replaceIndicator: HTMLElement;
 
     constructor(public element: ElementRef, private _dragDrop: DragDrop) {}
 
@@ -95,7 +95,7 @@ export class DndItemDirective implements AfterContentInit {
     public onCdkDragStart(): void {
         /** Adds class */
         this.element.nativeElement.classList.add(this.CLASS_WHEN_ELEMENT_DRAGGED);
-        if (!this.placeholderElement) {
+        if (!this._placeholderElement) {
             this.createPlaceHolder();
         }
         this.started.emit();
@@ -103,58 +103,58 @@ export class DndItemDirective implements AfterContentInit {
 
     /** @hidden */
     public removePlaceholder(): void {
-        if (this.placeholderElement && this.placeholderElement.parentNode) {
+        if (this._placeholderElement && this._placeholderElement.parentNode) {
             // IE11 workaround
-            this.placeholderElement.parentNode.removeChild(this.placeholderElement);
-            this.placeholderElement = null;
+            this._placeholderElement.parentNode.removeChild(this._placeholderElement);
+            this._placeholderElement = null;
         }
     }
 
     /** @hidden */
     public removeLine(): void {
-        if (this.lineElement && this.lineElement.parentNode) {
+        if (this._lineElement && this._lineElement.parentNode) {
             // IE11 workaround
-            this.lineElement.parentNode.removeChild(this.lineElement);
-            this.lineElement = null;
+            this._lineElement.parentNode.removeChild(this._lineElement);
+            this._lineElement = null;
         }
     }
 
     /** @hidden */
     public removeReplacement(): void {
-        if (this.replaceIndicator && this.replaceIndicator.parentNode) {
+        if (this._replaceIndicator && this._replaceIndicator.parentNode) {
             // IE11 workaround
-            this.replaceIndicator.parentNode.removeChild(this.replaceIndicator);
-            this.replaceIndicator = null;
+            this._replaceIndicator.parentNode.removeChild(this._replaceIndicator);
+            this._replaceIndicator = null;
         }
     }
 
     /** @hidden */
     public createReplaceIndicator(): void {
-        this.replaceIndicator = document.createElement('DIV');
-        this.replaceIndicator.classList.add('fd-replace-indicator');
-        this.element.nativeElement.appendChild(this.replaceIndicator);
+        this._replaceIndicator = document.createElement('DIV');
+        this._replaceIndicator.classList.add('fd-replace-indicator');
+        this.element.nativeElement.appendChild(this._replaceIndicator);
     }
 
     /** @hidden */
     public createLine(position: LinkPosition, listMode: boolean): void {
         /** Creating of line element */
-        this.lineElement = document.createElement('DIV');
+        this._lineElement = document.createElement('DIV');
         if (listMode) {
-            this.lineElement.classList.add('drop-area__line');
-            this.lineElement.classList.add('drop-area__line--horizontal');
+            this._lineElement.classList.add('drop-area__line');
+            this._lineElement.classList.add('drop-area__line--horizontal');
         } else {
-            this.lineElement.classList.add('drop-area__line');
-            this.lineElement.classList.add('drop-area__line--vertical');
+            this._lineElement.classList.add('drop-area__line');
+            this._lineElement.classList.add('drop-area__line--vertical');
         }
         if (position === 'after') {
-            this.lineElement.classList.add('after');
+            this._lineElement.classList.add('after');
         }
         if (position === 'before') {
-            this.lineElement.classList.add('before');
+            this._lineElement.classList.add('before');
         }
 
         /** Putting element to the container */
-        this.element.nativeElement.appendChild(this.lineElement);
+        this.element.nativeElement.appendChild(this._lineElement);
     }
 
     /** @hidden */
@@ -163,9 +163,9 @@ export class DndItemDirective implements AfterContentInit {
         const clone = this.element.nativeElement.cloneNode(true);
 
         /** Taking cloned element reference */
-        this.placeholderElement = clone.firstChild.parentElement;
+        this._placeholderElement = clone.firstChild.parentElement;
 
-        this.placeholderElement.classList.add('fd-dnd-placeholder');
+        this._placeholderElement.classList.add('fd-dnd-placeholder');
         this._setPlaceholderStyles();
 
         /** Including element to the container */
@@ -176,14 +176,14 @@ export class DndItemDirective implements AfterContentInit {
     private _setPlaceholderStyles(): void {
         const offset = this._getOffsetToParent(this.element.nativeElement);
 
-        this.placeholderElement.style.top = offset.y + 'px';
-        this.placeholderElement.style.left = offset.x + 'px';
-        this.placeholderElement.style.position = 'absolute';
-        this.placeholderElement.style.zIndex = '0';
-        this.placeholderElement.style.opacity = '0.3';
+        this._placeholderElement.style.top = offset.y + 'px';
+        this._placeholderElement.style.left = offset.x + 'px';
+        this._placeholderElement.style.position = 'absolute';
+        this._placeholderElement.style.zIndex = '0';
+        this._placeholderElement.style.opacity = '0.3';
 
-        this.placeholderElement.style.width = this.element.nativeElement.offsetWidth + 'px';
-        this.placeholderElement.style.height = this.element.nativeElement.offsetHeight + 'px';
+        this._placeholderElement.style.width = this.element.nativeElement.offsetWidth + 'px';
+        this._placeholderElement.style.height = this.element.nativeElement.offsetHeight + 'px';
     }
 
     /** @hidden */

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
@@ -146,7 +146,7 @@ export class DndItemDirective implements AfterContentInit, OnDestroy {
     /** @hidden */
     createLine(position: LinkPosition, gridMode: boolean): void {
         /** Creating of line element */
-        this._lineElement = document.createElement('DIV');
+        this._lineElement = document.createElement('div');
         this._lineElement.classList.add('drop-area__line');
 
         if (gridMode) {

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
@@ -12,7 +12,7 @@ import { ElementChord, LinkPosition } from '../dnd-list/dnd-list.directive';
         DragDrop
     ]
 })
-export class DndContainerDirective implements AfterContentInit {
+export class DndItemDirective implements AfterContentInit {
     /** Class added to element, when it's dragged. */
     readonly CLASS_WHEN_ELEMENT_DRAGGED: string = 'fd-dnd-on-drag';
 
@@ -119,6 +119,7 @@ export class DndContainerDirective implements AfterContentInit {
         }
     }
 
+    /** @hidden */
     public removeReplacement(): void {
         if (this.replaceIndicator && this.replaceIndicator.parentNode) {
             // IE11 workaround
@@ -127,6 +128,7 @@ export class DndContainerDirective implements AfterContentInit {
         }
     }
 
+    /** @hidden */
     public createReplaceIndicator(): void {
         this.replaceIndicator = document.createElement('DIV');
         this.replaceIndicator.classList.add('fd-replace-indicator');

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
@@ -24,7 +24,7 @@ describe('DndListDirective', () => {
     let component: TestDndListComponent;
     let fixture: ComponentFixture<TestDndListComponent>;
     let directive: DndListDirective;
-    let elementChords: ElementChord[];
+    let elementCoordinates: ElementChord[];
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -38,7 +38,7 @@ describe('DndListDirective', () => {
         component = fixture.componentInstance;
         directive = component.directive;
         component.list = ['item1', 'item2', 'item3', 'item4'];
-        elementChords = [
+        elementCoordinates = [
             { x: 145, y: 145, position: 'before' },
             { x: 200, y: 200, position: 'before' },
             { x: 250, y: 250, position: 'before' },
@@ -52,50 +52,46 @@ describe('DndListDirective', () => {
     });
 
     it('Should handle dragStart', () => {
-        expect((directive as any)._elementChords).toBeFalsy();
+        expect((directive as any)._elementCoordinates).toBeFalsy();
         directive.dragStart(3);
         expect((directive as any)._draggedItemIndex).toBe(3);
-        expect((directive as any)._elementChords.length).toBe(4);
+        expect((directive as any)._elementCoordinates.length).toBe(4);
     });
 
     it('Should handle move and detect good target (1)', () => {
-        spyOn(directive as any, '_generateLine');
+        spyOn(directive as any, '_createLine');
         const pointerPosition = { pointerPosition: { x: 150, y: 150 } };
-        (directive as any)._closestLinkIndex = 100;
-        (directive as any)._closestLinkPosition = 'after';
-        (directive as any)._draggedItemIndex = 3;
-        (directive as any)._elementChords = elementChords;
+        (directive as any)._closestItemIndex = 100;
+        (directive as any)._closestItemPosition = 'after';
+        (directive as any)._elementCoordinates = elementCoordinates;
 
-        directive.onMove(<any>pointerPosition);
+        directive.onMove(<any>pointerPosition, 3);
 
-        expect((directive as any)._closestLinkIndex).toBe(0);
-        expect((directive as any)._closestLinkPosition).toBe('before');
-        expect((directive as any)._generateLine).toHaveBeenCalledWith(0, 'before');
+        expect((directive as any)._closestItemIndex).toBe(0);
+        expect((directive as any)._closestItemPosition).toBe('before');
+        expect((directive as any)._createLine).toHaveBeenCalledWith(0, 'before');
     });
 
     it('Should handle move and detect good target (2)', () => {
-        spyOn(directive as any, '_generateLine');
+        spyOn(directive as any, '_createLine');
         const pointerPosition = { pointerPosition: { x: 230, y: 230 } };
-        (directive as any)._closestLinkIndex = 1000;
-        (directive as any)._closestLinkPosition = 'after';
-        (directive as any)._draggedItemIndex = 3;
-        (directive as any)._elementChords = elementChords;
+        (directive as any)._closestItemIndex = 1000;
+        (directive as any)._closestItemPosition = 'after';
+        (directive as any)._elementCoordinates = elementCoordinates;
 
-        directive.onMove(<any>pointerPosition);
+        directive.onMove(<any>pointerPosition, 3);
 
-        expect((directive as any)._closestLinkIndex).toBe(2);
-        expect((directive as any)._closestLinkPosition).toBe('before');
-        expect((directive as any)._generateLine).toHaveBeenCalledWith(2, 'before');
+        expect((directive as any)._closestItemIndex).toBe(2);
+        expect((directive as any)._closestItemPosition).toBe('before');
+        expect((directive as any)._createLine).toHaveBeenCalledWith(2, 'before');
     });
 
     it('should handle dragend', () => {
         spyOn(directive.itemsChange, 'emit');
         spyOn(directive as any, '_removeAllLines');
-        (directive as any)._draggedItemIndex = 3;
-        (directive as any)._closestLinkIndex = 1;
         directive.items = [...component.list];
 
-        directive.dragEnd();
+        directive.dragEnd(3);
 
         expect(directive.itemsChange.emit).toHaveBeenCalledWith(['item1', 'item4', 'item2', 'item3']);
 
@@ -103,22 +99,21 @@ describe('DndListDirective', () => {
     });
 
     it('should handle stickToPosition', () => {
-        spyOn(directive as any, '_generateLine');
+        spyOn(directive as any, '_createLine');
 
         const pointerPosition = { pointerPosition: { x: 230, y: 230 } };
-        (directive as any)._closestLinkIndex = 1000;
-        (directive as any)._closestLinkPosition = 'after';
-        (directive as any)._draggedItemIndex = 3;
+        (directive as any)._closestItemIndex = 1000;
+        (directive as any)._closestItemPosition = 'after';
 
         /** This is element tht should be ignored */
-        elementChords.push({ x: 235, y: 230, stickToPosition: true, position: 'after' });
+        elementCoordinates.push({ x: 235, y: 230, stickToPosition: true, position: 'after' });
 
-        (directive as any)._elementChords = elementChords;
+        (directive as any)._elementCoordinates = elementCoordinates;
 
-        directive.onMove(<any>pointerPosition);
+        directive.onMove(<any>pointerPosition, 3);
 
-        expect((directive as any)._closestLinkIndex).toBe(2);
-        expect((directive as any)._closestLinkPosition).toBe('before');
-        expect((directive as any)._generateLine).toHaveBeenCalledWith(2, 'before');
+        expect((directive as any)._closestItemIndex).toBe(2);
+        expect((directive as any)._closestItemPosition).toBe('before');
+        expect((directive as any)._createLine).toHaveBeenCalledWith(2, 'before');
     });
 });

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
@@ -60,12 +60,12 @@ describe('DndListDirective', () => {
 
     it('Should handle move and detect good target (1)', () => {
         spyOn(directive as any, '_createLine');
-        const pointerPosition = { pointerPosition: { x: 150, y: 150 } };
+        const pointerPosition = { x: 150, y: 150 };
         (directive as any)._closestItemIndex = 100;
         (directive as any)._closestItemPosition = 'after';
         (directive as any)._elementsCoordinates = elementCoordinates;
 
-        directive.onMove(<any>pointerPosition, 3);
+        directive.onMove(pointerPosition, 3);
 
         expect((directive as any)._closestItemIndex).toBe(0);
         expect((directive as any)._closestItemPosition).toBe('before');
@@ -74,12 +74,12 @@ describe('DndListDirective', () => {
 
     it('Should handle move and detect good target (2)', () => {
         spyOn(directive as any, '_createLine');
-        const pointerPosition = { pointerPosition: { x: 230, y: 230 } };
+        const pointerPosition = { x: 230, y: 230 };
         (directive as any)._closestItemIndex = 1000;
         (directive as any)._closestItemPosition = 'after';
         (directive as any)._elementsCoordinates = elementCoordinates;
 
-        directive.onMove(<any>pointerPosition, 3);
+        directive.onMove(pointerPosition, 3);
 
         expect((directive as any)._closestItemIndex).toBe(2);
         expect((directive as any)._closestItemPosition).toBe('before');

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
@@ -15,7 +15,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 })
 class TestDndListComponent {
     @ViewChild('directiveElement', { static: true, read: DndListDirective })
-    directive: DndListDirective;
+    directive: DndListDirective<string>;
 
     list: string[] = [];
 }
@@ -23,7 +23,7 @@ class TestDndListComponent {
 describe('DndListDirective', () => {
     let component: TestDndListComponent;
     let fixture: ComponentFixture<TestDndListComponent>;
-    let directive: DndListDirective;
+    let directive: DndListDirective<string>;
     let elementCoordinates: ElementChord[];
 
     beforeEach(async(() => {
@@ -87,13 +87,16 @@ describe('DndListDirective', () => {
     });
 
     it('should handle dragend', () => {
-        spyOn(directive.itemsChange, 'emit');
+        spyOn(directive.itemDropped, 'emit');
         spyOn(directive as any, '_removeAllLines');
         directive.items = [...component.list];
 
         directive.dragEnd(3);
-
-        expect(directive.itemsChange.emit).toHaveBeenCalledWith(['item1', 'item4', 'item2', 'item3']);
+        expect(directive.itemDropped.emit).toHaveBeenCalledWith({
+            replacedItemIndex: 1,
+            draggedItemIndex: 3,
+            items: ['item1', 'item4', 'item2', 'item3']
+        });
 
         expect((directive as any)._removeAllLines).toHaveBeenCalled();
     });

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { DndListDirective, ElementChord } from './dnd-list.directive';
 import { Component, ViewChild } from '@angular/core';
-import { DndContainerDirective } from '../dnd-container/dnd-container.directive';
+import { DndItemDirective } from '../dnd-item/dnd-item.directive';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @Component({
@@ -31,7 +31,7 @@ describe('DndListDirective', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [DragDropModule],
-            declarations: [DndListDirective, TestDndListComponent, DndContainerDirective]
+            declarations: [DndListDirective, TestDndListComponent, DndItemDirective]
         }).compileComponents();
     }));
 

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
@@ -8,9 +8,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     template: `
         <div #directiveElement fd-dnd-list>
             <div fd-dnd-item *ngFor="let item of list">
-                <div cdkDrag>
-                    <div>{{ item }}</div>
-                </div>
+                <div>{{ item }}</div>
             </div>
         </div>
     `
@@ -54,73 +52,73 @@ describe('DndListDirective', () => {
     });
 
     it('Should handle dragStart', () => {
-        expect((directive as any).elementChords).toBeFalsy();
+        expect((directive as any)._elementChords).toBeFalsy();
         directive.dragStart(3);
-        expect((directive as any).draggedItemIndex).toBe(3);
-        expect((directive as any).elementChords.length).toBe(4);
+        expect((directive as any)._draggedItemIndex).toBe(3);
+        expect((directive as any)._elementChords.length).toBe(4);
     });
 
     it('Should handle move and detect good target (1)', () => {
-        spyOn(directive as any, 'generateLine');
+        spyOn(directive as any, '_generateLine');
         const pointerPosition = { pointerPosition: { x: 150, y: 150 } };
-        (directive as any).closestLinkIndex = 100;
-        (directive as any).closestLinkPosition = 'after';
-        (directive as any).draggedItemIndex = 3;
-        (directive as any).elementChords = elementChords;
+        (directive as any)._closestLinkIndex = 100;
+        (directive as any)._closestLinkPosition = 'after';
+        (directive as any)._draggedItemIndex = 3;
+        (directive as any)._elementChords = elementChords;
 
         directive.onMove(<any>pointerPosition);
 
-        expect((directive as any).closestLinkIndex).toBe(0);
-        expect((directive as any).closestLinkPosition).toBe('before');
-        expect((directive as any).generateLine).toHaveBeenCalledWith(0, 'before');
+        expect((directive as any)._closestLinkIndex).toBe(0);
+        expect((directive as any)._closestLinkPosition).toBe('before');
+        expect((directive as any)._generateLine).toHaveBeenCalledWith(0, 'before');
     });
 
     it('Should handle move and detect good target (2)', () => {
-        spyOn(directive as any, 'generateLine');
+        spyOn(directive as any, '_generateLine');
         const pointerPosition = { pointerPosition: { x: 230, y: 230 } };
-        (directive as any).closestLinkIndex = 1000;
-        (directive as any).closestLinkPosition = 'after';
-        (directive as any).draggedItemIndex = 3;
-        (directive as any).elementChords = elementChords;
+        (directive as any)._closestLinkIndex = 1000;
+        (directive as any)._closestLinkPosition = 'after';
+        (directive as any)._draggedItemIndex = 3;
+        (directive as any)._elementChords = elementChords;
 
         directive.onMove(<any>pointerPosition);
 
-        expect((directive as any).closestLinkIndex).toBe(2);
-        expect((directive as any).closestLinkPosition).toBe('before');
-        expect((directive as any).generateLine).toHaveBeenCalledWith(2, 'before');
+        expect((directive as any)._closestLinkIndex).toBe(2);
+        expect((directive as any)._closestLinkPosition).toBe('before');
+        expect((directive as any)._generateLine).toHaveBeenCalledWith(2, 'before');
     });
 
     it('should handle dragend', () => {
         spyOn(directive.itemsChange, 'emit');
-        spyOn(directive as any, 'removeAllLines');
-        (directive as any).draggedItemIndex = 3;
-        (directive as any).closestLinkIndex = 1;
+        spyOn(directive as any, '_removeAllLines');
+        (directive as any)._draggedItemIndex = 3;
+        (directive as any)._closestLinkIndex = 1;
         directive.items = [...component.list];
 
         directive.dragEnd();
 
         expect(directive.itemsChange.emit).toHaveBeenCalledWith(['item1', 'item4', 'item2', 'item3']);
 
-        expect((directive as any).removeAllLines).toHaveBeenCalled();
+        expect((directive as any)._removeAllLines).toHaveBeenCalled();
     });
 
     it('should handle stickToPosition', () => {
-        spyOn(directive as any, 'generateLine');
+        spyOn(directive as any, '_generateLine');
 
         const pointerPosition = { pointerPosition: { x: 230, y: 230 } };
-        (directive as any).closestLinkIndex = 1000;
-        (directive as any).closestLinkPosition = 'after';
-        (directive as any).draggedItemIndex = 3;
+        (directive as any)._closestLinkIndex = 1000;
+        (directive as any)._closestLinkPosition = 'after';
+        (directive as any)._draggedItemIndex = 3;
 
         /** This is element tht should be ignored */
         elementChords.push({ x: 235, y: 230, stickToPosition: true, position: 'after' });
 
-        (directive as any).elementChords = elementChords;
+        (directive as any)._elementChords = elementChords;
 
         directive.onMove(<any>pointerPosition);
 
-        expect((directive as any).closestLinkIndex).toBe(2);
-        expect((directive as any).closestLinkPosition).toBe('before');
-        expect((directive as any).generateLine).toHaveBeenCalledWith(2, 'before');
+        expect((directive as any)._closestLinkIndex).toBe(2);
+        expect((directive as any)._closestLinkPosition).toBe('before');
+        expect((directive as any)._generateLine).toHaveBeenCalledWith(2, 'before');
     });
 });

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
@@ -7,7 +7,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 @Component({
     template: `
         <div #directiveElement fd-dnd-list>
-            <div fd-dnd-container *ngFor="let item of list">
+            <div fd-dnd-item *ngFor="let item of list">
                 <div cdkDrag>
                     <div>{{ item }}</div>
                 </div>

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
@@ -105,7 +105,7 @@ describe('DndListDirective', () => {
     it('should handle stickToPosition', () => {
         spyOn(directive as any, '_createLine');
 
-        const pointerPosition = { pointerPosition: { x: 230, y: 230 } };
+        const pointerPosition = { x: 230, y: 230 };
         (directive as any)._closestItemIndex = 1000;
         (directive as any)._closestItemPosition = 'after';
 
@@ -114,7 +114,7 @@ describe('DndListDirective', () => {
 
         (directive as any)._elementsCoordinates = elementCoordinates;
 
-        directive.onMove(<any>pointerPosition, 3);
+        directive.onMove(pointerPosition, 3);
 
         expect((directive as any)._closestItemIndex).toBe(2);
         expect((directive as any)._closestItemPosition).toBe('before');

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.spec.ts
@@ -52,10 +52,10 @@ describe('DndListDirective', () => {
     });
 
     it('Should handle dragStart', () => {
-        expect((directive as any)._elementCoordinates).toBeFalsy();
+        expect((directive as any)._elementsCoordinates).toBeFalsy();
+        (directive as any)._closestItemIndex = 1;
         directive.dragStart(3);
-        expect((directive as any)._draggedItemIndex).toBe(3);
-        expect((directive as any)._elementCoordinates.length).toBe(4);
+        expect((directive as any)._elementsCoordinates.length).toBe(4);
     });
 
     it('Should handle move and detect good target (1)', () => {
@@ -63,7 +63,7 @@ describe('DndListDirective', () => {
         const pointerPosition = { pointerPosition: { x: 150, y: 150 } };
         (directive as any)._closestItemIndex = 100;
         (directive as any)._closestItemPosition = 'after';
-        (directive as any)._elementCoordinates = elementCoordinates;
+        (directive as any)._elementsCoordinates = elementCoordinates;
 
         directive.onMove(<any>pointerPosition, 3);
 
@@ -77,7 +77,7 @@ describe('DndListDirective', () => {
         const pointerPosition = { pointerPosition: { x: 230, y: 230 } };
         (directive as any)._closestItemIndex = 1000;
         (directive as any)._closestItemPosition = 'after';
-        (directive as any)._elementCoordinates = elementCoordinates;
+        (directive as any)._elementsCoordinates = elementCoordinates;
 
         directive.onMove(<any>pointerPosition, 3);
 
@@ -91,6 +91,7 @@ describe('DndListDirective', () => {
         spyOn(directive as any, '_removeAllLines');
         directive.items = [...component.list];
 
+        (directive as any)._closestItemIndex = 1;
         directive.dragEnd(3);
         expect(directive.itemDropped.emit).toHaveBeenCalledWith({
             replacedItemIndex: 1,
@@ -111,7 +112,7 @@ describe('DndListDirective', () => {
         /** This is element tht should be ignored */
         elementCoordinates.push({ x: 235, y: 230, stickToPosition: true, position: 'after' });
 
-        (directive as any)._elementCoordinates = elementCoordinates;
+        (directive as any)._elementsCoordinates = elementCoordinates;
 
         directive.onMove(<any>pointerPosition, 3);
 

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
@@ -23,11 +23,17 @@ export interface ElementChord {
     stickToPosition?: boolean;
 }
 
+export interface FdDropEvent<T> {
+    items: Array<T>,
+    replacedItemIndex: number;
+    draggedItemIndex: number;
+}
+
 @Directive({
     // tslint:disable-next-line:directive-selector
     selector: '[fd-dnd-list]'
 })
-export class DndListDirective implements AfterContentInit, OnDestroy {
+export class DndListDirective<T> implements AfterContentInit, OnDestroy {
     /** @hidden */
     @ContentChildren(DndItemDirective)
     dndItems: QueryList<DndItemDirective>;
@@ -42,11 +48,15 @@ export class DndListDirective implements AfterContentInit, OnDestroy {
 
     /** Array of items, that will be sorted */
     @Input()
-    items: Array<any>;
+    items: Array<T>;
 
     /** Event that is thrown, when the item is dropped */
     @Output()
-    readonly itemsChange = new EventEmitter<any>();
+    readonly itemsChange = new EventEmitter<Array<T>>();
+
+    /** Event that is thrown, when the item is dropped */
+    @Output()
+    readonly itemDropped = new EventEmitter<FdDropEvent<T>>();
 
     /** @hidden */
     private _elementCoordinates: ElementChord[];
@@ -153,6 +163,12 @@ export class DndListDirective implements AfterContentInit, OnDestroy {
 
         this.itemsChange.emit(this.items);
 
+        this.itemDropped.emit({
+            replacedItemIndex: replacedItemIndex,
+            draggedItemIndex: draggedItemIndex,
+            items: this.items
+        })
+
         this._removeAllLines();
         this._removeAllReplaceIndicators();
 
@@ -186,7 +202,6 @@ export class DndListDirective implements AfterContentInit, OnDestroy {
 
     /** @hidden */
     private _refreshQueryList(): void {
-        console.log('done');
         const refresh$ = merge(
             this._refresh$,
             this._onDestroy$

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
@@ -9,7 +9,6 @@ import {
     Output,
     QueryList
 } from '@angular/core';
-import { CdkDragMove } from '@angular/cdk/drag-drop';
 import { DndItemDirective, ElementPosition } from '../dnd-item/dnd-item.directive';
 import { merge, Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
@@ -45,22 +45,22 @@ export class DndListDirective implements AfterContentInit {
 
     /** Event that is thrown, when the item is dropped */
     @Output()
-    readonly itemsChange: EventEmitter<Array<any>> = new EventEmitter<any>();
+    readonly itemsChange = new EventEmitter<any>();
 
     /** @hidden */
-    private elementChords: ElementChord[];
+    private _elementChords: ElementChord[];
 
     /** @hidden */
-    private draggedItemIndex = 1000000;
+    private _draggedItemIndex = 1000000;
 
     /** @hidden */
-    private closestLinkIndex: number = null;
+    private _closestLinkIndex: number = null;
 
     /** @hidden */
-    private closestLinkPosition: 'before' | 'after' = null;
+    private _closestLinkPosition: 'before' | 'after' = null;
 
     /** An RxJS Subject that will kill the current data stream (for unsubscribing)  */
-    private readonly refresh$: Subject<void> = new Subject<void>();
+    private readonly _refresh$ = new Subject<void>();
 
     /** @hidden */
     public ngAfterContentInit(): void {
@@ -82,7 +82,7 @@ export class DndListDirective implements AfterContentInit {
             distance: number;
         } = null;
 
-        this.elementChords.forEach((element, index) => {
+        this._elementChords.forEach((element, index) => {
             /** Check if element can be replaced */
             if (!element.stickToPosition) {
                 /** Counting the distances by the mileage of the corner of element and cursor position */
@@ -94,38 +94,38 @@ export class DndListDirective implements AfterContentInit {
         });
 
         /** If the closest element is different than the old one, new one is picked. It prevents from performance issues */
-        if (lowestDistanceItem.index !== this.closestLinkIndex) {
-            this.closestLinkIndex = lowestDistanceItem.index;
-            this.closestLinkPosition = this.elementChords[lowestDistanceItem.index].position;
+        if (lowestDistanceItem.index !== this._closestLinkIndex) {
+            this._closestLinkIndex = lowestDistanceItem.index;
+            this._closestLinkPosition = this._elementChords[lowestDistanceItem.index].position;
             // If closest item index is same as dragged item, just remove indicators
-            if (lowestDistanceItem.index === this.draggedItemIndex) {
+            if (lowestDistanceItem.index === this._draggedItemIndex) {
                 this._removeAllLines();
                 this._removeAllReplaceIndicators();
                 return;
             }
             /** Generating line, that shows where the element will be placed, on drop */
             if (this.replaceMode) {
-                this._generateReplacementIndicator(this.closestLinkIndex);
+                this._generateReplacementIndicator(this._closestLinkIndex);
             } else {
-                this._generateLine(this.closestLinkIndex, this.closestLinkPosition);
+                this._generateLine(this._closestLinkIndex, this._closestLinkPosition);
             }
         }
     }
 
     /** Method called, when element is started to be dragged */
     dragStart(ind: number): void {
-        this.draggedItemIndex = ind;
+        this._draggedItemIndex = ind;
         const draggedItemElement = this.dndContainerItems.toArray()[ind].element;
         /** Counting all of the elements's chords */
-        this.elementChords = this.dndContainerItems
+        this._elementChords = this.dndContainerItems
             .toArray()
             .map((link) => link.getElementChord(this._isBefore(draggedItemElement, link.element), this.listMode));
     }
 
     /** Method called, when element is released */
     dragEnd(): void {
-        const draggedItemIndex = this.draggedItemIndex;
-        const replacedItemIndex = this.closestLinkIndex;
+        const draggedItemIndex = this._draggedItemIndex;
+        const replacedItemIndex = this._closestLinkIndex;
         const draggedItem = this.items[draggedItemIndex];
 
         if (draggedItemIndex < replacedItemIndex) {
@@ -147,9 +147,9 @@ export class DndListDirective implements AfterContentInit {
         this._removeAllReplaceIndicators();
 
         /** Reset */
-        this.elementChords = [];
-        this.closestLinkIndex = null;
-        this.closestLinkPosition = null;
+        this._elementChords = [];
+        this._closestLinkIndex = null;
+        this._closestLinkPosition = null;
     }
 
     /** @hidden */
@@ -176,11 +176,11 @@ export class DndListDirective implements AfterContentInit {
 
     /** @hidden */
     private _refreshQueryList(): void {
-        this.refresh$.next();
+        this._refresh$.next();
         this.dndContainerItems.forEach((item, index) => {
-            item.moved.pipe(takeUntil(this.refresh$)).subscribe((eventMove) => this.onMove(eventMove));
-            item.started.pipe(takeUntil(this.refresh$)).subscribe(() => this.dragStart(index));
-            item.released.pipe(takeUntil(this.refresh$)).subscribe(() => this.dragEnd());
+            item.moved.pipe(takeUntil(this._refresh$)).subscribe((eventMove) => this.onMove(eventMove));
+            item.started.pipe(takeUntil(this._refresh$)).subscribe(() => this.dragStart(index));
+            item.released.pipe(takeUntil(this._refresh$)).subscribe(() => this.dragEnd());
         });
     }
 

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
@@ -9,7 +9,7 @@ import {
     QueryList
 } from '@angular/core';
 import { CdkDragMove } from '@angular/cdk/drag-drop';
-import { DndContainerDirective } from '../dnd-container/dnd-container.directive';
+import { DndItemDirective } from '../dnd-item/dnd-item.directive';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -28,13 +28,14 @@ export interface ElementChord {
 })
 export class DndListDirective implements AfterContentInit {
     /** @hidden */
-    @ContentChildren(DndContainerDirective)
-    dndContainerItems: QueryList<DndContainerDirective>;
+    @ContentChildren(DndItemDirective)
+    dndContainerItems: QueryList<DndItemDirective>;
 
     /** Defines if the distance between elements should be counted only by vertical distance */
     @Input()
     listMode = false;
 
+    /** When enabled, replace indicator will appear on whole element, instead of horizontal/vertical line */
     @Input()
     replaceMode = false;
 
@@ -104,7 +105,7 @@ export class DndListDirective implements AfterContentInit {
             }
             /** Generating line, that shows where the element will be placed, on drop */
             if (this.replaceMode) {
-                this.generateReplacementIndicator(this.closestLinkIndex);
+                this._generateReplacementIndicator(this.closestLinkIndex);
             } else {
                 this._generateLine(this.closestLinkIndex, this.closestLinkPosition);
             }
@@ -168,7 +169,7 @@ export class DndListDirective implements AfterContentInit {
     }
 
     /** @hidden */
-    private generateReplacementIndicator(closestLinkIndex: number): void {
+    private _generateReplacementIndicator(closestLinkIndex: number): void {
         this._removeAllReplaceIndicators();
         this.dndContainerItems.toArray()[closestLinkIndex].createReplaceIndicator();
     }

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
@@ -97,7 +97,7 @@ export class DndListDirective implements AfterContentInit {
             this.closestLinkIndex = lowestDistanceItem.index;
             this.closestLinkPosition = this.elementChords[lowestDistanceItem.index].position;
             // If closest item index is same as dragged item, just remove indicators
-            if (lowestDistanceItem.index !== this.draggedItemIndex) {
+            if (lowestDistanceItem.index === this.draggedItemIndex) {
                 this._removeAllLines();
                 this._removeAllReplaceIndicators();
                 return;

--- a/libs/core/src/lib/utils/drag-and-drop/drag-and-drop.module.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/drag-and-drop.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DndListDirective } from './dnd-list/dnd-list.directive';
-import { DndContainerDirective } from './dnd-container/dnd-container.directive';
+import { DndItemDirective } from './dnd-item/dnd-item.directive';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 
 @NgModule({
     imports: [CommonModule, DragDropModule],
-    exports: [DndContainerDirective, DndListDirective],
-    declarations: [DndListDirective, DndContainerDirective]
+    exports: [DndItemDirective, DndListDirective],
+    declarations: [DndListDirective, DndItemDirective]
 })
 export class DragAndDropModule {}

--- a/libs/core/src/lib/utils/public_api.ts
+++ b/libs/core/src/lib/utils/public_api.ts
@@ -17,7 +17,7 @@ export * from './pipes/search-highlight.pipe';
 
 export * from './drag-and-drop/drag-and-drop.module';
 export * from './drag-and-drop/dnd-list/dnd-list.directive';
-export * from './drag-and-drop/dnd-container/dnd-container.directive';
+export * from './drag-and-drop/dnd-item/dnd-item.directive';
 
 export * from './interfaces/css-class-builder.interface';
 export * from './interfaces/css-style-builder.interface';


### PR DESCRIPTION
#### Please provide a link to the associated issue.
related to: https://github.com/SAP/fundamental-ngx/issues/2776
#### Please provide a brief summary of this pull request.
Drag and drop directive for now is used only inside product switch. Before there was a requirement, to keep `cdkDrag` directive under `fd-dnd-container`. So the final structure had to be 
`ul fd-dnd-list` > `li fd-dnd-container` > `div cdkDrag`.
Now `fd-dnd-container` is changed to `fd-dnd-item` and has cdk drag as a service. It allows optimized usage of dnd.
`ul fd-dnd-list` > `li fd-dnd-item`
It changed final markup of product-switch, but it's not visible from end-user perspective

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

