### PR TITLE
fix: Update Dialog title styling

### DIFF
--- a/libs/core/src/lib/dialog/dialog-utils/dialog-directives.ts
+++ b/libs/core/src/lib/dialog/dialog-utils/dialog-directives.ts
@@ -11,7 +11,8 @@ import { Directive, Input } from '@angular/core';
     // tslint:disable-next-line:directive-selector
     selector: '[fd-dialog-title]',
     host: {
-        '[class.fd-dialog__title]': 'true'
+        '[class.fd-title]': 'true',
+        '[class.fd-title--h5]': 'true'
     }
 })
 export class DialogTitleDirective {}

--- a/libs/core/src/lib/dialog/dialog.component.scss
+++ b/libs/core/src/lib/dialog/dialog.component.scss
@@ -1,4 +1,5 @@
 @import '~fundamental-styles/dist/dialog';
+@import '~fundamental-styles/dist/title.css';
 
 .fd-dialog {
     z-index: 1000;
@@ -18,8 +19,8 @@
 
     &--with-header {
         .fd-dialog__body {
-            border-top-left-radius: 0px;
-            border-top-right-radius: 0px;
+            border-top-left-radius: 0;
+            border-top-right-radius: 0;
         }
     }
 }

--- a/libs/core/src/lib/dialog/dialog.component.scss
+++ b/libs/core/src/lib/dialog/dialog.component.scss
@@ -1,5 +1,5 @@
 @import '~fundamental-styles/dist/dialog';
-@import '~fundamental-styles/dist/title.css';
+@import '~fundamental-styles/dist/title';
 
 .fd-dialog {
     z-index: 1000;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #3420 

#### Please provide a brief summary of this pull request.
This PR:
- updates CSS classes used to style Dialog title according to Fundamental Styles v0.12.0

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

