### PR TITLE
fix: Bring support for shadow dom on Popover

### DIFF
--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
@@ -6,7 +6,7 @@
         <fd-popover-body *ngIf="list1 && list1.length">
             <ul fd-list>
                 <li fd-list-item *ngFor="let option of list1">
-                    <a [attr.href]="option.url" fd-list-title>{{option.text}}</a>
+                    <a fd-list-title>{{option.text}}</a>
                 </li>
             </ul>
         </fd-popover-body>
@@ -19,7 +19,7 @@
         <fd-popover-body *ngIf="list1 && list1.length">
             <ul fd-list>
                 <li fd-list-item *ngFor="let option of list1">
-                    <a [attr.href]="option.url" fd-list-title>{{option.text}}</a>
+                    <a fd-list-title>{{option.text}}</a>
                 </li>
             </ul>
         </fd-popover-body>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.ts
@@ -8,7 +8,7 @@ import { map } from 'rxjs/operators';
     selector: 'fd-popover-example',
     templateUrl: './popover-example.component.html',
     styleUrls: ['popover-example.component.scss'],
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.ShadowDom
 })
 export class PopoverExampleComponent {
     leftPlacement$: Observable<Placement>;

--- a/libs/core/src/lib/popover/popover-directive/popover.directive.spec.ts
+++ b/libs/core/src/lib/popover/popover-directive/popover.directive.spec.ts
@@ -108,20 +108,20 @@ describe('PopoverDirective', () => {
     it('should call close', () => {
         const popover = <any>fixtureTemplate.componentInstance.popoverDirective;
         popover.open();
-        const mouseEvent = { target: fixtureTemplate.componentInstance.divElement.nativeElement };
+        const mouseEvent = { composedPath: () => [fixtureTemplate.componentInstance.divElement.nativeElement] };
         expect(popover._shouldClose(mouseEvent)).toEqual(true);
     });
 
     it('shouldn\'t call close', () => {
         const popover = <any>fixtureTemplate.componentInstance.popoverDirective;
-        const mouseEvent = { target: fixtureTemplate.componentInstance.divElement.nativeElement };
+        const mouseEvent = { composedPath: () => [fixtureTemplate.componentInstance.divElement.nativeElement] };
         expect(popover._shouldClose(mouseEvent)).not.toEqual(true);
     });
 
     it('shouldn\'t call close on inside click', () => {
         const popover = <any>fixtureTemplate.componentInstance.popoverDirective;
         popover.open();
-        const mouseEvent = { target: popover.elRef.nativeElement };
+        const mouseEvent = { composedPath: () => [popover.elRef.nativeElement] };
         expect(popover._shouldClose(mouseEvent)).not.toEqual(true);
     });
 

--- a/libs/core/src/lib/popover/popover-directive/popover.directive.ts
+++ b/libs/core/src/lib/popover/popover-directive/popover.directive.ts
@@ -402,17 +402,34 @@ export class PopoverDirective implements OnInit, OnDestroy, OnChanges {
         }
     }
 
+    /** @hidden */
     private _shouldClose(event: MouseEvent): boolean {
         return (
             this.containerRef &&
             this.isOpen &&
             this.closeOnOutsideClick &&
-            event.target !== this.triggerRef.nativeElement &&
-            !this.triggerRef.nativeElement.contains(event.target) &&
-            !this.containerRef.location.nativeElement.contains(event.target)
+            !this._triggerContainsTarget(event) &&
+            !this._containerContainsTarget(event)
         );
     }
 
+    /** @hidden */
+    private _containerContainsTarget(event: Event): boolean {
+        const containerElement = this.containerRef.location.nativeElement;
+        return containerElement.contains(event.target) ||
+            containerElement.contains(event.composedPath()[0])
+        ;
+    }
+
+    /** @hidden */
+    private _triggerContainsTarget(event: Event): boolean {
+        const triggerElement = this.triggerRef.nativeElement;
+        return triggerElement.contains(event.target) ||
+            triggerElement.contains(event.composedPath()[0])
+        ;
+    }
+
+    /** @hidden */
     private _handleRtlChange(rtl: boolean): void {
         if (this.placement) {
             if (rtl) {

--- a/libs/core/src/lib/popover/popover-directive/popover.directive.ts
+++ b/libs/core/src/lib/popover/popover-directive/popover.directive.ts
@@ -416,17 +416,13 @@ export class PopoverDirective implements OnInit, OnDestroy, OnChanges {
     /** @hidden */
     private _containerContainsTarget(event: Event): boolean {
         const containerElement = this.containerRef.location.nativeElement;
-        return containerElement.contains(event.target) ||
-            containerElement.contains(event.composedPath()[0])
-        ;
+        return containerElement.contains(event.composedPath()[0]);
     }
 
     /** @hidden */
     private _triggerContainsTarget(event: Event): boolean {
         const triggerElement = this.triggerRef.nativeElement;
-        return triggerElement.contains(event.target) ||
-            triggerElement.contains(event.composedPath()[0])
-        ;
+        return triggerElement.contains(event.composedPath()[0]);
     }
 
     /** @hidden */


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/2772
#### Please provide a brief summary of this pull request.

In shadow DOM, event target returns a root container, not certain element. So there is another way to read it.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

