### PR TITLE
fix: (Core) remove token max-width

### DIFF
--- a/libs/core/src/lib/token/tokenizer.component.scss
+++ b/libs/core/src/lib/token/tokenizer.component.scss
@@ -1,5 +1,9 @@
 @import '~fundamental-styles/dist/tokenizer';
 
+.fd-tokenizer .fd-token {
+    max-width: inherit;
+}
+
 input {
     &.fd-input {
         &.fd-tokenizer__input {


### PR DESCRIPTION
#### Please provide a link to the associated issue.

part of #3922 

Removes max-width from .fd-token class 