### PR TITLE
chore: Limit travis only to build PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
 jobs:
   include:
   - stage: "Lint and Test"
+    if: type = pull_request
     before_script: export NODE_OPTIONS='–--max_old_space_size=4096'
     script: npm run lint && npm run test && npm run test:coveralls && npm run build-pack-library
   - stage: "Pre-release"


### PR DESCRIPTION
Part of: https://github.com/SAP/fundamental-ngx/issues/3433

This PR is going to improve travis CI by 
- skipping jobs from non-pr branches
- **To Check, after this PR merged** - Skip lint/tests, when PR is merged to master

Before:
![image](https://user-images.githubusercontent.com/26483208/95736522-a64ac100-0c86-11eb-9e7c-9f952936a02e.png)



After:
![image](https://user-images.githubusercontent.com/26483208/95736348-6552ac80-0c86-11eb-8900-ac5df75d17f6.png)



Taken from [requests](https://travis-ci.org/github/SAP/fundamental-ngx/requests)
![image](https://user-images.githubusercontent.com/26483208/95736760-ed38b680-0c86-11eb-885a-8f95617d0369.png)
