### PR TITLE
fix: Performance on time and datetime pickers

### DIFF
--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -58,6 +58,7 @@
                 ></fd-calendar>
                 <div class="fd-datetime__separator"></div>
                 <fd-time
+                    *ngIf="isOpen"
                     [disabled]="disabled"
                     [keepTwoDigits]="keepTwoDigitsTime"
                     [meridian]="meridian"
@@ -68,7 +69,6 @@
                     [displayMinutes]="displayMinutes"
                     [displayHours]="displayHours"
                     (ngModelChange)="handleTimeChange($event)"
-                    (focusArrowLeft)="focusArrowLeft()"
                 ></fd-time>
             </div>
             <div fd-popover-body-footer *ngIf="showFooter">

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -300,7 +300,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
      * @param fdDate FdDate
      */
     @Input()
-    disableFunction = function (fdDate: FdDate): boolean {
+    disableFunction = function(fdDate: FdDate): boolean {
         return false;
     };
 
@@ -454,7 +454,7 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
     submit(): void {
         this.selectedDate = this.tempDate;
         this.time = this.tempTime;
-        if (!this.date.isTimeValid()) {
+        if (!this.date.isTimeValid() && this.timeComponent) {
             this.time = this.timeComponent.time;
         }
         if (!this.selectedDate || !this.selectedDate.isDateValid()) {
@@ -581,5 +581,4 @@ export class DatetimePickerComponent implements OnInit, OnDestroy, ControlValueA
         this.tempDate = this.selectedDate;
         this.tempTime = this.time;
     }
-
 }

--- a/libs/core/src/lib/time-picker/time-picker.component.html
+++ b/libs/core/src/lib/time-picker/time-picker.component.html
@@ -33,6 +33,7 @@
     <fd-popover-body *ngIf="displaySeconds || displayMinutes || displayHours">
         <ng-content></ng-content>
         <fd-time
+            *ngIf="isOpen"
             [tablet]="tablet"
             [compact]="compact"
             [disabled]="disabled"

--- a/libs/core/src/lib/time-picker/time-picker.component.ts
+++ b/libs/core/src/lib/time-picker/time-picker.component.ts
@@ -45,7 +45,7 @@ import { delay, first, takeUntil } from 'rxjs/operators';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TimePickerComponent implements ControlValueAccessor, OnDestroy, AfterViewInit, Validator {
+export class TimePickerComponent implements ControlValueAccessor, OnDestroy, Validator {
 
     /**
      * @Input An object that contains three integer properties: 'hour' (ranging from 0 to 23),
@@ -89,7 +89,7 @@ export class TimePickerComponent implements ControlValueAccessor, OnDestroy, Aft
 
     /** @Input Default time picker placeholder which is set dependant on the hours, minutes and seconds.
      * Otherwise It can be set to a default value
-    */
+     */
     @Input()
     placeholder: string = this.getPlaceholder();
 
@@ -170,11 +170,6 @@ export class TimePickerComponent implements ControlValueAccessor, OnDestroy, Aft
     constructor(private _cd: ChangeDetectorRef, private _timeAdapter: TimeFormatParser) {}
 
     /** @hidden */
-    ngAfterViewInit(): void {
-        this.child.changeActive(null);
-    }
-
-    /** @hidden */
     ngOnDestroy(): void {
         this._onDestroy$.next();
         this._onDestroy$.complete();
@@ -227,9 +222,6 @@ export class TimePickerComponent implements ControlValueAccessor, OnDestroy, Aft
                     delay(0)
                 )
                 .subscribe(() => {
-                    if (!this.child.activeView) {
-                        this.child.changeActive('hour');
-                    }
                     this.child.refreshTime();
                 });
         }
@@ -246,7 +238,9 @@ export class TimePickerComponent implements ControlValueAccessor, OnDestroy, Aft
             if (this.allowNull && timeFromInput === '') {
                 this.isInvalidTimeInput = false;
                 this.onChange({ hour: null, minutes: null, seconds: null });
-                this.child.setDisplayedHour();
+                if (this.child) {
+                    this.child.setDisplayedHour();
+                }
             } else {
                 this.isInvalidTimeInput = true;
                 this.onChange(time);

--- a/libs/core/src/lib/time/time-column/time-column.component.ts
+++ b/libs/core/src/lib/time/time-column/time-column.component.ts
@@ -162,8 +162,7 @@ export class TimeColumnComponent implements AfterViewInit, OnInit, OnDestroy {
 
     constructor(
         private _changeDetRef: ChangeDetectorRef
-    ) {
-    }
+    ) { }
 
     /** @hidden */
     ngOnInit(): void {
@@ -173,7 +172,6 @@ export class TimeColumnComponent implements AfterViewInit, OnInit, OnDestroy {
 
     /** @hidden */
     ngAfterViewInit(): void {
-        this._setUpInitialValue();
         this._initialised = true;
     }
 

--- a/libs/core/src/lib/time/time.component.ts
+++ b/libs/core/src/lib/time/time.component.ts
@@ -9,7 +9,8 @@ import {
     OnInit,
     SimpleChanges,
     ViewChildren,
-    ViewEncapsulation
+    ViewEncapsulation,
+    AfterViewInit
 } from '@angular/core';
 import { TimeObject } from './time-object';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -37,7 +38,7 @@ export type FdTimeActiveView = 'hour' | 'minute' | 'second' | 'meridian';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class TimeComponent implements OnInit, OnChanges, ControlValueAccessor {
+export class TimeComponent implements OnInit, OnChanges, AfterViewInit, ControlValueAccessor {
     /**
      * @Input When set to false, uses the 24 hour clock (hours ranging from 0 to 23)
      * and does not display a period control.
@@ -165,6 +166,11 @@ export class TimeComponent implements OnInit, OnChanges, ControlValueAccessor {
     /** @hidden */
     ngOnInit(): void {
         this._setUpTimeGrid();
+    }
+
+    /** @hidden */
+    ngAfterViewInit(): void {
+        this.refreshTime();
     }
 
     /** @hidden */


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes https://github.com/SAP/fundamental-ngx/issues/3133
#### Please provide a brief summary of this pull request.
this PR removes time component inside time and datetime pickers. The `fd-time` there is completely removed from DOM / angular scope by `*ngIf`. So anytime popover with time/datetime picker is opened, there is enabled whole life cycling. It's still worth because otherwise multiple instances of timepicker, or datetimepicker completely breaks performance
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

