### PR TITLE
fix: (platform) step input component defects

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/step-input/platform-step-input-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/step-input/platform-step-input-docs.component.html
@@ -14,7 +14,7 @@
 </fd-docs-section-title>
 <description>This example shows how Step Input behaves with reactive form</description>
 <component-example>
-    <fdp-platform-number-step-input-form-example></fdp-platform-number-step-input-form-example>
+    <fdp-platform-number-step-input-reactive-example></fdp-platform-number-step-input-reactive-example>
 </component-example>
 <code-example [exampleFiles]="numberStepInputForm"></code-example>
 
@@ -27,6 +27,6 @@
     >This example shows how Step Input behaves with a template-driven form with an initial value set.</description
 >
 <component-example>
-    <fdp-platform-number-step-input-template-form-example></fdp-platform-number-step-input-template-form-example>
+    <fdp-platform-number-step-input-template-example></fdp-platform-number-step-input-template-example>
 </component-example>
 <code-example [exampleFiles]="numberStepInputTemplateForm"></code-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/step-input/platform-step-input-examples/platform-number-step-input-reactive-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/step-input/platform-step-input-examples/platform-number-step-input-reactive-example.component.ts
@@ -5,7 +5,7 @@ const MAX_VALUE = 20;
 const MIN_VALUE = 10;
 
 @Component({
-    selector: 'fdp-platform-number-step-input-form-example',
+    selector: 'fdp-platform-number-step-input-reactive-example',
     templateUrl: './platform-number-step-input-reactive-example.component.html'
 })
 export class PlatformNumberStepInputFormExampleComponent implements AfterViewInit {

--- a/apps/docs/src/app/platform/component-docs/platform-forms/step-input/platform-step-input-examples/platform-number-step-input-template-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/step-input/platform-step-input-examples/platform-number-step-input-template-example.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { ValidatorFn, Validators } from '@angular/forms';
 
 @Component({
-    selector: 'fdp-platform-number-step-input-template-form-example',
+    selector: 'fdp-platform-number-step-input-template-example',
     templateUrl: './platform-number-step-input-template-example.component.html'
 })
 export class PlatformNumberStepInputTemplateFormExampleComponent {

--- a/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.html
+++ b/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.html
@@ -3,7 +3,7 @@
 </ng-template>
 
 <ng-template #renderer>
-    <div (click)="control && control.onContainerClick($event)" [horizontal]="labelLayout === 'horizontal'" fd-form-item>
+    <div [horizontal]="labelLayout === 'horizontal'" fd-form-item>
         <label [attr.for]="id" [inlineHelp]="!!hint" [required]="editable && required" fd-form-label>
             <span *ngIf="!noLabelLayout">{{ label }}</span>
 

--- a/libs/platform/src/lib/components/form/step-input/number/number-step-input.component.html
+++ b/libs/platform/src/lib/components/form/step-input/number/number-step-input.component.html
@@ -8,18 +8,18 @@
     [class.is-error]="isErrorState"
 >
     <button
-        fd-button
-        fdType="transparent"
         class="fd-step-input__button"
-        fdpStepInputDecrement
         tabindex="-1"
         type="button"
+        fd-button
+        fdType="transparent"
         [compact]="isCompact"
+        [glyph]="showLabels ? null : 'less'"
+        fdpStepInputDecrement
         [attr.aria-disabled]="disabled || !canDecrement"
         [attr.title]="decrementLabel"
         [attr.aria-label]="decrementLabel"
         [attr.aria-controls]="id"
-        [glyph]="showLabels ? null : 'less'"
     >
         {{ showLabels ? decrementLabel : '' }}
     </button>
@@ -41,17 +41,17 @@
     />
     <button
         class="fd-step-input__button"
+        tabindex="-1"
+        type="button"
         fd-button
         fdType="transparent"
         [compact]="isCompact"
+        [glyph]="showLabels ? null : 'add'"
         fdpStepInputIncrement
-        tabindex="-1"
-        type="button"
         [attr.aria-disabled]="disabled || !canIncrement"
         [attr.title]="incrementLabel"
         [attr.aria-label]="incrementLabel"
         [attr.aria-controls]="id"
-        [glyph]="showLabels ? null : 'add'"
     >
         {{ showLabels ? incrementLabel : '' }}
     </button>

--- a/libs/platform/src/lib/components/form/step-input/number/number-step-input.component.spec.ts
+++ b/libs/platform/src/lib/components/form/step-input/number/number-step-input.component.spec.ts
@@ -139,28 +139,24 @@ describe('NumberStepInputComponent main functionality', () => {
 
     it('Should not allow value be less than minimum', () => {
         const nativeElement: HTMLInputElement = getInputDebugElement().nativeElement;
-        const commitEnteredValueSpy = spyOn(stepInputComponent, 'commitEnteredValue').and.callThrough();
         const enteredValue = (component.min - 1).toString();
         nativeElement.value = enteredValue;
+        nativeElement.dispatchEvent(new InputEvent('input'));
         nativeElement.dispatchEvent(new InputEvent('change'));
 
         fixture.detectChanges();
-
-        expect(commitEnteredValueSpy).toHaveBeenCalledWith(enteredValue);
 
         expect(stepInputComponent.value).toEqual(component.min);
     });
 
     it('Should not allow value be more than maximum', () => {
         const nativeElement: HTMLInputElement = getInputDebugElement().nativeElement;
-        const commitEnteredValueSpy = spyOn(stepInputComponent, 'commitEnteredValue').and.callThrough();
         const enteredValue = (component.max + 1).toString();
         nativeElement.value = enteredValue;
+        nativeElement.dispatchEvent(new InputEvent('input'));
         nativeElement.dispatchEvent(new InputEvent('change'));
 
         fixture.detectChanges();
-
-        expect(commitEnteredValueSpy).toHaveBeenCalledWith(enteredValue);
 
         expect(stepInputComponent.value).toEqual(component.max);
     });
@@ -391,7 +387,7 @@ describe('NumberStepInputComponent main functionality', () => {
         expect(component.value).toEqual(value);
     });
 
-    it('Should commit changes on input "change" event', () => {
+    it('Should catch changes on "input" event and apply them on "change" event', () => {
         const value = 10;
         const step = 2;
 
@@ -399,12 +395,12 @@ describe('NumberStepInputComponent main functionality', () => {
         component.step = step;
         fixture.detectChanges();
 
-        const inputChangeEvent = new InputEvent('change');
         const inputEl: HTMLInputElement = getInputDebugElement().nativeElement;
 
         inputEl.focus();
         inputEl.value = '25';
-        inputEl.dispatchEvent(inputChangeEvent);
+        inputEl.dispatchEvent(new InputEvent('input'));
+        inputEl.dispatchEvent(new InputEvent('change'));
         fixture.detectChanges();
 
         expect(component.value).toEqual(25);
@@ -542,7 +538,8 @@ describe('Basic number Step Input withing platforms form', () => {
 
         expect(stepInputEl.classes['is-error']).not.toBeTrue();
 
-        stepInputComponent.commitEnteredValue('not a valid number');
+        stepInputComponent.onEnterValue('not a valid number');
+        stepInputComponent.commitEnteredValue();
         await wait(fixture);
 
         expect(formControl.value).toBe(null);

--- a/libs/platform/src/lib/components/form/step-input/step-input-action-button.ts
+++ b/libs/platform/src/lib/components/form/step-input/step-input-action-button.ts
@@ -1,0 +1,49 @@
+import { Directive, HostListener, OnDestroy } from '@angular/core';
+import { fromEvent, timer, interval, Subject } from 'rxjs';
+import { switchMap, takeUntil } from 'rxjs/operators';
+
+/**
+ * This is a base step input directive to be used for increase/decrease buttons.
+ */
+@Directive()
+export abstract class StepInputActionButton implements OnDestroy {
+    /** @hidden */
+    protected _destroyed = new Subject<void>();
+
+    /**
+     * @hidden
+     * Indicates if action can be handled
+     */
+    abstract canHandleAction(): boolean;
+
+    /**
+     * @hidden
+     * Step input button action handler
+     */
+    abstract runAction(): void;
+
+    /** @hidden  */
+    ngOnDestroy(): void {
+        this._destroyed.next();
+        this._destroyed.complete();
+    }
+
+    /** @hidden */
+    @HostListener('mousedown')
+    click(): void {
+        if (!this.canHandleAction()) {
+            return;
+        }
+
+        // Run action while button is pressed
+        timer(500)
+            .pipe(
+                switchMap(() => interval(40)),
+                takeUntil(fromEvent(window, 'mouseup', { capture: true, once: true }))
+            )
+            .pipe(takeUntil(this._destroyed))
+            .subscribe(() => this.runAction());
+
+        this.runAction();
+    }
+}

--- a/libs/platform/src/lib/components/form/step-input/step-input-control.directive.ts
+++ b/libs/platform/src/lib/components/form/step-input/step-input-control.directive.ts
@@ -16,15 +16,27 @@ export class StepInputControlDirective {
 
     /**
      * @hidden
-     * Handle "change" event
+     * Handle "input" event to keep track of what user is entering
+     */
+    @HostListener('input')
+    onInput(): void {
+        if (!this.stepInput.canChangeValue) {
+            return;
+        }
+        const value: string = ((event.target as HTMLInputElement).value || '').trim();
+        this.stepInput.onEnterValue(value);
+    }
+
+    /**
+     * @hidden
+     * Handle "change" event to commit entered value
      */
     @HostListener('change')
     onChange(): void {
         if (!this.stepInput.canChangeValue) {
             return;
         }
-        const value: string = ((event.target as HTMLInputElement).value || '').trim();
-        this.stepInput.commitEnteredValue(value);
+        this.stepInput.commitEnteredValue();
     }
 
     /**

--- a/libs/platform/src/lib/components/form/step-input/step-input-decrement.directive.ts
+++ b/libs/platform/src/lib/components/form/step-input/step-input-decrement.directive.ts
@@ -1,9 +1,7 @@
-import { Directive, HostListener, SkipSelf } from '@angular/core';
-import { startWith } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { Directive, SkipSelf } from '@angular/core';
 
 import { StepInputComponent } from './base.step-input';
-import { streamUntilMouseUp$ } from './step-input-increment.directive';
+import { StepInputActionButton } from './step-input-action-button';
 
 /**
  * This Directive is used to be assigned to decrement button.
@@ -11,24 +9,17 @@ import { streamUntilMouseUp$ } from './step-input-increment.directive';
 @Directive({
     selector: '[fdpStepInputDecrement]'
 })
-export class StepInputDecrementDirective {
+export class StepInputDecrementDirective extends StepInputActionButton {
     /** @hidden */
-    private _streamUntilMouseUp$: Observable<number> = streamUntilMouseUp$;
+    constructor(@SkipSelf() private stepInput: StepInputComponent) {
+        super();
+    }
 
-    /** @hidden */
-    constructor(@SkipSelf() private stepInput: StepInputComponent) {}
+    canHandleAction(): boolean {
+        return !!this.stepInput.canChangeValue;
+    }
 
-    /** @hidden */
-    @HostListener('mousedown', ['$event'])
-    click($event: Event): void {
-        if (!this.stepInput.canChangeValue) {
-            return;
-        }
-
-        $event.preventDefault();
-
-        this._streamUntilMouseUp$.pipe(startWith(null)).subscribe(() => {
-            this.stepInput.decrease();
-        });
+    runAction(): void {
+        this.stepInput.decrease();
     }
 }

--- a/libs/platform/src/lib/components/form/step-input/step-input-increment.directive.ts
+++ b/libs/platform/src/lib/components/form/step-input/step-input-increment.directive.ts
@@ -1,13 +1,7 @@
-import { Directive, HostListener, SkipSelf } from '@angular/core';
-import { fromEvent, timer, interval, Observable } from 'rxjs';
-import { switchMap, takeUntil, startWith } from 'rxjs/operators';
+import { Directive, SkipSelf } from '@angular/core';
 
 import { StepInputComponent } from './base.step-input';
-
-export const streamUntilMouseUp$: Observable<number> = timer(500).pipe(
-    switchMap(() => interval(40)),
-    takeUntil(fromEvent(window, 'mouseup', { capture: true, once: true }))
-);
+import { StepInputActionButton } from './step-input-action-button';
 
 /**
  * This Directive is used to be assigned to increment button.
@@ -15,24 +9,17 @@ export const streamUntilMouseUp$: Observable<number> = timer(500).pipe(
 @Directive({
     selector: '[fdpStepInputIncrement]'
 })
-export class StepInputIncrementDirective {
+export class StepInputIncrementDirective extends StepInputActionButton {
     /** @hidden */
-    private _streamUntilMouseUp$: Observable<number> = streamUntilMouseUp$;
+    constructor(@SkipSelf() private stepInput: StepInputComponent) {
+        super();
+    }
 
-    /** @hidden */
-    constructor(@SkipSelf() private stepInput: StepInputComponent) {}
+    canHandleAction(): boolean {
+        return !!this.stepInput.canChangeValue;
+    }
 
-    /** @hidden */
-    @HostListener('mousedown', ['$event'])
-    click($event: Event): void {
-        if (!this.stepInput.canChangeValue) {
-            return;
-        }
-
-        $event.preventDefault();
-
-        this._streamUntilMouseUp$.pipe(startWith(null)).subscribe(() => {
-            this.stepInput.increase();
-        });
+    runAction(): void {
+        this.stepInput.increase();
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3225 
https://github.com/SAP/fundamental-ngx/issues/3086
#### Please provide a brief summary of this pull request.
It's a fix to handle `platform step-input` entry correctly
![image](https://user-images.githubusercontent.com/4380815/92053467-b0120800-ed5b-11ea-90fe-c3dad4020763.gif)
until that it relied only on 'change' event to commit new entered value.
From now it's also listening to `input` event and store intermediate value in variable so it can be used to perform `increase/decrease` actions without waiting for `change` event.

Regarding this issue:
![image](https://user-images.githubusercontent.com/4380815/92054740-24e54200-ed5c-11ea-84d6-4af9e3b2ca09.gif)
It's not connected to step-input itself actually and I believe should be resolved in a separate pull request.
The issue lays in `fdp-input-message-group` due to popover `triggers` settings
https://github.com/SAP/fundamental-ngx/blob/cd4932dd5edb59dbfc674fe755da1a7a4e4ddd90/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.html#L9
As result each click `toggles` validation message.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

