### PR TITLE
chore: Add overlay styles and hammerjs dep into stackblitz config file

### DIFF
--- a/apps/docs/src/app/documentation/core-helpers/stackblitz/code-example-stack/styles.scss
+++ b/apps/docs/src/app/documentation/core-helpers/stackblitz/code-example-stack/styles.scss
@@ -1,3 +1,5 @@
+@import "~@angular/cdk/overlay-prebuilt.css";
+
 @font-face {
     font-family: '72';
     src: url('node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_base_fiori/fonts/72-Regular-full.woff')

--- a/apps/docs/src/app/documentation/core-helpers/stackblitz/stackblitz-dependencies.ts
+++ b/apps/docs/src/app/documentation/core-helpers/stackblitz/stackblitz-dependencies.ts
@@ -19,6 +19,7 @@ export class StackblitzDependencies {
         'fundamental-styles',
         'moment',
         'popper.js',
+        'hammerjs',
         'tslib',
         'typescript'
     ];


### PR DESCRIPTION
There are added cdk-overlay styles and hammerjs dependency into stackblitz config file