### PR TITLE
fix: (Platform) fix a Range Error (Maximum calls) on Mobile View Combobox Safari

### DIFF
--- a/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.html
+++ b/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.html
@@ -39,7 +39,7 @@
         <ng-container></ng-container>
         <input
             #searchInputElement
-            fdp-auto-complete
+            [attr.fdp-auto-complete]="!mobile"
             [options]="_suggestions"
             [inputText]="inputText"
             type="text"

--- a/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.html
+++ b/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.html
@@ -39,9 +39,10 @@
         <ng-container></ng-container>
         <input
             #searchInputElement
-            [attr.fdp-auto-complete]="!mobile"
+            fdp-auto-complete
             [options]="_suggestions"
             [inputText]="inputText"
+            [mobile]="mobile"
             type="text"
             fd-input-group-input
             tabindex="0"


### PR DESCRIPTION
#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3978

#### Please provide a brief summary of this pull request.
Prevent maximum calls the `setSelectionRange` function on Safari
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

