### PR TITLE
fix: (platform) Fix detached menu while scrolling

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-menu/platform-menu-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-menu/platform-menu-docs.component.html
@@ -1,6 +1,5 @@
 <fd-docs-section-title [id]="'def'" [componentName]="'menu'">Menu</fd-docs-section-title>
-<description
-    >The Menu can be invoked from any element, by using the <code>fdpMenuTriggerFor</code> directive.
+<description>The Menu can be invoked from any element, by using the <code>fdpMenuTriggerFor</code> directive.
 </description>
 <component-example>
     <fdp-platform-menu-basic-example></fdp-platform-menu-basic-example>
@@ -10,10 +9,9 @@
 <separator></separator>
 
 <fd-docs-section-title [id]="'def'" [componentName]="'menu'">Menu with Horizontal Positioning</fd-docs-section-title>
-<description
-    >The horizontal position of the menu can be controlled via the <code>xPosition</code> property, which can be set to
-    either 'after' or 'before'. The default value is 'after'.</description
->
+<description>The horizontal position of the menu can be controlled via the <code>xPosition</code> property, which can be
+    set to
+    either 'after' or 'before'. The default value is 'after'.</description>
 <component-example>
     <fdp-platform-menu-x-position-example></fdp-platform-menu-x-position-example>
 </component-example>
@@ -39,7 +37,8 @@
     </p>
     <p>
         For containers that are scrollable (e.g. via the CSS <code>overflow: scroll</code> property), the user needs to
-        add the <code>cdk-scrollable</code> (or <code>cdkScrollable</code>) directive to that container.
+        add the <code>cdk-scrollable</code> (or <code>cdkScrollable</code>) directive to that container, and import the
+        CDK ScrollingModule.
     </p>
 </description>
 <component-example>

--- a/apps/docs/src/app/platform/component-docs/platform-menu/platform-menu.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-menu/platform-menu.module.ts
@@ -12,6 +12,7 @@ import { PlatformMenuScrollingExampleComponent } from './platform-menu-examples/
 import { PlatformMenuXPositionExampleComponent } from './platform-menu-examples/platform-menu-x-position-example.component';
 import { PlatformMenuModule, PlatformButtonModule, } from '@fundamental-ngx/platform';
 import { AvatarModule } from '@fundamental-ngx/core';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 
 const routes: Routes = [
@@ -31,7 +32,8 @@ const routes: Routes = [
         SharedDocumentationPageModule,
         PlatformMenuModule,
         PlatformButtonModule,
-        AvatarModule
+        AvatarModule,
+        ScrollingModule
     ],
     exports: [RouterModule],
     declarations: [
@@ -43,4 +45,4 @@ const routes: Routes = [
         PlatformMenuXPositionExampleComponent
     ]
 })
-export class PlatformMenuDocsModule {}
+export class PlatformMenuDocsModule { }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
 #3086 

#### Please provide a brief summary of this pull request.
This fixes the "Platform menu doesn't scroll" defect in platform. On the menu examples page in platform, the menu would detach from the target button, when the sub section would scroll. The issue was caused by a missing module import: CDK's ScrollingModule.

The documentation has also been updated to mention the required module import.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples

