### PR TITLE
fix: (Core) Combobox without expand button

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -41,7 +41,7 @@
     <fd-input-group
         [compact]="compact"
         [button]="showDropdownButton"
-        [glyph]="showDropdownButton ? glyph : ' '"
+        [glyph]="showDropdownButton ? glyph : null"
         [state]="state"
         [buttonFocusable]="buttonFocusable"
         [disabled]="disabled || readOnly"

--- a/libs/core/src/lib/input-group/input-group.component.scss
+++ b/libs/core/src/lib/input-group/input-group.component.scss
@@ -1,18 +1,9 @@
+@import '~fundamental-styles/dist/input';
 @import '~fundamental-styles/dist/input-group';
 
 fd-input-group {
     .fd-input-group__addon--button.fd-input-group__addon--textarea > * {
         max-height: 100%;
         height: 100%;
-    }
-
-    .fd-input-group__addon--button .fd-input-group__button {
-        &:hover {
-            border-color: transparent;
-        }
-    }
-
-    .fd-input-group__input {
-        width: 100%;
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of: #3922 

#### Please provide a brief summary of this pull request.
This PR:
- Brings `input` styles into `input-group`
- Removes outdated custom styling from `input-group`
- Removes glyph stub from `combobox` (it was used to keep proper height of the form-group, which collapsed when the addon was missing and all of this because of missing `input` styles which normally provide the height for the input).

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples