### PR TITLE
docs: (Core) update Popover documentation to point to CDK overlay

### DIFF
--- a/apps/docs/src/app/core/component-docs/popover/popover-header/popover-header.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/popover-header/popover-header.component.html
@@ -17,7 +17,7 @@
         As a general rule, it is suggested that one popover be revealed on the page at any given time. Opening one
         popover should close all others to prevent multiple layers and collisions of several popovers.
     </p>
-    <p>Fundamental-ngx popovers use <a href="https://popper.js.org/index.html">Popper.js.</a></p>
+    <p>Fundamental-ngx popovers use the <code>overlay</code> package provided by <a href="https://material.angular.io/cdk/overlay/overview" target="_blank">Angular CDK</a>.</p>
 </description>
 <import module="PopoverModule"></import>
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/3922

#### Please provide a brief summary of this pull request.
The Popover has moved from Popper.js to Angular CDK `overlay` package but the documentation wasn't updated.

