### PR TITLE
fix: (platform) fix for textarea breaking

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-docs.module.ts
@@ -12,6 +12,7 @@ import { PlatformTextareaCounterExampleComponent } from './platform-textarea-exa
 import { PlatformTextareaCounterTemplateExampleComponent } from './platform-textarea-examples/platform-textarea-counter-template-example.component';
 import { PlatformTextareaAutogrowExampleComponent } from './platform-textarea-examples/platform-textarea-autogrow-example.component';
 import { PlatformTextareaI18nExampleComponent } from './platform-textarea-examples/platform-textarea-i18n-example.component';
+import { FormMessageModule } from '@fundamental-ngx/core';
 
 const routes: Routes = [
     {
@@ -31,6 +32,7 @@ const routes: Routes = [
         PlatformTextAreaModule,
         FdpFormGroupModule,
         PlatformButtonModule,
+        FormMessageModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-examples/platform-textarea-basic-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-examples/platform-textarea-basic-example.component.html
@@ -72,11 +72,11 @@
             >
             </fdp-textarea>
             <fd-form-message
-                class="custom-form-message"
                 *ngIf="textarea.value && textarea.value.length > 10"
-                [type]="'warning'"
+                type="warning"
                 >This is an example warning when used without forms.
             </fd-form-message>
         </div>
+        <br />
     </div>
 </main>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-examples/platform-textarea-basic-example.component.scss
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-examples/platform-textarea-basic-example.component.scss
@@ -1,4 +1,0 @@
-.custom-form-message {
-    position: relative;
-    top: -1.875rem;
-}

--- a/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.scss
+++ b/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.scss
@@ -12,3 +12,8 @@
 .fd-popover__control {
   cursor: auto !important;
 }
+
+// the default style display:inline-block is restricting/shrinking the width, therefore we are overriding it to take flex width.
+.fd-popover-custom {
+  display: flex;
+}

--- a/libs/platform/src/lib/components/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/components/form/text-area/text-area.component.ts
@@ -148,7 +148,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
     isCompact: boolean = this._contentDensity === 'compact';
 
     /** @hidden */
-    @ViewChild('textareaElement')
+    @ViewChild('textareaElement', { read: ElementRef })
     textareaElement: ElementRef;
 
     /** @hidden */

--- a/libs/platform/src/lib/components/form/text-area/text-area.module.ts
+++ b/libs/platform/src/lib/components/form/text-area/text-area.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormModule as FdFormModule } from '@fundamental-ngx/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TextAreaComponent } from './text-area.component';
+import { FormControlModule } from '@fundamental-ngx/core';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ReactiveFormsModule, FdFormModule],
+    imports: [CommonModule, FormsModule, ReactiveFormsModule, FormControlModule],
     exports: [TextAreaComponent],
     declarations: [TextAreaComponent]
 })


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#3086 

#### Please provide a brief summary of this pull request.
- FormMessage had to be imported in the docs for one of the examples, without which the 'without Platform Forms' example was showing some broken form message styling.
- Removed custom class added to example
- The ElementRef being used was, for some reason, not able to get the component's reference. This was fixed by using the `read` attribute.
- Fix for width issue by overriding the `fd-popover` styles. A similar fix is already being used in core.
- Using only required FormControlModule iinstead of loading entire core FdFormModule in textarea module.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

