### PR TITLE
docs: fix missing Floating footer from documentation

### DIFF
--- a/apps/docs/src/app/core/component-docs/bar/bar-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/bar/bar-docs.component.html
@@ -70,7 +70,9 @@
 <description></description>
 
 <component-example>
-    <fd-bar-floating-footer-example></fd-bar-floating-footer-example>
+    <div style="position: relative; margin-top: 3rem;">
+        <fd-bar-floating-footer-example></fd-bar-floating-footer-example>
+    </div>
 </component-example>
 <code-example [exampleFiles]="barFloatingFooterExample"></code-example>
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/3420
#### Please provide a brief summary of this pull request.
Floating footer was missing from the documentation example due to latest release of styles where the floating footer got a `position: absolute` and now requires a parent component with relative position. 