### PR TITLE
docs: Adapt list icons to 0.12.0 styles

### DIFF
--- a/apps/docs/src/app/core/component-docs/list/examples/list-complex-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-complex-example.component.html
@@ -1,50 +1,50 @@
 <ul fd-list [noBorder]="true">
     <li fd-list-group-header>Group header 1</li>
     <li fd-list-item>
-        <span fd-list-icon glyph="cart"></span>
+        <i fd-list-icon role="presentation" glyph="cart"></i>
         <span fd-list-title>
             List item 1
         </span>
     </li>
     <li fd-list-item>
-        <span fd-list-icon glyph="wrench"></span>
+        <i fd-list-icon role="presentation" glyph="wrench"></i>
         <span fd-list-title>
             List item 2
         </span>
     </li>
     <li fd-list-item>
-        <span fd-list-icon glyph="lightbulb"></span>
+        <i fd-list-icon role="presentation" glyph="lightbulb"></i>
         <span fd-list-title>
             List item 3
         </span>
     </li>
     <li fd-list-item>
-        <span fd-list-icon glyph="history"></span>
+        <i fd-list-icon role="presentation" glyph="history"></i>
         <span fd-list-title>
             List item 4
         </span>
     </li>
     <li fd-list-group-header>Group Header 2</li>
     <li fd-list-item>
-        <fd-icon fd-list-icon glyph="cart"></fd-icon>
+        <i fd-list-icon role="presentation" glyph="cart"></i>
         <span fd-list-title>
             List item 5
         </span>
     </li>
     <li fd-list-item>
-        <span fd-list-icon glyph="wrench"></span>
+        <i fd-list-icon role="presentation" glyph="wrench"></i>
         <span fd-list-title>
             List item 6
         </span>
     </li>
     <li fd-list-item>
-        <span fd-list-icon glyph="lightbulb"></span>
+        <i fd-list-icon role="presentation" glyph="lightbulb"></i>
         <span fd-list-title>
             List item 7
         </span>
     </li>
     <li fd-list-item>
-        <span fd-list-icon glyph="history"></span>
+        <i fd-list-icon role="presentation" glyph="history"></i>
         <span fd-list-title>
             List item 8
         </span>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-complex-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-complex-example.component.html
@@ -1,50 +1,50 @@
 <ul fd-list [noBorder]="true">
     <li fd-list-group-header>Group header 1</li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="cart"></i>
+        <i fd-list-icon glyph="cart"></i>
         <span fd-list-title>
             List item 1
         </span>
     </li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="wrench"></i>
+        <i fd-list-icon glyph="wrench"></i>
         <span fd-list-title>
             List item 2
         </span>
     </li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="lightbulb"></i>
+        <i fd-list-icon glyph="lightbulb"></i>
         <span fd-list-title>
             List item 3
         </span>
     </li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="history"></i>
+        <i fd-list-icon glyph="history"></i>
         <span fd-list-title>
             List item 4
         </span>
     </li>
     <li fd-list-group-header>Group Header 2</li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="cart"></i>
+        <i fd-list-icon glyph="cart"></i>
         <span fd-list-title>
             List item 5
         </span>
     </li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="wrench"></i>
+        <i fd-list-icon glyph="wrench"></i>
         <span fd-list-title>
             List item 6
         </span>
     </li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="lightbulb"></i>
+        <i fd-list-icon glyph="lightbulb"></i>
         <span fd-list-title>
             List item 7
         </span>
     </li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="history"></i>
+        <i fd-list-icon glyph="history"></i>
         <span fd-list-title>
             List item 8
         </span>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-icon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-icon-example.component.html
@@ -1,24 +1,24 @@
 <ul fd-list>
     <li fd-list-item>
-        <fd-icon fd-list-icon glyph="cart"></fd-icon>
+        <i fd-list-icon role="presentation" glyph="cart"></i>
         <span fd-list-title>
             List item 1
         </span>
     </li>
     <li fd-list-item>
-        <fd-icon fd-list-icon glyph="wrench"></fd-icon>
+        <i fd-list-icon role="presentation" glyph="wrench"></i>
         <span fd-list-title>
             List item 2
         </span>
     </li>
     <li fd-list-item>
-        <fd-icon fd-list-icon glyph="lightbulb"></fd-icon>
+        <i fd-list-icon role="presentation" glyph="lightbulb"></i>
         <span fd-list-title>
             List item 3
         </span>
     </li>
     <li fd-list-item>
-        <fd-icon fd-list-icon glyph="history"></fd-icon>
+        <i fd-list-icon role="presentation" glyph="history"></i>
         <span fd-list-title>
             List item 4
         </span>
@@ -32,24 +32,24 @@
         <span fd-list-title>
             List item 1
         </span>
-        <fd-icon fd-list-icon glyph="navigation-right-arrow"></fd-icon>
+        <i fd-list-icon role="presentation" glyph="navigation-right-arrow"></i>
     </li>
     <li fd-list-item>
         <span fd-list-title>
             List item 2
         </span>
-        <fd-icon fd-list-icon glyph="navigation-right-arrow"></fd-icon>
+        <i fd-list-icon role="presentation" glyph="navigation-right-arrow"></i>
     </li>
     <li fd-list-item>
         <span fd-list-title>
             List item 3
         </span>
-        <fd-icon fd-list-icon glyph="navigation-right-arrow"></fd-icon>
+        <i fd-list-icon role="presentation" glyph="navigation-right-arrow"></i>
     </li>
     <li fd-list-item>
         <span fd-list-title>
             List item 4
         </span>
-        <fd-icon fd-list-icon glyph="navigation-right-arrow"></fd-icon>
+        <i fd-list-icon role="presentation" glyph="navigation-right-arrow"></i>
     </li>
 </ul>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-icon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-icon-example.component.html
@@ -1,24 +1,24 @@
 <ul fd-list>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="cart"></i>
+        <i fd-list-icon glyph="cart"></i>
         <span fd-list-title>
             List item 1
         </span>
     </li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="wrench"></i>
+        <i fd-list-icon glyph="wrench"></i>
         <span fd-list-title>
             List item 2
         </span>
     </li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="lightbulb"></i>
+        <i fd-list-icon glyph="lightbulb"></i>
         <span fd-list-title>
             List item 3
         </span>
     </li>
     <li fd-list-item>
-        <i fd-list-icon role="presentation" glyph="history"></i>
+        <i fd-list-icon glyph="history"></i>
         <span fd-list-title>
             List item 4
         </span>
@@ -32,24 +32,24 @@
         <span fd-list-title>
             List item 1
         </span>
-        <i fd-list-icon role="presentation" glyph="navigation-right-arrow"></i>
+        <i fd-list-icon glyph="navigation-right-arrow"></i>
     </li>
     <li fd-list-item>
         <span fd-list-title>
             List item 2
         </span>
-        <i fd-list-icon role="presentation" glyph="navigation-right-arrow"></i>
+        <i fd-list-icon glyph="navigation-right-arrow"></i>
     </li>
     <li fd-list-item>
         <span fd-list-title>
             List item 3
         </span>
-        <i fd-list-icon role="presentation" glyph="navigation-right-arrow"></i>
+        <i fd-list-icon glyph="navigation-right-arrow"></i>
     </li>
     <li fd-list-item>
         <span fd-list-title>
             List item 4
         </span>
-        <i fd-list-icon role="presentation" glyph="navigation-right-arrow"></i>
+        <i fd-list-icon glyph="navigation-right-arrow"></i>
     </li>
 </ul>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-nav-indicator-example/list-nav-indicator-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-nav-indicator-example/list-nav-indicator-example.component.html
@@ -8,7 +8,7 @@
     </li>
     <li fd-list-item>
         <a fd-list-link navigationIndicator="true" navigated="true">
-            <span fd-list-icon glyph="history"></span>
+            <i fd-list-icon role="presentation" glyph="history"></i>
             <span fd-list-title>
                 Link List item 2
             </span>
@@ -21,7 +21,7 @@
     </li>
     <li fd-list-item>
         <a fd-list-link navigationIndicator="true" selected="true">
-            <span fd-list-icon glyph="cart"></span>
+            <i fd-list-icon role="presentation" glyph="cart"></i>
             <span fd-list-title>
                 Link List item 4
             </span>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-nav-indicator-example/list-nav-indicator-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-nav-indicator-example/list-nav-indicator-example.component.html
@@ -8,7 +8,7 @@
     </li>
     <li fd-list-item>
         <a fd-list-link navigationIndicator="true" navigated="true">
-            <i fd-list-icon role="presentation" glyph="history"></i>
+            <i fd-list-icon glyph="history"></i>
             <span fd-list-title>
                 Link List item 2
             </span>
@@ -21,7 +21,7 @@
     </li>
     <li fd-list-item>
         <a fd-list-link navigationIndicator="true" selected="true">
-            <i fd-list-icon role="presentation" glyph="cart"></i>
+            <i fd-list-icon glyph="cart"></i>
             <span fd-list-title>
                 Link List item 4
             </span>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-navigation-example/list-navigation-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-navigation-example/list-navigation-example.component.html
@@ -8,7 +8,7 @@
     </li>
     <li fd-list-item>
         <a fd-list-link navigated="true">
-            <i fd-list-icon role="presentation" glyph="history"></i>
+            <i fd-list-icon glyph="history"></i>
             <span fd-list-title>
                 List item 2
             </span>
@@ -19,12 +19,12 @@
             <span fd-list-title>
                 List item 3
             </span>
-            <i fd-list-icon role="presentation" glyph="map"></i>
+            <i fd-list-icon glyph="map"></i>
         </a>
     </li>
     <li fd-list-item>
         <a fd-list-link>
-            <i fd-list-icon role="presentation" glyph="cart"></i>
+            <i fd-list-icon glyph="cart"></i>
             <span fd-list-title>
                 List item 4
             </span>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-navigation-example/list-navigation-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-navigation-example/list-navigation-example.component.html
@@ -8,7 +8,7 @@
     </li>
     <li fd-list-item>
         <a fd-list-link navigated="true">
-            <span fd-list-icon glyph="history"></span>
+            <i fd-list-icon role="presentation" glyph="history"></i>
             <span fd-list-title>
                 List item 2
             </span>
@@ -19,12 +19,12 @@
             <span fd-list-title>
                 List item 3
             </span>
-            <span fd-list-icon glyph="map"></span>
+            <i fd-list-icon role="presentation" glyph="map"></i>
         </a>
     </li>
     <li fd-list-item>
         <a fd-list-link>
-            <span fd-list-icon glyph="cart"></span>
+            <i fd-list-icon role="presentation" glyph="cart"></i>
             <span fd-list-title>
                 List item 4
             </span>

--- a/apps/docs/src/app/core/component-docs/select/examples/select-nested-options/select-nested-options.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-nested-options/select-nested-options.component.html
@@ -3,14 +3,14 @@
 
     <li fd-list-group-header>Fruits</li>
     <fd-option *ngFor="let option of fruits" [value]="option">
-        <span fd-list-icon [glyph]="'add'"></span>
+        <i fd-list-icon role="presentation" [glyph]="'add'"></i>
         <span fd-list-title>{{option.name}}</span>
         <span fd-list-secondary>{{option.kCal}} kcal</span>
     </fd-option>
 
     <li fd-list-group-header>Vegetables</li>
     <fd-option *ngFor="let option of vegetables" [value]="option">
-        <span fd-list-icon [glyph]="'add'"></span>
+        <i fd-list-icon role="presentation" [glyph]="'add'"></i>
         <span fd-list-title>{{option.name}}</span>
         <span fd-list-secondary>{{option.kCal}} kcal</span>
     </fd-option>

--- a/apps/docs/src/app/core/component-docs/select/examples/select-nested-options/select-nested-options.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-nested-options/select-nested-options.component.html
@@ -3,14 +3,14 @@
 
     <li fd-list-group-header>Fruits</li>
     <fd-option *ngFor="let option of fruits" [value]="option">
-        <i fd-list-icon role="presentation" [glyph]="'add'"></i>
+        <i fd-list-icon [glyph]="'add'"></i>
         <span fd-list-title>{{option.name}}</span>
         <span fd-list-secondary>{{option.kCal}} kcal</span>
     </fd-option>
 
     <li fd-list-group-header>Vegetables</li>
     <fd-option *ngFor="let option of vegetables" [value]="option">
-        <i fd-list-icon role="presentation" [glyph]="'add'"></i>
+        <i fd-list-icon [glyph]="'add'"></i>
         <span fd-list-title>{{option.name}}</span>
         <span fd-list-secondary>{{option.kCal}} kcal</span>
     </fd-option>

--- a/apps/docs/src/app/core/component-docs/table/examples/table-column-sorting-example.component.html
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-column-sorting-example.component.html
@@ -12,15 +12,15 @@
                     <fd-popover-body>
                         <ul fd-list [compact]="true">
                             <li fd-list-item (click)="sortColumn1(true)">
-                                <fd-icon fd-list-icon [glyph]="'sort-ascending'"></fd-icon>
+                                <i fd-list-icon role="presentation" [glyph]="'sort-ascending'"></i>
                                 <span fd-list-title>Sort Ascending</span>
                             </li>
                             <li fd-list-item (click)="sortColumn1(false)">
-                                <fd-icon fd-list-icon [glyph]="'sort-descending'"></fd-icon>
+                                <i fd-list-icon role="presentation" [glyph]="'sort-descending'"></i>
                                 <span fd-list-title>Sort Descending</span>
                             </li>
                             <li fd-list-item>
-                                <fd-icon fd-list-icon [glyph]="'filter'"></fd-icon>
+                                <i fd-list-icon role="presentation" [glyph]="'filter'"></i>
                                 <div fd-form-item [horizontal]="true">
                                     <label fd-form-label for="input-1">Filter</label>
                                     <input fd-form-control [compact]="true" id="input-1" (keyup)="inputKeyup($event)"

--- a/apps/docs/src/app/core/component-docs/table/examples/table-column-sorting-example.component.html
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-column-sorting-example.component.html
@@ -12,15 +12,15 @@
                     <fd-popover-body>
                         <ul fd-list [compact]="true">
                             <li fd-list-item (click)="sortColumn1(true)">
-                                <i fd-list-icon role="presentation" [glyph]="'sort-ascending'"></i>
+                                <i fd-list-icon [glyph]="'sort-ascending'"></i>
                                 <span fd-list-title>Sort Ascending</span>
                             </li>
                             <li fd-list-item (click)="sortColumn1(false)">
-                                <i fd-list-icon role="presentation" [glyph]="'sort-descending'"></i>
+                                <i fd-list-icon [glyph]="'sort-descending'"></i>
                                 <span fd-list-title>Sort Descending</span>
                             </li>
                             <li fd-list-item>
-                                <i fd-list-icon role="presentation" [glyph]="'filter'"></i>
+                                <i fd-list-icon [glyph]="'filter'"></i>
                                 <div fd-form-item [horizontal]="true">
                                     <label fd-form-label for="input-1">Filter</label>
                                     <input fd-form-control [compact]="true" id="input-1" (keyup)="inputKeyup($event)"

--- a/libs/core/src/lib/list/directives/list-icon.directive.ts
+++ b/libs/core/src/lib/list/directives/list-icon.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, OnChanges, OnInit } from '@angular/core';
+import { Directive, ElementRef, HostBinding, Input, OnChanges, OnInit } from '@angular/core';
 import { applyCssClass } from '../../utils/decorators/apply-css-class.decorator';
 
 @Directive({
@@ -15,6 +15,11 @@ export class ListIconDirective implements OnChanges, OnInit {
     /** Apply user custom styles */
     @Input()
     class: string;
+
+    /** Role attribute for list icon */
+    @Input()
+    @HostBinding('attr.role')
+    role = 'presentation'
 
     constructor(private _elementRef: ElementRef) {}
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3370
#### Please provide a brief summary of this pull request.
There are only A11y changes included.
From:
```
<span fd-list-icon glyph="cart"></span>
```

To:
```
<i fd-list-icon glyph="cart"></i>
```
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

