### PR TITLE
fix: (Core) change flex property on fixed card layout for IE11

### DIFF
--- a/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
+++ b/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
@@ -40,7 +40,7 @@ $fixedCardGroup: #{$fd-namespace}-fixed-card-group;
         margin-right: 0;
         min-width: 20rem;
 
-		.fd-card-content {
+		.fd-card__content {
 			overflow: hidden;
 		}
     }

--- a/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
+++ b/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
@@ -9,7 +9,7 @@ $fixedCardGroup: #{$fd-namespace}-fixed-card-group;
     }
 
     &--card-layout-column {
-        flex: 0;
+        flex: 1;
         margin-right: 1rem;
         margin-left: 0;
 

--- a/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
+++ b/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
@@ -58,4 +58,8 @@ $fixedCardGroup: #{$fd-namespace}-fixed-card-group;
                     0 8px 10px 1px rgba(0, 0, 0, 0.14),
                     0 3px 14px 2px rgba(0, 0, 0, 0.12);
     }
+
+	.fd-card-content {
+		overflow: hidden;
+	}
 }

--- a/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
+++ b/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
@@ -39,6 +39,10 @@ $fixedCardGroup: #{$fd-namespace}-fixed-card-group;
         margin-bottom: 1rem;
         margin-right: 0;
         min-width: 20rem;
+
+		.fd-card-content {
+			overflow: hidden;
+		}
     }
 
     &--card:last-child {
@@ -58,8 +62,4 @@ $fixedCardGroup: #{$fd-namespace}-fixed-card-group;
                     0 8px 10px 1px rgba(0, 0, 0, 0.14),
                     0 3px 14px 2px rgba(0, 0, 0, 0.12);
     }
-
-	.fd-card-content {
-		overflow: hidden;
-	}
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of: https://github.com/SAP/fundamental-ngx/issues/3786
#### Please provide a brief summary of this pull request.
Changed `flex: 0` to `flex: 1` in flexible card layout. IE11
Before:
![image](https://user-images.githubusercontent.com/26483208/99663125-6d142680-2a66-11eb-9f21-3ff346d44298.png)


After:
![image](https://user-images.githubusercontent.com/26483208/99662912-2e7e6c00-2a66-11eb-9c52-1922afeeecf2.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
