### PR TITLE
fix: (platform) Removed simple button use from Radio Group Documentation

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-content-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-content-example.component.html
@@ -60,7 +60,7 @@
             </ng-container>
         </ng-template>
     </fdp-form-group>
-    <button type="submit" style="margin-left: 2rem;">Submit</button>
+    <fdp-button contentDensity="compact" type="submit" style="margin-left: 2rem;">Submit</fdp-button>
 </form>
 <p style="margin-left: 2rem;">Selected value: {{ form4.controls.radioc4?.value }}</p>
 <br />

--- a/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-list-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-list-example.component.html
@@ -13,7 +13,7 @@
             </ng-container>
         </ng-template>
     </fdp-form-group>
-    <button type="submit" style="margin-left: 2rem;">Submit</button>
+    <fdp-button contentDensity="compact" type="submit" style="margin-left: 2rem;">Submit</fdp-button>
 </form>
 <p style="margin-left: 2rem;">Selected value: {{ form1.controls.radiol1?.value }}</p>
 <br />

--- a/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-list-items-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group-examples/platform-radio-group-list-items-example.component.html
@@ -13,7 +13,7 @@
             </ng-container>
         </ng-template>
     </fdp-form-group>
-    <button type="submit" style="margin-left: 2rem;">Submit</button>
+    <fdp-button contentDensity="compact" type="submit" style="margin-left: 2rem;">Submit</fdp-button>
 </form>
 <p style="margin-left: 2rem;">Selected value: {{ form1.controls.example1?.value }}</p>
 <br />

--- a/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/radio-group/platform-radio-group.module.ts
@@ -10,7 +10,7 @@ import { PlatformRadioGroupContentExampleComponent } from './platform-radio-grou
 import { PlatformRadioGroupDisabledExampleComponent } from './platform-radio-group-examples/platform-radio-group-disabled-examples.component';
 import { PlatformRadioGroupListExampleComponent } from './platform-radio-group-examples/platform-radio-group-list-examples.component';
 import { PlatformRadioGroupListItemsExampleComponent } from './platform-radio-group-examples/platform-radio-group-list-items-examples.component';
-import { FdpFormGroupModule, PlatformRadioGroupModule } from '@fundamental-ngx/platform';
+import { FdpFormGroupModule, PlatformRadioGroupModule, PlatformButtonModule } from '@fundamental-ngx/platform';
 
 const routes: Routes = [
     {
@@ -24,7 +24,13 @@ const routes: Routes = [
 ];
 
 @NgModule({
-    imports: [RouterModule.forChild(routes), SharedDocumentationPageModule, PlatformRadioGroupModule, FdpFormGroupModule],
+    imports: [
+        RouterModule.forChild(routes),
+        SharedDocumentationPageModule,
+        PlatformRadioGroupModule,
+        PlatformButtonModule,
+        FdpFormGroupModule
+    ],
     exports: [RouterModule],
     declarations: [
         PlatformRadioGroupDocsComponent,


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3356

#### Please provide a brief summary of this pull request.
We should be using simple button, as we have fundamental buttons available.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

