### PR TITLE
fix: (Core) RTL mode arrows is showing wrong in Panel

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-panel/platform-panel-examples/platform-panel-expandable-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-panel/platform-panel-examples/platform-panel-expandable-example.component.html
@@ -1,4 +1,4 @@
-<fdp-button (click)="expanded = !expanded" [attr.aria-pressed]="expanded">Toggle Expand</fdp-button>
+<fdp-button (click)="expanded = !expanded" [attr.aria-pressed]="expanded" label="Toggle Expand"></fdp-button>
 <br />
 <br />
 Expanded value is: {{ expanded }}

--- a/libs/core/src/lib/panel/panel.component.html
+++ b/libs/core/src/lib/panel/panel.component.html
@@ -4,7 +4,7 @@
             fd-button
             fdType="transparent"
             class="fd-panel__button"
-            [glyph]="expanded ? 'slim-arrow-down' : (_rtl$ | async) ? 'slim-arrow-left' : 'slim-arrow-right'"
+            [glyph]="_getButtonIcon()"
             [id]="expandId"
             [compact]="compact"
             [class.is-expanded]="expanded"

--- a/libs/core/src/lib/panel/panel.component.html
+++ b/libs/core/src/lib/panel/panel.component.html
@@ -4,7 +4,7 @@
             fd-button
             fdType="transparent"
             class="fd-panel__button"
-            [glyph]="expanded ? 'slim-arrow-down' : 'slim-arrow-right'"
+            [glyph]="expanded ? 'slim-arrow-down' : (_rtl$ | async) ? 'slim-arrow-left' : 'slim-arrow-right'"
             [id]="expandId"
             [compact]="compact"
             [class.is-expanded]="expanded"

--- a/libs/core/src/lib/panel/panel.component.scss
+++ b/libs/core/src/lib/panel/panel.component.scss
@@ -3,3 +3,8 @@
 .fd-panel__content:focus {
     outline: none;
 }
+
+/* TODO: remove it after https://github.com/SAP/fundamental-styles/pull/1861 will be merged */
+.fd-panel__button[dir=rtl]:before, [dir=rtl] .fd-panel__button:before {
+    content: '';
+}

--- a/libs/core/src/lib/panel/panel.component.spec.ts
+++ b/libs/core/src/lib/panel/panel.component.spec.ts
@@ -2,6 +2,7 @@ import { Component, ElementRef, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { PanelModule } from './panel.module';
+import { RtlService } from '../utils/services/rtl.service';
 
 @Component({
     template: `
@@ -30,7 +31,8 @@ describe('PanelComponent', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [TestComponent],
-            imports: [PanelModule]
+            imports: [PanelModule],
+            providers: [RtlService]
         }).compileComponents();
     }));
 

--- a/libs/core/src/lib/panel/panel.component.ts
+++ b/libs/core/src/lib/panel/panel.component.ts
@@ -134,11 +134,13 @@ export class PanelComponent implements CssClassBuilder, OnChanges, OnInit, OnDes
 
     /** @hidden */
     private _listenRtl(): void {
-        this._subscription.add(
-            this._rtlService.rtl.subscribe(rtl => {
-                this._rtl = rtl;
-                this._cdRef.markForCheck();
-            })
-        );
+        if (this._rtlService) {
+            this._subscription.add(
+                this._rtlService.rtl.subscribe(rtl => {
+                    this._rtl = rtl;
+                    this._cdRef.markForCheck();
+                })
+            );
+        }
     }
 }

--- a/libs/core/src/lib/panel/panel.component.ts
+++ b/libs/core/src/lib/panel/panel.component.ts
@@ -12,7 +12,7 @@ import {
     Output,
     ContentChild
 } from '@angular/core';
-import { applyCssClass, CssClassBuilder } from '../utils/public_api';
+import { applyCssClass, CssClassBuilder, RtlService } from '../utils/public_api';
 import { PanelContentDirective } from './panel-content/panel-content.directive';
 
 let panelUniqueId = 0;
@@ -74,7 +74,10 @@ export class PanelComponent implements CssClassBuilder, OnChanges, OnInit {
     panelContent: PanelContentDirective;
 
     /** @hidden */
-    constructor(private _cdRef: ChangeDetectorRef, private _elementRef: ElementRef) {}
+    _rtl$ = this._rtlService.rtl;
+
+    /** @hidden */
+    constructor(private _cdRef: ChangeDetectorRef, private _elementRef: ElementRef, private _rtlService: RtlService) {}
 
     /** @hidden */
     ngOnInit(): void {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Related https://github.com/SAP/fundamental-ngx/issues/3674 _(with [this PR](https://github.com/SAP/fundamental-styles/pull/1861) would close the issue)_
#### Please provide a brief summary of this pull request.
Arrow-button looks into wrong side and has an extra/redundant icon 
![image](https://user-images.githubusercontent.com/14160094/98351233-1ac61500-2025-11eb-85b2-461302c8d5ae.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

