### PR TITLE
fix: (Core) add fix for missing space between text and icon in Menu Button

### DIFF
--- a/libs/core/src/lib/button/button.component.scss
+++ b/libs/core/src/lib/button/button.component.scss
@@ -9,3 +9,14 @@
         line-height: 1rem;
     }
 }
+
+
+.fd-button * + * {
+  margin-left: .375rem !important;
+}
+
+.fd-button * + [dir=rtl],
+[dir=rtl] .fd-button * + * {
+  margin-left: 0;
+  margin-right: .375rem
+}

--- a/libs/core/src/lib/button/button.component.scss
+++ b/libs/core/src/lib/button/button.component.scss
@@ -10,13 +10,12 @@
     }
 }
 
-
 .fd-button * + * {
-  margin-left: .375rem !important;
+    margin-left: 0.375rem !important;
 }
 
-.fd-button * + [dir=rtl],
-[dir=rtl] .fd-button * + * {
-  margin-left: 0;
-  margin-right: .375rem
+.fd-button * + [dir='rtl'],
+[dir='rtl'] .fd-button * + * {
+    margin-left: 0 !important;
+    margin-right: 0.375rem !important;
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/3922

#### Please provide a brief summary of this pull request.
This PR introduces a temporary fix for the missing space between the Button text and icon. Once the newest version of fundamental-styles is adopted, the current fix won't be necessary and will be removed

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
