### PR TITLE
test: update imports on title test

### DIFF
--- a/libs/core/src/lib/title/title.component.spec.ts
+++ b/libs/core/src/lib/title/title.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TitleComponent } from './title.component';
-import { TitleModule } from '@fundamental-ngx/core';
+import { TitleModule } from './title.module';
 
 describe('TitleComponent', () => {
     let component: TitleComponent;


### PR DESCRIPTION
There shouldn't be any `@fundamental-ngx/core` imports, even on tests.