### PR TITLE
fix: Adapt Avatar to 0.12.0 Fundamental Styles

### DIFF
--- a/libs/core/src/lib/avatar/avatar.component.html
+++ b/libs/core/src/lib/avatar/avatar.component.html
@@ -1,7 +1,12 @@
 {{ abbreviate }}
-<span
-    *ngIf="zoomGlyph"
-    role="presentation"
-    class="fd-avatar__zoom-icon"
-    [ngClass]="zoomGlyph ? ' sap-icon--' + zoomGlyph : ''">
-</span>
+
+<i *ngIf="zoomGlyph"
+   role="presentation"
+   class="fd-avatar__zoom-icon"
+   [ngClass]="zoomGlyph ? ' sap-icon--' + zoomGlyph : ''">
+</i>
+<i *ngIf="glyph"
+   class="fd-avatar__icon"
+   [ngClass]="glyph ? ' sap-icon--' + glyph : ''"
+   role="presentation">
+</i>

--- a/libs/core/src/lib/avatar/avatar.component.ts
+++ b/libs/core/src/lib/avatar/avatar.component.ts
@@ -140,7 +140,6 @@ export class AvatarComponent implements OnChanges, OnInit, CssClassBuilder {
             'fd-avatar',
             this.size ? `fd-avatar--${this.size}` : '',
             this.showDefault ? 'sap-icon--person-placeholder' : '',
-            this.glyph ? `sap-icon--${this.glyph}` : '',
             this.colorAccent ? `fd-avatar--accent-color-${this.colorAccent}` : '',
             this.circle ? 'fd-avatar--circle' : '',
             this.border ? 'fd-avatar--border' : '',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13650,9 +13650,9 @@
       "dev": true
     },
     "fundamental-styles": {
-      "version": "0.12.0-rc.90",
-      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0-rc.90.tgz",
-      "integrity": "sha512-6qRSZl8zjxU7PMtraHNQPWwtQ6DRecB6xkdmcEmlmoh9JjY4vMlu7uSOqSVJpVLkVc77J9AgdYTOx4LoFbvtFA=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0.tgz",
+      "integrity": "sha512-ZuQlVdRJQjtlvhGrj80VvGtdydoCzzspOamgFSJH4wzYVIXDNcYuDHE6nRm0Ad01ttjp9NuyZDKcwIvi+rSVNw=="
     },
     "fuse.js": {
       "version": "3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13650,9 +13650,9 @@
       "dev": true
     },
     "fundamental-styles": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.11.0.tgz",
-      "integrity": "sha512-CspyvrCQoZ7+47LRtMwvRiLPF/24OJ4kauqdqmObE7WeFtU1g2OxRRabqjox+xIsZqp1a72xE6fCqgKzayzpxg=="
+      "version": "0.12.0-rc.90",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0-rc.90.tgz",
+      "integrity": "sha512-6qRSZl8zjxU7PMtraHNQPWwtQ6DRecB6xkdmcEmlmoh9JjY4vMlu7uSOqSVJpVLkVc77J9AgdYTOx4LoFbvtFA=="
     },
     "fuse.js": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "3.6.5",
     "flexboxgrid": "6.3.1",
     "focus-trap": "5.1.0",
-    "fundamental-styles": "0.11.0",
+    "fundamental-styles": "prerelease",
     "hammerjs": "2.0.8",
     "highlight.js": "9.18.1",
     "intl": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "3.6.5",
     "flexboxgrid": "6.3.1",
     "focus-trap": "5.1.0",
-    "fundamental-styles": "prerelease",
+    "fundamental-styles": "0.12.0",
     "hammerjs": "2.0.8",
     "highlight.js": "9.18.1",
     "intl": "1.2.5",


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #3370 

#### Please provide a brief summary of this pull request.
This PR updates Avatar Component to support Fundamental Styles v0.12.0 markup, by moving the icon to separate `<i>` element.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

