### PR TITLE
fix: (Core) Unify KeyUtil usages

### DIFF
--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -16,9 +16,10 @@ import {
 import { BreadcrumbItemDirective } from './breadcrumb-item.directive';
 import { RtlService } from '../utils/services/rtl.service';
 import { BehaviorSubject } from 'rxjs';
-import { KeyUtil } from '../utils/public_api';
+import { KeyUtil } from '../utils/functions';
 import { MenuComponent } from '../menu/menu.component';
 import { Placement } from 'popper.js';
+import { ENTER, SPACE } from '@angular/cdk/keycodes';
 
 /**
  * Breadcrumb parent wrapper directive. Must have breadcrumb item child directives.
@@ -101,7 +102,7 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit {
 
     /** @hidden */
     keyDownHandle(event: KeyboardEvent): void {
-        if (KeyUtil.isKey(event, ['Enter', ' '])) {
+        if (KeyUtil.isKeyCode(event, [ENTER, SPACE])) {
             this.menuComponent.toggle();
             event.preventDefault();
         }

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
@@ -7,7 +7,8 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import { KeyUtil } from '../utils/functions/key-util';
+import { KeyUtil } from '../utils/functions';
+import { TAB } from '@angular/cdk/keycodes';
 
 export type BusyIndicatorSize = 's' | 'm' | 'l';
 
@@ -57,7 +58,7 @@ export class BusyIndicatorComponent {
     /** @hidden If focus escapes busy container focus element after wrapped content */
     @HostListener('keydown', ['$event'])
     hostFocusChangeHandler(event: KeyboardEvent): void {
-        if (this.loading && KeyUtil.isKey(event, 'Tab') && !event.shiftKey) {
+        if (this.loading && KeyUtil.isKeyCode(event, TAB) && !event.shiftKey) {
             this.fakeFocusElement.nativeElement.focus();
         }
     }

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -14,9 +14,10 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { FdCheckboxValues } from './fd-checkbox-values.interface';
-import { compareObjects, KeyUtil } from '../../utils/public_api';
+import { compareObjects, KeyUtil } from '../../utils/functions';
 import { Platform } from '@angular/cdk/platform';
 import { LIST_ITEM_COMPONENT, ListItemInterface } from '../../list/list-item/list-item-utils';
+import { SPACE } from '@angular/cdk/keycodes';
 
 let checkboxUniqueId = 0;
 
@@ -223,7 +224,7 @@ export class CheckboxComponent implements ControlValueAccessor {
         event.stopPropagation();
         if (this._listItemComponent &&
             this._platform.FIREFOX &&
-            KeyUtil.isKey(event, ' ')) {
+            KeyUtil.isKeyCode(event, SPACE)) {
             event.preventDefault();
         }
     }
@@ -268,7 +269,7 @@ export class CheckboxComponent implements ControlValueAccessor {
 
     /** @hidden Determines event source based on key code */
     private _isSpaceBarEvent(event: KeyboardEvent): boolean {
-        return event.keyCode === 32;
+        return KeyUtil.isKeyCode(event, SPACE);
     }
 
     /** Method to trigger change detection in component */

--- a/libs/core/src/lib/combobox/auto-complete.directive.ts
+++ b/libs/core/src/lib/combobox/auto-complete.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
-import { KeyUtil } from '../utils/public_api';
+import { KeyUtil } from '../utils/functions';
+import { BACKSPACE, CONTROL, DELETE, ENTER, ESCAPE, LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 
 export interface AutoCompleteEvent {
     term: string;
@@ -39,19 +40,19 @@ export class AutoCompleteDirective {
     @Output()
     readonly onComplete: EventEmitter<AutoCompleteEvent> = new EventEmitter<AutoCompleteEvent>();
 
-    private readonly _completeKeys: string[] = [
-        'Enter'
+    private readonly _completeKeys: number[] = [
+        ENTER
     ];
 
-    private readonly _fillKeys: string[] = [
-        'ArrowLeft',
-        'ArrowRight'
+    private readonly _fillKeys: number[] = [
+        LEFT_ARROW,
+        RIGHT_ARROW
     ];
 
-    private readonly _stopKeys: string[] = [
-        'Backspace',
-        'Delete',
-        'Escape'
+    private readonly _stopKeys: number[] = [
+        BACKSPACE,
+        DELETE,
+        ESCAPE
     ];
 
     private oldValue: string;
@@ -65,11 +66,11 @@ export class AutoCompleteDirective {
     @HostListener('keyup', ['$event'])
     handleKeyboardEvent(event: KeyboardEvent): void {
         if (this.enable) {
-            if (KeyUtil.isKey(event, this._stopKeys)) {
+            if (KeyUtil.isKeyCode(event, this._stopKeys)) {
                 this._elementRef.nativeElement.value = this.inputText;
-            } else if (KeyUtil.isKey(event, this._completeKeys)) {
+            } else if (KeyUtil.isKeyCode(event, this._completeKeys)) {
                 this._sendCompleteEvent(true);
-            } else if (KeyUtil.isKey(event, this._fillKeys)) {
+            } else if (KeyUtil.isKeyCode(event, this._fillKeys)) {
                 this._sendCompleteEvent(false);
             } else if (!this._isControlKey(event) && this.inputText) {
 
@@ -99,7 +100,7 @@ export class AutoCompleteDirective {
     }
 
     private _isControlKey(event: KeyboardEvent): boolean {
-        return KeyUtil.isKey(event, 'Ctrl') || event.ctrlKey;
+        return KeyUtil.isKeyCode(event, CONTROL) || event.ctrlKey;
     }
 
     private _defaultDisplay(value: any): string {
@@ -108,7 +109,7 @@ export class AutoCompleteDirective {
 
     private _triggerTypeAhead(): boolean {
         if (this.lastKeyUpEvent &&
-            KeyUtil.isKey(this.lastKeyUpEvent, 'Ctrl') &&
+            KeyUtil.isKeyCode(this.lastKeyUpEvent, CONTROL) &&
             this.inputText === this.oldValue) {
             return false;
         } else {

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -29,7 +29,7 @@ import { FormStates } from '../form/form-control/form-states';
 import { PopoverComponent } from '../popover/popover.component';
 import { GroupFunction } from '../utils/pipes/list-group.pipe';
 import { InputGroupComponent } from '../input-group/input-group.component';
-import { KeyUtil } from '../utils/functions/key-util';
+import { KeyUtil } from '../utils/functions';
 import { AutoCompleteEvent } from './auto-complete.directive';
 import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
 import { COMBOBOX_COMPONENT, ComboboxInterface } from './combobox.interface';
@@ -37,6 +37,17 @@ import { DynamicComponentService } from '../utils/dynamic-component/dynamic-comp
 import { ComboboxMobileComponent } from './combobox-mobile/combobox-mobile.component';
 import { ListComponent } from '../list/list.component';
 import { FocusEscapeDirection } from '../..';
+import {
+    CONTROL,
+    DOWN_ARROW,
+    ENTER,
+    ESCAPE,
+    LEFT_ARROW,
+    RIGHT_ARROW,
+    SHIFT,
+    TAB,
+    UP_ARROW
+} from '@angular/cdk/keycodes';
 
 /**
  * Allows users to filter through results and select a value.
@@ -234,20 +245,20 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
     listTemplate: TemplateRef<any>;
 
     /** Keys, that won't trigger the popover's open state, when dispatched on search input */
-    readonly nonOpeningKeys: string[] = [
-        'Escape',
-        'Enter',
-        'ArrowLeft',
-        'ArrowRight',
-        'ArrowDown',
-        'ArrowUp',
-        'Ctrl',
-        'Tab',
-        'Shift'
+    readonly nonOpeningKeys: number[] = [
+        ESCAPE,
+        ENTER,
+        LEFT_ARROW,
+        RIGHT_ARROW,
+        DOWN_ARROW,
+        UP_ARROW,
+        CONTROL,
+        TAB,
+        SHIFT
     ];
 
     /** Keys, that will close popover's body, when dispatched on search input */
-    readonly closingKeys: string[] = ['Escape'];
+    readonly closingKeys: number[] = [ESCAPE];
 
     /** Whether the combobox is opened. */
     open = false;
@@ -316,11 +327,11 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
             return;
         }
 
-        if (KeyUtil.isKey(event, 'Enter')) {
+        if (KeyUtil.isKeyCode(event, ENTER)) {
             if (this.searchFn) {
                 this.searchFn();
             }
-        } else if (KeyUtil.isKey(event, 'ArrowDown')) {
+        } else if (KeyUtil.isKeyCode(event, DOWN_ARROW)) {
             if (event.altKey) {
                 this._resetDisplayedValues();
                 this.isOpenChangeHandle(true);
@@ -331,20 +342,20 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
                 this._chooseOtherItem(1);
             }
             event.preventDefault();
-        } else if (KeyUtil.isKey(event, 'ArrowUp')) {
+        } else if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             this._chooseOtherItem(-1);
             event.preventDefault();
-        } else if (KeyUtil.isKey(event, this.closingKeys)) {
+        } else if (KeyUtil.isKeyCode(event, this.closingKeys)) {
             this.isOpenChangeHandle(false);
             event.stopPropagation();
-        } else if (this.openOnKeyboardEvent && !event.ctrlKey && !KeyUtil.isKey(event, this.nonOpeningKeys)) {
+        } else if (this.openOnKeyboardEvent && !event.ctrlKey && !KeyUtil.isKeyCode(event, this.nonOpeningKeys)) {
             this.isOpenChangeHandle(true);
         }
     }
 
     /** @hidden */
     onItemKeyDownHandler(event: KeyboardEvent, value: any): void {
-        if (KeyUtil.isKey(event, 'Enter')) {
+        if (KeyUtil.isKeyCode(event, ENTER)) {
             this.onMenuClickHandler(value);
         }
     }

--- a/libs/core/src/lib/list/list-item/list-item.component.ts
+++ b/libs/core/src/lib/list/list-item/list-item.component.ts
@@ -22,8 +22,9 @@ import { ListLinkDirective } from '../directives/list-link.directive';
 import { Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 import { KeyboardSupportItemInterface } from '../../utils/interfaces/keyboard-support-item.interface';
-import { KeyUtil } from '../../utils/functions/key-util';
+import { KeyUtil } from '../../utils/functions';
 import { LIST_ITEM_COMPONENT, ListItemInterface } from './list-item-utils';
+import { ENTER, SPACE } from '@angular/cdk/keycodes';
 
 /**
  * The component that represents a list item.
@@ -108,7 +109,7 @@ export class ListItemComponent implements KeyboardSupportItemInterface, AfterCon
     /** @hidden */
     @HostListener('keydown', ['$event'])
     keydownHandler(event: KeyboardEvent): void {
-        if (KeyUtil.isKey(event, [' ', 'Enter'])) {
+        if (KeyUtil.isKeyCode(event, [ENTER, SPACE])) {
             if (this.checkbox) {
                 this.checkbox.nextValue();
                 this._muteEvent(event);

--- a/libs/core/src/lib/mega-menu/mega-menu-item/mega-menu-item.component.ts
+++ b/libs/core/src/lib/mega-menu/mega-menu-item/mega-menu-item.component.ts
@@ -22,7 +22,9 @@ import { MenuKeyboardService } from '../../menu/menu-keyboard.service';
 import { merge, Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 import { DefaultMenuItem } from '../../menu/default-menu-item.class';
-import { RtlService, unifyKeyboardKey } from '../../utils/public_api';
+import { RtlService } from '../../utils/services/rtl.service';
+import { KeyUtil } from '../../utils/functions';
+import { ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE } from '@angular/cdk/keycodes';
 
 export type MenuSubListPosition = 'left' | 'right';
 
@@ -243,42 +245,27 @@ export class MegaMenuItemComponent implements AfterContentInit, OnDestroy, Defau
     }
 
     private _keyboardLtr(event: KeyboardEvent): void {
-        switch (this.getKeyCode(event)) {
-            case 'ArrowLeft': {
-                this._handleCloseSubList();
-                break;
-            }
-            case 'ArrowRight': {
-                this._handleOpenSubList(event);
-                break;
-            }
+        if (KeyUtil.isKeyCode(event, LEFT_ARROW)) {
+            this._handleCloseSubList();
+        } else if (KeyUtil.isKeyCode(event, RIGHT_ARROW)) {
+            this._handleOpenSubList(event);
         }
     }
 
     private _keyboardRtl(event: KeyboardEvent): void {
-        switch (this.getKeyCode(event)) {
-            case 'ArrowRight': {
-                this._handleCloseSubList();
-                break;
-            }
-            case 'ArrowLeft': {
-                this._handleOpenSubList(event);
-                break;
-            }
+        if (KeyUtil.isKeyCode(event, LEFT_ARROW)) {
+            this._handleOpenSubList(event);
+        } else if (KeyUtil.isKeyCode(event, RIGHT_ARROW)) {
+            this._handleCloseSubList();
         }
     }
 
     private _keyboardDefault(event: KeyboardEvent): void {
-        switch (this.getKeyCode(event)) {
-            case ' ':
-            case 'Enter': {
-                this._handleOpenSubList(event);
-                break;
-            }
-            default: {
-                event.preventDefault();
-                this.keyDown.emit(event);
-            }
+        if (KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
+            this._handleOpenSubList(event);
+        } else {
+            event.preventDefault();
+            this.keyDown.emit(event);
         }
     }
 
@@ -294,10 +281,6 @@ export class MegaMenuItemComponent implements AfterContentInit, OnDestroy, Defau
             this.subItems.first.focus();
         }
         event.preventDefault();
-    }
-
-    private getKeyCode(event: KeyboardEvent): string {
-        return unifyKeyboardKey(event);
     }
 
     private subscribeToRtl(): void {

--- a/libs/core/src/lib/menu/menu-keyboard.service.ts
+++ b/libs/core/src/lib/menu/menu-keyboard.service.ts
@@ -2,7 +2,8 @@ import { Subject } from 'rxjs';
 import { Injectable, Output } from '@angular/core';
 import { DefaultMenuItem } from './default-menu-item.class';
 import { ListItemComponent } from '../list/list-item/list-item.component';
-import { KeyUtil } from '../utils/functions/key-util';
+import { KeyUtil } from '../utils/functions';
+import { DOWN_ARROW, ENTER, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 
 @Injectable()
 export class MenuKeyboardService {
@@ -31,7 +32,7 @@ export class MenuKeyboardService {
             return;
         }
 
-        if (KeyUtil.isKey(event, 'ArrowDown')) {
+        if (KeyUtil.isKeyCode(event, DOWN_ARROW)) {
             if (menuItems.length > index + 1) {
                 menuItems[index + 1].focus();
             } else {
@@ -42,7 +43,7 @@ export class MenuKeyboardService {
                 }
             }
             event.preventDefault();
-        } else if (KeyUtil.isKey(event, 'ArrowUp')) {
+        } else if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             if (index > 0) {
                 menuItems[index - 1].focus();
             } else {
@@ -53,7 +54,7 @@ export class MenuKeyboardService {
                 }
             }
             event.preventDefault();
-        } else if (KeyUtil.isKey(event, [' ', 'Enter'])) {
+        } else if (KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
             if (menuItems[index]) {
                 menuItems[index].click();
                 event.preventDefault();

--- a/libs/core/src/lib/menu/services/menu.service.ts
+++ b/libs/core/src/lib/menu/services/menu.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, Renderer2 } from '@angular/core';
 import { MenuItemComponent } from '../menu-item/menu-item.component';
 import { MenuComponent } from '../menu.component';
-import { KeyUtil } from '../../utils/functions/key-util';
+import { KeyUtil } from '../../utils/functions';
 import { Observable, Subject } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
+import { DOWN_ARROW, ENTER, ESCAPE, LEFT_ARROW, RIGHT_ARROW, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 
 interface MenuNode {
     item: MenuItemComponent;
@@ -215,33 +216,33 @@ export class MenuService {
         const focusRight = (node) => setTimeout(() => this.setFocused(node.children[0].item));
         let matched = true;
 
-        if (KeyUtil.isKey(event, 'ArrowRight')) {
+        if (KeyUtil.isKeyCode(event, RIGHT_ARROW)) {
             if (this.focusedNode.children.length) {
                 this.setActive(true, this.focusedNode.item);
                 focusRight(this.focusedNode);
             }
-        } else if (KeyUtil.isKey(event, 'ArrowLeft')) {
+        } else if (KeyUtil.isKeyCode(event, LEFT_ARROW)) {
             if (this.focusedNode.parent.item) {
                 this.setActive(false, this.focusedNode.parent.item);
                 this.setFocused(this.focusedNode.parent.item);
             }
-        } else if (KeyUtil.isKey(event, 'ArrowDown')) {
+        } else if (KeyUtil.isKeyCode(event, DOWN_ARROW)) {
             const closest = this._closestEnabled(this.focusedNode, 'down');
             if (closest) {
                 this.setFocused(closest.item);
             }
-        } else if (KeyUtil.isKey(event, 'ArrowUp')) {
+        } else if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             const closest = this._closestEnabled(this.focusedNode, 'up');
             if (closest) {
                 this.setFocused(closest.item);
             }
-        } else if (KeyUtil.isKey(event, [' ', 'Enter'])) {
+        } else if (KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
             this.setActive(true, this.focusedNode.item);
             this.focusedNode.item.click();
             if (this.focusedNode.children.length) {
                 focusRight(this.focusedNode);
             }
-        } else if (KeyUtil.isKey(event, 'Escape') && this.menu.closeOnEscapeKey) {
+        } else if (KeyUtil.isKeyCode(event, ESCAPE) && this.menu.closeOnEscapeKey) {
             this.menu.close();
         } else {
             matched = false;

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -22,13 +22,15 @@ import { PopoverComponent } from '../popover/popover.component';
 import { PopoverFillMode } from '../popover/popover-directive/popover.directive';
 import { MenuKeyboardService } from '../menu/menu-keyboard.service';
 import { FormStates } from '../form/form-control/form-states';
-import { applyCssClass, CssClassBuilder, DynamicComponentService, FocusEscapeDirection, KeyUtil } from '../utils/public_api';
+import { applyCssClass, CssClassBuilder, DynamicComponentService, FocusEscapeDirection } from '../utils/public_api';
+import { KeyUtil } from '../utils/functions';
 import { MultiInputMobileComponent } from './multi-input-mobile/multi-input-mobile.component';
 import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
 import { MULTI_INPUT_COMPONENT, MultiInputInterface } from './multi-input.interface';
 import { Subscription } from 'rxjs';
 import { TokenizerComponent } from '../token/tokenizer.component';
 import { ListComponent } from '../list/list.component';
+import { BACKSPACE, DELETE, DOWN_ARROW, TAB } from '@angular/cdk/keycodes';
 
 /**
  * Input field with multiple selection enabled. Should be used when a user can select between a
@@ -365,7 +367,7 @@ export class MultiInputComponent implements
     /** @hidden */
     removeSelectedTokens(event: KeyboardEvent): void {
         let allSelected = true;
-        if (KeyUtil.isKey(event, ['Delete', 'Backspace']) && !this.searchTerm) {
+        if (KeyUtil.isKeyCode(event, [DELETE, BACKSPACE]) && !this.searchTerm) {
             this.tokenizer.tokenList.forEach(token => {
                 if (token.selected || token.tokenWrapperElement.nativeElement === document.activeElement) {
                     this.handleSelect(false, token.elementRef.nativeElement.innerText);
@@ -379,7 +381,7 @@ export class MultiInputComponent implements
 
     /** @hidden */
     handleInputKeydown(event: KeyboardEvent): void {
-        if (KeyUtil.isKey(event, 'ArrowDown') && !this.mobile) {
+        if (KeyUtil.isKeyCode(event, DOWN_ARROW) && !this.mobile) {
             if (event.altKey) {
                 this.openChangeHandle(true);
             }
@@ -389,7 +391,7 @@ export class MultiInputComponent implements
             }
         }
 
-        if (KeyUtil.isKey(event, 'Tab') && this.open) {
+        if (KeyUtil.isKeyCode(event, TAB) && this.open) {
             if (this.listComponent) {
                 this.listComponent.setItemActive(0);
                 event.preventDefault();

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
@@ -4,7 +4,8 @@ import { Inject, Injectable } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { NestedItemInterface } from './nested-item/nested-item.interface';
 import { NestedListInterface } from './nested-list/nested-list.interface';
-import { KeyUtil } from '../utils/functions/key-util';
+import { KeyUtil } from '../utils/functions';
+import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 
 /**
  * Nested list keyboard service, which uses MenuKeyboardService, to deal with ArrowUp, ArrowDown, Space, Enter.
@@ -71,12 +72,12 @@ export class NestedListKeyboardService {
     private _handleKeyDown(keyboardEvent: KeyboardEvent, index: number, items: NestedItemInterface[]): void {
         const item: NestedItemInterface = items[index];
 
-        if (KeyUtil.isKey(keyboardEvent, 'ArrowRight')) {
+        if (KeyUtil.isKeyCode(keyboardEvent, RIGHT_ARROW)) {
             if (!item.expanded && item.hasChildren) {
                 item.triggerOpen();
             }
             keyboardEvent.preventDefault();
-        } else if (KeyUtil.isKey(keyboardEvent, 'ArrowLeft')) {
+        } else if (KeyUtil.isKeyCode(keyboardEvent, LEFT_ARROW)) {
             if (item.expanded && item.hasChildren) {
                 item.triggerClose();
             }

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.ts
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.ts
@@ -10,7 +10,8 @@ import {
 } from '@angular/core';
 import { ProductSwitchItem } from './product-switch.item';
 import { FdDropEvent } from '../../utils/drag-and-drop/dnd-list/dnd-list.directive';
-import { KeyUtil } from '../../utils/public_api';
+import { KeyUtil } from '../../utils/functions';
+import { DOWN_ARROW, ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE, TAB, UP_ARROW } from '@angular/cdk/keycodes';
 
 @Component({
     selector: 'fd-product-switch-body',
@@ -79,14 +80,14 @@ export class ProductSwitchBodyComponent implements OnInit {
     keyDownHandle(event: KeyboardEvent): void {
         const target = <HTMLElement>event.target;
         const i = Array.from(target.parentElement.children).indexOf(target);
-        if (!KeyUtil.isKey(event, 'Tab')) {
+        if (!KeyUtil.isKeyCode(event, TAB)) {
             event.preventDefault();
         }
-        if (KeyUtil.isKey(event, ['Enter', ' '])) {
+        if (KeyUtil.isKeyCode(event, [ENTER, SPACE])) {
             target.click();
         } else if (!this.isListMode()) {
             this._handleNoListKeydown(event, target, i);
-        } else if (this.isListMode() && KeyUtil.isKey(event, ['ArrowDown', 'ArrowUp'])) {
+        } else if (this.isListMode() && KeyUtil.isKeyCode(event, [DOWN_ARROW, UP_ARROW])) {
             this._handleListArrowUpDown(event, target);
         }
     }
@@ -112,11 +113,11 @@ export class ProductSwitchBodyComponent implements OnInit {
 
     /** @hidden */
     private _handleNoListKeydown(event: KeyboardEvent, target: HTMLElement, i: number): void {
-        if (KeyUtil.isKey(event, 'ArrowLeft') && target.previousElementSibling) {
+        if (KeyUtil.isKeyCode(event, LEFT_ARROW) && target.previousElementSibling) {
             (<HTMLElement>target.previousElementSibling).focus();
-        } else if (KeyUtil.isKey(event, 'ArrowRight') && target.nextElementSibling) {
+        } else if (KeyUtil.isKeyCode(event, RIGHT_ARROW) && target.nextElementSibling) {
             (<HTMLElement>target.nextElementSibling).focus();
-        } else if (KeyUtil.isKey(event, ['ArrowDown', 'ArrowUp'])) {
+        } else if (KeyUtil.isKeyCode(event, [DOWN_ARROW, UP_ARROW])) {
             if (this.products.length >= 7) {
                 this._handleNoListMoreThanSeven(event, target, i);
             } else if (this.products.length < 7) {
@@ -127,12 +128,12 @@ export class ProductSwitchBodyComponent implements OnInit {
 
     /** @hidden */
     private _handleNoListMoreThanSeven(event: KeyboardEvent, target: HTMLElement, i: number): void {
-        if (KeyUtil.isKey(event, 'ArrowDown')) {
+        if (KeyUtil.isKeyCode(event, DOWN_ARROW)) {
             if (target.parentElement.children[i + 4]) {
                 (<HTMLElement>target.parentElement.children[i + 4]).focus();
             }
         }
-        if (KeyUtil.isKey(event, 'ArrowUp')) {
+        if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             if (target.parentElement.children[i - 4]) {
                 (<HTMLElement>target.parentElement.children[i - 4]).focus();
             }
@@ -141,12 +142,12 @@ export class ProductSwitchBodyComponent implements OnInit {
 
     /** @hidden */
     private _handleNoListLessThanSeven(event: KeyboardEvent, target: HTMLElement, i: number): void {
-        if (KeyUtil.isKey(event, 'ArrowDown')) {
+        if (KeyUtil.isKeyCode(event, DOWN_ARROW)) {
             if (target.parentElement.children[i + 3]) {
                 (<HTMLElement>target.parentElement.children[i + 3]).focus();
             }
         }
-        if (KeyUtil.isKey(event, 'ArrowUp')) {
+        if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             if (target.parentElement.children[i - 3]) {
                 (<HTMLElement>target.parentElement.children[i - 3]).focus();
             }
@@ -155,9 +156,9 @@ export class ProductSwitchBodyComponent implements OnInit {
 
     /** @hidden */
     private _handleListArrowUpDown(event: KeyboardEvent, target: HTMLElement): void {
-        if (this.isListMode() && KeyUtil.isKey(event, 'ArrowDown') && target.nextElementSibling) {
+        if (this.isListMode() && KeyUtil.isKeyCode(event, DOWN_ARROW) && target.nextElementSibling) {
             (<HTMLElement>target.nextElementSibling).focus();
-        } else if (this.isListMode() && KeyUtil.isKey(event, 'ArrowUp') && target.previousElementSibling) {
+        } else if (this.isListMode() && KeyUtil.isKeyCode(event, UP_ARROW) && target.previousElementSibling) {
             (<HTMLElement>target.previousElementSibling).focus();
         }
     }

--- a/libs/core/src/lib/select/option/option.component.ts
+++ b/libs/core/src/lib/select/option/option.component.ts
@@ -12,8 +12,9 @@ import {
 } from '@angular/core';
 import { filter, map } from 'rxjs/operators';
 import { Subscription } from 'rxjs';
-import { KeyUtil } from '../../utils/functions/key-util';
+import { KeyUtil } from '../../utils/functions';
 import { SelectProxy } from '../select-proxy.service';
+import { ENTER, SPACE } from '@angular/cdk/keycodes';
 
 let optionUniqueId = 0;
 
@@ -72,7 +73,7 @@ export class OptionComponent implements OnInit, OnDestroy {
     @HostListener('click')
     @HostListener('keydown', ['$event'])
     selectionHandler(event?: KeyboardEvent): void {
-        if (!event || event && KeyUtil.isKey(event, [' ', 'Enter'])) {
+        if (!event || event && KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
             if (event) {
                 event.preventDefault();
                 event.stopPropagation();

--- a/libs/core/src/lib/select/select.component.ts
+++ b/libs/core/src/lib/select/select.component.ts
@@ -27,7 +27,7 @@ import { fromEvent, Subscription } from 'rxjs';
 import { PopperOptions } from 'popper.js';
 import { PopoverFillMode } from '../popover/popover-directive/popover.directive';
 import { createFocusTrap, FocusTrap } from 'focus-trap';
-import { KeyUtil } from '../utils/functions/key-util';
+import { KeyUtil } from '../utils/functions';
 import { SelectProxy } from './select-proxy.service';
 import { buffer, debounceTime, filter, map } from 'rxjs/operators';
 import { DynamicComponentService } from '../utils/dynamic-component/dynamic-component.service';
@@ -35,6 +35,7 @@ import { SelectMobileComponent } from './select-mobile/select-mobile.component';
 import { DIALOG_CONFIG, DialogConfig } from '../dialog/dialog-utils/dialog-config.class';
 import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
 import { SELECT_COMPONENT, SelectInterface } from './select.interface';
+import { DOWN_ARROW, ENTER, ESCAPE, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 
 let selectUniqueId = 0;
 
@@ -223,25 +224,25 @@ export class SelectComponent implements ControlValueAccessor, SelectInterface, O
     /** @hidden */
     @HostListener('keydown', ['$event'])
     keydownHandler(event: KeyboardEvent): void {
-        if (KeyUtil.isKey(event, 'ArrowUp')) {
+        if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             if (this.isInteractive) {
                 this._interactWithOptions('previous');
             }
             event.preventDefault();
 
-        } else if (KeyUtil.isKey(event, 'ArrowDown')) {
+        } else if (KeyUtil.isKeyCode(event, DOWN_ARROW)) {
             if (this.isInteractive) {
                 this._interactWithOptions('next');
             }
             event.preventDefault();
 
-        } else if (KeyUtil.isKey(event, 'Escape')) {
+        } else if (KeyUtil.isKeyCode(event, ESCAPE)) {
             if (this.isInteractive) {
                 this.close();
             }
             event.preventDefault();
 
-        } else if (KeyUtil.isKey(event, [' ', 'Enter'])) {
+        } else if (KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
             if (this.isInteractive) {
                 this.toggle();
             }

--- a/libs/core/src/lib/step-input/step-input.component.ts
+++ b/libs/core/src/lib/step-input/step-input.component.ts
@@ -18,10 +18,11 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { FormStates } from '../form/form-control/form-states';
-import { KeyUtil } from '../utils/functions/key-util';
+import { KeyUtil } from '../utils/functions';
 import { defer, fromEvent, interval, merge, Observable, Subscription, timer } from 'rxjs';
 import { switchMap, takeUntil } from 'rxjs/operators';
 import NumberFormat = Intl.NumberFormat;
+import { DOWN_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 
 let stepInputUniqueId = 0;
 
@@ -322,10 +323,10 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
             return
         }
 
-        if (KeyUtil.isKey(event, 'ArrowUp')) {
+        if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             this.increment();
             muteEvent(event);
-        } else if (KeyUtil.isKey(event, 'ArrowDown')) {
+        } else if (KeyUtil.isKeyCode(event, DOWN_ARROW)) {
             this.decrement();
             muteEvent(event);
         }

--- a/libs/core/src/lib/tabs/tabs.service.ts
+++ b/libs/core/src/lib/tabs/tabs.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, Optional } from '@angular/core';
 import { Subject } from 'rxjs';
 import { RtlService } from '../utils/services/rtl.service';
-import { KeyUtil } from '../utils/functions/key-util';
+import { KeyUtil } from '../utils/functions';
+import { ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE } from '@angular/cdk/keycodes';
 
 /**
  * Service that is responsible for providing keyboard actions support
@@ -20,19 +21,19 @@ export class TabsService {
     tabHeaderKeyHandler(index: number, event: any, elements: HTMLElement[]): void {
         const rtlDirection: boolean = this._rtlService && this._rtlService.rtl.getValue();
 
-        if (KeyUtil.isKey(event, 'ArrowLeft')) {
+        if (KeyUtil.isKeyCode(event, LEFT_ARROW)) {
             if (!rtlDirection) {
                 this._focusPrevious(index, elements);
             } else {
                 this._focusNext(index, elements);
             }
-        } else if (KeyUtil.isKey(event, 'ArrowRight')) {
+        } else if (KeyUtil.isKeyCode(event, RIGHT_ARROW)) {
             if (!rtlDirection) {
                 this._focusNext(index, elements);
             } else {
                 this._focusPrevious(index, elements);
             }
-        } else if (KeyUtil.isKey(event, [' ', 'Enter'])) {
+        } else if (KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
             event.preventDefault();
             this.tabSelected.next(index);
         }

--- a/libs/core/src/lib/time/time-column/time-column.component.ts
+++ b/libs/core/src/lib/time/time-column/time-column.component.ts
@@ -17,10 +17,11 @@ import {
 } from '@angular/core';
 import { CarouselConfig, CarouselDirective, PanEndOutput } from '../../utils/directives/carousel/carousel.directive';
 import { CarouselItemDirective } from '../../utils/directives/carousel/carousel-item.directive';
-import { KeyUtil } from '../../utils/functions/key-util';
+import { KeyUtil } from '../../utils/functions';
 import { TimeColumnConfig } from './time-column-config';
 import { Subject, Subscription } from 'rxjs';
 import { buffer, debounceTime, map } from 'rxjs/operators';
+import { DOWN_ARROW, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
 
 
 let timeColumnUniqueId = 0;
@@ -189,10 +190,10 @@ export class TimeColumnComponent implements AfterViewInit, OnInit, OnDestroy {
     /** @hidden */
     @HostListener('keydown', ['$event'])
     keyDownHandler(event: KeyboardEvent): void {
-        if (KeyUtil.isKey(event, 'ArrowDown')) {
+        if (KeyUtil.isKeyCode(event, DOWN_ARROW)) {
             this.scrollDown();
             event.preventDefault();
-        } else if (KeyUtil.isKey(event, 'ArrowUp')) {
+        } else if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             this.scrollUp();
             event.preventDefault();
         } else if (KeyUtil.isKeyType(event, 'numeric') || KeyUtil.isKeyType(event, 'alphabetical')) {
@@ -202,7 +203,7 @@ export class TimeColumnComponent implements AfterViewInit, OnInit, OnDestroy {
 
     /** @hidden */
     spinnerButtonKeydownHandle(event: KeyboardEvent, upButton?: boolean): void {
-        if (KeyUtil.isKey(event, ' ')) {
+        if (KeyUtil.isKeyCode(event, SPACE)) {
             if (upButton) {
                 this.scrollUp();
             } else {

--- a/libs/core/src/lib/time/time.component.ts
+++ b/libs/core/src/lib/time/time.component.ts
@@ -17,7 +17,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TimeI18n } from './i18n/time-i18n';
 import { TimeColumnConfig } from './time-column/time-column-config';
 import { TimeColumnComponent, TimeColumnItemOutput } from './time-column/time-column.component';
-import { KeyUtil } from '../utils/functions/key-util';
+import { KeyUtil } from '../utils/functions';
+import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 
 export type FdTimeActiveView = 'hour' | 'minute' | 'second' | 'meridian';
 
@@ -232,10 +233,10 @@ export class TimeComponent implements OnInit, OnChanges, AfterViewInit, ControlV
 
     /** @hidden */
     handleKeyDownEvent(event: KeyboardEvent): void {
-        if (KeyUtil.isKey(event, 'ArrowLeft')) {
+        if (KeyUtil.isKeyCode(event, LEFT_ARROW)) {
             this.handlePreviousColumnFocus(this.activeView);
             event.preventDefault();
-        } else if (KeyUtil.isKey(event, 'ArrowRight')) {
+        } else if (KeyUtil.isKeyCode(event, RIGHT_ARROW)) {
             this.handleNextColumnFocus(this.activeView);
             event.preventDefault();
         }

--- a/libs/core/src/lib/token/tokenizer.component.ts
+++ b/libs/core/src/lib/token/tokenizer.component.ts
@@ -7,14 +7,16 @@ import {
     Component,
     ContentChild,
     ContentChildren,
-    ElementRef, EventEmitter,
+    ElementRef,
+    EventEmitter,
     forwardRef,
     HostListener,
     Input,
     OnChanges,
     OnDestroy,
     OnInit,
-    Optional, Output,
+    Optional,
+    Output,
     QueryList,
     Renderer2,
     ViewChild,
@@ -24,7 +26,9 @@ import { FormControlComponent } from '../form/form-control/form-control.componen
 import { TokenComponent } from './token.component';
 import { RtlService } from '../utils/services/rtl.service';
 import { Subscription } from 'rxjs';
-import { applyCssClass, CssClassBuilder, KeyUtil } from '../utils/public_api';
+import { applyCssClass, CssClassBuilder } from '../utils/public_api';
+import { KeyUtil } from '../utils/functions';
+import { A, ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE } from '@angular/cdk/keycodes';
 
 @Component({
     selector: 'fd-tokenizer',
@@ -285,7 +289,7 @@ export class TokenizerComponent implements AfterViewChecked, AfterViewInit, Afte
     handleKeyDown(event: KeyboardEvent, fromIndex: number): void {
         let newIndex: number;
         const rtl = this._rtlService && this._rtlService.rtl ? this._rtlService.rtl.getValue() : false;
-        if (KeyUtil.isKey(event, ' ') && document.activeElement !== this.input.elementRef().nativeElement) {
+        if (KeyUtil.isKeyCode(event, SPACE) && document.activeElement !== this.input.elementRef().nativeElement) {
             const token = this.tokenList.find((element, index) => index === fromIndex);
             this.tokenList.forEach(shadowedToken => {
                 if (shadowedToken !== token) {
@@ -294,15 +298,15 @@ export class TokenizerComponent implements AfterViewChecked, AfterViewInit, Afte
             });
             token.selected = !token.selected;
             event.preventDefault();
-        } else if (KeyUtil.isKey(event, 'Enter')) {
+        } else if (KeyUtil.isKeyCode(event, ENTER)) {
             this.input.elementRef().nativeElement.focus();
-        } else if ((KeyUtil.isKey(event, 'ArrowLeft') && !rtl) || (KeyUtil.isKey(event, 'ArrowRight') && rtl)) {
+        } else if ((KeyUtil.isKeyCode(event, LEFT_ARROW) && !rtl) || (KeyUtil.isKeyCode(event, RIGHT_ARROW) && rtl)) {
             this._handleArrowLeft(fromIndex);
             newIndex = fromIndex - 1;
-        } else if ((KeyUtil.isKey(event, 'ArrowRight') && !rtl) || (KeyUtil.isKey(event, 'ArrowLeft') && rtl)) {
+        } else if ((KeyUtil.isKeyCode(event, RIGHT_ARROW) && !rtl) || (KeyUtil.isKeyCode(event, LEFT_ARROW) && rtl)) {
             this._handleArrowRight(fromIndex);
             newIndex = fromIndex + 1;
-        } else if (KeyUtil.isKey(event, 'KeyA') && this.input.elementRef().nativeElement.value === '') {
+        } else if (KeyUtil.isKeyCode(event, A) && this.input.elementRef().nativeElement.value === '') {
             if (event.ctrlKey || event.metaKey) {
                 if (!this.input.elementRef().nativeElement.value) {
                     event.preventDefault();
@@ -313,7 +317,7 @@ export class TokenizerComponent implements AfterViewChecked, AfterViewInit, Afte
             }
         }
         if (newIndex === this.tokenList.length &&
-            ((KeyUtil.isKey(event, 'ArrowRight') && !rtl) || (KeyUtil.isKey(event, 'ArrowLeft') && rtl))
+            ((KeyUtil.isKeyCode(event, RIGHT_ARROW) && !rtl) || (KeyUtil.isKeyCode(event, LEFT_ARROW) && rtl))
         ) {
             this.input.elementRef().nativeElement.focus();
         } else if (

--- a/libs/core/src/lib/utils/functions/index.ts
+++ b/libs/core/src/lib/utils/functions/index.ts
@@ -1,0 +1,4 @@
+export * from './key-util';
+export * from './closest-element';
+export * from './compare-objects';
+export * from './uuidv4-generator';

--- a/libs/core/src/lib/utils/functions/key-util.spec.ts
+++ b/libs/core/src/lib/utils/functions/key-util.spec.ts
@@ -1,44 +1,45 @@
 import { KeyUtil } from './key-util';
 import { isDevMode } from '@angular/core';
+import { A, B, CONTROL, DOWN_ARROW, SHIFT, TAB, UP_ARROW, Z } from '@angular/cdk/keycodes';
 
 
 describe('KeyUtil', () => {
 
-    describe('isKey', () => {
+    describe('isKeyCode', () => {
 
         interface TestValue {
             event: KeyboardEvent,
-            key: string | string[]
+            keyCode: number | number[]
         }
 
         const positiveTestValues: TestValue[] = [
             {
                 event: {
                     ...new KeyboardEvent('ArrowUp', {key: 'ArrowUp'}),
-                    keyCode: 38
+                    keyCode: UP_ARROW
                 },
-                key: 'ArrowUp'
+                keyCode: UP_ARROW
             },
             {
                 event: {
                     ...new KeyboardEvent('ArrowUp', {key: 'Up'}),
-                    keyCode: 38
+                    keyCode: UP_ARROW
                 },
-                key: 'ArrowUp'
+                keyCode: UP_ARROW
             },
             {
                 event: {
                     ...new KeyboardEvent('ArrowUp', {key: 'Up'}),
-                    keyCode: 38
+                    keyCode: UP_ARROW
                 },
-                key: ['ArrowDown', 'ArrowUp']
+                keyCode: [DOWN_ARROW, UP_ARROW]
             },
             {
                 event: {
                     ...new KeyboardEvent('ArrowUp', {key: null}),
-                    keyCode: 38
+                    keyCode: UP_ARROW
                 },
-                key: 'ArrowUp'
+                keyCode: UP_ARROW
             }
         ];
 
@@ -46,23 +47,23 @@ describe('KeyUtil', () => {
             {
                 event: {
                     ...new KeyboardEvent('ArrowDown', {key: 'ArrowDown'}),
-                    keyCode: 40
+                    keyCode: DOWN_ARROW
                 },
-                key: 'ArrowUp'
+                keyCode: UP_ARROW
             },
             {
                 event: {
                     ...new KeyboardEvent('ArrowDown', {key: 'ArrowDown'}),
-                    keyCode: 40
+                    keyCode: DOWN_ARROW
                 },
-                key: ['ArrowUp', 'Tab']
+                keyCode: [UP_ARROW, TAB]
             },
             {
                 event: {
                     ...new KeyboardEvent('ArrowDown', {key: 'ArrowUp'}),
                     keyCode: null
                 },
-                key: 'ArrowDown'
+                keyCode: DOWN_ARROW
             }
         ];
 
@@ -72,32 +73,32 @@ describe('KeyUtil', () => {
                     ...new KeyboardEvent('MagicBananaKey', {key: 'MagicBananaKey'}),
                     keyCode: -1
                 },
-                key: 'StandardPineappleKey'
+                keyCode: -2
             },
             {
                 event: {
                     ...new KeyboardEvent('ArrowUp', {key: null}),
-                    keyCode: 38
+                    keyCode: UP_ARROW
                 },
-                key: null
+                keyCode: null
             },
             {
                 event: null,
-                key: 'ArrowDown'
+                keyCode: DOWN_ARROW
             }
         ];
 
         it('should identify positive key examples', () =>
-            positiveTestValues.forEach(example => expect(KeyUtil.isKey(example.event, example.key)).toBeTrue())
+            positiveTestValues.forEach(example => expect(KeyUtil.isKeyCode(example.event, example.keyCode)).toBeTrue())
         );
 
         it('should identify negative key examples', () =>
-            negativeTestValues.forEach(example => expect(KeyUtil.isKey(example.event, example.key)).toBeFalse())
+            negativeTestValues.forEach(example => expect(KeyUtil.isKeyCode(example.event, example.keyCode)).toBeFalse())
         );
 
         it('should throw error for broken examples', () => {
             if (isDevMode()) {
-                errorTestValues.forEach(example => expect(() => KeyUtil.isKey(example.event, example.key)).toThrow())
+                errorTestValues.forEach(example => expect(() => KeyUtil.isKeyCode(example.event, example.keyCode)).toThrow())
             }
         });
     });
@@ -113,21 +114,21 @@ describe('KeyUtil', () => {
             {
                 event: {
                     ...new KeyboardEvent('KeyA', {code: 'KeyA'}),
-                    keyCode: 65
+                    keyCode: A
                 },
                 keyType: 'alphabetical'
             },
             {
                 event: {
                     ...new KeyboardEvent('KeyB', {code: 'KeyB'}),
-                    keyCode: 66
+                    keyCode: B
                 },
                 keyType: 'alphabetical'
             },
             {
                 event: {
                     ...new KeyboardEvent('KeyZ', {code: null}),
-                    keyCode: 90
+                    keyCode: Z
                 },
                 keyType: 'alphabetical'
             },
@@ -165,14 +166,14 @@ describe('KeyUtil', () => {
             {
                 event: {
                     ...new KeyboardEvent('Shift', {code: 'Shift'}),
-                    keyCode: 16
+                    keyCode: SHIFT
                 },
                 keyType: 'alphabetical'
             },
             {
                 event: {
                     ...new KeyboardEvent('Control', {code: 'Control'}),
-                    keyCode: 17
+                    keyCode: CONTROL
                 },
                 keyType: 'numeric'
             },
@@ -193,7 +194,7 @@ describe('KeyUtil', () => {
             {
                 event: {
                     ...new KeyboardEvent('KeyB', {code: 'KeyB'}),
-                    keyCode: 66
+                    keyCode: B
                 },
                 keyType: undefined
             }
@@ -209,7 +210,7 @@ describe('KeyUtil', () => {
 
         it('should throw error for broken keyType examples', () => {
             if (isDevMode()) {
-                errorTestValues.forEach(example => expect(() => KeyUtil.isKey(example.event, example.keyType)).toThrow())
+                errorTestValues.forEach(example => expect(() => KeyUtil.isKeyType(example.event, example.keyType)).toThrow())
             }
         });
     })

--- a/libs/core/src/lib/utils/functions/key-util.ts
+++ b/libs/core/src/lib/utils/functions/key-util.ts
@@ -11,7 +11,8 @@ import {
     ESCAPE,
     HOME,
     LEFT_ARROW,
-    META, PAGE_DOWN, PAGE_UP,
+    META, PAGE_DOWN,
+    PAGE_UP,
     RIGHT_ARROW,
     SHIFT,
     SPACE,
@@ -19,95 +20,34 @@ import {
     UP_ARROW
 } from '@angular/cdk/keycodes';
 
-/**
- * This is going to be deprecated as working with string directly will cause problems.
- *  Instead of doing:
- *      KeyUtil.isKey(event, ['ArrowDown', 'ArrowUp']) we need should be ble to do
- *      KeyUtil.isKey(event, [DOWN_ARROW, UP_ARROW]).
- *
- */
-
-const keyMap: Map<string, { aliases: string[], keyCode: number }> = new Map(
-    [
-        ['ArrowRight', {aliases: ['ArrowRight', 'Right'], keyCode: 39}],
-        ['ArrowDown', {aliases: ['ArrowDown', 'Down'], keyCode: 40}],
-        ['ArrowLeft', {aliases: ['ArrowLeft', 'Left'], keyCode: 37}],
-        ['ArrowUp', {aliases: ['ArrowUp', 'Up'], keyCode: 38}],
-        [' ', {aliases: ['Space', 'Spacebar', ' '], keyCode: 32}],
-        ['Escape', {aliases: ['Escape', 'Esc'], keyCode: 27}],
-        ['Delete', {aliases: ['Delete', 'Del'], keyCode: 46}],
-        ['Enter', {aliases: ['Enter'], keyCode: 13}],
-        ['Tab', {aliases: ['Tab'], keyCode: 9}],
-        ['Alt', {aliases: ['Alt'], keyCode: 18}],
-        ['Ctrl', {aliases: ['Ctrl', 'Control', 'Meta'], keyCode: 17}],
-        ['Meta', {aliases: ['Meta'], keyCode: 91}],
-        ['Shift', {aliases: ['Shift'], keyCode: 16}],
-        ['Backspace', {aliases: ['Backspace'], keyCode: 8}],
-        ['KeyA', {aliases: ['KeyA'], keyCode: 65}],
-        ['PageUp', { aliases: ['PageUp'], keyCode: 33 }],
-        ['PageDown', { aliases: ['PageDown'], keyCode: 34 }]
-    ]
-);
-
-/**
- * This new KeyMap will allows us to check the key with KeyCodes.
- * Using strings can lead into situation where we are checking space with
- * KeyUtil.isKey(event, ' ']) which might generate issues
- */
-const keyMapByCode: Map<number, { aliases: string[]; keyCode: number }> = new Map([
-    [RIGHT_ARROW, { aliases: ['ArrowRight', 'Right'], keyCode: RIGHT_ARROW }],
-    [DOWN_ARROW, { aliases: ['ArrowDown', 'Down'], keyCode: DOWN_ARROW }],
-    [LEFT_ARROW, { aliases: ['ArrowLeft', 'Left'], keyCode: LEFT_ARROW }],
-    [UP_ARROW, { aliases: ['ArrowUp', 'Up'], keyCode: UP_ARROW }],
-    [SPACE, { aliases: ['Space', 'Spacebar', ' '], keyCode: SPACE }],
-    [ESCAPE, { aliases: ['Escape', 'Esc'], keyCode: ESCAPE }],
-    [DELETE, { aliases: ['Delete', 'Del'], keyCode: DELETE }],
-    [ENTER, { aliases: ['Enter'], keyCode: ENTER }],
-    [TAB, { aliases: ['Tab'], keyCode: TAB }],
-    [HOME, { aliases: ['Home'], keyCode: HOME }],
-    [END, { aliases: ['End'], keyCode: END }],
-    [ALT, { aliases: ['Alt'], keyCode: ALT }],
-    [CONTROL, { aliases: ['Ctrl', 'Control', 'Meta'], keyCode: CONTROL }],
-    [META, { aliases: ['Meta'], keyCode: META }],
-    [SHIFT, { aliases: ['Shift'], keyCode: SHIFT }],
-    [BACKSPACE, { aliases: ['Backspace'], keyCode: BACKSPACE }],
-    [A, {aliases: ['KeyA'], keyCode: A}],
-    [PAGE_UP, { aliases: ['PageUp'], keyCode: PAGE_UP }],
-    [PAGE_DOWN, { aliases: ['PageDown'], keyCode: PAGE_DOWN }]
+/** Map of keyCodes and their corresponding "key" values */
+const keyMap: Map<number, string[]> = new Map([
+    [RIGHT_ARROW, ['ArrowRight', 'Right']],
+    [DOWN_ARROW, ['ArrowDown', 'Down']],
+    [LEFT_ARROW, ['ArrowLeft', 'Left']],
+    [UP_ARROW, ['ArrowUp', 'Up']],
+    [SPACE, ['Space', 'Spacebar', ' ']],
+    [ESCAPE, ['Escape', 'Esc']],
+    [DELETE, ['Delete', 'Del']],
+    [ENTER, ['Enter']],
+    [TAB, ['Tab']],
+    [HOME, ['Home']],
+    [END, ['End']],
+    [ALT, ['Alt']],
+    [CONTROL, ['Ctrl', 'Control', 'Meta']],
+    [META, ['Meta']],
+    [SHIFT, ['Shift']],
+    [BACKSPACE, ['Backspace']],
+    [A, ['KeyA']],
+    [PAGE_UP, ['PageUp']],
+    [PAGE_DOWN, ['PageDown']]
 ]);
 
 export class KeyUtil {
     /**
-     * Function used to unify key identification across different browsers
-     *
-     * @param event - KeyboardEvent
-     * @param keyCode   - event.key name matching W3C specification
-     * */
-    static isKey(event: KeyboardEvent, keyCode: string | string[]): boolean {
-        if (Array.isArray(keyCode)) {
-            return keyCode.some((key) => this.isKey(event, key));
-        }
-
-        if (event && keyMap.get(keyCode)) {
-            return (
-                keyMap.get(keyCode).aliases.some((alias) => alias === event.key) ||
-                keyMap.get(keyCode).keyCode === event.keyCode
-            );
-        }
-
-        if (isDevMode()) {
-            throw new Error(
-                `Invalid function arguments. Check if "event" is a KeyboardEvent or "key" is defined in keyMap`
-            );
-        }
-
-        return false;
-    }
-
-    /**
      * Function used to unify key identification across different browsers using KeyCodes
      *
-     * @param event - KeyboardEvent
+     * @param event     - KeyboardEvent
      * @param keyCode   - event.key name matching W3C specification / (ASSCI char. codes)
      * */
     static isKeyCode(event: KeyboardEvent, keyCode: number | number[]): boolean {
@@ -115,10 +55,10 @@ export class KeyUtil {
             return keyCode.some((key) => this.isKeyCode(event, key));
         }
 
-        if (event && keyMapByCode.get(keyCode)) {
+        if (event && keyMap.get(keyCode)) {
             return (
-                keyMapByCode.get(keyCode).aliases.some((alias) => alias === event.key) ||
-                keyMapByCode.get(keyCode).keyCode === event.keyCode
+                keyMap.get(keyCode).some((alias) => alias === event.key) ||
+                keyCode === event.keyCode
             );
         }
 

--- a/libs/core/src/lib/utils/functions/keyboard-unification.ts
+++ b/libs/core/src/lib/utils/functions/keyboard-unification.ts
@@ -1,9 +1,0 @@
-export function unifyKeyboardKey(event: KeyboardEvent): string {
-    const ieKeys = {
-        left: 'ArrowLeft',
-        right: 'ArrowRight',
-        down: 'ArrowDown',
-        up: 'ArrowUp'
-    };
-    return ieKeys[event.key.toLowerCase()] || event.key;
-}

--- a/libs/core/src/lib/utils/public_api.ts
+++ b/libs/core/src/lib/utils/public_api.ts
@@ -37,10 +37,6 @@ export * from './datatypes/hash.datatype';
 export * from './services/rtl.service';
 export * from './services/keyboard-support/keyboard-support.service';
 
-export * from './functions/compare-objects';
-export * from './functions/closest-element';
-export * from './functions/keyboard-unification';
-export * from './functions/uuidv4-generator';
-export * from './functions/key-util';
+export * from './functions';
 
 export * from './base-class/mobile-mode.class';

--- a/libs/core/src/lib/utils/services/keyboard-support/keyboard-support.service.ts
+++ b/libs/core/src/lib/utils/services/keyboard-support/keyboard-support.service.ts
@@ -3,7 +3,8 @@ import { QueryList } from '@angular/core';
 import { KeyboardSupportItemInterface } from '../../interfaces/keyboard-support-item.interface';
 import { merge, Subject } from 'rxjs';
 import { filter, startWith, takeUntil, tap } from 'rxjs/operators';
-import { KeyUtil } from '../../functions/key-util';
+import { KeyUtil } from '../../functions';
+import { DOWN_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 
 export type FocusEscapeDirection = 'up' | 'down';
 
@@ -50,11 +51,11 @@ export class KeyboardSupportService<T> {
     private _refreshEscapeLogic(queryList: QueryList<KeyboardSupportItemInterface & T>): void {
 
         const createEscapeListener = (
-            listItem: KeyboardSupportItemInterface & T, onKey: string, escapeDirection: FocusEscapeDirection
+            listItem: KeyboardSupportItemInterface & T, onKeyCode: number, escapeDirection: FocusEscapeDirection
         ): void => {
             listItem.keyDown.pipe(
                 takeUntil(unsubscribe$),
-                filter(event => KeyUtil.isKey(event, onKey)),
+                filter(event => KeyUtil.isKeyCode(event, onKeyCode)),
                 tap(event => event.preventDefault())
             ).subscribe(() => this.focusEscapeList.next(escapeDirection));
         };
@@ -65,8 +66,8 @@ export class KeyboardSupportService<T> {
         const unsubscribe$ = merge(this._onRefresh$, this._onDestroy$);
 
         if (queryList.length) {
-            createEscapeListener(queryList.last, 'ArrowDown', 'down');
-            createEscapeListener(queryList.first, 'ArrowUp', 'up');
+            createEscapeListener(queryList.last, DOWN_ARROW, 'down');
+            createEscapeListener(queryList.first, UP_ARROW, 'up');
         }
     }
 }

--- a/libs/core/src/lib/wizard/wizard-step/wizard-step.component.ts
+++ b/libs/core/src/lib/wizard/wizard-step/wizard-step.component.ts
@@ -9,10 +9,10 @@ import {
     Output,
     SimpleChanges,
     ViewChild,
-    ViewEncapsulation
 } from '@angular/core';
 import { WizardContentComponent } from '../wizard-content/wizard-content.component';
-import { KeyUtil } from '../../utils/public_api';
+import { KeyUtil } from '../../utils/functions';
+import { ENTER, SPACE } from '@angular/cdk/keycodes';
 
 export type WizardStepStatus = 'completed' | 'current' | 'upcoming' | 'active';
 
@@ -101,7 +101,7 @@ export class WizardStepComponent implements OnChanges {
         if (event) {
             event.preventDefault();
         }
-        if (this.visited && (!event || KeyUtil.isKey(event, [' ', 'Enter']))) {
+        if (this.visited && (!event || KeyUtil.isKeyCode(event, [SPACE, ENTER]))) {
             this.stepClicked.emit(this);
         }
     }

--- a/libs/platform/src/lib/components/form/step-input/step-input-control.directive.ts
+++ b/libs/platform/src/lib/components/form/step-input/step-input-control.directive.ts
@@ -3,6 +3,7 @@ import { Directive, HostListener, SkipSelf } from '@angular/core';
 import { KeyUtil } from '@fundamental-ngx/core';
 
 import { StepInputComponent } from './base.step-input';
+import { DOWN_ARROW, PAGE_DOWN, PAGE_UP, UP_ARROW } from '@angular/cdk/keycodes';
 
 /**
  * This directive is intendant to be a bridge between input control and BaseStepInput Component.
@@ -66,19 +67,19 @@ export class StepInputControlDirective {
         if (!this.stepInput.canChangeValue) {
             return;
         }
-        if (KeyUtil.isKey(event, 'ArrowUp')) {
+        if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             this.stepInput.increase();
             this._muteEvent(event);
         }
-        if (KeyUtil.isKey(event, 'ArrowDown')) {
+        if (KeyUtil.isKeyCode(event, DOWN_ARROW)) {
             this.stepInput.decrease();
             this._muteEvent(event);
         }
-        if (KeyUtil.isKey(event, 'PageUp')) {
+        if (KeyUtil.isKeyCode(event, PAGE_UP)) {
             this.stepInput.largeStepIncrease();
             this._muteEvent(event);
         }
-        if (KeyUtil.isKey(event, 'PageDown')) {
+        if (KeyUtil.isKeyCode(event, PAGE_DOWN)) {
             this.stepInput.largeStepDecrease();
             this._muteEvent(event);
         }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes: #3105 

#### Please provide a brief summary of this pull request.

This PR:
- Updates existing `KeyUtil` implementations
- Removes `KeyUtil.isKey` in favor of `KeyUtil.isKeyCode`
- Removes `UnifyKeyboardKey` util

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples