### PR TITLE
chore: Remove redundant build command from netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "ng build",
     "build-all": "npm run build-artifacts && npm run build-docs -- --prod --base-href=\"/fundamental-ngx/\"",
-    "build-docs-netlify": "npm run build-artifacts && npm run build-docs -- --configuration=\"production-unoptimized\" --base-href=\"/\"",
+    "build-docs-netlify": "npm run build-docs -- --configuration=\"production-unoptimized\" --base-href=\"/\"",
     "build-docs-github-pages": "npm run build-docs -- --prod --base-href=\"/fundamental-ngx/\"",
     "build-docs": "npm run compile-typedoc-all && npm run copy-docs && ng build",
     "build-artifacts": "ng build core && ng build platform && ng build docs",


### PR DESCRIPTION
It seems like one of commands is not necessary and takes time from netlify's build

### Previous PR netlify build:
7m 17s
![image](https://user-images.githubusercontent.com/26483208/96102546-ef914f80-0ed6-11eb-9fce-6d203b0e59b4.png)

### This PR netlify build:
6m 11s
![image](https://user-images.githubusercontent.com/26483208/96102457-d5f00800-0ed6-11eb-9813-d45be4d59417.png)
