### PR TITLE
fix: (platform) defect fix for the input width reduced

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.scss
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.scss
@@ -1,3 +1,3 @@
 .fd-popover {
-    width: 100%;
+    display: block;
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-input/platform-input-example/platform-input-auto-complete-validation-example.component.ts
@@ -54,6 +54,7 @@ export class PlatformInputAutoCompleteValidationExampleComponent implements OnIn
 
     onItemClick(clickedValue): void {
         this.inputText = clickedValue;
+        this.options = this.filter(this.inputText);
         this.open = false;
     }
 }


### PR DESCRIPTION
defect fix for the input width reduced 3086 issue

#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3086

#### Please provide a brief summary of this pull request.
FormMessage had to be imported in the docs for one of the examples, without which the 'without Platform Forms' example was showing some broken form message styling.
Fix for width issue by overriding the fd-popover styles. A similar fix is already being used in core.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples


