### PR TITLE
fix: (Core) adapt the Breaking Changes from fundamental-styles v.0.13.0

### DIFF
--- a/apps/docs/src/app/core/component-docs/inline-help/inline-help-header/inline-help-header.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/inline-help-header/inline-help-header.component.html
@@ -1,7 +1,11 @@
 <header>Inline Help</header>
 <description
     >Inline help is used to display help text in a popover, often inline with headers, body text and form labels. It
-    also uses the fd-popover component and supports much of its functionality.</description
+    also uses the fd-popover component and supports much of its functionality.
+    <fd-message-strip [type]="'warning'" [dismissible]="false">
+        DEPRECATED. Inline Help component will be refactored to a pattern component using already existing Fundamental-ngx components and no additional styling.
+    </fd-message-strip>
+    </description
 >
 <import module="InlineHelpModule"></import>
 

--- a/apps/docs/src/app/core/component-docs/inline-help/inline-help-header/inline-help-header.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/inline-help-header/inline-help-header.component.html
@@ -2,7 +2,7 @@
 <description
     >Inline help is used to display help text in a popover, often inline with headers, body text and form labels. It
     also uses the fd-popover component and supports much of its functionality.
-    <fd-message-strip [type]="'warning'" [dismissible]="false">
+    <fd-message-strip type="warning" [dismissible]="false">
         DEPRECATED. Inline Help component will be refactored to a pattern component using already existing Fundamental-ngx components and no additional styling.
     </fd-message-strip>
     </description

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -16,7 +16,7 @@
        class="fd-breadcrumb__collapsed"
        (keydown)="keyDownHandle($event)">
         ...
-        <span role="presentation" class="fd-breadcrumb__dropdown-icon"></span>
+        <i role="presentation" class="fd-breadcrumb__dropdown-icon sap-icon sap-icon--slim-arrow-down"></i>
     </a>
 </fd-breadcrumb-item>
 

--- a/libs/core/src/lib/form/form-control/form-control.component.scss
+++ b/libs/core/src/lib/form/form-control/form-control.component.scss
@@ -1,3 +1,2 @@
 @import '~fundamental-styles/dist/input';
 @import '~fundamental-styles/dist/textarea';
-@import '~fundamental-styles/dist/form-select';

--- a/libs/core/src/lib/form/form-control/form-control.component.ts
+++ b/libs/core/src/lib/form/form-control/form-control.component.ts
@@ -56,8 +56,6 @@ export class FormControlComponent implements CssClassBuilder, OnInit, OnChanges 
         switch (this._getElementTag()) {
             case 'input':
                 return 'fd-input';
-            case 'select':
-                return 'fd-form-select';
             case 'textarea':
                 return 'fd-textarea';
         }

--- a/libs/core/src/lib/inline-help/inline-help.component.scss
+++ b/libs/core/src/lib/inline-help/inline-help.component.scss
@@ -1,4 +1,83 @@
-@import '~fundamental-styles/dist/inline-help';
+/*!
+ * Fundamental Library Styles v0.13.0-rc.50
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company.
+ * Licensed under Apache License 2.0 (https://github.com/SAP/fundamental-styles/blob/master/LICENSE)
+ */
+ @charset "UTF-8";
+ .fd-inline-help {
+   font-size: .875rem;
+   font-size: var(--sapFontSize,.875rem);
+   line-height: 1.4;
+   line-height: var(--sapContent_LineHeight,1.4);
+   color: #32363a;
+   color: var(--sapTextColor,#32363a);
+   font-family: "72", "72full", Arial, Helvetica, sans-serif;
+   font-family: var(--sapFontFamily, "72", "72full", Arial, Helvetica, sans-serif);
+   font-weight: 400;
+   -webkit-font-smoothing: antialiased;
+   -webkit-box-sizing: border-box;
+   box-sizing: border-box;
+   padding: 0;
+   margin: 0;
+   border: 0;
+   position: relative;
+   display: inline-block;
+   width: 1.125rem;
+   height: 1.125rem;
+   top: .188rem
+ }
+ .fd-inline-help::after,
+ .fd-inline-help::before {
+   -webkit-box-sizing: inherit;
+   box-sizing: inherit;
+   font-size: inherit
+ }
+ .fd-inline-help::before {
+   content: "?";
+   width: 1.125rem;
+   height: 1.125rem;
+   line-height: 1.125rem;
+   font-style: normal;
+   position: absolute;
+   left: 0;
+   border-radius: 50%;
+   color: #fff;
+   color: var(--sapContent_ContrastIconColor,#fff);
+   background-color: #6a6d70;
+   background-color: var(--sapButton_Neutral_Background,#6a6d70);
+   text-align: center
+ }
+ .fd-inline-help__content {
+   font-size: .75rem;
+   font-size: var(--sapFontSmallSize,.75rem);
+   line-height: normal;
+   background-color: #fff;
+   background-color: var(--sapTile_Background,#fff);
+   padding: .75rem;
+   display: block;
+   color: #32363a;
+   color: var(--sapTextColor,#32363a);
+   top: 1.25rem;
+   right: -.5rem;
+   min-width: 21.875rem;
+   -webkit-transition: opacity 125ms ease-in;
+   transition: opacity 125ms ease-in;
+   text-align: left;
+   z-index: 1;
+   border-radius: .313rem;
+   -webkit-filter: drop-shadow(0 0 0 .0625rem rgba(0,0,0,.1), 0 .125rem .5rem 0 rgba(0,0,0,.1));
+   -webkit-filter: drop-shadow(var(--sapContent_Shadow0, 0 0 0 .0625rem rgba(0,0,0,.1), 0 .125rem .5rem 0 rgba(0,0,0,.1)));
+   filter: drop-shadow(0 0 0 .0625rem rgba(0,0,0,.1), 0 .125rem .5rem 0 rgba(0,0,0,.1));
+   filter: drop-shadow(var(--sapContent_Shadow0, 0 0 0 .0625rem rgba(0,0,0,.1), 0 .125rem .5rem 0 rgba(0,0,0,.1)))
+ }
+ .fd-inline-help:hover .fd-inline-help__content {
+   visibility: visible;
+   opacity: 1;
+   overflow: visible
+ }
+ .fd-inline-help:focus {
+   outline: 0
+ }
 
 //TODO evaluate whether this should go to fd-styles?
 .fd-inline-help__content {

--- a/libs/core/src/lib/inline-help/inline-help.component.ts
+++ b/libs/core/src/lib/inline-help/inline-help.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { Placement } from 'popper.js';
 /**
+ * @deprecated
  * The component that represents an inline-help.
  * Inline help is used to display help text in a popover, often inline with headers, body text and form labels.
  *

--- a/libs/core/src/lib/inline-help/inline-help.module.ts
+++ b/libs/core/src/lib/inline-help/inline-help.module.ts
@@ -4,6 +4,9 @@ import { CommonModule } from '@angular/common';
 import { InlineHelpComponent } from './inline-help.component';
 import { PopoverModule } from '../popover/public_api';
 
+/**
+ * @deprecated
+ */
 @NgModule({
     imports: [CommonModule, PopoverModule],
     exports: [InlineHelpComponent],


### PR DESCRIPTION
### Please provide a brief summary of this pull request.
Address the breaking changes introduced in v.0.13.0 release of  fundamental-styles.
1. Removed `form-select` from form control
2. Added a deprecation message to Inline help and brought temporary the styling in ngx
3. Adapted the template of Breadcrumb

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [NA ] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [NA] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [NA] Documentation Examples
- [NA] Stackblitz works for all examples

