### PR TITLE
fix: (Platform) add accessibility fixes for Dynamic Page

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-example.component.html
@@ -4,19 +4,19 @@
         <div class="overlay-content">
             <fdp-dynamic-page background="transparent" size="large" ariaLabel="Example Dynamic Page">
                 <fdp-dynamic-page-title
-                    title="Balenciaga Tripple S Trainers"
+                    [title]="pageTitle"
                     subtitle="Oversized multimaterial sneakers with quilted effect"
                 >
                     <!-- breadcrumb content -->
                     <fd-breadcrumb>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Men</a>
+                            <a fd-breadcrumb-link href="#">Men</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Shoes</a>
+                            <a fd-breadcrumb-link href="#">Shoes</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Running Shoes</a>
+                            <a fd-breadcrumb-link href="#">Running Shoes</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
                             <span>Jogging</span>
@@ -37,6 +37,7 @@
                                 fdType="positive"
                                 (click)="closePage($event)"
                                 label="Accept"
+                                title="Accept"
                             ></button>
                             <button
                                 fd-toolbar-item
@@ -45,6 +46,7 @@
                                 fdType="negative"
                                 (click)="closePage($event)"
                                 label="Reject"
+                                title="Reject"
                             ></button>
                             <fd-toolbar-separator></fd-toolbar-separator>
                         </fd-toolbar>
@@ -52,7 +54,13 @@
                     <fdp-dynamic-page-layout-actions>
                         <!-- layout actions -->
                         <fd-toolbar fdType="transparent" [clearBorder]="true">
-                            <button fd-button fdType="transparent" aria-label="Resize" (click)="resizeClicked($event)">
+                            <button
+                                fd-button
+                                fdType="transparent"
+                                aria-label="Resize"
+                                (click)="resizeClicked($event)"
+                                title="Resize"
+                            >
                                 <i class="sap-icon--resize"></i>
                             </button>
                             <button
@@ -60,10 +68,17 @@
                                 fdType="transparent"
                                 aria-label="Exit Fullscreen"
                                 (click)="closePage($event)"
+                                title="Exit Fullscreen"
                             >
                                 <i class="sap-icon--exitfullscreen"></i>
                             </button>
-                            <button fd-button fdType="transparent" aria-label="Close" (click)="closePage($event)">
+                            <button
+                                fd-button
+                                fdType="transparent"
+                                aria-label="Close"
+                                (click)="closePage($event)"
+                                title="Close"
+                            >
                                 <i class="sap-icon--decline"></i>
                             </button>
                         </fd-toolbar>

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-example.component.ts
@@ -13,6 +13,8 @@ export class PlatformDynamicPageExampleComponent {
 
     fullscreen = false;
 
+    pageTitle = 'Balenciaga Tripple S Trainers';
+
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
     }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-responsive-padding-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-responsive-padding-example.component.html
@@ -4,19 +4,19 @@
         <div class="overlay-content">
             <fdp-dynamic-page size="small" ariaLabel="Example Dynamic Page">
                 <fdp-dynamic-page-title
-                    title="Balenciaga Tripple S Trainers"
+                    [title]="pageTitle"
                     subtitle="Oversized multimaterial sneakers with quilted effect"
                 >
                     <!-- breadcrumb content -->
                     <fd-breadcrumb>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Men</a>
+                            <a fd-breadcrumb-link href="#">Men</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Shoes</a>
+                            <a fd-breadcrumb-link href="#">Shoes</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Running Shoes</a>
+                            <a fd-breadcrumb-link href="#">Running Shoes</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
                             <span>Jogging</span>
@@ -37,6 +37,7 @@
                                 fdType="positive"
                                 (click)="closePage($event)"
                                 label="Accept"
+                                title="Accept"
                             ></button>
                             <button
                                 fd-toolbar-item
@@ -45,6 +46,7 @@
                                 fdType="negative"
                                 (click)="closePage($event)"
                                 label="Reject"
+                                title="Reject"
                             ></button>
                             <fd-toolbar-separator></fd-toolbar-separator>
                         </fd-toolbar>
@@ -52,7 +54,13 @@
                     <fdp-dynamic-page-layout-actions>
                         <!-- layout actions -->
                         <fd-toolbar fdType="transparent" [clearBorder]="true">
-                            <button fd-button fdType="transparent" aria-label="Resize" (click)="resizeClicked($event)">
+                            <button
+                                fd-button
+                                fdType="transparent"
+                                aria-label="Resize"
+                                (click)="resizeClicked($event)"
+                                title="Resize"
+                            >
                                 <i class="sap-icon--resize"></i>
                             </button>
                             <button
@@ -60,10 +68,17 @@
                                 fdType="transparent"
                                 aria-label="Exit Fullscreen"
                                 (click)="closePage($event)"
+                                title="Exit Fullscreen"
                             >
                                 <i class="sap-icon--exitfullscreen"></i>
                             </button>
-                            <button fd-button fdType="transparent" aria-label="Close" (click)="closePage($event)">
+                            <button
+                                fd-button
+                                fdType="transparent"
+                                aria-label="Close"
+                                (click)="closePage($event)"
+                                title="Close"
+                            >
                                 <i class="sap-icon--decline"></i>
                             </button>
                         </fd-toolbar>

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-responsive-padding-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-responsive-padding-example.component.ts
@@ -13,6 +13,8 @@ export class PlatformDynamicPageResponsivePaddingExampleComponent {
 
     fullscreen = false;
 
+    pageTitle = 'Balenciaga Tripple S Trainers';
+
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
     }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-snap-scroll-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-snap-scroll-example.component.html
@@ -4,19 +4,19 @@
         <div class="overlay-content">
             <fdp-dynamic-page size="medium" ariaLabel="Example Dynamic Page">
                 <fdp-dynamic-page-title
-                    title="Balenciaga Tripple S Trainers"
+                    [title]="pageTitle"
                     subtitle="Oversized multimaterial sneakers with quilted effect"
                 >
                     <!-- breadcrumb content -->
                     <fd-breadcrumb>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Men</a>
+                            <a fd-breadcrumb-link href="#">Men</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Shoes</a>
+                            <a fd-breadcrumb-link href="#">Shoes</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Running Shoes</a>
+                            <a fd-breadcrumb-link href="#">Running Shoes</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
                             <span>Jogging</span>
@@ -37,6 +37,7 @@
                                 fdType="positive"
                                 (click)="closePage($event)"
                                 label="Accept"
+                                title="Accept"
                             ></button>
                             <button
                                 fd-toolbar-item
@@ -45,13 +46,21 @@
                                 fdType="negative"
                                 (click)="closePage($event)"
                                 label="Reject"
+                                title="Reject"
                             ></button>
+                            <fd-toolbar-separator></fd-toolbar-separator>
                         </fd-toolbar>
                     </fdp-dynamic-page-global-actions>
                     <fdp-dynamic-page-layout-actions>
                         <!-- layout actions -->
                         <fd-toolbar fdType="transparent" [clearBorder]="true">
-                            <button fd-button fdType="transparent" aria-label="Resize" (click)="resizeClicked($event)">
+                            <button
+                                fd-button
+                                fdType="transparent"
+                                aria-label="Resize"
+                                (click)="resizeClicked($event)"
+                                title="Resize"
+                            >
                                 <i class="sap-icon--resize"></i>
                             </button>
                             <button
@@ -59,10 +68,17 @@
                                 fdType="transparent"
                                 aria-label="Exit Fullscreen"
                                 (click)="closePage($event)"
+                                title="Exit Fullscreen"
                             >
                                 <i class="sap-icon--exitfullscreen"></i>
                             </button>
-                            <button fd-button fdType="transparent" aria-label="Close" (click)="closePage($event)">
+                            <button
+                                fd-button
+                                fdType="transparent"
+                                aria-label="Close"
+                                (click)="closePage($event)"
+                                title="Close"
+                            >
                                 <i class="sap-icon--decline"></i>
                             </button>
                         </fd-toolbar>

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-snap-scroll-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-snap-scroll-example.component.ts
@@ -13,6 +13,8 @@ export class PlatformDynamicPageSnapScrollExampleComponent {
 
     fullscreen = false;
 
+    pageTitle = 'Balenciaga Tripple S Trainers';
+
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
     }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.html
@@ -4,19 +4,19 @@
         <div class="overlay-content">
             <fdp-dynamic-page background="list">
                 <fdp-dynamic-page-title
-                    title="Balenciaga Tripple S Trainers"
+                    [title]="pageTitle"
                     subtitle="Oversized multimaterial sneakers with quilted effect"
                 >
                     <!-- breadcrumb content -->
                     <fd-breadcrumb>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Men</a>
+                            <a fd-breadcrumb-link href="#">Men</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Shoes</a>
+                            <a fd-breadcrumb-link href="#">Shoes</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
-                            <a fd-breadcrumb-link [attr.href]="'#'">Running Shoes</a>
+                            <a fd-breadcrumb-link href="#">Running Shoes</a>
                         </fd-breadcrumb-item>
                         <fd-breadcrumb-item>
                             <span>Jogging</span>
@@ -37,6 +37,7 @@
                                 fdType="positive"
                                 (click)="closePage($event)"
                                 label="Accept"
+                                title="Accept"
                             ></button>
                             <button
                                 fd-toolbar-item
@@ -45,6 +46,7 @@
                                 fdType="negative"
                                 (click)="closePage($event)"
                                 label="Reject"
+                                title="Reject"
                             ></button>
                             <fd-toolbar-separator></fd-toolbar-separator>
                         </fd-toolbar>
@@ -52,7 +54,13 @@
                     <fdp-dynamic-page-layout-actions>
                         <!-- layout actions -->
                         <fd-toolbar fdType="transparent" [clearBorder]="true">
-                            <button fd-button fdType="transparent" aria-label="Resize" (click)="closePage($event)">
+                            <button
+                                fd-button
+                                fdType="transparent"
+                                aria-label="Resize"
+                                (click)="closePage($event)"
+                                title="Resize"
+                            >
                                 <i class="sap-icon--resize"></i>
                             </button>
                             <button
@@ -60,10 +68,17 @@
                                 fdType="transparent"
                                 aria-label="Exit Fullscreen"
                                 (click)="closePage($event)"
+                                title="Exit Fullscreen"
                             >
                                 <i class="sap-icon--exitfullscreen"></i>
                             </button>
-                            <button fd-button fdType="transparent" aria-label="Close" (click)="closePage($event)">
+                            <button
+                                fd-button
+                                fdType="transparent"
+                                aria-label="Close"
+                                (click)="closePage($event)"
+                                title="Close"
+                            >
                                 <i class="sap-icon--decline"></i>
                             </button>
                         </fd-toolbar>

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
@@ -13,6 +13,8 @@ export class PlatformDynamicPageTabbedExampleComponent {
 
     fullscreen = false;
 
+    pageTitle = 'Balenciaga Tripple S Trainers';
+
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
     }

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page-content/dynamic-page-content.component.html
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page-content/dynamic-page-content.component.html
@@ -5,3 +5,4 @@
 
 <!-- if tab content, get the contentTemplate for passing it on to each individual tab -->
 <ng-template #contentTemplate><ng-content></ng-content></ng-template>
+<div class="footer-spacer"></div>

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.html
@@ -18,6 +18,7 @@
                         [contentTop]="tab.contentTop"
                     >
                         <ng-container *ngTemplateOutlet="tab.contentTemplate"></ng-container>
+                        <div class="footer-spacer"></div>
                     </fdp-dynamic-page-tabbed-content>
                 </fd-tab>
             </ng-container>

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
@@ -969,6 +969,9 @@
     bottom: 0;
     margin: 0 0.5rem 0.5rem;
 }
+.footer-spacer {
+    height: 3rem;
+}
 
 .tab-sticker {
     left: 0;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#3840
#3839 

#### Please provide a brief summary of this pull request.
PR fixes some a11y issues:
- hovering over title area gives same tooltip everywhere: this is because on removing input binding from `title` field, the native action of setting to tooltip from the title attribute takes place. Hence, we need to specify `[title]` with the binding, while giving the toolbar buttons their own `title` attributes.
- content going behind floating bar is not visible when end of scroll is reached: since no specs or requirements are provided for this, following the same behaviour as UI5- by providing an empty div with height~floating bar height to give ample space for content visibility.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

