### PR TITLE
fix: (Core) add title to close button in Message Strip component

### DIFF
--- a/apps/docs/src/app/core/component-docs/message-strip/examples/message-strip-width-example.component.html
+++ b/apps/docs/src/app/core/component-docs/message-strip/examples/message-strip-width-example.component.html
@@ -1,4 +1,4 @@
-<fd-message-strip [type]="'warning'" [noIcon]="true" [minWidth]="'400px'">
+<fd-message-strip [type]="'warning'" [noIcon]="true" [minWidth]="'200px'">
     A dismissible warning message strip.
 </fd-message-strip>
 <fd-message-strip [type]="'success'" [dismissible]="false" [width]="'70%'">
@@ -7,9 +7,9 @@
 <fd-message-strip [type]="'information'" [width]="'50%'">
     A dismissible information message strip.
 </fd-message-strip>
-<fd-message-strip [type]="'error'" [dismissible]="false" [width]="'400px'">
+<fd-message-strip [type]="'error'" [dismissible]="false" [width]="'200px'">
     A non-dismissible error message strip.
 </fd-message-strip>
-<fd-message-strip [width]="'300px'">
+<fd-message-strip [width]="'200px'">
     A dismissible normal message strip.
 </fd-message-strip>

--- a/libs/core/src/lib/message-strip/message-strip.component.html
+++ b/libs/core/src/lib/message-strip/message-strip.component.html
@@ -2,12 +2,13 @@
     class="fd-message-strip__close"
     fd-button
     glyph="decline"
+    fdType="transparent"
     [compact]="true"
-    [fdType]="'transparent'"
     *ngIf="dismissible"
     (click)="dismiss()"
     [attr.aria-controls]="id"
     [attr.aria-label]="dismissLabel"
+    [attr.title]="dismissLabel"
 ></button>
 <p class="fd-message-strip__text">
     <ng-content></ng-content>


### PR DESCRIPTION
 and small fix for a message strip examples

#### Please provide a link to the associated issue.
Closes: https://github.com/SAP/fundamental-ngx/issues/3121
Closes: https://github.com/SAP/fundamental-ngx/issues/3122
#### Please provide a brief summary of this pull request.
- Added a `title` to close button
- Changed value of `width` in examples
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

