### PR TITLE
fix: Stop emitting change events on ViewInit and OnChanges

### DIFF
--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -45,84 +45,84 @@ describe('TabListComponent', () => {
     it('should create', () => {
         expect(component).toBeTruthy();
     });
-    
+
     it('should handle ngAfterContentInit', () => {
         component.ngAfterViewInit();
         expect(component.selectedIndex).toBe(0);
         expect(component.tabLinks.length).toBe(4);
     });
-    
+
     it('should select tab', fakeAsync(() => {
         component.ngAfterViewInit();
         component.selectTab(3);
-    
+
         tick(10);
         fixture.detectChanges();
         expect(component.selectedIndex).toBe(3);
     }));
-    
+
     it('should call reset tab', fakeAsync(() => {
         spyOn((component as any), '_resetTabHook').and.callThrough();
         component.ngAfterViewInit();
         component.selectTab(3);
-    
+
         tick(10);
         fixture.detectChanges();
-    
+
         fixture.componentInstance.showDisabled = false;
         fixture.detectChanges();
         tick(10);
         fixture.detectChanges();
         expect((component as any)._resetTabHook).toHaveBeenCalled();
-    
+
     }));
-    
+
     it('should not call reset tab', fakeAsync(() => {
         spyOn((component as any), '_resetTabHook').and.callThrough();
         component.ngAfterViewInit();
         component.selectTab(2);
-    
+
         tick(10);
         fixture.detectChanges();
-    
+
         fixture.componentInstance.showDisabled = false;
         fixture.detectChanges();
         tick(10);
         fixture.detectChanges();
         expect((component as any)._resetTabHook).not.toHaveBeenCalled();
-    
+
     }));
-    
+
     it('should not select out of range tab', fakeAsync(() => {
         component.ngAfterViewInit();
         component.selectTab(1);
-    
+
         tick(10);
         fixture.detectChanges();
         expect(component.selectedIndex).toBe(1);
-    
+
         component.selectTab(7);
-    
+
         tick(10);
         fixture.detectChanges();
         expect(component.selectedIndex).toBe(1);
     }));
-    
+
     it('should call select tab on service event', fakeAsync(() => {
         component.ngAfterViewInit();
         component.selectTab(1);
-    
+
         tick(10);
         fixture.detectChanges();
         expect(component.selectedIndex).toBe(1);
-    
+
         spyOn((component as any), 'selectTab').and.callThrough();
-    
+
         (component as any)._tabsService.tabSelected.next(2);
-    
+
         tick(10);
         fixture.detectChanges();
-        expect(component.selectTab).toHaveBeenCalledWith(2);
+        expect(component.selectTab).toHaveBeenCalledWith(2, true);
         expect(component.selectedIndex).toBe(2);
     }));
 });

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -73,8 +73,7 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
     @Output()
     selectedIndexChange = new EventEmitter<number>();
 
-    constructor(private _tabsService: TabsService, private _changeRef: ChangeDetectorRef) {
-    }
+    constructor(private _tabsService: TabsService, private _changeRef: ChangeDetectorRef) {}
 
     /** @hidden */
     ngAfterViewInit(): void {
@@ -101,7 +100,7 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
      * Function to select a new tab from an index.
      * @param tabIndex Index of the tab to select.
      */
-    selectTab(tabIndex: number): void {
+    selectTab(tabIndex: number, emitEvent?: boolean): void {
         if (this._canBeSelected(tabIndex)) {
             timer(10)
                 .pipe(takeUntil(this._onDestroy$))
@@ -110,7 +109,9 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
                         tab.triggerExpandedPanel(index === tabIndex);
                     });
                     this.selectedIndex = tabIndex;
-                    this.selectedIndexChange.emit(tabIndex);
+                    if (emitEvent) {
+                        this.selectedIndexChange.emit(tabIndex);
+                    }
                     this._detectChanges();
                 });
         }
@@ -119,7 +120,7 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
     /** @hidden */
     tabHeaderClickHandler(tabIndex: number): void {
         if (tabIndex !== this.selectedIndex) {
-            this.selectTab(tabIndex);
+            this.selectTab(tabIndex, true);
         }
     }
 
@@ -139,7 +140,7 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
                 takeUntil(this._onDestroy$),
                 filter(index => index !== this.selectedIndex)
             )
-            .subscribe((index) => this.selectTab(index));
+            .subscribe((index) => this.selectTab(index, true));
     }
 
     /**
@@ -175,7 +176,7 @@ export class TabListComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     /** @hidden */
     private _resetTabHook(): void {
-        this.selectTab(0);
+        this.selectTab(0, true);
     }
 
     private _detectChanges(): void {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: #1785 
#### Please provide a brief summary of this pull request.
The event is not emited in `ngAfterViewInit` and `ngOnChanges`
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

