### PR TITLE
fix: (Platform) add aria tags to Textarea to read counter messages

### DIFF
--- a/libs/platform/src/lib/components/form/text-area/text-area.component.html
+++ b/libs/platform/src/lib/components/form/text-area/text-area.component.html
@@ -3,6 +3,9 @@
     fd-form-control
     [compact]="isCompact"
     [attr.id]="id"
+    [attr.aria-label]="ariaLabel"
+    [attr.aria-labelledby]="ariaLabelledBy"
+    [attr.aria-describedby]="id+'-counter'"
     [attr.placeholder]="placeholder"
     [disabled]="disabled"
     [readonly]="readonly"
@@ -18,7 +21,7 @@
 ></textarea>
 
 <!-- ICU recommends full text in format -->
-<div class="fd-textarea-counter" *ngIf="showExceededText" aria-live="polite" aria-atomic="true">
+<div class="fd-textarea-counter" *ngIf="showExceededText" aria-live="polite" aria-atomic="true" [attr.id]="id+'-counter'">
     <span i18n="textarea counter|The counter message for this textarea element@@platformI18nTextareaCounterMessage">
         {{ exceededCharCount | number: '1.0-0' }} {exceededCharCount, plural, =1{ character {counterExcessOrRemaining,
         select, excess {over the limit} remaining {remaining}} } other { characters {counterExcessOrRemaining, select,


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #3439 
#### Please provide a brief summary of this pull request.
PR adds aria tags, specifically `aria-describedby` is needed for screen readers to read the counter message when textarea is accessed.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

