### PR TITLE
fix: Migrate nested list icon due to 0.12.0 styles

### DIFF
--- a/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav/shellbar-side-nav-example.component.html
+++ b/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav/shellbar-side-nav-example.component.html
@@ -17,25 +17,25 @@
             <ul fd-nested-list [textOnly]="false">
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="'menu'"></span>
+                        <i role="presentation" fd-nested-list-icon [glyph]="'menu'"></i>
                         <span fd-nested-list-title>Link 1</span>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="'home'"></span>
+                        <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
                         <span fd-nested-list-title>Link 2</span>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="'settings'"></span>
+                        <i role="presentation" fd-nested-list-icon [glyph]="'settings'"></i>
                         <span fd-nested-list-title>Link 3</span>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="'settings'"></span>
+                        <i role="presentation" fd-nested-list-icon [glyph]="'settings'"></i>
                         <span fd-nested-list-title>Link 4</span>
                     </a>
                 </li>
@@ -46,13 +46,13 @@
             <ul fd-nested-list [textOnly]="false">
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="'menu'"></span>
+                        <i role="presentation" fd-nested-list-icon [glyph]="'menu'"></i>
                         <span fd-nested-list-title>Link 1</span>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="'home'"></span>
+                        <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
                         <span fd-nested-list-title>Link 2</span>
                     </a>
                 </li>

--- a/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav/shellbar-side-nav-example.component.html
+++ b/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav/shellbar-side-nav-example.component.html
@@ -3,7 +3,7 @@
         fd-shellbar-side-nav
         fd-button
         [fdType]="'transparent'"
-        [glyph]="'menu2'"
+        glyph="menu2'"
         (click)="condensed = !condensed"
     ></button>
 
@@ -17,25 +17,25 @@
             <ul fd-nested-list [textOnly]="false">
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <i role="presentation" fd-nested-list-icon [glyph]="'menu'"></i>
+                        <i fd-nested-list-icon glyph="menu"></i>
                         <span fd-nested-list-title>Link 1</span>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
+                        <i fd-nested-list-icon glyph="home"></i>
                         <span fd-nested-list-title>Link 2</span>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <i role="presentation" fd-nested-list-icon [glyph]="'settings'"></i>
+                        <i fd-nested-list-icon glyph="settings"></i>
                         <span fd-nested-list-title>Link 3</span>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <i role="presentation" fd-nested-list-icon [glyph]="'settings'"></i>
+                        <i fd-nested-list-icon glyph="settings"></i>
                         <span fd-nested-list-title>Link 4</span>
                     </a>
                 </li>
@@ -46,13 +46,13 @@
             <ul fd-nested-list [textOnly]="false">
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <i role="presentation" fd-nested-list-icon [glyph]="'menu'"></i>
+                        <i fd-nested-list-icon glyph="menu"></i>
                         <span fd-nested-list-title>Link 1</span>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
+                        <i fd-nested-list-icon glyph="home"></i>
                         <span fd-nested-list-title>Link 2</span>
                     </a>
                 </li>

--- a/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-condensed-example/side-navigation-condensed-example.component.html
+++ b/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-condensed-example/side-navigation-condensed-example.component.html
@@ -3,13 +3,13 @@
         <ul fd-nested-list>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
+                    <i fd-nested-list-icon glyph="home"></i>
                     <span fd-nested-list-title>Link 1</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'appointment-2'"></i>
+                    <i fd-nested-list-icon glyph="appointment-2"></i>
                     <span fd-nested-list-title>Link 2</span>
                 </a>
             </li>
@@ -17,7 +17,7 @@
                 <fd-nested-list-popover>
                     <div fd-nested-list-content [selected]="true">
                         <a fd-nested-list-link>
-                            <i role="presentation" fd-nested-list-icon [glyph]="'settings'"></i>
+                            <i fd-nested-list-icon glyph="settings"></i>
                             <span fd-nested-list-title>Link 3</span>
                         </a>
                         <button fd-nested-list-expand-icon></button>
@@ -48,7 +48,7 @@
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'activity-items'"></i>
+                    <i fd-nested-list-icon glyph="activity-items"></i>
                     <span fd-nested-list-title>Link 4</span>
                 </a>
             </li>
@@ -59,13 +59,13 @@
         <ul fd-nested-list [textOnly]="false">
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'notification-2'"></i>
+                    <i fd-nested-list-icon glyph="notification-2"></i>
                     <span fd-nested-list-title>Link 1</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'world'"></i>
+                    <i fd-nested-list-icon glyph="world"></i>
                     <span fd-nested-list-title>Link 2</span>
                 </a>
             </li>

--- a/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-condensed-example/side-navigation-condensed-example.component.html
+++ b/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-condensed-example/side-navigation-condensed-example.component.html
@@ -3,13 +3,13 @@
         <ul fd-nested-list>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'home'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
                     <span fd-nested-list-title>Link 1</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'appointment-2'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'appointment-2'"></i>
                     <span fd-nested-list-title>Link 2</span>
                 </a>
             </li>
@@ -17,7 +17,7 @@
                 <fd-nested-list-popover>
                     <div fd-nested-list-content [selected]="true">
                         <a fd-nested-list-link>
-                            <span fd-nested-list-icon [glyph]="'settings'"></span>
+                            <i role="presentation" fd-nested-list-icon [glyph]="'settings'"></i>
                             <span fd-nested-list-title>Link 3</span>
                         </a>
                         <button fd-nested-list-expand-icon></button>
@@ -48,7 +48,7 @@
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'activity-items'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'activity-items'"></i>
                     <span fd-nested-list-title>Link 4</span>
                 </a>
             </li>
@@ -59,13 +59,13 @@
         <ul fd-nested-list [textOnly]="false">
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'notification-2'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'notification-2'"></i>
                     <span fd-nested-list-title>Link 1</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'world'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'world'"></i>
                     <span fd-nested-list-title>Link 2</span>
                 </a>
             </li>

--- a/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-icons-example.component.html
+++ b/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-icons-example.component.html
@@ -3,20 +3,20 @@
         <ul fd-nested-list>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
+                    <i fd-nested-list-icon glyph="home"></i>
                     <span fd-nested-list-title>Link 1</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'crossed-line-chart'"></i>
+                    <i fd-nested-list-icon glyph="crossed-line-chart"></i>
                     <span fd-nested-list-title>Link 2</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <div fd-nested-list-content>
                     <a fd-nested-list-link>
-                        <i role="presentation" fd-nested-list-icon [glyph]="'settings'"></i>
+                        <i fd-nested-list-icon glyph="settings"></i>
                         <span fd-nested-list-title>Link 3</span>
                     </a>
                     <button fd-nested-list-expand-icon></button>
@@ -46,7 +46,7 @@
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'add-equipment'"></i>
+                    <i fd-nested-list-icon glyph="add-equipment"></i>
                     <span fd-nested-list-title>Link 4</span>
                 </a>
             </li>
@@ -57,13 +57,13 @@
         <ul fd-nested-list>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'menu'"></i>
+                    <i fd-nested-list-icon glyph="menu"></i>
                     <span fd-nested-list-title>Link 1</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
+                    <i fd-nested-list-icon glyph="home"></i>
                     <span fd-nested-list-title>Link 2</span>
                 </a>
             </li>

--- a/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-icons-example.component.html
+++ b/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-icons-example.component.html
@@ -3,20 +3,20 @@
         <ul fd-nested-list>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'home'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
                     <span fd-nested-list-title>Link 1</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'crossed-line-chart'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'crossed-line-chart'"></i>
                     <span fd-nested-list-title>Link 2</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <div fd-nested-list-content>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="'settings'"></span>
+                        <i role="presentation" fd-nested-list-icon [glyph]="'settings'"></i>
                         <span fd-nested-list-title>Link 3</span>
                     </a>
                     <button fd-nested-list-expand-icon></button>
@@ -46,7 +46,7 @@
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'add-equipment'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'add-equipment'"></i>
                     <span fd-nested-list-title>Link 4</span>
                 </a>
             </li>
@@ -57,13 +57,13 @@
         <ul fd-nested-list>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'menu'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'menu'"></i>
                     <span fd-nested-list-title>Link 1</span>
                 </a>
             </li>
             <li fd-nested-list-item>
                 <a fd-nested-list-link>
-                    <span fd-nested-list-icon [glyph]="'home'"></span>
+                    <i role="presentation" fd-nested-list-icon [glyph]="'home'"></i>
                     <span fd-nested-list-title>Link 2</span>
                 </a>
             </li>

--- a/libs/core/src/lib/nested-list/nested-list-directives.ts
+++ b/libs/core/src/lib/nested-list/nested-list-directives.ts
@@ -29,6 +29,11 @@ export class NestedListIconDirective implements CssClassBuilder, OnChanges, OnIn
      */
     @Input() glyph: string;
 
+    /** Role attribute */
+    @Input()
+    @HostBinding('attr.role')
+    role = 'presentation';
+
     /** @hidden */
     @HostBinding('class.fd-nested-list__icon')
     fdNestedListIconClass = true;

--- a/src/stories/sidenav/fd-side-nav.stories.ts
+++ b/src/stories/sidenav/fd-side-nav.stories.ts
@@ -28,19 +28,19 @@ export const SideNavigation = () => ({
                         [textOnly]="mainTextOnlyVar">
                     <li fd-nested-list-item>
                         <a fd-nested-list-link>
-                            <span *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></span>
+                            <i *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></i>
                             <span fd-nested-list-title>{{textValue1}}</span>
                         </a>
                     </li>
                     <li fd-nested-list-item>
                         <a fd-nested-list-link>
-                            <span *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></span>
+                            <i *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></i>
                             <span fd-nested-list-title>{{textValue1}}</span>
                         </a>
                     </li>
                     <li fd-nested-list-item>
                         <a fd-nested-list-link>
-                            <span *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></span>
+                            <i *ngIf="!mainTextOnlyVar" fd-nested-list-icon [glyph]="icon"></i>
                             <span fd-nested-list-title>{{textValue1}}</span>
                         </a>
                         <ul fd-nested-list [textOnly]="true">
@@ -63,13 +63,13 @@ export const SideNavigation = () => ({
                         [textOnly]="utilityTextOnlyVar">
                     <li fd-nested-list-item>
                         <a fd-nested-list-link>
-                            <span *ngIf="!utilityTextOnlyVar" fd-nested-list-icon [glyph]="iconUtility"></span>
+                            <i *ngIf="!utilityTextOnlyVar" fd-nested-list-icon [glyph]="iconUtility"></i>
                             <span fd-nested-list-title>{{textValue1}}</span>
                         </a>
                     </li>
                     <li fd-nested-list-item>
                         <a fd-nested-list-link>
-                            <span *ngIf="!utilityTextOnlyVar" fd-nested-list-icon [glyph]="iconUtility"></span>
+                            <i *ngIf="!utilityTextOnlyVar" fd-nested-list-icon [glyph]="iconUtility"></i>
                             <span fd-nested-list-title>{{textValue1}}</span>
                         </a>
                     </li>
@@ -96,18 +96,18 @@ export const SideNavigationCondensed = () => ({
             <ul fd-nested-list [compact]="mainCompactVar">
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="icon"></span>
+                        <i fd-nested-list-icon [glyph]="icon"></i>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="icon"></span>
+                        <i fd-nested-list-icon [glyph]="icon"></i>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <fd-nested-list-popover>
                         <a fd-nested-list-link>
-                            <span fd-nested-list-icon [glyph]="icon"></span>
+                            <i fd-nested-list-icon [glyph]="icon"></i>
                             <span fd-nested-list-title>{{textValue1}}</span>
 
                         </a>
@@ -137,7 +137,7 @@ export const SideNavigationCondensed = () => ({
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="icon"></span>
+                        <i fd-nested-list-icon [glyph]="icon"></i>
                         <span fd-nested-list-title>{{textValue1}}</span>
                     </a>
                 </li>
@@ -148,12 +148,12 @@ export const SideNavigationCondensed = () => ({
             <ul fd-nested-list [compact]="utilityCompactVar">
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="icon"></span>
+                        <i fd-nested-list-icon [glyph]="icon"></i>
                     </a>
                 </li>
                 <li fd-nested-list-item>
                     <a fd-nested-list-link>
-                        <span fd-nested-list-icon [glyph]="icon"></span>
+                        <i fd-nested-list-icon [glyph]="icon"></i>
                     </a>
                 </li>
             </ul>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3370
#### Please provide a brief summary of this pull request.

There are only A11y changes included.
From:
```
<span fd-nested-list-icon [glyph]="'menu'"></span>
```
To:
```
<i fd-nested-list-icon glyph="menu"></i>
```
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist


