### PR TITLE
fix: (Core) Update form message to match Fundamental Styles

### DIFF
--- a/libs/core/src/lib/form/form-message/constants.ts
+++ b/libs/core/src/lib/form/form-message/constants.ts
@@ -1,4 +1,4 @@
-import { MessageStates } from '@fundamental-ngx/core';
+import { MessageStates } from './form-message.component';
 
 export const CSS_CLASS_NAME = {
     message: 'fd-form-message',

--- a/libs/core/src/lib/form/form-message/consts.ts
+++ b/libs/core/src/lib/form/form-message/consts.ts
@@ -1,0 +1,26 @@
+import { MessageStates } from '@fundamental-ngx/core';
+
+export const CSS_CLASS_NAME = {
+    message: 'fd-form-message',
+    messageStatic: 'fd-form-message--static',
+    messageEmbedded: 'fd-form-message--embedded',
+    messageSuccess: 'fd-form-message--success',
+    messageError: 'fd-form-message--error',
+    messageWarning: 'fd-form-message--warning',
+    messageInformation: 'fd-form-message--information'
+};
+
+export function getTypeClassName(size: MessageStates): string {
+    switch (size) {
+        case 'error':
+            return CSS_CLASS_NAME.messageError;
+        case 'success':
+            return CSS_CLASS_NAME.messageSuccess;
+        case 'warning':
+            return CSS_CLASS_NAME.messageWarning;
+        case 'information':
+            return CSS_CLASS_NAME.messageInformation;
+        default:
+            return null;
+    }
+}

--- a/libs/core/src/lib/form/form-message/form-message.component.html
+++ b/libs/core/src/lib/form/form-message/form-message.component.html
@@ -1,11 +1,1 @@
-<span
-    class="fd-form-message"
-    [ngClass]="[
-        type ? ' fd-form-message--' + type : '',
-        compact ? ' fd-form-message--' + compact : '',
-        static ? ' fd-form-message--static' : '',
-        embedded? ' fd-form-message--embedded' : ''
-    ]"
->
-    <ng-content></ng-content>
-</span>
+<ng-content></ng-content>

--- a/libs/core/src/lib/form/form-message/form-message.component.scss
+++ b/libs/core/src/lib/form/form-message/form-message.component.scss
@@ -1,6 +1,10 @@
 @import '~fundamental-styles/dist/form-message';
 
-.fd-form-message--embedded {
-    box-shadow: none;
-    max-width: 100%;
+.fd-form-message {
+    display: block;
+
+    &--embedded {
+        box-shadow: none;
+        max-width: 100%;
+    }
 }

--- a/libs/core/src/lib/form/form-message/form-message.component.ts
+++ b/libs/core/src/lib/form/form-message/form-message.component.ts
@@ -1,4 +1,15 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    Input,
+    OnChanges,
+    OnInit,
+    ViewEncapsulation
+} from '@angular/core';
+import { CssClassBuilder } from '../../utils/interfaces/css-class-builder.interface';
+import { applyCssClass } from '../../utils/decorators/apply-css-class.decorator';
+import { CSS_CLASS_NAME, getTypeClassName } from './consts';
 
 export type MessageStates = 'success' | 'error' | 'warning' | 'information';
 
@@ -12,14 +23,10 @@ export type MessageStates = 'success' | 'error' | 'warning' | 'information';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class FormMessageComponent {
+export class FormMessageComponent implements CssClassBuilder, OnInit, OnChanges {
     /** Type of the message. Can be 'success' | 'error' | 'warning' | 'information' */
     @Input()
     type: MessageStates;
-
-    /** Whether to apply compact mode to the message. */
-    @Input()
-    compact = false;
 
     /** Whether message should be in static mode, without popover. It's mostly used for forms component, that contain dropdown */
     @Input()
@@ -31,4 +38,37 @@ export class FormMessageComponent {
      */
     @Input()
     embedded = false;
+
+    /** @hidden User's custom classes */
+    @Input()
+    class: string;
+
+    constructor(private _elementRef: ElementRef) {}
+
+    /** @hidden */
+    ngOnChanges(): void {
+        this.buildComponentCssClass();
+    }
+
+    /** @hidden */
+    ngOnInit(): void {
+        this.buildComponentCssClass();
+    }
+
+    /** @hidden */
+    @applyCssClass
+    buildComponentCssClass(): string[] {
+        return [
+            CSS_CLASS_NAME.message,
+            this.static ? CSS_CLASS_NAME.messageStatic : '',
+            this.embedded ? CSS_CLASS_NAME.messageEmbedded : '',
+            getTypeClassName(this.type),
+            this.class
+        ];
+    }
+
+    /** @hidden */
+    elementRef(): ElementRef {
+        return this._elementRef;
+    }
 }

--- a/libs/core/src/lib/form/form-message/form-message.component.ts
+++ b/libs/core/src/lib/form/form-message/form-message.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { CssClassBuilder } from '../../utils/interfaces/css-class-builder.interface';
 import { applyCssClass } from '../../utils/decorators/apply-css-class.decorator';
-import { CSS_CLASS_NAME, getTypeClassName } from './consts';
+import { CSS_CLASS_NAME, getTypeClassName } from './constants';
 
 export type MessageStates = 'success' | 'error' | 'warning' | 'information';
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #3922 

#### Please provide a brief summary of this pull request.
Previous implementation of the Form Message has diverged from Fundamental Styles.

This PR:
- Flattens the component by moving `fd-form-message` classes to the host element
- Removes outdated `compact` input
- Changes message form `display` property to `block` (as shown in Fundamental Styles)

**Breaking change**
- `[compact]` input has been removed

The issue found during the deffect hunting was caused by `display: inline`.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

