### PR TITLE
fix: (Platform) show default format for placeholder in DatetimePicker docs

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-basic-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-basic-example.component.html
@@ -1,17 +1,10 @@
 <label for="simple">Simple datetime picker:</label>
 <br />
-<fdp-datetime-picker
-    name="simple"
-    placeholder="Enter a date"
-></fdp-datetime-picker>
+<fdp-datetime-picker name="simple"></fdp-datetime-picker>
 <br />
 <label for="withAllowNull">With allowNull not enabled to disallow input from taking null value:</label>
 <br />
-<fdp-datetime-picker
-    name="withAllowNull"
-    [allowNull]="false"
-    placeholder="Enter a date mandatorily"
->
+<fdp-datetime-picker name="withAllowNull" [allowNull]="false" placeholder="Enter a date mandatorily">
 </fdp-datetime-picker>
 <br />
 <label for="compactDatetime">Compact datetime picker. Click on the button to change the date:</label>
@@ -24,26 +17,18 @@
 >
 </fdp-datetime-picker>
 <br />
-<button
-    fd-button
-    name="changeBtn"
-    (click)="changeDay()"
->Change datetime value</button>
+<button fd-button name="changeBtn" (click)="changeDay()">Change datetime value</button>
 <br />
 <br />
 <label for="disabledDatetime">Disabled datetime picker:</label>
 <br />
-<fdp-datetime-picker
-    name="disabledDatetime"
-    [disabled]="true"
-    [value]="date2"
-> </fdp-datetime-picker>
+<fdp-datetime-picker name="disabledDatetime" [disabled]="true" [value]="date2"> </fdp-datetime-picker>
 <br />
 <label for="placementDatetime">Placement for datetime picker:</label>
 <br />
-<fdp-datetime-picker
-    name="placementDatetime"
-    placement="bottom-end"
-    [value]="date2"
-> </fdp-datetime-picker>
+<fdp-datetime-picker name="placementDatetime" placement="bottom-end" [value]="date2"> </fdp-datetime-picker>
+<br />
+<label for="defaultFormatDatetime">Default format in placeholder:</label>
+<br />
+<fdp-datetime-picker name="defaultFormatDatetime"> </fdp-datetime-picker>
 <br />

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-basic-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-basic-example.component.html
@@ -1,6 +1,6 @@
 <label for="simple">Simple datetime picker:</label>
 <br />
-<fdp-datetime-picker name="simple"></fdp-datetime-picker>
+<fdp-datetime-picker name="simple" placeholder="MM/dd/YYYY, hh:mm"></fdp-datetime-picker>
 <br />
 <label for="withAllowNull">With allowNull not enabled to disallow input from taking null value:</label>
 <br />
@@ -26,9 +26,6 @@
 <br />
 <label for="placementDatetime">Placement for datetime picker:</label>
 <br />
-<fdp-datetime-picker name="placementDatetime" placement="bottom-end" [value]="date2"> </fdp-datetime-picker>
-<br />
-<label for="defaultFormatDatetime">Default format in placeholder:</label>
-<br />
-<fdp-datetime-picker name="defaultFormatDatetime"> </fdp-datetime-picker>
+<fdp-datetime-picker name="placementDatetime" placement="bottom-end" [value]="date2" placeholder="MM/dd/YYYY, hh:mm">
+</fdp-datetime-picker>
 <br />

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-disable-function-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-disable-function-example.component.html
@@ -8,7 +8,12 @@
         [validators]="requiredDateValidator"
         label="Date:"
     >
-        <fdp-datetime-picker name="simple" [formControl]="ffl1.formControl" [disableFunction]="disableFunction">
+        <fdp-datetime-picker
+            name="simple"
+            [formControl]="ffl1.formControl"
+            [disableFunction]="disableFunction"
+            placeholder="MM/dd/YYYY, hh:mm"
+        >
         </fdp-datetime-picker>
     </fdp-form-field>
 

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-disable-function-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-disable-function-example.component.html
@@ -6,26 +6,17 @@
         rank="1"
         required="true"
         [validators]="requiredDateValidator"
-        placeholder="Enter a date"
         label="Date:"
     >
         <fdp-datetime-picker name="simple" [formControl]="ffl1.formControl" [disableFunction]="disableFunction">
         </fdp-datetime-picker>
     </fdp-form-field>
 
-    <fdp-form-field
-        id="disabledDatetime"
-        zone="zLeft"
-        rank="2"
-        placeholder="This is a disabled datetime picker"
-        label="Disabled Datetime Picker:"
-    >
+    <fdp-form-field id="disabledDatetime" zone="zLeft" rank="2" label="Disabled Datetime Picker:">
         <fdp-datetime-picker name="disabledDatetime" [disabled]="true" [value]="date"> </fdp-datetime-picker>
     </fdp-form-field>
 
     <ng-template #i18n let-errors>
-        <span *ngIf="errors.required">
-            Value is required
-        </span>
+        <span *ngIf="errors.required"> Value is required </span>
     </ng-template>
 </fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-reactive-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-reactive-example.component.html
@@ -12,7 +12,6 @@
         rank="1"
         required="true"
         [validators]="requiredDateValidator"
-        placeholder="Enter a date"
         label="Date:"
     >
         <fdp-datetime-picker

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-reactive-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-reactive-example.component.html
@@ -12,6 +12,7 @@
         rank="1"
         required="true"
         [validators]="requiredDateValidator"
+        placeholder="MM/dd/YYYY, hh:mm"
         label="Date:"
     >
         <fdp-datetime-picker


### PR DESCRIPTION
### Please provide a link to the associated issue.
#3906 
#### Please provide a brief summary of this pull request.
The format of datetime picker appears in the placeholder by default. Since previously all examples explicitly had a placeholder, there was no example showcasing the default format in placeholder. This PR adjusts some examples to show that specifying no placeholder shows up the default datetime format instead. It also fixes a couple of failing unit tests.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

