### PR TITLE
fix: Breadcrumb expand collapsed items styling 

### DIFF
--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,6 +1,9 @@
-<fd-menu #menu [placement]="placement$ | async" [compact]="compact">
+<fd-menu #menu
+         [compact]="compact"
+         [placement]="placement$ | async">
     <li fd-menu-item *ngFor="let collapsedBreadcrumbItem of collapsedBreadcrumbItems">
-        <a fd-menu-interactive [attr.href]="collapsedBreadcrumbItem.href"
+        <a fd-menu-interactive
+           [attr.href]="collapsedBreadcrumbItem.href"
            [routerLink]="collapsedBreadcrumbItem.routerLink">
             <span fd-menu-title>{{collapsedBreadcrumbItem.elementRef.nativeElement.innerText}}</span>
         </a>
@@ -8,9 +11,12 @@
 </fd-menu>
 
 <fd-breadcrumb-item *ngIf="collapsedBreadcrumbItems.length" [fdMenuTrigger]="menu">
-    <a fd-breadcrumb-link tabindex="0" (keydown)="keyDownHandle($event)">
+    <a fd-breadcrumb-link
+       tabindex="0"
+       class="fd-breadcrumb__collapsed"
+       (keydown)="keyDownHandle($event)">
         ...
-        <fd-icon [glyph]="'slim-arrow-down'"></fd-icon>
+        <span role="presentation" class="fd-breadcrumb__dropdown-icon"></span>
     </a>
 </fd-breadcrumb-item>
 

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.scss
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.scss
@@ -3,4 +3,8 @@
 .fd-breadcrumb {
     display: inline-block;
     white-space: nowrap;
+
+    .fd-breadcrumb__collapsed {
+        cursor: pointer;
+    }
 }

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -18,6 +18,7 @@ import { RtlService } from '../utils/services/rtl.service';
 import { BehaviorSubject } from 'rxjs';
 import { KeyUtil } from '../utils/public_api';
 import { MenuComponent } from '../menu/menu.component';
+import { Placement } from 'popper.js';
 
 /**
  * Breadcrumb parent wrapper directive. Must have breadcrumb item child directives.
@@ -63,7 +64,7 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
     previousContainerWidth: number;
 
     /** @hidden */
-    placement$: BehaviorSubject<string> = new BehaviorSubject<string>('bottom-start');
+    placement$ = new BehaviorSubject<Placement>('bottom-start');
 
     /**
      * The element to act as the breadcrumb container. When provided, the breadcrumb's responsive collapsing behavior


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #3420

#### Please provide a brief summary of this pull request.
This PR:
- updates breadcrumb markup to match Fundamental Styles v0.12.0 (yes, this should be a span with `fd-breadcrumb__dropdown-icon` class)
- fixes `Placement` typing

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

