### PR TITLE
fix: (Core) Shellbar IE11 shrink

### DIFF
--- a/libs/core/src/lib/shellbar/shellbar.component.scss
+++ b/libs/core/src/lib/shellbar/shellbar.component.scss
@@ -14,8 +14,6 @@
     .fd-input-group__addon {
         background-color: transparent;
     }
-<<<<<<< Updated upstream
-=======
 
 	.fd-counter {
 		z-index: 1;
@@ -24,5 +22,4 @@
 	.fd-shellbar__group {
 		flex-basis: auto;
 	}
->>>>>>> Stashed changes
 }

--- a/libs/core/src/lib/shellbar/shellbar.component.scss
+++ b/libs/core/src/lib/shellbar/shellbar.component.scss
@@ -14,8 +14,15 @@
     .fd-input-group__addon {
         background-color: transparent;
     }
+<<<<<<< Updated upstream
+=======
 
 	.fd-counter {
 		z-index: 1;
 	}
+
+	.fd-shellbar__group {
+		flex-basis: auto;
+	}
+>>>>>>> Stashed changes
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of: https://github.com/SAP/fundamental-ngx/issues/3786
#### Please provide a brief summary of this pull request.

fex-basis had to be changed to auto. IE11 doesn't like `flex-basis: 0` 
before:
![image](https://user-images.githubusercontent.com/26483208/99660987-75b72d80-2a63-11eb-9415-64c85fbaf3d2.png)

after:
![image](https://user-images.githubusercontent.com/26483208/99660953-6932d500-2a63-11eb-8f53-5130fcce6f75.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
