### PR TITLE
fix: (Platform) remove popover classes from menu component

### DIFF
--- a/libs/platform/src/lib/components/menu/menu.component.html
+++ b/libs/platform/src/lib/components/menu/menu.component.html
@@ -1,10 +1,16 @@
 <ng-template #menuTemplate>
-    <div class="fd-popover__body fd-popover__body--no-arrow fd-menu-popover__body--static" [attr.id]="menuId" [attr.dir]="direction">
-        <nav class="fd-menu" [class.fd-menu--compact]="contentDensity==='compact'" tabindex="0" role="menu"
-            (click)="onClick($event)" (keydown)="onKeydown($event)">
-            <div class="fd-menu__list">
-                <ng-content></ng-content>
-            </div>
-        </nav>
-    </div>
+    <nav
+        [attr.id]="menuId"
+        [attr.dir]="direction"
+        class="fd-menu"
+        [class.fd-menu--compact]="contentDensity === 'compact'"
+        tabindex="0"
+        role="menu"
+        (click)="onClick($event)"
+        (keydown)="onKeydown($event)"
+    >
+        <div class="fd-menu__list">
+            <ng-content></ng-content>
+        </div>
+    </nav>
 </ng-template>


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Closes https://github.com/SAP/fundamental-ngx/issues/4088

#### Please provide a brief summary of this pull request.
Removed popover classes from `fdp-menu`
#### Please check whether the PR fulfills the following requirements

- [X] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [X] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist