### PR TITLE
fix: remove deprecated isCheck from FormItemComponent

### DIFF
--- a/libs/core/src/lib/form/form-item/form-item.component.ts
+++ b/libs/core/src/lib/form/form-item/form-item.component.ts
@@ -19,9 +19,6 @@ import { ChangeDetectionStrategy, Component, HostBinding, Input, ViewEncapsulati
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FormItemComponent {
-    /** @deprecated  */
-    @Input()
-    isCheck = false;
 
     /** Whether the form item is inline. */
     @Input()


### PR DESCRIPTION
BREAKING CHANGE:
remove deprecated input `isCheck` from `FormItemComponent`

