### PR TITLE
feat: (Platform) bring Form Grid styles for Platform Forms

### DIFF
--- a/apps/docs/src/app/platform/api-files.ts
+++ b/apps/docs/src/app/platform/api-files.ts
@@ -16,6 +16,7 @@ export const API_FILES = {
         'DynamicPageHeaderComponent',
         'DynamicPageContentComponent'
     ],
+    formContainer: ['FormGroupComponent, FormFieldComponent'],
     infoLabel: ['InfoLabelComponent'],
     input: ['InputComponent'],
     link: ['LinkComponent'],
@@ -36,7 +37,6 @@ export const API_FILES = {
         'FdpHeaderCellDef',
         'FdpTableCell',
         'FdpCellDef'
-
     ],
     textarea: ['TextAreaComponent'],
     panel: [
@@ -54,6 +54,20 @@ export const API_FILES = {
     thumbnail: ['ThumbnailComponent'],
     objectAttribute: ['ObjectAttributeComponent'],
     actionlistitem: ['ActionListItemComponent', 'ListComponent', 'ListConfig'],
-    displaylistitem: ['DisplayListItemComponent', 'ListComponent', 'ListFooter', 'ListGroupHeader', 'ListHeader', 'ListConfig'],
-    objectlistitem: ['ObjectListItemComponent', 'ListComponent', 'ListFooter', 'ListGroupHeader', 'ListHeader', 'ListConfig']
+    displaylistitem: [
+        'DisplayListItemComponent',
+        'ListComponent',
+        'ListFooter',
+        'ListGroupHeader',
+        'ListHeader',
+        'ListConfig'
+    ],
+    objectlistitem: [
+        'ObjectListItemComponent',
+        'ListComponent',
+        'ListFooter',
+        'ListGroupHeader',
+        'ListHeader',
+        'ListConfig'
+    ]
 };

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
@@ -1,0 +1,43 @@
+<fd-docs-section-title id="formContainerRecommended" componentName="formContainer">
+    Recommended form layouts
+</fd-docs-section-title>
+<description>This example shows recommended layouts for form container</description>
+<component-example>
+    <fdp-platform-form-container-recommended-example></fdp-platform-form-container-recommended-example>
+</component-example>
+<code-example [exampleFiles]="formContainerRecommended"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="formContainerPossible" componentName="formContainer">
+    Possible form layouts
+</fd-docs-section-title>
+<description>This example shows other possible layout combinations for form container</description>
+<component-example>
+    <fdp-platform-form-container-possible-example></fdp-platform-form-container-possible-example>
+</component-example>
+<code-example [exampleFiles]="formContainerPossible"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="formContainerNotRecommended" componentName="formContainer">
+    Not recommended form layouts
+</fd-docs-section-title>
+<description
+    >This example shows more possile layout combinations for form container usage that are not recommended</description
+>
+<component-example>
+    <fdp-platform-form-container-not-recommended-example></fdp-platform-form-container-not-recommended-example>
+</component-example>
+<code-example [exampleFiles]="formContainerNotRecommended"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="formContainerComplex" componentName="formContainer"> Complex form </fd-docs-section-title>
+<description>This example shows visualizes various Platform Form components in the form container</description>
+<component-example>
+    <fdp-platform-form-container-complex-example></fdp-platform-form-container-complex-example>
+</component-example>
+<code-example [exampleFiles]="formContainerComplex"></code-example>
+
+<separator></separator>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.ts
@@ -11,10 +11,10 @@ import * as platformComplexFormContainerSrc from '!raw-loader!./platform-form-co
 import * as platformComplexFormContainerTsCode from '!raw-loader!./platform-form-container-examples/platform-form-container-complex-example.component.ts';
 
 @Component({
-    selector: 'app-textarea',
+    selector: 'app-form-container',
     templateUrl: './platform-form-container-docs.component.html'
 })
-export class PlatformFormContainerDocsComponent implements OnInit {
+export class PlatformFormContainerDocsComponent {
     formContainerRecommended: ExampleFile[] = [
         {
             language: 'html',
@@ -69,5 +69,4 @@ export class PlatformFormContainerDocsComponent implements OnInit {
             component: 'PlatformFormContainerComplexExampleComponent'
         }
     ];
-    ngOnInit(): void {}
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.ts
@@ -1,0 +1,73 @@
+import { OnInit, Component } from '@angular/core';
+import { ExampleFile } from '../../../../documentation/core-helpers/code-example/example-file';
+
+import * as platformFormLayoutContainerSrc from '!raw-loader!./platform-form-container-examples/platform-form-container-recommended-example.component.html';
+import * as platformFormLayoutContainerTsCode from '!raw-loader!./platform-form-container-examples/platform-form-container-recommended-example.component.ts';
+import * as platformPossibleFormContainerSrc from '!raw-loader!./platform-form-container-examples/platform-form-container-possible-example.component.html';
+import * as platformPossibleFormContainerTsCode from '!raw-loader!./platform-form-container-examples/platform-form-container-possible-example.component.ts';
+import * as platformNotRecommendedFormContainerSrc from '!raw-loader!./platform-form-container-examples/platform-form-container-not-recommended-example.component.html';
+import * as platformNotRecommendedFormContainerTsCode from '!raw-loader!./platform-form-container-examples/platform-form-container-not-recommended-example.component.ts';
+import * as platformComplexFormContainerSrc from '!raw-loader!./platform-form-container-examples/platform-form-container-complex-example.component.html';
+import * as platformComplexFormContainerTsCode from '!raw-loader!./platform-form-container-examples/platform-form-container-complex-example.component.ts';
+
+@Component({
+    selector: 'app-textarea',
+    templateUrl: './platform-form-container-docs.component.html'
+})
+export class PlatformFormContainerDocsComponent implements OnInit {
+    formContainerRecommended: ExampleFile[] = [
+        {
+            language: 'html',
+            code: platformFormLayoutContainerSrc,
+            fileName: 'platform-form-container-recommended-example'
+        },
+        {
+            language: 'typescript',
+            code: platformFormLayoutContainerTsCode,
+            fileName: 'platform-form-container-recommended-example',
+            component: 'PlatformFormContainerRecommendedExampleComponent'
+        }
+    ];
+
+    formContainerPossible: ExampleFile[] = [
+        {
+            language: 'html',
+            code: platformPossibleFormContainerSrc,
+            fileName: 'platform-form-container-possible-example'
+        },
+        {
+            language: 'typescript',
+            code: platformPossibleFormContainerTsCode,
+            fileName: 'platform-form-container-possible-example',
+            component: 'PlatformFormContainerPossibleExampleComponent'
+        }
+    ];
+
+    formContainerNotRecommended: ExampleFile[] = [
+        {
+            language: 'html',
+            code: platformNotRecommendedFormContainerSrc,
+            fileName: 'platform-form-container-not-recommended-example'
+        },
+        {
+            language: 'typescript',
+            code: platformNotRecommendedFormContainerTsCode,
+            fileName: 'platform-form-container-not-recommended-example',
+            component: 'PlatformFormContainerNotRecommendedExampleComponent'
+        }
+    ];
+    formContainerComplex: ExampleFile[] = [
+        {
+            language: 'html',
+            code: platformComplexFormContainerSrc,
+            fileName: 'platform-form-container-complex-example'
+        },
+        {
+            language: 'typescript',
+            code: platformComplexFormContainerTsCode,
+            fileName: 'platform-form-container-complex-example',
+            component: 'PlatformFormContainerComplexExampleComponent'
+        }
+    ];
+    ngOnInit(): void {}
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.module.ts
@@ -1,0 +1,60 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ApiComponent } from '../../../../documentation/core-helpers/api/api.component';
+import { API_FILES } from '../../../api-files';
+import { SharedDocumentationPageModule } from '../../../../documentation/shared-documentation-page.module';
+
+import {
+    PlatformTextAreaModule,
+    FdpFormGroupModule,
+    PlatformButtonModule,
+    PlatformRadioGroupModule,
+    PlatformInputModule,
+    PlatformCheckboxGroupModule,
+    PlatformStepInputModule,
+    PlatformInputGroupModule,
+    PlatformSwitchModule
+} from '@fundamental-ngx/platform';
+import { PlatformFormContainerDocsComponent } from './platform-form-container-docs.component';
+import { PlatformFormContainerRecommendedExampleComponent } from './platform-form-container-examples/platform-form-container-recommended-example.component';
+import { PlatformFormContainerPossibleExampleComponent } from './platform-form-container-examples/platform-form-container-possible-example.component';
+import { PlatformFormContainerNotRecommendedExampleComponent } from './platform-form-container-examples/platform-form-container-not-recommended-example.component';
+import { PlatformFormContainerComplexExampleComponent } from './platform-form-container-examples/platform-form-container-complex-example.component';
+import { PlatformFormContainerHeaderComponent } from './platform-form-container-header/platform-form-container-header.component';
+
+const routes: Routes = [
+    {
+        path: '',
+        component: PlatformFormContainerHeaderComponent,
+        children: [
+            { path: '', component: PlatformFormContainerDocsComponent },
+            { path: 'api', component: ApiComponent, data: { content: API_FILES.formContainer } }
+        ]
+    }
+];
+
+@NgModule({
+    imports: [
+        RouterModule.forChild(routes),
+        SharedDocumentationPageModule,
+        PlatformTextAreaModule,
+        PlatformButtonModule,
+        PlatformRadioGroupModule,
+        PlatformInputModule,
+        PlatformCheckboxGroupModule,
+        PlatformStepInputModule,
+        PlatformInputGroupModule,
+        PlatformSwitchModule,
+        FdpFormGroupModule
+    ],
+    exports: [RouterModule],
+    declarations: [
+        PlatformFormContainerDocsComponent,
+        PlatformFormContainerHeaderComponent,
+        PlatformFormContainerRecommendedExampleComponent,
+        PlatformFormContainerPossibleExampleComponent,
+        PlatformFormContainerNotRecommendedExampleComponent,
+        PlatformFormContainerComplexExampleComponent
+    ]
+})
+export class PlatformFormContainerDocsModule {}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-complex-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-complex-example.component.html
@@ -1,0 +1,90 @@
+<fdp-form-group #fg1 [multiLayout]="true" [formGroup]="form" mainTitle="XL2-L2-M2-S1" columnLayoutType="XL2-L2-M2-S1">
+    <!-- Left side -->
+    <fdp-form-field
+        #ff1
+        id="basicTextarea22"
+        label="Basic Textarea"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zLeft"
+        rank="1"
+        hintPlacement="left"
+    >
+        <fdp-textarea name="basicTextarea22" [formControl]="ff1.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field #ff8 id="switch1" label="Switch" zone="zLeft" rank="2">
+        <fdp-switch
+            [formControl]="ff8.formControl"
+            name="switch-1"
+            ariaLabel="switch-label"
+            ariaLabelledby="switch-label"
+            contentDensity="cozy"
+            [semantic]="false"
+        >
+        </fdp-switch>
+    </fdp-form-field>
+
+    <fdp-form-field #ff3 label="Input Field" id="inputField" zone="zLeft" rank="3" placeholder="Field placeholder text">
+        <fdp-input name="inputField" id="inputField" type="text" [formControl]="ff3.formControl"> </fdp-input>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff7
+        id="number"
+        label="Step Input"
+        placeholder="Things quantity"
+        hint="This is tooltip to help"
+        zone="zLeft"
+        rank="7"
+        hintPlacement="left"
+    >
+        <fdp-number-step-input name="qty" [formControl]="ff7.formControl"></fdp-number-step-input>
+    </fdp-form-field>
+
+    <!-- Right side -->
+    <fdp-form-field #ff5 id="seasons6" label="Checkbox group " zone="zRight" rank="4">
+        <fdp-checkbox-group
+            [list]="seasons"
+            name="seasons6"
+            [isInline]="true"
+            ariaLabel="My favourite Seasons"
+            [formControl]="ff5.formControl"
+        ></fdp-checkbox-group>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff2
+        id="qty"
+        label="Input Group"
+        placeholder="Things quantity"
+        zone="zRight"
+        rank="5"
+        [required]="true"
+    >
+        <fdp-input-group name="qty" [formControl]="ff2.formControl">
+            <fdp-input-group-addon>$</fdp-input-group-addon>
+            <fdp-input-group-input type="number"></fdp-input-group-input>
+            <fdp-input-group-addon>0.00</fdp-input-group-addon>
+            <fdp-input-group-addon>
+                <fdp-button label="Submit"></fdp-button>
+            </fdp-input-group-addon>
+        </fdp-input-group>
+    </fdp-form-field>
+    <fdp-form-field #ff6 id="radioc1" zone="zRight" rank="6" label="Radio Group ">
+        <fdp-radio-group
+            name="radioc1"
+            contentDensity="compact"
+            selected="spring"
+            [isInline]="true"
+            [formControl]="ff6.formControl"
+        >
+            <fdp-radio-button value="winter">Winter</fdp-radio-button>
+            <fdp-radio-button value="spring">Spring</fdp-radio-button>
+            <fdp-radio-button value="summer">Summer</fdp-radio-button>
+            <fdp-radio-button value="autumn">Autumn</fdp-radio-button>
+        </fdp-radio-group>
+    </fdp-form-field>
+
+    <ng-template #i18n let-errors>
+        <span *ngIf="errors.required"> Value is required </span>
+    </ng-template>
+</fdp-form-group>
+<br />

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-complex-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-complex-example.component.ts
@@ -7,11 +7,7 @@ import { FormGroup } from '@angular/forms';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PlatformFormContainerComplexExampleComponent {
-    form: FormGroup;
+    form: FormGroup = new FormGroup({});
     seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
     qty = 10;
-
-    constructor() {
-        this.form = new FormGroup({});
-    }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-complex-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-complex-example.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+    selector: 'fdp-platform-form-container-complex-example',
+    templateUrl: './platform-form-container-complex-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PlatformFormContainerComplexExampleComponent {
+    form: FormGroup;
+    seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
+    qty = 10;
+
+    constructor() {
+        this.form = new FormGroup({});
+    }
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-not-recommended-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-not-recommended-example.component.html
@@ -1,0 +1,67 @@
+<main class="fd-page">
+    <div *ngIf="true" class="fd-page__content fd-has-background-color-neutral-2">
+        <fdp-form-group
+            #fg2
+            [multiLayout]="true"
+            [formGroup]="form"
+            mainTitle="XL3-L2-M2-S1"
+            columnLayoutType="XL3-L2-M2-S1"
+        >
+            <fdp-form-field
+                #ff1
+                id="basicTextarea18"
+                label="Basic Textarea with Platform Forms"
+                placeholder="Start entering detailed description"
+                hint="This is tooltip help"
+                zone="zLeft"
+                rank="1"
+                hintPlacement="left"
+            >
+                <fdp-textarea name="basicTextarea18" [formControl]="ff1.formControl"></fdp-textarea>
+            </fdp-form-field>
+            <fdp-form-field #ff2 id="seasons5" label="My favourite Seasons:" zone="zLeft" rank="2">
+                <fdp-checkbox-group
+                    [list]="seasons"
+                    name="seasons5"
+                    [isInline]="true"
+                    ariaLabel="My favourite Seasons"
+                    [formControl]="ff2.formControl"
+                ></fdp-checkbox-group>
+            </fdp-form-field>
+            <fdp-form-field
+                #ff3
+                id="basicTextarea19"
+                label="Basic Textarea with Platform Forms 2"
+                [placeholder]="'Start entering detailed description'"
+                hint="This is tooltip help"
+                zone="zLeft"
+                rank="3"
+            >
+                <fdp-textarea name="basicTextarea19" [formControl]="ff3.formControl"></fdp-textarea>
+            </fdp-form-field>
+            <fdp-form-field
+                #ff5
+                id="basicTextarea20"
+                label="Basic Textarea with Platform Forms 5"
+                [placeholder]="'Start entering detailed description'"
+                hint="This is tooltip help"
+                zone="zRight"
+                rank="5"
+            >
+                <fdp-textarea name="basicTextarea20" [formControl]="ff5.formControl"></fdp-textarea>
+            </fdp-form-field>
+            <fdp-form-field
+                #ff6
+                id="basicTextarea21"
+                label="Basic Textarea with Platform Forms 6"
+                [placeholder]="'Start entering detailed description'"
+                hint="This is tooltip help"
+                zone="zRight"
+                rank="6"
+            >
+                <fdp-textarea name="basicTextarea21" [formControl]="ff6.formControl"></fdp-textarea>
+            </fdp-form-field>
+        </fdp-form-group>
+        <br />
+    </div>
+</main>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-not-recommended-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-not-recommended-example.component.ts
@@ -7,13 +7,8 @@ import { FormGroup } from '@angular/forms';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PlatformFormContainerNotRecommendedExampleComponent {
-    form: FormGroup;
-    form1: FormGroup;
+    form: FormGroup = new FormGroup({});
+    form1: FormGroup = new FormGroup({});
 
     seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
-
-    constructor() {
-        this.form = new FormGroup({});
-        this.form1 = new FormGroup({});
-    }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-not-recommended-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-not-recommended-example.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+    selector: 'fdp-platform-form-container-not-recommended-example',
+    templateUrl: './platform-form-container-not-recommended-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PlatformFormContainerNotRecommendedExampleComponent {
+    form: FormGroup;
+    form1: FormGroup;
+
+    seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
+
+    constructor() {
+        this.form = new FormGroup({});
+        this.form1 = new FormGroup({});
+    }
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-possible-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-possible-example.component.html
@@ -1,0 +1,118 @@
+<main class="fd-page">
+    <div *ngIf="true" class="fd-page__content fd-has-background-color-neutral-2">
+        <fdp-form-group
+            #fg2
+            [multiLayout]="true"
+            [formGroup]="form"
+            mainTitle="XL3-L1-M1-S1"
+            columnLayoutType="XL3-L1-M1-S1"
+        >
+            <fdp-form-field
+                #ff1
+                id="basicTextarea12"
+                label="Basic Textarea with Platform Forms"
+                placeholder="Start entering detailed description"
+                hint="This is tooltip help"
+                zone="zLeft"
+                rank="1"
+                hintPlacement="left"
+            >
+                <fdp-textarea name="basicTextarea12" [formControl]="ff1.formControl"></fdp-textarea>
+            </fdp-form-field>
+            <fdp-form-field #ff2 id="favSeasons" label="My favourite Seasons:" zone="zLeft" rank="2">
+                <fdp-checkbox-group
+                    [list]="seasons"
+                    name="favSeasons"
+                    [isInline]="true"
+                    ariaLabel="My favourite Seasons"
+                    [formControl]="ff2.formControl"
+                ></fdp-checkbox-group>
+            </fdp-form-field>
+            <fdp-form-field
+                #ff3
+                id="basicTextarea13"
+                label="Basic Textarea with Platform Forms 2"
+                placeholder="Start entering detailed description"
+                hint="This is tooltip help"
+                zone="zLeft"
+                rank="3"
+            >
+                <fdp-textarea name="basicTextarea13" [formControl]="ff3.formControl"></fdp-textarea>
+            </fdp-form-field>
+            <fdp-form-field
+                #ff5
+                id="basicTextarea14"
+                label="Basic Textarea with Platform Forms 5"
+                placeholder="Start entering detailed description"
+                hint="This is tooltip help"
+                zone="zRight"
+                rank="5"
+            >
+                <fdp-textarea name="basicTextarea14" [formControl]="ff5.formControl"></fdp-textarea>
+            </fdp-form-field>
+            <fdp-form-field
+                #ff6
+                id="basicTextarea15"
+                label="Basic Textarea with Platform Forms 6"
+                placeholder="Start entering detailed description"
+                hint="This is tooltip help"
+                zone="zRight"
+                rank="6"
+            >
+                <fdp-textarea name="basicTextarea15" [formControl]="ff6.formControl"></fdp-textarea>
+            </fdp-form-field>
+        </fdp-form-group>
+        <fdp-form-group
+            #fg1
+            [multiLayout]="true"
+            [formGroup]="form"
+            mainTitle="XL1-L1-M1-S1"
+            columnLayoutType="XL1-L1-M1-S1"
+        >
+            <fdp-form-field
+                #ff1
+                id="basicTextarea16"
+                label="Basic Textarea with Platform Forms"
+                placeholder="Start entering detailed description"
+                hint="This is tooltip help"
+                zone="zLeft"
+                rank="1"
+                hintPlacement="left"
+            >
+                <fdp-textarea name="basicTextarea16" [formControl]="ff1.formControl"></fdp-textarea>
+            </fdp-form-field>
+
+            <fdp-form-field #ff2 id="seasons3" label="My favourite Seasons:" zone="zLeft" rank="2">
+                <fdp-checkbox-group
+                    [list]="seasons"
+                    name="seasons3"
+                    [isInline]="true"
+                    ariaLabel="My favourite Seasons"
+                    [formControl]="ff2.formControl"
+                ></fdp-checkbox-group>
+            </fdp-form-field>
+            <fdp-form-field
+                #ff3
+                id="basicTextarea17"
+                label="Basic Textarea with Platform Forms"
+                placeholder="Start entering detailed description"
+                hint="This is tooltip help"
+                zone="zLeft"
+                rank="3"
+                hintPlacement="left"
+            >
+                <fdp-textarea name="basicTextarea17" [formControl]="ff3.formControl"></fdp-textarea>
+            </fdp-form-field>
+            <fdp-form-field #ff4 id="seasons4" label="My favourite Seasons:" zone="zLeft" rank="4">
+                <fdp-checkbox-group
+                    [list]="seasons"
+                    name="seasons4"
+                    [isInline]="true"
+                    ariaLabel="My favourite Seasons"
+                    [formControl]="ff4.formControl"
+                ></fdp-checkbox-group>
+            </fdp-form-field>
+        </fdp-form-group>
+        <br />
+    </div>
+</main>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-possible-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-possible-example.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+    selector: 'fdp-platform-form-container-possible-example',
+    templateUrl: './platform-form-container-possible-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PlatformFormContainerPossibleExampleComponent {
+    form: FormGroup;
+    form1: FormGroup;
+
+    seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
+
+    constructor() {
+        this.form = new FormGroup({});
+        this.form1 = new FormGroup({});
+    }
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-possible-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-possible-example.component.ts
@@ -7,13 +7,8 @@ import { FormGroup } from '@angular/forms';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PlatformFormContainerPossibleExampleComponent {
-    form: FormGroup;
-    form1: FormGroup;
+    form: FormGroup = new FormGroup({});
+    form1: FormGroup = new FormGroup({});
 
     seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
-
-    constructor() {
-        this.form = new FormGroup({});
-        this.form1 = new FormGroup({});
-    }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-recommended-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-recommended-example.component.html
@@ -1,0 +1,171 @@
+<fdp-form-group #fg1 [multiLayout]="true" [formGroup]="form" mainTitle="XL2-L2-M2-S1" columnLayoutType="XL2-L2-M2-S1">
+    <fdp-form-field
+        #ff1
+        id="basicTextarea"
+        label="Basic Textarea with Platform Forms"
+        placeholder="Start entering detailed description"
+        hint="This is tooltip help"
+        zone="zLeft"
+        rank="1"
+        hintPlacement="left"
+    >
+        <fdp-textarea name="basicTextarea" [formControl]="ff1.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field #ff2 id="seasons0" label="My favourite Seasons:" zone="zLeft" rank="2">
+        <fdp-checkbox-group
+            [list]="seasons"
+            name="seasons0"
+            [isInline]="true"
+            ariaLabel="My favourite Seasons"
+            [formControl]="ff2.formControl"
+        ></fdp-checkbox-group>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff3
+        id="basicTextarea2"
+        label="Basic Textarea with Platform Forms 2"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zLeft"
+        rank="3"
+    >
+        <fdp-textarea name="basicTextarea2" [formControl]="ff3.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff5
+        id="basicTextarea3"
+        label="Basic Textarea with Platform Forms 5"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zRight"
+        rank="5"
+    >
+        <fdp-textarea name="basicTextarea3" [formControl]="ff5.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff6
+        id="basicTextarea6"
+        label="Basic Textarea with Platform Forms 6"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zRight"
+        rank="6"
+    >
+        <fdp-textarea name="basicTextarea6" [formControl]="ff6.formControl"></fdp-textarea>
+    </fdp-form-field>
+</fdp-form-group>
+<br />
+
+<fdp-form-group #fg2 [multiLayout]="true" [formGroup]="form" mainTitle="XL2-L2-M1-S1" columnLayoutType="XL2-L2-M1-S1">
+    <fdp-form-field
+        #ff1
+        id="basicTextarea4"
+        label="Basic Textarea with Platform Forms"
+        placeholder="Start entering detailed description"
+        hint="This is tooltip help"
+        zone="zLeft"
+        rank="1"
+        hintPlacement="left"
+    >
+        <fdp-textarea name="basicTextarea4" [formControl]="ff1.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field #ff2 id="seasons1" label="My favourite Seasons:" zone="zLeft" rank="2">
+        <fdp-checkbox-group
+            [list]="seasons"
+            name="seasons1"
+            [isInline]="true"
+            ariaLabel="My favourite Seasons"
+            [formControl]="ff2.formControl"
+        ></fdp-checkbox-group>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff3
+        id="basicTextarea5"
+        label="Basic Textarea with Platform Forms 2"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zLeft"
+        rank="3"
+    >
+        <fdp-textarea name="basicTextarea5" [formControl]="ff3.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff5
+        id="basicTextarea7"
+        label="Basic Textarea with Platform Forms 5"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zRight"
+        rank="5"
+    >
+        <fdp-textarea name="basicTextarea7" [formControl]="ff5.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff6
+        id="basicTextarea6"
+        label="Basic Textarea with Platform Forms 6"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zRight"
+        rank="6"
+    >
+        <fdp-textarea name="basicTextarea6" [formControl]="ff6.formControl"></fdp-textarea>
+    </fdp-form-field>
+</fdp-form-group>
+
+<fdp-form-group #fg3 [multiLayout]="true" [formGroup]="form" mainTitle="XL2-L1-M1-S1" columnLayoutType="XL2-L1-M1-S1">
+    <fdp-form-field
+        #ff1
+        id="basicTextarea8"
+        label="Basic Textarea with Platform Forms"
+        placeholder="Start entering detailed description"
+        hint="This is tooltip help"
+        zone="zLeft"
+        rank="1"
+        hintPlacement="left"
+    >
+        <fdp-textarea name="basicTextarea8" [formControl]="ff1.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field #ff2 id="seasons2" label="My favourite Seasons:" zone="zLeft" rank="2">
+        <fdp-checkbox-group
+            [list]="seasons"
+            name="seasons2"
+            [isInline]="true"
+            ariaLabel="My favourite Seasons"
+            [formControl]="ff2.formControl"
+        ></fdp-checkbox-group>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff3
+        id="basicTextarea9"
+        label="Basic Textarea with Platform Forms 2"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zLeft"
+        rank="3"
+    >
+        <fdp-textarea name="basicTextarea9" [formControl]="ff3.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff5
+        id="basicTextarea10"
+        label="Basic Textarea with Platform Forms 5"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zRight"
+        rank="5"
+    >
+        <fdp-textarea name="basicTextarea10" [formControl]="ff5.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff6
+        id="basicTextarea11"
+        label="Basic Textarea with Platform Forms 6"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        zone="zRight"
+        rank="6"
+    >
+        <fdp-textarea name="basicTextarea11" [formControl]="ff6.formControl"></fdp-textarea>
+    </fdp-form-field>
+</fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-recommended-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-recommended-example.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+    selector: 'fdp-platform-form-container-recommended-example',
+    templateUrl: './platform-form-container-recommended-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PlatformFormContainerRecommendedExampleComponent {
+    form: FormGroup;
+    form1: FormGroup;
+    form2: FormGroup;
+
+    seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
+
+    constructor() {
+        this.form = new FormGroup({});
+        this.form1 = new FormGroup({});
+        this.form2 = new FormGroup({});
+    }
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-recommended-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-container-recommended-example.component.ts
@@ -7,15 +7,9 @@ import { FormGroup } from '@angular/forms';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PlatformFormContainerRecommendedExampleComponent {
-    form: FormGroup;
-    form1: FormGroup;
-    form2: FormGroup;
+    form: FormGroup = new FormGroup({});
+    form1: FormGroup = new FormGroup({});
+    form2: FormGroup = new FormGroup({});
 
     seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
-
-    constructor() {
-        this.form = new FormGroup({});
-        this.form1 = new FormGroup({});
-        this.form2 = new FormGroup({});
-    }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-header/platform-form-container-header.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-header/platform-form-container-header.component.html
@@ -1,0 +1,43 @@
+<header>Form Container</header>
+<description>
+    Platform Forms' structure can be broken down into 3 groups:
+    <ul>
+        <li>
+            Form Group (actual Form Layout)
+            <ul>
+                <li>Manages global Error handling navigation</li>
+                <li>Responsible for layout (multizone)</li>
+                <li>Can pre-set common properties to be applied for whole forms</li>
+            </ul>
+        </li>
+        <li>
+            Form Field
+            <ul>
+                <li>Aggregates common behavior for input field (Errors, Hints, Labels,..)</li>
+                <li>
+                    If multi zone layout is enabled ability to specify where the field should appear (e.g.: left/right
+                    column)
+                </li>
+                <li>Responsible for change detection and UI updates</li>
+            </ul>
+        </li>
+        <li>
+            Form Control (eg: input widget)
+            <ul>
+                <li>Shares common properties among other input form controls</li>
+                <li>Notify its parent (FormField) about any state change.</li>
+            </ul>
+        </li>
+    </ul>
+
+    Specify the <code>columnLayoutType</code> at the <code>fdp-form-group</code> level to render the layout in that
+    particular form. For example, if you want a 2 column layout in XL, 2 column layout in L, 2 column layout in M, and
+    single-column layout in S, the corresponding <code>columnLayoutType</code> would be <code>XL2-L2-M2-S1</code>.
+    <br />
+    <br />
+
+    <import module="FdpFormGroupModule"></import>
+</description>
+
+<fd-header-tabs></fd-header-tabs>
+<router-outlet></router-outlet>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-header/platform-form-container-header.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-header/platform-form-container-header.component.ts
@@ -1,12 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
     selector: 'app-form-container-header',
     templateUrl: './platform-form-container-header.component.html',
     styleUrls: ['./platform-form-container-header.component.scss']
 })
-export class PlatformFormContainerHeaderComponent implements OnInit {
-    constructor() {}
-
-    ngOnInit(): void {}
-}
+export class PlatformFormContainerHeaderComponent {}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-header/platform-form-container-header.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-header/platform-form-container-header.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'app-form-container-header',
+    templateUrl: './platform-form-container-header.component.html',
+    styleUrls: ['./platform-form-container-header.component.scss']
+})
+export class PlatformFormContainerHeaderComponent implements OnInit {
+    constructor() {}
+
+    ngOnInit(): void {}
+}

--- a/apps/docs/src/app/platform/documentation/platform-documentation.component.ts
+++ b/apps/docs/src/app/platform/documentation/platform-documentation.component.ts
@@ -41,15 +41,20 @@ export class PlatformDocumentationComponent extends DocumentationBaseComponent {
             { url: 'platform/combobox', name: 'Combobox' },
             {
                 name: 'List And Items',
-                subItems: [{ url: 'platform/list', name: 'List' },
-                { url: 'platform/standard-list-item', name: 'Standard List Item' },
-                { url: 'platform/action-list-item', name: 'Action List Item' },
-                { url: 'platform/display-list-item', name: 'Display List Item' },
-                { url: 'platform/object-list-item', name: 'Object List Item' }]
+                subItems: [
+                    { url: 'platform/list', name: 'List' },
+                    { url: 'platform/standard-list-item', name: 'Standard List Item' },
+                    { url: 'platform/action-list-item', name: 'Action List Item' },
+                    { url: 'platform/display-list-item', name: 'Display List Item' },
+                    { url: 'platform/object-list-item', name: 'Object List Item' }
+                ]
             }
         ];
 
-        this.layouts = [{ url: 'platform/dynamic-page', name: 'Dynamic Page' }];
+        this.layouts = [
+            { url: 'platform/dynamic-page', name: 'Dynamic Page' },
+            { url: 'platform/form-container', name: 'Form Container' }
+        ];
 
         this.utilities = [];
 

--- a/apps/docs/src/app/platform/platform-documentation.routes.ts
+++ b/apps/docs/src/app/platform/platform-documentation.routes.ts
@@ -48,6 +48,13 @@ export const ROUTES: Routes = [
                     )
             },
             {
+                path: 'form-container',
+                loadChildren: () =>
+                    import('./component-docs/platform-forms/platform-form-container/platform-form-container-docs.module').then(
+                        (m) => m.PlatformFormContainerDocsModule
+                    )
+            },
+            {
                 path: 'link',
                 loadChildren: () =>
                     import('./component-docs/platform-link/platform-link.module').then((m) => m.PlatformLinkDocsModule)

--- a/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.html
+++ b/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.html
@@ -3,21 +3,23 @@
 </ng-template>
 
 <ng-template #renderer>
-    <div [horizontal]="labelLayout === 'horizontal'" fd-form-item>
-        <label [attr.for]="id" [inlineHelp]="!!hint" [required]="editable && required" fd-form-label>
-            <span *ngIf="!noLabelLayout">{{ label }}</span>
-
-            <!-- We can support placement on FormGroup Level to be applied to all the form fields     -->
-            <fd-inline-help *ngIf="hint" [placement]="hintPlacement">
-                {{ hint }}
-            </fd-inline-help>
-        </label>
+    <div [horizontal]="labelLayout === 'horizontal'" fd-form-item class="fd-row">
+        <!-- Following current Styles implementation, for now we assume each field takes only these values -->
+        <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
+            <label [attr.for]="id" [inlineHelp]="!!hint" [required]="editable && required" fd-form-label>
+                <span *ngIf="!noLabelLayout" [title]="label">{{ label }}</span>
+                <!-- We can support placement on FormGroup Level to be applied to all the form fields     -->
+                <fd-inline-help *ngIf="hint" [placement]="hintPlacement">
+                    {{ hint }}
+                </fd-inline-help>
+            </label>
+        </div>
         <ng-container *ngTemplateOutlet="withFormMessage"></ng-container>
     </div>
 </ng-template>
 
 <ng-template #withFormMessage>
-    <fdp-input-message-group>
+    <fdp-input-message-group class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
         <!--
          Todo: we should extend this on FormGroup Level and have error trigger strategy that will be applied to
          all the field e.g.: [triggers]="['mouseenter', 'mouseleave']"

--- a/libs/platform/src/lib/components/form/form-group/form-group.component.html
+++ b/libs/platform/src/lib/components/form/form-group/form-group.component.html
@@ -15,23 +15,21 @@
 </ng-template>
 
 <ng-template #zone let-fields let-multiColumn="multiColumn" let-title="title">
+    <div *ngIf="title" class="fd-form-header">
+        <span class="fd-form-header__text">{{ title }}</span>
+    </div>
     <div
         *ngIf="fields"
         [formGroup]="formGroup"
         [ngClass]="{ 'is-editable': editable }"
-        class="fd-section fd-section--no-border fd-has-margin-regular"
+        class="fd-container fd-form-layout-grid-container"
     >
-        <div *ngIf="title" class="fd-section__header">
-            <h3 class="fd-section__title">{{ title }}</h3>
-        </div>
-
-        <div *ngIf="mZone" class="row start-xs">
+        <div *ngIf="mZone" class="fd-row">
             <div
                 *ngFor="let f of fields; trackBy: trackByFieldName"
                 [ngClass]="f.styleClass"
+                class="fd-col fd-col--wrap"
                 [style.order]="f.rank"
-                class="col-xs-12"
-                fd-form-set
             >
                 <ng-container *ngTemplateOutlet="f?.renderer"></ng-container>
             </div>

--- a/libs/platform/src/lib/components/form/form-group/form-group.component.scss
+++ b/libs/platform/src/lib/components/form/form-group/form-group.component.scss
@@ -1,9 +1,100 @@
 // Todo: Remove once there is responsive layout in fundamental styles.
-@import '~flexboxgrid/dist/flexboxgrid.min';
+// @import '~flexboxgrid/dist/flexboxgrid.min';
+@import '~fundamental-styles/dist/form-layout-grid';
 @import '~fundamental-styles/dist/section';
 
-.row {
-    .col-xs-12 {
-        padding: 5px;
-    }
+// revert core styles overriding the form label styles
+.fd-form-label {
+    overflow: hidden;
+}
+
+.fd-form-group--inline {
+    flex-wrap: wrap;
+}
+
+// form header styles. Remove when 0.14.0 of styles is incorporated.
+/*!
+ * Fundamental Library Styles v0.13.0-rc.48
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company.
+ * Licensed under Apache License 2.0 (https://github.com/SAP/fundamental-styles/blob/master/LICENSE)
+ */
+@charset "UTF-8";
+/*!
+.fd-form-header
+   .fd-form-header__text
+*/
+.fd-form-header {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    width: 100%;
+    height: 2.75rem;
+    background-color: transparent;
+    background-color: var(--sapGroup_TitleBackground, transparent);
+    padding-left: 1rem;
+    padding-right: 1rem;
+    -webkit-box-shadow: 0 0.0625rem 0.0625rem #d9d9d9;
+    -webkit-box-shadow: 0 var(--fdFormHeader_Border_Width, var(--sapList_BorderWidth, 0.0625rem))
+        var(--fdFormHeader_Border_Width, var(--sapList_BorderWidth, 0.0625rem))
+        var(--sapGroup_TitleBorderColor, #d9d9d9);
+    box-shadow: 0 0.0625rem 0.0625rem #d9d9d9;
+    box-shadow: 0 var(--fdFormHeader_Border_Width, var(--sapList_BorderWidth, 0.0625rem))
+        var(--fdFormHeader_Border_Width, var(--sapList_BorderWidth, 0.0625rem))
+        var(--sapGroup_TitleBorderColor, #d9d9d9);
+}
+.fd-form-header::after,
+.fd-form-header::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
+}
+.fd-form-header__text {
+    font-size: 0.875rem;
+    font-size: var(--sapFontSize, 0.875rem);
+    line-height: 1.4;
+    line-height: var(--sapContent_LineHeight, 1.4);
+    color: #32363a;
+    color: var(--sapTextColor, #32363a);
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-weight: 400;
+    -webkit-font-smoothing: antialiased;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: '72', '72full', Arial, Helvetica, sans-serif;
+    font-family: var(--sapFontHeaderFamily, '72', '72full', Arial, Helvetica, sans-serif);
+    font-size: 1.125rem;
+    font-size: var(--sapFontHeader4Size, 1.125rem);
+    color: #32363a;
+    color: var(--sapGroup_TitleTextColor, #32363a);
+}
+.fd-form-header__text::after,
+.fd-form-header__text::before {
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
+    font-size: inherit;
 }

--- a/libs/platform/src/lib/components/form/form-group/form-group.component.ts
+++ b/libs/platform/src/lib/components/form/form-group/form-group.component.ts
@@ -480,10 +480,10 @@ export class FormGroupComponent implements FormGroupContainer, OnInit, AfterCont
      * if `columnLayoutType` is given, set those column layouts appropriately
      */
     private _setUserSpecifiedLayout(groupField: GroupField): void {
-        const layoutString = this.columnLayoutType.split('-');
-        const xlColumnsNumber = parseInt(layoutString[0].slice(2, layoutString[0].length), 10);
-        const lgColumnsNumber = parseInt(layoutString[1].slice(1, layoutString[1].length), 10);
-        const mdColumnsNumber = parseInt(layoutString[2].slice(1, layoutString[2].length), 10);
+        const [xl, lg, md] = this.columnLayoutType.split('-');
+        const xlColumnsNumber = parseInt(xl.slice(2, xl.length), 10);
+        const lgColumnsNumber = parseInt(lg.slice(1, lg.length), 10);
+        const mdColumnsNumber = parseInt(md.slice(1, md.length), 10);
 
         if (isNaN(xlColumnsNumber) || isNaN(lgColumnsNumber) || isNaN(mdColumnsNumber)) {
             throw new Error('Input a valid number for columns');
@@ -497,10 +497,9 @@ export class FormGroupComponent implements FormGroupContainer, OnInit, AfterCont
             // for `lg` single-column layout, Styles does not use any class, and providing `fd-col-lg--12` has unintended side-effects
             // therefore, we remove the lg class for single-column layout
             if (lgColumns === 12) {
-                groupField.styleClass = `fd-col-xl--` + xlColumns + ` fd-col-md--` + mdColumns;
+                groupField.styleClass = `fd-col-xl--${xlColumns} fd-col-md--${mdColumns}`;
             } else {
-                groupField.styleClass =
-                    `fd-col-xl--` + xlColumns + ` fd-col-md--` + mdColumns + ` fd-col-lg--` + lgColumns;
+                groupField.styleClass = `fd-col-xl--${xlColumns} fd-col-md--${mdColumns} fd-col-lg--${lgColumns}`;
             }
         }
     }

--- a/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.html
+++ b/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.html
@@ -1,6 +1,6 @@
 <fd-popover
     (isOpenChange)="openChanged($event)"
-    [addContainerClass]="'fd-popover-container-custom--message'"
+    additionalBodyClass="fd-popover__popper--input-message-group"
     [closeOnOutsideClick]="closeOnOutsideClick"
     [closeOnEscapeKey]="closeOnEscapeKey"
     [fillControlMode]="fillControlMode"

--- a/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.scss
+++ b/libs/platform/src/lib/components/form/input-message-group-with-template/input-message-group-with-template.component.scss
@@ -16,6 +16,11 @@
 // the default style display:inline-block is restricting/shrinking the width, therefore we are overriding it to take flex width.
 fdp-input-message-group {
     .fd-popover-custom {
-        display: flex;
+        display: block;
     }
+}
+
+.fd-popover__popper.fd-popover__popper--input-message-group {
+    margin-top: 0 !important;
+    z-index: 999;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11530,11 +11530,6 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
-    "flexboxgrid": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/flexboxgrid/-/flexboxgrid-6.3.1.tgz",
-      "integrity": "sha1-6ZiYr8B7cEdyK7galYpfuk1OIP0="
-    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@types/node": "14.11.7",
     "classlist.js": "1.1.20150312",
     "core-js": "3.7.0",
-    "flexboxgrid": "6.3.1",
     "focus-trap": "6.1.4",
     "fundamental-styles": "0.12.0",
     "hammerjs": "2.0.8",


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#3806 
#### Please provide a brief summary of this pull request.
Currently, Platform Forms uses 3rd party library flexboxgrid to achieve responsive layouts. This PR replaces it with Form Grid from Fundamental Styles.
Group Header styles are not implemented, therefore Group Header integration will happen separately at a later point.

BREAKING CHANGE:
A new input field `columnLayoutType` introduced that takes the column layout in the format `XLn-Ln-Mn-Sn` where n is the number of columns and can be different for each size.
For eg: XL2-L2-M2-S1 would create 2-column layouts for XL, L, and M sizes and single-column layout for S size.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

