### PR TITLE
fix: uicomp-1102 change standard-version commit message format

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "dep-graph": "./node_modules/.bin/nx dep-graph",
     "workspace-schematic": "./node_modules/.bin/nx workspace-schematic",
     "help": "./node_modules/.bin/nx help",
-    "std-version": "standard-version --infile ./CHANGELOG.md -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
+    "std-version": "standard-version --infile ./CHANGELOG.md --releaseCommitMessageFormat \"chore(release): version {{currentTag}} build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "nx": "nx",


### PR DESCRIPTION
## Jira ID [UICOMP-1102](https://jira.concur.com/jira/browse/UICOMP-1102)

### Description
`-m` or `--message` is deprecated https://github.com/conventional-changelog/standard-version/blob/master/command.js#L33

Instead of using `%s` we can use `{{currentTag}}` -- https://github.com/conventional-changelog/standard-version/blob/ae032bfa9268a0a14351b0d78b6deedee7891e3a/test.js#L1244
