### PR TITLE
fix: (platform) Menu position in split-menu-button and Sub-menu padding fix in cascading menu

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-behaviors-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-behaviors-example.component.html
@@ -3,7 +3,7 @@ Default behavior:
     title="Default behavior for split menu button" menuTitle="More options"
     (primaryButtonClick)="onPrimaryButtonClick1()">
 </fdp-split-menu-button>
-<fdp-menu #menu1 xPosition="before">
+<fdp-menu #menu1 xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelect1('Option 1')">Option 1</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelect1('Option 2')">Option 2</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelect1('Option 3')">Option 3</fdp-menu-item>
@@ -16,7 +16,7 @@ Longer text in menu:
     title="option with longer text gets truncated" menuTitle="More options"
     (primaryButtonClick)="onPrimaryButtonClick2()">
 </fdp-split-menu-button>
-<fdp-menu #menu2 xPosition="before">
+<fdp-menu #menu2 xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelect2('Option 1')">Option 1</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelect2('Option 2 with long text')">Option 2 with long text</fdp-menu-item>
 </fdp-menu>
@@ -28,7 +28,7 @@ fixedWidth=false:
     title="option with longer text gets truncated" menuTitle="More options"
     (primaryButtonClick)="onPrimaryButtonClick3()">
 </fdp-split-menu-button>
-<fdp-menu #menu3 xPosition="before">
+<fdp-menu #menu3 xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelect3('Option 1')">Option 1</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelect3('Option 2 with text')">Option 2 with text</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelect3('Split menu button width more than 12rem')">Split menu button width more

--- a/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-behaviors-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-behaviors-example.component.ts
@@ -20,6 +20,7 @@ export class PlatformDocsSplitMenuButtonBehaviorComponent {
 
     public onPrimaryButtonClick1(): void {
         this.selectedItem1 = this.label1;
+        alert('primary button clicked');
     }
 
     public onItemSelect2(menuItemValue: string): void {
@@ -29,6 +30,7 @@ export class PlatformDocsSplitMenuButtonBehaviorComponent {
 
     public onPrimaryButtonClick2(): void {
         this.selectedItem1 = this.label2;
+        alert('primary button clicked');
     }
 
     public onItemSelect3(menuItemValue: string): void {
@@ -38,5 +40,6 @@ export class PlatformDocsSplitMenuButtonBehaviorComponent {
 
     public onPrimaryButtonClick3(): void {
         this.selectedItem3 = this.label3;
+        alert('primary button clicked');
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-icons-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-icons-example.component.html
@@ -3,7 +3,7 @@ Cozy Split Menu Button:
     title="Default behavior for split menu button" menuTitle="More options" [fixedWidth]="false"
     (primaryButtonClick)="onPrimaryButtonClick1()">
 </fdp-split-menu-button>
-<fdp-menu #menu1 xPosition="before">
+<fdp-menu #menu1 xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelect1('Option 1')">Option 1</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelect1('Option 2')">Option 2</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelect1('Option 3')">Option 3</fdp-menu-item>
@@ -17,7 +17,7 @@ Compact Split Menu Button:
     title="option with longer text gets truncated" menuTitle="More options" [fixedWidth]="false"
     (primaryButtonClick)="onPrimaryButtonClick2()">
 </fdp-split-menu-button>
-<fdp-menu #menu2 xPosition="before" contentDensity="compact">
+<fdp-menu #menu2 xPosition="after" contentDensity="compact">
     <fdp-menu-item (itemSelect)="onItemSelect2('Option 1')">Option 1</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelect2('Option 2 with long text')">Option 2 with long text</fdp-menu-item>
 </fdp-menu>
@@ -31,7 +31,7 @@ Split Menu Button with only Icon and Without icon & text. fixedWidth=false.
     [fixedWidth]="false" ariaLabel="Split button with icon" type="standard"
     (primaryButtonClick)="onPrimaryButtonClick3()">
 </fdp-split-menu-button>
-<fdp-menu #menu3 xPosition="before">
+<fdp-menu #menu3 xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelect3('')">Option 1 with blank value</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelect3('Option 2 with text')">Option 2 with text</fdp-menu-item>
 </fdp-menu>

--- a/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-icons-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-icons-example.component.ts
@@ -21,6 +21,7 @@ export class PlatformDocsSplitMenuButtonIconsComponent {
 
     public onPrimaryButtonClick1(): void {
         this.selectedItem1 = this.label1;
+        alert('primary button clicked');
     }
 
     public onItemSelect2(menuItemValue: string): void {
@@ -30,6 +31,7 @@ export class PlatformDocsSplitMenuButtonIconsComponent {
 
     public onPrimaryButtonClick2(): void {
         this.selectedItem2 = this.label2;
+        alert('primary button clicked');
     }
 
     public onItemSelect3(menuItemValue: string): void {
@@ -40,5 +42,6 @@ export class PlatformDocsSplitMenuButtonIconsComponent {
 
     public onPrimaryButtonClick3(): void {
         this.selectedItem3 = this.label3;
+        alert('primary button clicked');
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-types-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-types-example.component.html
@@ -51,31 +51,31 @@
 <p>Selected Item: {{ selectedCozyItem }}</p>
 
 <!--To be attached Menu. For Cozy-->
-<fdp-menu #basicMenuCozyStandard xPosition="before">
+<fdp-menu #basicMenuCozyStandard xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelectCozyStandard('Standard Button')">Standard Button</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyStandard('Standard Button 2')">Standard Button 2</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyStandard('Standard Button 3')">Standard Button 3</fdp-menu-item>
 </fdp-menu>
 
-<fdp-menu #basicMenuCozyPositive xPosition="before">
+<fdp-menu #basicMenuCozyPositive xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelectCozyPositive('Positive Button')">Positive Button</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyPositive('Positive Button 2')">Positive Button 2</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyPositive('Positive Button 3')">Positive Button 3</fdp-menu-item>
 </fdp-menu>
 
-<fdp-menu #basicMenuCozyNegative xPosition="before">
+<fdp-menu #basicMenuCozyNegative xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelectCozyNegative('Negative Button')">Negative Button</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyNegative('Negative Button 2')">Negative Button 2</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyNegative('Negative Button 3')">Negative Button 3</fdp-menu-item>
 </fdp-menu>
 
-<fdp-menu #basicMenuCozyGhost xPosition="before">
+<fdp-menu #basicMenuCozyGhost xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelectCozyGhost('Ghost Button')">Ghost Button</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyGhost('Ghost Button 2')">Ghost Button 2</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyGhost('Ghost Button 3')">Ghost Button 3</fdp-menu-item>
 </fdp-menu>
 
-<fdp-menu #basicMenuCozyTransparent xPosition="before">
+<fdp-menu #basicMenuCozyTransparent xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelectCozyTransparent('Transparent Button')">Transparent Button</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyTransparent('Transparent Button 2')">Transparent Button 2
     </fdp-menu-item>
@@ -83,7 +83,7 @@
     </fdp-menu-item>
 </fdp-menu>
 
-<fdp-menu #basicMenuCozyEmphasized xPosition="before">
+<fdp-menu #basicMenuCozyEmphasized xPosition="after">
     <fdp-menu-item (itemSelect)="onItemSelectCozyEmphasized('Emphasized Button')">Emphasized Button</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyEmphasized('Emphasized Button 2')">Emphasized Button 2</fdp-menu-item>
     <fdp-menu-item (itemSelect)="onItemSelectCozyEmphasized('Emphasized Button 3')">Emphasized Button 3</fdp-menu-item>

--- a/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-types-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-split-menu-button/platform-split-menu-button-examples/platform-split-button-types-example.component.ts
@@ -21,6 +21,7 @@ export class PlatformDocsSplitMenuButtonTypesComponent {
 
     public onPrimaryButtonClickCozyStandard(): void {
         this.selectedCozyItem = this.labelStandardCozy;
+        alert('standard primary button clicked');
     }
 
     public onItemSelectCozyPositive(menuItemValue: string): void {
@@ -30,6 +31,7 @@ export class PlatformDocsSplitMenuButtonTypesComponent {
 
     public onPrimaryButtonClickCozyPositive(): void {
         this.selectedCozyItem = this.labelPositiveCozy;
+        alert('Positive primary button clicked');
     }
 
     public onItemSelectCozyNegative(menuItemValue: string): void {
@@ -39,6 +41,7 @@ export class PlatformDocsSplitMenuButtonTypesComponent {
 
     public onPrimaryButtonClickCozyNegative(): void {
         this.selectedCozyItem = this.labelNegativeCozy;
+        alert('Negative primary button clicked');
     }
 
     public onItemSelectCozyGhost(menuItemValue: string): void {
@@ -48,6 +51,7 @@ export class PlatformDocsSplitMenuButtonTypesComponent {
 
     public onPrimaryButtonClickCozyGhost(): void {
         this.selectedCozyItem = this.labelGhostCozy;
+        alert('Ghost primary button clicked');
     }
 
     public onItemSelectCozyTransparent(menuItemValue: string): void {
@@ -57,6 +61,7 @@ export class PlatformDocsSplitMenuButtonTypesComponent {
 
     public onPrimaryButtonClickCozyTransparent(): void {
         this.selectedCozyItem = this.labelTransparentCozy;
+        alert('Transparent primary button clicked');
     }
 
     public onItemSelectCozyEmphasized(menuItemValue: string): void {
@@ -66,5 +71,6 @@ export class PlatformDocsSplitMenuButtonTypesComponent {
 
     public onPrimaryButtonClickCozyEmphasized(): void {
         this.selectedCozyItem = this.labelEmphasizedCozy;
+        alert('Emphasized primary button clicked');
     }
 }

--- a/libs/platform/src/lib/components/menu/menu-trigger.directive.ts
+++ b/libs/platform/src/lib/components/menu/menu-trigger.directive.ts
@@ -55,7 +55,7 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
         private _viewContainerRef: ViewContainerRef,
         @Optional() @Self() private _menuItem: MenuItemComponent,
         @Optional() private _parentMenu: MenuComponent
-    ) { }
+    ) {}
 
     ngAfterContentInit(): void {
         if (this._isMenuItem()) {
@@ -97,7 +97,6 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
         if ($event.detail > 0) {
             this.toggleMenu();
         }
-
     }
 
     /** @hidden Handled keypress which focus is on trigger element. */
@@ -242,8 +241,8 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
         let positions: ConnectedPosition[] = [];
         const offsetYPosition = 0;
         const offsetXPosition = 0;
-        const subMenuXPadding = 4;
-        const subMenuYPadding = 4;
+        const subMenuXPadding = 4; // horizontal padding of 0.25rem(4px) is needed for sub-menu
+        const subMenuYPadding = 4; // vertical padding of 0.25rem(4px) is needed for sub-menu
 
         if (this._isMenuItem()) {
             if (this._menu.cascadesLeft()) {

--- a/libs/platform/src/lib/components/menu/menu-trigger.directive.ts
+++ b/libs/platform/src/lib/components/menu/menu-trigger.directive.ts
@@ -242,6 +242,9 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
         let positions: ConnectedPosition[] = [];
         const offsetYPosition = 0;
         const offsetXPosition = 0;
+        const subMenuXPadding = 4;
+        const subMenuYPadding = 4;
+
         if (this._isMenuItem()) {
             if (this._menu.cascadesLeft()) {
                 positions = [
@@ -250,14 +253,16 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
                         originY: 'top',
                         overlayX: 'end',
                         overlayY: 'top',
-                        offsetX: offsetXPosition
+                        offsetX: 4,
+                        offsetY: 4
                     },
                     {
                         originX: 'start',
                         originY: 'bottom',
                         overlayX: 'end',
                         overlayY: 'bottom',
-                        offsetX: offsetXPosition
+                        offsetX: subMenuXPadding,
+                        offsetY: subMenuYPadding
                     }
                 ];
             } else {
@@ -267,14 +272,16 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
                         originY: 'top',
                         overlayX: 'start',
                         overlayY: 'top',
-                        offsetX: -offsetXPosition
+                        offsetX: -subMenuXPadding,
+                        offsetY: subMenuYPadding
                     },
                     {
                         originX: 'end',
                         originY: 'bottom',
                         overlayX: 'start',
                         overlayY: 'bottom',
-                        offsetX: -offsetXPosition
+                        offsetX: -4,
+                        offsetY: 4
                     }
                 ];
             }

--- a/libs/platform/src/lib/components/menu/menu-trigger.directive.ts
+++ b/libs/platform/src/lib/components/menu/menu-trigger.directive.ts
@@ -253,8 +253,8 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
                         originY: 'top',
                         overlayX: 'end',
                         overlayY: 'top',
-                        offsetX: 4,
-                        offsetY: 4
+                        offsetX: subMenuXPadding,
+                        offsetY: subMenuYPadding
                     },
                     {
                         originX: 'start',
@@ -262,7 +262,7 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
                         overlayX: 'end',
                         overlayY: 'bottom',
                         offsetX: subMenuXPadding,
-                        offsetY: subMenuYPadding
+                        offsetY: -subMenuYPadding
                     }
                 ];
             } else {
@@ -280,8 +280,8 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
                         originY: 'bottom',
                         overlayX: 'start',
                         overlayY: 'bottom',
-                        offsetX: -4,
-                        offsetY: 4
+                        offsetX: -subMenuXPadding,
+                        offsetY: -subMenuYPadding
                     }
                 ];
             }

--- a/libs/platform/src/lib/components/split-menu-button/split-menu-button.component.html
+++ b/libs/platform/src/lib/components/split-menu-button/split-menu-button.component.html
@@ -1,4 +1,11 @@
-<div class="fd-button-split" role="group" aria-label="split-button" [attr.dir]="dir" [style.max-width]="splitButtonMaxWidth">
+<div
+    class="fd-button-split"
+    role="group"
+    aria-label="split-button"
+    [attr.dir]="dir"
+    [style.max-width]="splitButtonMaxWidth"
+    [fdpMenuTriggerFor]="menu"
+>
     <button
         fd-button
         #primaryBtn
@@ -27,7 +34,6 @@
         [fdType]="type"
         [attr.tabindex]="0"
         [compact]="contentDensity === 'compact'"
-        [fdpMenuTriggerFor]="menu"
         [attr.aria-haspopup]="true"
     ></button>
 </div>

--- a/libs/platform/src/lib/components/split-menu-button/split-menu-button.component.spec.ts
+++ b/libs/platform/src/lib/components/split-menu-button/split-menu-button.component.spec.ts
@@ -29,7 +29,7 @@ function mouseClickOnElement(el: Element): void {
         >
         </fdp-split-menu-button>
 
-        <fdp-menu #basicMenu id="basic-menu">
+        <fdp-menu #basicMenu id="basic-menu" xPosition="after">
             <fdp-menu-item (itemSelect)="onItemSelect('First Item')">First Item</fdp-menu-item>
             <fdp-menu-item (itemSelect)="onItemSelect('Second Item')">Second Item</fdp-menu-item>
             <fdp-menu-item (itemSelect)="onItemSelect('Third Item')">Third Item</fdp-menu-item>
@@ -82,7 +82,7 @@ describe('SplitMenuButtonComponent', () => {
     });
 
     it('should call onPrimaryButtonClick on Primary Button click', () => {
-        const buttons = fixture.debugElement.queryAll(By.css('button'));
+        const buttons = fixture.debugElement.queryAll(By.css('.fd-button'));
         buttons[0].nativeElement.click();
         fixture.detectChanges();
         expect(host.actionValue).toEqual('Default Button');
@@ -92,8 +92,8 @@ describe('SplitMenuButtonComponent', () => {
         /**
          * FIRST-CLICK On Menu Button (OPEN MENU)
          */
-        const buttons = fixture.debugElement.queryAll(By.css('button'));
-        mouseClickOnElement(buttons[1].nativeElement);
+        const splitMenuButton = fixture.debugElement.query(By.css('.fd-button-split'));
+        mouseClickOnElement(splitMenuButton.nativeElement);
         tick(1);
         fixture.detectChanges();
 
@@ -112,8 +112,7 @@ describe('SplitMenuButtonComponent', () => {
         /**
          * FIRST-CLICK On Menu Button (OPEN MENU)
          */
-        const buttons1 = fixture.debugElement.queryAll(By.css('button'));
-        mouseClickOnElement(buttons[1].nativeElement);
+        mouseClickOnElement(splitMenuButton.nativeElement);
         tick(1);
         fixture.detectChanges();
 
@@ -130,7 +129,7 @@ describe('SplitMenuButtonComponent', () => {
          * KEYPRESS ENTER
          */
         const keyboardEvent2 = createKeyboardEvent('keydown', ENTER, 'Enter');
-        items1[1].dispatchEvent(keyboardEvent);
+        items1[1].dispatchEvent(keyboardEvent2);
         fixture.detectChanges();
         expect(host.actionValue).toBe('Second Item');
     }));

--- a/libs/platform/src/lib/components/split-menu-button/split-menu-button.component.ts
+++ b/libs/platform/src/lib/components/split-menu-button/split-menu-button.component.ts
@@ -14,11 +14,14 @@ import { MenuComponent } from './../menu/menu.component';
 import { BaseComponent } from '../base';
 
 /**
- * Split Menu Button implementation based on the
- * https://github.com/SAP/fundamental-ngx/wiki/Platform:-Split-Menu-Button-Component-V1.0-Technical-Design
- * documents.
+ * <fdp-split-menu-button [menu]="menu" [buttonLabel]="Default button" (primaryButtonClick)="onPrimaryButtonClick1()">
+ * </fdp-split-menu-button>
  *
- *
+ * <fdp-menu #menu xPosition="after|before">
+ *      <fdp-menu-item (itemSelect)="onItemSelect1('Option 1')">Option 1</fdp-menu-item>
+ *      <fdp-menu-item (itemSelect)="onItemSelect1('Option 2')">Option 2</fdp-menu-item>
+ *      <fdp-menu-item (itemSelect)="onItemSelect1('Option 3')">Option 3</fdp-menu-item>
+ * </fdp-menu>
  */
 @Component({
     selector: 'fdp-split-menu-button',


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#3535 #3637 

#### Please provide a brief summary of this pull request.
1. fix for Overlay position relative to split-menu-button
2. fix for padding of sub-menu in case of cascading menu.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

