### PR TITLE
fix: remove spacing between message and select

### DIFF
--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -2,6 +2,7 @@
 
 <ng-template #selectDesktopTemplate>
     <fd-popover
+        style="display: block"
         [isOpen]="isOpen"
         [triggers]="[]"
         [disabled]="disabled"


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/3261
#### Please provide a brief summary of this pull request.
There is included old trick from inputs/textareas, to remove spacing between select and message component.
Before:
![image](https://user-images.githubusercontent.com/26483208/93337957-1a31af00-f82a-11ea-995c-bb38bbc5c40d.png)

After:
![image](https://user-images.githubusercontent.com/26483208/93337881-0128fe00-f82a-11ea-83f5-02f505fce48d.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
