### PR TITLE
fix: (Core) remove wrong examples Object marker and Object Status

### DIFF
--- a/apps/docs/src/app/core/component-docs/object-marker/examples/object-marker-Icon-text-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-marker/examples/object-marker-Icon-text-example.component.html
@@ -1,5 +1,3 @@
-<span fd-object-marker glyph="add-favorite" aria-label="Favourite Icon with Text" label="Favourite"></span>
-<span fd-object-marker glyph="flag" aria-label="Flag Icon with Text" label="Flag"></span>
 <span fd-object-marker glyph="user-edit" aria-label="Edit Icon with Text" label="Edit"></span>
 <span fd-object-marker glyph="private" aria-label="Locked Icon with Text" label="Locked"></span>
 <span fd-object-marker glyph="request" aria-label="Request Icon with Text" label="Request"></span>

--- a/apps/docs/src/app/core/component-docs/object-marker/examples/object-marker-clickable-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-marker/examples/object-marker-clickable-example.component.html
@@ -1,9 +1,9 @@
 <a
     fd-object-marker
-    glyph="add-favorite"
+    glyph="user-edit"
     clickable="true"
     aria-label="Object Maker with Text Clickable"
-    label="Favourite"
+    label="Editable"
 ></a>
 <a
     fd-object-marker

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-large-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-large-example.component.html
@@ -67,7 +67,7 @@
     [clickable]="true"
     [large]="true"
     [inverted]="true"
-    label="Criitical"
+    label="Critical"
 ></a>
 <a
     fd-object-status


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3797
https://github.com/SAP/fundamental-ngx/issues/3749

#### Please provide a brief summary of this pull request.

correct misspelling of "Critical" in object status Object.

The self-explanatory statuses Flag and Favorite are always displayed as an icon.", not icon and text - Visual core.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

