### PR TITLE
fix: Update menu addon to 0.12.0 styles

### DIFF
--- a/apps/docs/src/app/core/component-docs/menu/examples/menu-addon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/examples/menu-addon-example.component.html
@@ -4,23 +4,23 @@
     <fd-menu #menuIcons>
         <li fd-menu-item>
             <a fd-menu-interactive href="#">
-                <fd-icon fd-menu-addon position="before" [glyph]="'cart'"></fd-icon>
+                <fd-menu-addon position="before" [glyph]="'cart'"></fd-menu-addon>
                 <span fd-menu-title>Option 1</span>
             </a>
         </li>
 
         <li fd-menu-item>
             <a fd-menu-interactive href="#">
-                <fd-icon fd-menu-addon position="before" [glyph]="'accept'"></fd-icon>
+                <fd-menu-addon position="before" [glyph]="'accept'"></fd-menu-addon>
                 <span fd-menu-title>Option 2</span>
-                <fd-icon fd-menu-addon [glyph]="'decline'"></fd-icon>
+                <fd-menu-addon [glyph]="'decline'"></fd-menu-addon>
             </a>
         </li>
 
         <li fd-menu-item>
             <a fd-menu-interactive href="#">
                 <span fd-menu-title>Option 3</span>
-                <fd-icon fd-menu-addon [glyph]="'menu'"></fd-icon>
+                <fd-menu-addon [glyph]="'menu'"></fd-menu-addon>
             </a>
         </li>
     </fd-menu>

--- a/apps/docs/src/app/core/component-docs/menu/examples/menu-mobile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/examples/menu-mobile-example.component.html
@@ -4,21 +4,21 @@
     <li fd-menu-item [submenu]="fruits">
         <div fd-menu-interactive>
             <span fd-menu-title>Fruits</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 
     <li fd-menu-item [submenu]="vegetables">
         <div fd-menu-interactive>
             <span fd-menu-title>Vegetables</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 
     <li fd-menu-item [submenu]="milkProducts">
         <div fd-menu-interactive>
             <span fd-menu-title>Milk products</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 </fd-menu>
@@ -55,14 +55,14 @@
     <li fd-menu-item [submenu]="cheeses">
         <div fd-menu-interactive>
             <span fd-menu-title>Cheese</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 
     <li fd-menu-item [submenu]="yogurts">
         <div fd-menu-interactive>
             <span fd-menu-title>Yogurts</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 </fd-submenu>

--- a/apps/docs/src/app/core/component-docs/menu/examples/menu-with-submenu-example.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/examples/menu-with-submenu-example.component.html
@@ -11,21 +11,21 @@
     <li fd-menu-item [submenu]="fruits">
         <div fd-menu-interactive>
             <span fd-menu-title>Fruits</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 
     <li fd-menu-item [submenu]="vegetables">
         <div fd-menu-interactive>
             <span fd-menu-title>Vegetables</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 
     <li fd-menu-item [submenu]="milkProducts">
         <div fd-menu-interactive>
             <span fd-menu-title>Milk products</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 </fd-menu>
@@ -62,14 +62,14 @@
     <li fd-menu-item [submenu]="cheeses">
         <div fd-menu-interactive>
             <span fd-menu-title>Cheese</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 
     <li fd-menu-item [submenu]="yogurts">
         <div fd-menu-interactive>
             <span fd-menu-title>Yogurts</span>
-            <fd-icon fd-menu-addon [submenuIndicator]="true"></fd-icon>
+            <fd-menu-addon [submenuIndicator]="true"></fd-menu-addon>
         </div>
     </li>
 </fd-submenu>

--- a/libs/core/src/lib/menu/directives/menu-addon.directive.ts
+++ b/libs/core/src/lib/menu/directives/menu-addon.directive.ts
@@ -1,8 +1,12 @@
-import { Directive, HostBinding, Input } from '@angular/core';
+import { Component, HostBinding, Input } from '@angular/core';
 
-@Directive({
-    // tslint:disable-next-line:directive-selector
-    selector: '[fd-menu-addon]'
+@Component({
+    // tslint:disable-next-line:component-selector
+    selector: 'fd-menu-addon',
+    template: `
+        <fd-icon [glyph]="glyph" *ngIf="glyph" role="presentation"></fd-icon>
+        <ng-content></ng-content>
+    `
 })
 export class MenuAddonDirective {
     /** Whether addon is used before or after text */
@@ -10,6 +14,12 @@ export class MenuAddonDirective {
         this.fdAddonBeforeClass = position === 'before';
         this.fdAddonAfterClass = position === 'after';
     }
+
+    /** The icon name to display. See the icon page for the list of icons
+     * here: https://sap.github.io/fundamental-ngx/icon
+     * */
+    @Input()
+    glyph: string;
 
     /** Whether is used as submenu indicator */
     @Input()

--- a/libs/core/src/lib/menu/menu.module.ts
+++ b/libs/core/src/lib/menu/menu.module.ts
@@ -10,9 +10,10 @@ import { MenuItemComponent, SubmenuComponent } from './menu-item/menu-item.compo
 import { MenuShortcutDirective } from './directives/menu-shortcut.directive';
 import { PopoverModule } from '../popover/popover.module';
 import { MenuTriggerDirective } from './directives/menu-trigger.directive';
+import { IconModule } from '../icon/icon.module';
 
 @NgModule({
-    imports: [CommonModule, PopoverModule],
+    imports: [CommonModule, PopoverModule, IconModule],
     declarations: [
         MenuComponent,
         MenuItemComponent,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13650,9 +13650,9 @@
       "dev": true
     },
     "fundamental-styles": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.11.0.tgz",
-      "integrity": "sha512-CspyvrCQoZ7+47LRtMwvRiLPF/24OJ4kauqdqmObE7WeFtU1g2OxRRabqjox+xIsZqp1a72xE6fCqgKzayzpxg=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.12.0.tgz",
+      "integrity": "sha512-ZuQlVdRJQjtlvhGrj80VvGtdydoCzzspOamgFSJH4wzYVIXDNcYuDHE6nRm0Ad01ttjp9NuyZDKcwIvi+rSVNw=="
     },
     "fuse.js": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "core-js": "3.6.5",
     "flexboxgrid": "6.3.1",
     "focus-trap": "5.1.0",
-    "fundamental-styles": "0.11.0",
+    "fundamental-styles": "0.12.0",
     "hammerjs": "2.0.8",
     "highlight.js": "9.18.1",
     "intl": "1.2.5",


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3370
#### Please provide a brief summary of this pull request.
In this PR `fd-menu-addon` directive is changed to component and the way how it can be used:
Before:
```
<fd-icon fd-menu-addon position="before" [glyph]="'cart'"></fd-icon>
```

After:
```
<fd-menu-addon position="before" [glyph]="'cart'"></fd-menu-addon>
```

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
