### PR TITLE
fix: (platform) Fixing unsubscribe error onDestroy of DynamicPage component

### DIFF
--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.ts
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.ts
@@ -113,13 +113,13 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
     /**
      * subscription for when collapse value has changed
      */
-    private _collapseValSubscription: Subscription;
+    private _collapseValSubscription: Subscription = new Subscription();
 
     /**
      * @hidden
      * subscription for when content is scrolled
      */
-    private _scrollSubscription: Subscription;
+    private _scrollSubscription: Subscription = new Subscription();
 
     /** @hidden */
     constructor(
@@ -131,6 +131,9 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
         private _zone: NgZone
     ) {
         super(_cd);
+        if (this._collapseValSubscription) {
+            this._collapseValSubscription.unsubscribe();
+        }
         this._collapseValSubscription = this._dynamicPageService.$collapseValue.subscribe((val) => {
             this._setTabsPosition();
             this._setContainerPosition();
@@ -184,6 +187,9 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
      * Snap the header to expand or collapse based on scrolling. Uses CDKScrollable.
      */
     snapOnScroll(): void {
+        if (this._scrollSubscription) {
+            this._scrollSubscription.unsubscribe();
+        }
         this._scrollSubscription = this._scrollDispatcher.scrolled(10).subscribe((cdk: CdkScrollable) => {
             this._zone.run(() => {
                 const scrollPosition = cdk?.measureScrollOffset('top');


### PR DESCRIPTION
#### Please provide a link to the associated issue.

fixes #3793

#### Please provide a brief summary of this pull request.

Adding initialization of dummy subscriptions so that during the `OnDestroy` lifecycle hook, the code will not error trying to call `unsubscribe()` on an undefined variable.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist


