### PR TITLE
chore: deprecate icon size

### DIFF
--- a/apps/docs/src/app/core/component-docs/combobox/examples/combobox-template-example.component.html
+++ b/apps/docs/src/app/core/component-docs/combobox/examples/combobox-template-example.component.html
@@ -14,7 +14,7 @@
 <!-- Note that in this case you are responsible for highlighting. -->
 <ng-template #template let-item>
     <div class="fd-template-container-div">
-        <fd-icon [glyph]="item.icon" size="l" class="fd-template-icon"></fd-icon>
+        <fd-icon [glyph]="item.icon" class="fd-template-icon"></fd-icon>
         <span>{{ item.name }}</span>
     </div>
 </ng-template>

--- a/apps/docs/src/app/core/component-docs/file-input/examples/file-input-custom-example/file-input-custom-example.component.html
+++ b/apps/docs/src/app/core/component-docs/file-input/examples/file-input-custom-example/file-input-custom-example.component.html
@@ -51,7 +51,7 @@
     <div class="outer-div">
         <div class="inner-div" [ngClass]="{ 'state-over': state === 'over' }">
             <div class="content-div" *ngIf="!files || files.length === 0">
-                <fd-icon [glyph]="'upload-to-cloud'" [size]="'xl'"></fd-icon>
+                <fd-icon [glyph]="'upload-to-cloud'"></fd-icon>
                 <span style="margin-top: 10px;">
                     Drop files here, or
                     <a style="cursor: pointer;" (click)="fdInput.open()"> browse </a>.
@@ -63,7 +63,7 @@
                         {{ file.name }}
                         <span style="flex-grow: 1;"></span>
                         <span class="delete-icon">
-                            <fd-icon [glyph]="'sys-cancel'" [size]="'l'" (click)="removeFile(i)"></fd-icon>
+                            <fd-icon [glyph]="'sys-cancel'" (click)="removeFile(i)"></fd-icon>
                         </span>
                     </li>
                 </ul>

--- a/apps/docs/src/app/core/component-docs/icon/icon-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/icon/icon-docs.component.html
@@ -5,25 +5,3 @@
     <fd-icon-example></fd-icon-example>
 </component-example>
 <code-example [exampleFiles]="iconExample"></code-example>
-
-<separator></separator>
-
-<description
-    >The inputs for <code>fd-icon</code> will be translated into classes attributed to fundamental-styles guidelines.
-    <br />For example: <br />if it is passed <code>accept</code> for glyph the class <code>sap-icon--accept</code> will
-    be added to the element. <br />if it is passed <code>xs</code> for size the class <code>sap-icon--xs</code> will be
-    added to the element.
-</description>
-
-<separator></separator>
-
-<fd-docs-section-title [id]="'icon-extensibility'" [componentName]="'icon'">
-    Extensibility
-</fd-docs-section-title>
-<description>
-    The icon implementation allows certain extensibility in terms of options for the inputs. <code>fd-icon</code>
-    inputs doesn't have a restriction for the predefined values.
-    <br />The predefined values for the input <code>size</code> are <code>xs</code>, <code>s</code>, <code>l</code>,
-    <code>xl</code>, but <code>size</code> can accept any other string, for example <code>xxs</code>, which will be
-    translated into class <code>sap-icon--xxs</code>.
-</description>

--- a/apps/docs/src/app/core/component-docs/link/examples/link-example.component.html
+++ b/apps/docs/src/app/core/component-docs/link/examples/link-example.component.html
@@ -5,11 +5,11 @@
 <br /><br />
 <a [routerLink]="['./']" fd-link>
     Icon Right Link
-    <fd-icon [glyph]="arrowRight$ | async" [size]="'s'"></fd-icon>
+    <fd-icon [glyph]="arrowRight$ | async"></fd-icon>
 </a>
 <br /><br />
 <a [routerLink]="['./']" fd-link>
-    <fd-icon [glyph]="arrowLeft$ | async" [size]="'s'"></fd-icon>
+    <fd-icon [glyph]="arrowLeft$ | async"></fd-icon>
     Icon Left Link
 </a>
 <br /><br />

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
@@ -14,7 +14,7 @@
 
     <fd-popover placement="top">
         <fd-popover-control>
-            <fd-icon [glyph]="'menu2'" [size]="'l'"></fd-icon>
+            <fd-icon [glyph]="'menu2'"></fd-icon>
         </fd-popover-control>
         <fd-popover-body *ngIf="list1 && list1.length">
             <ul fd-list>

--- a/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-example/scroll-spy-custom-example.component.html
+++ b/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-example/scroll-spy-custom-example.component.html
@@ -1,7 +1,7 @@
 <div class="header-container">
     <div class="header-item" *ngFor="let item of items" [ngClass]="{ selected: selectedSpy === item.id }">
         <span class="fd-scroll-spy-example-icon-class icon">
-            <fd-icon [glyph]="'arrow-right'" [size]="'xs'"></fd-icon> </span
+            <fd-icon [glyph]="'arrow-right'"></fd-icon> </span
         >{{ item.name }}
     </div>
 </div>

--- a/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-offset/scroll-spy-offset-example.component.html
+++ b/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-custom-offset/scroll-spy-offset-example.component.html
@@ -1,7 +1,7 @@
 <div class="header-container">
     <div class="header-item" *ngFor="let item of items" [ngClass]="{ selected: selectedSpy === item.id }">
         <span class="fd-scroll-spy-example-icon-class icon">
-            <fd-icon [glyph]="'arrow-right'" [size]="'xs'"></fd-icon> </span
+            <fd-icon [glyph]="'arrow-right'"></fd-icon> </span
         >{{ item.name }}
     </div>
 </div>

--- a/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-example/scroll-spy-example.component.html
+++ b/apps/docs/src/app/core/component-docs/scroll-spy/examples/scroll-spy-example/scroll-spy-example.component.html
@@ -1,7 +1,7 @@
 <div class="header-container">
     <div class="header-item" *ngFor="let item of items" [ngClass]="{ selected: selectedSpy === item.id }">
         <span class="fd-scroll-spy-example-icon-class icon">
-            <fd-icon [glyph]="'arrow-right'" [size]="'xs'"></fd-icon> </span
+            <fd-icon [glyph]="'arrow-right'"></fd-icon> </span
         >{{ item.name }}
     </div>
 </div>

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-templates/combobox-templates-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-templates/combobox-templates-example.component.html
@@ -10,7 +10,7 @@
             (selectionChange)="onSelect($event)">
             <ng-template fdTemplate="optionItemTemplate" let-item let-index="index">
                 <div class="fd-template-container-div">
-                    <fd-icon glyph="accept" size="l" class="fd-template-icon"></fd-icon>
+                    <fd-icon glyph="accept" class="fd-template-icon"></fd-icon>
                     <span [innerText]="item.name"></span>
                 </div>
             </ng-template>
@@ -64,7 +64,7 @@
             (selectionChange)="onSelect3($event)">
             <ng-template fdTemplate="selectedItemTemplate" let-item>
                 <div class="fd-template-container-div">
-                    <fd-icon glyph="accept" size="l" class="fd-template-icon"></fd-icon>
+                    <fd-icon glyph="accept" class="fd-template-icon"></fd-icon>
                     <span [innerText]="item.name"></span>
                 </div>
             </ng-template>

--- a/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-disabled-emphasized-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-disabled-emphasized-example.component.html
@@ -6,7 +6,7 @@
         [title]="'Extra info as tooltip text and aria-label'"
         [disabled]="true"
     >
-        <fd-icon [glyph]="'chain-link'" [size]="'l'"></fd-icon>
+        <fd-icon [glyph]="'chain-link'"></fd-icon>
         DisabledEmphasizedLink
     </fdp-link>
 

--- a/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-disabled-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-disabled-example.component.html
@@ -1,7 +1,7 @@
 <p>
     This is an Example of
     <fdp-link [href]="'http://www.google.com'" [title]="'Extra info as tooltip text and aria-label'" [disabled]="true">
-        <fd-icon [glyph]="'chain-link'" [size]="'l'"></fd-icon>DisabledLink
+        <fd-icon [glyph]="'chain-link'"></fd-icon>DisabledLink
     </fdp-link>
     text after link
 </p>

--- a/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-emphasized-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-emphasized-example.component.html
@@ -5,7 +5,7 @@
         [title]="'Extra info as tooltip text and aria-label'"
         [linkType]="'emphasized'"
     >
-        <fd-icon [glyph]="'chain-link'" [size]="'l'"></fd-icon>
+        <fd-icon [glyph]="'chain-link'"></fd-icon>
         EmphasizedLink
     </fdp-link>
     text after link

--- a/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-icon-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-icon-example.component.html
@@ -1,7 +1,7 @@
 <div>
     This is an Example of an Icon Link
     <fdp-link [href]="'http://www.google.com'" [title]="'Extra info as tooltip text and aria-label'">
-        <fd-icon [glyph]="'chain-link'" [size]="'l'"></fd-icon>
+        <fd-icon [glyph]="'chain-link'"></fd-icon>
     </fdp-link>
     text after link
 </div>

--- a/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-standard-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-standard-example.component.html
@@ -1,7 +1,7 @@
 <p>
     This is an Example of
     <fdp-link [href]="'http://www.google.com'" [title]="'Extra info as tooltip text'">
-        <fd-icon [glyph]="'chain-link'" [size]="'l'"></fd-icon>
+        <fd-icon [glyph]="'chain-link'"></fd-icon>
         Standard Link
     </fdp-link>
     text after link

--- a/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-truncated-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-link/platform-link-examples/platform-link-truncated-example.component.html
@@ -2,7 +2,7 @@
     This is an Example of
     <p style="display: inline-block; width: 150px;">
         <fdp-link [href]="'http://www.google.com'" title="this is a long text link. so getting truncated.">
-            <fd-icon [glyph]="'chain-link'" [size]="'l'"></fd-icon>
+            <fd-icon [glyph]="'chain-link'"></fd-icon>
             TruncatedLink TruncatedLink TruncatedLink
         </fdp-link>
     </p>

--- a/libs/core/src/lib/icon/icon.component.spec.ts
+++ b/libs/core/src/lib/icon/icon.component.spec.ts
@@ -9,11 +9,10 @@ const ICON_SIZE = 'l';
 
 @Component({
     selector: 'fd-test-icon',
-    template: ` <fd-icon [glyph]="iconName" [size]="iconSize"></fd-icon> `
+    template: ` <fd-icon [glyph]="iconName"></fd-icon> `
 })
 class TestWrapperComponent {
     readonly iconName = ICON_NAME;
-    readonly iconSize = ICON_SIZE;
 }
 
 describe('IconComponent', () => {
@@ -40,6 +39,5 @@ describe('IconComponent', () => {
     it('Should Add icon class with glyph on input', () => {
         const icon = fixture.debugElement.nativeElement.querySelector('fd-icon');
         expect(icon.className).toContain('sap-icon--' + ICON_NAME);
-        expect(icon.className).toContain('sap-icon--' + ICON_SIZE);
     });
 });

--- a/libs/core/src/lib/icon/icon.component.ts
+++ b/libs/core/src/lib/icon/icon.component.ts
@@ -17,7 +17,7 @@ const PREFIX_ICON_CLASS = BASE_ICON_CLASS + '--';
  * The component that represents an icon.
  *
  * ```html
- * <fd-icon [glyph]="cart-approval" [size]="'l'"></fd-icon>
+ * <fd-icon [glyph]="cart-approval"></fd-icon>
  * ```
  */
 @Component({

--- a/libs/core/src/lib/icon/icon.component.ts
+++ b/libs/core/src/lib/icon/icon.component.ts
@@ -36,7 +36,8 @@ export class IconComponent extends AbstractFdNgxClass {
      * */
     @Input() glyph;
 
-    /**
+    /** @deprecated
+     * Icon size is deprecated. The size can be set by font-size. It will be removed after version 0.23
      * The size of the icon
      * The predefined values for the input size are *xs*, *s*, *l*, and *xl*.
      * *size* can accept any other string, for example *xxs*, which will be translated into class *sap-icon--xxs*.
@@ -47,10 +48,6 @@ export class IconComponent extends AbstractFdNgxClass {
     _setProperties(): void {
         if (this.glyph) {
             this._addClassToElement(PREFIX_ICON_CLASS + this.glyph);
-        }
-
-        if (this.size) {
-            this._addClassToElement(PREFIX_ICON_CLASS + this.size);
         }
     }
 

--- a/libs/platform/src/lib/components/select/select.component.html
+++ b/libs/platform/src/lib/components/select/select.component.html
@@ -14,7 +14,7 @@
                [value]="item">
 
         <ng-template [ngIf]="!optionValueTemplate">
-            <fd-icon [glyph]="item.icon" size="m" class="fd-template-icon icon-margin"></fd-icon>
+            <fd-icon [glyph]="item.icon" class="fd-template-icon icon-margin"></fd-icon>
             {{item.label ? item.label : item }}
         </ng-template>
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.

deprecate icon size since we don't support predefined sizes and remove its usage from the examples in the doc
#### Please provide a brief summary of this pull request.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

