### PR TITLE
fix: Add temporary styles for overflow toolbar

### DIFF
--- a/libs/core/src/lib/toolbar/toolbar.component.scss
+++ b/libs/core/src/lib/toolbar/toolbar.component.scss
@@ -1,21 +1,86 @@
 @import '~fundamental-styles/dist/toolbar';
 
 .fd-toolbar {
-    position: relative;
+	position: relative;
 }
 
 .fd-toolbar > * {
-    flex-shrink: 0;
+	flex-shrink: 0;
 }
 
 .fd-toolbar-fade-out {
-    visibility: hidden;
-    opacity: 0;
-    transition: visibility 0s linear 1s, opacity 1ms;
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s linear 1s, opacity 1ms;
 }
 
 .fd-toolbar-fade-in {
-    visibility: visible;
-    opacity: 1;
-    transition: visibility 0s linear 0s, opacity 1s;
+	visibility: visible;
+	opacity: 1;
+	transition: visibility 0s linear 0s, opacity 1s;
+}
+
+// TODO: Remove after merging https://github.com/SAP/fundamental-styles/pull/1851
+
+$fd-namespace: fd;
+$block: fd-toolbar;
+
+.#{$block}__overflow__body {
+	font-size: .875rem;
+	font-size: var(--sapFontSize, .875rem);
+	line-height: 1.4;
+	line-height: var(--sapContent_LineHeight, 1.4);
+	color: #32363a;
+	color: var(--sapTextColor, #32363a);
+	font-family: "72", "72full", Arial, Helvetica, sans-serif;
+	font-family: var(--sapFontFamily, "72", "72full", Arial, Helvetica, sans-serif);
+	font-weight: 400;
+	-webkit-font-smoothing: antialiased;
+	box-sizing: border-box;
+	margin: 0;
+	border: 0;
+	display: flex;
+	flex-direction: column;
+	max-width: 20rem;
+	padding: .1875rem .375rem;
+
+	> *,
+	> .fd-button {
+		display: block;
+		text-align: left;
+		width: auto;
+
+		@at-root {
+			[dir="rtl"] &,
+			&[dir="rtl"] {
+				text-align: right;
+			}
+		}
+	}
+
+	> .#{$block}__separator {
+		height: 0.0625rem;
+		margin: 0.375rem 0.1875rem;
+		width: auto;
+		background-color: var(--sapToolbar_SeparatorColor);
+	}
+
+	.#{$block}__overflow__label {
+		&.#{$fd-namespace}-label {
+			margin: 0.375rem 0;
+		}
+	}
+
+	.#{$block}__overflow__form-label {
+		&.#{$fd-namespace}-form-label {
+			margin: 0.625rem 0 0.125rem 0;
+		}
+	}
+
+	.#{$block}__overflow__form-label,
+	.#{$block}__overflow__label {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3685
#### Please provide a brief summary of this pull request.
Right now popover-body is rendered outside popover DOM. So styles for `.fd-toolbar {}` are not visible in `fd-toolbar__overflow__body {}` anymore. This is already addressed in styles on https://github.com/SAP/fundamental-styles/pull/1851. But it will take time to merge/adapt everything form newest version

