### PR TITLE
docs: align vertically the GitHub icon in documentation shellbar

### DIFF
--- a/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.scss
+++ b/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.scss
@@ -61,7 +61,7 @@
 
 .logo-github {
     width: 1rem;
-    height: 1rem;
+    height: 100%;
     margin: 0 0.5rem;
     fill: #fff;
     fill: var(--sapShell_TextColor, #fff);


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of [#3420](https://github.com/SAP/fundamental-ngx/issues/3420)
