### PR TITLE
fix: (Core) unify the naming of the cozy property

### DIFF
--- a/apps/docs/src/app/core/component-docs/bar/bar-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/bar/bar-docs.component.html
@@ -2,8 +2,8 @@
     Default Bar
 </fd-docs-section-title>
 <description>
-    The default mode of the Bar component is Desktop. For Tablet and Mobile use the Cosy mode by adding
-    <code>[cosy]="true"</code> to <code>fd-bar</code>
+    The default mode of the Bar component is Desktop. For Tablet and Mobile use the Cozy mode by adding
+    <code>[cozy]="true"</code> to <code>fd-bar</code>
 </description>
 
 <component-example>

--- a/apps/docs/src/app/core/component-docs/bar/bar-header/bar-header.component.html
+++ b/apps/docs/src/app/core/component-docs/bar/bar-header/bar-header.component.html
@@ -2,7 +2,7 @@
 <description
     >The Bar component is a container that holds titles, buttons and input controls. Its content is distributed in three
     areas - left, middle and right. The Bar has 2 modes - <code>Desktop (default)</code> and
-    <code>Tablet/Mobile (cosy)</code>.</description
+    <code>Tablet/Mobile (cozy)</code>.</description
 >
 <import module="barModule"></import>
 

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-complex-example/popover-complex-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-complex-example/popover-complex-example.component.html
@@ -18,9 +18,9 @@
         </fd-popover-control>
         <fd-popover-body>
             <div fd-popover-body-header>
-                <div fd-bar [cosy]="true">
+                <div fd-bar [cozy]="true">
                     <div fd-bar-left>
-                        <fd-bar-element>Cosy Header</fd-bar-element>
+                        <fd-bar-element>Cozy Header</fd-bar-element>
                     </div>
                 </div>
             </div>
@@ -38,9 +38,9 @@
         </fd-popover-control>
         <fd-popover-body>
             <div fd-popover-body-header>
-                <div fd-bar [cosy]="true">
+                <div fd-bar [cozy]="true">
                     <div fd-bar-left>
-                        <fd-bar-element>Cosy Header</fd-bar-element>
+                        <fd-bar-element>Cozy Header</fd-bar-element>
                     </div>
                 </div>
             </div>
@@ -50,7 +50,7 @@
                 </li>
             </ul>
             <div fd-popover-body-footer>
-                <div fd-bar [barDesign]="'footer'" [cosy]="true">
+                <div fd-bar [barDesign]="'footer'" [cozy]="true">
                     <div fd-bar-right>
                         <fd-bar-element>
                             <button fd-button label="Save" [fdType]="'emphasized'" [compact]="true"></button>
@@ -70,12 +70,12 @@
         </fd-popover-control>
         <fd-popover-body>
             <div fd-popover-body-header>
-                <div fd-bar [barDesign]="'header-with-subheader'" [cosy]="true">
+                <div fd-bar [barDesign]="'header-with-subheader'" [cozy]="true">
                     <div fd-bar-left>
-                        <fd-bar-element>Cosy Header</fd-bar-element>
+                        <fd-bar-element>Cozy Header</fd-bar-element>
                     </div>
                 </div>
-                <div fd-bar [barDesign]="'subheader'" [cosy]="true">
+                <div fd-bar [barDesign]="'subheader'" [cozy]="true">
                     <div fd-bar-middle>
                         <fd-bar-element>Cozy Subheader</fd-bar-element>
                     </div>
@@ -89,7 +89,7 @@
             </ul>
 
             <div fd-popover-body-footer>
-                <div fd-bar [barDesign]="'footer'" [cosy]="true">
+                <div fd-bar [barDesign]="'footer'" [cozy]="true">
                     <div fd-bar-right>
                         <fd-bar-element>
                             <button fd-button fdType="emphasized" label="Save" [compact]="true"></button>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
@@ -60,12 +60,12 @@
         </fd-popover-control>
         <fd-popover-body *ngIf="list1 && list1.length">
             <div fd-popover-body-header>
-                <div fd-bar [barDesign]="'header-with-subheader'" [cosy]="true">
+                <div fd-bar [barDesign]="'header-with-subheader'" [cozy]="true">
                     <div fd-bar-left>
-                        <fd-bar-element>Cosy Header</fd-bar-element>
+                        <fd-bar-element>Cozy Header</fd-bar-element>
                     </div>
                 </div>
-                <div fd-bar [barDesign]="'subheader'" [cosy]="true">
+                <div fd-bar [barDesign]="'subheader'" [cozy]="true">
                     <div fd-bar-middle>
                         <fd-bar-element [fullWidth]="true"
                             >SubHeader Middle section with Full Width Element
@@ -79,7 +79,7 @@
                 </li>
             </ul>
             <div fd-popover-body-footer>
-                <div fd-bar [barDesign]="'footer'" [cosy]="true">
+                <div fd-bar [barDesign]="'footer'" [cozy]="true">
                     <div fd-bar-right>
                         <fd-bar-element>
                             <button fd-button label="Save" [fdType]="'emphasized'" [compact]="true"></button>

--- a/libs/core/src/lib/bar/bar.component.ts
+++ b/libs/core/src/lib/bar/bar.component.ts
@@ -15,7 +15,7 @@ export type BarDesignType = 'header' | 'subheader' | 'header-with-subheader' | '
 /**
  * The Bar component is a container that holds titles, buttons and input controls.
  * Its content is distributed in three areas - left, middle and right.
- * The Bar has 2 modes - Desktop (default) and Tablet/Mobile (cosy).
+ * The Bar has 2 modes - Desktop (default) and Tablet/Mobile (cozy).
  */
 @Component({
     // tslint:disable-next-line:component-selector
@@ -50,9 +50,9 @@ export class BarComponent implements OnChanges, OnInit, CssClassBuilder {
     @Input()
     size: SizeType = '';
 
-    /** Whether to apply cosy mode to the Bar. */
+    /** Whether to apply cozy mode to the Bar. */
     @Input()
-    cosy: boolean;
+    cozy: boolean;
 
     /** @hidden */
     constructor(private _elementRef: ElementRef) {}
@@ -75,7 +75,7 @@ export class BarComponent implements OnChanges, OnInit, CssClassBuilder {
     buildComponentCssClass(): string[] {
         return [
             'fd-bar',
-            this.cosy ? 'fd-bar--cozy' : '',
+            this.cozy ? 'fd-bar--cozy' : '',
             this.barDesign ? `fd-bar--${this.barDesign}` : '',
             this.inPage && !this.size ? 'fd-bar--page' : '',
             this.inPage && this.size ? `fd-bar--page-${this.size}` : '',

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -72,7 +72,7 @@
                 ></fd-time>
             </div>
             <div fd-popover-body-footer *ngIf="showFooter">
-                <div fd-bar barDesign="footer" [cosy]="!compact">
+                <div fd-bar barDesign="footer" [cozy]="!compact">
                     <div fd-bar-right>
                         <fd-bar-element>
                             <button fd-button fdType="emphasized" label="Submit" [compact]="compact" (click)="submit()"></button>

--- a/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.html
+++ b/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.html
@@ -1,4 +1,4 @@
-<footer fd-bar class="fd-dialog__footer" barDesign="footer" [cosy]="dialogConfig.mobile">
+<footer fd-bar class="fd-dialog__footer" barDesign="footer" [cozy]="dialogConfig.mobile">
     <ng-container *ngTemplateOutlet="footerTemplate ? footerTemplate : defaultTemplate"></ng-container>
 
     <ng-template #defaultTemplate>

--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
@@ -1,6 +1,6 @@
 <header
     fd-bar
-    [cosy]="dialogConfig.mobile"
+    [cozy]="dialogConfig.mobile"
     [class]="'fd-dialog__header'"
     [barDesign]="subHeaderTemplate ? 'header-with-subheader' : 'header'"
 >
@@ -20,6 +20,6 @@
     </ng-template>
 </header>
 
-<div fd-bar *ngIf="subHeaderTemplate" class="fd-dialog__subheader" barDesign="subheader" [cosy]="dialogConfig.mobile">
+<div fd-bar *ngIf="subHeaderTemplate" class="fd-dialog__subheader" barDesign="subheader" [cozy]="dialogConfig.mobile">
     <ng-container *ngTemplateOutlet="subHeaderTemplate"></ng-container>
 </div>

--- a/src/stories/bar/fd-bar.stories.ts
+++ b/src/stories/bar/fd-bar.stories.ts
@@ -39,7 +39,7 @@ export const Bar = () => ({
     <div style="padding:20px;">
         <div fd-bar
             [barDesign]="barDesignVar"
-            [cosy]="cosy"
+            [cozy]="cozy"
             [inHomePage]="inHomePage"
             [inPage]="inPage"
             [size]="size">
@@ -82,7 +82,7 @@ export const Bar = () => ({
     </div>
   `,
     props: {
-        cosy: boolean('cosy', false),
+        cozy: boolean('cozy', false),
         showLeft: boolean('Show Left Section', true),
         showRight: boolean('Show Right Section', true),
         showMiddle: boolean('Show Middle Section', true),


### PR DESCRIPTION
#### Please provide a link to the associated issue.
close #3518

#### Please provide a brief summary of this pull request.
for the cozy property both `cosy` and `cozy` were used. It was decided that only `cozy` should be used. This PR is removing all the appearances of `cosy` in the Bar component and in the documentation examples.

BREAKING CHANGE:
In Bar component the Input property `cosy` was renamed to `cozy` for consistency with other components and Fiori 3 naming. Affected components: DateTime Picker, Dialog (footer and header).

Before:

```
<div fd-bar barDesign="footer" [cosy]="!compact">
```

Now:
```
<div fd-bar barDesign="footer" [cozy]="!compact">
```

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md

Documentation checklist:
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples

