### PR TITLE
fix: (Core) replace datetime picker button label from 'Submit' to 'OK'

### DIFF
--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -99,7 +99,7 @@
                             <button
                                 fd-button
                                 fdType="emphasized"
-                                label="Submit"
+                                label="OK"
                                 [compact]="compact"
                                 (click)="submit()"
                             ></button>

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -210,7 +210,7 @@ export class DatetimePickerComponent<D> implements OnInit, OnDestroy, OnChanges,
     @Input()
     showWeekNumbers = true;
 
-    /** Whether or not to show the datetime picker footer with submit/cancel buttons. */
+    /** Whether or not to show the datetime picker footer with OK/cancel buttons. */
     @Input()
     showFooter = true;
 
@@ -257,10 +257,10 @@ export class DatetimePickerComponent<D> implements OnInit, OnDestroy, OnChanges,
     /** @hidden */
     _isInvalidDateInput = false;
 
-    /** @hidden The temporary Time object for use before 'Submit' is pressed. Internal use. */
+    /** @hidden The temporary Time object for use before 'OK' is pressed. Internal use. */
     _tempTime: D;
 
-    /** @hidden The temporary CalendarDay object for use before 'Submit' is pressed. Internal use. */
+    /** @hidden The temporary CalendarDay object for use before 'OK' is pressed. Internal use. */
     _tempDate: D;
 
     /** @hidden */
@@ -463,7 +463,7 @@ export class DatetimePickerComponent<D> implements OnInit, OnDestroy, OnChanges,
 
     /**
      * @hidden
-     * Method that is triggered when 'Submit' button is pressed.
+     * Method that is triggered when 'OK' button is pressed.
      */
     submit(): void {
         const currentDate = this._tempDate;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#3970 
#### Please provide a brief summary of this pull request.
This PR replaced the 'Submit' button in datetime picker to the recommended 'OK' button as per visual spec.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

