### PR TITLE
fix: (Core) remove DIALOG_CONFIG and DIALOG_REF and make DialogConfig and DialogRef injectable

### DIFF
--- a/apps/docs/src/app/core/component-docs/dialog/examples/component-based/dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/component-based/dialog-example.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
+import { DialogRef } from '@fundamental-ngx/core';
 
 @Component({
     template: `
@@ -45,5 +45,5 @@ import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
     `
 })
 export class DialogExampleComponent {
-    constructor(@Inject(DIALOG_REF) public dialogRef: DialogRef) {}
+    constructor(public dialogRef: DialogRef) {}
 }

--- a/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { DIALOG_REF, DialogConfig, DialogRef, DialogService } from '@fundamental-ngx/core';
+import { DialogConfig, DialogRef, DialogService } from '@fundamental-ngx/core';
 import { SecondDialogExampleComponent } from './second-dialog-example.component';
 
 @Component({
@@ -32,7 +32,7 @@ import { SecondDialogExampleComponent } from './second-dialog-example.component'
     `
 })
 export class FirstDialogExampleComponent {
-    constructor(@Inject(DIALOG_REF) public dialogRef: DialogRef, public _dialogService: DialogService) {}
+    constructor(public dialogRef: DialogRef, public _dialogService: DialogService) {}
 
     openDialog(): void {
         this._dialogService.open(SecondDialogExampleComponent, { responsivePadding: true });

--- a/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
+import { DialogRef } from '@fundamental-ngx/core';
 
 @Component({
     template: `
@@ -31,5 +31,5 @@ import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
     `
 })
 export class SecondDialogExampleComponent {
-    constructor(@Inject(DIALOG_REF) public dialogRef: DialogRef) {}
+    constructor(public dialogRef: DialogRef) {}
 }

--- a/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-dialog.component.ts
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-custom-columns-example/table-custom-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
+import { DialogRef } from '@fundamental-ngx/core';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { DisplayedColumn } from './table-custom-columns-example.component';
 
@@ -95,7 +95,7 @@ export class TableCustomDialogComponent {
     allSelected = false;
     showError = false;
 
-    constructor(@Inject(DIALOG_REF) public dialogRef: DialogRef) {
+    constructor(public dialogRef: DialogRef) {
         this.columns = this.dialogRef.data.columns;
         this.allSelected = this._areAllSelected();
     }

--- a/libs/core/src/lib/dialog/dialog-body/dialog-body.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog-body/dialog-body.component.spec.ts
@@ -1,8 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DialogBodyComponent } from './dialog-body.component';
-import { DIALOG_CONFIG, DialogConfig } from '../utils/dialog-config.class';
-import { DIALOG_REF, DialogRef } from '../utils/dialog-ref.class';
+import { DialogConfig } from '../utils/dialog-config.class';
+import { DialogRef } from '../utils/dialog-ref.class';
 import { BusyIndicatorModule } from '../../busy-indicator/busy-indicator.module';
 
 describe('DialogBodyComponent', () => {
@@ -14,8 +14,8 @@ describe('DialogBodyComponent', () => {
             imports: [BusyIndicatorModule],
             declarations: [DialogBodyComponent],
             providers: [
-                { provide: DIALOG_CONFIG, useClass: DialogConfig },
-                { provide: DIALOG_REF, useClass: DialogRef }
+                { provide: DialogConfig, useClass: DialogConfig },
+                { provide: DialogRef, useClass: DialogRef }
             ]
         }).compileComponents();
     }));

--- a/libs/core/src/lib/dialog/dialog-body/dialog-body.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog-body/dialog-body.component.spec.ts
@@ -13,10 +13,7 @@ describe('DialogBodyComponent', () => {
         TestBed.configureTestingModule({
             imports: [BusyIndicatorModule],
             declarations: [DialogBodyComponent],
-            providers: [
-                { provide: DialogConfig, useClass: DialogConfig },
-                { provide: DialogRef, useClass: DialogRef }
-            ]
+            providers: [DialogConfig, DialogRef]
         }).compileComponents();
     }));
 

--- a/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
+++ b/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
@@ -1,6 +1,6 @@
-import { Component, Inject, Optional } from '@angular/core';
-import { DIALOG_CONFIG, DialogConfig } from '../utils/dialog-config.class';
-import { DIALOG_REF, DialogRef } from '../../dialog/utils/dialog-ref.class';
+import { Component, Optional } from '@angular/core';
+import { DialogConfig } from '../utils/dialog-config.class';
+import { DialogRef } from '../../dialog/utils/dialog-ref.class';
 
 /**
  * Applies fundamental layout and styling to the contents of a dialog body.
@@ -23,7 +23,7 @@ export class DialogBodyComponent {
 
     /** @hidden */
     constructor(
-        @Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig,
-        @Optional() @Inject(DIALOG_REF) public dialogRef: DialogRef
+        @Optional() public dialogConfig: DialogConfig,
+        @Optional() public dialogRef: DialogRef
     ) {}
 }

--- a/libs/core/src/lib/dialog/dialog-container/dialog-container.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog-container/dialog-container.component.spec.ts
@@ -3,8 +3,8 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 import { Component } from '@angular/core';
 
 import { DialogContainerComponent } from '../dialog-container/dialog-container.component';
-import { DIALOG_CONFIG, DialogConfig } from '../utils/dialog-config.class';
-import { DIALOG_REF, DialogRef } from '../utils/dialog-ref.class';
+import { DialogConfig } from '../utils/dialog-config.class';
+import { DialogRef } from '../utils/dialog-ref.class';
 import { DialogDefaultContent } from '../utils/dialog-default-content.class';
 import { whenStable } from '../../utils/tests';
 
@@ -25,8 +25,8 @@ describe('DialogContainerComponent', () => {
         TestBed.configureTestingModule({
             declarations: [DialogContainerComponent, ContentTestComponent],
             providers: [
-                { provide: DIALOG_CONFIG, useValue: dialogConfig },
-                { provide: DIALOG_REF, useClass: DialogRef }
+                { provide: DialogConfig, useValue: dialogConfig },
+                { provide: DialogRef, useClass: DialogRef }
             ]
         }).overrideModule(BrowserDynamicTestingModule, {
             set: { entryComponents: [ContentTestComponent] }

--- a/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
+++ b/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
@@ -4,15 +4,14 @@ import {
     Component,
     ComponentFactoryResolver,
     ElementRef,
-    Inject,
     Input,
     TemplateRef,
     Type,
     ViewChild,
     ViewContainerRef
 } from '@angular/core';
-import { DIALOG_REF, DialogRef } from '../utils/dialog-ref.class';
-import { DIALOG_CONFIG, DialogConfig } from '../utils/dialog-config.class';
+import { DialogRef } from '../utils/dialog-ref.class';
+import { DialogConfig } from '../utils/dialog-config.class';
 import { applyCssClass } from '../../utils/decorators/apply-css-class.decorator';
 import { CssClassBuilder } from '../../utils/interfaces/css-class-builder.interface';
 import { DynamicComponentContainer } from '../../utils/dynamic-component/dynamic-component-container';
@@ -42,8 +41,8 @@ export class DialogContainerComponent extends DynamicComponentContainer<DialogCo
 
     /** @hidden */
     constructor(
-        @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig,
-        @Inject(DIALOG_REF) private _dialogRef: DialogRef,
+        public dialogConfig: DialogConfig,
+        private _dialogRef: DialogRef,
         elementRef: ElementRef,
         componentFactoryResolver: ComponentFactoryResolver,
         private _changeDetectorRef: ChangeDetectorRef

--- a/libs/core/src/lib/dialog/dialog-default/dialog-default.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog-default/dialog-default.component.spec.ts
@@ -5,7 +5,7 @@ import { DialogDecisiveButtonDirective } from '../directives/dialog-decisive-but
 import { DialogDefaultContent } from '../utils/dialog-default-content.class';
 import { DialogHeaderComponent } from '../dialog-header/dialog-header.component';
 import { DialogCloseButtonComponent } from '../dialog-close-button/dialog-close-button.component';
-import { DIALOG_CONFIG, DialogConfig } from '../utils/dialog-config.class';
+import { DialogConfig } from '../utils/dialog-config.class';
 
 describe('DefaultDialogComponent', () => {
     let component: DialogDefaultComponent;
@@ -21,7 +21,7 @@ describe('DefaultDialogComponent', () => {
                 DialogDecisiveButtonDirective,
                 DialogHeaderComponent
             ],
-            providers: [{ provide: DIALOG_CONFIG, useClass: DialogConfig }]
+            providers: [{ provide: DialogConfig, useClass: DialogConfig }]
         }).compileComponents();
     });
 

--- a/libs/core/src/lib/dialog/dialog-default/dialog-default.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog-default/dialog-default.component.spec.ts
@@ -21,7 +21,7 @@ describe('DefaultDialogComponent', () => {
                 DialogDecisiveButtonDirective,
                 DialogHeaderComponent
             ],
-            providers: [{ provide: DialogConfig, useClass: DialogConfig }]
+            providers: [DialogConfig]
         }).compileComponents();
     });
 

--- a/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.spec.ts
@@ -4,7 +4,7 @@ import { DialogFooterComponent } from './dialog-footer.component';
 import { Component, Type, ViewChild } from '@angular/core';
 import { BarModule } from '../../bar/bar.module';
 import { TemplateModule } from '../../utils/directives/template/template.module';
-import { DIALOG_CONFIG, DialogConfig } from '../utils/dialog-config.class';
+import { DialogConfig } from '../utils/dialog-config.class';
 
 @Component({
     template: `
@@ -37,7 +37,7 @@ describe('DialogFooterComponent', () => {
         TestBed.configureTestingModule({
             declarations: [DialogFooterComponent, CustomFooterTestComponent, DefaultFooterTestComponent],
             imports: [BarModule, TemplateModule],
-            providers: [{ provide: DIALOG_CONFIG, useClass: DialogConfig }]
+            providers: [{ provide: DialogConfig, useClass: DialogConfig }]
         });
     }));
 

--- a/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.spec.ts
@@ -37,7 +37,7 @@ describe('DialogFooterComponent', () => {
         TestBed.configureTestingModule({
             declarations: [DialogFooterComponent, CustomFooterTestComponent, DefaultFooterTestComponent],
             imports: [BarModule, TemplateModule],
-            providers: [{ provide: DialogConfig, useClass: DialogConfig }]
+            providers: [DialogConfig]
         });
     }));
 

--- a/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.ts
+++ b/libs/core/src/lib/dialog/dialog-footer/dialog-footer.component.ts
@@ -1,5 +1,5 @@
-import { AfterContentInit, Component, Inject, Optional } from '@angular/core';
-import { DIALOG_CONFIG, DialogConfig } from '../utils/dialog-config.class';
+import { AfterContentInit, Component, Optional } from '@angular/core';
+import { DialogConfig } from '../utils/dialog-config.class';
 import { DialogFooterBase } from '../base/dialog-footer-base.class';
 
 /**
@@ -21,7 +21,7 @@ import { DialogFooterBase } from '../base/dialog-footer-base.class';
 export class DialogFooterComponent extends DialogFooterBase implements AfterContentInit {
 
     /** @hidden */
-    constructor(@Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig) {
+    constructor(@Optional() public dialogConfig: DialogConfig) {
         super();
         this.dialogConfig = this.dialogConfig || {};
     }

--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DialogHeaderComponent } from './dialog-header.component';
 import { Component, Type, ViewChild } from '@angular/core';
-import { DIALOG_CONFIG, DialogConfig } from '../utils/dialog-config.class';
+import { DialogConfig } from '../utils/dialog-config.class';
 import { TemplateModule } from '../../utils/directives/template/template.module';
 import { BarModule } from '../../bar/bar.module';
 
@@ -47,7 +47,7 @@ describe('DialogHeaderComponent', () => {
         TestBed.configureTestingModule({
             declarations: [DialogHeaderComponent, CustomHeaderTestComponent, DefaultHeaderTestComponent],
             imports: [BarModule, TemplateModule],
-            providers: [{ provide: DIALOG_CONFIG, useClass: DialogConfig }]
+            providers: [{ provide: DialogConfig, useClass: DialogConfig }]
         });
     }));
 

--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.spec.ts
@@ -47,7 +47,7 @@ describe('DialogHeaderComponent', () => {
         TestBed.configureTestingModule({
             declarations: [DialogHeaderComponent, CustomHeaderTestComponent, DefaultHeaderTestComponent],
             imports: [BarModule, TemplateModule],
-            providers: [{ provide: DialogConfig, useClass: DialogConfig }]
+            providers: [DialogConfig]
         });
     }));
 

--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.ts
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.ts
@@ -1,5 +1,5 @@
-import { AfterContentInit, ChangeDetectorRef, Component, Inject, Optional } from '@angular/core';
-import { DIALOG_CONFIG, DialogConfig } from '../utils/dialog-config.class';
+import { AfterContentInit, ChangeDetectorRef, Component, Optional } from '@angular/core';
+import { DialogConfig } from '../utils/dialog-config.class';
 import { DialogHeaderBase } from '../base/dialog-header-base.class';
 
 /**
@@ -20,7 +20,7 @@ export class DialogHeaderComponent extends DialogHeaderBase implements AfterCont
 
     /** @hidden */
     constructor(
-        @Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig,
+        @Optional() public dialogConfig: DialogConfig,
         changeDetectorRef: ChangeDetectorRef
     ) {
         super(changeDetectorRef);

--- a/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
+++ b/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
@@ -1,8 +1,8 @@
 import { Inject, Injectable, Injector, Optional, TemplateRef, Type } from '@angular/core';
 import { DialogContainerComponent } from '../dialog-container/dialog-container.component';
-import { DIALOG_CONFIG, DIALOG_DEFAULT_CONFIG, DialogConfig } from '../utils/dialog-config.class';
+import { DIALOG_DEFAULT_CONFIG, DialogConfig } from '../utils/dialog-config.class';
 import { DynamicComponentService } from '../../utils/dynamic-component/dynamic-component.service';
-import { DIALOG_REF, DialogRef } from '../utils/dialog-ref.class';
+import { DialogRef } from '../utils/dialog-ref.class';
 import { DialogBaseService } from '../base/dialog-base.service';
 import { DialogDefaultContent } from '../utils/dialog-default-content.class';
 
@@ -33,8 +33,8 @@ export class DialogService extends DialogBaseService<DialogContainerComponent> {
 
         const injector = Injector.create({
             providers: [
-                { provide: DIALOG_CONFIG, useValue: dialogConfig },
-                { provide: DIALOG_REF, useValue: dialogRef }
+                { provide: DialogConfig, useValue: dialogConfig },
+                { provide: DialogRef, useValue: dialogRef }
             ]
         });
 

--- a/libs/core/src/lib/dialog/dialog.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog.component.spec.ts
@@ -6,8 +6,8 @@ import { Component, NgModule, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { DIALOG_REF, DialogRef } from './utils/dialog-ref.class';
-import { DIALOG_CONFIG, DialogConfig } from './utils/dialog-config.class';
+import { DialogRef } from './utils/dialog-ref.class';
+import { DialogConfig } from './utils/dialog-config.class';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NavigationStart, Router, RouterEvent, RouterModule } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -51,8 +51,8 @@ describe('DialogComponent', () => {
         TestBed.configureTestingModule({
             imports: [TestModule, RouterModule, RouterTestingModule],
             providers: [
-                { provide: DIALOG_REF, useValue: dialogRef },
-                { provide: DIALOG_CONFIG, useValue: dialogConfig },
+                { provide: DialogRef, useValue: dialogRef },
+                { provide: DialogConfig, useValue: dialogConfig },
                 { provide: Router, useValue: mockRouter }
             ]
         });
@@ -118,7 +118,7 @@ describe('DialogComponent', () => {
 
     it('should set custom position', () => {
         const customDialogConfig = { ...new DialogConfig(), position: { bottom: '100px', right: '50px' } };
-        setup([{ token: DIALOG_CONFIG, provider: { useValue: customDialogConfig } }]);
+        setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
 
         expect(dialogComponent.dialogWindow.nativeElement.style.right).toEqual('50px');
         expect(dialogComponent.dialogWindow.nativeElement.style.bottom).toEqual('100px');
@@ -135,7 +135,7 @@ describe('DialogComponent', () => {
         };
         const customDialogConfig = { ...new DialogConfig(), ...customSize };
 
-        setup([{ token: DIALOG_CONFIG, provider: { useValue: customDialogConfig } }]);
+        setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
 
         expect(dialogComponent.dialogWindow.nativeElement.style.width).toEqual(customSize.width);
         expect(dialogComponent.dialogWindow.nativeElement.style.height).toEqual(customSize.height);
@@ -151,7 +151,7 @@ describe('DialogComponent', () => {
             backdropClass: 'customBackdropClass',
             dialogPanelClass: 'customPanelClass'
         };
-        setup([{ token: DIALOG_CONFIG, provider: { useValue: customDialogConfig } }]);
+        setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
 
         expect(fixture.nativeElement.querySelector('.fd-dialog')).toHaveClass('customBackdropClass');
         expect(fixture.nativeElement.querySelector('.fd-dialog__content')).toHaveClass('customPanelClass');
@@ -159,14 +159,14 @@ describe('DialogComponent', () => {
 
     it('should display in mobile mode', () => {
         const customDialogConfig = { ...new DialogConfig(), mobile: true };
-        setup([{ token: DIALOG_CONFIG, provider: { useValue: customDialogConfig } }]);
+        setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
 
         expect(fixture.nativeElement.querySelector('.fd-dialog__content')).toHaveClass('fd-dialog__content--mobile');
     });
 
     it('should display in mobile mode', () => {
         const customDialogConfig = { ...new DialogConfig(), fullScreen: true };
-        setup([{ token: DIALOG_CONFIG, provider: { useValue: customDialogConfig } }]);
+        setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
 
         expect(fixture.nativeElement.querySelector('.fd-dialog__content')).toHaveClass(
             'fd-dialog__content--full-screen'
@@ -175,7 +175,7 @@ describe('DialogComponent', () => {
 
     it('should display in mobile mode with no stretch', () => {
         const customDialogConfig = { ...new DialogConfig(), mobileOuterSpacing: true };
-        setup([{ token: DIALOG_CONFIG, provider: { useValue: customDialogConfig } }]);
+        setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
 
         expect(fixture.nativeElement.querySelector('.fd-dialog__content')).toHaveClass(
             'fd-dialog__content--no-mobile-stretch'
@@ -184,7 +184,7 @@ describe('DialogComponent', () => {
 
     it('should be draggable', () => {
         const customDialogConfig = { ...new DialogConfig(), draggable: true };
-        setup([{ token: DIALOG_CONFIG, provider: { useValue: customDialogConfig } }]);
+        setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
 
         expect(fixture.nativeElement.querySelector('.fd-dialog__content')).toHaveClass(
             'fd-dialog__content--draggable-grab'
@@ -195,7 +195,7 @@ describe('DialogComponent', () => {
 
     it('should be resizable', () => {
         const customDialogConfig = { ...new DialogConfig(), resizable: true };
-        setup([{ token: DIALOG_CONFIG, provider: { useValue: customDialogConfig } }]);
+        setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
 
         expect(fixture.nativeElement.querySelector('.fd-dialog__resize-handle')).toBeTruthy();
 
@@ -210,7 +210,7 @@ describe('DialogComponent', () => {
             ariaLabelledBy: 'customAriLabelledBy',
             ariaDescribedBy: 'customAriaDescribedBy'
         };
-        setup([{ token: DIALOG_CONFIG, provider: { useValue: customDialogConfig } }]);
+        setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
 
         const dialogWindowEl = fixture.nativeElement.querySelector('.fd-dialog__content');
 

--- a/libs/core/src/lib/dialog/dialog.component.ts
+++ b/libs/core/src/lib/dialog/dialog.component.ts
@@ -17,11 +17,11 @@ import { Router } from '@angular/router';
 
 import { Subscription } from 'rxjs';
 import { dialogFadeNgIf } from './utils/dialog.animations';
-import { DIALOG_CONFIG, DialogConfig } from './utils/dialog-config.class';
+import { DialogConfig } from './utils/dialog-config.class';
 import { DialogHeaderComponent } from './dialog-header/dialog-header.component';
 import { DialogBodyComponent } from './dialog-body/dialog-body.component';
 import { DialogFooterComponent } from './dialog-footer/dialog-footer.component';
-import { DIALOG_REF, DialogRef } from './utils/dialog-ref.class';
+import { DialogRef } from './utils/dialog-ref.class';
 import { applyCssClass } from '../utils/decorators/apply-css-class.decorator';
 import { CssClassBuilder } from '../utils/interfaces/css-class-builder.interface';
 import { DialogBase } from './base/dialog-base.class';
@@ -113,8 +113,8 @@ export class DialogComponent extends DialogBase implements OnInit, OnChanges, Af
 
     /** @hidden */
     constructor(
-        @Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig,
-        @Optional() @Inject(DIALOG_REF) private _dialogRef: DialogRef,
+        @Optional() public dialogConfig: DialogConfig,
+        @Optional() private _dialogRef: DialogRef,
         @Optional() router: Router,
         changeDetectorRef: ChangeDetectorRef,
         elementRef: ElementRef

--- a/libs/core/src/lib/dialog/utils/dialog-config.class.ts
+++ b/libs/core/src/lib/dialog/utils/dialog-config.class.ts
@@ -2,12 +2,12 @@
 /**
  * Configuration for opening a dialog with the DialogService.
  */
-import { InjectionToken } from '@angular/core';
+import { Injectable, InjectionToken } from '@angular/core';
 import { DialogConfigBase } from '../base/dialog-config-base.class';
 
-export const DIALOG_CONFIG = new InjectionToken<string[]>('DialogConfig');
-export const DIALOG_DEFAULT_CONFIG = new InjectionToken<string[]>('Default DialogConfig');
+export const DIALOG_DEFAULT_CONFIG = new InjectionToken<DialogConfig>('Default DialogConfig');
 
+@Injectable()
 export class DialogConfig<T = any> extends DialogConfigBase<T> {
     /** Whether the dialog should be displayed in full screen mode. */
     fullScreen?: boolean;

--- a/libs/core/src/lib/dialog/utils/dialog-ref.class.ts
+++ b/libs/core/src/lib/dialog/utils/dialog-ref.class.ts
@@ -1,5 +1,5 @@
 import { BehaviorSubject, Observable } from 'rxjs';
-import { InjectionToken } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { DialogRefBase } from '../base/dialog-ref-base.class';
 
 /**
@@ -8,9 +8,7 @@ import { DialogRefBase } from '../base/dialog-ref-base.class';
  * For a template, it is declared as part of the implicit context, see examples.
  */
 
-/** DialogRef injection token */
-export const DIALOG_REF = new InjectionToken<string[]>('DialogRef');
-
+@Injectable()
 export class DialogRef<T = any> extends DialogRefBase<T> {
     private readonly _onHide = new BehaviorSubject<boolean>(false);
     private readonly _onLoading = new BehaviorSubject<boolean>(false);

--- a/libs/core/src/lib/flexible-column-layout/flexible-column-layout.component.spec.ts
+++ b/libs/core/src/lib/flexible-column-layout/flexible-column-layout.component.spec.ts
@@ -123,6 +123,7 @@ describe('FlexibleColumnLayoutComponent', () => {
 
     it('TWO_COLUMNS_START_EXPANDED should render 2 columns, start expanded, mid open', async () => {
         whenStable(fixture);
+        viewport.set(1023, 900);
 
         testComponent.layout = TWO_COLUMNS_START_EXPANDED;
         fixture.detectChanges();
@@ -140,6 +141,7 @@ describe('FlexibleColumnLayoutComponent', () => {
 
     it('TWO_COLUMNS_MID_EXPANDED should render 2 columns, start open, mid expanded', async () => {
         whenStable(fixture);
+        viewport.set(1023, 900);
 
         testComponent.layout = TWO_COLUMNS_MID_EXPANDED;
         fixture.detectChanges();

--- a/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.spec.ts
+++ b/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.spec.ts
@@ -7,7 +7,6 @@ import { MenuInteractiveDirective } from '../directives/menu-interactive.directi
 import { MenuItemComponent, SubmenuComponent } from '../menu-item/menu-item.component';
 import { PopoverModule } from '../../popover/popover.module';
 import { CommonModule } from '@angular/common';
-import { DIALOG_CONFIG, DialogConfig } from '../../dialog/utils/dialog-config.class';
 import { MenuMobileModule } from './menu-mobile.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MenuTitleDirective } from '../directives/menu-title.directive';

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -9,7 +9,6 @@ import {
     ContentChildren,
     ElementRef,
     EventEmitter,
-    Inject,
     Injector,
     Input,
     OnDestroy,
@@ -27,7 +26,7 @@ import { MenuService } from './services/menu.service';
 import { DynamicComponentService } from '../utils/dynamic-component/dynamic-component.service';
 import { MenuMobileComponent } from './menu-mobile/menu-mobile.component';
 import { Subscription } from 'rxjs';
-import { DIALOG_CONFIG, DialogConfig } from '../dialog/utils/dialog-config.class';
+import { DialogConfig } from '../dialog/utils/dialog-config.class';
 import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
 import { PopoverFillMode } from '../popover/popover-position/popover-position';
 import { Placement, PopperOptions } from 'popper.js';
@@ -172,7 +171,7 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     private _mobileModeComponentRef: ComponentRef<MenuMobileComponent>;
 
     constructor(public elementRef: ElementRef,
-                @Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig,
+                @Optional() public dialogConfig: DialogConfig,
                 private _rendered: Renderer2,
                 private _menuService: MenuService,
                 private _changeDetectorRef: ChangeDetectorRef,

--- a/libs/core/src/lib/select/select.component.ts
+++ b/libs/core/src/lib/select/select.component.ts
@@ -9,7 +9,6 @@ import {
     EventEmitter,
     forwardRef,
     HostListener,
-    Inject,
     Injector,
     Input,
     OnDestroy,
@@ -31,7 +30,7 @@ import { SelectProxy } from './select-proxy.service';
 import { buffer, debounceTime, filter, map, startWith, takeUntil } from 'rxjs/operators';
 import { DynamicComponentService } from '../utils/dynamic-component/dynamic-component.service';
 import { SelectMobileComponent } from './select-mobile/select-mobile.component';
-import { DIALOG_CONFIG, DialogConfig } from '../dialog/utils/dialog-config.class';
+import { DialogConfig } from '../dialog/utils/dialog-config.class';
 import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
 import { SELECT_COMPONENT, SelectInterface } from './select.interface';
 import { DOWN_ARROW, ENTER, ESCAPE, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
@@ -268,7 +267,7 @@ export class SelectComponent implements ControlValueAccessor, SelectInterface, O
         private _selectProxy: SelectProxy,
         private _changeDetectorRef: ChangeDetectorRef,
         @Optional() private _dynamicComponentService: DynamicComponentService,
-        @Optional() @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig
+        @Optional() public dialogConfig: DialogConfig
     ) { }
 
     /** @hidden */

--- a/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.ts
+++ b/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.ts
@@ -22,7 +22,6 @@ import { takeUntil } from 'rxjs/operators';
 
 import {
     closestElement,
-    DIALOG_CONFIG,
     DialogConfig,
     DynamicComponentService,
     RtlService
@@ -77,7 +76,7 @@ export class ComboboxComponent extends BaseCombobox implements OnInit, AfterView
         readonly elementRef: ElementRef,
         @Optional() @Self() readonly ngControl: NgControl,
         @Optional() @Self() readonly ngForm: NgForm,
-        @Optional() @Inject(DIALOG_CONFIG) readonly dialogConfig: DialogConfig,
+        @Optional() readonly dialogConfig: DialogConfig,
         readonly _dynamicComponentService: DynamicComponentService,
         @Inject(DATA_PROVIDERS) private providers: Map<string, DataProvider<any>>,
         readonly _comboboxConfig: ComboboxConfig,

--- a/libs/platform/src/lib/components/form/combobox/commons/base-combobox.ts
+++ b/libs/platform/src/lib/components/form/combobox/commons/base-combobox.ts
@@ -6,7 +6,6 @@ import {
     ElementRef,
     EventEmitter,
     Host,
-    Inject,
     Input,
     OnDestroy,
     Optional,
@@ -34,7 +33,6 @@ import { fromEvent, isObservable, Observable, Subject, Subscription } from 'rxjs
 import { takeUntil } from 'rxjs/operators';
 
 import {
-    DIALOG_CONFIG,
     DialogConfig,
     FocusEscapeDirection,
     KeyUtil,
@@ -285,7 +283,7 @@ export abstract class BaseCombobox extends CollectionBaseInput implements AfterV
         protected readonly elementRef: ElementRef,
         @Optional() @Self() readonly ngControl: NgControl,
         @Optional() @Self() readonly ngForm: NgForm,
-        @Optional() @Inject(DIALOG_CONFIG) readonly dialogConfig: DialogConfig,
+        @Optional() readonly dialogConfig: DialogConfig,
         protected comboboxConfig: ComboboxConfig,
         @Optional() @SkipSelf() @Host() formField: FormField,
         @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>

--- a/libs/platform/src/lib/components/form/multi-input/base-multi-input.ts
+++ b/libs/platform/src/lib/components/form/multi-input/base-multi-input.ts
@@ -6,7 +6,6 @@ import {
     ElementRef,
     EventEmitter,
     Host,
-    Inject,
     Input,
     OnDestroy,
     Optional,
@@ -34,7 +33,6 @@ import { fromEvent, isObservable, Observable, Subject, Subscription } from 'rxjs
 import { takeUntil } from 'rxjs/operators';
 
 import {
-    DIALOG_CONFIG,
     DialogConfig,
     FocusEscapeDirection,
     KeyUtil,
@@ -296,7 +294,7 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
         protected readonly elementRef: ElementRef,
         @Optional() @Self() readonly ngControl: NgControl,
         @Optional() @Self() readonly ngForm: NgForm,
-        @Optional() @Inject(DIALOG_CONFIG) readonly dialogConfig: DialogConfig,
+        @Optional() readonly dialogConfig: DialogConfig,
         protected listConfig: ListConfig,
         @Optional() @SkipSelf() @Host() formField: FormField,
         @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>

--- a/libs/platform/src/lib/components/form/multi-input/multi-input.component.ts
+++ b/libs/platform/src/lib/components/form/multi-input/multi-input.component.ts
@@ -28,7 +28,6 @@ import {
     TokenizerComponent,
     KeyUtil,
     DialogConfig,
-    DIALOG_CONFIG,
     DynamicComponentService,
     RtlService
 } from '@fundamental-ngx/core';
@@ -146,7 +145,7 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
         readonly elementRef: ElementRef,
         @Optional() @Self() readonly ngControl: NgControl,
         @Optional() @Self() readonly ngForm: NgForm,
-        @Optional() @Inject(DIALOG_CONFIG) readonly dialogConfig: DialogConfig,
+        @Optional() readonly dialogConfig: DialogConfig,
         readonly _dynamicComponentService: DynamicComponentService,
         @Inject(DATA_PROVIDERS) private providers: Map<string, DataProvider<any>>,
         readonly _listConfig: ListConfig,

--- a/libs/platform/src/lib/components/table/components/dialogs/filtering/filters.component.spec.ts
+++ b/libs/platform/src/lib/components/table/components/dialogs/filtering/filters.component.spec.ts
@@ -1,5 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { DialogRef, DIALOG_REF } from '@fundamental-ngx/core';
+import { DialogRef } from '@fundamental-ngx/core';
 
 import { FiltersComponent, FiltersDialogData } from './filters.component';
 
@@ -14,7 +14,7 @@ describe('PlatformTableFiltersDialogComponent', () => {
         waitForAsync(() => {
             TestBed.configureTestingModule({
                 declarations: [FiltersComponent],
-                providers: [{ provide: DIALOG_REF, useValue: dialogRef }]
+                providers: [{ provide: DialogRef, useValue: dialogRef }]
             }).compileComponents();
         })
     );

--- a/libs/platform/src/lib/components/table/components/dialogs/filtering/filters.component.ts
+++ b/libs/platform/src/lib/components/table/components/dialogs/filtering/filters.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
-import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
+import { DialogRef } from '@fundamental-ngx/core';
 
 import { CollectionFilter } from '../../../interfaces';
 import { TableColumnComponent } from '../../table-column/table-column.component';
@@ -84,7 +84,7 @@ export class FiltersComponent implements Resettable, AfterViewInit {
     /** Current step component to render */
     activeFilterStepView: FiltersViewStep;
 
-    constructor(@Inject(DIALOG_REF) public dialogRef: DialogRef, private _cd: ChangeDetectorRef) {
+    constructor(public dialogRef: DialogRef, private _cd: ChangeDetectorRef) {
         const dialogData: FiltersDialogData = this.dialogRef.data;
         this.initialFilterBy = [...dialogData.filterBy];
         this.filterBy = [...dialogData.filterBy];

--- a/libs/platform/src/lib/components/table/components/dialogs/grouping/grouping.component.spec.ts
+++ b/libs/platform/src/lib/components/table/components/dialogs/grouping/grouping.component.spec.ts
@@ -1,5 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { DialogRef, DIALOG_REF } from '@fundamental-ngx/core';
+import { DialogRef } from '@fundamental-ngx/core';
 
 import { GroupingComponent, GroupDialogData } from './grouping.component';
 
@@ -14,7 +14,7 @@ describe('PlatformTableGroupDialogComponent', () => {
         waitForAsync(() => {
             TestBed.configureTestingModule({
                 declarations: [GroupingComponent],
-                providers: [{ provide: DIALOG_REF, useValue: dialogRef }]
+                providers: [{ provide: DialogRef, useValue: dialogRef }]
             }).compileComponents();
         })
     );

--- a/libs/platform/src/lib/components/table/components/dialogs/grouping/grouping.component.ts
+++ b/libs/platform/src/lib/components/table/components/dialogs/grouping/grouping.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, forwardRef, Inject } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
-import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
+import { DialogRef } from '@fundamental-ngx/core';
 
 import { SortDirection } from '../../../enums';
 import { Resettable, RESETTABLE_TOKEN } from '../reset-button/reset-button.component';
@@ -57,7 +57,7 @@ export class GroupingComponent implements Resettable {
     /** Not Grouped Option model value */
     readonly NOT_GROUPED_OPTION_VALUE = NOT_GROUPED_OPTION_VALUE;
 
-    constructor(@Inject(DIALOG_REF) public dialogRef: DialogRef) {
+    constructor(public dialogRef: DialogRef) {
         const data: GroupDialogData = this.dialogRef.data;
 
         this.initialDirection = data.direction || this.initialDirection;

--- a/libs/platform/src/lib/components/table/components/dialogs/sorting/sorting.component.spec.ts
+++ b/libs/platform/src/lib/components/table/components/dialogs/sorting/sorting.component.spec.ts
@@ -1,5 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
+import { DialogRef } from '@fundamental-ngx/core';
 
 import { SortingComponent, SortDialogData } from './sorting.component';
 
@@ -14,7 +14,7 @@ describe('PlatformTableSortDialogComponent', () => {
         waitForAsync(() => {
             TestBed.configureTestingModule({
                 declarations: [SortingComponent],
-                providers: [{ provide: DIALOG_REF, useValue: dialogRef }]
+                providers: [{ provide: DialogRef, useValue: dialogRef }]
             }).compileComponents();
         })
     );

--- a/libs/platform/src/lib/components/table/components/dialogs/sorting/sorting.component.ts
+++ b/libs/platform/src/lib/components/table/components/dialogs/sorting/sorting.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, forwardRef, Inject, Optional } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
-import { DIALOG_REF, DialogRef } from '@fundamental-ngx/core';
+import { DialogRef } from '@fundamental-ngx/core';
 
 import { SortDirection } from '../../../enums';
 import { Resettable, RESETTABLE_TOKEN } from '../reset-button/reset-button.component';
@@ -56,7 +56,7 @@ export class SortingComponent implements Resettable {
     /** @hidden */
     readonly NOT_SORTED_OPTION_VALUE = NOT_SORTED_OPTION_VALUE;
 
-    constructor(@Inject(DIALOG_REF) public dialogRef: DialogRef) {
+    constructor(public dialogRef: DialogRef) {
         const data: SortDialogData = this.dialogRef.data;
 
         this.initialDirection = data.direction || this.initialDirection;

--- a/libs/platform/src/lib/components/upload-collection/dialogs/move-to/move-to.component.ts
+++ b/libs/platform/src/lib/components/upload-collection/dialogs/move-to/move-to.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
 import { take } from 'rxjs/operators';
 
-import { DIALOG_REF, DialogRef, DialogService, DialogConfig } from '@fundamental-ngx/core';
+import { DialogRef, DialogService, DialogConfig } from '@fundamental-ngx/core';
 import { isObject } from '../../../../utils/lang';
 
 import { UploadCollectionItem, UploadCollectionFolder } from '../../models/upload-collection.models';
@@ -46,7 +46,7 @@ export class MoveToComponent implements OnInit {
     _foldersList: UploadCollectionFolder[] = [];
 
     constructor(
-        @Inject(DIALOG_REF) private readonly dialogRef: DialogRef,
+        private readonly dialogRef: DialogRef,
         private readonly _dialogService: DialogService,
         private readonly _cd: ChangeDetectorRef
     ) {}

--- a/libs/platform/src/lib/components/upload-collection/dialogs/new-folder/new-folder.component.ts
+++ b/libs/platform/src/lib/components/upload-collection/dialogs/new-folder/new-folder.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, ViewChild, AfterViewInit } from '@angular/core';
 
-import { DIALOG_REF, DialogRef, FormControlComponent } from '@fundamental-ngx/core';
+import { DialogRef, FormControlComponent } from '@fundamental-ngx/core';
 import { UploadCollectionFolder } from '../../models/upload-collection.models';
 
 @Component({
@@ -27,7 +27,7 @@ export class NewFolderComponent implements AfterViewInit {
     @ViewChild(FormControlComponent)
     private readonly formControl: FormControlComponent;
 
-    constructor(@Inject(DIALOG_REF) public readonly dialogRef: DialogRef) {}
+    constructor(public readonly dialogRef: DialogRef) {}
 
     ngAfterViewInit(): void {
         const el = this.formControl.elementRef().nativeElement as HTMLInputElement;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes https://github.com/SAP/fundamental-ngx/issues/3903

#### Please provide a brief summary of this pull request.

BREAKING CHANGE:
removed DIALOG_CONFIG and DIALOG_REF and made DialogConfig and DialogRef classes injectable

**Before:**
```
constructor(
    @Inject(DIALOG_CONFIG) public dialogConfig: DialogConfig,
    @Inject(DIALOG_REF) private _dialogRef: DialogRef
)
```

**Now:**
```
constructor(
    public dialogConfig: DialogConfig,
    private _dialogRef: DialogRef
)
```

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [na] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

