### PR TITLE
fix: (platform) panel - space between the actions & console error

### DIFF
--- a/libs/core/src/lib/toolbar/toolbar.component.ts
+++ b/libs/core/src/lib/toolbar/toolbar.component.ts
@@ -332,6 +332,7 @@ export class ToolbarComponent implements OnInit, AfterViewInit, OnDestroy, After
         }, {});
 
         const groupIds = Object.keys(groups).map(g => parseInt(g, 10)).filter(g => g !== 0);
+
         return groupIds
             .map(g => {
                 let minIndex = Number.MAX_SAFE_INTEGER;
@@ -343,7 +344,7 @@ export class ToolbarComponent implements OnInit, AfterViewInit, OnDestroy, After
 
                 return { group: groups[g].map(({ element }) => element), minIndex: minIndex, maxPriority: maxPriority };
             })
-            .concat(groups[0].map(item => {
+            .concat(!groups[0] ? [] : groups[0].map(item => {
                 return {
                     group: [item.element],
                     maxPriority: OVERFLOW_PRIORITY_SCORE.get(this._getElementPriority(item.element)),

--- a/libs/platform/src/lib/components/panel/panel-actions/panel-actions.component.html
+++ b/libs/platform/src/lib/components/panel/panel-actions/panel-actions.component.html
@@ -1,1 +1,3 @@
-<ng-content></ng-content>
+<ng-template>
+    <ng-content></ng-content>
+</ng-template>

--- a/libs/platform/src/lib/components/panel/panel-actions/panel-actions.component.ts
+++ b/libs/platform/src/lib/components/panel/panel-actions/panel-actions.component.ts
@@ -1,8 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewChild, TemplateRef } from '@angular/core';
 
 @Component({
     selector: 'fdp-panel-actions',
     templateUrl: './panel-actions.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PanelActionsComponent {}
+export class PanelActionsComponent {
+    @ViewChild(TemplateRef) contentTemplateRef: TemplateRef<any>;
+}

--- a/libs/platform/src/lib/components/panel/panel.component.html
+++ b/libs/platform/src/lib/components/panel/panel.component.html
@@ -10,7 +10,7 @@
 
     <ng-container *ngIf="panelActionsComponent">
         <fd-toolbar [size]="_contentDensity" [shouldOverflow]="true" fdType="transparent" [clearBorder]="true">
-            <ng-content select="fdp-panel-actions"></ng-content>
+            <ng-container *ngTemplateOutlet="panelActionsComponent.contentTemplateRef"></ng-container>
         </fd-toolbar>
     </ng-container>
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#3086 
#### Please provide a brief summary of this pull request.
- [x] **Platform** Panel on load give below error in console. 
`libs/core/src/lib/toolbar/toolbar.component.ts.ToolbarComponent._getSortedByPriorityAndGroupItems`
- [x] **Platform** Panel component with Actions example
There is no space between the action buttons in the Panel with Actions Example.
<img width="800" alt="" src="https://user-images.githubusercontent.com/53512176/92225580-06e52200-eec1-11ea-8bc8-d0949af3c31a.png">

- [x] **Platform** - Panel - when going to panel documentation page it throws Error TypeError: undefined is not an object (evaluating 'groups[0].map')

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

