### PR TITLE
fix: (platform) input group states

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/input-group/platform-input-group-examples/platform-input-group-form-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/input-group/platform-input-group-examples/platform-input-group-form-example.component.html
@@ -9,7 +9,6 @@
                 hint="This is tooltip to help"
                 zone="zLeft"
                 rank="1"
-                hintPlacement="left"
                 [required]="true"
             >
                 <fdp-input-group name="qty" [formControl]="ff.formControl">

--- a/apps/docs/src/app/platform/component-docs/platform-forms/input-group/platform-input-group-examples/platform-input-group-standard-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/input-group/platform-input-group-examples/platform-input-group-standard-example.component.html
@@ -30,7 +30,7 @@
 <p>Icon as an addon</p>
 <fdp-input-group name="employee" placeholder="Email">
     <fdp-input-group-addon>
-        <span class="sap-icon--email" title="Email"></span>
+        <span class="sap-icon--email" title="Email" aria-hidden="true"></span>
     </fdp-input-group-addon>
     <fdp-input-group-input type="email"></fdp-input-group-input>
 </fdp-input-group>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/input-group/platform-input-group-examples/platform-input-group-standard-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/input-group/platform-input-group-examples/platform-input-group-standard-example.component.html
@@ -30,7 +30,7 @@
 <p>Icon as an addon</p>
 <fdp-input-group name="employee" placeholder="Email">
     <fdp-input-group-addon>
-        <span class="sap-icon--email" title="Email" aria-hidden="true"></span>
+        <i class="sap-icon--email" title="Email" aria-hidden="true"></i>
     </fdp-input-group-addon>
     <fdp-input-group-input type="email"></fdp-input-group-input>
 </fdp-input-group>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/input-group/platform-input-group-examples/platform-input-group-standard-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/input-group/platform-input-group-examples/platform-input-group-standard-example.component.html
@@ -30,7 +30,7 @@
 <p>Icon as an addon</p>
 <fdp-input-group name="employee" placeholder="Email">
     <fdp-input-group-addon>
-        <i class="sap-icon--email"></i>
+        <span class="sap-icon--email" title="Email"></span>
     </fdp-input-group-addon>
     <fdp-input-group-input type="email"></fdp-input-group-input>
 </fdp-input-group>

--- a/libs/platform/src/lib/components/form/input-group/addon.component.ts
+++ b/libs/platform/src/lib/components/form/input-group/addon.component.ts
@@ -58,6 +58,15 @@ export class InputGroupAddonComponent implements AfterContentInit {
     }
 
     /** @hidden */
+    set disabled(disabled: boolean) {
+        this._disabled = disabled;
+        this._setButtonControlOptions();
+    }
+    get disabled(): boolean {
+        return this._disabled;
+    }
+
+    /** @hidden */
     @ViewChild(TemplateRef)
     contentTemplateRef: TemplateRef<any>;
 
@@ -73,6 +82,9 @@ export class InputGroupAddonComponent implements AfterContentInit {
 
     /** @hidden */
     private _contentDensity: ContentDensity;
+
+    /** @hidden */
+    private _disabled = false;
 
     /** @hidden */
     constructor(private _renderer: Renderer2) {}
@@ -91,6 +103,8 @@ export class InputGroupAddonComponent implements AfterContentInit {
         }
 
         button.contentDensity = this._contentDensity;
+        button.disabled = this._disabled;
+
         button.markForCheck();
     }
 

--- a/libs/platform/src/lib/components/form/input-group/input-group.component.html
+++ b/libs/platform/src/lib/components/form/input-group/input-group.component.html
@@ -14,8 +14,9 @@
                    [placeholder]="placeholder"
                    [contentDensity]="contentDensity"
                    [type]="_input.type"
-                   [(ngModel)]="value"
-                   [ngModelOptions]="{ standalone: true }"
+                   [disabled]="disabled"
+                   [value]="value"
+                   (input)="_onChangeInputValue($event.target.value)"
                    (focusChange)="_onFocusChanged($event)"></fdp-input>
     </ng-container>
 

--- a/libs/platform/src/lib/components/form/input-group/input-group.component.ts
+++ b/libs/platform/src/lib/components/form/input-group/input-group.component.ts
@@ -133,6 +133,20 @@ export class InputGroupComponent extends BaseInput implements OnInit, AfterConte
         this._listenToChildrenQueryListChanges();
     }
 
+    /**
+     * @hidden
+     * override base functionality to catch new disabled state
+     */
+    setDisabledState(disabled: boolean): void {
+        super.setDisabledState(disabled);
+        this._setAddonsOptions();
+    }
+
+    /** @hidden */
+    _onChangeInputValue(value: string): void {
+        this.value = value;
+    }
+
     /** @hidden */
     private _listenToChildrenQueryListChanges(): void {
         this._children.changes.pipe(startWith(this._children)).subscribe(() => {
@@ -189,6 +203,7 @@ export class InputGroupComponent extends BaseInput implements OnInit, AfterConte
         const after = this._afterInputAddons || [];
         [...before, ...after].forEach((addon) => {
             addon.contentDensity = this._contentDensity;
+            addon.disabled = this.disabled;
         });
     }
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3324
https://github.com/SAP/fundamental-ngx/issues/3316
#### Please provide a brief summary of this pull request.
Added disabled state for fdp-input-group input and addon buttons.
In example added tootlip for an icon.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

