### PR TITLE
fix: add first option as title and remove mainActionTitle

### DIFF
--- a/apps/docs/src/app/core/component-docs/split-button/examples/split-button-icons-example.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/examples/split-button-icons-example.component.html
@@ -1,27 +1,27 @@
-<fd-split-button [glyph]="'menu'" [mainActionTitle]="'Action Button'">
+<fd-split-button [glyph]="'menu'">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Action Button 1</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Action Button 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
-<fd-split-button [glyph]="'cart'" [mainActionTitle]="'Action Button'">
+<fd-split-button [glyph]="'cart'">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Action Button 1</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Action Button 2</span>
             </div>
         </li>
     </fd-menu>

--- a/apps/docs/src/app/core/component-docs/split-button/examples/split-button-options-example.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/examples/split-button-options-example.component.html
@@ -1,64 +1,58 @@
-<fd-split-button [mainActionTitle]="'Disabled Button'" [disabled]="true" (primaryButtonClicked)="primaryButtonClicked()">
+<fd-split-button [disabled]="true" (primaryButtonClicked)="primaryButtonClicked()">
     <fd-menu>
         <li fd-menu-item (click)="itemClicked()">
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Disabled 1</span>
             </div>
         </li>
         <li fd-menu-item (click)="itemClicked()">
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Disabled 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button [mainActionTitle]="'Default Button'" (primaryButtonClicked)="primaryButtonClicked()">
+<fd-split-button (primaryButtonClicked)="primaryButtonClicked()">
     <fd-menu>
         <li fd-menu-item (click)="itemClicked()">
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Default Button 1</span>
             </div>
         </li>
         <li fd-menu-item (click)="itemClicked()">
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Default Button 1</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button
-    [fdType]="'emphasized'"
-    [mainActionTitle]="'Emphasized Button'"
-    (primaryButtonClicked)="primaryButtonClicked()">
+<fd-split-button [fdType]="'emphasized'" (primaryButtonClicked)="primaryButtonClicked()">
     <fd-menu>
         <li fd-menu-item (click)="itemClicked()">
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Emphasized Button 1</span>
             </div>
         </li>
         <li fd-menu-item (click)="itemClicked()">
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Emphasized Button 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button
-    [fdType]="'transparent'"
-    [mainActionTitle]="'Light Button'"
-    (primaryButtonClicked)="primaryButtonClicked()">
+<fd-split-button [fdType]="'transparent'" (primaryButtonClicked)="primaryButtonClicked()">
     <fd-menu>
         <li fd-menu-item (click)="itemClicked()">
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Light Button 1</span>
             </div>
         </li>
         <li fd-menu-item (click)="itemClicked()">
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Light Button 2</span>
             </div>
         </li>
     </fd-menu>

--- a/apps/docs/src/app/core/component-docs/split-button/examples/split-button-programmatical-example.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/examples/split-button-programmatical-example.component.html
@@ -1,4 +1,4 @@
-<fd-split-button [mainActionTitle]="'Action Button'">
+<fd-split-button>
     <fd-menu #menu [closeOnOutsideClick]="false">
         <li fd-menu-item>
             <div fd-menu-interactive>

--- a/apps/docs/src/app/core/component-docs/split-button/examples/split-button-template-example.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/examples/split-button-template-example.component.html
@@ -6,12 +6,12 @@
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Action 1</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Action 2</span>
             </div>
         </li>
     </fd-menu>

--- a/apps/docs/src/app/core/component-docs/split-button/examples/split-button-types-example.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/examples/split-button-types-example.component.html
@@ -1,8 +1,8 @@
-<fd-split-button>
+<fd-split-button mainActionTitle="Action Menu">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Action Button</span>
+                <span fd-menu-title>Action</span>
             </div>
         </li>
         <li fd-menu-item>

--- a/apps/docs/src/app/core/component-docs/split-button/examples/split-button-types-example.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/examples/split-button-types-example.component.html
@@ -1,118 +1,118 @@
-<fd-split-button [mainActionTitle]="'Action Button'">
+<fd-split-button>
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Action Button</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Action Button 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button [fdType]="'standard'" [mainActionTitle]="'Standard Button'">
+<fd-split-button [fdType]="'standard'">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Standard Button</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Standard Button 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button [fdType]="'emphasized'" [mainActionTitle]="'Emphasized Button'">
+<fd-split-button [fdType]="'emphasized'">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Emphasized Button</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Emphasized Button 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button [fdType]="'ghost'" [mainActionTitle]="'Ghost Button'">
+<fd-split-button [fdType]="'ghost'">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Ghost Button</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Ghost Button 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button [fdType]="'positive'" [mainActionTitle]="'Positive Button'">
+<fd-split-button [fdType]="'positive'">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Positive Button</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Positive Button 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button [fdType]="'negative'" [mainActionTitle]="'Negative Button'">
+<fd-split-button [fdType]="'negative'">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Negative Button</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Negative Button 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button [fdType]="'attention'" [mainActionTitle]="'Attention Button'">
+<fd-split-button [fdType]="'attention'">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Attention Button</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Attention Button 2</span>
             </div>
         </li>
     </fd-menu>
 </fd-split-button>
 
-<fd-split-button [fdType]="'transparent'" [mainActionTitle]="'Transparent Button'">
+<fd-split-button [fdType]="'transparent'">
     <fd-menu>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 1</span>
+                <span fd-menu-title>Transparent Button</span>
             </div>
         </li>
         <li fd-menu-item>
             <div fd-menu-interactive>
-                <span fd-menu-title>Option 2</span>
+                <span fd-menu-title>Transparent Button 2</span>
             </div>
         </li>
     </fd-menu>

--- a/apps/docs/src/app/core/component-docs/split-button/split-button-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/split-button-docs.component.html
@@ -12,7 +12,7 @@
     <code class="code-snippet">[fdType]="'attention'"</code>
     <code class="code-snippet">[fdType]="'transparent'"</code>. Leave
     <code class="code-snippet">[fdType]=""</code> empty to use Action button<br />
-    To add a custom title use the <code class="code-snippet">mainActionTitle</code> input directive.
+    To add a custom title use the <code class="code-snippet">mainActionTitle</code> input.
 </description>
 <component-example>
     <fd-split-button-types-example></fd-split-button-types-example>

--- a/apps/docs/src/app/core/component-docs/split-button/split-button-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/split-button-docs.component.html
@@ -11,7 +11,8 @@
     <code class="code-snippet">[fdType]="'negative'"</code>
     <code class="code-snippet">[fdType]="'attention'"</code>
     <code class="code-snippet">[fdType]="'transparent'"</code>. Leave
-    <code class="code-snippet">[fdType]=""</code> empty to use Action button
+    <code class="code-snippet">[fdType]=""</code> empty to use Action button<br />
+    To add a custom title use the <code class="code-snippet">mainActionTitle</code> input directive.
 </description>
 <component-example>
     <fd-split-button-types-example></fd-split-button-types-example>
@@ -38,7 +39,8 @@
     Open/Close Programmatically
 </fd-docs-section-title>
 <description>
-    It is possible to control the open state of the popover using <code>MenuComponent.open()</code> and <code>MenuComponent.close()</code>
+    It is possible to control the open state of the popover using <code>MenuComponent.open()</code> and
+    <code>MenuComponent.close()</code>
     methods.
 </description>
 <component-example>

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -129,6 +129,10 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     @Output()
     readonly activePath: EventEmitter<MenuItemComponent[]> = new EventEmitter<MenuItemComponent[]>();
 
+    /** Emits array of active menu items */
+    @Output()
+    readonly selected: EventEmitter<string> = new EventEmitter<string>();
+
     /** @hidden Emits event when the menu is opened/closed */
     @Output()
     isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
@@ -142,11 +146,11 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     menuWithPopover: TemplateRef<any>;
 
     /** @hidden Reference  the container where component views are instantiated */
-    @ViewChild('viewContainer', {read: ViewContainerRef})
+    @ViewChild('viewContainer', { read: ViewContainerRef })
     viewContainer: ViewContainerRef;
 
     /** @hidden Reference to all menu Items */
-    @ContentChildren(MenuItemComponent, {descendants: true})
+    @ContentChildren(MenuItemComponent, { descendants: true })
     menuItems: QueryList<MenuItemComponent>;
 
     /** Whether use menu in mobile mode */
@@ -168,13 +172,13 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     private _mobileModeComponentRef: ComponentRef<MenuMobileComponent>;
 
     constructor(public elementRef: ElementRef,
-                @Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig,
-                private _rendered: Renderer2,
-                private _menuService: MenuService,
-                private _changeDetectorRef: ChangeDetectorRef,
-                private _componentFactoryResolver: ComponentFactoryResolver,
-                @Optional() private _rtlService: RtlService,
-                @Optional() private _dynamicComponentService: DynamicComponentService) {
+        @Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig,
+        private _rendered: Renderer2,
+        private _menuService: MenuService,
+        private _changeDetectorRef: ChangeDetectorRef,
+        private _componentFactoryResolver: ComponentFactoryResolver,
+        @Optional() private _rtlService: RtlService,
+        @Optional() private _dynamicComponentService: DynamicComponentService) {
     }
 
     /** @hidden */
@@ -187,6 +191,7 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     ngAfterViewInit(): void {
         this._listenOnMenuMode();
         this._menuService.setMenuMode(this.mobile);
+        this._menuService.sendSelected(this.menuItems.first);
     }
 
     /** @hidden */
@@ -283,8 +288,9 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
                 MenuMobileComponent,
                 { container: this.elementRef.nativeElement },
                 {
-                    injector: Injector.create({providers: [{ provide: MENU_COMPONENT, useValue: this }]}),
-                    services: [this._menuService, this._rtlService] }
+                    injector: Injector.create({ providers: [{ provide: MENU_COMPONENT, useValue: this }] }),
+                    services: [this._menuService, this._rtlService]
+                }
             )
     }
 

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -131,7 +131,7 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
 
     /** Emits array of active menu items */
     @Output()
-    readonly selected: EventEmitter<string> = new EventEmitter<string>();
+    readonly selected: EventEmitter<MenuItemComponent> = new EventEmitter<MenuItemComponent>();
 
     /** @hidden Emits event when the menu is opened/closed */
     @Output()
@@ -191,7 +191,6 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     ngAfterViewInit(): void {
         this._listenOnMenuMode();
         this._menuService.setMenuMode(this.mobile);
-        this._menuService.sendSelected(this.menuItems.first);
     }
 
     /** @hidden */

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -129,9 +129,9 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     @Output()
     readonly activePath: EventEmitter<MenuItemComponent[]> = new EventEmitter<MenuItemComponent[]>();
 
-    /** Emits array of active menu items */
+    /** Emits menu item which is selected */
     @Output()
-    readonly selected: EventEmitter<MenuItemComponent> = new EventEmitter<MenuItemComponent>();
+    selected: EventEmitter<MenuItemComponent>;
 
     /** @hidden Emits event when the menu is opened/closed */
     @Output()
@@ -189,6 +189,7 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
 
     /** @hidden */
     ngAfterViewInit(): void {
+        this.selected = new EventEmitter<MenuItemComponent>();
         this._listenOnMenuMode();
         this._menuService.setMenuMode(this.mobile);
     }

--- a/libs/core/src/lib/menu/services/menu.service.ts
+++ b/libs/core/src/lib/menu/services/menu.service.ts
@@ -141,7 +141,7 @@ export class MenuService {
         if (menuItem) {
             if (!menuItem.submenu) {
                 if (menuItem.menuItemTitle) {
-                    this._emitSelected(menuItem.menuItemTitle.title)
+                    this._emitSelected(menuItem)
                 }
             }
         }
@@ -273,8 +273,8 @@ export class MenuService {
     }
 
     /** @hidden Emits an array of the selected menu item */
-    private _emitSelected(title: string): void {
-        this.menu.selected.emit(title);
+    private _emitSelected(item: MenuItemComponent): void {
+        this.menu.selected.emit(item);
     }
 
     /** @hidden Depending on direction returns closest enabled sibling of given node */

--- a/libs/core/src/lib/menu/services/menu.service.ts
+++ b/libs/core/src/lib/menu/services/menu.service.ts
@@ -4,6 +4,7 @@ import { MenuComponent } from '../menu.component';
 import { KeyUtil } from '../../utils/functions/key-util';
 import { Observable, Subject } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
+import { isTemplateExpression } from 'typescript';
 
 interface MenuNode {
     item: MenuItemComponent;
@@ -132,6 +133,14 @@ export class MenuService {
         this._removeActiveSibling(menuItem);
         this.activeNodePath.push(menuNode);
         menuNode.item.setSelected(true);
+        this.sendSelected(menuNode.item)
+    }
+
+    /** @hidden Sends current selected menu item*/
+    sendSelected(menuItem: MenuItemComponent): void {
+        if (!menuItem.submenu) {
+            this._emitSelected(menuItem.menuItemTitle.title)
+        }
     }
 
     /** @hidden Removes given element and all its successors from the Active Node Path and setts as inactive*/
@@ -257,6 +266,11 @@ export class MenuService {
         this.menu.activePath.emit(
             this.activeNodePath.map(node => node.item)
         );
+    }
+
+    /** @hidden Emits an array of the selected menu item */
+    private _emitSelected(title: string): void {
+        this.menu.selected.emit(title);
     }
 
     /** @hidden Depending on direction returns closest enabled sibling of given node */

--- a/libs/core/src/lib/menu/services/menu.service.ts
+++ b/libs/core/src/lib/menu/services/menu.service.ts
@@ -138,8 +138,12 @@ export class MenuService {
 
     /** @hidden Sends current selected menu item*/
     sendSelected(menuItem: MenuItemComponent): void {
-        if (!menuItem.submenu) {
-            this._emitSelected(menuItem.menuItemTitle.title)
+        if (menuItem) {
+            if (!menuItem.submenu) {
+                if (menuItem.menuItemTitle) {
+                    this._emitSelected(menuItem.menuItemTitle.title)
+                }
+            }
         }
     }
 

--- a/libs/core/src/lib/split-button/split-button.component.html
+++ b/libs/core/src/lib/split-button/split-button.component.html
@@ -1,23 +1,18 @@
 <div class="fd-button-split fd-has-margin-right-small" role="group" aria-label="button-split" [fdMenuTrigger]="menu">
-    <button fd-button
-            [fdType]="fdType"
-            [compact]="compact"
-            [disabled]="disabled"
-            (click)="onMainButtonClick($event)">
-
+    <button fd-button [fdType]="fdType" [compact]="compact" [disabled]="disabled" (click)="onMainButtonClick($event)">
         <ng-container *ngTemplateOutlet="titleTemplate || buttonTitle"></ng-container>
 
         <ng-template #buttonTitle>{{ mainActionTitle }}</ng-template>
-
     </button>
 
-    <button fd-button
-            [glyph]="glyph"
-            [fdType]="fdType"
-            [compact]="compact"
-            [disabled]="disabled"
-            [attr.aria-label]="expandButtonAriaLabel">
-    </button>
+    <button
+        fd-button
+        [glyph]="glyph"
+        [fdType]="fdType"
+        [compact]="compact"
+        [disabled]="disabled"
+        [attr.aria-label]="expandButtonAriaLabel"
+    ></button>
 
     <ng-content select="fd-menu"></ng-content>
 </div>

--- a/libs/core/src/lib/split-button/split-button.component.html
+++ b/libs/core/src/lib/split-button/split-button.component.html
@@ -1,9 +1,5 @@
 <div class="fd-button-split fd-has-margin-right-small" role="group" aria-label="button-split" [fdMenuTrigger]="menu">
-    <button fd-button 
-    [fdType]="fdType" 
-    [compact]="compact" 
-    [disabled]="disabled" 
-    (click)="onMainButtonClick($event)">
+    <button fd-button [fdType]="fdType" [compact]="compact" [disabled]="disabled" (click)="onMainButtonClick($event)">
         <ng-container *ngTemplateOutlet="titleTemplate || buttonTitle"></ng-container>
 
         <ng-template #buttonTitle>{{ mainActionTitle }}</ng-template>

--- a/libs/core/src/lib/split-button/split-button.component.html
+++ b/libs/core/src/lib/split-button/split-button.component.html
@@ -1,5 +1,9 @@
 <div class="fd-button-split fd-has-margin-right-small" role="group" aria-label="button-split" [fdMenuTrigger]="menu">
-    <button fd-button [fdType]="fdType" [compact]="compact" [disabled]="disabled" (click)="onMainButtonClick($event)">
+    <button fd-button 
+    [fdType]="fdType" 
+    [compact]="compact" 
+    [disabled]="disabled" 
+    (click)="onMainButtonClick($event)">
         <ng-container *ngTemplateOutlet="titleTemplate || buttonTitle"></ng-container>
 
         <ng-template #buttonTitle>{{ mainActionTitle }}</ng-template>

--- a/libs/core/src/lib/split-button/split-button.component.ts
+++ b/libs/core/src/lib/split-button/split-button.component.ts
@@ -91,10 +91,12 @@ export class SplitButtonComponent implements AfterContentChecked {
 
     ngAfterContentChecked(): void {
         if (!this.mainActionTitle) {
-            this.menu.selected.subscribe(value => {
-                this.mainActionTitle = value;
-                this._changeDetectorRef.detectChanges();
-            });
+            if (this.menu) {
+                this.menu.selected.subscribe(value => {
+                    this.mainActionTitle = value;
+                    this._changeDetectorRef.detectChanges();
+                });
+            }
         }
     }
 }

--- a/libs/core/src/lib/split-button/split-button.component.ts
+++ b/libs/core/src/lib/split-button/split-button.component.ts
@@ -4,6 +4,7 @@ import {
     ContentChild,
     EventEmitter,
     Input,
+    OnDestroy,
     Output,
     TemplateRef,
     ViewEncapsulation,
@@ -13,7 +14,9 @@ import {
 import { SplitButtonActionTitle } from './split-button-utils/split-button.directives';
 import { ButtonType } from '../button/button.component';
 import { MenuComponent } from '../menu/menu.component';
+import { MenuItemComponent } from '../menu/menu-item/menu-item.component'
 import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 
 /**
  * Split Button component, used to enhance standard HTML button and add possibility to put some dropdown with
@@ -43,7 +46,7 @@ import { takeUntil } from 'rxjs/operators';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class SplitButtonComponent implements AfterContentChecked {
+export class SplitButtonComponent implements AfterContentChecked, OnDestroy {
 
     /** Whether to apply compact mode to the button. */
     @Input()
@@ -58,7 +61,8 @@ export class SplitButtonComponent implements AfterContentChecked {
     disabled: boolean;
 
     /** The Title for main  action button */
-    @Input() mainActionTitle: string;
+    @Input()
+    mainActionTitle: string;
 
     /** The type of the button. Types include 'standard', 'positive', 'medium', and 'negative'.
      * Leave empty for default (Action button).'*/
@@ -81,22 +85,63 @@ export class SplitButtonComponent implements AfterContentChecked {
     @ContentChild(MenuComponent)
     menu: MenuComponent;
 
+    /** @hidden */
+    private _firstElement: MenuItemComponent;
+
+    get firstElement(): MenuItemComponent {
+        return this._firstElement;
+    }
+
+    set firstElement(item: MenuItemComponent) {
+        this._firstElement = item;
+    }
+
+    /** An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */
+    private readonly _onDestroy$: Subject<void> = new Subject<void>();
+
     constructor(private _changeDetectorRef: ChangeDetectorRef) { }
 
     /** @hidden Emits event when main button is clicked */
     onMainButtonClick(event: MouseEvent): void {
-        this.primaryButtonClicked.emit(event);
+        this.mainButtonClicked();
         event.stopPropagation();
     }
 
     ngAfterContentChecked(): void {
+        this.selectedSubscribed();
+        this.getFirstMenuItem();
+    }
+
+    /** @hidden */
+    ngOnDestroy(): void {
+        this._onDestroy$.next();
+        this._onDestroy$.complete();
+    }
+
+    /** @hidden */
+    private mainButtonClicked(): void {
+        if (this.mainActionTitle) {
+            this.primaryButtonClicked.emit(event);
+        } else {
+            this.firstElement.menuInteractive.elementRef.nativeElement.click();
+        }
+    }
+
+    /** @hidden */
+    private getFirstMenuItem(): void {
         if (!this.mainActionTitle) {
-            if (this.menu) {
-                this.menu.selected.subscribe(value => {
-                    this.mainActionTitle = value;
-                    this._changeDetectorRef.detectChanges();
-                });
-            }
+            this.firstElement = this.menu.menuItems.first;
+            this.mainActionTitle = this.firstElement.menuItemTitle.title;
+        }
+    }
+
+    /** @hidden */
+    private selectedSubscribed(): void {
+        if (!this.mainActionTitle && this.menu) {
+            this.menu.selected.pipe(takeUntil(this._onDestroy$)).subscribe(value => {
+                this.mainActionTitle = value.menuItemTitle.title;
+                this._changeDetectorRef.detectChanges();
+            });
         }
     }
 }

--- a/libs/core/src/lib/split-button/split-button.component.ts
+++ b/libs/core/src/lib/split-button/split-button.component.ts
@@ -6,11 +6,14 @@ import {
     Input,
     Output,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    AfterContentInit,
+    ChangeDetectorRef
 } from '@angular/core';
 import { SplitButtonActionTitle } from './split-button-utils/split-button.directives';
 import { ButtonType } from '../button/button.component';
 import { MenuComponent } from '../menu/menu.component';
+import { takeUntil } from 'rxjs/operators';
 
 /**
  * Split Button component, used to enhance standard HTML button and add possibility to put some dropdown with
@@ -40,7 +43,7 @@ import { MenuComponent } from '../menu/menu.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class SplitButtonComponent {
+export class SplitButtonComponent implements AfterContentInit {
 
     /** Whether to apply compact mode to the button. */
     @Input()
@@ -55,8 +58,15 @@ export class SplitButtonComponent {
     disabled: boolean;
 
     /** The Title for main  action button */
-    @Input()
-    mainActionTitle: string;
+    private _mainActionTitle: string;
+
+    set mainActionTitle(title: string) {
+        this._mainActionTitle = title;
+    }
+
+    get mainActionTitle(): string {
+        return this._mainActionTitle;
+    }
 
     /** The type of the button. Types include 'standard', 'positive', 'medium', and 'negative'.
      * Leave empty for default (Action button).'*/
@@ -79,9 +89,18 @@ export class SplitButtonComponent {
     @ContentChild(MenuComponent)
     menu: MenuComponent;
 
+    constructor(private _changeDetectorRef: ChangeDetectorRef) { }
+
     /** @hidden Emits event when main button is clicked */
     onMainButtonClick(event: MouseEvent): void {
         this.primaryButtonClicked.emit(event);
         event.stopPropagation();
+    }
+
+    ngAfterContentInit(): void {
+        this.menu.selected.subscribe(value => {
+            this.mainActionTitle = value;
+            this._changeDetectorRef.detectChanges();
+        })
     }
 }

--- a/libs/core/src/lib/split-button/split-button.component.ts
+++ b/libs/core/src/lib/split-button/split-button.component.ts
@@ -7,7 +7,7 @@ import {
     Output,
     TemplateRef,
     ViewEncapsulation,
-    AfterContentInit,
+    AfterContentChecked,
     ChangeDetectorRef
 } from '@angular/core';
 import { SplitButtonActionTitle } from './split-button-utils/split-button.directives';
@@ -43,7 +43,7 @@ import { takeUntil } from 'rxjs/operators';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class SplitButtonComponent implements AfterContentInit {
+export class SplitButtonComponent implements AfterContentChecked {
 
     /** Whether to apply compact mode to the button. */
     @Input()
@@ -58,15 +58,7 @@ export class SplitButtonComponent implements AfterContentInit {
     disabled: boolean;
 
     /** The Title for main  action button */
-    private _mainActionTitle: string;
-
-    set mainActionTitle(title: string) {
-        this._mainActionTitle = title;
-    }
-
-    get mainActionTitle(): string {
-        return this._mainActionTitle;
-    }
+    @Input() mainActionTitle: string;
 
     /** The type of the button. Types include 'standard', 'positive', 'medium', and 'negative'.
      * Leave empty for default (Action button).'*/
@@ -97,10 +89,12 @@ export class SplitButtonComponent implements AfterContentInit {
         event.stopPropagation();
     }
 
-    ngAfterContentInit(): void {
-        this.menu.selected.subscribe(value => {
-            this.mainActionTitle = value;
-            this._changeDetectorRef.detectChanges();
-        })
+    ngAfterContentChecked(): void {
+        if (!this.mainActionTitle) {
+            this.menu.selected.subscribe(value => {
+                this.mainActionTitle = value;
+                this._changeDetectorRef.detectChanges();
+            });
+        }
     }
 }


### PR DESCRIPTION
BREAKING CHANGES: remove mainActionTitle 

#### Please provide a link to the associated issue.
fixes: #3028 
#### Please provide a brief summary of this pull request.
This PR will make the first item the title and then change to the selected item. mainActionTitle is removed as input and replace it behind the scenes. If the user wants to put a custom name, he can use the template example.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

