### PR TITLE
fix: add partial keyword in DialogConfig

### DIFF
--- a/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
+++ b/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
@@ -34,7 +34,7 @@ export class DialogService {
      * @param contentType Content of the dialog component.
      * @param dialogConfig Configuration of the dialog component.
      */
-    public open(contentType: Type<any> | TemplateRef<any> | DefaultDialogObject, dialogConfig?: DialogConfig): DialogRef {
+    public open(contentType: Type<any> | TemplateRef<any> | DefaultDialogObject, dialogConfig?: Partial<DialogConfig>): DialogRef {
         const dialogRef: DialogRef = new DialogRef();
 
         dialogConfig = this._applyDefaultConfig(dialogConfig, this._defaultConfig || new DialogConfig());
@@ -77,7 +77,7 @@ export class DialogService {
     }
 
     /** @hidden Extends dialog config using default values*/
-    private _applyDefaultConfig(config: DialogConfig, defaultConfig: DialogConfig): DialogConfig {
+    private _applyDefaultConfig(config: Partial<DialogConfig>, defaultConfig: DialogConfig): DialogConfig {
         return { ...defaultConfig, ...config };
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: #3106 
#### Please provide a brief summary of this pull request.
Adds partial keyword so not all properties have to be defined in the dialog config with the open message
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

