### PR TITLE
fix: refactor Object Status to use an input property instead of content projection

### DIFF
--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-clickable-and-icon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-clickable-and-icon-example.component.html
@@ -1,10 +1,10 @@
-<a fd-object-status [status]="'negative'" [glyph]="'status-negative'" [clickable]="true">Negative</a>
-<a fd-object-status [status]="'critical'" [glyph]="'status-critical'" [clickable]="true">Critical</a>
-<a fd-object-status [status]="'positive'" [glyph]="'status-positive'" [clickable]="true">Positive</a>
-<a fd-object-status [status]="'informative'" [glyph]="'hint'" [clickable]="true">Informative</a>
-<a fd-object-status [glyph]="'to-be-reviewed'" [clickable]="true">Default</a>
+<a fd-object-status status="negative" glyph="status-negative" clickable="true" label="Negative"></a>
+<a fd-object-status status="critical" glyph="status-critical" clickable="true" label="Critical"></a>
+<a fd-object-status status="positive" glyph="status-positive" clickable="true" label="Positive"></a>
+<a fd-object-status status="informative" glyph="hint" clickable="true" label="Informative"></a>
+<a fd-object-status glyph="to-be-reviewed" clickable="true" label="Default"></a>
 <br />
 <br />
 <ng-container *ngFor="let item of [1, 2, 3, 4, 5, 6, 7, 8]">
-    <a fd-object-status [indicationColor]="item" [clickable]="true">Indication Color {{ item }}</a>
+    <a fd-object-status [indicationColor]="item" clickable="true" label="Indication Color"></a>
 </ng-container>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-clickable-and-icon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-clickable-and-icon-example.component.html
@@ -1,10 +1,10 @@
-<a fd-object-status status="negative" glyph="status-negative" clickable="true" label="Negative"></a>
-<a fd-object-status status="critical" glyph="status-critical" clickable="true" label="Critical"></a>
-<a fd-object-status status="positive" glyph="status-positive" clickable="true" label="Positive"></a>
-<a fd-object-status status="informative" glyph="hint" clickable="true" label="Informative"></a>
-<a fd-object-status glyph="to-be-reviewed" clickable="true" label="Default"></a>
+<a fd-object-status status="negative" glyph="status-negative" [clickable]="true" label="Negative"></a>
+<a fd-object-status status="critical" glyph="status-critical" [clickable]="true" label="Critical"></a>
+<a fd-object-status status="positive" glyph="status-positive" [clickable]="true" label="Positive"></a>
+<a fd-object-status status="informative" glyph="hint" [clickable]="true" label="Informative"></a>
+<a fd-object-status glyph="to-be-reviewed" [clickable]="true" label="Default"></a>
 <br />
 <br />
 <ng-container *ngFor="let item of [1, 2, 3, 4, 5, 6, 7, 8]">
-    <a fd-object-status [indicationColor]="item" clickable="true" label="Indication Color"></a>
+    <a fd-object-status [indicationColor]="item" [clickable]="true" label="Indication Color"></a>
 </ng-container>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-generic-text-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-generic-text-example.component.html
@@ -1,3 +1,3 @@
 <ng-container *ngFor="let item of [1, 2, 3, 4, 5, 6, 7, 8]">
-    <span fd-object-status [indicationColor]="item">Indication Color {{ item }}</span>
+    <span fd-object-status [indicationColor]="item" label="Indication Color"></span>
 </ng-container>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-icon-text-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-icon-text-example.component.html
@@ -1,5 +1,5 @@
-<span fd-object-status [status]="'negative'" [glyph]="'status-negative'">Negative</span>
-<span fd-object-status [status]="'critical'" [glyph]="'status-critical'">Critical</span>
-<span fd-object-status [status]="'positive'" [glyph]="'status-positive'">Positive</span>
-<span fd-object-status [status]="'informative'" [glyph]="'hint'">Informative</span>
-<span fd-object-status [glyph]="'to-be-reviewed'">Default</span>
+<span fd-object-status status="negative" glyph="status-negative" label="Negative"></span>
+<span fd-object-status status="critical" glyph="status-critical" label="Critical"></span>
+<span fd-object-status status="positive" glyph="status-positive" label="Positive"></span>
+<span fd-object-status status="informative" glyph="hint" label="Informative"></span>
+<span fd-object-status glyph="to-be-reviewed" label="Default"></span>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-example.component.html
@@ -1,37 +1,37 @@
-<span fd-object-status status="negative" glyph="status-negative" inverted="true"></span>
-<span fd-object-status status="critical" glyph="status-critical" inverted="true"></span>
-<span fd-object-status status="positive" glyph="status-positive" inverted="true"></span>
-<span fd-object-status status="informative" glyph="hint" inverted="true"></span>
-<span fd-object-status glyph="to-be-reviewed" inverted="true"></span>
+<span fd-object-status status="negative" glyph="status-negative" [inverted]="true"></span>
+<span fd-object-status status="critical" glyph="status-critical" [inverted]="true"></span>
+<span fd-object-status status="positive" glyph="status-positive" [inverted]="true"></span>
+<span fd-object-status status="informative" glyph="hint" [inverted]="true"></span>
+<span fd-object-status glyph="to-be-reviewed" [inverted]="true"></span>
 
 <br /><br />
 
-<span fd-object-status status="negative" inverted="true" label="Negative"></span>
-<span fd-object-status status="critical" inverted="true" label="Critical"></span>
-<span fd-object-status status="positive" inverted="true" label="Positive"></span>
-<span fd-object-status status="informative" inverted="true" label="Informative"></span>
-<span fd-object-status inverted="true" label="Default"></span>
+<span fd-object-status status="negative" [inverted]="true" label="Negative"></span>
+<span fd-object-status status="critical" [inverted]="true" label="Critical"></span>
+<span fd-object-status status="positive" [inverted]="true" label="Positive"></span>
+<span fd-object-status status="informative" [inverted]="true" label="Informative"></span>
+<span fd-object-status [inverted]="true" label="Default"></span>
 
 <br /><br />
 
-<span fd-object-status status="negative" inverted="true" label="5"></span>
-<span fd-object-status status="critical" inverted="true" label="20"></span>
-<span fd-object-status status="positive" inverted="true" label="2.99"></span>
-<span fd-object-status status="informative" inverted="true" label="10"></span>
-<span fd-object-status inverted="true" label="99+"></span>
+<span fd-object-status status="negative" [inverted]="true" label="5"></span>
+<span fd-object-status status="critical" [inverted]="true" label="20"></span>
+<span fd-object-status status="positive" [inverted]="true" label="2.99"></span>
+<span fd-object-status status="informative" [inverted]="true" label="10"></span>
+<span fd-object-status [inverted]="true" label="99+"></span>
 
 <br /><br />
 
-<span fd-object-status status="negative" glyph="status-negative" inverted="true" label="Negative"></span>
-<span fd-object-status status="critical" glyph="status-critical" inverted="true" label="Critical"></span>
-<span fd-object-status status="positive" glyph="status-positive" inverted="true" label="Positive"></span>
-<span fd-object-status status="informative" glyph="hint" inverted="true" label="Informative"></span>
-<span fd-object-status glyph="to-be-reviewed" inverted="true" label="Default"></span>
+<span fd-object-status status="negative" glyph="status-negative" [inverted]="true" label="Negative"></span>
+<span fd-object-status status="critical" glyph="status-critical" [inverted]="true" label="Critical"></span>
+<span fd-object-status status="positive" glyph="status-positive" [inverted]="true" label="Positive"></span>
+<span fd-object-status status="informative" glyph="hint" [inverted]="true" label="Informative"></span>
+<span fd-object-status glyph="to-be-reviewed" [inverted]="true" label="Default"></span>
 
 <br /><br />
 
-<a fd-object-status status="negative" glyph="status-negative" [clickable]="true" inverted="true" label="Negative"></a>
-<a fd-object-status status="critical" glyph="status-critical" [clickable]="true" inverted="true" label="Critical"></a>
-<a fd-object-status status="positive" glyph="status-positive" [clickable]="true" inverted="true" label="Positive"></a>
-<a fd-object-status status="informative" glyph="hint" [clickable]="true" inverted="true" label="Informative"></a>
-<a fd-object-status glyph="to-be-reviewed" [clickable]="true" inverted="true" label="Default"></a>
+<a fd-object-status status="negative" glyph="status-negative" [clickable]="true" [inverted]="true" label="Negative"></a>
+<a fd-object-status status="critical" glyph="status-critical" [clickable]="true" [inverted]="true" label="Critical"></a>
+<a fd-object-status status="positive" glyph="status-positive" [clickable]="true" [inverted]="true" label="Positive"></a>
+<a fd-object-status status="informative" glyph="hint" [clickable]="true" [inverted]="true" label="Informative"></a>
+<a fd-object-status glyph="to-be-reviewed" [clickable]="true" [inverted]="true" label="Default"></a>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-example.component.html
@@ -1,37 +1,37 @@
-<span fd-object-status [status]="'negative'" [glyph]="'status-negative'" [inverted]="true"></span>
-<span fd-object-status [status]="'critical'" [glyph]="'status-critical'" [inverted]="true"></span>
-<span fd-object-status [status]="'positive'" [glyph]="'status-positive'" [inverted]="true"></span>
-<span fd-object-status [status]="'informative'" [glyph]="'hint'" [inverted]="true"></span>
-<span fd-object-status [glyph]="'to-be-reviewed'" [inverted]="true"></span>
+<span fd-object-status status="negative" glyph="status-negative" inverted="true"></span>
+<span fd-object-status status="critical" glyph="status-critical" inverted="true"></span>
+<span fd-object-status status="positive" glyph="status-positive" inverted="true"></span>
+<span fd-object-status status="informative" glyph="hint" inverted="true"></span>
+<span fd-object-status glyph="to-be-reviewed" inverted="true"></span>
 
 <br /><br />
 
-<span fd-object-status [status]="'negative'" [inverted]="true">Negative</span>
-<span fd-object-status [status]="'critical'" [inverted]="true">Critical</span>
-<span fd-object-status [status]="'positive'" [inverted]="true">Positive</span>
-<span fd-object-status [status]="'informative'" [inverted]="true">Informative</span>
-<span fd-object-status [inverted]="true">Default</span>
+<span fd-object-status status="negative" inverted="true" label="Negative"></span>
+<span fd-object-status status="critical" inverted="true" label="Critical"></span>
+<span fd-object-status status="positive" inverted="true" label="Positive"></span>
+<span fd-object-status status="informative" inverted="true" label="Informative"></span>
+<span fd-object-status inverted="true" label="Default"></span>
 
 <br /><br />
 
-<span fd-object-status [status]="'negative'" [inverted]="true">5</span>
-<span fd-object-status [status]="'critical'" [inverted]="true">20</span>
-<span fd-object-status [status]="'positive'" [inverted]="true">2.99</span>
-<span fd-object-status [status]="'informative'" [inverted]="true">10</span>
-<span fd-object-status [inverted]="true">99+</span>
+<span fd-object-status status="negative" inverted="true" label="5"></span>
+<span fd-object-status status="critical" inverted="true" label="20"></span>
+<span fd-object-status status="positive" inverted="true" label="2.99"></span>
+<span fd-object-status status="informative" inverted="true" label="10"></span>
+<span fd-object-status inverted="true" label="99+"></span>
 
 <br /><br />
 
-<span fd-object-status [status]="'negative'" [glyph]="'status-negative'" [inverted]="true">Negative</span>
-<span fd-object-status [status]="'critical'" [glyph]="'status-critical'" [inverted]="true">Critical</span>
-<span fd-object-status [status]="'positive'" [glyph]="'status-positive'" [inverted]="true">Positive</span>
-<span fd-object-status [status]="'informative'" [glyph]="'hint'" [inverted]="true">Informative</span>
-<span fd-object-status [glyph]="'to-be-reviewed'" [inverted]="true">Default</span>
+<span fd-object-status status="negative" glyph="status-negative" inverted="true" label="Negative"></span>
+<span fd-object-status status="critical" glyph="status-critical" inverted="true" label="Critical"></span>
+<span fd-object-status status="positive" glyph="status-positive" inverted="true" label="Positive"></span>
+<span fd-object-status status="informative" glyph="hint" inverted="true" label="Informative"></span>
+<span fd-object-status glyph="to-be-reviewed" inverted="true" label="Default"></span>
 
 <br /><br />
 
-<a fd-object-status [status]="'negative'" [glyph]="'status-negative'" [clickable]="true" [inverted]="true">Negative</a>
-<a fd-object-status [status]="'critical'" [glyph]="'status-critical'" [clickable]="true" [inverted]="true">Critical</a>
-<a fd-object-status [status]="'positive'" [glyph]="'status-positive'" [clickable]="true" [inverted]="true">Positive</a>
-<a fd-object-status [status]="'informative'" [glyph]="'hint'" [clickable]="true" [inverted]="true">Informative</a>
-<a fd-object-status [glyph]="'to-be-reviewed'" [clickable]="true" [inverted]="true">Default</a>
+<a fd-object-status status="negative" glyph="status-negative" [clickable]="true" inverted="true" label="Negative"></a>
+<a fd-object-status status="critical" glyph="status-critical" [clickable]="true" inverted="true" label="Critical"></a>
+<a fd-object-status status="positive" glyph="status-positive" [clickable]="true" inverted="true" label="Positive"></a>
+<a fd-object-status status="informative" glyph="hint" [clickable]="true" inverted="true" label="Informative"></a>
+<a fd-object-status glyph="to-be-reviewed" [clickable]="true" inverted="true" label="Default"></a>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-generic-text-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-generic-text-example.component.html
@@ -1,3 +1,3 @@
 <ng-container *ngFor="let item of [1, 2, 3, 4, 5, 6, 7, 8]">
-    <a fd-object-status [indicationColor]="item" [clickable]="true" [inverted]="true">Indication Color {{ item }}</a>
+    <a fd-object-status [indicationColor]="item" clickable="true" inverted="true" label="Indication Color"></a>
 </ng-container>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-generic-text-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-generic-text-example.component.html
@@ -1,3 +1,3 @@
 <ng-container *ngFor="let item of [1, 2, 3, 4, 5, 6, 7, 8]">
-    <a fd-object-status [indicationColor]="item" clickable="true" inverted="true" label="Indication Color"></a>
+    <a fd-object-status [indicationColor]="item" [clickable]="true" [inverted]="true" label="Indication Color"></a>
 </ng-container>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-large-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-large-example.component.html
@@ -1,32 +1,32 @@
-<span fd-object-status status="negative" glyph="status-negative" inverted="true" large="true"></span>
-<span fd-object-status status="critical" glyph="status-critical" inverted="true" large="true"></span>
-<span fd-object-status status="positive" glyph="status-positive" inverted="true" large="true"></span>
-<span fd-object-status status="informative" glyph="hint" inverted="true" large="true"></span>
-<span fd-object-status glyph="to-be-reviewed" inverted="true" large="true"></span>
+<span fd-object-status status="negative" glyph="status-negative" [inverted]="true" [large]="true"></span>
+<span fd-object-status status="critical" glyph="status-critical" [inverted]="true" [large]="true"></span>
+<span fd-object-status status="positive" glyph="status-positive" [inverted]="true" [large]="true"></span>
+<span fd-object-status status="informative" glyph="hint" [inverted]="true" [large]="true"></span>
+<span fd-object-status glyph="to-be-reviewed" [inverted]="true" [large]="true"></span>
 
 <br /><br />
 
-<span fd-object-status status="negative" large="true" label="Negative"></span>
-<span fd-object-status status="critical" large="true" label="Critical"></span>
-<span fd-object-status status="positive" large="true" label="Positive"></span>
-<span fd-object-status status="informative" large="true" label="Informative"></span>
-<span fd-object-status large="true" label="Default"></span>
+<span fd-object-status status="negative" [large]="true" label="Negative"></span>
+<span fd-object-status status="critical" [large]="true" label="Critical"></span>
+<span fd-object-status status="positive" [large]="true" label="Positive"></span>
+<span fd-object-status status="informative" [large]="true" label="Informative"></span>
+<span fd-object-status [large]="true" label="Default"></span>
 
 <br /><br />
 
-<span fd-object-status status="negative" large="true" label="5"></span>
-<span fd-object-status status="critical" large="true" label="20"></span>
-<span fd-object-status status="positive" large="true" label="2.99"></span>
-<span fd-object-status status="informative" large="true" label="10"></span>
-<span fd-object-status large="true" label="99+"></span>
+<span fd-object-status status="negative" [large]="true" label="5"></span>
+<span fd-object-status status="critical" [large]="true" label="20"></span>
+<span fd-object-status status="positive" [large]="true" label="2.99"></span>
+<span fd-object-status status="informative" [large]="true" label="10"></span>
+<span fd-object-status [large]="true" label="99+"></span>
 
 <br /><br />
 
-<span fd-object-status status="negative" glyph="status-negative" large="true" label="Negative"></span>
-<span fd-object-status status="critical" glyph="status-critical" large="true" label="Critical"></span>
-<span fd-object-status status="positive" glyph="status-positive" large="true" label="Positive"></span>
-<span fd-object-status status="informative" glyph="hint" large="true" label="Informative"></span>
-<span fd-object-status glyph="to-be-reviewed" large="true" label="Default"></span>
+<span fd-object-status status="negative" glyph="status-negative" [large]="true" label="Negative"></span>
+<span fd-object-status status="critical" glyph="status-critical" [large]="true" label="Critical"></span>
+<span fd-object-status status="positive" glyph="status-positive" [large]="true" label="Positive"></span>
+<span fd-object-status status="informative" glyph="hint" [large]="true" label="Informative"></span>
+<span fd-object-status glyph="to-be-reviewed" [large]="true" label="Default"></span>
 
 <br /><br />
 
@@ -35,8 +35,8 @@
     status="negative"
     glyph="status-negative"
     [clickable]="true"
-    large="true"
-    inverted="true"
+    [large]="true"
+    [inverted]="true"
     label="Negative"
 ></a>
 <a
@@ -44,8 +44,8 @@
     status="critical"
     glyph="status-critical"
     [clickable]="true"
-    large="true"
-    inverted="true"
+    [large]="true"
+    [inverted]="true"
     label="Criitical"
 ></a>
 <a
@@ -53,8 +53,8 @@
     status="positive"
     glyph="status-positive"
     [clickable]="true"
-    large="true"
-    inverted="true"
+    [large]="true"
+    [inverted]="true"
     label="Positive"
 ></a>
 <a
@@ -62,8 +62,8 @@
     status="informative"
     glyph="hint"
     [clickable]="true"
-    large="true"
-    inverted="true"
+    [large]="true"
+    [inverted]="true"
     label="Informative"
 ></a>
-<a fd-object-status glyph="to-be-reviewed" [clickable]="true" large="true" inverted="true" label="Default"></a>
+<a fd-object-status glyph="to-be-reviewed" [clickable]="true" [large]="true" [inverted]="true" label="Default"></a>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-large-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-large-example.component.html
@@ -1,70 +1,69 @@
-<span
-    fd-object-status
-    [status]="'negative'"
-    [glyph]="'status-negative'"
-    [inverted]="true"
-    [large]="true"
-    [large]="true"
-></span>
-<span fd-object-status [status]="'critical'" [glyph]="'status-critical'" [inverted]="true" [large]="true"></span>
-<span fd-object-status [status]="'positive'" [glyph]="'status-positive'" [inverted]="true" [large]="true"></span>
-<span fd-object-status [status]="'informative'" [glyph]="'hint'" [inverted]="true" [large]="true"></span>
-<span fd-object-status [glyph]="'to-be-reviewed'" [inverted]="true" [large]="true"></span>
+<span fd-object-status status="negative" glyph="status-negative" inverted="true" large="true"></span>
+<span fd-object-status status="critical" glyph="status-critical" inverted="true" large="true"></span>
+<span fd-object-status status="positive" glyph="status-positive" inverted="true" large="true"></span>
+<span fd-object-status status="informative" glyph="hint" inverted="true" large="true"></span>
+<span fd-object-status glyph="to-be-reviewed" inverted="true" large="true"></span>
 
 <br /><br />
 
-<span fd-object-status [status]="'negative'" [large]="true">Negative</span>
-<span fd-object-status [status]="'critical'" [large]="true">Critical</span>
-<span fd-object-status [status]="'positive'" [large]="true">Positive</span>
-<span fd-object-status [status]="'informative'" [large]="true">Informative</span>
-<span fd-object-status [large]="true">Default</span>
+<span fd-object-status status="negative" large="true" label="Negative"></span>
+<span fd-object-status status="critical" large="true" label="Critical"></span>
+<span fd-object-status status="positive" large="true" label="Positive"></span>
+<span fd-object-status status="informative" large="true" label="Informative"></span>
+<span fd-object-status large="true" label="Default"></span>
 
 <br /><br />
 
-<span fd-object-status [status]="'negative'" [large]="true">5</span>
-<span fd-object-status [status]="'critical'" [large]="true">20</span>
-<span fd-object-status [status]="'positive'" [large]="true">2.99</span>
-<span fd-object-status [status]="'informative'" [large]="true">10</span>
-<span fd-object-status [large]="true">99+</span>
+<span fd-object-status status="negative" large="true" label="5"></span>
+<span fd-object-status status="critical" large="true" label="20"></span>
+<span fd-object-status status="positive" large="true" label="2.99"></span>
+<span fd-object-status status="informative" large="true" label="10"></span>
+<span fd-object-status large="true" label="99+"></span>
 
 <br /><br />
 
-<span fd-object-status [status]="'negative'" [glyph]="'status-negative'" [large]="true">Negative</span>
-<span fd-object-status [status]="'critical'" [glyph]="'status-critical'" [large]="true">Critical</span>
-<span fd-object-status [status]="'positive'" [glyph]="'status-positive'" [large]="true">Positive</span>
-<span fd-object-status [status]="'informative'" [glyph]="'hint'" [large]="true">Informative</span>
-<span fd-object-status [glyph]="'to-be-reviewed'" [large]="true">Default</span>
+<span fd-object-status status="negative" glyph="status-negative" large="true" label="Negative"></span>
+<span fd-object-status status="critical" glyph="status-critical" large="true" label="Critical"></span>
+<span fd-object-status status="positive" glyph="status-positive" large="true" label="Positive"></span>
+<span fd-object-status status="informative" glyph="hint" large="true" label="Informative"></span>
+<span fd-object-status glyph="to-be-reviewed" large="true" label="Default"></span>
 
 <br /><br />
 
 <a
     fd-object-status
-    [status]="'negative'"
-    [glyph]="'status-negative'"
+    status="negative"
+    glyph="status-negative"
     [clickable]="true"
-    [large]="true"
-    [inverted]="true"
-    >Negative</a
->
+    large="true"
+    inverted="true"
+    label="Negative"
+></a>
 <a
     fd-object-status
-    [status]="'critical'"
-    [glyph]="'status-critical'"
+    status="critical"
+    glyph="status-critical"
     [clickable]="true"
-    [large]="true"
-    [inverted]="true"
-    >Critical</a
->
+    large="true"
+    inverted="true"
+    label="Criitical"
+></a>
 <a
     fd-object-status
-    [status]="'positive'"
-    [glyph]="'status-positive'"
+    status="positive"
+    glyph="status-positive"
     [clickable]="true"
-    [large]="true"
-    [inverted]="true"
-    >Positive</a
->
-<a fd-object-status [status]="'informative'" [glyph]="'hint'" [clickable]="true" [large]="true" [inverted]="true"
-    >Informative</a
->
-<a fd-object-status [glyph]="'to-be-reviewed'" [clickable]="true" [large]="true" [inverted]="true">Default</a>
+    large="true"
+    inverted="true"
+    label="Positive"
+></a>
+<a
+    fd-object-status
+    status="informative"
+    glyph="hint"
+    [clickable]="true"
+    large="true"
+    inverted="true"
+    label="Informative"
+></a>
+<a fd-object-status glyph="to-be-reviewed" [clickable]="true" large="true" inverted="true" label="Default"></a>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-text-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-text-example.component.html
@@ -1,5 +1,5 @@
-<span fd-object-status [status]="'negative'">Negative</span>
-<span fd-object-status [status]="'critical'">Critical</span>
-<span fd-object-status [status]="'positive'">Positive</span>
-<span fd-object-status [status]="'informative'">Informative</span>
-<span fd-object-status>Default</span>
+<span fd-object-status status="negative" label="Negative"></span>
+<span fd-object-status status="critical" label="Critical"></span>
+<span fd-object-status status="positive" label=""></span>
+<span fd-object-status status="informative" label="Positive"></span>
+<span fd-object-status label="Default"></span>

--- a/libs/core/src/lib/object-status/object-status.component.spec.ts
+++ b/libs/core/src/lib/object-status/object-status.component.spec.ts
@@ -1,19 +1,40 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, ViewChild } from '@angular/core';
 
 import { ObjectStatusComponent } from './object-status.component';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 
 @Component({
     selector: 'fd-test-object-status',
-    template: ` <span fd-object-status>Test Object Status</span> `
+    template: `
+        <span
+            fd-object-status
+            [status]="status"
+            [glyph]="glyph"
+            [label]="label"
+            [indicationColor]="indicationColor"
+            [clickable]="clickable"
+            [inverted]="inverted"
+            [large]="large"
+        >
+        </span>
+    `
 })
 class TestObjectStatusComponent {
-    @ViewChild(ObjectStatusComponent, { static: true })
-    objectStatusComponent: ObjectStatusComponent;
+    @ViewChild(ObjectStatusComponent, { static: true, read: ElementRef })
+    objectStatusElementRef: ElementRef;
+
+    status: 'negative' | 'critical' | 'positive' | 'informative';
+    glyph: string;
+    label: string;
+    indicationColor: number;
+    clickable: boolean;
+    inverted: boolean;
+    large: boolean;
 }
 
 describe('ObjectStatusComponent', () => {
-    let component: ObjectStatusComponent;
+    let objectStatusElementRef: ElementRef;
+    let testComponent: TestObjectStatusComponent;
     let fixture: ComponentFixture<TestObjectStatusComponent>;
 
     beforeEach(async(() => {
@@ -24,46 +45,63 @@ describe('ObjectStatusComponent', () => {
 
     beforeEach(() => {
         fixture = TestBed.createComponent(TestObjectStatusComponent);
-        component = fixture.componentInstance.objectStatusComponent;
+        objectStatusElementRef = fixture.componentInstance.objectStatusElementRef;
+        testComponent = fixture.componentInstance;
         fixture.detectChanges();
     });
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
+    it('Should create', () => {
+        expect(testComponent).toBeTruthy();
+        expect(objectStatusElementRef).toBeTruthy();
     });
 
-    it('Should Add Status', () => {
-        component.status = 'positive';
-        component.buildComponentCssClass();
+    it('Should add status', () => {
+        testComponent.status = 'positive';
         fixture.detectChanges();
-        expect(component.elementRef().nativeElement.classList.contains('fd-object-status--positive')).toBe(true);
+        expect(objectStatusElementRef.nativeElement.classList.contains('fd-object-status--positive')).toBeTrue();
     });
 
-    it('Should Add Indication Color', () => {
-        component.indicationColor = 2;
-        component.buildComponentCssClass();
+    it('Should add indication color', () => {
+        testComponent.indicationColor = 2;
         fixture.detectChanges();
-        expect(component.elementRef().nativeElement.classList.contains('fd-object-status--indication-2')).toBe(true);
+        expect(objectStatusElementRef.nativeElement.classList.contains('fd-object-status--indication-2')).toBeTrue();
     });
 
-    it('Should Add Clickable Class', () => {
-        component.clickable = true;
-        component.buildComponentCssClass();
+    it('Should add icon', () => {
+        testComponent.glyph = 'future';
         fixture.detectChanges();
-        expect(component.elementRef().nativeElement.classList.contains('fd-object-status--link')).toBe(true);
+        const iconElement = fixture.nativeElement.querySelector('i');
+
+        expect(iconElement).toBeTruthy();
+        expect(iconElement.classList.contains('sap-icon--future')).toBeTrue();
     });
 
-    it('Should Add Inverted Class', () => {
-        component.inverted = true;
-        component.buildComponentCssClass();
+    it('Should add inverted class', () => {
+        testComponent.inverted = true;
         fixture.detectChanges();
-        expect(component.elementRef().nativeElement.classList.contains('fd-object-status--inverted')).toBe(true);
+        expect(objectStatusElementRef.nativeElement.classList.contains('fd-object-status--inverted')).toBeTrue();
     });
 
-    it('Should Apply Large Design', () => {
-        component.large = true;
-        component.buildComponentCssClass();
+    it('Should add large design', () => {
+        testComponent.large = true;
         fixture.detectChanges();
-        expect(component.elementRef().nativeElement.classList.contains('fd-object-status--large')).toBe(true);
+        expect(objectStatusElementRef.nativeElement.classList.contains('fd-object-status--large')).toBeTrue();
+    });
+
+    it('Should add clickable class', () => {
+        testComponent.clickable = true;
+        fixture.detectChanges();
+        expect(objectStatusElementRef.nativeElement.classList.contains('fd-object-status--link')).toBeTrue();
+    });
+
+    it('Should display label', () => {
+        const label = 'Test label';
+        testComponent.label = label;
+        fixture.detectChanges();
+
+        const labelTextElement = fixture.nativeElement.querySelector('.fd-object-status__text');
+
+        expect(labelTextElement).toBeTruthy();
+        expect(labelTextElement.textContent.trim()).toBe(label);
     });
 });

--- a/libs/core/src/lib/object-status/object-status.component.ts
+++ b/libs/core/src/lib/object-status/object-status.component.ts
@@ -15,14 +15,17 @@ export type ObjectStatus = 'negative' | 'critical' | 'positive' | 'informative';
     // tslint:disable-next-line:component-selector
     selector: '[fd-object-status]',
     template: `
-        <i class="fd-object-status__icon"
-           *ngIf="glyph"
-           [ngClass]="'sap-icon--' + glyph"
-           [attr.role]="glyphAriaLabel ? 'presentation': ''"
-           [attr.aria-label]="glyphAriaLabel"></i>
-        <span class="fd-object-status__text">
-            <ng-content></ng-content>
-        </span>
+        <i
+            class="fd-object-status__icon"
+            *ngIf="glyph"
+            [ngClass]="'sap-icon--' + glyph"
+            [attr.role]="glyphAriaLabel ? 'presentation' : ''"
+            [attr.aria-label]="glyphAriaLabel"
+        ></i>
+        <span *ngIf="label" class="fd-object-status__text">{{ label }}</span>
+
+        <!-- DEPRECATED - Remove in v0.23.0 -->
+        <ng-content></ng-content>
     `,
     styleUrls: ['./object-status.component.scss'],
     encapsulation: ViewEncapsulation.None,
@@ -46,6 +49,10 @@ export class ObjectStatusComponent implements OnChanges, OnInit, CssClassBuilder
      */
     @Input()
     glyph: string;
+
+    /** Define the text content of the Object Status */
+    @Input()
+    label: string;
 
     /**
      * Label applied to glyph element, should be used when there is not text included


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of [#3420](https://github.com/SAP/fundamental-ngx/issues/3420)

#### Please provide a brief summary of this pull request.
Replace the content projection with an input property in order to apply the `<span *ngIf="label" class="fd-object-status__text">{{ label }}</span>` conditionally.

Before:
```
<span fd-object-status status="negative" inverted="true">Negative</span>
```
After:
```
<span fd-object-status status="negative" inverted="true" label="Negative"></span>
```

BREAKING CHANGE:
Replace the content projection of the Object Status with an input property called `label`.
