### PR TITLE
fix: stop opening pickers on input click

### DIFF
--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -20,7 +20,6 @@
                 [attr.aria-label]="dateInputLabel"
                 [(ngModel)]="inputFieldDate"
                 (ngModelChange)="handleInputChange($event)"
-                (click)="openCalendar()"
             />
             <span fd-input-group-addon [button]="true" [compact]="compact">
                 <button

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -1,8 +1,6 @@
 <div class="fd-datetime">
     <fd-popover
         [(isOpen)]="isOpen"
-        [closeOnOutsideClick]="false"
-        [closeOnEscapeKey]="false"
         [focusTrapped]="true"
         [triggers]="[]"
         [disabled]="disabled"
@@ -19,7 +17,6 @@
                     [(ngModel)]="inputFieldDate"
                     (ngModelChange)="handleInputChange($event)"
                     [placeholder]="placeholder"
-                    (click)="openPopover()"
                     [compact]="compact"
                     [ngClass]="{ 'is-error': isInvalidDateInput && useValidation }"
                     [disabled]="disabled"

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -27,8 +27,8 @@ import { DatePipe } from '@angular/common';
 import { CalendarYearGrid, SpecialDayRule } from '../..';
 import { PopoverComponent } from '../popover/popover.component';
 import { PopoverBodyComponent } from '../popover/popover-body/popover-body.component';
-import { Subject, Subscription } from 'rxjs';
-import { delay, filter, first, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { delay, first, takeUntil } from 'rxjs/operators';
 
 /**
  * The datetime picker component is an opinionated composition of the fd-popover,
@@ -368,20 +368,6 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     /** @hidden */
     isInvalidDateInputHandler(e): void {
         this.isInvalidDateInput = e;
-    }
-
-    /** @hidden */
-    @HostListener('document:keydown.escape', [])
-    onEscapeKeydownHandler(): void {
-        this.closePopover();
-    }
-
-    /** @hidden */
-    @HostListener('document:click', ['$event'])
-    public onGlobalClick(event: MouseEvent): void {
-        if (!this._elRef.nativeElement.contains(event.target) && !this.popoverBodyComponent.elRef.nativeElement.contains(event.target)) {
-            this.closePopover();
-        }
     }
 
     /** @hidden */

--- a/libs/core/src/lib/time-picker/time-picker.component.html
+++ b/libs/core/src/lib/time-picker/time-picker.component.html
@@ -26,7 +26,6 @@
                 [placeholder]="placeholder"
                 [attr.aria-label]="timePickerInputLabel"
                 (keyup.enter)="timeInputChanged($event.currentTarget.value)"
-                (click)="inputGroupClicked($event)"
             />
         </fd-input-group>
     </fd-popover-control>

--- a/libs/core/src/lib/time-picker/time-picker.component.ts
+++ b/libs/core/src/lib/time-picker/time-picker.component.ts
@@ -17,8 +17,8 @@ import { TimeFormatParser } from './format/time-parser';
 import { FormStates } from '../form/form-control/form-states';
 import { PopoverComponent } from '../popover/popover.component';
 import { Placement } from 'popper.js';
-import { Subject, Subscription } from 'rxjs';
-import { delay, filter, first, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { delay, first, takeUntil } from 'rxjs/operators';
 
 @Component({
     selector: 'fd-time-picker',


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3085
#### Please provide a brief summary of this pull request.
DateTimePicker had old implementation of handling closing popover. Now this functionality is provided by popover component.
Also clicking on input now won't trigger popovers. This behaviour is same on SapUi5. 
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
