### PR TITLE
fix: migrate buttons 0.12.0

### DIFF
--- a/apps/docs/src/app/core/component-docs/action-bar/examples/action-bar-back-example.component.html
+++ b/apps/docs/src/app/core/component-docs/action-bar/examples/action-bar-back-example.component.html
@@ -11,8 +11,8 @@
         </div>
         <h3 fd-action-bar-title>Page Title</h3>
         <div fd-action-bar-actions>
-            <button fd-button [compact]="true">Cancel</button>
-            <button fd-button [compact]="true" [fdType]="'emphasized'">Save</button>
+            <button fd-button label="Cancel" [compact]="true"></button>
+            <button fd-button label="Save" [compact]="true" [fdType]="'emphasized'"></button>
         </div>
     </div>
     <p fd-action-bar-description [withBackBtn]="true">Action bar Description</p>

--- a/apps/docs/src/app/core/component-docs/action-bar/examples/action-bar-long-string-title-truncation-example.component.html
+++ b/apps/docs/src/app/core/component-docs/action-bar/examples/action-bar-long-string-title-truncation-example.component.html
@@ -14,8 +14,8 @@
             very very long text
         </h3>
         <div fd-action-bar-actions>
-            <button fd-button [compact]="true">Cancel</button>
-            <button fd-button [compact]="true" [fdType]="'emphasized'">Save</button>
+            <button fd-button label="Cancel" [compact]="true"></button>
+            <button fd-button label="Save" [compact]="true" [fdType]="'emphasized'"></button>
         </div>
     </div>
     <p fd-action-bar-description [withBackBtn]="true">

--- a/apps/docs/src/app/core/component-docs/action-bar/examples/action-bar-no-back-example.component.html
+++ b/apps/docs/src/app/core/component-docs/action-bar/examples/action-bar-no-back-example.component.html
@@ -2,8 +2,8 @@
     <div fd-action-bar-header>
         <h3 fd-action-bar-title>Page Title</h3>
         <div fd-action-bar-actions>
-            <button fd-button [compact]="true">Cancel</button>
-            <button fd-button [compact]="true" [fdType]="'emphasized'">Save</button>
+            <button fd-button label="Cancel" [compact]="true"></button>
+            <button fd-button label="Save" [compact]="true" [fdType]="'emphasized'"></button>
         </div>
     </div>
     <p fd-action-bar-description>Action bar Description</p>

--- a/apps/docs/src/app/core/component-docs/alert/alert-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/alert/alert-docs.component.html
@@ -71,5 +71,5 @@
         [mousePersist]="data.properties.mousePersist"
     >
     </fd-alert>
-    <button style="margin-top: 12px;" fd-button (click)="alert.open()">Open Dynamic Alert</button>
+    <button style="margin-top: 12px;" fd-button label="Open Dynamic Alert" (click)="alert.open()"></button>
 </playground>

--- a/apps/docs/src/app/core/component-docs/alert/examples/alert-component-as-content-example.component.html
+++ b/apps/docs/src/app/core/component-docs/alert/examples/alert-component-as-content-example.component.html
@@ -1,20 +1,22 @@
-<button fd-button (click)="openFromComponent()">Open from Component</button>
-<button fd-button (click)="openFromTemplate(template)">Open from Template</button>
-<button fd-button (click)="openFromString()">Open from String</button>
+<button fd-button label="Open from Component" (click)="openFromComponent()"></button>
+<button fd-button label="Open from Template" (click)="openFromTemplate(template)"></button>
+<button fd-button label="Open from String" (click)="openFromString()"></button>
 <button
     fd-button
+    label="Dismiss All"
     [fdType]="'emphasized'"
     (click)="alertService.dismissAll()"
-    [disabled]="!alertService.hasOpenAlerts()"
->
-    Dismiss All
+    [disabled]="!alertService.hasOpenAlerts()">
 </button>
 
 <!-- Defining a template to open -->
 <ng-template let-alert #template>
     <p>{{ alert.data.firstLine }}</p>
     <p>{{ alert.data.secondLine }}</p>
-    <button fd-button [fdType]="'positive'" [compact]="true" (click)="alert.dismiss('Data passed back')">
-        Click to dismiss
+    <button fd-button
+            label="Click to dismiss"
+            [fdType]="'positive'"
+            [compact]="true"
+            (click)="alert.dismiss('Data passed back')">
     </button>
 </ng-template>

--- a/apps/docs/src/app/core/component-docs/alert/examples/alert-inline-example.component.html
+++ b/apps/docs/src/app/core/component-docs/alert/examples/alert-inline-example.component.html
@@ -6,4 +6,4 @@
     This inline alert simulates the service behaviour and will disappear after 7500ms.
 </fd-alert>
 
-<button fd-button (click)="alert.open()">Open Dynamic Alert</button>
+<button fd-button label="Open Dynamic Alert" (click)="alert.open()"></button>

--- a/apps/docs/src/app/core/component-docs/alert/examples/alert-width-example.component.html
+++ b/apps/docs/src/app/core/component-docs/alert/examples/alert-width-example.component.html
@@ -1,4 +1,4 @@
-<button fd-button (click)="openAlert1()">Open 250px Alert</button>
-<button fd-button (click)="openAlert2()">Open 550px Alert</button>
-<button fd-button (click)="openAlert3()">Open 70vw Alert</button>
-<button fd-button (click)="openAlert4()">Open 100vw Alert</button>
+<button fd-button (click)="openAlert1()" label="Open 250px Alert"></button>
+<button fd-button (click)="openAlert2()" label="Open 550px Alert"></button>
+<button fd-button (click)="openAlert3()" label="Open 70vw Alert"></button>
+<button fd-button (click)="openAlert4()" label="Open 100vw Alert"></button>

--- a/apps/docs/src/app/core/component-docs/bar/examples/bar-floating-footer-example.component.html
+++ b/apps/docs/src/app/core/component-docs/bar/examples/bar-floating-footer-example.component.html
@@ -1,10 +1,10 @@
 <div fd-bar [barDesign]="'floating-footer'">
     <div fd-bar-right>
         <fd-bar-element>
-            <button fd-button [fdType]="'transparent'" [compact]="true">Save</button>
+            <button fd-button label="Save" [fdType]="'transparent'" [compact]="true"></button>
         </fd-bar-element>
         <fd-bar-element>
-            <button fd-button [fdType]="'transparent'" [compact]="true">Cancel</button>
+            <button fd-button label="Cancel" [fdType]="'transparent'" [compact]="true"></button>
         </fd-bar-element>
     </div>
 </div>

--- a/apps/docs/src/app/core/component-docs/bar/examples/bar-footer-example.component.html
+++ b/apps/docs/src/app/core/component-docs/bar/examples/bar-footer-example.component.html
@@ -1,10 +1,10 @@
 <div fd-bar [barDesign]="'footer'">
     <div fd-bar-right>
         <fd-bar-element>
-            <button fd-button [fdType]="'transparent'" [compact]="true">Save</button>
+            <button fd-button label="Save" [fdType]="'transparent'" [compact]="true"></button>
         </fd-bar-element>
         <fd-bar-element>
-            <button fd-button [fdType]="'transparent'" [compact]="true">Cancel</button>
+            <button fd-button label="Cancel" [fdType]="'transparent'" [compact]="true"></button>
         </fd-bar-element>
     </div>
 </div>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-wrapper-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-wrapper-example.component.html
@@ -21,12 +21,10 @@
 
 <h5>Use Busy Indicator as a inline wrapper</h5>
 <fd-busy-indicator [loading]="loading" size="s">
-    <button fd-button>Save</button>
+    <button fd-button label="Save"></button>
 </fd-busy-indicator>
 
 <br/>
 <br/>
 
-<button fd-button (click)="loading = !loading">
-    {{loading ? 'Disable' : 'Enable'}} loading
-</button>
+<button fd-button [label]="loading ? 'Disable' : 'Enable' + ' loading'" (click)="loading = !loading"></button>

--- a/apps/docs/src/app/core/component-docs/button/button-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/button/button-docs.component.html
@@ -68,8 +68,7 @@
         [fdType]="data.properties.fdType"
         [fdMenu]="data.properties.fdMenu"
         [compact]="data.properties.compact"
-        [glyph]="data.properties.icon"
-    >
-        {{ data.properties.label }}
+        [label]="data.properties.label"
+        [glyph]="data.properties.icon">
     </button>
 </playground>

--- a/apps/docs/src/app/core/component-docs/button/examples/button-icons-example.component.html
+++ b/apps/docs/src/app/core/component-docs/button/examples/button-icons-example.component.html
@@ -1,13 +1,12 @@
-<button fd-button [glyph]="'cart'">Add to Cart</button>
-<button fd-button [fdType]="'emphasized'" [glyph]="'cart'">Add to Cart</button>
-<button fd-button [fdType]="'ghost'" [glyph]="'cart'">Add to Cart</button>
-<button fd-button [fdType]="'positive'" [glyph]="'filter'">Filter</button>
-<button fd-button [fdType]="'negative'" [glyph]="'filter'">Filter</button>
-<button fd-button [fdType]="'attention'" [glyph]="'filter'">Filter</button>
-<button fd-button [fdType]="'transparent'" [glyph]="'filter'">Filter</button>
+<button fd-button label="Add to Cart" [glyph]="'cart'"></button>
+<button fd-button label="Add to Cart" [fdType]="'emphasized'" [glyph]="'cart'"></button>
+<button fd-button label="Add to Cart" [fdType]="'ghost'" [glyph]="'cart'"></button>
+<button fd-button label="Filter" [fdType]="'positive'" [glyph]="'filter'"></button>
+<button fd-button label="Filter" [fdType]="'negative'" [glyph]="'filter'"></button>
+<button fd-button label="Filter" [fdType]="'attention'" [glyph]="'filter'"></button>
+<button fd-button label="Filter" [fdType]="'transparent'" [glyph]="'filter'"></button>
 
 <button fd-button [glyph]="'cart'" aria-label="Add to Cart" title="Add to Cart"></button>
-
 <button fd-button [fdType]="'emphasized'" [glyph]="'cart'" aria-label="Add to Cart" title="Add to Cart"></button>
 <button fd-button [fdType]="'ghost'" [glyph]="'cart'" aria-label="Add to Cart" title="Add to Cart"></button>
 <button fd-button [fdType]="'positive'" [glyph]="'accept'" aria-label="accept" title="accept"></button>

--- a/apps/docs/src/app/core/component-docs/button/examples/button-menu-example.component.html
+++ b/apps/docs/src/app/core/component-docs/button/examples/button-menu-example.component.html
@@ -1,10 +1,10 @@
-<button fd-button [fdMenu]="true" [glyph]="'cart'">Add to Cart</button>
-<button fd-button [fdMenu]="true" [fdType]="'emphasized'" [glyph]="'cart'">Add to Cart</button>
-<button fd-button [fdMenu]="true" [fdType]="'ghost'" [glyph]="'cart'">Add to Cart</button>
-<button fd-button [fdMenu]="true" [fdType]="'positive'" [glyph]="'filter'">Filter</button>
-<button fd-button [fdMenu]="true" [fdType]="'negative'" [glyph]="'filter'">Filter</button>
-<button fd-button [fdMenu]="true" [fdType]="'attention'" [glyph]="'filter'">Filter</button>
-<button fd-button [fdMenu]="true" [fdType]="'transparent'" [glyph]="'filter'">Filter</button>
+<button fd-button [fdMenu]="true" [glyph]="'cart'" label="Add to Cart"></button>
+<button fd-button [fdMenu]="true" [fdType]="'emphasized'" [glyph]="'cart'" label="Add to Cart"></button>
+<button fd-button [fdMenu]="true" [fdType]="'ghost'" [glyph]="'cart'" label="Add to Cart"></button>
+<button fd-button [fdMenu]="true" [fdType]="'positive'" [glyph]="'filter'" label="Filter"></button>
+<button fd-button [fdMenu]="true" [fdType]="'negative'" [glyph]="'filter'" label="Filter"></button>
+<button fd-button [fdMenu]="true" [fdType]="'attention'" [glyph]="'filter'" label="Filter"></button>
+<button fd-button [fdMenu]="true" [fdType]="'transparent'" [glyph]="'filter'" label="Filter"></button>
 
 <button fd-button [fdMenu]="true" [fdType]="'emphasized'" [glyph]="'cart'" aria-label="cart" title="cart"></button>
 <button fd-button [fdMenu]="true" [fdType]="'ghost'" [glyph]="'cart'" aria-label="cart" title="cart"></button>

--- a/apps/docs/src/app/core/component-docs/button/examples/button-sizes-example.component.html
+++ b/apps/docs/src/app/core/component-docs/button/examples/button-sizes-example.component.html
@@ -1,2 +1,2 @@
-<button fd-button>Cozy Button</button>
-<button fd-button [compact]="true">Compact Button</button>
+<button fd-button label="Cozy Button"></button>
+<button fd-button label="Compact Button" [compact]="true"></button>

--- a/apps/docs/src/app/core/component-docs/button/examples/button-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/button/examples/button-state-example.component.html
@@ -1,3 +1,3 @@
-<button fd-button aria-selected="true">Selected State</button>
-<button fd-button aria-disabled="true">Disabled State</button>
-<button fd-button disabled>Disabled State</button>
+<button fd-button aria-selected="true" label="Selected State"></button>
+<button fd-button aria-disabled="true" label="Disabled State"></button>
+<button fd-button disabled label="Disabled State"></button>

--- a/apps/docs/src/app/core/component-docs/button/examples/button-types-example.component.html
+++ b/apps/docs/src/app/core/component-docs/button/examples/button-types-example.component.html
@@ -1,7 +1,7 @@
-<button fd-button>Standard Button</button>
-<button fd-button [fdType]="'emphasized'">Emphasized Button</button>
-<button fd-button [fdType]="'ghost'">Ghost Button</button>
-<button fd-button [fdType]="'positive'">Positive Button</button>
-<button fd-button [fdType]="'negative'">Negative Button</button>
-<button fd-button [fdType]="'attention'">Attention Button</button>
-<button fd-button [fdType]="'transparent'">Transparent Button</button>
+<button fd-button label="Standard Button"></button>
+<button fd-button label="Emphasized Button" [fdType]="'emphasized'"></button>
+<button fd-button label="Ghost Button" [fdType]="'ghost'"></button>
+<button fd-button label="Positive Button" [fdType]="'positive'"></button>
+<button fd-button label="Negative Button" [fdType]="'negative'"></button>
+<button fd-button label="Attention Button" [fdType]="'attention'"></button>
+<button fd-button label="Transparent Button" [fdType]="'transparent'"></button>

--- a/apps/docs/src/app/core/component-docs/calendar/examples/calendar--i18n-moment-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/calendar/examples/calendar--i18n-moment-example.component.ts
@@ -33,30 +33,14 @@ export class CustomI18nMomentCalendar extends CalendarI18n {
     selector: 'fd-calendar-i18n-moment-example',
     template: ` <label fd-form-label for="language">Select language:</label>
         <fd-segmented-button id="language" style="margin-bottom:20px">
-            <button fd-button (click)="setLocale('en-gb')" [class]="isSelected('en-gb')">
-                English
-            </button>
-            <button fd-button (click)="setLocale('fr')" [class]="isSelected('fr')">
-                French
-            </button>
-            <button fd-button (click)="setLocale('de')" [class]="isSelected('de')">
-                German
-            </button>
-            <button fd-button (click)="setLocale('es')" [class]="isSelected('es')">
-                Spanish
-            </button>
-            <button fd-button (click)="setLocale('bg')" [class]="isSelected('bg')">
-                Bulgarian
-            </button>
-            <button fd-button (click)="setLocale('ja')" [class]="isSelected('ja')">
-                Japanese
-            </button>
-            <button fd-button (click)="setLocale('tr')" [class]="isSelected('tr')">
-                Turkish
-            </button>
-            <button fd-button (click)="setLocale('uk')" [class]="isSelected('uk')">
-            Ukrainian
-            </button>
+            <button fd-button label="English" (click)="setLocale('en-gb')" [class]="isSelected('en-gb')"></button>
+            <button fd-button label="French" (click)="setLocale('fr')" [class]="isSelected('fr')"></button>
+            <button fd-button label="German" (click)="setLocale('de')" [class]="isSelected('de')"></button>
+            <button fd-button label="Spanish" (click)="setLocale('es')" [class]="isSelected('es')"></button>
+            <button fd-button label="Bulgarian" (click)="setLocale('bg')" [class]="isSelected('bg')"></button>
+            <button fd-button label="Japanese" (click)="setLocale('ja')" [class]="isSelected('zh-cn')"></button>
+            <button fd-button label="Turkish" (click)="setLocale('tr')" [class]="isSelected('zh-hk')"></button>
+            <button fd-button label="Ukrainian" (click)="setLocale('uk')" [class]="isSelected('zh-tw')"></button>
         </fd-segmented-button>
         <fd-calendar [(ngModel)]="date"></fd-calendar>`,
 

--- a/apps/docs/src/app/core/component-docs/calendar/examples/calendar-form-example.component.html
+++ b/apps/docs/src/app/core/component-docs/calendar/examples/calendar-form-example.component.html
@@ -7,7 +7,7 @@
         Selected Date:
         {{ customForm.controls.date.value.toDateString() ? customForm.controls.date.value.toDateString() : 'null' }}
         <br />
-        <button fd-button (click)="setInvalid()">Set Invalid Single Date</button>
+        <button fd-button label="Set Invalid Single Date" (click)="setInvalid()"></button>
     </div>
     <div fd-form-item>
         <fd-calendar [calType]="'range'" formControlName="dateRange" [startingDayOfWeek]="1"> </fd-calendar>
@@ -24,6 +24,6 @@
         {{ customForm.controls.dateRange.value.end ? customForm.controls.dateRange.value.end.toDateString() : 'null' }}
         <br />
         Valid: {{ customForm.controls.dateRange.valid }} <br />
-        <button fd-button (click)="setInvalidRange()">Set Invalid Range Date</button>
+        <button fd-button label="Set Invalid Range Date" (click)="setInvalidRange()"></button>
     </div>
 </form>

--- a/apps/docs/src/app/core/component-docs/calendar/examples/calendar-mobile-example/calendar-mobile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/calendar/examples/calendar-mobile-example/calendar-mobile-example.component.html
@@ -13,18 +13,17 @@
             <fd-dialog-footer-button>
                 <button
                     fd-button
-                    fdType="emphasized"
                     fd-dialog-decisive-button
-                    (click)="dialog.close('Continue'); dateChanged(landscapeCalendar.selectedDate)"
-                >
-                    Ok
+                    fdType="emphasized"
+                    label="Ok"
+                    (click)="dialog.close('Continue'); dateChanged(landscapeCalendar.selectedDate)">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>
     </fd-dialog>
 </ng-template>
 
-<button fd-button (click)="openLandScapeDialog(landScapeDialog)">Open Calendar in landscape mobile mode</button>
+<button fd-button label="Open Calendar in landscape mobile mode" (click)="openLandScapeDialog(landScapeDialog)"></button>
 
 <ng-template let-dialog let-dialogConfig="dialogConfig" #portraitDialog>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
@@ -46,18 +45,17 @@
             <fd-dialog-footer-button>
                 <button
                     fd-button
-                    fdType="emphasized"
                     fd-dialog-decisive-button
-                    (click)="dialog.close('Continue'); dateChanged(portraitCalendar.selectedDate)"
-                >
-                    Ok
+                    fdType="emphasized"
+                    label="Ok"
+                    (click)="dialog.close('Continue'); dateChanged(portraitCalendar.selectedDate)">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>
     </fd-dialog>
 </ng-template>
 
-<button fd-button (click)="openPortraitDialog(portraitDialog)">Open Calendar in portrait mobile mode</button>
+<button fd-button label="Open Calendar in portrait mobile mode" (click)="openPortraitDialog(portraitDialog)"></button>
 
 <div>
     <label fd-label>Date Picked: {{ datePicked.toDateString() }}</label>

--- a/apps/docs/src/app/core/component-docs/calendar/examples/calendar-programmatically-change-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/calendar/examples/calendar-programmatically-change-example.component.ts
@@ -7,7 +7,7 @@ import { FdDate } from '@fundamental-ngx/core';
         <fd-calendar [calType]="'single'" [(ngModel)]="date"> </fd-calendar>
         <br />
         <div>Selected Date: {{ date.toDateString() }}</div>
-        <button fd-button (click)="changeDay()">Next Day</button>
+        <button fd-button label="Next Day" (click)="changeDay()"></button>
     `,
     styles: [
         `

--- a/apps/docs/src/app/core/component-docs/calendar/examples/calendar-single-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/calendar/examples/calendar-single-example.component.ts
@@ -7,7 +7,7 @@ import { CalendarYearGrid, FdDate, SpecialDayRule } from '@fundamental-ngx/core'
         <fd-calendar [calType]="'single'" [(ngModel)]="date" [disableFunction]="myDisableFunction"> </fd-calendar>
         <br />
         <div>Selected Date: {{ date.toDateString() }}</div>
-        <button fd-button (click)="disableWednesday()">Disable Wednesday</button>
+        <button fd-button label="Disable Wednesday" (click)="disableWednesday()"></button>
     `,
     styles: [
         `

--- a/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-complex-i18n-example/date-picker-complex-i18n-example.component.html
+++ b/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-complex-i18n-example/date-picker-complex-i18n-example.component.html
@@ -1,12 +1,10 @@
 <label fd-form-label>Languages</label>
 <fd-segmented-button id="language" style="margin-bottom: 20px;">
-    <button fd-button (click)="setLocale('en-gb')" [class]="isSelected('en-gb')">
-        English
-    </button>
-    <button fd-button (click)="setLocale('fr')" [class]="isSelected('fr')">French</button>
-    <button fd-button (click)="setLocale('de')" [class]="isSelected('de')">German</button>
-    <button fd-button (click)="setLocale('bg')" [class]="isSelected('bg')">Bulgarian</button>
-    <button fd-button (click)="setLocale('pl')" [class]="isSelected('pl')">Polish</button>
+    <button fd-button label="English" (click)="setLocale('en-gb')" [class]="isSelected('en-gb')"></button>
+    <button fd-button label="French" (click)="setLocale('fr')" [class]="isSelected('fr')"></button>
+    <button fd-button label="German" (click)="setLocale('de')" [class]="isSelected('de')"></button>
+    <button fd-button label="Bulgarian" (click)="setLocale('bg')" [class]="isSelected('bg')"></button>
+    <button fd-button label="Polish" (click)="setLocale('pl')" [class]="isSelected('pl')"></button>
 </fd-segmented-button>
 
 <br />

--- a/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-i18n-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-i18n-example.component.ts
@@ -124,11 +124,9 @@ export class CustomI18nLabels extends CalendarI18nLabels {
     template: `
         <label fd-form-label for="language">Select language:</label>
         <fd-segmented-button id="language" style="margin-bottom:20px">
-            <button fd-button (click)="setFrench()" [class]="isSelected('fr')">French</button>
-            <button fd-button (click)="setGerman()" [class]="isSelected('de')">German</button>
-            <button fd-button (click)="setBulgarian()" [class]="isSelected('bg')">
-                Bulgarian
-            </button>
+            <button fd-button label="French" (click)="setFrench()" [class]="isSelected('fr')"></button>
+            <button fd-button label="German" (click)="setGerman()" [class]="isSelected('de')"></button>
+            <button fd-button label="Bulgarian" (click)="setBulgarian()" [class]="isSelected('bg')"></button>
         </fd-segmented-button>
         <br />
         <fd-date-picker [(ngModel)]="date" [startingDayOfWeek]="1"></fd-date-picker>

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-program-example/datetime-program-example.component.html
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-program-example/datetime-program-example.component.html
@@ -1,6 +1,6 @@
 <fd-datetime-picker [(ngModel)]="date"></fd-datetime-picker>
 
-<button style="margin-left: 20px;" fd-button (click)="changeDay()">Change</button>
+<button style="margin-left: 20px;" label="Change" fd-button (click)="changeDay()"></button>
 
 <br />
 <br />

--- a/apps/docs/src/app/core/component-docs/dialog/dialog-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/dialog-docs.component.html
@@ -196,7 +196,7 @@
 <code-example [exampleFiles]="customBackdropContainer"></code-example>
 
 <playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
-    <button fd-button (click)="openDialog(playgroundDialog)">Open Dialog</button>
+    <button fd-button label="Open Dialog" (click)="openDialog(playgroundDialog)"></button>
 </playground>
 
 <ng-template let-dialog let-dialogConfig="dialogConfig" #playgroundDialog>
@@ -214,12 +214,11 @@
             <fd-dialog-footer-button>
                 <button
                     fd-button
-                    fdType="emphasized"
                     fd-dialog-decisive-button
+                    fdType="emphasized"
+                    label="Close"
                     [compact]="true"
-                    (click)="dialog.close()"
-                >
-                    Close
+                    (click)="dialog.close()">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/component-based/component-based-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/component-based/component-based-dialog-example.component.ts
@@ -5,7 +5,7 @@ import { DialogConfig, DialogService } from '@fundamental-ngx/core';
 @Component({
     selector: 'fd-component-based-dialog-example',
     template: `
-        <button fd-button (click)="open()">Open from Component</button>
+        <button fd-button label="Open from Component" (click)="open()"></button>
         <p>{{ closeReason }}</p>
     `
 })

--- a/apps/docs/src/app/core/component-docs/dialog/examples/component-based/dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/component-based/dialog-example.component.ts
@@ -23,10 +23,9 @@ import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
                         fd-button
                         fdType="emphasized"
                         fd-dialog-decisive-button
+                        label="Interesting"
                         [compact]="true"
-                        (click)="this.dialogRef.close('Continue')"
-                    >
-                        Interesting
+                        (click)="this.dialogRef.close('Continue')">
                     </button>
                 </fd-dialog-footer-button>
 
@@ -36,10 +35,9 @@ import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
                         fdType="transparent"
                         fd-dialog-decisive-button
                         fd-initial-focus
+                        label="Cancel"
                         [compact]="true"
-                        (click)="this.dialogRef.dismiss('Cancel')"
-                    >
-                        Cancel
+                        (click)="this.dialogRef.dismiss('Cancel')">
                     </button>
                 </fd-dialog-footer-button>
             </fd-dialog-footer>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.html
@@ -1,13 +1,15 @@
-<button fd-button (click)="openCustomBackdrop(dialogTemplate)">
-    Custom Backdrop
+<button fd-button label="Custom Backdrop" (click)="openCustomBackdrop(dialogTemplate)"></button>
+
+<button fd-button
+        (click)="openInCustomContainer(dialogTemplate, customContainer)"
+        style="margin-left: 1rem;"
+        label="Custom Container">
 </button>
 
-<button fd-button (click)="openInCustomContainer(dialogTemplate, customContainer)" style="margin-left: 1rem;">
-    Custom Container
-</button>
-
-<button fd-button (click)="openStaticDialog(dialogTemplate, customContainer)" style="margin-left: 1rem;">
-    Static Dialog
+<button fd-button
+        (click)="openStaticDialog(dialogTemplate, customContainer)"
+        style="margin-left: 1rem;"
+        label="Static Dialog">
 </button>
 
 <div #customContainer style="margin-top: 0.5rem;"></div>
@@ -28,12 +30,11 @@
                 <button
                     fd-button
                     fd-initial-focus
-                    fdType="emphasized"
                     fd-dialog-decisive-button
+                    fdType="emphasized"
+                    label="Close"
                     [compact]="true"
-                    (click)="dialog.close()"
-                >
-                    Close
+                    (click)="dialog.close()">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-complex/dialog-complex-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-complex/dialog-complex-example.component.html
@@ -9,9 +9,7 @@
                 </div>
                 <div fd-bar-right>
                     <fd-bar-element>
-                        <button fd-button fdType="transparent" compact="true" (click)="clear()">
-                            Clear
-                        </button>
+                        <button fd-button fdType="transparent" compact="true" label="Clear" (click)="clear()"></button>
                     </fd-bar-element>
                 </div>
             </ng-template>
@@ -60,10 +58,9 @@
                             fd-dialog-decisive-button
                             glyph="cart"
                             fdType="emphasized"
+                            label="Checkout"
                             [compact]="true"
-                            (click)="checkout()"
-                        >
-                            Checkout
+                            (click)="checkout()">
                         </button>
                     </fd-bar-element>
                 </div>
@@ -72,4 +69,4 @@
     </fd-dialog>
 </ng-template>
 
-<button fd-button (click)="openDialog(dialogTemplate)">Open with custom configuration</button>
+<button fd-button label="Open with custom configuration" (click)="openDialog(dialogTemplate)"></button>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
@@ -19,10 +19,9 @@
                     fdType="emphasized"
                     fd-initial-focus
                     fd-dialog-decisive-button
+                    label="Interesting"
                     [compact]="true"
-                    (click)="dialog.close()"
-                >
-                    Interesting
+                    (click)="dialog.close()">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
@@ -28,10 +28,11 @@
     </fd-dialog>
 </ng-template>
 
-<button fd-button (click)="openDraggableDialog(dialogTemplate)">Open draggable Dialog</button>
-<button fd-button (click)="openResizableDialog(dialogTemplate)" style="margin-left: 1rem;">
-    Open resizable Dialog
+<button fd-button label="Open draggable Dialog" (click)="openDraggableDialog(dialogTemplate)"></button>
+<button fd-button (click)="openResizableDialog(dialogTemplate)" style="margin-left: 1rem;" label="Open resizable Dialog">
 </button>
-<button fd-button (click)="openClosableByButtonDialog(dialogTemplate)" style="margin-left: 1rem;">
-    Open Dialog closable only with footer button
+<button fd-button
+        (click)="openClosableByButtonDialog(dialogTemplate)"
+        style="margin-left: 1rem;"
+        label="Open Dialog closable only with footer button">
 </button>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
@@ -12,11 +12,11 @@
         <fd-dialog-footer>
             <fd-dialog-footer-button>
                 <button fd-button
-                        fdType="emphasized"
                         fd-initial-focus
                         fd-dialog-decisive-button
+                        fdType="emphasized"
+                        label="Interesting"
                         (click)="dialog.close()">
-                    Interesting
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
@@ -23,4 +23,4 @@
     </fd-dialog>
 </ng-template>
 
-<button fd-button (click)="openDialog(dialogTemplate)">Open in mobile mode</button>
+<button fd-button label="Open in mobile mode" (click)="openDialog(dialogTemplate)"></button>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-object-example/dialog-object-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-object-example/dialog-object-example.component.html
@@ -1,6 +1,4 @@
-<button fd-button (click)="openDialog()">
-    Open Dialog From Object
-</button>
+<button fd-button label="Open Dialog From Object" (click)="openDialog()"></button>
 
 <ng-template #dialogContent>
     <div style="padding: 0 1rem">

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-position/dialog-position-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-position/dialog-position-example.component.html
@@ -17,14 +17,13 @@
                     fdType="emphasized"
                     fd-initial-focus
                     fd-dialog-decisive-button
+                    label="Interesting"
                     [compact]="true"
-                    (click)="dialog.close()"
-                >
-                    Interesting
+                    (click)="dialog.close()">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>
     </fd-dialog>
 </ng-template>
 
-<button fd-button (click)="openDialog(dialogTemplate)">Open in Bottom Right</button>
+<button fd-button label="Open in Bottom Right" (click)="openDialog(dialogTemplate)"></button>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-state/dialog-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-state/dialog-state-example.component.html
@@ -13,20 +13,18 @@
                 <button
                     fd-button
                     fdType="emphasized"
+                    label="Ok"
                     fd-initial-focus
                     fd-dialog-decisive-button
                     [compact]="true"
                     (click)="dialog.close()">
-                    Ok
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>
     </fd-dialog>
 </ng-template>
 
-<button fd-button (click)="openCloseDialog(dialogTemplate)">Open self closing Dialog</button>
-<button fd-button (click)="openDismissDialog(dialogTemplate)" style="margin-left: 1rem;">
-    Open self dismissing Dialog
-</button>
-<button fd-button (click)="openHideDialog(dialogTemplate)" style="margin-left: 1rem;">Open self hiding Dialog</button>
-<button fd-button (click)="openLoadingDialog(dialogTemplate)" style="margin-left: 1rem;">Open loading Dialog</button>
+<button fd-button label="Open self closing Dialog" (click)="openCloseDialog(dialogTemplate)"></button>
+<button fd-button label="Open self dismissing Dialog" (click)="openDismissDialog(dialogTemplate)" style="margin-left: 1rem;"></button>
+<button fd-button label="Open self hiding Dialog" (click)="openHideDialog(dialogTemplate)" style="margin-left: 1rem;"></button>
+<button fd-button label="Open loading Dialog" (click)="openLoadingDialog(dialogTemplate)" style="margin-left: 1rem;"></button>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/dialog-stacked-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/dialog-stacked-example.component.ts
@@ -4,7 +4,7 @@ import { DialogConfig, DialogService } from '@fundamental-ngx/core';
 
 @Component({
     selector: 'fd-dialog-stacked-example',
-    template: '<button fd-button (click)="openDialog()">Open First Dialog</button>'
+    template: '<button fd-button label="Open First Dialog" (click)="openDialog()"></button>'
 })
 export class DialogStackedExampleComponent {
     constructor(private _dialogService: DialogService) {}

--- a/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
@@ -22,10 +22,9 @@ import { SecondDialogExampleComponent } from './second-dialog-example.component'
                         fdType="emphasized"
                         fd-initial-focus
                         fd-dialog-decisive-button
+                        label="Open Second Dialog"
                         [compact]="true"
-                        (click)="openDialog()"
-                    >
-                        Open Second Dialog
+                        (click)="openDialog()">
                     </button>
                 </fd-dialog-footer-button>
             </fd-dialog-footer>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
@@ -21,10 +21,9 @@ import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
                         fdType="emphasized"
                         fd-initial-focus
                         fd-dialog-decisive-button
+                        label="Close"
                         [compact]="true"
-                        (click)="dialogRef.close()"
-                    >
-                        Close
+                        (click)="dialogRef.close()">
                     </button>
                 </fd-dialog-footer-button>
             </fd-dialog-footer>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/template-based/template-based-dialog-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/template-based/template-based-dialog-example.component.html
@@ -24,17 +24,17 @@
             <fd-dialog-footer-button>
                 <button
                     fd-button
-                    fdType="transparent"
                     fd-initial-focus
                     fd-dialog-decisive-button
+                    fdType="transparent"
+                    label="Cancel"
                     [compact]="true"
                     (click)="dialog.dismiss('Cancel')">
-                    Cancel
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>
     </fd-dialog>
 </ng-template>
 
-<button fd-button (click)="openDialog(confirmationDialog)">Open from Template</button>
+<button fd-button label="Open from Template" (click)="openDialog(confirmationDialog)"></button>
 <p>{{ confirmationReason }}</p>

--- a/apps/docs/src/app/core/component-docs/dialog/examples/template-based/template-based-dialog-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/template-based/template-based-dialog-example.component.html
@@ -13,11 +13,11 @@
             <fd-dialog-footer-button>
                 <button
                     fd-button
-                    fdType="emphasized"
                     fd-dialog-decisive-button
+                    fdType="emphasized"
+                    label="Interested"
                     [compact]="true"
                     (click)="dialog.close('Continue')">
-                    Interested
                 </button>
             </fd-dialog-footer-button>
 

--- a/apps/docs/src/app/core/component-docs/file-input/examples/file-input-drag-disabled-example/file-input-drag-disabled-example.component.html
+++ b/apps/docs/src/app/core/component-docs/file-input/examples/file-input-drag-disabled-example/file-input-drag-disabled-example.component.html
@@ -4,9 +4,7 @@
     (onInvalidFiles)="this.invalidFiles = $event"
     [accept]="'.png'"
 >
-    <button fd-button (click)="fileInput.open()">
-        Drag a .jpg file on me!
-    </button>
+    <button fd-button label="Drag a .jpg file on me!" (click)="fileInput.open()"></button>
 </fd-file-input>
 
 <br /><br />

--- a/apps/docs/src/app/core/component-docs/file-input/examples/file-input-example/file-input-example.component.html
+++ b/apps/docs/src/app/core/component-docs/file-input/examples/file-input-example/file-input-example.component.html
@@ -1,7 +1,5 @@
 <fd-file-input #fileInput [(ngModel)]="files" [multiple]="true" [accept]="'.png,.jpg'">
-    <button fd-button (click)="fileInput.open()">
-        Browse (.jpg or .png)
-    </button>
+    <button fd-button label="Browse (.jpg or .png)" (click)="fileInput.open()"></button>
 </fd-file-input>
 
 <br /><br />

--- a/apps/docs/src/app/core/component-docs/file-input/examples/file-input-max-example/file-input-max-example.component.html
+++ b/apps/docs/src/app/core/component-docs/file-input/examples/file-input-max-example/file-input-max-example.component.html
@@ -4,9 +4,7 @@
     (onInvalidFiles)="this.invalid_files = $event"
     [maxFileSize]="1048576"
 >
-    <button fd-button (click)="fileInput.open()">
-        Files larger than 1mb are rejected!
-    </button>
+    <button fd-button label="Files larger than 1mb are rejected!" (click)="fileInput.open()"></button>
 </fd-file-input>
 
 <br /><br />

--- a/apps/docs/src/app/core/component-docs/input/examples/input-form-group-example.component.html
+++ b/apps/docs/src/app/core/component-docs/input/examples/input-form-group-example.component.html
@@ -53,6 +53,6 @@
         </div>
     </div>
     <br />
-    <button fd-button type="button" (click)="addItem()" style="margin-right: 5px;">Add</button>
-    <button fd-button type="submit">Submit</button>
+    <button fd-button type="button" label="Add" (click)="addItem()" style="margin-right: 5px;"></button>
+    <button fd-button type="submit" label="Submit"></button>
 </form>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-keyboard-example/list-keyboard-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-keyboard-example/list-keyboard-example.component.html
@@ -1,4 +1,4 @@
-<button fd-button (click)="focusFirst()">Element focused, when keyboard service goes before list</button>
+<button fd-button label="Element focused, when keyboard service goes before list" (click)="focusFirst()"></button>
 <ul fd-list (focusEscapeList)="handleFocusEscape($event)">
     <li fd-list-item>
         <span fd-list-title>

--- a/apps/docs/src/app/core/component-docs/menu/examples/menu-addon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/examples/menu-addon-example.component.html
@@ -1,5 +1,5 @@
 <div style="width: 50%; display: inline-block">
-    <button fd-button [fdMenu]="true" [fdMenuTrigger]="menuIcons">Menu with icons</button>
+    <button fd-button label="Menu with icons" [fdMenu]="true" [fdMenuTrigger]="menuIcons"></button>
 
     <fd-menu #menuIcons>
         <li fd-menu-item>
@@ -27,7 +27,7 @@
 </div>
 
 <div style="width: 50%; display: inline-block">
-    <button fd-button [fdMenu]="true" [fdMenuTrigger]="menuShortcut">Menu with shortcuts</button>
+    <button fd-button label="Menu with shortcuts" [fdMenu]="true" [fdMenuTrigger]="menuShortcut"></button>
 
     <fd-menu #menuShortcut>
         <li fd-menu-item>

--- a/apps/docs/src/app/core/component-docs/menu/examples/menu-example.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/examples/menu-example.component.html
@@ -1,4 +1,4 @@
-<button fd-button [fdMenuTrigger]="menu">Menu</button>
+<button fd-button label="Menu" [fdMenuTrigger]="menu"></button>
 
 <fd-menu #menu>
     <li fd-menu-item>

--- a/apps/docs/src/app/core/component-docs/menu/examples/menu-separator-example.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/examples/menu-separator-example.component.html
@@ -1,5 +1,5 @@
 <div style="display: inline-block; width: 50%;">
-    <button fd-button [fdMenu]="true" [fdMenuTrigger]="menu">Menu</button>
+    <button fd-button label="Menu" [fdMenu]="true" [fdMenuTrigger]=""></button>
 
     <fd-menu #menu>
         <li fd-menu-item>
@@ -37,7 +37,7 @@
 </div>
 
 <div style="display: inline-block; width: 50%;">
-    <button fd-button [fdMenu]="true" [compact]="true" [fdMenuTrigger]="menuCompact">Compact Menu</button>
+    <button fd-button label="Compact Menu" [fdMenu]="true" [compact]="true" [fdMenuTrigger]="menuCompact"></button>
 
     <fd-menu #menuCompact [compact]="true">
         <li fd-menu-item>

--- a/apps/docs/src/app/core/component-docs/menu/examples/menu-separator-example.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/examples/menu-separator-example.component.html
@@ -1,5 +1,5 @@
 <div style="display: inline-block; width: 50%;">
-    <button fd-button label="Menu" [fdMenu]="true" [fdMenuTrigger]=""></button>
+    <button fd-button label="Menu" [fdMenu]="true" [fdMenuTrigger]="menu"></button>
 
     <fd-menu #menu>
         <li fd-menu-item>

--- a/apps/docs/src/app/core/component-docs/menu/examples/menu-with-submenu-example.component.html
+++ b/apps/docs/src/app/core/component-docs/menu/examples/menu-with-submenu-example.component.html
@@ -1,4 +1,4 @@
-<button fd-button [fdMenu]="true" [fdMenuTrigger]="menu">Menu with submenu</button>
+<button fd-button label="Menu with submenu" [fdMenu]="true" [fdMenuTrigger]="menu"></button>
 
 <div style="display: inline-block">
     <span style="padding-left: .5rem">Active path:</span>

--- a/apps/docs/src/app/core/component-docs/notification/examples/component-as-content/notification-component-as-content-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/notification/examples/component-as-content/notification-component-as-content-example.component.ts
@@ -5,7 +5,7 @@ import { NotificationContentComponent } from './notification-content.component';
 @Component({
     selector: 'fd-notification-component-as-content-example',
     template: `
-        <button fd-button (click)="open()">Open from Component</button>
+        <button fd-button label="Open from Component" (click)="open()"></button>
         <span style="margin-left: 24px;">{{ closeReason }}</span>
     `
 })

--- a/apps/docs/src/app/core/component-docs/notification/examples/component-as-content/notification-content.component.ts
+++ b/apps/docs/src/app/core/component-docs/notification/examples/component-as-content/notification-content.component.ts
@@ -25,15 +25,17 @@ import { NotificationRef } from '@fundamental-ngx/core';
                 </div>
             </div>
             <fd-notification-footer>
-                <button fd-button [fdType]="'transparent'">
-                    {{ notificationRef.data.moreInfo }}
-                </button>
+                <button fd-button [fdType]="'transparent'" [label]="notificationRef.data.moreInfo"></button>
                 <div fd-notification-actions>
-                    <button fd-button [fdType]="'positive'" (click)="notificationRef.close('Approve Button Click')">
-                        {{ notificationRef.data.approve }}
+                    <button fd-button
+                            [fdType]="'positive'"
+                            [label]="notificationRef.data.approve"
+                            (click)="notificationRef.close('Approve Button Click')">
                     </button>
-                    <button fd-button [fdType]="'negative'" (click)="notificationRef.dismiss('Cancel Button Click')">
-                        {{ notificationRef.data.cancel }}
+                    <button fd-button
+                            [fdType]="'negative'"
+                            [label]="notificationRef.data.cancel"
+                            (click)="notificationRef.dismiss('Cancel Button Click')">
                     </button>
                 </div>
             </fd-notification-footer>

--- a/apps/docs/src/app/core/component-docs/notification/examples/group-notification/notification-group-template-example.component.html
+++ b/apps/docs/src/app/core/component-docs/notification/examples/group-notification/notification-group-template-example.component.html
@@ -1,5 +1,5 @@
-<button fd-button *ngIf="!currentGroup" (click)="newGroup(notificationGroupTemplate)">Create Group</button>
-<button fd-button *ngIf="currentGroup" (click)="addToGroup(notificationTemplate)">Add To Group</button>
+<button fd-button label="Create Group" *ngIf="!currentGroup" (click)="newGroup(notificationGroupTemplate)"></button>
+<button fd-button label="Add To Group" *ngIf="currentGroup" (click)="addToGroup(notificationTemplate)"></button>
 <span style="margin-left: 20px;">{{ closeReason }}</span>
 
 <ng-template let-notification #notificationTemplate>
@@ -17,13 +17,11 @@
             </div>
         </div>
         <fd-notification-footer>
-            <button fd-button [fdType]="'transparent'">More Info</button>
+            <button fd-button label="More Info" [fdType]="'transparent'"></button>
             <div fd-notification-actions>
-                <button fd-button [fdType]="'positive'" (click)="notification.close('Approve Button Click')">
-                    Approve
+                <button fd-button label="Approve" [fdType]="'positive'" (click)="notification.close('Approve Button Click')">
                 </button>
-                <button fd-button [fdType]="'negative'" (click)="notification.dismiss('Reject Button Click')">
-                    Reject
+                <button fd-button label="Reject" [fdType]="'negative'" (click)="notification.dismiss('Reject Button Click')">
                 </button>
             </div>
         </fd-notification-footer>
@@ -48,13 +46,17 @@
             </div>
         </div>
         <fd-notification-footer>
-            <button fd-button [fdType]="'transparent'">More Info</button>
+            <button fd-button label="More Info" [fdType]="'transparent'"></button>
             <div fd-notification-actions>
-                <button fd-button [fdType]="'positive'" (click)="notification.closeWholeGroup('Approve Button Click')">
-                    Approve All
+                <button fd-button
+                        label="Approve All"
+                        [fdType]="'positive'"
+                        (click)="notification.closeWholeGroup('Approve Button Click')">
                 </button>
-                <button fd-button [fdType]="'negative'" (click)="notification.dismissWholeGroup('Reject Button Click')">
-                    Reject All
+                <button fd-button
+                        label="Reject All"
+                        [fdType]="'negative'"
+                        (click)="notification.dismissWholeGroup('Reject Button Click')">
                 </button>
             </div>
         </fd-notification-footer>

--- a/apps/docs/src/app/core/component-docs/notification/examples/notification-as-object.component.ts
+++ b/apps/docs/src/app/core/component-docs/notification/examples/notification-as-object.component.ts
@@ -7,7 +7,7 @@ import { NotificationService } from '@fundamental-ngx/core';
         <ng-template #avatarRef>
             <fd-avatar size="s" [circle]="true" label="John Doe">JD</fd-avatar>
         </ng-template>
-        <button fd-button (click)="open()">Open from Object</button>
+        <button fd-button label="Open from Object" (click)="open()"></button>
         <span style="margin-left: 24px;">{{ closeReason }}</span>
     `
 })

--- a/apps/docs/src/app/core/component-docs/notification/examples/notification-options/notification-options-content.component.ts
+++ b/apps/docs/src/app/core/component-docs/notification/examples/notification-options/notification-options-content.component.ts
@@ -25,15 +25,17 @@ import { NotificationRef } from '@fundamental-ngx/core';
                 </div>
             </div>
             <fd-notification-footer>
-                <button fd-button [fdType]="'transparent'">
-                    {{ notificationRef.data.moreInfo }}
-                </button>
+                <button fd-button [label]="notificationRef.data.moreInfo" [fdType]="'transparent'"></button>
                 <div fd-notification-actions>
-                    <button fd-button [fdType]="'positive'" (click)="notificationRef.close('Approve Button Click')">
-                        {{ notificationRef.data.approve }}
+                    <button fd-button
+                            [fdType]="'positive'"
+                            [label]="notificationRef.data.approve"
+                            (click)="notificationRef.close('Approve Button Click')">
                     </button>
-                    <button fd-button [fdType]="'negative'" (click)="notificationRef.dismiss('Cancel Button Click')">
-                        {{ notificationRef.data.cancel }}
+                    <button fd-button
+                            [fdType]="'negative'"
+                            [label]="notificationRef.data.cancel"
+                            (click)="notificationRef.dismiss('Cancel Button Click')">
                     </button>
                 </div>
             </fd-notification-footer>

--- a/apps/docs/src/app/core/component-docs/notification/examples/notification-options/notification-options-example.component.html
+++ b/apps/docs/src/app/core/component-docs/notification/examples/notification-options/notification-options-example.component.html
@@ -1,5 +1,5 @@
 <div>
-    <button fd-button (click)="openNotifications()">Create Notifications</button>
+    <button fd-button label="Create Notifications" (click)="openNotifications()"></button>
 </div>
 
 <div class="docs-notifications-inline-container" #vc></div>

--- a/apps/docs/src/app/core/component-docs/notification/examples/template-as-content/notification-open-template-example.component.html
+++ b/apps/docs/src/app/core/component-docs/notification/examples/template-as-content/notification-open-template-example.component.html
@@ -1,4 +1,4 @@
-<button fd-button (click)="open(notificationTemplate)">Open Notification</button>
+<button fd-button label="Open Notification" (click)="open(notificationTemplate)"></button>
 <span style="margin-left: 24px;">{{ closeReason }}</span>
 
 <ng-template let-notification #notificationTemplate>
@@ -16,13 +16,11 @@
             </div>
         </div>
         <fd-notification-footer>
-            <button fd-button [fdType]="'transparent'">More Info</button>
+            <button fd-button label="More Info" [fdType]="'transparent'"></button>
             <div fd-notification-actions>
-                <button fd-button [fdType]="'positive'" (click)="notification.close('Approve Button Click')">
-                    Approve
+                <button fd-button label="Approve" [fdType]="'positive'" (click)="notification.close('Approve Button Click')">
                 </button>
-                <button fd-button [fdType]="'negative'" (click)="notification.dismiss('Reject Button Click')">
-                    Reject
+                <button fd-button label="Reject" [fdType]="'negative'" (click)="notification.dismiss('Reject Button Click')">
                 </button>
             </div>
         </fd-notification-footer>

--- a/apps/docs/src/app/core/component-docs/pagination/examples/pagination-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/pagination/examples/pagination-example.component.ts
@@ -11,7 +11,7 @@ import { PaginationComponent } from '@fundamental-ngx/core';
             [currentPage]="currentPage"
         ></fd-pagination>
         <br /><br />
-        <button fd-button (click)="goToPage1()">Go to page 1</button>`
+        <button fd-button label="Go to page 1" (click)="goToPage1()"></button>`
 })
 export class PaginationExampleComponent {
     totalItems = 50;

--- a/apps/docs/src/app/core/component-docs/panel/examples/panel-expandable-example.component.html
+++ b/apps/docs/src/app/core/component-docs/panel/examples/panel-expandable-example.component.html
@@ -1,4 +1,4 @@
-<button class="docs-button" fd-button (click)="expanded = !expanded">Toggle Expand</button>
+<button class="docs-button" fd-button label="Toggle Expand" (click)="expanded = !expanded"></button>
 <br><br>
 Expanded value is: {{expanded}}
 <br><br><br>
@@ -6,12 +6,12 @@ Expanded value is: {{expanded}}
 <fd-panel [(expanded)]="expanded" [expandId]="'panel-expand-1'" [expandAriaLabel]="'Panel Expand'">
     <h5 fd-panel-title>Panel Header</h5>
     <div fd-panel-content [ariaLabel]="'Panel Content'" [id]="'panel-content-1'">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ut laoreet lorem. Vestibulum ante ipsum primis in faucibus orci luctus 
-        et ultrices posuere cubilia curae; Aenean sagittis aliquam justo et suscipit. 
-        Nam molestie, magna at elementum pulvinar, nisi enim venenatis ante, id convallis mi neque nec risus. Cras blandit sagittis augue at facilisis. 
-        Mauris egestas nunc nec diam mollis auctor. Vestibulum sed euismod elit, eget accumsan quam. Donec eleifend porttitor viverra. 
-        Nunc porttitor dictum erat at molestie. Sed quis velit dolor. Vestibulum et turpis eget enim gravida gravida vitae at massa. 
-        Suspendisse facilisis elit ut dolor posuere consectetur. Morbi ac nibh sit amet dolor lobortis tincidunt in ornare erat. 
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ut laoreet lorem. Vestibulum ante ipsum primis in faucibus orci luctus
+        et ultrices posuere cubilia curae; Aenean sagittis aliquam justo et suscipit.
+        Nam molestie, magna at elementum pulvinar, nisi enim venenatis ante, id convallis mi neque nec risus. Cras blandit sagittis augue at facilisis.
+        Mauris egestas nunc nec diam mollis auctor. Vestibulum sed euismod elit, eget accumsan quam. Donec eleifend porttitor viverra.
+        Nunc porttitor dictum erat at molestie. Sed quis velit dolor. Vestibulum et turpis eget enim gravida gravida vitae at massa.
+        Suspendisse facilisis elit ut dolor posuere consectetur. Morbi ac nibh sit amet dolor lobortis tincidunt in ornare erat.
         Vestibulum tristique euismod enim, ac volutpat odio cursus sit amet.
     </div>
 </fd-panel>

--- a/apps/docs/src/app/core/component-docs/popover-directive/examples/popover-directive-example/popover-directive-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover-directive/examples/popover-directive-example/popover-directive-example.component.html
@@ -1,10 +1,11 @@
-<button fd-button placement="bottom" fdPopover="This popover is created from a string!" [noArrow]="false">
-    Popover from String
+<button fd-button
+        placement="bottom"
+        fdPopover="This popover is created from a string!"
+        label="Popover from String"
+        [noArrow]="false">
 </button>
 
-<button fd-button placement="bottom" [fdPopover]="template" [noArrow]="false">
-    Popover from Template
-</button>
+<button fd-button placement="bottom" label="Popover from Template" [fdPopover]="template" [noArrow]="false"></button>
 
 <ng-template #template>
     <p>

--- a/apps/docs/src/app/core/component-docs/popover-directive/examples/popover-programmatic/popover-programmatic.component.html
+++ b/apps/docs/src/app/core/component-docs/popover-directive/examples/popover-programmatic/popover-programmatic.component.html
@@ -12,6 +12,7 @@
 
 <button
     fd-button
+    label="Hover Custom Trigger"
     placement="bottom"
     [fdPopover]="hoverTemplate"
     [noArrow]="false"
@@ -20,7 +21,6 @@
     (mouseenter)="isOpenHover = true"
     (mouseleave)="isOpenHover = false"
 >
-    Hover Custom Trigger
 </button>
 
 <ng-template #clickTemplate>

--- a/apps/docs/src/app/core/component-docs/popover-directive/examples/popover-triggers/popover-triggers.component.html
+++ b/apps/docs/src/app/core/component-docs/popover-directive/examples/popover-triggers/popover-triggers.component.html
@@ -1,24 +1,25 @@
 <button
     fd-button
     fdPopover="This popover is only triggered by focus events."
-    [noArrow]="false"
+    label="Focus Trigger"
     placement="bottom"
+    [noArrow]="false"
     [triggers]="['focus']"
-    [focusTrapped]="false"
->
-    Focus Trigger
+    [focusTrapped]="false">
 </button>
 
-<button fd-button fdPopover="This popover is only triggered by click events." placement="bottom" [noArrow]="false">
-    Click Trigger
+<button fd-button
+        label="Click Trigger"
+        fdPopover="This popover is only triggered by click events."
+        placement="bottom"
+        [noArrow]="false">
 </button>
 
 <button
     fd-button
+    label="Hover Trigger"
     fdPopover="This popover is only triggered by hover events."
     placement="bottom"
     [triggers]="['mouseenter', 'mouseleave']"
-    [noArrow]="false"
->
-    Hover Trigger
+    [noArrow]="false">
 </button>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-complex-example/popover-complex-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-complex-example/popover-complex-example.component.html
@@ -1,7 +1,7 @@
 <div class="fd-docs-flex-display-helper">
     <fd-popover>
         <fd-popover-control>
-            <button fd-button>Simple</button>
+            <button fd-button label="Simple"></button>
         </fd-popover-control>
         <fd-popover-body>
             <ul fd-list>
@@ -14,7 +14,7 @@
 
     <fd-popover>
         <fd-popover-control>
-            <button fd-button>With Header</button>
+            <button fd-button label="With Header"></button>
         </fd-popover-control>
         <fd-popover-body>
             <div fd-popover-body-header>
@@ -34,7 +34,7 @@
 
     <fd-popover>
         <fd-popover-control>
-            <button fd-button>With Header And Footer</button>
+            <button fd-button label="With Header And Footer"></button>
         </fd-popover-control>
         <fd-popover-body>
             <div fd-popover-body-header>
@@ -53,10 +53,10 @@
                 <div fd-bar [barDesign]="'footer'" [cosy]="true">
                     <div fd-bar-right>
                         <fd-bar-element>
-                            <button fd-button [fdType]="'emphasized'" [compact]="true">Save</button>
+                            <button fd-button label="Save" [fdType]="'emphasized'" [compact]="true"></button>
                         </fd-bar-element>
                         <fd-bar-element>
-                            <button fd-button [compact]="true">Cancel</button>
+                            <button fd-button label="Cancel" [compact]="true"></button>
                         </fd-bar-element>
                     </div>
                 </div>
@@ -66,7 +66,7 @@
 
     <fd-popover>
         <fd-popover-control>
-            <button fd-button>With Header, SubHeader And Footer</button>
+            <button fd-button label="With Header, SubHeader And Footer"></button>
         </fd-popover-control>
         <fd-popover-body>
             <div fd-popover-body-header>
@@ -92,10 +92,10 @@
                 <div fd-bar [barDesign]="'footer'" [cosy]="true">
                     <div fd-bar-right>
                         <fd-bar-element>
-                            <button fd-button fdType="emphasized" [compact]="true">Save</button>
+                            <button fd-button fdType="emphasized" label="Save" [compact]="true"></button>
                         </fd-bar-element>
                         <fd-bar-element>
-                            <button fd-button [compact]="true">Cancel</button>
+                            <button fd-button label="Cancel" [compact]="true"></button>
                         </fd-bar-element>
                     </div>
                 </div>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dialog/popover-dialog-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dialog/popover-dialog-example.component.html
@@ -1,6 +1,4 @@
-<button fd-button (click)="openDialog(template)">
-    Open Dialog
-</button>
+<button fd-button label="Open Dialog" (click)="openDialog(template)"></button>
 
 <ng-template #template let-dialog let-dialogConfig="dialogConfig">
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
@@ -12,7 +10,7 @@
         <fd-dialog-body>
             <fd-popover [noArrow]="false" [placement]="'bottom'">
                 <fd-popover-control>
-                    <button fd-button>Click me!</button>
+                    <button fd-button label="Click me!"></button>
                 </fd-popover-control>
                 <fd-popover-body>
                     <div style="padding: 12px;">

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.html
@@ -1,6 +1,6 @@
 <fd-popover [placement]="dropDownPlacement$ | async">
     <fd-popover-control>
-        <button fd-button [fdMenu]="true">Dropdown Popover</button>
+        <button fd-button label="Dropdown Popover" [fdMenu]="true"></button>
     </fd-popover-control>
     <fd-popover-body>
         <ul fd-list>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown.component.html
@@ -12,7 +12,7 @@
 </fd-popover>
 <fd-popover [placement]="dropDownPlacement$ | async" [disabled]="true">
     <fd-popover-control>
-        <button fd-button [disabled]="true" [fdMenu]="true">Disabled Dropdown Popover</button>
+        <button fd-button label="Disabled Dropdown Popover" [disabled]="true" [fdMenu]="true"></button>
     </fd-popover-control>
     <fd-popover-body>
         <ul fd-list>
@@ -24,7 +24,7 @@
 </fd-popover>
 <fd-popover [placement]="dropDownPlacement$ | async">
     <fd-popover-control>
-        <button fd-button [fdMenu]="true" [glyph]="'filter'">Dropdown with icon</button>
+        <button fd-button label="Dropdown with icon" [fdMenu]="true" [glyph]="'filter'"></button>
     </fd-popover-control>
     <fd-popover-body>
         <ul fd-list>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.html
@@ -18,5 +18,5 @@
     </fd-popover-body>
 </fd-popover>
 
-<button fd-button (click)="this.isOpen = true">Open Popover</button>
-<button fd-button (click)="this.isOpen = false">Close Popover</button>
+<button fd-button label="Open Popover" (click)="this.isOpen = true"></button>
+<button fd-button label="Close Popover" (click)="this.isOpen = false"></button>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
@@ -56,7 +56,7 @@
 
     <fd-popover [placement]="rightPlacement$ | async">
         <fd-popover-control>
-            <button fd-button>Button</button>
+            <button fd-button label="Button"></button>
         </fd-popover-control>
         <fd-popover-body *ngIf="list1 && list1.length">
             <div fd-popover-body-header>
@@ -82,10 +82,10 @@
                 <div fd-bar [barDesign]="'footer'" [cosy]="true">
                     <div fd-bar-right>
                         <fd-bar-element>
-                            <button fd-button [fdType]="'emphasized'" [compact]="true">Save</button>
+                            <button fd-button label="Save" [fdType]="'emphasized'" [compact]="true"></button>
                         </fd-bar-element>
                         <fd-bar-element>
-                            <button fd-button [fdType]="'transparent'" [compact]="true">Cancel</button>
+                            <button fd-button label="Cancel" [fdType]="'transparent'" [compact]="true"></button>
                         </fd-bar-element>
                     </div>
                 </div>
@@ -112,7 +112,7 @@
         [options]="{ modifiers: { flip: { enabled: false }, preventOverflow: { enabled: false } } }"
     >
         <fd-popover-control>
-            <button fd-button>Fixed Position</button>
+            <button fd-button label="Fixed Position"></button>
         </fd-popover-control>
         <fd-popover-body *ngIf="list1 && list1.length">
             <ul fd-list>

--- a/apps/docs/src/app/core/component-docs/segmented-button/examples/segmented-button-default-example.component.html
+++ b/apps/docs/src/app/core/component-docs/segmented-button/examples/segmented-button-default-example.component.html
@@ -1,11 +1,8 @@
 <fd-segmented-button style="margin-right: 10px; margin-left: 10px;">
-    <button fd-button [glyph]="'survey'" (click)="setLocaleIcon(0)" [class]="isSelectedIcon(0)">
-        survey
+    <button fd-button label="survey" [glyph]="'survey'" (click)="setLocaleIcon(0)" [class]="isSelectedIcon(0)">
     </button>
-    <button fd-button [glyph]="'pie-chart'" (click)="setLocaleIcon(1)" [class]="isSelectedIcon(1)">
-        pie-chart
+    <button fd-button label="pie-chart" [glyph]="'pie-chart'" (click)="setLocaleIcon(1)" [class]="isSelectedIcon(1)">
     </button>
-    <button fd-button [glyph]="'pool'" (click)="setLocaleIcon(2)" [class]="isSelectedIcon(2)">
-        pool
+    <button fd-button label="pool" [glyph]="'pool'" (click)="setLocaleIcon(2)" [class]="isSelectedIcon(2)">
     </button>
 </fd-segmented-button>

--- a/apps/docs/src/app/core/component-docs/segmented-button/examples/segmented-button-toggle-example.component.html
+++ b/apps/docs/src/app/core/component-docs/segmented-button/examples/segmented-button-toggle-example.component.html
@@ -1,5 +1,5 @@
 <fd-segmented-button>
-    <button fd-button (click)="toggleLMR(0)" [class]="isSelectedLMR(0)">Left</button>
-    <button fd-button (click)="toggleLMR(1)" [class]="isSelectedLMR(1)">Middle</button>
-    <button fd-button (click)="toggleLMR(2)" [class]="isSelectedLMR(2)">Right</button>
+    <button fd-button label="Left" (click)="toggleLMR(0)" [class]="isSelectedLMR(0)"></button>
+    <button fd-button label="Middle" (click)="toggleLMR(1)" [class]="isSelectedLMR(1)"></button>
+    <button fd-button label="Right" (click)="toggleLMR(2)" [class]="isSelectedLMR(2)"></button>
 </fd-segmented-button>

--- a/apps/docs/src/app/core/component-docs/segmented-button/segmented-button-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/segmented-button/segmented-button-docs.component.html
@@ -29,18 +29,16 @@
         <button
             *ngIf="data.properties.label2.length > 0"
             fd-button
+            [label]="data.properties.label2"
             [compact]="data.properties.compact"
-            [class]="data.properties.state2"
-        >
-            {{ data.properties.label2 }}
+            [class]="data.properties.state2">
         </button>
         <button
             *ngIf="data.properties.label3.length > 0"
             fd-button
+            [label]="data.properties.label3"
             [compact]="data.properties.compact"
-            [class]="data.properties.state3"
-        >
-            {{ data.properties.label3 }}
+            [class]="data.properties.state3">
         </button>
         <button
             *ngIf="data.properties.icon4.length > 0"

--- a/apps/docs/src/app/core/component-docs/select/examples/select-adding-example/select-adding-example.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-adding-example/select-adding-example.component.html
@@ -1,6 +1,6 @@
 <div class="example-btn-holder">
-    <button fd-button (click)="addOption()">Add Option</button>
-    <button fd-button (click)="removeOption()">Remove Option</button>
+    <button fd-button label="Add Option" (click)="addOption()"></button>
+    <button fd-button label="Remove Option" (click)="removeOption()"></button>
 </div>
 
 <fd-select placeholder="Select an option" [(value)]="selectedValue" [closeOnOutsideClick]="false">

--- a/apps/docs/src/app/core/component-docs/select/examples/select-programmatic-example/select-programmatic-example.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-programmatic-example/select-programmatic-example.component.html
@@ -1,7 +1,7 @@
 <div class="example-btn-holder">
-    <button fd-button (click)="changeValue()">Change Value</button>
-    <button fd-button (click)="select.open()">Open</button>
-    <button fd-button (click)="select.close()">Close</button>
+    <button fd-button label="Change Value" (click)="changeValue()"></button>
+    <button fd-button label="Open" (click)="select.open()"></button>
+    <button fd-button label="Close" (click)="select.close()"></button>
 </div>
 
 <fd-select placeholder="Select value" #select [(value)]="selectedValue" [closeOnOutsideClick]="false">

--- a/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-programmatically-example/side-navigation-programmatically-example.component.html
+++ b/apps/docs/src/app/core/component-docs/side-navigation/examples/side-navigation-programmatically-example/side-navigation-programmatically-example.component.html
@@ -65,5 +65,5 @@
     </div>
 </fd-side-nav>
 
-<button fd-button (click)="selected = !selected">Selected Child {{ selected }}</button>
-<button fd-button (click)="open = !open">Open {{ open }}</button>
+<button fd-button [label]="'Selected Child ' + selected" (click)="selected = !selected"></button>
+<button fd-button [label]="'Open' + open " (click)="open = !open"></button>

--- a/apps/docs/src/app/core/component-docs/split-button/examples/split-button-programmatical-example.component.html
+++ b/apps/docs/src/app/core/component-docs/split-button/examples/split-button-programmatical-example.component.html
@@ -13,8 +13,8 @@
     </fd-menu>
 </fd-split-button>
 
-<button class="docs-button" fd-button (click)="menu.open()">Open</button>
-<button class="docs-button" fd-button (click)="menu.close()">Close</button>
+<button label="Open" class="docs-button" fd-button (click)="menu.open()"></button>
+<button label="Close" class="docs-button" fd-button (click)="menu.close()"></button>
 
-<button class="docs-button" fd-button (click)="select(option1)">Select Option 1</button>
-<button class="docs-button" fd-button (click)="select(option2)">Select Option 2</button>
+<button label="Select Option 1" class="docs-button" fd-button (click)="select(option1)"></button>
+<button label="Select Option 2" class="docs-button" fd-button (click)="select(option2)"></button>

--- a/apps/docs/src/app/core/component-docs/switch/examples/switch-binding-example/switch-binding-example.component.html
+++ b/apps/docs/src/app/core/component-docs/switch/examples/switch-binding-example/switch-binding-example.component.html
@@ -10,6 +10,6 @@
 </label>
 <fd-switch [(checked)]="secondSwitch"></fd-switch>
 
-<button fd-button (click)="switchBoth()">Switch Both</button>
-<button fd-button (click)="switchOne()">Switch 1</button>
-<button fd-button (click)="switchTwo()">Switch 2</button>
+<button fd-button label="Switch Both" (click)="switchBoth()"></button>
+<button fd-button label="Switch 1" (click)="switchOne()"></button>
+<button fd-button label="Switch 2" (click)="switchTwo()"></button>

--- a/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-columns-example.component.html
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-columns-example.component.html
@@ -25,4 +25,4 @@ Chosen Columns: {{displayedColumns}}
 <br>
 <br>
 
-<button fd-button (click)="openDialog()">Open Table Customization</button>
+<button fd-button label="Open Table Customization" (click)="openDialog()"></button>

--- a/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-dialog.component.ts
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-dialog.component.ts
@@ -65,22 +65,20 @@ import { DisplayedColumn } from './table-custom-columns-example.component';
                     <button
                             fd-button
                             fd-dialog-decisive-button
+                            label="Save and Close"
                             fdType="emphasized"
                             [compact]="true"
-                            (click)="save()"
-                    >
-                        Save and Close
+                            (click)="save()">
                     </button>
                 </fd-dialog-footer-button>
                 <fd-dialog-footer-button>
                     <button
                             fd-button
                             fd-dialog-decisive-button
+                            label="Close without Saving"
                             fdType="transparent"
                             [compact]="true"
-                            (click)="dismiss()"
-                    >
-                        Close without Saving
+                            (click)="dismiss()">
                     </button>
                 </fd-dialog-footer-button>
             </fd-dialog-footer>

--- a/apps/docs/src/app/core/component-docs/table/examples/table-pagination-example.component.html
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-pagination-example.component.html
@@ -17,8 +17,8 @@
     </tbody>
     <br/>
     <tfoot fd-table-footer>
-        <button fd-button [fdMenu]="true" [fdMenuTrigger]="itemsPerPageMenu"
-                [ngStyle]="{'margin-left': (rtl$ | async) ? '20px' : '0', 'margin-right': (rtl$ | async) ? '0' : '20px'}">Items Per Page</button>
+        <button label="Items Per Page" fd-button [fdMenu]="true" [fdMenuTrigger]="itemsPerPageMenu"
+                [ngStyle]="{'margin-left': (rtl$ | async) ? '20px' : '0', 'margin-right': (rtl$ | async) ? '0' : '20px'}"></button>
         <fd-pagination
             [totalItems]="totalItems"
             (pageChangeStart)="newPageClicked($event)"

--- a/apps/docs/src/app/core/component-docs/table/examples/table-toolbar-example.component.html
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-toolbar-example.component.html
@@ -14,7 +14,13 @@
         (addOnButtonClicked)="resetSearch()"
     >
     </fd-input-group>
-    <button fd-toolbar-item fd-button (click)="openDialog(newItemDialog)" [compact]="true" [fdType]="'transparent'" [glyph]="'add'">New Item</button>
+    <button fd-toolbar-item
+            fd-button
+            label="New Item"
+            (click)="openDialog(newItemDialog)"
+            [compact]="true"
+            [fdType]="'transparent'"
+            [glyph]="'add'"></button>
 </fd-toolbar>
 <table fd-table>
     <thead fd-table-header>
@@ -61,24 +67,22 @@
             <fd-dialog-footer-button>
                 <button
                     fd-button
-                    fdType="emphasized"
                     fd-dialog-decisive-button
+                    fdType="emphasized"
+                    label="Save"
                     [compact]="true"
                     (click)="dialog.close('Save')"
-                    type="submit"
-                >
-                    Save
+                    type="submit">
                 </button>
             </fd-dialog-footer-button>
             <fd-dialog-footer-button>
                 <button
                     fd-button
                     fdType="transparent"
+                    label="Cancel"
                     fd-dialog-decisive-button
                     [compact]="true"
-                    (click)="dialog.dismiss('Cancel')"
-                >
-                    Cancel
+                    (click)="dialog.dismiss('Cancel')">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/adding-tab-example/adding-tab-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/adding-tab-example/adding-tab-example.component.html
@@ -4,5 +4,5 @@
     </fd-tab>
 </fd-tab-list>
 
-<button fd-button (click)="addTab()">Add a Tab</button>
-<button fd-button (click)="removeTab()">Remove a Tab</button>
+<button fd-button label="Add a Tab" (click)="addTab()"></button>
+<button fd-button label="Remove a Tab" (click)="removeTab()"></button>

--- a/apps/docs/src/app/core/component-docs/tabs/examples/tab-selection-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tabs/examples/tab-selection-example.component.html
@@ -12,11 +12,7 @@
 <br />
 
 <!-- First method, requires maintaining a flag -->
-<button fd-button (click)="selectedTab = 0">
-    Select Tab 1
-</button>
+<button fd-button label="Select Tab 1" (click)="selectedTab = 0"></button>
 
 <!-- Second method, does not require a flag -->
-<button fd-button (click)="tabList.selectTab(1)">
-    Select Tab 2
-</button>
+<button fd-button label="Select Tab 2" (click)="tabList.selectTab(1)"></button>

--- a/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-allow-null-example.component.html
+++ b/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-allow-null-example.component.html
@@ -13,6 +13,6 @@ Selected Time:
 <br/>
 <br/>
 <fd-segmented-button>
-    <button fd-button (click)="setNull()">Set To Null</button>
-    <button fd-button (click)="setValid()">Set Valid Time</button>
+    <button fd-button label="Set To Null" (click)="setNull()"></button>
+    <button fd-button label="Set Valid Time" (click)="setValid()"></button>
 </fd-segmented-button>

--- a/apps/docs/src/app/core/component-docs/time/examples/time-programmatically-example.component.html
+++ b/apps/docs/src/app/core/component-docs/time/examples/time-programmatically-example.component.html
@@ -1,4 +1,4 @@
 <fd-time [(ngModel)]="timeObject"></fd-time>
 Selected Time: {{ timeObject.hour }}h {{ timeObject.minute }}m {{ timeObject.second }}s
 
-<button fd-button (click)="change()">Change</button>
+<button fd-button label="Change" (click)="change()"></button>

--- a/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-example.component.html
+++ b/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-example.component.html
@@ -11,11 +11,11 @@
         }}</fd-option>
     </fd-select>
 
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
 
     <fd-checkbox fd-toolbar-item label="Option 1" [tristate]="true"> </fd-checkbox>
 
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
 
     <fd-split-button fd-toolbar-item [compact]="true">
         <ng-template fd-split-button-action-title>
@@ -42,10 +42,10 @@
         <button fd-button label="Right" [compact]="true"></button>
     </fd-segmented-button>
 
-    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
-    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
     <fd-toolbar-spacer fd-toolbar-item [fixed]="true" [width]="'200px'"></fd-toolbar-spacer>
-    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
-    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
-    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
 </fd-toolbar>

--- a/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-example.component.html
+++ b/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-example.component.html
@@ -1,7 +1,7 @@
 <fd-toolbar [shouldOverflow]="true">
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true"></button>
 
     <fd-datetime-picker fd-toolbar-item [compact]="true"></fd-datetime-picker>
 
@@ -34,18 +34,18 @@
         style="max-width: 200px;"
     />
 
-    <button fd-toolbar-item fd-button [fdMenu]="true" [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [fdMenu]="true" [compact]="true"></button>
 
     <fd-segmented-button fd-toolbar-item>
-        <button fd-button [compact]="true">Left</button>
-        <button fd-button [compact]="true">Middle</button>
-        <button fd-button [compact]="true">Right</button>
+        <button fd-button label="Left" [compact]="true"></button>
+        <button fd-button label="Middle" [compact]="true"></button>
+        <button fd-button label="Right" [compact]="true"></button>
     </fd-segmented-button>
 
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
     <fd-toolbar-spacer fd-toolbar-item [fixed]="true" [width]="'200px'"></fd-toolbar-spacer>
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
+    <button fd-toolbar-item fd-button label="Button" [compact]="true">Button</button>
 </fd-toolbar>

--- a/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-grouping-example.component.html
+++ b/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-grouping-example.component.html
@@ -1,10 +1,10 @@
 <fd-toolbar [shouldOverflow]="true">
-    <button fd-toolbar-item fd-button [compact]="true">Button</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="always">Always</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="never">Never</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="1">Gr 1 / Low</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="2">Gr 2 / Low</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="disappear" fdOverflowGroup="2">Gr 2 / Disappear</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="2" >Gr 2 / Low</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="high" fdOverflowGroup="1">Gr 1 / High</button>
+    <button fd-toolbar-item fd-button [compact]="true" label="Button"></button>
+    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="always" label="Always"></button>
+    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="never" label="Never"></button>
+    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="1" label="Gr 1 / Low"></button>
+    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="2" label="Gr 2 / Low"></button>
+    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="disappear" fdOverflowGroup="2" label="Gr 2 / Disappear"></button>
+    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="2" >Gr 2 / Low"></button>
+    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="high" fdOverflowGroup="1" label="Gr 1 / High"></button>
 </fd-toolbar>

--- a/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-grouping-example.component.html
+++ b/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-grouping-example.component.html
@@ -5,6 +5,6 @@
     <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="1" label="Gr 1 / Low"></button>
     <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="2" label="Gr 2 / Low"></button>
     <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="disappear" fdOverflowGroup="2" label="Gr 2 / Disappear"></button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="2" >Gr 2 / Low"></button>
+    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="2" label="Gr 2 / Low">" ></button>
     <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="high" fdOverflowGroup="1" label="Gr 1 / High"></button>
 </fd-toolbar>

--- a/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-priority-example.component.html
+++ b/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-priority-example.component.html
@@ -1,9 +1,9 @@
 <fd-toolbar [shouldOverflow]="true">
-    <button fd-toolbar-item fd-button [compact]="true">Button First</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="always">Always</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="never">Never</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low">Low</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="high">High</button>
-    <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="disappear">Disappear</button>
-    <button fd-toolbar-item fd-button [compact]="true">Button Last</button>
+    <button fd-toolbar-item fd-button label="Button First" [compact]="true"></button>
+    <button fd-toolbar-item fd-button label="Always" [compact]="true" fdOverflowPriority="always"></button>
+    <button fd-toolbar-item fd-button label="Never" [compact]="true" fdOverflowPriority="never"></button>
+    <button fd-toolbar-item fd-button label="Low" [compact]="true" fdOverflowPriority="low"></button>
+    <button fd-toolbar-item fd-button label="High" [compact]="true" fdOverflowPriority="high"></button>
+    <button fd-toolbar-item fd-button label="Disappear" [compact]="true" fdOverflowPriority="disappear"></button>
+    <button fd-toolbar-item fd-button label="Button Last" [compact]="true"></button>
 </fd-toolbar>

--- a/apps/docs/src/app/documentation/core-helpers/api/api.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/api/api.component.html
@@ -4,9 +4,9 @@
 
     <button *ngIf="files.length > 1"
             fd-button
+            [label]="'Select a file (' + files.length + ')'"
             [fdMenu]="true"
             [fdMenuTrigger]="menu">
-        Select a file ({{ files.length }})
     </button>
 
     <fd-menu #menu

--- a/apps/docs/src/app/documentation/core-helpers/code-example/code-example.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/code-example/code-example.component.html
@@ -1,11 +1,24 @@
 <div class="docs-code-example-toolbar">
-    <button fd-button [glyph]="expandIcon" (click)="isOpen = !isOpen">{{ isOpen ? 'Hide' : 'Show' }} Code</button>
+    <button fd-button
+            [glyph]="expandIcon"
+            [label]="(isOpen ? 'Hide' : 'Show') + ' Code'"
+            (click)="isOpen = !isOpen">
+    </button>
     <div>
-        <button fd-button glyph="copy" title="Copy example to clipboard" (click)="copyText()" *ngIf="isOpen" style="margin-right: 1rem;">
-            Copy
+        <button fd-button
+                glyph="copy"
+                title="Copy example to clipboard"
+                label="Copy"
+                style="margin-right: 1rem;"
+                *ngIf="isOpen"
+                (click)="copyText()">
         </button>
-        <button fd-button glyph="play" title="Open code in stackblitz" (click)="openStackBlitz()" *ngIf="isOpen">
-            StackBlitz
+        <button fd-button
+                glyph="play"
+                title="Open code in stackblitz"
+                label="StackBlitz"
+                *ngIf="isOpen"
+                (click)="openStackBlitz()" >
         </button>
     </div>
 </div>

--- a/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.html
@@ -6,7 +6,6 @@
             glyph="menu2"
             aria-label="Switch Navigation"
             (click)="this.btnClicked.emit()"></button>
-
     <fd-shellbar-logo>
         <a aria-label="Home"
            class="fd-shellbar__logo fd-docs--toolbar__home-logo"

--- a/libs/core/src/lib/alert/alert.component.html
+++ b/libs/core/src/lib/alert/alert.component.html
@@ -1,6 +1,7 @@
 <button
     class="fd-alert__close"
     fd-button
+    glyph="decline"
     [compact]="true"
     [fdType]="'transparent'"
     *ngIf="dismissible"

--- a/libs/core/src/lib/alert/alert.component.scss
+++ b/libs/core/src/lib/alert/alert.component.scss
@@ -2,6 +2,13 @@
 
 .fd-alert {
     display: block;
+
+    &__close {
+        &::before,
+        &::after {
+            content: none
+        }
+    }
 }
 
 .fd-has-display-block {

--- a/libs/core/src/lib/button/button.component.html
+++ b/libs/core/src/lib/button/button.component.html
@@ -1,0 +1,22 @@
+<ng-container *ngIf="glyphPosition === 'before' && glyph">
+    <ng-container *ngTemplateOutlet="iconTemplate"></ng-container>
+</ng-container>
+
+<span class="fd-button__text" *ngIf="label">
+    {{label}}
+</span>
+
+<ng-content></ng-content>
+
+<ng-container *ngIf="glyphPosition === 'after' && glyph">
+    <ng-container *ngTemplateOutlet="iconTemplate"></ng-container>
+</ng-container>
+
+<fd-icon glyph="slim-arrow-down" *ngIf="fdMenu" role="presentation"></fd-icon>
+
+<ng-template #iconTemplate>
+    <fd-icon
+        role="presentation"
+        [glyph]="glyph">
+    </fd-icon>
+</ng-template>

--- a/libs/core/src/lib/button/button.component.html
+++ b/libs/core/src/lib/button/button.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="glyphPosition === 'before' && glyph">
-    <ng-container *ngTemplateOutlet="iconTemplate"></ng-container>
+    <fd-icon [glyph]="glyph"></fd-icon>
 </ng-container>
 
 <span class="fd-button__text" *ngIf="label">
@@ -9,14 +9,7 @@
 <ng-content></ng-content>
 
 <ng-container *ngIf="glyphPosition === 'after' && glyph">
-    <ng-container *ngTemplateOutlet="iconTemplate"></ng-container>
+    <fd-icon [glyph]="glyph"></fd-icon>
 </ng-container>
 
-<fd-icon glyph="slim-arrow-down" *ngIf="fdMenu" role="presentation"></fd-icon>
-
-<ng-template #iconTemplate>
-    <fd-icon
-        role="presentation"
-        [glyph]="glyph">
-    </fd-icon>
-</ng-template>
+<fd-icon glyph="slim-arrow-down" *ngIf="fdMenu"></fd-icon>

--- a/libs/core/src/lib/button/button.component.scss
+++ b/libs/core/src/lib/button/button.component.scss
@@ -1,1 +1,11 @@
 @import '~fundamental-styles/dist/button';
+
+// TODO: Remove after adding flex to buttons on fundamental-styles library
+.fd-button--menu {
+    display: inline-flex;
+    align-items: center;
+
+    .fd-button__text {
+        line-height: 1;
+    }
+}

--- a/libs/core/src/lib/button/button.component.scss
+++ b/libs/core/src/lib/button/button.component.scss
@@ -6,6 +6,6 @@
     align-items: center;
 
     .fd-button__text {
-        line-height: 1;
+        line-height: 1rem;
     }
 }

--- a/libs/core/src/lib/button/button.component.spec.ts
+++ b/libs/core/src/lib/button/button.component.spec.ts
@@ -33,14 +33,15 @@ describe('ButtonComponent', () => {
         expect(component).toBeTruthy();
     });
 
-    it('should add appropriate classes', () => {
+   it('should add appropriate classes', () => {
         componentInstance.compact = true;
-        componentInstance.glyph = 'someGlyph';
         componentInstance.fdType = 'standard';
+        componentInstance.fdMenu = true;
         componentInstance.buildComponentCssClass();
 
         const cssClass = componentInstance.buildComponentCssClass().join(' ');
-        expect(cssClass).toContain('someGlyph');
         expect(cssClass).toContain('standard');
+        expect(cssClass).toContain('fd-button--menu');
+        expect(cssClass).toContain('compact');
     });
 });

--- a/libs/core/src/lib/button/button.component.spec.ts
+++ b/libs/core/src/lib/button/button.component.spec.ts
@@ -5,7 +5,7 @@ import { By } from '@angular/platform-browser';
 
 @Component({
     selector: 'fd-test-component',
-    template: '<button fd-button>Button</button>'
+    template: '<button fd-button label="Button"></button>'
 })
 export class TestComponent {}
 

--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -2,12 +2,11 @@ import {
     ChangeDetectionStrategy,
     Component,
     ElementRef,
+    HostBinding,
     Input,
-    ViewEncapsulation,
     OnChanges,
     OnInit,
-    HostBinding,
-    ViewChild
+    ViewEncapsulation
 } from '@angular/core';
 import { applyCssClass, CssClassBuilder } from '../utils/public_api';
 
@@ -93,10 +92,6 @@ export class ButtonComponent implements OnChanges, CssClassBuilder, OnInit {
      */
     @Input()
     public fdMenu = false;
-
-    /** @hidden */
-    @ViewChild('textElementRef')
-    textElementRef: ElementRef;
 
     /** @hidden */
     constructor(private _elementRef: ElementRef) {}

--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -5,9 +5,14 @@ import {
     Input,
     ViewEncapsulation,
     OnChanges,
-    OnInit, HostBinding
+    OnInit,
+    HostBinding,
+    ViewChild
 } from '@angular/core';
 import { applyCssClass, CssClassBuilder } from '../utils/public_api';
+
+export type GlyphPosition = 'before' | 'after';
+
 
 export type ButtonType =
     | ''
@@ -27,7 +32,7 @@ export type ButtonType =
  * ``` selector: button[fd-button], a[fd-button] ```
  *
  * ```html
- * <button fd-button>Button Text</button>
+ * <button fd-button [label]="'Button Text'"></button>
  * <a fd-button>Button Text</a>
  * ```
  */
@@ -35,7 +40,7 @@ export type ButtonType =
     // tslint:disable-next-line:component-selector
     selector: 'button[fd-button], a[fd-button]',
     exportAs: 'fd-button',
-    template: ` <ng-content></ng-content> `,
+    templateUrl: './button.component.html',
     styleUrls: ['./button.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -48,10 +53,13 @@ export class ButtonComponent implements OnChanges, CssClassBuilder, OnInit {
     @HostBinding('attr.type')
     type = 'button';
 
-    /** The property allows user to pass additional css classes
-     */
+    /** The property allows user to pass additional css classes*/
     @Input()
     public class = '';
+
+    /** Position of glyph related to text */
+    @Input()
+    public glyphPosition: GlyphPosition = 'before';
 
     /** The icon to include in the button. See the icon page for the list of icons.
      * Setter is used to control when css class have to be rebuilded.
@@ -74,11 +82,21 @@ export class ButtonComponent implements OnChanges, CssClassBuilder, OnInit {
     @Input()
     public fdType: ButtonType = 'standard';
 
+    /**
+     * Text rendered inside button component
+     */
+    @Input()
+    label: string;
+
     /** Whether to apply menu mode to the button.
      * Default value is set to false
      */
     @Input()
     public fdMenu = false;
+
+    /** @hidden */
+    @ViewChild('textElementRef')
+    textElementRef: ElementRef;
 
     /** @hidden */
     constructor(private _elementRef: ElementRef) {}
@@ -106,7 +124,6 @@ export class ButtonComponent implements OnChanges, CssClassBuilder, OnInit {
             this.fdType ? `fd-button--${this.fdType}` : '',
             this.compact ? 'fd-button--compact' : '',
             this.fdMenu ? `fd-button--menu` : '',
-            this.glyph ? `sap-icon--${this.glyph}` : '',
             this.class
         ];
     }

--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -32,7 +32,7 @@ export type ButtonType =
  *
  * ```html
  * <button fd-button [label]="'Button Text'"></button>
- * <a fd-button>Button Text</a>
+ * <a fd-button [label]="'Button Text'"></a>
  * ```
  */
 @Component({

--- a/libs/core/src/lib/button/button.module.ts
+++ b/libs/core/src/lib/button/button.module.ts
@@ -2,9 +2,10 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { ButtonComponent } from './button.component';
+import { IconModule } from '../icon/icon.module';
 
 @NgModule({
-    imports: [CommonModule],
+    imports: [CommonModule, IconModule],
     exports: [ButtonComponent],
     declarations: [ButtonComponent]
 })

--- a/libs/core/src/lib/calendar/calendar-header/calendar-header.component.html
+++ b/libs/core/src/lib/calendar/calendar-header/calendar-header.component.html
@@ -43,7 +43,7 @@
                     fd-button
                     [compact]="compact"
                     [fdType]="'transparent'"
-                    [label]="currentlyDisplayed.year + ' - ' + currentlyDisplayed.year + amountOfYearsPerPeriod()"
+                    [label]="currentlyDisplayed.year + ' - ' + (currentlyDisplayed.year + amountOfYearsPerPeriod())"
                     [attr.aria-label]="calendarI18nLabels.yearSelectionLabel + ' ' + currentlyDisplayed.year"
                     (click)="processViewChange('aggregatedYear', $event)"
                     type="button">

--- a/libs/core/src/lib/calendar/calendar-header/calendar-header.component.html
+++ b/libs/core/src/lib/calendar/calendar-header/calendar-header.component.html
@@ -17,25 +17,23 @@
             <div class="fd-calendar__action">
                 <button
                     fd-button
+                    type="button"
                     [compact]="compact"
                     [fdType]="'transparent'"
+                    [label]="monthLabel"
                     [attr.aria-label]="calendarI18nLabels.monthSelectionLabel + ' ' + monthLabel"
-                    (click)="processViewChange('month', $event)"
-                    type="button"
-                >
-                    {{ monthLabel }}
+                    (click)="processViewChange('month', $event)">
                 </button>
             </div>
             <div class="fd-calendar__action">
                 <button
                     fd-button
+                    type="button"
                     [compact]="compact"
                     [fdType]="'transparent'"
+                    [label]="currentlyDisplayed.year"
                     [attr.aria-label]="calendarI18nLabels.yearSelectionLabel + ' ' + currentlyDisplayed.year"
-                    (click)="processViewChange('year', $event)"
-                    type="button"
-                >
-                    {{ currentlyDisplayed.year }}
+                    (click)="processViewChange('year', $event)">
                 </button>
             </div>
         </ng-container>
@@ -45,12 +43,10 @@
                     fd-button
                     [compact]="compact"
                     [fdType]="'transparent'"
+                    [label]="currentlyDisplayed.year + ' - ' + currentlyDisplayed.year + amountOfYearsPerPeriod()"
                     [attr.aria-label]="calendarI18nLabels.yearSelectionLabel + ' ' + currentlyDisplayed.year"
                     (click)="processViewChange('aggregatedYear', $event)"
-                    type="button"
-                >
-                    {{ currentlyDisplayed.year }} -
-                    {{ currentlyDisplayed.year + amountOfYearsPerPeriod() }}
+                    type="button">
                 </button>
             </div>
         </ng-container>

--- a/libs/core/src/lib/combobox/combobox-mobile/combobox-mobile.component.html
+++ b/libs/core/src/lib/combobox/combobox-mobile/combobox-mobile.component.html
@@ -25,9 +25,8 @@
                 <button fd-button
                         fdType="emphasized"
                         fd-dialog-decisive-button
-                        (click)="handleApprove()"
-                >
-                    {{mobileConfig?.approveButtonText}}
+                        [label]="mobileConfig?.approveButtonText"
+                        (click)="handleApprove()">
                 </button>
             </fd-dialog-footer-button>
 
@@ -35,9 +34,8 @@
                 <button fd-button
                         fdType="transparent"
                         fd-dialog-decisive-button
-                        (click)="handleDismiss()"
-                >
-                    {{mobileConfig?.cancelButtonText}}
+                        [label]="mobileConfig?.cancelButtonText"
+                        (click)="handleDismiss()">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -75,10 +75,10 @@
                 <div fd-bar barDesign="footer" [cosy]="!compact">
                     <div fd-bar-right>
                         <fd-bar-element>
-                            <button fd-button fdType="emphasized" [compact]="compact" (click)="submit()">Submit</button>
+                            <button fd-button fdType="emphasized" label="Submit" [compact]="compact" (click)="submit()"></button>
                         </fd-bar-element>
                         <fd-bar-element>
-                            <button fd-button [compact]="compact" (click)="cancel()">Cancel</button>
+                            <button fd-button [compact]="compact" label="Cancel" (click)="cancel()"></button>
                         </fd-bar-element>
                     </div>
                 </div>

--- a/libs/core/src/lib/dialog/default-dialog/default-dialog.component.html
+++ b/libs/core/src/lib/dialog/default-dialog/default-dialog.component.html
@@ -23,9 +23,8 @@
                 fdType="emphasized"
                 fd-dialog-decisive-button
                 [compact]="true"
-                (click)="approveButtonClicked()"
-            >
-                {{defaultDialogConfig?.approveButton}}
+                [label]="defaultDialogConfig?.approveButton"
+                (click)="approveButtonClicked()">
             </button>
         </fd-dialog-footer-button>
 
@@ -35,9 +34,8 @@
                 fdType="transparent"
                 fd-dialog-decisive-button
                 [compact]="true"
-                (click)="cancelButtonClicked()"
-            >
-                {{defaultDialogConfig?.cancelButton}}
+                [label]="defaultDialogConfig?.cancelButton"
+                (click)="cancelButtonClicked()">
             </button>
         </fd-dialog-footer-button>
     </fd-dialog-footer>

--- a/libs/core/src/lib/dialog/dialog-utils/dialog-directives.ts
+++ b/libs/core/src/lib/dialog/dialog-utils/dialog-directives.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { Component, Directive, Input } from '@angular/core';
 
 /**
  * Directive that applies fundamental dialog styling to a header.
@@ -23,16 +23,16 @@ export class DialogTitleDirective {}
  * <button fd-dialog-close-button></button>
  * ```
  */
-@Directive({
-    // tslint:disable-next-line:directive-selector
+@Component({
+    // tslint:disable-next-line:component-selector
     selector: '[fd-dialog-close-button]',
     host: {
         'attr.aria-label': 'close',
         '[class.fd-button]': 'true',
         '[class.fd-button--compact]': '!mobile',
         '[class.fd-button--transparent]': 'true',
-        '[class.sap-icon--decline]': 'true'
-    }
+    },
+    template: `<fd-icon glyph="decline"></fd-icon><ng-content></ng-content>`
 })
 export class DialogCloseButtonDirective {
 

--- a/libs/core/src/lib/file-uploader/file-uploader.component.html
+++ b/libs/core/src/lib/file-uploader/file-uploader.component.html
@@ -33,9 +33,8 @@
         [attr.aria-label]="buttonAriaLabel"
         class="file-uploader__button"
         (click)="open()"
-        [compact]="compact"
-    >
-        {{ buttonLabel }}
+        [label]="buttonLabel"
+        [compact]="compact">
     </button>
     <ng-content select="[fd-form-control]"></ng-content>
 </div>

--- a/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.html
+++ b/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.html
@@ -42,8 +42,8 @@
                         id="menu-mobile-approve-button"
                         fdType="emphasized"
                         fd-dialog-decisive-button
+                        [label]="mobileConfig.approveButtonText"
                         (click)="close()">
-                    {{mobileConfig.approveButtonText}}
                 </button>
             </fd-dialog-footer-button>
 
@@ -52,8 +52,8 @@
                         id="menu-mobile-cancel-button"
                         fdType="transparent"
                         fd-dialog-decisive-button
+                        [label]="mobileConfig.cancelButtonText"
                         (click)="close()">
-                    {{mobileConfig.cancelButtonText}}
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>

--- a/libs/core/src/lib/message-strip/message-strip.component.html
+++ b/libs/core/src/lib/message-strip/message-strip.component.html
@@ -1,6 +1,7 @@
 <button
     class="fd-message-strip__close"
     fd-button
+    glyph="decline"
     [compact]="true"
     [fdType]="'transparent'"
     *ngIf="dismissible"

--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.html
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.html
@@ -29,9 +29,8 @@
                 <button fd-button
                         fdType="emphasized"
                         fd-dialog-decisive-button
-                        (click)="handleApprove()"
-                >
-                    {{mobileConfig?.approveButtonText}}
+                        [label]="mobileConfig?.approveButtonText"
+                        (click)="handleApprove()">
                 </button>
             </fd-dialog-footer-button>
 
@@ -39,9 +38,8 @@
                 <button fd-button
                         fdType="transparent"
                         fd-dialog-decisive-button
-                        (click)="handleDismiss()"
-                >
-                    {{mobileConfig?.cancelButtonText}}
+                        [label]="mobileConfig?.cancelButtonText"
+                        (click)="handleDismiss()">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>

--- a/libs/core/src/lib/notification/notification-utils/default-notification/default-notification.component.html
+++ b/libs/core/src/lib/notification/notification-utils/default-notification/default-notification.component.html
@@ -22,25 +22,26 @@
         </div>
     </div>
     <fd-notification-footer>
-        <button fd-button [fdType]="'transparent'" *ngIf="defaultConfigurationNotification?.moreInfo">
-            {{ defaultConfigurationNotification?.moreInfo }}
+        <button fd-button
+                [label]="defaultConfigurationNotification?.moreInfo"
+                [fdType]="'transparent'"
+                *ngIf="defaultConfigurationNotification?.moreInfo">
         </button>
         <div fd-notification-actions>
             <button
                 fd-button
                 [fdType]="'positive'"
+                [label]="defaultConfigurationNotification?.approve"
                 *ngIf="defaultConfigurationNotification?.approve"
-                (click)="handleApproveButtonClick()"
-            >
-                {{ defaultConfigurationNotification?.approve }}
+                (click)="handleApproveButtonClick()">
             </button>
             <button
                 fd-button
                 [fdType]="'negative'"
+                [label]="defaultConfigurationNotification?.cancel"
                 *ngIf="defaultConfigurationNotification?.cancel"
                 (click)="handleCancelButtonClick()"
             >
-                {{ defaultConfigurationNotification?.cancel }}
             </button>
         </div>
     </fd-notification-footer>

--- a/libs/core/src/lib/panel/panel.component.html
+++ b/libs/core/src/lib/panel/panel.component.html
@@ -4,6 +4,7 @@
             fd-button
             fdType="transparent"
             class="fd-panel__button"
+            [glyph]="expanded ? 'slim-arrow-down' : 'slim-arrow-right'"
             [id]="expandId"
             [compact]="compact"
             [class.is-expanded]="expanded"

--- a/libs/core/src/lib/select/select-mobile/select-mobile.component.html
+++ b/libs/core/src/lib/select/select-mobile/select-mobile.component.html
@@ -16,14 +16,16 @@
 
         <fd-dialog-footer *ngIf="mobileConfig.approveButtonText || mobileConfig.cancelButtonText">
             <fd-dialog-footer-button *ngIf="mobileConfig.approveButtonText">
-                <button fd-button fdType="emphasized" fd-dialog-decisive-button (click)="approve()">
-                    {{mobileConfig.approveButtonText}}
+                <button fd-button fdType="emphasized" fd-dialog-decisive-button [label]="mobileConfig.approveButtonText" (click)="approve()">
                 </button>
             </fd-dialog-footer-button>
 
             <fd-dialog-footer-button *ngIf="mobileConfig.cancelButtonText">
-                <button fd-button fdType="transparent" fd-dialog-decisive-button (click)="cancel()">
-                    {{mobileConfig.cancelButtonText}}
+                <button fd-button
+                        fd-dialog-decisive-button
+                        fdType="transparent"
+                        [label]="mobileConfig.cancelButtonText"
+                        (click)="cancel()">
                 </button>
             </fd-dialog-footer-button>
         </fd-dialog-footer>

--- a/libs/core/src/lib/split-button/split-button.component.html
+++ b/libs/core/src/lib/split-button/split-button.component.html
@@ -1,14 +1,13 @@
 <div class="fd-button-split fd-has-margin-right-small" role="group" aria-label="button-split" [fdMenuTrigger]="menu">
     <button fd-button #mainActionButton
+            [label]="mainActionTitle"
             [ngStyle]="{width: mainButtonWidth}"
             [fdType]="fdType"
             [compact]="compact"
             [disabled]="disabled"
             (click)="onMainButtonClick($event)">
 
-        <ng-container *ngTemplateOutlet="titleTemplate || buttonTitle"></ng-container>
-
-        <ng-template #buttonTitle>{{ mainActionTitle }}</ng-template>
+        <ng-container *ngTemplateOutlet="titleTemplate"></ng-container>
 
     </button>
 

--- a/libs/core/src/lib/split-button/split-button.component.scss
+++ b/libs/core/src/lib/split-button/split-button.component.scss
@@ -1,1 +1,13 @@
 @import '~fundamental-styles/dist/button-split';
+
+// TODO: Remove after fix on styles https://github.com/SAP/fundamental-styles/issues/1721
+.fd-button-split {
+    .fd-button {
+        display: flex;
+        align-items: center;
+
+        &__text {
+            display: inline-block;
+        }
+    }
+}

--- a/libs/core/src/lib/time/time-column/time-column.component.html
+++ b/libs/core/src/lib/time/time-column/time-column.component.html
@@ -1,6 +1,9 @@
 <label class="fd-time__slider-label">{{timeConfig?.label}}</label>
-<button class="fd-button fd-button fd-button--transparent sap-icon--navigation-up-arrow"
-        *ngIf="active && spinners"
+<button *ngIf="active && spinners"
+        fd-button
+        fdType="transparent"
+        glyph="navigation-up-arrow"
+        [compact]="compact"
         [attr.aria-label]="timeConfig?.decreaseLabel"
         (keydown)="spinnerButtonKeydownHandle($event, true)"
         (click)="scrollUp($event)"></button>
@@ -34,8 +37,11 @@
             {{activeValue | twoDigits: keepTwoDigits}}
     </span>
 </div>
-<button class="fd-button fd-button fd-button--transparent sap-icon--navigation-down-arrow"
-        *ngIf="active && spinners"
+<button *ngIf="active && spinners"
+        fd-button
+        fdType="transparent"
+        glyph="navigation-down-arrow"
+        [compact]="compact"
         [attr.aria-label]="timeConfig?.increaseLabel"
         (keydown)="spinnerButtonKeydownHandle($event)"
         (click)="scrollDown()">

--- a/src/stories/toolbar/fd-toolbar.stories.ts
+++ b/src/stories/toolbar/fd-toolbar.stories.ts
@@ -74,7 +74,7 @@ export const ToolbarWithSegmentedButtonAndMenuButton = () => ({
         <fd-select fd-toolbar-item [compact]="true" placeholder="Select an option" [closeOnOutsideClick]="false">
             <fd-option *ngFor="let option of ['Apple', 'Pineapple', 'Tomato', 'Strawberry']" [value]="option">{{option}}</fd-option>
         </fd-select>
-        
+
         <button fd-toolbar-item fd-button [compact]="true">Button</button>
 
         <fd-checkbox fd-toolbar-item label="Option 1" [tristate]="true"> </fd-checkbox>
@@ -86,18 +86,18 @@ export const ToolbarWithSegmentedButtonAndMenuButton = () => ({
                 Action
             </ng-template>
         </fd-split-button>
-      
+
         <label fd-toolbar-item fd-toolbar-label fd-form-label for="input-1">Default Input</label>
         <input [compact]="true" fd-toolbar-item fd-form-control type="text" id="input-1" placeholder="Field placeholder text" style="max-width:200px"/>
 
-        <button fd-toolbar-item fd-button [fdMenu]="true" [compact]="true">Button</button>
-        
+        <button fd-toolbar-item label="Button" fd-button [fdMenu]="true" [compact]="true"></button>
+
         <fd-segmented-button fd-toolbar-item>
             <button fd-button [compact]="true">Left</button>
             <button fd-button [compact]="true">Middle</button>
             <button fd-button [compact]="true">Right</button>
         </fd-segmented-button>
-        
+
         <button fd-toolbar-item fd-button [compact]="true">Button</button>
         <button fd-toolbar-item fd-button [compact]="true">Button</button>
         <fd-toolbar-spacer fd-toolbar-item [fixed]="true" [width]="'200px'"></fd-toolbar-spacer>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3370

#### Please provide a brief summary of this pull request.
There is new way to add text inside button component. The `[label]` property should be used now instead of adding text as a content. The content still works fine, unless it's used with icons.

BREAKING CHANGE:

The value for the text button is now passed as an input property, not as content projection.

Before: `<button fd-button>Text</button>`
After: `<button fd-button [label]="'Text'"></button`
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

