### PR TITLE
fix: (Core) removed angular-resize-event from fixed card layout and documention

### DIFF
--- a/apps/docs/src/app/core/component-docs/fixed-card-layout/examples/default/fixed-card-layout-examples.component.html
+++ b/apps/docs/src/app/core/component-docs/fixed-card-layout/examples/default/fixed-card-layout-examples.component.html
@@ -10,7 +10,7 @@
     </button>
 </fd-segmented-button>
 
-<div (resized)="onResized()" style="padding: 1rem; overflow: auto;">
+<div style="padding: 1rem; overflow: auto;">
     <fd-fixed-card-layout>
         <ng-container *ngIf="card1Visibility">
             <fd-card *fdCardDef>

--- a/apps/docs/src/app/core/component-docs/fixed-card-layout/examples/disabled-drag-drop/fixed-card-layout-disabled-drag.component.html
+++ b/apps/docs/src/app/core/component-docs/fixed-card-layout/examples/disabled-drag-drop/fixed-card-layout-disabled-drag.component.html
@@ -2,7 +2,7 @@
     <button fd-button (click)="changeDragBehaviour()">{{ dragDisabled ? 'Enable' : 'Disable' }} Drag</button>
 </div>
 
-<div (resized)="onResized()" style="padding: 1rem; overflow: auto;">
+<div style="padding: 1rem; overflow: auto;">
     <fd-fixed-card-layout [disableDragDrop]="dragDisabled">
         <fd-card *fdCardDef>
             <fd-card-header>

--- a/apps/docs/src/app/core/component-docs/fixed-card-layout/fixed-card-layout-docs-header/fixed-card-layout-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/fixed-card-layout/fixed-card-layout-docs-header/fixed-card-layout-docs-header.component.html
@@ -7,11 +7,11 @@
 <import module="FixedCardLayoutModule"></import>
 
 <description>
-    <b>Notes:</b> 
-    we have used <a [routerLink]="'https://www.npmjs.com/package/angular-resize-event'">angular-resize-event</a>
-    library for detecting layout size change in documentation examples. Example: when we collapse side navigation bar,
-    available size for layout
-    changes.Using this library, we are able to detect the layout size change and then refresh the layout.
+    <b>Notes:</b> <br/>
+    Layout available size change can be detected when angular triggers change detection.
+    For example <a [routerLink]="'https://www.npmjs.com/package/angular-resize-event'">angular-resize-event</a> can be used for
+    detecting layout size change and then angular can trigger change detection. Using which Fixed card layout will be able
+    to re-distribute card.
 </description>
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/fixed-card-layout/fixed-card-layout-docs-header/fixed-card-layout-docs-header.component.html
+++ b/apps/docs/src/app/core/component-docs/fixed-card-layout/fixed-card-layout-docs-header/fixed-card-layout-docs-header.component.html
@@ -7,11 +7,11 @@
 <import module="FixedCardLayoutModule"></import>
 
 <description>
-    <b>Notes:</b> <br/>
+    <b>Notes:</b> <br />
     Layout available size change can be detected when angular triggers change detection.
-    For example <a [routerLink]="'https://www.npmjs.com/package/angular-resize-event'">angular-resize-event</a> can be used for
-    detecting layout size change and then angular can trigger change detection. Using which Fixed card layout will be able
-    to re-distribute card.
+    For example <a href="https://www.npmjs.com/package/angular-resize-event/" target="_blank">angular-resize-event</a> can be used for
+    detecting layout size change and then angular can trigger change detection. Using which Fixed card layout will be
+    able to re-distribute card.
 </description>
 <fd-header-tabs></fd-header-tabs>
 <router-outlet></router-outlet>

--- a/apps/docs/src/app/core/component-docs/fixed-card-layout/fixed-card-layout-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/fixed-card-layout/fixed-card-layout-docs.module.ts
@@ -9,7 +9,6 @@ import {
     TableModule,
     ToolbarModule
 } from '@fundamental-ngx/core';
-import { AngularResizedEventModule } from 'angular-resize-event';
 import { SharedDocumentationPageModule } from '../../../documentation/shared-documentation-page.module';
 import { ApiComponent } from '../../../documentation/core-helpers/api/api.component';
 import { API_FILES } from '../../api-files';
@@ -36,7 +35,6 @@ const routes: Routes = [
     imports: [
         RouterModule.forChild(routes),
         SharedDocumentationPageModule,
-        AngularResizedEventModule,
         CardModule,
         DialogModule,
         FixedCardLayoutModule,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6527,15 +6527,6 @@
         }
       }
     },
-    "angular-resize-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/angular-resize-event/-/angular-resize-event-2.0.0.tgz",
-      "integrity": "sha512-xN+xuPv3v0AjOlQ5MV82U2iNcHEAeEwQcwpXx/dVBEvK7W2QcoqxpKn8YAvBWWQcq1mA5rHXvljBNmlVd2lw8A==",
-      "requires": {
-        "css-element-queries": "^1.2.3",
-        "tslib": "^2.0.0"
-      }
-    },
     "ansi-align": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -9316,11 +9307,6 @@
         "postcss": "^7.0.1",
         "timsort": "^0.3.0"
       }
-    },
-    "css-element-queries": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/css-element-queries/-/css-element-queries-1.2.3.tgz",
-      "integrity": "sha512-QK9uovYmKTsV2GXWQiMOByVNrLn2qz6m3P7vWpOR4IdD6I3iXoDw5qtgJEN3Xq7gIbdHVKvzHjdAtcl+4Arc4Q=="
     },
     "css-loader": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@stackblitz/sdk": "1.5.1",
     "@types/google.visualization": "0.0.56",
     "@types/node": "14.11.7",
-    "angular-resize-event": "2.0.0",
     "classlist.js": "1.1.20150312",
     "core-js": "3.7.0",
     "flexboxgrid": "6.3.1",


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3809

#### Please provide a brief summary of this pull request.
We were using "https://www.npmjs.com/package/angular-resize-event"  for detecting Fixed card layout available width change detection. As this is third party library. we have decided to remove this dependency and have documentation for guiding user to use such technique to trigger change detection.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] Documentation Examples
- [x] Stackblitz works for all examples

