### PR TITLE
docs: fix Popover Placement documentation

### DIFF
--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-complex-example/popover-complex-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-complex-example/popover-complex-example.component.scss
@@ -1,0 +1,7 @@
+.fd-docs-flex-display-helper {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    flex-flow: row wrap;
+    width: 100%;
+}

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-placement/popover-placement-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-placement/popover-placement-example.component.html
@@ -1,5 +1,5 @@
-<div class="fd-container">
-    <div class="fd-col--shift-3 fd-col--2 fd-has-text-align-center">
+<div class="docs-popover-container docs-popover-container--horizontal">
+    <div class="docs-popover-element">
         <fd-popover placement="top-start" [noArrow]="false" title="top-start">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-up-arrow'"></button>
@@ -13,7 +13,7 @@
             </fd-popover-body>
         </fd-popover>
     </div>
-    <div class="fd-col--2 fd-has-text-align-center">
+    <div class="docs-popover-element">
         <fd-popover placement="top" [noArrow]="false" title="top">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-up-arrow'"></button>
@@ -27,7 +27,7 @@
             </fd-popover-body>
         </fd-popover>
     </div>
-    <div class="fd-col--2 fd-has-text-align-center">
+    <div class="docs-popover-element">
         <fd-popover placement="top-end" [noArrow]="false" title="top-end">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-up-arrow'"></button>
@@ -42,8 +42,8 @@
         </fd-popover>
     </div>
 </div>
-<div class="fd-container">
-    <div class="fd-col--shift-2 fd-col--2">
+<div class="docs-popover-container">
+    <div class="docs-popover-element">
         <fd-popover placement="left-start" [noArrow]="false" title="left-start">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-left-arrow'"></button>
@@ -57,7 +57,7 @@
             </fd-popover-body>
         </fd-popover>
     </div>
-    <div class="fd-col--shift-4 fd-col--2 fd-has-text-align-right">
+    <div class="docs-popover-element">
         <fd-popover placement="right-start" [noArrow]="false" title="right-start">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-right-arrow'"></button>
@@ -72,8 +72,8 @@
         </fd-popover>
     </div>
 </div>
-<div class="fd-container">
-    <div class="fd-col--shift-2 fd-col--2">
+<div class="docs-popover-container">
+    <div class="docs-popover-element">
         <fd-popover placement="left" [noArrow]="false" title="left">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-left-arrow'"></button>
@@ -87,7 +87,7 @@
             </fd-popover-body>
         </fd-popover>
     </div>
-    <div class="fd-col--shift-4 fd-col--2 fd-has-text-align-right">
+    <div class="docs-popover-element">
         <fd-popover placement="right" [noArrow]="false" title="right">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-right-arrow'"></button>
@@ -102,8 +102,8 @@
         </fd-popover>
     </div>
 </div>
-<div class="fd-container">
-    <div class="fd-col--shift-2 fd-col--2">
+<div class="docs-popover-container">
+    <div class="docs-popover-element">
         <fd-popover placement="left-end" [noArrow]="false" title="left-end">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-left-arrow'"></button>
@@ -117,7 +117,7 @@
             </fd-popover-body>
         </fd-popover>
     </div>
-    <div class="fd-col--shift-4 fd-col--2 fd-has-text-align-right">
+    <div class="docs-popover-element">
         <fd-popover placement="right-end" [noArrow]="false" title="right-end">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-right-arrow'"></button>
@@ -132,8 +132,8 @@
         </fd-popover>
     </div>
 </div>
-<div class="fd-container">
-    <div class="fd-col--shift-3 fd-col--2 fd-has-text-align-center">
+<div class="docs-popover-container docs-popover-container--horizontal">
+    <div class="docs-popover-element">
         <fd-popover placement="bottom-start" [noArrow]="false" title="bottom-start">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-down-arrow'"></button>
@@ -147,7 +147,7 @@
             </fd-popover-body>
         </fd-popover>
     </div>
-    <div class="fd-col--2 fd-has-text-align-center">
+    <div class="docs-popover-element">
         <fd-popover placement="bottom" [noArrow]="false" title="bottom">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-down-arrow'"></button>
@@ -161,7 +161,7 @@
             </fd-popover-body>
         </fd-popover>
     </div>
-    <div class="fd-col--2 fd-has-text-align-center">
+    <div class="docs-popover-element">
         <fd-popover placement="bottom-end" [noArrow]="false" title="bottom-end">
             <fd-popover-control>
                 <button fd-button [glyph]="'navigation-down-arrow'"></button>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-placement/popover-placement-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-placement/popover-placement-example.component.scss
@@ -1,93 +1,17 @@
 @import '../../../../../../../../../node_modules/fundamental-styles/dist/variables.css';
 @import '../../../../../../../../../node_modules/fundamental-styles/dist/layout.css';
 
-@media (min-width: 600px) {
-    .fd-col--2 {
-        float: left;
-        margin-right: 8px;
-        margin-right: 8px;
-        margin-right: var(--fd-width-gutter, 16px);
-        width: calc((((100% - 88px) / 12) * 2) + 8px);
-        width: calc((((100% - (11 * 8px)) / 12) * 2) + (8px * (2 - 1)));
-        width: calc(
-            (((100% - (11 * var(--fd-width-gutter, 16px))) / 12) * 2) + (var(--fd-width-gutter, 16px) * (2 - 1))
-        );
-    }
-    .fd-col--2:last-child {
-        margin-right: 0;
-    }
-    .fd-col--2[dir='rtl'],
-    [dir='rtl'] .fd-col--2 {
-        float: right;
-        margin-right: 0;
-        margin-left: 8px;
-        margin-left: 8px;
-        margin-left: var(--fd-width-gutter, 16px);
-    }
-    .fd-col--2[dir='rtl']:last-child,
-    [dir='rtl'] .fd-col--2:last-child {
-        margin-left: 0;
-    }
-    .fd-col--shift-2 {
-        margin-left: calc((((100% - 88px) / 12) * 2) + 16px);
-        margin-left: calc((((100% - (11 * 8px)) / 12) * 2) + (8px * (2)));
-        margin-left: calc(
-            (((100% - (11 * var(--fd-width-gutter, 16px))) / 12) * 2) + (var(--fd-width-gutter, 16px) * (2))
-        );
-    }
-    .fd-col--shift-2[dir='rtl'],
-    [dir='rtl'] .fd-col--shift-2 {
-        margin-left: 0;
-        margin-right: calc((((100% - 88px) / 12) * 2) + 16px);
-        margin-right: calc((((100% - (11 * 8px)) / 12) * 2) + (8px * (2)));
-        margin-right: calc(
-            (((100% - (11 * var(--fd-width-gutter, 16px))) / 12) * 2) + (var(--fd-width-gutter, 16px) * (2))
-        );
-    }
-    .fd-col--shift-3 {
-        margin-left: calc((((100% - 88px) / 12) * 3) + 24px);
-        margin-left: calc((((100% - (11 * 8px)) / 12) * 3) + (8px * (3)));
-        margin-left: calc(
-            (((100% - (11 * var(--fd-width-gutter, 16px))) / 12) * 3) + (var(--fd-width-gutter, 16px) * (3))
-        );
-    }
-    .fd-col--shift-3[dir='rtl'],
-    [dir='rtl'] .fd-col--shift-3 {
-        margin-left: 0;
-        margin-right: calc((((100% - 88px) / 12) * 3) + 24px);
-        margin-right: calc((((100% - (11 * 8px)) / 12) * 3) + (8px * (3)));
-        margin-right: calc(
-            (((100% - (11 * var(--fd-width-gutter, 16px))) / 12) * 3) + (var(--fd-width-gutter, 16px) * (3))
-        );
-    }
-    .fd-col--shift-4 {
-        margin-left: calc((((100% - 88px) / 12) * 4) + 32px);
-        margin-left: calc((((100% - (11 * 8px)) / 12) * 4) + (8px * (4)));
-        margin-left: calc(
-            (((100% - (11 * var(--fd-width-gutter, 16px))) / 12) * 4) + (var(--fd-width-gutter, 16px) * (4))
-        );
-    }
-    .fd-col--shift-4[dir='rtl'],
-    [dir='rtl'] .fd-col--shift-4 {
-        margin-left: 0;
-        margin-right: calc((((100% - 88px) / 12) * 4) + 32px);
-        margin-right: calc((((100% - (11 * 8px)) / 12) * 4) + (8px * (4)));
-        margin-right: calc(
-            (((100% - (11 * var(--fd-width-gutter, 16px))) / 12) * 4) + (var(--fd-width-gutter, 16px) * (4))
-        );
-    }
+.docs-popover-container {
+    display: flex;
+    max-width: 100%;
+    justify-content: space-between;
 }
-[class^='fd-col'] {
-    -webkit-box-flex: 1;
-    -ms-flex: 1;
-    flex: 1;
-    margin-bottom: 12px;
+
+.docs-popover-container--horizontal {
+    justify-content: space-evenly;
+    margin: 0 5rem;
 }
-[class^='fd-col']:last-child {
-    margin-bottom: 0;
-}
-@media (min-width: 320px) {
-    [class^='fd-col'] {
-        margin-bottom: 0;
-    }
+
+.docs-popover-element {
+    margin: 1rem;
 }

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.scss
@@ -3,4 +3,5 @@
     align-items: center;
     justify-content: space-around;
     flex-flow: row wrap;
+    width: 100%;
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/3420

#### Please provide a brief summary of this pull request.
Removed styling related to grid that was used for displaying the Popover placement documentation. Added much simpler styles for this purpose

