### PR TITLE
fix: remove deprecated input from input group - buttonType

### DIFF
--- a/libs/core/src/lib/input-group/input-group.component.ts
+++ b/libs/core/src/lib/input-group/input-group.component.ts
@@ -80,12 +80,6 @@ export class InputGroupComponent implements ControlValueAccessor {
     @Input()
     buttonFocusable = true;
 
-    /**
-     * @deprecated, leaving for backwards compatibility, it will be removed in `0.17.0`.
-     */
-    @Input()
-    buttonType: ButtonType;
-
     /** The type of the input, used in Input Group. By default value is set to 'text' */
     @Input()
     type = 'text';


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
BREAKING CHANGE:
remove deprecated input`buttonType` from `input-group`

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

