### PR TITLE
fix: migrate product switch to 0.12.0 styles

### DIFF
--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.html
@@ -21,9 +21,7 @@
             (click)="itemClick(product, $event)"
             [draggable]="!product.disabledDragAndDrop && dragAndDropEnabled"
             [stickInPlace]="product.stickToPosition">
-            <div class="fd-product-switch__icon" [ngClass]="product.icon ? 'sap-icon--' + product.icon : ''">
-                <img *ngIf="product.image" [src]="product.image"/>
-            </div>
+            <i role="presentation" class="fd-product-switch__icon" [ngClass]="product.icon ? 'sap-icon--' + product.icon : ''"></i>
             <div class="fd-product-switch__text">
                 <div class="fd-product-switch__title">{{ product.title }}</div>
                 <div *ngIf="product.subtitle" class="fd-product-switch__subtitle">{{ product.subtitle }}</div>

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch.item.ts
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch.item.ts
@@ -5,7 +5,9 @@ export interface ProductSwitchItem {
     /** Subtitle of product */
     subtitle?: string;
 
-    /** Url of product image */
+    /** @deprecated
+     * Use icon property instead of image
+     */
     image?: string;
 
     /** Callback function that will be called on selecting this product from dropdown */

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch.item.ts
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch.item.ts
@@ -6,7 +6,7 @@ export interface ProductSwitchItem {
     subtitle?: string;
 
     /** @deprecated
-     * Use icon property instead of image
+     * Use icon property instead
      */
     image?: string;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13650,9 +13650,9 @@
       "dev": true
     },
     "fundamental-styles": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.11.0.tgz",
-      "integrity": "sha512-CspyvrCQoZ7+47LRtMwvRiLPF/24OJ4kauqdqmObE7WeFtU1g2OxRRabqjox+xIsZqp1a72xE6fCqgKzayzpxg=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0.tgz",
+      "integrity": "sha512-ZuQlVdRJQjtlvhGrj80VvGtdydoCzzspOamgFSJH4wzYVIXDNcYuDHE6nRm0Ad01ttjp9NuyZDKcwIvi+rSVNw=="
     },
     "fuse.js": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "3.6.5",
     "flexboxgrid": "6.3.1",
     "focus-trap": "5.1.0",
-    "fundamental-styles": "0.11.0",
+    "fundamental-styles": "prerelease",
     "hammerjs": "2.0.8",
     "highlight.js": "9.18.1",
     "intl": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "3.6.5",
     "flexboxgrid": "6.3.1",
     "focus-trap": "5.1.0",
-    "fundamental-styles": "prerelease",
+    "fundamental-styles": "0.12.0",
     "hammerjs": "2.0.8",
     "highlight.js": "9.18.1",
     "intl": "1.2.5",


### PR DESCRIPTION
#### Please provide a link to the associated issue.

#### Please provide a brief summary of this pull request.
There are minor changes inside product switch component. Also one of property `image` has been deprecated

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
