### PR TITLE
fix: (Core) throw error on theme switcher via url, when router is not imported

### DIFF
--- a/apps/docs/src/app/core/component-docs/theme-switcher/theme-switcher-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/theme-switcher/theme-switcher-docs.component.html
@@ -16,8 +16,10 @@
     Setting theme via url
 </fd-docs-section-title>
 <description>
-    Theme can be set by adding property in URL providing name of the theme like in the following example. Parameter is configurable, it can be set by calling <code>setThemeByRoute</code>.
-    See example by adding <code>?customQueryParam=sap_fiori_3_dark</code> to URL.
+    Theme can be set by adding property in URL providing name of the theme like in the following example.
+    Parameter is configurable, it can be set by calling <code>setThemeByRoute</code>.
+    See example by adding <code>?customQueryParam=sap_fiori_3_dark</code> to URL. To make it work properly,
+    you need to have imported <code>RouterModule</code> into the project.
 </description>
 <component-example>
     <fd-theme-url-example (themeChanged)="handleThemeChanged($event)"></fd-theme-url-example>

--- a/libs/core/src/lib/utils/consts/error-messages.ts
+++ b/libs/core/src/lib/utils/consts/error-messages.ts
@@ -1,1 +1,3 @@
 export const MOBILE_CONFIG_ERROR = `Missing configuration object for mobile version of the component. Consult the documentation on how to provide MobileModeConfiguration object for this component.`;
+
+export const THEME_SWITCHER_ROUTER_MISSING_ERROR = `You need to import RouterModule, to enable setting theme via url.`

--- a/libs/core/src/lib/utils/consts/error-messages.ts
+++ b/libs/core/src/lib/utils/consts/error-messages.ts
@@ -1,3 +1,3 @@
 export const MOBILE_CONFIG_ERROR = `Missing configuration object for mobile version of the component. Consult the documentation on how to provide MobileModeConfiguration object for this component.`;
 
-export const THEME_SWITCHER_ROUTER_MISSING_ERROR = `You need to import RouterModule, to enable setting theme via url.`
+export const THEME_SWITCHER_ROUTER_MISSING_ERROR = `You need to import RouterModule to enable theme settings via the url.`

--- a/libs/core/src/lib/utils/services/themes.service.ts
+++ b/libs/core/src/lib/utils/services/themes.service.ts
@@ -4,6 +4,8 @@ import { ActivatedRoute } from '@angular/router';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
+import { THEME_SWITCHER_ROUTER_MISSING_ERROR } from '../consts';
+
 export interface ThemeServiceOutput {
     themeUrl: SafeResourceUrl;
     customThemeUrl: SafeResourceUrl;
@@ -63,7 +65,12 @@ export class ThemesService {
      * By default it's `theme`.
      **/
     setThemeByRoute(themeParamName?: string): void {
-        const paramName = themeParamName || 'theme'
+        const paramName = themeParamName || 'theme';
+
+        if (!this._activatedRoute) {
+            throw new Error(THEME_SWITCHER_ROUTER_MISSING_ERROR);
+        }
+
         this._activatedRoute.queryParams
             .pipe(takeUntil(this._onDestroy$))
             .subscribe(param => this.onThemeQueryParamChange.next({


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
There is a need to handle lack of router module import, when theme switching via url is enabled
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

