### PR TITLE
fix: (Core) FormMessage width reduce

### DIFF
--- a/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.scss
+++ b/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.scss
@@ -21,4 +21,8 @@
 .fd-popover__popper.fd-popover__popper--input-message-group {
     margin-top: 0 !important;
     z-index: 999;
+
+	.fd-form-message {
+		display: block;
+	}
 }

--- a/libs/core/src/lib/form/form-message/form-message.component.scss
+++ b/libs/core/src/lib/form/form-message/form-message.component.scss
@@ -1,9 +1,5 @@
 @import '~fundamental-styles/dist/form-message';
 
-.fd-form-message {
-    display: block;
-}
-
 .fd-form-message--embedded {
     box-shadow: none;
     max-width: 100%;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of: #3786

#### Please provide a brief summary of this pull request.
Width of form message outside the popover has been reduced only to needed width.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist


