### PR TITLE
fix: Add missing styles to List

### DIFF
--- a/libs/core/src/lib/list/list.component.scss
+++ b/libs/core/src/lib/list/list.component.scss
@@ -9,3 +9,12 @@
 .fd-list__secondary {
     pointer-events: all;
 }
+
+// REMOVE AFTER CLOSING https://github.com/SAP/fundamental-styles/issues/1588
+.fd-list .fd-list__item {
+    &[aria-selected="true"],
+    &.is-selected {
+        background: var(--sapList_SelectionBackgroundColor, #e5f0fa);
+        border-bottom: var(--sapList_BorderWidth, 0.0625rem) solid var(--sapList_SelectionBorderColor, #0854a0);
+    }
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #3085 

#### Please provide a brief summary of this pull request.
This PR:
- Adds custom styles patch missing in Fundamental Styles, making it possible to mark list items as selected without the necessity of using `fd-list__item--link` or `fd-list--selectable`.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples