### PR TITLE
fix: (Core) add optional typing for class properties

### DIFF
--- a/apps/docs/src/app/core/component-docs/message-toast/examples/message-toast-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/message-toast/examples/message-toast-example.component.ts
@@ -15,14 +15,14 @@ export class MessageToastExampleComponent {
             mousePersist: true,
             duration: 5000,
             maxWidth: '25rem'
-        } as MessageToastConfig);
+        });
     }
 
     openFromString(): void {
         const content = 'Message Toast created from string. Will disappear after 5000ms';
         this.messageToastService.open(content, {
             duration: 5000
-        } as MessageToastConfig);
+        });
     }
 
     openFromTemplate(template): void {
@@ -30,6 +30,6 @@ export class MessageToastExampleComponent {
             data: {
                 content: 'Message Toast created from template.'
             }
-        } as MessageToastConfig);
+        });
     }
 }

--- a/libs/core/src/lib/message-toast/message-toast-utils/message-toast-config.ts
+++ b/libs/core/src/lib/message-toast/message-toast-utils/message-toast-config.ts
@@ -11,10 +11,10 @@ export class MessageToastConfig implements DynamicComponentConfig {
     data?: any;
 
     /** Duration of time *in milliseconds* that the message toast will be visible. Set to -1 for indefinite. */
-    duration = 3000;
+    duration? = 3000;
 
     /** Whether the message toast should stay visible if the cursor is over it. */
-    mousePersist = false;
+    mousePersist? = false;
 
     /** Aria label for the message toast component element. */
     ariaLabel?: string = null;

--- a/libs/core/src/lib/message-toast/message-toast-utils/message-toast-config.ts
+++ b/libs/core/src/lib/message-toast/message-toast-utils/message-toast-config.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:no-inferrable-types */
 import { DynamicComponentConfig } from '../../utils/dynamic-component/dynamic-component-config';
 
 /**
@@ -11,10 +12,10 @@ export class MessageToastConfig implements DynamicComponentConfig {
     data?: any;
 
     /** Duration of time *in milliseconds* that the message toast will be visible. Set to -1 for indefinite. */
-    duration? = 3000;
+    duration?: number = 3000;
 
     /** Whether the message toast should stay visible if the cursor is over it. */
-    mousePersist? = false;
+    mousePersist?: boolean = false;
 
     /** Aria label for the message toast component element. */
     ariaLabel?: string = null;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3641
#### Please provide a brief summary of this pull request.
There is added nullable typing for message toast classes, to get rid of `as ...` casting.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

