### PR TITLE
fix: (Platform) remove wrong examples Object marker

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-object-marker/object-marker-example/object-marker-text-and-icon-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-object-marker/object-marker-example/object-marker-text-and-icon-example.component.html
@@ -1,5 +1,3 @@
-<fdp-object-marker glyph="add-favorite" ariaLable="Favourite Icon with Text" label="Favourite"></fdp-object-marker>
-<fdp-object-marker glyph="flag" ariaLable="Flag Icon with Text" label="flag"></fdp-object-marker>
 <fdp-object-marker glyph="user-edit" ariaLabel="Edit Icon with Text" label="Edit"></fdp-object-marker>
 <fdp-object-marker glyph="private" ariaLabel="Locked Icon with Text" label="Locked"></fdp-object-marker>
 <fdp-object-marker glyph="request" ariaLabel="Request Icon with Text" label="Request"></fdp-object-marker>

--- a/apps/docs/src/app/platform/component-docs/platform-object-marker/object-marker-example/object-marker-text-clickable-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-object-marker/object-marker-example/object-marker-text-clickable-example.component.html
@@ -1,9 +1,4 @@
-<fdp-object-marker
-    glyph="add-favorite"
-    clickable="true"
-    ariaLabel="Object Marker with Text Clickable"
-    label="Favourite"
->
+<fdp-object-marker glyph="user-edit" clickable="true" ariaLabel="Object Marker with Text Clickable" label="Editable">
 </fdp-object-marker>
 <fdp-object-marker glyph="private" clickable="true" ariaLabel="Object Marker with Text Clickable" label="Locked">
 </fdp-object-marker>


### PR DESCRIPTION

#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3749

#### Please provide a brief summary of this pull request.

The self-explanatory statuses Flag and Favorite are always displayed as an icon.", not icon and text - Visual core.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

