### PR TITLE
fix: migrate tabs to 0.12.0 styles

### DIFF
--- a/apps/docs/src/app/core/api-files.ts
+++ b/apps/docs/src/app/core/api-files.ts
@@ -203,7 +203,7 @@ export const API_FILES = {
         'TabLinkDirective',
         'TabItemDirective',
         'TabTagDirective',
-        'TabIconDirective',
+        'TabIconComponent',
         'TabCountDirective',
         'TabLabelDirective',
         'TabProcessDirective',

--- a/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
+++ b/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
@@ -7,7 +7,7 @@ import {
     OnInit,
     TemplateRef,
     ViewContainerRef,
-    OnChanges
+    OnChanges, Component
 } from '@angular/core';
 import { applyCssClass, CssClassBuilder } from '../../utils/public_api';
 
@@ -70,12 +70,16 @@ export class TabCountDirective {
 /**
  * Directive for icon element, available in most of modes on `tab` component
  */
-@Directive({
+@Component({
     // TODO to be discussed
     // tslint:disable-next-line:directive-selector
-    selector: '[fd-tab-icon]'
+    selector: '[fd-tab-icon]',
+    template: `
+        <fd-icon role="presentation" *ngIf="icon" [glyph]="icon"></fd-icon>
+        <ng-content></ng-content>
+    `
 })
-export class TabIconDirective implements CssClassBuilder, OnChanges {
+export class TabIconComponent implements CssClassBuilder, OnChanges {
     /** Apply user custom styles */
     @Input()
     class: string;
@@ -108,7 +112,7 @@ export class TabIconDirective implements CssClassBuilder, OnChanges {
      * function is responsible for order which css classes are applied
      */
     buildComponentCssClass(): string[] {
-        return [this.fdTabIconClass ? 'fd-tabs__icon' : '', this.icon ? `sap-icon--${this.icon}` : '', this.class];
+        return [this.fdTabIconClass ? 'fd-tabs__icon' : '', this.class];
     }
 
     /** HasElementRef interface implementation

--- a/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
+++ b/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
@@ -1,13 +1,16 @@
 import {
+    ChangeDetectionStrategy,
+    Component,
     Directive,
     ElementRef,
     EmbeddedViewRef,
     HostBinding,
     Input,
+    OnChanges,
     OnInit,
     TemplateRef,
     ViewContainerRef,
-    OnChanges, Component
+    ViewEncapsulation
 } from '@angular/core';
 import { applyCssClass, CssClassBuilder } from '../../utils/public_api';
 
@@ -71,21 +74,19 @@ export class TabCountDirective {
  * Directive for icon element, available in most of modes on `tab` component
  */
 @Component({
-    // TODO to be discussed
-    // tslint:disable-next-line:directive-selector
+    // tslint:disable-next-line:directive-selector component-selector
     selector: '[fd-tab-icon]',
     template: `
         <fd-icon role="presentation" *ngIf="icon" [glyph]="icon"></fd-icon>
         <ng-content></ng-content>
-    `
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None
 })
 export class TabIconComponent implements CssClassBuilder, OnChanges {
     /** Apply user custom styles */
     @Input()
     class: string;
-
-    /** Defines if there will be added fd-tabs-icon class. Enabled by default. */
-    fdTabIconClass = true;
 
     /**
      * The icon to include inside the element
@@ -112,7 +113,7 @@ export class TabIconComponent implements CssClassBuilder, OnChanges {
      * function is responsible for order which css classes are applied
      */
     buildComponentCssClass(): string[] {
-        return [this.fdTabIconClass ? 'fd-tabs__icon' : '', this.class];
+        return ['fd-tabs__icon', this.class];
     }
 
     /** HasElementRef interface implementation

--- a/libs/core/src/lib/tabs/tab-utils/tab-icon.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-utils/tab-icon.component.spec.ts
@@ -10,7 +10,7 @@ class TestNestedContainerComponent {
     directiveElement: TabIconComponent;
 }
 
-describe('TabIconDirective', () => {
+describe('TabIconComponent', () => {
     let component: TestNestedContainerComponent;
     let directiveElement: TabIconComponent;
     let fixture: ComponentFixture<TestNestedContainerComponent>;
@@ -29,21 +29,9 @@ describe('TabIconDirective', () => {
     });
 
     it('Should have good classes', () => {
-        directiveElement.icon = 'menu';
         directiveElement.buildComponentCssClass();
         fixture.detectChanges();
 
         expect((directiveElement as any)._elementRef.nativeElement.classList.contains('fd-tabs__icon')).toBeTruthy();
-        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('sap-icon--menu')).toBeTruthy();
-    });
-
-    it('Should be able to change icon', () => {
-        directiveElement.icon = 'edit';
-        directiveElement.buildComponentCssClass();
-        fixture.detectChanges();
-
-        directiveElement.icon = 'menu';
-        directiveElement.buildComponentCssClass();
-        expect((directiveElement as any)._elementRef.nativeElement.classList.contains('sap-icon--menu')).toBeTruthy();
     });
 });

--- a/libs/core/src/lib/tabs/tab-utils/tab-icon.directive.spec.ts
+++ b/libs/core/src/lib/tabs/tab-utils/tab-icon.directive.spec.ts
@@ -1,23 +1,23 @@
 import { Component, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { TabIconDirective } from './tab-directives';
+import { TabIconComponent } from './tab-directives';
 
 @Component({
     template: ` <li fd-tab-icon #directiveElement></li> `
 })
 class TestNestedContainerComponent {
-    @ViewChild('directiveElement', { static: true, read: TabIconDirective })
-    directiveElement: TabIconDirective;
+    @ViewChild('directiveElement', { static: true, read: TabIconComponent })
+    directiveElement: TabIconComponent;
 }
 
 describe('TabIconDirective', () => {
     let component: TestNestedContainerComponent;
-    let directiveElement: TabIconDirective;
+    let directiveElement: TabIconComponent;
     let fixture: ComponentFixture<TestNestedContainerComponent>;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [TestNestedContainerComponent, TabIconDirective]
+            declarations: [TestNestedContainerComponent, TabIconComponent]
         }).compileComponents();
     }));
 

--- a/libs/core/src/lib/tabs/tabs.module.ts
+++ b/libs/core/src/lib/tabs/tabs.module.ts
@@ -8,7 +8,7 @@ import {
     TabCountDirective,
     TabCounterHeaderDirective,
     TabHeaderDirective,
-    TabIconDirective,
+    TabIconComponent,
     TabLabelDirective,
     TabLoadTitleDirective,
     TabProcessDirective,
@@ -20,6 +20,7 @@ import {
 import { TabNavComponent } from './tab-nav/tab-nav.component';
 import { TabLinkDirective } from './tab-link/tab-link.directive';
 import { TabItemDirective } from './tab-item/tab-item.directive';
+import { IconModule } from '../icon/icon.module';
 
 @NgModule({
     declarations: [
@@ -31,7 +32,7 @@ import { TabItemDirective } from './tab-item/tab-item.directive';
         TabLinkDirective,
         TabItemDirective,
         TabTagDirective,
-        TabIconDirective,
+        TabIconComponent,
         TabCountDirective,
         TabLabelDirective,
         TabProcessDirective,
@@ -40,7 +41,7 @@ import { TabItemDirective } from './tab-item/tab-item.directive';
         TabProcessIconDirective,
         TabSeparatorDirective
     ],
-    imports: [CommonModule],
+    imports: [CommonModule, IconModule],
     exports: [
         TabListComponent,
         TabPanelComponent,
@@ -50,7 +51,7 @@ import { TabItemDirective } from './tab-item/tab-item.directive';
         TabItemDirective,
         TabLinkDirective,
         TabTagDirective,
-        TabIconDirective,
+        TabIconComponent,
         TabCountDirective,
         TabLabelDirective,
         TabProcessDirective,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13650,9 +13650,9 @@
       "dev": true
     },
     "fundamental-styles": {
-      "version": "0.12.0-rc.90",
-      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0-rc.90.tgz",
-      "integrity": "sha512-6qRSZl8zjxU7PMtraHNQPWwtQ6DRecB6xkdmcEmlmoh9JjY4vMlu7uSOqSVJpVLkVc77J9AgdYTOx4LoFbvtFA=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0.tgz",
+      "integrity": "sha512-ZuQlVdRJQjtlvhGrj80VvGtdydoCzzspOamgFSJH4wzYVIXDNcYuDHE6nRm0Ad01ttjp9NuyZDKcwIvi+rSVNw=="
     },
     "fuse.js": {
       "version": "3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13650,9 +13650,9 @@
       "dev": true
     },
     "fundamental-styles": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.11.0.tgz",
-      "integrity": "sha512-CspyvrCQoZ7+47LRtMwvRiLPF/24OJ4kauqdqmObE7WeFtU1g2OxRRabqjox+xIsZqp1a72xE6fCqgKzayzpxg=="
+      "version": "0.12.0-rc.90",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0-rc.90.tgz",
+      "integrity": "sha512-6qRSZl8zjxU7PMtraHNQPWwtQ6DRecB6xkdmcEmlmoh9JjY4vMlu7uSOqSVJpVLkVc77J9AgdYTOx4LoFbvtFA=="
     },
     "fuse.js": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "3.6.5",
     "flexboxgrid": "6.3.1",
     "focus-trap": "5.1.0",
-    "fundamental-styles": "0.11.0",
+    "fundamental-styles": "prerelease",
     "hammerjs": "2.0.8",
     "highlight.js": "9.18.1",
     "intl": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "3.6.5",
     "flexboxgrid": "6.3.1",
     "focus-trap": "5.1.0",
-    "fundamental-styles": "prerelease",
+    "fundamental-styles": "0.12.0",
     "hammerjs": "2.0.8",
     "highlight.js": "9.18.1",
     "intl": "1.2.5",


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#### Please provide a brief summary of this pull request.

There is change from `TabIconDirective` to `TabIconComponent`, but the selector hasn't been changed so this is not breaking change

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

