### PR TITLE
fix: bring temporary the old styling of Notifications

### DIFF
--- a/libs/core/src/lib/notification/notification/notification.component.scss
+++ b/libs/core/src/lib/notification/notification/notification.component.scss
@@ -1,5 +1,621 @@
-@import '~fundamental-styles/dist/notification';
+// @import '~fundamental-styles/dist/notification';
 
 .fd-notification-custom-block {
     display: block;
+}
+
+.fd-notification {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    max-width: 60rem;
+    background-color: #fff;
+    background-color: var(--sapList_Background, #fff);
+    -webkit-box-shadow: 0 0 0 0.0625rem rgba(0, 0, 0, 0.1), 0 0.125rem 0.5rem 0 rgba(0, 0, 0, 0.1);
+    -webkit-box-shadow: var(
+        --sapContent_Shadow0,
+        0 0 0 0.0625rem rgba(0, 0, 0, 0.1),
+        0 0.125rem 0.5rem 0 rgba(0, 0, 0, 0.1)
+    );
+    box-shadow: 0 0 0 0.0625rem rgba(0, 0, 0, 0.1), 0 0.125rem 0.5rem 0 rgba(0, 0, 0, 0.1);
+    box-shadow: var(--sapContent_Shadow0, 0 0 0 0.0625rem rgba(0, 0, 0, 0.1), 0 0.125rem 0.5rem 0 rgba(0, 0, 0, 0.1));
+    border-radius: 0.25rem;
+    border-left: 0.375rem solid;
+    border-left-color: #6a6d70;
+    border-left-color: var(--sapNeutralBorderColor, #6a6d70);
+    margin-bottom: 0.5rem;
+}
+.fd-notification::after,
+.fd-notification::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification[dir='rtl'],
+[dir='rtl'] .fd-notification {
+    border-left: none;
+    border-right: 0.375rem solid;
+    border-right-color: #6a6d70;
+    border-right-color: var(--sapNeutralBorderColor, #6a6d70);
+}
+.fd-notification__header {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-shadow: inset 0 -0.0625rem #d9d9d9;
+    -webkit-box-shadow: inset 0 -0.0625rem var(--sapPageHeader_BorderColor, #d9d9d9);
+    box-shadow: inset 0 -0.0625rem #d9d9d9;
+    box-shadow: inset 0 -0.0625rem var(--sapPageHeader_BorderColor, #d9d9d9);
+}
+.fd-notification__header::after,
+.fd-notification__header::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__indicator {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+}
+.fd-notification__indicator::after,
+.fd-notification__indicator::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__indicator--error {
+    margin: 1px 0 0 0;
+    padding: 1rem 0.5rem 0 1rem;
+    font-family: SAP-icons;
+    color: #b00;
+    color: var(--sapErrorColor, #b00);
+}
+.fd-notification__indicator--error[dir='rtl'],
+[dir='rtl'] .fd-notification__indicator--error {
+    padding: 1rem 1rem 0 0.5rem;
+}
+.fd-notification__indicator--error::before {
+    font-family: SAP-icons;
+    text-align: center;
+    text-decoration: inherit;
+    text-transform: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+.fd-notification__indicator--error::before {
+    content: '';
+}
+.fd-notification__indicator--success {
+    margin: 1px 0 0 0;
+    padding: 1rem 0.5rem 0 1rem;
+    font-family: SAP-icons;
+    color: #107e3e;
+    color: var(--sapSuccessColor, #107e3e);
+}
+.fd-notification__indicator--success[dir='rtl'],
+[dir='rtl'] .fd-notification__indicator--success {
+    padding: 1rem 1rem 0 0.5rem;
+}
+.fd-notification__indicator--success::before {
+    font-family: SAP-icons;
+    text-align: center;
+    text-decoration: inherit;
+    text-transform: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+.fd-notification__indicator--success::before {
+    content: '';
+}
+.fd-notification__indicator--warning {
+    margin: 1px 0 0 0;
+    padding: 1rem 0.5rem 0 1rem;
+    font-family: SAP-icons;
+    color: #e9730c;
+    color: var(--sapWarningColor, #e9730c);
+}
+.fd-notification__indicator--warning[dir='rtl'],
+[dir='rtl'] .fd-notification__indicator--warning {
+    padding: 1rem 1rem 0 0.5rem;
+}
+.fd-notification__indicator--warning::before {
+    font-family: SAP-icons;
+    text-align: center;
+    text-decoration: inherit;
+    text-transform: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+.fd-notification__indicator--warning::before {
+    content: '';
+}
+.fd-notification__indicator--information {
+    margin: 1px 0 0 0;
+    padding: 1rem 0.5rem 0 1rem;
+    font-family: SAP-icons;
+    color: #0a6ed1;
+    color: var(--sapInformationColor, #0a6ed1);
+}
+.fd-notification__indicator--information[dir='rtl'],
+[dir='rtl'] .fd-notification__indicator--information {
+    padding: 1rem 1rem 0 0.5rem;
+}
+.fd-notification__indicator--information::before {
+    font-family: SAP-icons;
+    text-align: center;
+    text-decoration: inherit;
+    text-transform: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+.fd-notification__indicator--information::before {
+    content: '';
+}
+.fd-notification__title {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    color: #32363a;
+    color: var(--sapGroup_TitleTextColor, #32363a);
+    padding: 1rem 0;
+    margin-right: 1rem;
+    font-weight: 700;
+    width: 100%;
+}
+.fd-notification__title::after,
+.fd-notification__title::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__title[dir='rtl'],
+[dir='rtl'] .fd-notification__title {
+    margin-right: 0;
+    margin-left: 1rem;
+}
+.fd-notification__title:first-child {
+    padding-left: 1rem;
+}
+.fd-notification__title:first-child[dir='rtl'],
+[dir='rtl'] .fd-notification__title:first-child {
+    padding-left: 0;
+    padding-right: 1rem;
+}
+.fd-notification__close {
+    position: relative;
+    top: 0.45rem;
+    right: 0.45rem;
+}
+.fd-notification__close[dir='rtl'],
+[dir='rtl'] .fd-notification__close {
+    right: -0.45rem;
+}
+.fd-notification__body {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: end;
+    -ms-flex-align: end;
+    align-items: flex-end;
+    width: 100%;
+}
+.fd-notification__body::after,
+.fd-notification__body::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__content {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    padding: 1rem;
+    width: 60%;
+}
+.fd-notification__content::after,
+.fd-notification__content::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__avatar {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    margin-right: 1rem;
+    min-width: 2rem;
+    min-height: 2rem;
+}
+.fd-notification__avatar::after,
+.fd-notification__avatar::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__avatar[dir='rtl'],
+[dir='rtl'] .fd-notification__avatar {
+    margin-right: 0;
+    margin-left: 1rem;
+}
+.fd-notification__text {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    width: 100%;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    padding-right: 1rem;
+}
+.fd-notification__text::after,
+.fd-notification__text::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__description {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    position: relative;
+    line-height: 1.45em;
+    max-height: 2.9em;
+    overflow: hidden;
+    margin-right: -1em;
+    padding-right: 1em;
+    color: #6a6d70;
+    color: var(--sapContent_LabelColor, #6a6d70);
+}
+.fd-notification__description::after,
+.fd-notification__description::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__description::before {
+    position: absolute;
+    content: '...';
+    right: 0;
+    bottom: 1px;
+}
+.fd-notification__description::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    width: 1em;
+    height: 1em;
+    margin-top: 0.2em;
+    background: #fff;
+    background: var(--sapList_Background, #fff);
+}
+.fd-notification__metadata {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    color: #6a6d70;
+    color: var(--sapContent_LabelColor, #6a6d70);
+    margin-top: 0.375rem;
+}
+.fd-notification__metadata::after,
+.fd-notification__metadata::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__footer {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    width: 40%;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: justify;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
+    padding: 0 0.5rem 0.5rem 1rem;
+}
+.fd-notification__footer::after,
+.fd-notification__footer::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__footer > :not(:last-child) {
+    margin: 0.25rem;
+}
+.fd-notification__actions {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    margin-left: auto;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+}
+.fd-notification__actions::after,
+.fd-notification__actions::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-notification__actions > * {
+    margin: 0.25rem;
+}
+.fd-notification__actions[dir='rtl'],
+[dir='rtl'] .fd-notification__actions {
+    margin-left: 0;
+}
+.fd-notification--error {
+    border-left-color: #b00;
+    border-left-color: var(--sapErrorBorderColor, #b00);
+}
+.fd-notification--error[dir='rtl'],
+[dir='rtl'] .fd-notification--error {
+    border-right-color: #b00;
+    border-right-color: var(--sapErrorBorderColor, #b00);
+}
+.fd-notification--success {
+    border-left-color: #107e3e;
+    border-left-color: var(--sapSuccessBorderColor, #107e3e);
+}
+.fd-notification--success[dir='rtl'],
+[dir='rtl'] .fd-notification--success {
+    border-right-color: #107e3e;
+    border-right-color: var(--sapSuccessBorderColor, #107e3e);
+}
+.fd-notification--warning {
+    border-left-color: #e9730c;
+    border-left-color: var(--sapWarningBorderColor, #e9730c);
+}
+.fd-notification--warning[dir='rtl'],
+[dir='rtl'] .fd-notification--warning {
+    border-right-color: #e9730c;
+    border-right-color: var(--sapWarningBorderColor, #e9730c);
+}
+.fd-notification--information {
+    border-left-color: #0a6ed1;
+    border-left-color: var(--sapInformationBorderColor, #0a6ed1);
+}
+.fd-notification--information[dir='rtl'],
+[dir='rtl'] .fd-notification--information {
+    border-right-color: #0a6ed1;
+    border-right-color: var(--sapInformationBorderColor, #0a6ed1);
+}
+.fd-notification--m .fd-notification__body,
+.fd-notification--s .fd-notification__body {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-box-align: start;
+    -ms-flex-align: start;
+    align-items: flex-start;
+    width: 100%;
+}
+.fd-notification--m .fd-notification__content,
+.fd-notification--s .fd-notification__content {
+    width: 100%;
+    padding: 1rem 1rem 0.5rem 1rem;
+}
+.fd-notification--m .fd-notification__content:last-child,
+.fd-notification--s .fd-notification__content:last-child {
+    padding-bottom: 1rem;
+}
+.fd-notification--m .fd-notification__footer,
+.fd-notification--s .fd-notification__footer {
+    width: 100%;
+}
+.fd-notification--m {
+    max-width: 640px;
+    min-width: 320px;
+}
+.fd-notification--s {
+    width: 320px;
+}
+.fd-notification--group > * {
+    border-radius: 0;
+}
+.fd-notification--group > :not(:first-child) .fd-notification__header {
+    -webkit-box-shadow: none;
+    box-shadow: none;
+}
+.fd-notification--group .fd-notification {
+    margin-bottom: 0;
+}
+.fd-notification--group .fd-notification:first-child {
+    border-radius: 0.25rem 0.25rem 0 0;
+}
+.fd-notification--group .fd-notification:last-child {
+    border-radius: 0 0 0.25rem 0.25rem;
+}
+.fd-notification--group .fd-notification:only-child {
+    border-radius: 0.25rem;
+}
+.fd-notification--group .fd-notification__content {
+    padding-top: 0.75rem;
+    padding-bottom: 0.5rem;
+}
+.fd-notification--group .fd-notification__title {
+    padding: 0.75rem 0;
+}
+.fd-notification--group .fd-notification__close {
+    top: 0.1875rem;
+    right: 0.1875rem;
+}
+.fd-notification--group[dir='rtl'] .fd-notification__close,
+[dir='rtl'] .fd-notification--group .fd-notification__close {
+    right: -0.1875rem;
+}
+.fd-notification--group .fd-notification__indicator--error,
+.fd-notification--group .fd-notification__indicator--information,
+.fd-notification--group .fd-notification__indicator--success,
+.fd-notification--group .fd-notification__indicator--warning {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of [#3420](https://github.com/SAP/fundamental-ngx/issues/3420)

#### Please provide a brief summary of this pull request.
Notifications have been completely refactored in 0.12.0 version of Fundamental-styles. Temporary we are bringing back the old styling in ngx so we can release 0.22.0 in ngx and later work on adopting the new styling and markup of Notifications

