### PR TITLE
fix: add submit/cancel buttons for datetime picker

### DIFF
--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -84,7 +84,7 @@ export class DatetimePickerComplexI18nExampleComponent {
         this.datetimePickerComponent.format = this.actualFormat;
         this.placeholder = placeholders.get(this.actualLocale);
 
-        this.datetimePickerComponent.handleDateChange(this.date.date);
+        this.datetimePickerComponent.submit();
         this.calendarI18nService.i18nChange.next();
     }
 

--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -20,7 +20,6 @@
                 [attr.aria-label]="dateInputLabel"
                 [(ngModel)]="inputFieldDate"
                 (ngModelChange)="handleInputChange($event)"
-                (click)="openCalendar()"
             />
             <span fd-input-group-addon [button]="true" [compact]="compact">
                 <button

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -72,11 +72,11 @@
                     (focusArrowLeft)="focusArrowLeft()"
                 ></fd-time>
             </div>
-            <div fd-popover-body-footer>
-                <div fd-bar [barDesign]="'footer'" [cosy]="!compact">
+            <div fd-popover-body-footer *ngIf="showFooter">
+                <div fd-bar barDesign="footer" [cosy]="!compact">
                     <div fd-bar-right>
                         <fd-bar-element>
-                            <button fd-button [fdType]="'emphasized'" [compact]="compact" (click)="submit()">Submit</button>
+                            <button fd-button fdType="emphasized" [compact]="compact" (click)="submit()">Submit</button>
                         </fd-bar-element>
                         <fd-bar-element>
                             <button fd-button [compact]="compact" (click)="cancel()">Cancel</button>

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -15,14 +15,13 @@
                     type="text"
                     class="fd-input"
                     fd-input-group-input
-                    [attr.aria-label]="datetimeInputLabel"
                     [(ngModel)]="inputFieldDate"
-                    (ngModelChange)="handleInputChange($event)"
+                    [attr.aria-label]="datetimeInputLabel"
                     [placeholder]="placeholder"
-                    (click)="openPopover()"
                     [compact]="compact"
                     [ngClass]="{ 'is-error': isInvalidDateInput && useValidation }"
                     [disabled]="disabled"
+                    (ngModelChange)="handleInputChange($event)"
                 />
                 <span fd-input-group-addon [state]="state" [compact]="compact" [button]="true">
                     <button
@@ -32,9 +31,9 @@
                         [fdType]="'transparent'"
                         [compact]="compact"
                         [attr.tabindex]="buttonFocusable ? 0 : -1"
-                        (click)="togglePopover()"
                         [attr.aria-label]="displayDatetimeToggleLabel"
                         [attr.aria-expanded]="isOpen"
+                        (click)="togglePopover()"
                     ></button>
                 </span>
             </fd-input-group>
@@ -44,11 +43,8 @@
                 <fd-calendar
                     calType="single"
                     [activeView]="activeView"
-                    (activeViewChange)="handleCalendarActiveViewChange($event)"
                     [disableFunction]="disableFunction ? disableFunction : null"
-                    (selectedDateChange)="handleDateChange($event)"
                     [selectedDate]="tempDate"
-                    (isValidDateChange)="isInvalidDateInputHandler($event)"
                     [escapeFocusFunction]="null"
                     [compact]="compact"
                     [markWeekends]="markWeekends"
@@ -57,6 +53,9 @@
                     [aggregatedYearGrid]="aggregatedYearGrid"
                     [yearGrid]="yearGrid"
                     [startingDayOfWeek]="startingDayOfWeek"
+                    (activeViewChange)="handleCalendarActiveViewChange($event)"
+                    (selectedDateChange)="handleDateChange($event)"
+                    (isValidDateChange)="isInvalidDateInputHandler($event)"
                 ></fd-calendar>
                 <div class="fd-datetime__separator"></div>
                 <fd-time
@@ -66,21 +65,21 @@
                     [ngModel]="tempTime"
                     [compact]="compact"
                     [spinnerButtons]="spinnerButtons"
-                    (ngModelChange)="handleTimeChange($event)"
                     [displaySeconds]="displaySeconds"
                     [displayMinutes]="displayMinutes"
                     [displayHours]="displayHours"
+                    (ngModelChange)="handleTimeChange($event)"
                     (focusArrowLeft)="focusArrowLeft()"
                 ></fd-time>
             </div>
             <div fd-popover-body-footer>
-                <div fd-bar [barDesign]="'footer'" [cosy]="true">
+                <div fd-bar [barDesign]="'footer'" [cosy]="!compact">
                     <div fd-bar-right>
                         <fd-bar-element>
-                            <button fd-button [fdType]="'emphasized'" [compact]="true" (click)="submit()">Submit</button>
+                            <button fd-button [fdType]="'emphasized'" [compact]="compact" (click)="submit()">Submit</button>
                         </fd-bar-element>
                         <fd-bar-element>
-                            <button fd-button [compact]="true" (click)="cancel()">Cancel</button>
+                            <button fd-button [compact]="compact" (click)="cancel()">Cancel</button>
                         </fd-bar-element>
                     </div>
                 </div>

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -46,8 +46,8 @@
                     [activeView]="activeView"
                     (activeViewChange)="handleCalendarActiveViewChange($event)"
                     [disableFunction]="disableFunction ? disableFunction : null"
-                    [selectedDate]="selectedDate"
                     (selectedDateChange)="handleDateChange($event)"
+                    [selectedDate]="tempDate"
                     (isValidDateChange)="isInvalidDateInputHandler($event)"
                     [escapeFocusFunction]="null"
                     [compact]="compact"
@@ -63,7 +63,7 @@
                     [disabled]="disabled"
                     [keepTwoDigits]="keepTwoDigitsTime"
                     [meridian]="meridian"
-                    [ngModel]="time"
+                    [ngModel]="tempTime"
                     [compact]="compact"
                     [spinnerButtons]="spinnerButtons"
                     (ngModelChange)="handleTimeChange($event)"
@@ -72,6 +72,18 @@
                     [displayHours]="displayHours"
                     (focusArrowLeft)="focusArrowLeft()"
                 ></fd-time>
+            </div>
+            <div fd-popover-body-footer>
+                <div fd-bar [barDesign]="'footer'" [cosy]="true">
+                    <div fd-bar-right>
+                        <fd-bar-element>
+                            <button fd-button [fdType]="'emphasized'" [compact]="true" (click)="submit()">Submit</button>
+                        </fd-bar-element>
+                        <fd-bar-element>
+                            <button fd-button [compact]="true" (click)="cancel()">Cancel</button>
+                        </fd-bar-element>
+                    </div>
+                </div>
             </div>
         </fd-popover-body>
     </fd-popover>

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.spec.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.spec.ts
@@ -112,14 +112,15 @@ describe('DatetimePickerComponent', () => {
 
     it('should update input from time but no date', () => {
         spyOn(component, 'onChange');
-        component.selectedDate = FdDate.getToday();
+        component.tempDate = FdDate.getToday();
         const timeModel = { hour: 12, minute: 30, second: 45 };
-        const dateTime = new FdDatetime(component.selectedDate, timeModel);
+        const dateTime = new FdDatetime(component.tempDate, timeModel);
         component.handleTimeChange(timeModel);
+        component.submit();
 
         expect(component.onChange).toHaveBeenCalledWith(dateTime);
         expect(component.inputFieldDate).toEqual(
-            (<any>component)._formatDateTime(new FdDatetime(component.selectedDate, timeModel))
+            (<any>component)._formatDateTime(new FdDatetime(component.tempDate, timeModel))
         );
     });
 
@@ -143,14 +144,15 @@ describe('DatetimePickerComponent', () => {
 
     it('should update input from calendar', () => {
         spyOn(component, 'onChange');
-        component.time = FdDatetime.getToday().time;
+        component.tempTime = FdDatetime.getToday().time;
         const date = new FdDate(2018, 10, 10);
-        const dateTime = new FdDatetime(date, component.time);
+        const dateTime = new FdDatetime(date, component.tempTime);
         component.handleDateChange(date);
+        component.submit();
 
         expect(component.onChange).toHaveBeenCalledWith(dateTime);
         expect(component.inputFieldDate).toEqual(
-            (<any>component)._formatDateTime(new FdDatetime(date, component.time))
+            (<any>component)._formatDateTime(new FdDatetime(date, component.tempTime))
         );
     });
 
@@ -185,6 +187,20 @@ describe('DatetimePickerComponent', () => {
         component.handleInputChange(internalParser(invalidDate));
         expect(component.inputFieldDate).toEqual(internalParser(dateTime));
         expect(component.isInvalidDateInput).toBeTruthy();
+    });
+
+    it('should cancel', () => {
+        component.selectedDate = FdDate.getToday();
+        component.tempDate = null;
+        component.time = {hour: 1, minute: 1, second: 1};
+        component.tempTime = null;
+        spyOn(component, 'closePopover');
+
+        component.cancel();
+
+        expect(component.tempDate).toEqual(component.selectedDate);
+        expect(component.tempTime).toEqual(component.time);
+        expect(component.closePopover).toHaveBeenCalled();
     });
 
     it('should handle other types than FdTimeDate', () => {

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -269,8 +269,14 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     /** @hidden The Time object which interacts with the inner Time component. Internal use. */
     time: TimeObject = { hour: 0, minute: 0, second: 0 };
 
+    /** @hidden The temporary Time object for use before 'Submit' is pressed. Internal use. */
+    tempTime: TimeObject;
+
     /** @hidden The CalendarDay object which interacts with the inner Calendar component. Internal use. */
     selectedDate: FdDate;
+
+    /** @hidden The temporary CalendarDay object for use before 'Submit' is pressed. Internal use. */
+    tempDate: FdDate;
 
     /** @hidden */
     private readonly _onDestroy$: Subject<void> = new Subject<void>();
@@ -300,9 +306,10 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
 
     /** @hidden */
     ngOnInit(): void {
-        if (this.date && this.inputFieldDate !== null) {
+        if (this.date) {
             this.selectedDate = this.date.date;
             this.time = this.date.time;
+            this._setTempDateTime();
         }
     }
 
@@ -412,6 +419,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         }
         this.selectedDate = selected.date;
         this.time = selected.time;
+        this._setTempDateTime();
         this.date = new FdDatetime(this.selectedDate, this.time);
         if (this.isCurrentModelValid()) {
             this._refreshCurrentlyDisplayedCalendarDate(this.date.date);
@@ -426,14 +434,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
      * If invalid time model is detected, it takes time model data from TimeComponent.
      */
     handleDateChange(date: FdDate): void {
-        this.selectedDate = date;
-        if (!this.date.isTimeValid()) {
-            this.time = this.timeComponent.time;
-        }
-        this.date = new FdDatetime(this.selectedDate, this.time);
-        this.isInvalidDateInput = !this.isCurrentModelValid();
-        this._setInput(this.date);
-        this.onChange(this.date);
+        this.tempDate = date;
     }
 
     /**
@@ -441,7 +442,19 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
      * Method that is triggered by events from time component, when there is selected time changed
      */
     handleTimeChange(time: TimeObject): void {
-        this.time = time;
+        this.tempTime = time;
+    }
+
+    /**
+     * @hidden
+     * Method that is triggered when 'Submit' button is pressed.
+     */
+    submit(): void {
+        this.selectedDate = this.tempDate;
+        this.time = this.tempTime;
+        if (!this.date.isTimeValid()) {
+            this.time = this.timeComponent.time;
+        }
         if (!this.selectedDate || !this.selectedDate.isDateValid()) {
             this.selectedDate = FdDate.getToday();
         }
@@ -449,6 +462,17 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         this.isInvalidDateInput = !this.isCurrentModelValid();
         this._setInput(this.date);
         this.onChange(this.date);
+        this.closePopover();
+    }
+
+    /**
+     * @hidden
+     * Function that is called when 'Cancel' button is pressed.
+     */
+    cancel(): void {
+        this.tempDate = this.selectedDate;
+        this.tempTime = this.time;
+        this.closePopover();
     }
 
     /** @hidden */
@@ -469,6 +493,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         if (!this.isInvalidDateInput) {
             this.selectedDate = fdTimeDate.date;
             this.time = fdTimeDate.time;
+            this._setTempDateTime();
             this.date = new FdDatetime(this.selectedDate, this.time);
             this.onChange(fdTimeDate);
             this._refreshCurrentlyDisplayedCalendarDate(fdTimeDate.date);
@@ -480,6 +505,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
             this.date = FdDatetime.getToday();
             this.selectedDate = this.date.date;
             this.time = this.date.time;
+            this._setTempDateTime();
             this._refreshCurrentlyDisplayedCalendarDate(this.date.date);
             this.onChange(null);
         } else if (!date && !this.allowNull) {
@@ -544,6 +570,12 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
                 }
                 this.timeComponent.refreshTime();
             });
+    }
+
+    /** @hidden */
+    private _setTempDateTime(): void {
+        this.tempDate = this.selectedDate;
+        this.tempTime = this.time;
     }
 
 }

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -221,6 +221,10 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     @Input()
     showWeekNumbers = true;
 
+    /** Whether or not to show the datetime picker footer with submit/cancel buttons. */
+    @Input()
+    showFooter = true;
+
     /** Event thrown every time calendar active view is changed */
     @Output()
     public readonly activeViewChange: EventEmitter<FdCalendarView> = new EventEmitter<FdCalendarView>();
@@ -435,6 +439,9 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
      */
     handleDateChange(date: FdDate): void {
         this.tempDate = date;
+        if (!this.showFooter) {
+            this.submit();
+        }
     }
 
     /**
@@ -443,6 +450,9 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
      */
     handleTimeChange(time: TimeObject): void {
         this.tempTime = time;
+        if (!this.showFooter) {
+            this.submit();
+        }
     }
 
     /**
@@ -462,7 +472,9 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         this.isInvalidDateInput = !this.isCurrentModelValid();
         this._setInput(this.date);
         this.onChange(this.date);
-        this.closePopover();
+        if (this.showFooter) {
+            this.closePopover();
+        }
     }
 
     /**

--- a/libs/core/src/lib/datetime-picker/datetime-picker.module.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.module.ts
@@ -8,6 +8,7 @@ import { DatetimePickerComponent } from './datetime-picker.component';
 import { TimeModule } from '../time/time.module';
 import { ButtonModule } from '../button/button.module';
 import { InputGroupModule } from '../input-group/input-group.module';
+import { BarModule } from '../bar/bar.module';
 
 @NgModule({
     declarations: [DatetimePickerComponent],
@@ -19,7 +20,8 @@ import { InputGroupModule } from '../input-group/input-group.module';
         FormsModule,
         TimeModule,
         InputGroupModule,
-        ButtonModule
+        ButtonModule,
+        BarModule
     ],
     exports: [DatetimePickerComponent]
 })


### PR DESCRIPTION
fixes #2950 

Add submit and cancel buttons for datetime picker.

This does not have breaking changes for the developer but results in a slightly different UX which developers may need to consider