### PR TITLE
fix: (Core) add fix for numeric content IE11 overflow issues in Cards

### DIFF
--- a/libs/core/src/lib/card/card.component.scss
+++ b/libs/core/src/lib/card/card.component.scss
@@ -42,3 +42,12 @@
         }
     }
 }
+
+.fd-card__numeric-content.fd-numeric-content {
+    width: auto;
+    flex-shrink: 0;
+}
+
+.fd-numeric-content__scale-container {
+    flex: auto;
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/3922

#### Please provide a brief summary of this pull request.
this PR temporary brings styling rules for fixing overflow issues for Numeric content used in Cards. The issues were browser related and due to IE11 not supporting `width: initial`.
The fix in styles is https://github.com/SAP/fundamental-styles/pull/1940


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [na] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [na] Documentation Examples
- [na] Stackblitz works for all examples

