### PR TITLE
fix: (platform) add types to contentDensity to fix build error

### DIFF
--- a/libs/platform/src/lib/components/form/switch/switch/switch.component.ts
+++ b/libs/platform/src/lib/components/form/switch/switch/switch.component.ts
@@ -68,7 +68,7 @@ export class SwitchComponent extends BaseInput {
     }
 
     /** @hidden */
-    _contentDensity = this._switchConfig.contentDensity;
+    _contentDensity: ContentDensity = this._switchConfig.contentDensity;
 
     /**
      * @hidden

--- a/libs/platform/src/lib/components/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/components/form/text-area/text-area.component.ts
@@ -134,7 +134,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
     }
 
     /** @hidden */
-    _contentDensity = this._textAreaConfig.contentDensity;
+    _contentDensity: ContentDensity = this._textAreaConfig.contentDensity;
 
     /**
      * @hidden


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#3039 
#### Please provide a brief summary of this pull request.
missing return type was resulting in some random type added on running `ng build`
![image](https://user-images.githubusercontent.com/53509521/90506781-70033080-e172-11ea-835f-587ab18b757d.png)

This can be observed even on running `ng build` in ngx repo, and looking for the affected files in the dist lib, but no error is thrown on terminal. 
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

