### PR TITLE
fix: Disable no-inferrable-types for DialogConfig

### DIFF
--- a/apps/docs/src/app/core/component-docs/calendar/examples/calendar-mobile-example/calendar-mobile-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/calendar/examples/calendar-mobile-example/calendar-mobile-example.component.ts
@@ -18,7 +18,7 @@ export class CalendarMobileExampleComponent {
             verticalPadding: false,
             width: '640px',
             height: '400px'
-        } as DialogConfig);
+        });
     }
 
     openPortraitDialog(dialog: TemplateRef<any>): void {
@@ -28,7 +28,7 @@ export class CalendarMobileExampleComponent {
             verticalPadding: false,
             width: '360px',
             height: '640px'
-        } as DialogConfig);
+        });
     }
 
     dateChanged(date: FdDate): void {

--- a/apps/docs/src/app/core/component-docs/dialog/examples/component-based/component-based-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/component-based/component-based-dialog-example.component.ts
@@ -29,7 +29,7 @@ export class ComponentBasedDialogExampleComponent {
                 ]
             },
             width: '400px'
-        } as DialogConfig);
+        });
 
         dialogRef.afterClosed.subscribe(
             (result) => {

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.ts
@@ -26,7 +26,7 @@ export class DialogBackdropContainerExampleComponent {
             responsivePadding: true,
             backdropClass: 'dialog-custom-overlay-example',
             data: `This dialog has a custom backdrop!`
-        } as DialogConfig);
+        });
     }
 
     openInCustomContainer(dialog, containerRef: HTMLElement): void {
@@ -35,7 +35,7 @@ export class DialogBackdropContainerExampleComponent {
             container: containerRef,
             responsivePadding: true,
             data: `This dialog has been opened inside a local div!`
-        } as DialogConfig);
+        });
     }
 
     openStaticDialog(dialog, containerRef: HTMLElement): void {
@@ -46,6 +46,6 @@ export class DialogBackdropContainerExampleComponent {
             responsivePadding: true,
             backdropClass: 'static-dialog',
             data: `This dialog has been opened inside a local div and displayed as a static element!`
-        } as DialogConfig);
+        });
     }
 }

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-complex/dialog-complex-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-complex/dialog-complex-example.component.ts
@@ -47,7 +47,7 @@ export class DialogComplexExampleComponent {
             resizable: true,
             verticalPadding: false,
             backdropClickCloseable: false
-        } as DialogConfig);
+        });
         this.dialogRef.loading(true);
         setTimeout(() => this.dialogRef.loading(false), 2000);
     }

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-configuration/dialog-configuration-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-configuration/dialog-configuration-example.component.ts
@@ -13,7 +13,7 @@ export class DialogConfigurationExample {
             width: '300px',
             draggable: true,
             responsivePadding: true
-        } as DialogConfig);
+        });
     }
 
     openResizableDialog(template): void {
@@ -21,7 +21,7 @@ export class DialogConfigurationExample {
             width: '300px',
             resizable: true,
             responsivePadding: true
-        } as DialogConfig);
+        });
     }
 
     openClosableByButtonDialog(template): void {
@@ -30,6 +30,6 @@ export class DialogConfigurationExample {
             escKeyCloseable: false,
             responsivePadding: true,
             backdropClickCloseable: false
-        } as DialogConfig);
+        });
     }
 }

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-mobile/dialog-mobile-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-mobile/dialog-mobile-example.component.ts
@@ -12,6 +12,6 @@ export class DialogMobileExampleComponent {
         this._dialogService.open(dialogTemplate, {
             mobile: true,
             responsivePadding: true
-        } as DialogConfig);
+        });
     }
 }

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-position/dialog-position-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-position/dialog-position-example.component.ts
@@ -13,6 +13,6 @@ export class DialogPositionExampleComponent {
             width: '300px',
             responsivePadding: true,
             position: { bottom: '100px', right: '100px' }
-        } as DialogConfig);
+        });
     }
 }

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-state/dialog-state-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-state/dialog-state-example.component.ts
@@ -13,7 +13,7 @@ export class DialogStateExample {
             width: '300px',
             responsivePadding: true,
             data: 'This Dialog will be closed after 4s'
-        } as DialogConfig);
+        });
         setTimeout(() => dialogRef.close(), 4000);
     }
 
@@ -22,7 +22,7 @@ export class DialogStateExample {
             width: '300px',
             responsivePadding: true,
             data: 'This Dialog will be dismissed after 4s'
-        } as DialogConfig);
+        });
         setTimeout(() => dialogRef.dismiss(), 4000);
     }
 
@@ -31,7 +31,7 @@ export class DialogStateExample {
             width: '300px',
             responsivePadding: true,
             data: 'This Dialog will be hidden after 4s'
-        } as DialogConfig);
+        });
         setTimeout(() => dialogRef.hide(true), 4000);
     }
 
@@ -39,7 +39,7 @@ export class DialogStateExample {
         const dialogRef = this.dialogService.open(template, {
             width: '300px',
             responsivePadding: true
-        } as DialogConfig);
+        });
         dialogRef.loading(true);
     }
 }

--- a/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/dialog-stacked-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/dialog-stacked-example.component.ts
@@ -10,6 +10,6 @@ export class DialogStackedExampleComponent {
     constructor(private _dialogService: DialogService) {}
 
     openDialog(): void {
-        this._dialogService.open(FirstDialogExampleComponent, { responsivePadding: true } as DialogConfig);
+        this._dialogService.open(FirstDialogExampleComponent, { responsivePadding: true });
     }
 }

--- a/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
@@ -36,6 +36,6 @@ export class FirstDialogExampleComponent {
     constructor(@Inject(DIALOG_REF) public dialogRef: DialogRef, public _dialogService: DialogService) {}
 
     openDialog(): void {
-        this._dialogService.open(SecondDialogExampleComponent, { responsivePadding: true } as DialogConfig);
+        this._dialogService.open(SecondDialogExampleComponent, { responsivePadding: true });
     }
 }

--- a/apps/docs/src/app/core/component-docs/dialog/examples/template-based/template-based-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/template-based/template-based-dialog-example.component.ts
@@ -11,7 +11,7 @@ export class TemplateBasedDialogExampleComponent {
     constructor(private _dialogService: DialogService) {}
 
     openDialog(dialog: TemplateRef<any>): void {
-        const dialogRef = this._dialogService.open(dialog, { responsivePadding: true } as DialogConfig);
+        const dialogRef = this._dialogService.open(dialog, { responsivePadding: true });
 
         dialogRef.afterClosed.subscribe(
             (result) => {

--- a/apps/docs/src/app/core/component-docs/global-config/examples/dialog-global-config-example/dialog-global-config-example.module.ts
+++ b/apps/docs/src/app/core/component-docs/global-config/examples/dialog-global-config-example/dialog-global-config-example.module.ts
@@ -5,7 +5,7 @@ const DEFAULT_CONFIG: DialogConfig = {
     draggable: true,
     escKeyCloseable: false,
     backdropClickCloseable: false
-} as DialogConfig;
+};
 
 @NgModule({
     providers: [{ provide: DIALOG_DEFAULT_CONFIG, useValue: DEFAULT_CONFIG }]

--- a/apps/docs/src/app/core/component-docs/global-config/examples/mobile-mode-global-config-example/mobile-mode-global-config-example.module.ts
+++ b/apps/docs/src/app/core/component-docs/global-config/examples/mobile-mode-global-config-example/mobile-mode-global-config-example.module.ts
@@ -3,7 +3,7 @@ import { MOBILE_MODE_CONFIG, MobileModeControl, MobileModeConfigToken, DialogCon
 
 const SELECT_MOBILE_CONFIG: MobileModeConfigToken = {
     target: MobileModeControl.SELECT,
-    config: { hasCloseButton: true, dialogConfig: { mobileOuterSpacing: true } as DialogConfig }
+    config: { hasCloseButton: true, dialogConfig: { mobileOuterSpacing: true } }
 };
 
 @NgModule({

--- a/apps/docs/src/app/core/component-docs/multi-input/examples/multi-input-mobile-example/multi-input-mobile-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/multi-input/examples/multi-input-mobile-example/multi-input-mobile-example.component.ts
@@ -14,7 +14,7 @@ export class MultiInputMobileExampleComponent {
         hasCloseButton: true,
         dialogConfig: {
             ariaLabel: 'Select fruits dialog'
-        } as DialogConfig
+        }
     };
 
     values: any[] = ['Apple', 'Banana', 'Pineapple', 'Tomato', 'Kiwi', 'Strawberry', 'Blueberry', 'Orange'];

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dialog/popover-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dialog/popover-dialog-example.component.ts
@@ -12,6 +12,6 @@ export class PopoverDialogExampleComponent {
         this._dialogService.open(template, {
             width: '500px',
             responsivePadding: true
-        } as DialogConfig);
+        });
     }
 }

--- a/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-columns-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-columns-example.component.ts
@@ -60,7 +60,7 @@ export class TableCustomColumnsExampleComponent {
             data: {
                 columns: this.originalDisplayedColumns
             }
-        } as DialogConfig);
+        });
 
 
         dialogRef.afterClosed.subscribe(

--- a/apps/docs/src/app/core/component-docs/table/examples/table-toolbar-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-toolbar-example.component.ts
@@ -68,7 +68,7 @@ export class TableToolbarExampleComponent implements OnInit {
     }
 
     openDialog(dialog: TemplateRef<any>): void {
-        const dialogRef = this._dialogService.open(dialog, { responsivePadding: true } as DialogConfig);
+        const dialogRef = this._dialogService.open(dialog, { responsivePadding: true });
 
         dialogRef.afterClosed.subscribe(
             (result) => {

--- a/apps/docs/src/app/documentation/utilities/consts/mobile-dialog.consts.ts
+++ b/apps/docs/src/app/documentation/utilities/consts/mobile-dialog.consts.ts
@@ -3,9 +3,9 @@ import { DialogConfig } from '@fundamental-ngx/core';
 export const MOBILE_DIALOG_PORTRAIT: DialogConfig = {
     width: '360px',
     height: '640px'
-} as DialogConfig;
+};
 
 export const MOBILE_DIALOG_LANDSCAPE: DialogConfig = {
     width: '640px',
     height: '360px'
-} as DialogConfig;
+};

--- a/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
+++ b/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
@@ -61,7 +61,10 @@ export class DialogContainerComponent implements AfterViewInit, CssClassBuilder 
     /** @hidden */
     @applyCssClass
     buildComponentCssClass(): string[] {
-        return [this.dialogConfig.containerClass, this._class];
+        return [
+            this.dialogConfig.containerClass ? this.dialogConfig.containerClass : '',
+            this._class
+        ];
     }
 
     /** @hidden */

--- a/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.ts
+++ b/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.ts
@@ -23,7 +23,7 @@ export class DialogFooterComponent implements AfterContentInit {
     @ContentChildren(TemplateDirective) customTemplates: QueryList<TemplateDirective>;
 
     constructor(@Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig) {
-        this.dialogConfig = this.dialogConfig || {} as DialogConfig;
+        this.dialogConfig = this.dialogConfig || {};
     }
 
     /** @hidden */

--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.ts
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.ts
@@ -27,7 +27,7 @@ export class DialogHeaderComponent implements AfterContentInit {
     @ContentChildren(TemplateDirective) customTemplates: QueryList<TemplateDirective>;
 
     constructor(@Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig) {
-        this.dialogConfig = this.dialogConfig || {} as DialogConfig;
+        this.dialogConfig = this.dialogConfig || {};
     }
 
     /** @hidden */

--- a/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
+++ b/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
@@ -34,7 +34,7 @@ export class DialogService {
      * @param contentType Content of the dialog component.
      * @param dialogConfig Configuration of the dialog component.
      */
-    public open(contentType: Type<any> | TemplateRef<any> | DefaultDialogObject, dialogConfig?: Partial<DialogConfig>): DialogRef {
+    public open(contentType: Type<any> | TemplateRef<any> | DefaultDialogObject, dialogConfig?: DialogConfig): DialogRef {
         const dialogRef: DialogRef = new DialogRef();
 
         dialogConfig = this._applyDefaultConfig(dialogConfig, this._defaultConfig || new DialogConfig());
@@ -77,7 +77,7 @@ export class DialogService {
     }
 
     /** @hidden Extends dialog config using default values*/
-    private _applyDefaultConfig(config: Partial<DialogConfig>, defaultConfig: DialogConfig): DialogConfig {
+    private _applyDefaultConfig(config: DialogConfig, defaultConfig: DialogConfig): DialogConfig {
         return { ...defaultConfig, ...config };
     }
 }

--- a/libs/core/src/lib/dialog/dialog-utils/dialog-config.class.ts
+++ b/libs/core/src/lib/dialog/dialog-utils/dialog-config.class.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:no-inferrable-types */
 /**
  * Configuration for opening a dialog with the DialogService.
  */
@@ -43,25 +44,25 @@ export class DialogConfig implements DynamicComponentConfig {
     ariaDescribedBy?: string = null;
 
     /** Whether the dialog should have a backdrop. */
-    hasBackdrop = true;
+    hasBackdrop?: boolean = true;
 
     /** Whether clicking on the backdrop should close the dialog. Only works if hasBackdrop is true. */
-    backdropClickCloseable = true;
+    backdropClickCloseable?: boolean = true;
 
     /** Global classes to apply to the backdrop. */
-    backdropClass = '';
+    backdropClass?: string;
 
     /** Classes to apply to the `fd-dialog-container`  */
-    containerClass = '';
+    containerClass?: string;
 
     /** Global classes to apply to the dialog panel. */
-    dialogPanelClass = '';
+    dialogPanelClass?: string;
 
     /** Whether the escape key should close the dialog. */
-    escKeyCloseable = true;
+    escKeyCloseable?: boolean = true;
 
     /** Whether the dialog should be focus trapped. */
-    focusTrapped = true;
+    focusTrapped?: boolean = true;
 
     /** The container that the dialog is appended to. By default, it is appended to the body. */
     container?: HTMLElement | 'body' = 'body';
@@ -85,7 +86,7 @@ export class DialogConfig implements DynamicComponentConfig {
     resizable?: boolean;
 
     /** Whether the dialog should have vertical padding. */
-    verticalPadding = true;
+    verticalPadding?: boolean = true;
 
     /** Whether the dialog should have responsive horizontal padding changing with Dialogs window width.
      * max-width: 599px                         - .fd-dialog__content--s
@@ -93,8 +94,8 @@ export class DialogConfig implements DynamicComponentConfig {
      * min-width: 1024px and max-width: 1439px  - .fd-dialog__content--l
      * min-width: 1440px                        - .fd-dialog__content--xl
      * */
-    responsivePadding = false;
+    responsivePadding?: boolean = false;
 
     /** Whether to close the dialog on router navigation start. */
-    closeOnNavigation = true;
+    closeOnNavigation?: boolean = true;
 }

--- a/libs/core/src/lib/dialog/dialog.component.ts
+++ b/libs/core/src/lib/dialog/dialog.component.ts
@@ -159,7 +159,7 @@ export class DialogComponent implements OnInit, AfterViewInit, OnDestroy, CssCla
             this.dialogConfig.hasBackdrop ? 'fd-dialog' : '',
             this.showDialogWindow ? 'fd-dialog--active' : '',
             this._class,
-            this.dialogConfig.backdropClass
+            this.dialogConfig.backdropClass ? this.dialogConfig.backdropClass : ''
         ];
     }
 

--- a/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.spec.ts
+++ b/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.spec.ts
@@ -96,7 +96,7 @@ describe('MenuMobileComponent', () => {
     it('should use custom dialog configuration', fakeAsync(() => {
         const customDialogClass = 'test-dialog-class';
 
-        setup({ dialogConfig: { dialogPanelClass: customDialogClass } as DialogConfig});
+        setup({ dialogConfig: { dialogPanelClass: customDialogClass }});
 
         menu.open();
         fixture.detectChanges();


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
This PR:
- Disables `no-inferrable-types` for `dialog-config.class.ts` file
- Removes `Partial<T>` type annotation from `Dialog.open` and `Dialog._applyDefaultConfig`
- Removes unnecessary `as DialogConfig` type casting



`DialogConfig` is a class that is used both to describe the default config of the Dialog (with optional properties and default values), and to describe config properties which all should remain optional.

Previously introduced changes made optional parameters required, which is conflicting with the main idea of the `DialogConfig`, and required users to cast the `DialogConfig` type, or specify the required properties.

Solution with `Partial<T>` annotation is partially good, but it remains some use-cases of `DialogConfig` still requiring type casting , using `DialogConfig` constructor or again using `Partial<T>`.

Example:
Lets assume that we want to create an interface which will provide also a configuration for the Dialog.
```
interface NewInterface {
   a: string,
  dialogConfig: DialogConfig;
}

const newProperty = {
  a: '123',
  dialogConfig: { maxHeight: '400px' } // TYPE ERROR
}
```

Proper solution of this case without disabling `no-inferrable-types` would be splitting `DialogConfig` into:
- `DialogConfig` - with all optional properties
- `DilogDefaultConfig implements DialogConfig` - with default values for the dialog config

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

