### PR TITLE
fix: (Platform) Combobox - Two columns wrong align and add value states

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-columns/combobox-columns-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-columns/combobox-columns-example.component.ts
@@ -10,6 +10,7 @@ export class ComboboxColumnsExampleComponent {
     dataSource = [
         { name: 'Apple', type: 'Fruits' },
         { name: 'Banana', type: 'Fruits' },
+        { name: 'Biiiiiiiiiiiiiiiiiiiiiiggggggggggggggggggggggggg Banananananananananananananananananananananananananananananananananananananana', type: 'Fruits' },
         { name: 'Pineapple', type: 'Fruits' },
         { name: 'Strawberry', type: 'Fruits' },
         { name: 'Broccoli', type: 'Vegetables' },

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-states/combobox-states-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-states/combobox-states-example.component.html
@@ -1,0 +1,60 @@
+<fdp-form-group [multiLayout]="true" [noLabelLayout]="false" mainTitle="Combobox playground">
+    <fdp-form-field id="combobox-states" label="Select state" zone="zLeft" rank="4">
+        <fdp-combobox
+            name="combobox-states"
+            placeholder="Select state"
+            contentDensity="compact"
+            [dataSource]="states"
+            (selectionChange)="onSelectState($event)"
+        ></fdp-combobox>
+    </fdp-form-field>
+    <fdp-form-field id="combobox-state" label="Combobox with selected state" zone="zLeft" rank="4">
+        <fdp-combobox
+            name="combobox-state"
+            placeholder="Type some text..."
+            contentDensity="compact"
+            [state]="selectedState"
+            [dataSource]="dataSource"
+        >
+        </fdp-combobox>
+    </fdp-form-field>
+</fdp-form-group>
+
+<fdp-form-group [multiLayout]="true" [noLabelLayout]="false" mainTitle="Static states">
+    <fdp-form-field id="combobox-state-success" label="Combobox with success state" zone="zLeft" rank="4">
+        <fdp-combobox
+            name="combobox-state"
+            placeholder="Type some text..."
+            state="success"
+            contentDensity="compact"
+            [dataSource]="dataSource"
+        ></fdp-combobox>
+    </fdp-form-field>
+    <fdp-form-field id="combobox-state-error" label="Combobox with error state" zone="zLeft" rank="4">
+        <fdp-combobox
+            name="combobox-state"
+            placeholder="Type some text..."
+            state="error"
+            contentDensity="compact"
+            [dataSource]="dataSource"
+        ></fdp-combobox>
+    </fdp-form-field>
+    <fdp-form-field id="combobox-state-warning" label="Combobox with warning state" zone="zLeft" rank="4">
+        <fdp-combobox
+            name="combobox-state"
+            placeholder="Type some text..."
+            state="warning"
+            contentDensity="compact"
+            [dataSource]="dataSource"
+        ></fdp-combobox>
+    </fdp-form-field>
+    <fdp-form-field id="combobox-state-info" label="Combobox with information state" zone="zLeft" rank="4">
+        <fdp-combobox
+            name="combobox-state"
+            placeholder="Type some text..."
+            state="information"
+            contentDensity="compact"
+            [dataSource]="dataSource"
+        ></fdp-combobox>
+    </fdp-form-field>
+</fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-states/combobox-states-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-states/combobox-states-example.component.ts
@@ -1,0 +1,27 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComboboxSelectionChangeEvent } from '@fundamental-ngx/platform';
+
+@Component({
+    selector: 'fdp-combobox-states-example',
+    templateUrl: './combobox-states-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ComboboxStateComponent {
+    dataSource = [
+        'Apple',
+        'Banana',
+        'Pineapple',
+        'Strawberry',
+        'Broccoli',
+        'Carrot',
+        'Jalapeño',
+        'Spinach'
+    ];
+
+    states = ['success', 'error', 'warning', 'information'];
+    selectedState: string = null;
+
+    onSelectState(item: ComboboxSelectionChangeEvent): void {
+        this.selectedState = item.payload;
+    }
+}

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/platform-combobox-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/platform-combobox-docs.component.html
@@ -7,6 +7,22 @@
 
 <separator></separator>
 
+<fd-docs-section-title id="combobox-state" componentName="combobox">
+    Combobox states.
+</fd-docs-section-title>
+<description>
+    The Combobox component with states.
+    <ul>
+        <li>Set <code>[state]</code>property to: <code>'success' | 'error' | 'warning' | 'information'</code></li>
+    </ul>
+</description>
+<component-example>
+    <fdp-combobox-states-example></fdp-combobox-states-example>
+</component-example>
+<code-example [exampleFiles]="comboboxStateExample"></code-example>
+
+<separator></separator>
+
 <fd-docs-section-title id="combobox-mobile" componentName="combobox">Combobox Mobile Mode</fd-docs-section-title>
 <description>
     To use Combobox in mobile mode:

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/platform-combobox-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/platform-combobox-docs.component.ts
@@ -23,6 +23,9 @@ import * as comboboxTemplatesTs from '!raw-loader!./examples/combobox-templates/
 import * as comboboxFormHtml from '!raw-loader!./examples/combobox-forms/combobox-forms-example.component.html';
 import * as comboboxFormTs from '!raw-loader!./examples/combobox-forms/combobox-forms-example.component';
 
+import * as comboboxStatesHtml from '!raw-loader!./examples/combobox-states/combobox-states-example.component.html';
+import * as comboboxStatesTs from '!raw-loader!./examples/combobox-states/combobox-states-example.component';
+
 @Component({
     selector: 'platform-combobox-docs',
     templateUrl: './platform-combobox-docs.component.html'
@@ -90,5 +93,14 @@ export class PlatformComboboxDocsComponent {
         language: 'typescript',
         fileName: 'combobox-forms-example',
         code: comboboxFormTs
+    }];
+    comboboxStateExample: ExampleFile[] = [{
+        language: 'html',
+        fileName: 'combobox-states-example',
+        code: comboboxStatesHtml
+    }, {
+        language: 'typescript',
+        fileName: 'combobox-states-example',
+        code: comboboxStatesTs
     }];
 }

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/platform-combobox-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/platform-combobox-docs.module.ts
@@ -22,6 +22,7 @@ import { ComboboxColumnsExampleComponent } from './examples/combobox-columns/com
 import { ComboboxTemplatesExampleComponent } from './examples/combobox-templates/combobox-templates-example.component';
 import { ComboboxGroupExampleComponent } from './examples/combobox-group/combobox-group-example.component';
 import { ComboboxFormsExampleComponent } from './examples/combobox-forms/combobox-forms-example.component';
+import { ComboboxStateComponent } from './examples/combobox-states/combobox-states-example.component';
 import { SharedDocumentationPageModule } from '../../../documentation/shared-documentation-page.module';
 
 const routes: Routes = [
@@ -58,7 +59,8 @@ const routes: Routes = [
         ComboboxColumnsExampleComponent,
         ComboboxTemplatesExampleComponent,
         ComboboxGroupExampleComponent,
-        ComboboxFormsExampleComponent
+        ComboboxFormsExampleComponent,
+        ComboboxStateComponent
     ]
 })
 export class PlatformComboboxDocsModule {

--- a/libs/core/src/lib/form/public_api.ts
+++ b/libs/core/src/lib/form/public_api.ts
@@ -1,4 +1,5 @@
 export * from './form.module';
+export * from './form-control/form-states';
 export * from './form-control/form-control.component';
 export * from './form-control/form-control.module';
 export * from './form-group/form-group.component';

--- a/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.html
+++ b/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.html
@@ -27,7 +27,7 @@
         [compact]="isCompact"
         [button]="!readonly"
         [glyph]="!readonly ? 'navigation-down-arrow' : ' '"
-        [state]="status === 'error' ? 'error' : null"
+        [state]="status === 'error' ? 'error' : state"
         [buttonFocusable]="false"
         [disabled]="disabled || readonly"
         [isControl]="true"

--- a/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.scss
+++ b/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.scss
@@ -13,5 +13,13 @@
 
     &__list {
         overflow: auto;
+        .fd-list__item {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            span {
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
     }
 }

--- a/libs/platform/src/lib/components/form/combobox/commons/base-combobox.ts
+++ b/libs/platform/src/lib/components/form/combobox/commons/base-combobox.ts
@@ -40,7 +40,8 @@ import {
     KeyUtil,
     ListComponent,
     MobileModeConfig,
-    TemplateDirective
+    TemplateDirective,
+    FormStates
 } from '@fundamental-ngx/core';
 import {
     ArrayComboBoxDataSource,
@@ -74,6 +75,13 @@ export abstract class BaseCombobox extends CollectionBaseInput implements AfterV
     /** Provides maximum height for the optionPanel */
     @Input()
     maxHeight = '250px';
+
+    /**
+     *  The state of the form control - applies css classes.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
+     */
+    @Input()
+    state: FormStates;
 
     /** Datasource for suggestion list */
     @Input()


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Issue link https://github.com/SAP/fundamental-ngx/issues/3767

#### Please provide a brief summary of this pull request.
Fixed issue related to two columnt align
**Before**
![image](https://user-images.githubusercontent.com/38053194/102610539-07cf5600-4136-11eb-8ae1-8e947bacb89b.png)
**After**
![image](https://user-images.githubusercontent.com/38053194/102610555-14ec4500-4136-11eb-9c69-482eeac12d1c.png)

Implement state property to combobox
![image](https://user-images.githubusercontent.com/38053194/102610450-e0788900-4135-11eb-9e84-ee344dea78d2.png)


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/master/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples

