### PR TITLE
fix: (Platform) First avatar in Thumbnail needs highlight on default load

### DIFF
--- a/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.html
+++ b/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.html
@@ -1,6 +1,7 @@
 <div class="fdp-thumbnail-image-container">
     <div
         [class]="isHorizontal ? 'fdp-thumbnail-image--horizontal' : 'fdp-thumbnail-image'"
+        [class.fdp-thumbnail-image--selected]="image.selected"
         *ngFor="let image of mediaList"
         (click)="thumbnailClick(image)"
         (keydown.enter)="thumbnailClick(image)"

--- a/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.scss
+++ b/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.scss
@@ -4,6 +4,8 @@
   $fdp-thumbnail-image-margin-size: 1rem;
   $fdp-thumbnail-image-border: 0.015rem solid;
   $fdp-thumbnail-image-border-radius: 0.25rem;
+  $fdp-thumbnail-image-border-color-default: #085caf;
+  $fdp-thumbnail-image-border-color: var(--sapButton_Emphasized_Hover_BorderColor, #085caf);
 
   display: block;
 
@@ -26,7 +28,8 @@
     margin-right: $fdp-thumbnail-image-margin-size;
     &:hover {
         cursor: pointer;
-        border-color: var(--sapLink_Hover_Color);
+        border-color: $fdp-thumbnail-image-border-color-default;
+        border-color: $fdp-thumbnail-image-border-color;
         border-radius: $fdp-thumbnail-image-border-radius;
     }
     [dir='rtl'] & {
@@ -39,6 +42,13 @@
     height: $fdp-thumbnail-image-size;
     max-width: $fdp-thumbnail-image-size;
     max-height: $fdp-thumbnail-image-size;
+  }
+
+  .fdp-thumbnail-image--selected, .fdp-thumbnail-image--horizontal.fdp-thumbnail-image--selected {
+    border: $fdp-thumbnail-image-border;
+    border-radius: $fdp-thumbnail-image-border-radius;
+    border-color: $fdp-thumbnail-image-border-color-default;
+    border-color: $fdp-thumbnail-image-border-color;
   }
 
 }

--- a/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.spec.ts
+++ b/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.spec.ts
@@ -16,6 +16,12 @@ class DefaultThumbnailImageTestComponent {
         mediaUrl: 'https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mp4-file.mp4',
         alt: 'Failed to load http://lorempixel.com/400/400/nature',
         label: 'nature'
+    }, {
+        thumbnailUrl: 'http://lorempixel.com/400/400/nature',
+        mediaType: 'image',
+        mediaUrl: 'https://www.learningcontainer.com/wp-content/uploads/2020/05/sample-mp4-file.mp4',
+        alt: 'Failed to load http://lorempixel.com/400/400/nature',
+        label: 'nature2'
     }];
     @ViewChild(ThumbnailImageComponent, { static: true })
     thumbnailImage: ThumbnailImageComponent;
@@ -54,6 +60,12 @@ describe('DefaultThumbnailImageComponent', () => {
         expect(thumbNailImageComponent.thumbnailClicked.emit).toHaveBeenCalled();
         expect(thumbNailImageComponent.thumbnailClicked.emit).toHaveBeenCalledWith(component.mediaList[0]);
 
+    });
+
+    it('should highlight the first thumbnail by default', () => {
+        const thumbnails = fixture.debugElement.queryAll(By.css('.fdp-thumbnail-image'));
+        expect(thumbnails[0].classes['fdp-thumbnail-image--selected']).toBeTruthy();
+        expect(thumbnails[1].classes['fdp-thumbnail-image--selected']).toBeFalsy();
     });
 
 });

--- a/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.ts
+++ b/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.ts
@@ -21,9 +21,7 @@ export class ThumbnailImageComponent implements OnChanges {
     ngOnChanges(changes: SimpleChanges): void {
         // Select first image by default, if none has been selected
         if (changes.mediaList && Array.isArray(this.mediaList)) {
-            const alreadySelected: boolean = this.mediaList.reduce((selected, image) => {
-              return  selected || image.selected;
-            }, false);
+            const alreadySelected: boolean = this.mediaList.some(image => image.selected);
             if (!alreadySelected) {
                 this.mediaList[0].selected = true;
             }

--- a/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.ts
+++ b/libs/platform/src/lib/components/thumbnail/thumbnail-image/thumbnail-image.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, ViewEncapsulation } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ViewEncapsulation, OnChanges, SimpleChanges } from '@angular/core';
 import { Media } from '../thumbnail.component';
 
 @Component({
@@ -7,7 +7,7 @@ import { Media } from '../thumbnail.component';
     styleUrls: ['./thumbnail-image.component.scss'],
     encapsulation: ViewEncapsulation.None,
 })
-export class ThumbnailImageComponent {
+export class ThumbnailImageComponent implements OnChanges {
 
     @Input()
     mediaList: Media[];
@@ -18,8 +18,22 @@ export class ThumbnailImageComponent {
     @Output()
     thumbnailClicked: EventEmitter<Media> = new EventEmitter();
 
+    ngOnChanges(changes: SimpleChanges): void {
+        // Select first image by default, if none has been selected
+        if (changes.mediaList && Array.isArray(this.mediaList)) {
+            const alreadySelected: boolean = this.mediaList.reduce((selected, image) => {
+              return  selected || image.selected;
+            }, false);
+            if (!alreadySelected) {
+                this.mediaList[0].selected = true;
+            }
+        }
+    }
+
     /** @hidden */
     thumbnailClick(selectedMedia: Media): void {
+        this.mediaList.forEach(item => item.selected = false);
+        selectedMedia.selected = true;
         this.thumbnailClicked.emit(selectedMedia);
     }
 

--- a/libs/platform/src/lib/components/thumbnail/thumbnail.component.ts
+++ b/libs/platform/src/lib/components/thumbnail/thumbnail.component.ts
@@ -5,7 +5,8 @@ export interface Media {
     mediaType: string;
     mediaUrl: string;
     alt: string;
-    label: string
+    label: string;
+    selected?: boolean;
 }
 
 export class ThumbnailClickedEvent<T extends ThumbnailComponent = ThumbnailComponent, K = Media> {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#3964

#### Please provide a brief summary of this pull request.
On load of the Thumbnail component the first avatar is not highlighted to indicate the currently selected image.

<img width="708" alt="Screen Shot 2020-12-02 at 8 26 32 AM" src="https://user-images.githubusercontent.com/48103491/100900841-1e0fbd80-3478-11eb-9187-369b0a96c1ec.png">


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist


