### PR TITLE
fix: (Core) wizard quick fix for bug related to marking step as not completed

### DIFF
--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -291,8 +291,9 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
                 step.visited = true;
             }
         }
-        if (this.steps.last.content) {
-            this.steps.last.content.tallContent = true;
+        const lastVisibleTemplate = this.steps.toArray()[this.contentTemplates.length - 1];
+        if (lastVisibleTemplate && lastVisibleTemplate.content) {
+            lastVisibleTemplate.content.tallContent = true;
         }
         this.steps.last.finalStep = true;
     }

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -406,7 +406,7 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
             lastNonSummaryStep.content.tallContent = true;
             lastNonSummaryStep.finalStep = true;
             // TODO: remove the line below when https://github.com/SAP/fundamental-styles/issues/1978 is addressed
-            lastNonSummaryStep.completed = false;
+            lastNonSummaryStep.getClassList().remove('fd-wizard__step--completed');
             this.steps.last.removeFromDom();
         } else if (lastNonSummaryStep) {
             if (lastNonSummaryStep.content) {


### PR DESCRIPTION
Should simply be removing the step completed class rather than setting the component's completed property.  Setting the property caused the action sheet to display on step indicator click when the step indicator had no stacked steps. Also, this issue would sometimes cause the "next steps" buttons to remain visible when they should be hidden.

![Screen Shot 2020-12-30 at 12 11 28 PM](https://user-images.githubusercontent.com/2471874/103375777-39321500-4a98-11eb-9d69-de2d8d54d589.png)
