### PR TITLE
chore: Remove Loading Spinner docs references

### DIFF
--- a/apps/docs/src/app/core/api-files.ts
+++ b/apps/docs/src/app/core/api-files.ts
@@ -83,7 +83,6 @@ export const API_FILES = {
         'ListIconDirective',
         'ListFooterDirective'
     ],
-    loadingSpinner: ['LoadingSpinnerComponent'],
     localizationEditor: [
         'LocalizationEditorComponent',
         'LocalizationEditorItemComponent',

--- a/apps/docs/src/app/core/documentation/core-documentation.component.ts
+++ b/apps/docs/src/app/core/documentation/core-documentation.component.ts
@@ -42,7 +42,6 @@ export class CoreDocumentationComponent extends DocumentationBaseComponent {
             { url: 'core/inputGroup', name: 'Input Group' },
             { url: 'core/link', name: 'Link' },
             { url: 'core/list', name: 'List' },
-            { url: 'core/loadingSpinner', name: 'Loading Spinner' },
             { url: 'core/localizationEditor', name: 'Localization Editor' },
             { url: 'core/mega-menu', name: 'Mega Menu' },
             { url: 'core/menu', name: 'Menu' },


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #2976

#### Please provide a brief summary of this pull request.
This PR removed documentation references to Loading Spinner missed in #2988.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

