### PR TITLE
docs: re-order the Table columns in the Customizable Columns example

### DIFF
--- a/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-columns-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-columns-example.component.ts
@@ -16,11 +16,11 @@ export interface CellData {
 }
 
 const CELL_DATA: CellData[] = [
-    { column2: 'Row 221', column1: 'Row 111', column3: 'Row 1', date: '09-07-18', type: 'search' },
-    { column2: 'Row 222', column1: 'Row 112', column3: 'Row 2', date: '09-08-18', type: 'cart' },
-    { column2: 'Row 223', column1: 'Row 113', column3: 'Row 3', date: '02-14-18', type: 'calendar' },
-    { column2: 'Row 224', column1: 'Row 114', column3: 'Row 4', date: '12-30-17', type: 'search' },
-    { column2: 'Row 225', column1: 'Row 115', column3: 'Row 5', date: '11-12-18', type: 'search' }
+    { column1: 'Row 111', column2: 'Row 221', column3: 'Row 1', date: '09-07-18', type: 'search' },
+    { column1: 'Row 112', column2: 'Row 222', column3: 'Row 2', date: '09-08-18', type: 'cart' },
+    { column1: 'Row 113', column2: 'Row 223', column3: 'Row 3', date: '02-14-18', type: 'calendar' },
+    { column1: 'Row 114', column2: 'Row 224', column3: 'Row 4', date: '12-30-17', type: 'search' },
+    { column1: 'Row 115', column2: 'Row 225', column3: 'Row 5', date: '11-12-18', type: 'search' }
 ];
 
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/3922

#### Please provide a brief summary of this pull request.
In Customizable Columns example Column 1 was appearing after Column 2. Now Column 1 comes before Column 2

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [na] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

