### PR TITLE
fix: (Core) Popover sides position

### DIFF
--- a/libs/core/src/lib/popover/popover.component.scss
+++ b/libs/core/src/lib/popover/popover.component.scss
@@ -141,6 +141,6 @@ $fd-popover-background-color: var(--sapGroup_ContentBackground, #fff) !default;
     }
 }
 
-.cdk-overlay-connected-position-bounding-box {
-	height: auto !important;
+.cdk-overlay-pane {
+	max-height: initial;
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of: https://github.com/SAP/fundamental-ngx/issues/3786
#### Please provide a brief summary of this pull request.
For some unknown reason this height has to be specified by CDK functionality.
To prevent datetime-picker / other talll components to be cut, I had to change `max-height` of another component from 100% to initial.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

