### PR TITLE
fix: Popover shadow dom for IE11

### DIFF
--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dialog/popover-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dialog/popover-dialog-example.component.ts
@@ -1,5 +1,5 @@
 import { Component, TemplateRef } from '@angular/core';
-import { DialogConfig, DialogService } from '@fundamental-ngx/core';
+import { DialogService } from '@fundamental-ngx/core';
 
 @Component({
     selector: 'fd-popover-dialog-example',

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-dropdown/popover-dropdown-example.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { RtlService } from '@fundamental-ngx/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 const bottomStart = 'bottom-start';

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.ts
@@ -8,7 +8,7 @@ import { map } from 'rxjs/operators';
     selector: 'fd-popover-example',
     templateUrl: './popover-example.component.html',
     styleUrls: ['popover-example.component.scss'],
-    encapsulation: ViewEncapsulation.ShadowDom
+    encapsulation: ViewEncapsulation.None
 })
 export class PopoverExampleComponent {
     leftPlacement$: Observable<Placement>;
@@ -23,11 +23,5 @@ export class PopoverExampleComponent {
         { text: 'Option 1', url: '#' },
         { text: 'Option 2', url: '#' },
         { text: 'Option 3', url: '#' }
-    ];
-
-    list2 = [
-        { text: 'Option 3', url: '#' },
-        { text: 'Option 4', url: '#' },
-        { text: 'Option 5', url: '#' }
     ];
 }

--- a/libs/core/src/lib/popover/popover-directive/popover.directive.ts
+++ b/libs/core/src/lib/popover/popover-directive/popover.directive.ts
@@ -416,13 +416,19 @@ export class PopoverDirective implements OnInit, OnDestroy, OnChanges {
     /** @hidden */
     private _containerContainsTarget(event: Event): boolean {
         const containerElement = this.containerRef.location.nativeElement;
-        return containerElement.contains(event.composedPath()[0]);
+        return containerElement.contains(this._getEventTarget(event));
     }
 
     /** @hidden */
     private _triggerContainsTarget(event: Event): boolean {
         const triggerElement = this.triggerRef.nativeElement;
-        return triggerElement.contains(event.composedPath()[0]);
+        return triggerElement.contains(this._getEventTarget(event));
+    }
+
+    private _getEventTarget(event: Event): EventTarget {
+        return event.composedPath
+            ? event.composedPath()[0]
+            : event.target;
     }
 
     /** @hidden */


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #3420 

#### Please provide a brief summary of this pull request.
This PR:
- Removes example with shadow dom from the documentation
- Adds check for `composedPath` method
- Removes unused imports/variables


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples