### PR TITLE
fix: deprecate Popper.js and refactor Menu component

### DIFF
--- a/apps/docs/src/app/core/component-docs/popover-directive/popover-directive-header/popover-directive-header.component.html
+++ b/apps/docs/src/app/core/component-docs/popover-directive/popover-directive-header/popover-directive-header.component.html
@@ -1,13 +1,10 @@
 <header>Popover Directive</header>
 <description>
-    <p>
-        The popover directive is used by the fd-popover component. It constitutes an abstraction of both Popper.js and
-        Fundamental-ngx features.
-    </p>
-    <p>
-        In cases where the popover component is insufficient, or even unneeded, this directive can serve as a powerful
-        alternative.
-    </p>
+    <fd-message-strip [type]="'warning'" [dismissible]="false">
+        DEPRECATED. Popover directive shouldn't be used anymore. There is great successor of popover directive -
+        <a routerLink="/core/popover" fragment="trigger">Simple Popover</a>, which has whole functionality of popover
+        component.
+    </fd-message-strip>
 </description>
 <import module="PopoverModule"></import>
 

--- a/apps/docs/src/app/core/component-docs/popover-directive/popover-directive-header/popover-directive-header.component.html
+++ b/apps/docs/src/app/core/component-docs/popover-directive/popover-directive-header/popover-directive-header.component.html
@@ -1,6 +1,6 @@
 <header>Popover Directive</header>
 <description>
-    <fd-message-strip [type]="'warning'" [dismissible]="false">
+    <fd-message-strip type="warning" [dismissible]="false">
         DEPRECATED. Popover directive shouldn't be used anymore. There is great successor of popover directive -
         <a routerLink="/core/popover" fragment="trigger">Simple Popover</a>, which has whole functionality of popover
         component.

--- a/libs/core/src/lib/form/form-label/form-label.component.scss
+++ b/libs/core/src/lib/form/form-label/form-label.component.scss
@@ -71,18 +71,3 @@ $form-label-inline-help-placement-space: 1.25rem;
 		}
 	}
 }
-
-.fd-form__inline-help {
-	position: absolute;
-	top: 0;
-	left: 0;
-
-
-	@at-root {
-		[dir="rtl"] &,
-		&[dir="rtl"] {
-			left: auto;
-			right: 0;
-		}
-	}
-}

--- a/libs/core/src/lib/form/form-label/form-label.component.scss
+++ b/libs/core/src/lib/form/form-label/form-label.component.scss
@@ -71,3 +71,18 @@ $form-label-inline-help-placement-space: 1.25rem;
 		}
 	}
 }
+
+.fd-form__inline-help {
+	position: absolute;
+	top: 0;
+	left: 0;
+
+
+	@at-root {
+		[dir="rtl"] &,
+		&[dir="rtl"] {
+			left: auto;
+			right: 0;
+		}
+	}
+}

--- a/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.spec.ts
+++ b/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { MenuMobileComponent } from './menu-mobile.component';
-import { Component, Inject, InjectionToken, ViewChild } from '@angular/core';
+import { Component, ElementRef, Inject, InjectionToken, ViewChild } from '@angular/core';
 import { MenuComponent } from '../menu.component';
 import { MenuInteractiveDirective } from '../directives/menu-interactive.directive';
 import { MenuItemComponent, SubmenuComponent } from '../menu-item/menu-item.component';
@@ -40,7 +40,10 @@ class TesNestedMenuItemComponent {
 
     menuItemTitle = 'Test item title';
 
-    constructor(@Inject(MOBILE_CONFIG_TEST_TOKEN) public mobileConfig: MobileModeConfig) {}
+    constructor(
+        public elementRef: ElementRef,
+        @Inject(MOBILE_CONFIG_TEST_TOKEN) public mobileConfig: MobileModeConfig
+    ) {}
 }
 
 describe('MenuMobileComponent', () => {

--- a/libs/core/src/lib/menu/menu.component.html
+++ b/libs/core/src/lib/menu/menu.component.html
@@ -15,22 +15,3 @@
         </ul>
     </nav>
 </ng-template>
-
-<ng-template #menuWithPopover>
-    <div #popoverContainer
-         [triggers]="[]"
-         [isOpen]="isOpen"
-         [options]="options"
-         [disabled]="disabled"
-         [placement]="placement"
-         [popoverTrigger]="trigger"
-         [appendTo]="popoverContainer"
-         [fdPopover]="menuRootTemplate"
-         [noArrow]="noArrow"
-         [fillControlMode]="fillControlMode"
-         [closeOnEscapeKey]="closeOnEscapeKey"
-         [closeOnOutsideClick]="closeOnOutsideClick"
-         (loaded)="focusFirst()"
-         (isOpenChange)="handlePopoverOpenChange($event)">
-    </div>
-</ng-template>

--- a/libs/core/src/lib/menu/menu.component.html
+++ b/libs/core/src/lib/menu/menu.component.html
@@ -2,6 +2,8 @@
 
 <ng-template #menuRootTemplate>
     <nav class="fd-menu"
+         fdInitialFocus
+         [enabled]="focusTrapped"
          [id]="id"
          [attr.aria-labelledby]="ariaLabelledby"
          [attr.aria-label]="ariaLabel"

--- a/libs/core/src/lib/menu/menu.component.spec.ts
+++ b/libs/core/src/lib/menu/menu.component.spec.ts
@@ -122,13 +122,14 @@ describe('MenuComponent', () => {
         menu.setMobileMode = true;
         (<any>menu)._listenOnTriggerRefClicks();
 
-        fixture.detectChanges();
+        expect(menu.isOpen).toBeFalse();
 
+        fixture.detectChanges();
         menu.trigger.nativeElement.dispatchEvent(new MouseEvent('click'));
 
         fixture.detectChanges();
 
-        expect(menu.isOpen).toBeTrue()
+        expect(menu.isOpen).toBeTrue();
     });
 
     it('should destroy all references', () => {

--- a/libs/core/src/lib/menu/menu.component.spec.ts
+++ b/libs/core/src/lib/menu/menu.component.spec.ts
@@ -42,7 +42,7 @@ export class TestMenuComponent {
     trigger: ElementRef;
 }
 
-fdescribe('MenuComponent', () => {
+describe('MenuComponent', () => {
     let menu: MenuComponent;
     let menuService: MenuService;
     let menuItems: QueryList<MenuItemComponent>;

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -246,6 +246,7 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
      * This is going to be removed in feature, on dialog and dynamic service component refactor
      */
     private _listenOnTriggerRefClicks(): void {
+        this._destroyEventListeners();
         if (this.trigger) {
             this._clickEventListener = this._rendered.listen(
                 this.trigger.nativeElement, 'click', () => this.toggle()

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -205,8 +205,10 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
 
     /** @hidden */
     private _setupPopoverService(): void {
-        this._popoverService._onLoad.subscribe(elementRef =>
-            this._manageKeyboardSupport(elementRef)
+        this._subscriptions.add(
+            this._popoverService._onLoad.subscribe(elementRef =>
+                this._manageKeyboardSupport(elementRef)
+            )
         )
 
         this._popoverService.templateContent = this.menuRootTemplate;

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -4,7 +4,6 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    ComponentFactoryResolver,
     ComponentRef,
     ContentChildren,
     ElementRef,
@@ -19,7 +18,6 @@ import {
     Renderer2,
     TemplateRef,
     ViewChild,
-    ViewContainerRef,
     ViewEncapsulation
 } from '@angular/core';
 import { MenuItemComponent } from './menu-item/menu-item.component';
@@ -110,14 +108,6 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
     @ViewChild('menuRootTemplate')
     menuRootTemplate: TemplateRef<any>;
 
-    /** @hidden Reference to the menu root template */
-    @ViewChild('menuRootTemplate', { read: ElementRef })
-    menuList: ElementRef;
-
-    /** @hidden Reference  the container where component views are instantiated */
-    @ViewChild('viewContainer', {read: ViewContainerRef})
-    viewContainer: ViewContainerRef;
-
     /** @hidden Reference to all menu Items */
     @ContentChildren(MenuItemComponent, {descendants: true})
     menuItems: QueryList<MenuItemComponent>;
@@ -166,8 +156,8 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
     /** @hidden */
     ngOnDestroy(): void {
         this._destroyMobileComponent();
-        this._menuService.onDestroy();
         this._destroyEventListeners();
+        this._menuService.onDestroy();
         this._subscriptions.unsubscribe();
     }
 
@@ -177,6 +167,8 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
 
     set trigger(trigger: ElementRef) {
         this._externalTrigger = trigger;
+        this._destroyEventListeners();
+        this._listenOnTriggerRefClicks();
     }
 
     /** Opens the menu */
@@ -255,7 +247,9 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
      */
     private _listenOnTriggerRefClicks(): void {
         if (this.trigger) {
-            this._clickEventListener = this._rendered.listen(this.trigger.nativeElement, 'click', () => this.toggle());
+            this._clickEventListener = this._rendered.listen(
+                this.trigger.nativeElement, 'click', () => this.toggle()
+            );
         }
     }
 

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -138,7 +138,7 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
     private _mobileModeComponentRef: ComponentRef<MenuMobileComponent>;
 
     /** @hidden */
-    private _listeners: Function;
+    private _clickEventListener: Function;
 
     constructor(public elementRef: ElementRef,
                 @Optional() public dialogConfig: DialogConfig,
@@ -255,7 +255,7 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
      */
     private _listenOnTriggerRefClicks(): void {
         if (this.trigger) {
-            this._listeners = this._rendered.listen(this.trigger.nativeElement, 'click', () => this.toggle());
+            this._clickEventListener = this._rendered.listen(this.trigger.nativeElement, 'click', () => this.toggle());
         }
     }
 
@@ -264,8 +264,9 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
      * This is going to be removed in feature, on dialog and dynamic service component refactor
      */
     private _destroyEventListeners(): void {
-        if (this._listeners) {
-            this._listeners();
+        if (this._clickEventListener) {
+            this._clickEventListener();
+            this._clickEventListener = null;
         }
     }
 

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -69,13 +69,6 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
     @Input()
     focusTrapped = true;
 
-    /**
-     * Whether the popover should automatically move focus into the trapped region upon
-     * initialization and return focus to the previous activeElement upon destruction.
-     */
-    @Input()
-    focusAutoCapture = true;
-
     /** Open submenu on hover after given milliseconds */
     @Input()
     openOnHoverTime = 0;
@@ -185,6 +178,7 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
         this._popoverService.close();
         this._menuService.resetMenuState();
         this.isOpenChange.emit(this.isOpen);
+        this._focusTrigger();
         this._changeDetectorRef.markForCheck();
     }
 
@@ -271,6 +265,13 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
     private _destroyMobileComponent(): void {
         if (this._mobileModeComponentRef) {
             this._mobileModeComponentRef.destroy();
+        }
+    }
+
+    /** @hidden */
+    private _focusTrigger(): void {
+        if (this.focusTrapped && this.trigger) {
+            this.trigger.nativeElement.focus();
         }
     }
 }

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -9,6 +9,7 @@ import {
     ContentChildren,
     ElementRef,
     EventEmitter,
+    Inject,
     Injector,
     Input,
     OnDestroy,
@@ -28,10 +29,10 @@ import { MenuMobileComponent } from './menu-mobile/menu-mobile.component';
 import { Subscription } from 'rxjs';
 import { DialogConfig } from '../dialog/utils/dialog-config.class';
 import { MobileModeConfig } from '../utils/interfaces/mobile-mode-config';
-import { PopoverFillMode } from '../popover/popover-position/popover-position';
-import { Placement, PopperOptions } from 'popper.js';
 import { RtlService } from '../utils/services/rtl.service';
 import { MENU_COMPONENT, MenuInterface } from './menu.interface';
+import { BasePopoverClass } from '../popover/base/base-popover.class';
+import { PopoverService } from '../popover/popover-service/popover.service';
 
 let menuUniqueId = 0;
 
@@ -44,9 +45,12 @@ let menuUniqueId = 0;
     styleUrls: ['menu.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [MenuService],
+    providers: [
+        MenuService,
+        PopoverService
+    ],
 })
-export class MenuComponent implements MenuInterface, AfterContentInit, AfterViewInit, OnDestroy {
+export class MenuComponent extends BasePopoverClass implements MenuInterface, AfterContentInit, AfterViewInit, OnDestroy {
 
     /** Set menu in mobile mode */
     @Input('mobile')
@@ -55,58 +59,24 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
         this._menuService.setMenuMode(this.mobile);
     }
 
-    /** The placement of the popover. It can be one of: top, top-start, top-end, bottom,
-     *  bottom-start, bottom-end, right, right-start, right-end, left, left-start, left-end. */
-    @Input()
-    placement: Placement = 'bottom-start';
-
-    /** Whether or not to display the popover arrow. */
-    @Input()
-    noArrow = true;
-
-    /** The Popper.js options to attach to this popover.
-     * See the [Popper.js Documentation](https://popper.js.org/popper-documentation.html) for details. */
-    @Input()
-    options: PopperOptions = {
-        placement: 'bottom-start',
-        modifiers: {
-            preventOverflow: {
-                enabled: true,
-                escapeWithReference: true,
-                boundariesElement: 'scrollParent'
-            }
-        }
-    };
-
-    /**
-     * Preset options for the popover body width.
-     * * `at-least` will apply a minimum width to the body equivalent to the width of the control.
-     * * `equal` will apply a width to the body equivalent to the width of the control.
-     * * 'fit-content' will apply width needed to properly display items inside, independent of control.
-     */
-    @Input()
-    fillControlMode: PopoverFillMode = 'at-least';
-
-    /** The trigger events that will open/close the popover.
-     *  Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp). */
-    @Input()
-    triggers: string[] = ['click'];
-
-    /** Whether the popover should close when a click is made outside its boundaries. */
-    @Input()
-    closeOnOutsideClick = true;
-
     /** Whether the popover is disabled. */
     @Input()
     disabled = false;
 
-    /** Whether the popover should close when the escape key is pressed. */
-    @Input()
-    closeOnEscapeKey = true;
-
     /** Display menu in compact mode */
     @Input()
     compact = false;
+
+    /** Whether the popover should be focusTrapped. */
+    @Input()
+    focusTrapped = true;
+
+    /**
+     * Whether the popover should automatically move focus into the trapped region upon
+     * initialization and return focus to the previous activeElement upon destruction.
+     */
+    @Input()
+    focusAutoCapture = true;
 
     /** Open submenu on hover after given milliseconds */
     @Input()
@@ -140,9 +110,9 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     @ViewChild('menuRootTemplate')
     menuRootTemplate: TemplateRef<any>;
 
-    /** @hidden Reference to the menu with popover template */
-    @ViewChild('menuWithPopover')
-    menuWithPopover: TemplateRef<any>;
+    /** @hidden Reference to the menu root template */
+    @ViewChild('menuRootTemplate', { read: ElementRef })
+    menuList: ElementRef;
 
     /** @hidden Reference  the container where component views are instantiated */
     @ViewChild('viewContainer', {read: ViewContainerRef})
@@ -158,9 +128,6 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     /** @hidden Whether Popover with the menu is opened */
     isOpen = false;
 
-    /** @hidden */
-    private _eventRef: Function[] = [];
-
     /** @hidden Reference to external menu trigger */
     private _externalTrigger: ElementRef;
 
@@ -170,14 +137,18 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     /** @hidden */
     private _mobileModeComponentRef: ComponentRef<MenuMobileComponent>;
 
+    /** @hidden */
+    private _listeners: Function;
+
     constructor(public elementRef: ElementRef,
                 @Optional() public dialogConfig: DialogConfig,
                 private _rendered: Renderer2,
                 private _menuService: MenuService,
                 private _changeDetectorRef: ChangeDetectorRef,
-                private _componentFactoryResolver: ComponentFactoryResolver,
+                private _popoverService: PopoverService,
                 @Optional() private _rtlService: RtlService,
                 @Optional() private _dynamicComponentService: DynamicComponentService) {
+        super();
     }
 
     /** @hidden */
@@ -188,15 +159,15 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
 
     /** @hidden */
     ngAfterViewInit(): void {
-        this._listenOnMenuMode();
-        this._menuService.setMenuMode(this.mobile);
+        this._menuService.setMenuMode(this.mobile)
+        this._setupView();
     }
 
     /** @hidden */
     ngOnDestroy(): void {
         this._destroyMobileComponent();
-        this._destroyEventListeners();
         this._menuService.onDestroy();
+        this._destroyEventListeners();
         this._subscriptions.unsubscribe();
     }
 
@@ -206,13 +177,12 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
 
     set trigger(trigger: ElementRef) {
         this._externalTrigger = trigger;
-        this._destroyEventListeners();
-        this.listenOnTriggerEvents();
     }
 
     /** Opens the menu */
     open(): void {
         this.isOpen = true;
+        this._popoverService.open();
         this.isOpenChange.emit(this.isOpen);
         this._changeDetectorRef.markForCheck();
     }
@@ -220,16 +190,10 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     /** Closes the menu */
     close(): void {
         this.isOpen = false;
+        this._popoverService.close();
         this._menuService.resetMenuState();
         this.isOpenChange.emit(this.isOpen);
         this._changeDetectorRef.markForCheck();
-    }
-
-    /** Focuses first menu item */
-    focusFirst(): void {
-        if (this.menuItems.first) {
-            this._menuService.setFocused(this.menuItems.first);
-        }
     }
 
     /** Toggles menu open/close state */
@@ -237,45 +201,29 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
         this.isOpen ? this.close() : this.open();
     }
 
-    /** @hidden Toggles menu open/close state */
-    handlePopoverOpenChange(isOpen: boolean): void {
-        isOpen ? this.open() : this.close();
-    }
-
-    /** @hidden Sets listeners based on triggers array */
-    listenOnTriggerEvents(): void {
-        if (Array.isArray(this.triggers)) {
-            this.triggers.forEach(trigger => {
-                this._eventRef.push(this._rendered.listen(this.trigger.nativeElement, trigger, () => {
-                    this.toggle();
-                }));
-            });
-        }
-    }
-
     /** @hidden Select and instantiate menu view mode */
     private _setupView(): void {
         if (this.mobile) {
             this._setupMobileMode();
         } else {
-            this._loadView(this.menuWithPopover);
+            this._setupPopoverService();
         }
         this._changeDetectorRef.detectChanges();
     }
 
     /** @hidden */
-    private _manageKeyboardSupport(shouldHaveKeyboardSupport?: boolean): void {
-        if (shouldHaveKeyboardSupport) {
-            this._menuService.addKeyboardSupport();
-        } else {
-            this._menuService.removeKeyboardSupport();
-        }
+    private _setupPopoverService(): void {
+        this._popoverService._onLoad.subscribe(elementRef =>
+            this._manageKeyboardSupport(elementRef)
+        )
+
+        this._popoverService.templateContent = this.menuRootTemplate;
+        this._popoverService.initialise(this._externalTrigger, this);
     }
 
-    /** @hidden Embed given template in view container */
-    private _loadView(template: TemplateRef<any>): void {
-        this.viewContainer.clear();
-        this.viewContainer.createEmbeddedView(template);
+    /** @hidden */
+    private _manageKeyboardSupport(elementRef: ElementRef): void {
+        this._menuService.addKeyboardSupport(elementRef)
     }
 
     /** @hidden Open Menu in mobile mode */
@@ -289,6 +237,9 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
                     injector: Injector.create({providers: [{ provide: MENU_COMPONENT, useValue: this }]}),
                     services: [this._menuService, this._rtlService] }
             )
+        ;
+
+        this._listenOnTriggerRefClicks();
     }
 
     /** @hidden Listen on menu items change and rebuild menu */
@@ -298,30 +249,30 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
         );
     }
 
-    /** @hidden Listen on menu mode */
-    private _listenOnMenuMode(): void {
-        this._subscriptions.add(
-            this._menuService.isMobileMode.subscribe(isMobile => {
-                if (this.isOpen) {
-                    this.close();
-                }
-                this.viewContainer.clear();
-                this._destroyMobileComponent();
-                this._setupView();
-                this._manageKeyboardSupport(!isMobile);
-            })
-        )
-    }
-
-    private _destroyMobileComponent(): void {
-        if (this._mobileModeComponentRef) {
-            this._mobileModeComponentRef.destroy();
+    /**
+     * @hidden
+     * This is going to be removed in feature, on dialog and dynamic service component refactor
+     */
+    private _listenOnTriggerRefClicks(): void {
+        if (this.trigger) {
+            this._listeners = this._rendered.listen(this.trigger.nativeElement, 'click', () => this.toggle());
         }
     }
 
+    /**
+     * @hidden
+     * This is going to be removed in feature, on dialog and dynamic service component refactor
+     */
     private _destroyEventListeners(): void {
-        if (Array.isArray(this._eventRef)) {
-            this._eventRef.forEach(ref => ref());
+        if (this._listeners) {
+            this._listeners();
+        }
+    }
+
+    /** @hidden */
+    private _destroyMobileComponent(): void {
+        if (this._mobileModeComponentRef) {
+            this._mobileModeComponentRef.destroy();
         }
     }
 }

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -249,7 +249,7 @@ export class MenuComponent extends BasePopoverClass implements MenuInterface, Af
      */
     private _listenOnTriggerRefClicks(): void {
         this._destroyEventListeners();
-        if (this.trigger) {
+        if (this.trigger && this.mobile) {
             this._clickEventListener = this._rendered.listen(
                 this.trigger.nativeElement, 'click', () => this.toggle()
             );

--- a/libs/core/src/lib/menu/menu.module.ts
+++ b/libs/core/src/lib/menu/menu.module.ts
@@ -11,9 +11,10 @@ import { MenuShortcutDirective } from './directives/menu-shortcut.directive';
 import { PopoverModule } from '../popover/popover.module';
 import { MenuTriggerDirective } from './directives/menu-trigger.directive';
 import { IconModule } from '../icon/icon.module';
+import { InitialFocusModule } from '../utils/directives/initial-focus/initial-focus.module';
 
 @NgModule({
-    imports: [CommonModule, PopoverModule, IconModule],
+    imports: [CommonModule, PopoverModule, IconModule, InitialFocusModule],
     declarations: [
         MenuComponent,
         MenuItemComponent,

--- a/libs/core/src/lib/menu/services/menu.service.ts
+++ b/libs/core/src/lib/menu/services/menu.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Renderer2 } from '@angular/core';
+import { ElementRef, Injectable, Renderer2 } from '@angular/core';
 import { MenuItemComponent } from '../menu-item/menu-item.component';
 import { MenuComponent } from '../menu.component';
 import { KeyUtil } from '../../utils/functions';
@@ -104,9 +104,9 @@ export class MenuService {
     }
 
     /** Adds Menu keyboard support */
-    addKeyboardSupport(): void {
+    addKeyboardSupport(elementRef: ElementRef): void {
         this.removeKeyboardSupport();
-        this._setKeyboardSupport();
+        this._setKeyboardSupport(elementRef);
     }
 
     /** Removes Menu keyboard support */
@@ -204,9 +204,9 @@ export class MenuService {
     }
 
     /** @hidden Adds keyboard support */
-    private _setKeyboardSupport(): void {
+    private _setKeyboardSupport(elementRef: ElementRef): void {
         this._destroyKeyboardHandlerListener = this._renderer.listen(
-            this.menu.elementRef.nativeElement,
+            elementRef.nativeElement,
             'keydown',
             (event: KeyboardEvent) => this._handleKey(event)
         );

--- a/libs/core/src/lib/popover/base/base-popover.class.ts
+++ b/libs/core/src/lib/popover/base/base-popover.class.ts
@@ -5,6 +5,10 @@ import { Placement, PopoverFillMode } from '../popover-position/popover-position
 @Directive()
 export class BasePopoverClass {
 
+    @Input()
+    /** Whether to close the popover on router navigation start. */
+    closeOnNavigation = true;
+
     /** Whether the popover is disabled. */
     @Input()
     @HostBinding('class.fd-popover-custom--disabled')

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.spec.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { PopoverBodyComponent } from './popover-body.component';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { ConnectedPosition } from '@angular/cdk/overlay';
-import { DefaultPositions, PopoverPosition } from '@fundamental-ngx/core';
+import { DefaultPositions, PopoverPosition } from '../popover-position/popover-position';
 
 describe('PopoverBodyComponent', () => {
     let component: PopoverBodyComponent;

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.spec.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.spec.ts
@@ -2,8 +2,10 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverBodyComponent } from './popover-body.component';
 import { ESCAPE } from '@angular/cdk/keycodes';
-import { ConnectedPosition } from '@angular/cdk/overlay';
+import { ConnectedPosition, OverlayModule } from '@angular/cdk/overlay';
 import { DefaultPositions, PopoverPosition } from '../popover-position/popover-position';
+import { PopoverModule } from '../popover.module';
+import { A11yModule } from '@angular/cdk/a11y';
 
 describe('PopoverBodyComponent', () => {
     let component: PopoverBodyComponent;
@@ -11,7 +13,7 @@ describe('PopoverBodyComponent', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [PopoverBodyComponent]
+            imports: [PopoverModule, OverlayModule, A11yModule]
         }).compileComponents();
     }));
 

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.ts
@@ -79,9 +79,9 @@ export class PopoverBodyComponent {
     onClose = new Subject<void>();
 
     constructor(
+        readonly _elementRef: ElementRef,
         private _changeDetectorRef: ChangeDetectorRef,
-        private _renderer2: Renderer2,
-        private readonly _elementRef: ElementRef
+        private _renderer2: Renderer2
     ) {}
 
     /** @hidden */

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.ts
@@ -14,7 +14,7 @@ import { ESCAPE } from '@angular/cdk/keycodes';
 import { Subject } from 'rxjs';
 
 import { ARROW_SIZE, ArrowPosition } from '../popover-position/popover-position';
-import { PopoverFlippedDirection } from '../popover-position/popover-position';
+import { PopoverFlippedXDirection } from '../popover-position/popover-position';
 import { KeyUtil } from '../../utils/functions/key-util';
 import { PopoverPosition } from '../popover-position/popover-position';
 
@@ -95,7 +95,7 @@ export class PopoverBodyComponent {
         if (arrowDirection === 'top' || arrowDirection === 'bottom') {
             let _position: string = position.overlayX;
             if (rtl === 'rtl') {
-                _position = PopoverFlippedDirection[_position];
+                _position = PopoverFlippedXDirection[_position];
             }
             this._arrowClasses.push(`fd-popover__arrow-x--${_position}`)
         } else if (arrowDirection === 'start' || arrowDirection === 'end') {

--- a/libs/core/src/lib/popover/popover-directive/popover.directive.ts
+++ b/libs/core/src/lib/popover/popover-directive/popover.directive.ts
@@ -34,6 +34,7 @@ import { PopoverFillMode } from '../popover-position/popover-position';
  *     Popover Body
  * </ng-template>
  * ```
+ * @deprecated
  */
 @Directive({
     selector: '[fdPopover]'

--- a/libs/core/src/lib/popover/popover-position/popover-position.ts
+++ b/libs/core/src/lib/popover/popover-position/popover-position.ts
@@ -22,8 +22,22 @@ export const DefaultPositions: ConnectedPosition[] = [
     { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top' },
     { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom' },
     { originX: 'end', originY: 'bottom', overlayX: 'end', overlayY: 'top' },
-    { originX: 'end', originY: 'top', overlayX: 'end', overlayY: 'bottom' }
+    { originX: 'end', originY: 'top', overlayX: 'end', overlayY: 'bottom' },
 ];
+
+export const GetDefaultPosition = (position: ConnectedPosition[]): ConnectedPosition[] => {
+    const resultPosition: ConnectedPosition[] = [];
+    if (position && position[0]) {
+        const firstPosition: ConnectedPosition = position[0];
+        resultPosition.push({
+            ...firstPosition,
+            originY: PopoverFlippedYDirection[firstPosition.originY],
+            overlayY: PopoverFlippedYDirection[firstPosition.overlayY]
+        });
+    }
+
+    return resultPosition.concat(DefaultPositions);
+}
 
 /**
  * Preset options for the popover body width.
@@ -56,9 +70,15 @@ export type XPositions = 'start' | 'center' | 'end';
 export type YPositions = 'top' | 'center' | 'bottom';
 export type ArrowPosition = 'top' | 'bottom' | 'start' | 'end' | 'center';
 
-export const PopoverFlippedDirection: {[key: string]: ArrowPosition} = {
+export const PopoverFlippedXDirection: {[key: string]: ArrowPosition} = {
     'start': 'end',
     'end': 'start',
+    'center': 'center'
+};
+
+export const PopoverFlippedYDirection: {[key: string]: YPositions} = {
+    'bottom': 'top',
+    'top': 'bottom',
     'center': 'center'
 };
 
@@ -88,7 +108,7 @@ export class PopoverPosition {
             _position = position.overlayX;
 
             if (rtl) {
-                _position = PopoverFlippedDirection[_position];
+                _position = PopoverFlippedXDirection[_position];
             }
         }
 

--- a/libs/core/src/lib/popover/popover-service/popover.service.ts
+++ b/libs/core/src/lib/popover/popover-service/popover.service.ts
@@ -42,6 +42,9 @@ export class PopoverService extends BasePopoverClass {
     templateContent: TemplateRef<any>;
 
     /** @hidden */
+    _onLoad = new Subject<ElementRef>();
+
+    /** @hidden */
     private _eventRef: Function[] = [];
 
     /** @hidden */
@@ -140,6 +143,7 @@ export class PopoverService extends BasePopoverClass {
 
             this._listenOnClose();
             this._listenOnOutClicks();
+            this._onLoad.next(this._getPopoverBody()._elementRef);
         }
     }
 

--- a/libs/core/src/lib/popover/popover-service/popover.service.ts
+++ b/libs/core/src/lib/popover/popover-service/popover.service.ts
@@ -21,7 +21,7 @@ import { ConnectedOverlayPositionChange } from '@angular/cdk/overlay/position/co
 import { merge, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, filter, startWith, takeUntil } from 'rxjs/operators';
 
-import { DefaultPositions, PopoverPosition } from '../popover-position/popover-position';
+import { GetDefaultPosition, PopoverPosition } from '../popover-position/popover-position';
 import { BasePopoverClass } from '../base/base-popover.class';
 import { RtlService } from '../../utils/services/rtl.service';
 import { PopoverBodyComponent } from '../popover-body/popover-body.component';
@@ -218,6 +218,7 @@ export class PopoverService extends BasePopoverClass {
 
         return new OverlayConfig({
             direction: direction,
+            disposeOnNavigation: this.closeOnNavigation,
             positionStrategy: position,
             scrollStrategy: this.scrollStrategy || this._overlay.scrollStrategies.reposition()
         });
@@ -246,7 +247,7 @@ export class PopoverService extends BasePopoverClass {
         let resultPosition = forcedPositions ? forcedPositions : this._getPositions();
 
         if (!this.fixedPosition) {
-            resultPosition = resultPosition.concat(DefaultPositions);
+            resultPosition = resultPosition.concat(GetDefaultPosition(resultPosition));
         }
 
         return this._overlay

--- a/libs/core/src/lib/time/time.module.ts
+++ b/libs/core/src/lib/time/time.module.ts
@@ -13,6 +13,6 @@ import { CarouselModule } from '../utils/directives/carousel/carousel.module';
 @NgModule({
     declarations: [TimeComponent, OnlyDigitsDirective, TimeColumnComponent],
     imports: [CommonModule, FormsModule, FormModule, ButtonModule, PipeModule, CarouselModule],
-    exports: [TimeComponent, OnlyDigitsDirective]
+    exports: [TimeComponent, OnlyDigitsDirective, TimeColumnComponent]
 })
 export class TimeModule {}

--- a/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.ts
+++ b/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.ts
@@ -1,10 +1,14 @@
-import { AfterViewInit, Directive, ElementRef } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Input } from '@angular/core';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 
 @Directive({
     selector: '[fdInitialFocus], [fd-initial-focus]'
 })
 export class InitialFocusDirective implements AfterViewInit {
+
+    /** Whether initial focus functionality should be enabled */
+    @Input()
+    enabled = true;
 
     constructor(
         private _elementRef: ElementRef,
@@ -13,7 +17,9 @@ export class InitialFocusDirective implements AfterViewInit {
 
     /** @hidden */
     ngAfterViewInit(): void {
-        this._focusFirstTabbableElement();
+        if (this.enabled) {
+            this._focusFirstTabbableElement();
+        }
     }
 
     private _focusFirstTabbableElement(): void {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes: https://github.com/SAP/fundamental-ngx/issues/4203
#### Please provide a brief summary of this pull request.

There is added deprecation of popover directive. now simple popover can easly replace it. 

Also menu component
- Now uses popover service with CDK Overlay, instead of popover directive with popper.js.
- Mobile mode (false|true) can't be dynamically changed - I don't see any reason of having it.
- Has all properties extended from popover base class.
 
#### BREAKING CHANGES:
- Removed `[options]` from menu component

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

