### PR TITLE
fix: Adapt Tile to 0.12.0 Fundamental Styles

### DIFF
--- a/apps/docs/src/app/core/component-docs/tile/examples/kpi-tile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tile/examples/kpi-tile-example.component.html
@@ -25,7 +25,7 @@
     </div>
     <div fd-tile-footer [twoColumn]="true">
         <div fd-tile-section>
-            <span fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></span>
+            <i fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></i>
             <span fd-tile-footer-text>Now</span>
         </div>
         <div fd-tile-section>
@@ -63,7 +63,7 @@
     </div>
     <div fd-tile-footer [twoColumn]="true">
         <div fd-tile-section>
-            <span fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></span>
+            <i fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></i>
             <span fd-tile-footer-text>Now</span>
         </div>
         <div fd-tile-section>
@@ -104,7 +104,7 @@
     </div>
     <div fd-tile-footer [twoColumn]="true">
         <div fd-tile-section>
-            <span fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></span>
+            <i fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></i>
             <span fd-tile-footer-text>Now</span>
         </div>
         <div fd-tile-section>
@@ -142,7 +142,7 @@
     </div>
     <div fd-tile-footer [twoColumn]="true">
         <div fd-tile-section>
-            <span fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></span>
+            <i fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></i>
             <span fd-tile-footer-text>Now</span>
         </div>
         <div fd-tile-section>
@@ -183,7 +183,7 @@
     </div>
     <div fd-tile-footer [twoColumn]="true">
         <div fd-tile-section>
-            <span fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></span>
+            <i fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></i>
             <span fd-tile-footer-text>Now</span>
         </div>
         <div fd-tile-section>
@@ -221,7 +221,7 @@
     </div>
     <div fd-tile-footer [twoColumn]="true">
         <div fd-tile-section>
-            <span fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></span>
+            <i fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></i>
             <span fd-tile-footer-text>Now</span>
         </div>
         <div fd-tile-section>

--- a/apps/docs/src/app/core/component-docs/tile/examples/launch-tile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tile/examples/launch-tile-example.component.html
@@ -25,7 +25,7 @@
     </div>
     <div fd-tile-footer [twoColumn]="true">
         <div fd-tile-section>
-            <span fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></span>
+            <i fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></i>
             <span fd-tile-footer-text>Now</span>
         </div>
         <div fd-tile-section>
@@ -69,7 +69,7 @@
     </div>
     <div fd-tile-footer [twoColumn]="true">
         <div fd-tile-section>
-            <span fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></span>
+            <i fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></i>
             <span fd-tile-footer-text>Now</span>
         </div>
         <div fd-tile-section>
@@ -87,7 +87,7 @@
     </div>
     <div fd-tile-footer [twoColumn]="true">
         <div fd-tile-section>
-            <span fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></span>
+            <i fd-tile-refresh (click)="window.alert('Refresh clicked')" glyph="refresh"></i>
             <span fd-tile-footer-text>Now</span>
         </div>
         <div fd-tile-section>

--- a/libs/core/src/lib/tile/directives/tile.directives.spec.ts
+++ b/libs/core/src/lib/tile/directives/tile.directives.spec.ts
@@ -41,7 +41,7 @@ import {
         <div #content fd-tile-content [twoColumn]="true">
             <div fd-tile-content-text></div>
             <div fd-tile-content-byline></div>
-            <span fd-tile-refresh [glyph]="'refresh'"></span>
+            <i fd-tile-refresh [glyph]="'refresh'"></i>
             <span #profileImg fd-tile-profile-img [backgroundImage]="'http://lorempixel.com/60/60/nature'"></span>
             <span #backgroundImg fd-tile-background-img [backgroundImage]="'http://lorempixel.com/60/60/nature'"></span>
             <span fd-tile-logo></span>

--- a/libs/core/src/lib/tile/directives/tile.directives.ts
+++ b/libs/core/src/lib/tile/directives/tile.directives.ts
@@ -116,7 +116,7 @@ export class TileTitleContainerDirective {
 }
 
 @Directive({
-    selector: '[fdTileRefresh], [fd-tile-refresh]'
+    selector: '[fdTileRefresh], [fd-tile-refresh]',
 })
 export class TileRefreshDirective implements OnInit, OnChanges, CssClassBuilder {
     /** Glyph */
@@ -126,6 +126,11 @@ export class TileRefreshDirective implements OnInit, OnChanges, CssClassBuilder 
     /** Apply user custom styles */
     @Input()
     class: string;
+
+    /** Apply user custom styles */
+    @Input()
+    @HostBinding('attr.aria-label')
+    ariaLabel = 'Refresh';
 
     constructor(private _elementRef: ElementRef) {}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13650,9 +13650,9 @@
       "dev": true
     },
     "fundamental-styles": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.11.0.tgz",
-      "integrity": "sha512-CspyvrCQoZ7+47LRtMwvRiLPF/24OJ4kauqdqmObE7WeFtU1g2OxRRabqjox+xIsZqp1a72xE6fCqgKzayzpxg=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0.tgz",
+      "integrity": "sha512-ZuQlVdRJQjtlvhGrj80VvGtdydoCzzspOamgFSJH4wzYVIXDNcYuDHE6nRm0Ad01ttjp9NuyZDKcwIvi+rSVNw=="
     },
     "fuse.js": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "3.6.5",
     "flexboxgrid": "6.3.1",
     "focus-trap": "5.1.0",
-    "fundamental-styles": "0.11.0",
+    "fundamental-styles": "prerelease",
     "hammerjs": "2.0.8",
     "highlight.js": "9.18.1",
     "intl": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "3.6.5",
     "flexboxgrid": "6.3.1",
     "focus-trap": "5.1.0",
-    "fundamental-styles": "prerelease",
+    "fundamental-styles": "0.12.0",
     "hammerjs": "2.0.8",
     "highlight.js": "9.18.1",
     "intl": "1.2.5",


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #3370

#### Please provide a brief summary of this pull request.
This PR updates Tile component to match Fundamental Styles v0.12.0, by changing refresh-icon tag from `<span>` to `<i>`.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples