### PR TITLE
fix: applyCssClass value initialization

### DIFF
--- a/libs/core/src/lib/utils/decorators/apply-css-class.decorator.ts
+++ b/libs/core/src/lib/utils/decorators/apply-css-class.decorator.ts
@@ -42,22 +42,23 @@ export function applyCssClass(target: any, propertyKey: string, descriptor: Prop
     };
 }
 
-/** Removes falsy elements from string array */
+/** Splits merged classes and removes falsy elements from string array */
 function sanitize(array: string[]): string [] {
-    return array.filter(Boolean)
+    return array
+        .filter(Boolean)
+        .reduce((classList: string[], cssClass: string) => [...classList, ...cssClass.split(' ')], []);
 }
 
 /** Returns an array1[index] of first array1 and array2 shared element */
-function firstCommonElementIndex(array1: string[], array2): number {
-    const index = array2.findIndex(element => array1.indexOf(element) !== -1);
-    return index === -1 ? 0 : index;
+function firstCommonElementIndex(array1: string[], array2: string[]): number {
+    return array1.findIndex(element => array2.indexOf(element) !== -1);
 }
 
 /** Replaces previous set of component classes with new set of component classes */
-function updateComponentClassList(allClasses: string[],  previousComponentClassList: string[], newComponentClassList: string[]): string[] {
-    const index = firstCommonElementIndex(allClasses, previousComponentClassList);
-    const externalClasses = allClasses.filter(element => previousComponentClassList.indexOf(element) === -1);
-    externalClasses.splice(index, 0, ...newComponentClassList);
+function updateComponentClassList(allClasses: string[], previousComponentClassList: string[], newComponentClassList: string[]): string[] {
+    let index = firstCommonElementIndex(allClasses, previousComponentClassList);
+    index = index === -1 ? 0 : index;
+    allClasses.splice(index, previousComponentClassList.length, ...newComponentClassList);
 
-    return externalClasses;
+    return allClasses;
 }

--- a/libs/core/src/lib/utils/decorators/apply-css-class.decorator.ts
+++ b/libs/core/src/lib/utils/decorators/apply-css-class.decorator.ts
@@ -27,7 +27,7 @@ export function applyCssClass(target: any, propertyKey: string, descriptor: Prop
 
             if (!this._uuidv4) {
                 this._uuidv4 = uuidv4();
-                elementRef.nativeElement._classMap[this._uuidv4] = [newComponentClassList];
+                elementRef.nativeElement._classMap[this._uuidv4] = newComponentClassList;
             }
 
             const allClassList = [...elementRef.nativeElement.classList];
@@ -54,9 +54,9 @@ function firstCommonElementIndex(array1: string[], array2): number {
 }
 
 /** Replaces previous set of component classes with new set of component classes */
-function updateComponentClassList(allClasses: string[],  previousComponentClassList, newComponentClassList: string[]): string[] {
+function updateComponentClassList(allClasses: string[],  previousComponentClassList: string[], newComponentClassList: string[]): string[] {
     const index = firstCommonElementIndex(allClasses, previousComponentClassList);
-    const externalClasses = allClasses.filter(element => !previousComponentClassList.includes(element));
+    const externalClasses = allClasses.filter(element => previousComponentClassList.indexOf(element) === -1);
     externalClasses.splice(index, 0, ...newComponentClassList);
 
     return externalClasses;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes: #3181

#### Please provide a brief summary of this pull request.
This PR brings:
- Proper initialization of `_classMap[this._uuidv4]` value, previously initialized with nested array instead of an array
- Proper typing for `updateComponentClassList(..., previousComponentClassList,..)` argument

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples