### PR TITLE
fix: add enter key support for list in combobox

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -44,32 +44,32 @@
         [buttonFocusable]="buttonFocusable"
         [disabled]="disabled || readOnly"
         [isControl]="true"
-        (addOnButtonClicked)="onPrimaryButtonClick()"
         [isExpanded]="!mobile && open && displayedValues.length"
         [attr.aria-readonly]="readOnly"
+        (addOnButtonClicked)="onPrimaryButtonClick()"
         (click)="mobile && isOpenChangeHandle(true)"
     >
         <input
+            #searchInputElement
             fd-auto-complete
+            fd-input-group-input
+            type="text"
             [enable]="autoComplete && !mobile"
             [displayFn]="displayFn"
             [options]="dropdownValues"
             [inputText]="inputText"
-            (onComplete)="handleAutoComplete($event)"
-            #searchInputElement
-            type="text"
-            fd-input-group-input
             [compact]="compact"
-            (keydown)="onInputKeydownHandler($event)"
             [disabled]="disabled"
-            [(ngModel)]="inputText"
-            (ngModelChange)="handleSearchTermChange()"
-            [placeholder]="placeholder"
-            (focus)="onTouched()"
-            (blur)="handleBlur()"
             [attr.aria-expanded]="open && displayedValues.length"
             [readonly]="readOnly"
             [attr.aria-readonly]="readOnly"
+            [placeholder]="placeholder"
+            [(ngModel)]="inputText"
+            (onComplete)="handleAutoComplete($event)"
+            (keydown)="onInputKeydownHandler($event)"
+            (ngModelChange)="handleSearchTermChange()"
+            (focus)="onTouched()"
+            (blur)="handleBlur()"
         />
     </fd-input-group>
 </ng-template>
@@ -78,10 +78,10 @@
     <ul
         fd-list
         class="fd-combobox-custom-list fd-combobox-input-menu-overflow"
-        (focusEscapeList)="handleListFocusEscape($event)"
         [dropdownMode]="true"
         [style.maxHeight]="!mobile && maxHeight"
         [hasMessage]="listMessages && listMessages.length > 0"
+        (focusEscapeList)="handleListFocusEscape($event)"
     >
         <ng-content></ng-content>
         <ng-container *ngIf="groupFn">
@@ -90,12 +90,13 @@
                     {{ group.key }}
                 </li>
                 <li
-                    *ngFor="let term of group.value"
-                    (click)="onMenuClickHandler(term)"
                     fd-list-item
                     tabindex="0"
                     class="fd-combobox-list-item"
+                    *ngFor="let term of group.value"
                     [selected]="inputText === (term | displayFnPipe: displayFn)"
+                    (keyDown)="onItemKeyDownHandler($event, term)"
+                    (click)="onMenuClickHandler(term)"
                 >
                     <ng-container
                         [ngTemplateOutlet]="itemSource"
@@ -106,12 +107,13 @@
         </ng-container>
         <ng-container *ngIf="!groupFn">
             <li
-                *ngFor="let term of displayedValues"
-                (click)="onMenuClickHandler(term)"
                 fd-list-item
                 tabindex="0"
                 class="fd-combobox-list-item"
+                *ngFor="let term of displayedValues"
                 [selected]="inputText === (term | displayFnPipe: displayFn)"
+                (keyDown)="onItemKeyDownHandler($event, term)"
+                (click)="onMenuClickHandler(term)"
             >
                 <ng-container [ngTemplateOutlet]="itemSource" [ngTemplateOutletContext]="{ term: term }"></ng-container>
             </li>

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -17,16 +17,13 @@ import {
     SimpleChanges,
     TemplateRef,
     ViewChild,
-    ViewChildren,
     ViewEncapsulation
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { ListItemComponent } from '../list/list-item/list-item.component';
 import { ListMessageDirective } from '../list/list-message.directive';
 import { ComboboxItem } from './combobox-item';
 import { MenuKeyboardService } from '../menu/menu-keyboard.service';
 import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import focusTrap, { FocusTrap } from 'focus-trap';
 import { FormStates } from '../form/form-control/form-states';
 import { PopoverComponent } from '../popover/popover.component';
@@ -342,6 +339,13 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
             event.stopPropagation();
         } else if (this.openOnKeyboardEvent && !event.ctrlKey && !KeyUtil.isKey(event, this.nonOpeningKeys)) {
             this.isOpenChangeHandle(true);
+        }
+    }
+
+    /** @hidden */
+    onItemKeyDownHandler(event: KeyboardEvent, value: any): void {
+        if (KeyUtil.isKey(event, 'Enter')) {
+            this.onMenuClickHandler(value);
         }
     }
 

--- a/libs/core/src/lib/utils/services/keyboard-support/keyboard-support.service.ts
+++ b/libs/core/src/lib/utils/services/keyboard-support/keyboard-support.service.ts
@@ -55,7 +55,7 @@ export class KeyboardSupportService<T> {
             listItem.keyDown.pipe(
                 takeUntil(unsubscribe$),
                 filter(event => KeyUtil.isKey(event, onKey)),
-                tap(() => event.preventDefault())
+                tap(event => event.preventDefault())
             ).subscribe(() => this.focusEscapeList.next(escapeDirection));
         };
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3085
#### Please provide a brief summary of this pull request.
Now combobox items react on `enter` keyboard event, so now user can select item by pressing enter.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

