### PR TITLE
fix: (core) remove icon-only prop of Info Label and fix the vertical alignment

### DIFF
--- a/apps/docs/src/app/core/component-docs/info-label/examples/info-label-icon-numeric-example.component.html
+++ b/apps/docs/src/app/core/component-docs/info-label/examples/info-label-icon-numeric-example.component.html
@@ -1,4 +1,4 @@
 <span fd-info-label [type]="'numeric'" [color]="'2'" style="margin-right: 20px;">6</span>
 <span fd-info-label [type]="'numeric'" [color]="'3'" style="margin-right: 20px;">42k</span>
 <span fd-info-label [type]="'numeric'" [color]="'3'" style="margin-right: 20px;">14.7</span>
-<span fd-info-label [type]="'only-icon'" [color]="'5'" [glyph]="'hide'" style="margin-right: 20px;"></span>
+<span fd-info-label [type]="'icon'" [color]="'5'" [glyph]="'hide'" style="margin-right: 20px;"></span>

--- a/apps/docs/src/app/core/component-docs/info-label/info-label-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/info-label/info-label-docs.component.html
@@ -38,7 +38,7 @@
 </fd-docs-section-title>
 <description
     >Set the <code>[type]</code> property to 'numeric' for Info Label with a number. For Info Label with icon only set
-    the property to 'only-icon'.
+    the property to 'icon'.
 </description>
 <component-example>
     <fd-info-label-numeric-icon-example></fd-info-label-numeric-icon-example>

--- a/apps/docs/src/app/platform/component-docs/platform-info-label/platform-info-label-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-info-label/platform-info-label-docs.component.html
@@ -1,53 +1,61 @@
 <fd-docs-section-title [id]="'default'" [componentName]="'infolabel default'">
-	Default Info Label
+    Default Info Label
 </fd-docs-section-title>
 <component-example>
-	<fdp-platform-info-label-example></fdp-platform-info-label-example>
+    <fdp-platform-info-label-example></fdp-platform-info-label-example>
 </component-example>
 <code-example [exampleFiles]="platformDefaultInfoLabelHtmlType"></code-example>
 
 <separator></separator>
 
 <fd-docs-section-title [id]="'infoLabelText'" [componentName]="'infolabel text'">
-	Info Label With Text
+    Info Label With Text
 </fd-docs-section-title>
-<description>To apply semantic color to the Info Label use the <code>[color]</code> property. Available options are numbers from 1 to 10.</description>
+<description
+    >To apply semantic color to the Info Label use the <code>[color]</code> property. Available options are numbers from
+    1 to 10.</description
+>
 <component-example>
-	<fdp-platform-info-label-text-example></fdp-platform-info-label-text-example>
+    <fdp-platform-info-label-text-example></fdp-platform-info-label-text-example>
 </component-example>
 <code-example [exampleFiles]="platformTextInfoLabelHtmlType"></code-example>
 
 <separator></separator>
 
 <fd-docs-section-title [id]="'infoLabelTextAndIcon'" [componentName]="'infolabel icon and text'">
-	Info Label With Text and Icon
+    Info Label With Text and Icon
 </fd-docs-section-title>
 <description>Set the <code>[type]</code> property to 'icon' for Info Label with text and icon. </description>
 <component-example>
-	<fdp-platform-info-label-text-icon-example></fdp-platform-info-label-text-icon-example>
+    <fdp-platform-info-label-text-icon-example></fdp-platform-info-label-text-icon-example>
 </component-example>
 <code-example [exampleFiles]="platformTextAndIconInfoLabelHtmlType"></code-example>
 
 <separator></separator>
 
 <fd-docs-section-title [id]="'infoLabelNumeric'" [componentName]="'InfoLabel Numberic'">
-	Info Label With a Number or an Icon
+    Info Label With a Number or an Icon
 </fd-docs-section-title>
-<description>Set the <code>[type]</code> property to 'numeric' for Info Label with a number. For Info Label with icon only set the property to 'only-icon'. </description>
+<description
+    >Set the <code>[type]</code> property to 'numeric' for Info Label with a number. For Info Label with icon only set
+    the property to 'icon'.
+</description>
 <component-example>
-	<fdp-platform-info-label-numeric-icon-example></fdp-platform-info-label-numeric-icon-example>
+    <fdp-platform-info-label-numeric-icon-example></fdp-platform-info-label-numeric-icon-example>
 </component-example>
 <code-example [exampleFiles]="platformNumericInfoLabelHtmlType"></code-example>
 
 <separator></separator>
 
-
 <fd-docs-section-title [id]="'infoLabelAriaLabel'" [componentName]="'ArailabelInfoLabel'">
-	Info Label With a Aria Label for accessibility.
+    Info Label With a Aria Label for accessibility.
 </fd-docs-section-title>
-<description>Set the <code>[ariaLabel]</code> and <code>[ariaLabelledBy]</code> property to 'user defined string', Info Label which allows user to add browser readablity to the respective component . </description>
+<description
+    >Set the <code>[ariaLabel]</code> and <code>[ariaLabelledBy]</code> property to 'user defined string', Info Label
+    which allows user to add browser readablity to the respective component .
+</description>
 <component-example>
-	<fdp-platform-info-label-aria-label-example></fdp-platform-info-label-aria-label-example>
+    <fdp-platform-info-label-aria-label-example></fdp-platform-info-label-aria-label-example>
 </component-example>
 <code-example [exampleFiles]="platformAraiaLabelInfoLabelHtmlType"></code-example>
 

--- a/apps/docs/src/app/platform/component-docs/platform-info-label/platform-info-label-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-info-label/platform-info-label-docs.component.html
@@ -11,10 +11,10 @@
 <fd-docs-section-title [id]="'infoLabelText'" [componentName]="'infolabel text'">
     Info Label With Text
 </fd-docs-section-title>
-<description
-    >To apply semantic color to the Info Label use the <code>[color]</code> property. Available options are numbers from
-    1 to 10.</description
->
+<description>
+    To apply semantic color to the Info Label use the <code>[color]</code> property. Available options are numbers from
+    1 to 10.
+</description>
 <component-example>
     <fdp-platform-info-label-text-example></fdp-platform-info-label-text-example>
 </component-example>
@@ -36,8 +36,8 @@
 <fd-docs-section-title [id]="'infoLabelNumeric'" [componentName]="'InfoLabel Numberic'">
     Info Label With a Number or an Icon
 </fd-docs-section-title>
-<description
-    >Set the <code>[type]</code> property to 'numeric' for Info Label with a number. For Info Label with icon only set
+<description>
+    Set the <code>[type]</code> property to 'numeric' for Info Label with a number. For Info Label with icon only set
     the property to 'icon'.
 </description>
 <component-example>
@@ -50,8 +50,8 @@
 <fd-docs-section-title [id]="'infoLabelAriaLabel'" [componentName]="'ArailabelInfoLabel'">
     Info Label With a Aria Label for accessibility.
 </fd-docs-section-title>
-<description
-    >Set the <code>[ariaLabel]</code> and <code>[ariaLabelledBy]</code> property to 'user defined string', Info Label
+<description>
+    Set the <code>[ariaLabel]</code> and <code>[ariaLabelledBy]</code> property to 'user defined string', Info Label
     which allows user to add browser readablity to the respective component .
 </description>
 <component-example>

--- a/apps/docs/src/app/platform/component-docs/platform-info-label/platform-info-label-example/platform-info-label-numeric-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-info-label/platform-info-label-example/platform-info-label-numeric-example.component.html
@@ -1,4 +1,4 @@
 <fdp-info-label [type]="'numeric'" [color]="'2'" style="margin-right: 20px;">6</fdp-info-label>
 <fdp-info-label [type]="'numeric'" [color]="'2'" style="margin-right: 20px;">42k</fdp-info-label>
-<fdp-info-label [type]="'numeric'" [color]="'2'"  style="margin-right: 20px;">14.7</fdp-info-label>
-<fdp-info-label [type]="'only-icon'" [color]="'5'" [glyph]="'hide'" style="margin-right: 20px;"></fdp-info-label>
+<fdp-info-label [type]="'numeric'" [color]="'2'" style="margin-right: 20px;">14.7</fdp-info-label>
+<fdp-info-label [type]="'icon'" [color]="'5'" [glyph]="'hide'" style="margin-right: 20px;"></fdp-info-label>

--- a/libs/core/src/lib/info-label/info-label.component.spec.ts
+++ b/libs/core/src/lib/info-label/info-label.component.spec.ts
@@ -40,14 +40,6 @@ describe('InfoLabelComponent', () => {
         expect(component.elementRef().nativeElement.classList.contains('fd-info-label--numeric')).toBe(true);
     });
 
-    it('Should Add  label Type only icon', () => {
-        component.ngOnInit();
-        component.type = 'only-icon';
-        component.buildComponentCssClass();
-        fixture.detectChanges();
-        expect(component.elementRef().nativeElement.classList.contains('fd-info-label--only-icon')).toBe(true);
-    });
-
     it('Should Add  label Type icon', () => {
         component.ngOnInit();
         component.type = 'icon';

--- a/libs/core/src/lib/info-label/info-label.component.ts
+++ b/libs/core/src/lib/info-label/info-label.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { CssClassBuilder, applyCssClass } from '../utils/public_api';
 
-export type LabelType = 'numeric' | 'only-icon' | 'icon';
+export type LabelType = 'numeric' | 'icon';
 
 @Component({
     // tslint:disable-next-line:component-selector


### PR DESCRIPTION
fixing infolabel Defects raised

#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3086

#### Please provide a brief summary of this pull request.

>  info label only icon not matching the spec and its vertical alignment shifted.
> Icon-only type has been removed as its not necessary.

<img width="853" alt="Screenshot 2020-09-10 at 7 30 27 PM" src="https://user-images.githubusercontent.com/53534379/92741319-1b7f5980-f39c-11ea-89be-fbe5381b9ee1.png">


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

