### PR TITLE
fix: remove deprecated input isDropdown from popover

### DIFF
--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -53,12 +53,6 @@ export class PopoverComponent {
     @HostBinding('class.fd-popover-custom--disabled')
     disabled = false;
 
-    /** @deprecated
-     * Left for backward compatibility. It's going to be removed on 0.20.0
-     */
-    @Input()
-    isDropdown = false;
-
     /** The element to which the popover should be appended. */
     @Input()
     appendTo: HTMLElement | 'body';


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
BREAKING CHANGE:
remove deprecated method `isDropdown` from popover

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

