### PR TITLE
chore: fix Schematics for NG versions above 10.1

### DIFF
--- a/libs/core/ng-package.json
+++ b/libs/core/ng-package.json
@@ -6,6 +6,7 @@
         "styleIncludePaths": ["../../node_modules"]
     },
     "whitelistedNonPeerDependencies": [
+        "@angular/cdk",
         "focus-trap",
         "popper.js",
         "fundamental-styles",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -13,7 +13,6 @@
     "node": ">= 10"
   },
   "peerDependencies": {
-    "@angular/cdk": "CDK_VER_PLACEHOLDER",
     "@angular/common": "ANGULAR_VER_PLACEHOLDER",
     "@angular/core": "ANGULAR_VER_PLACEHOLDER",
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
@@ -22,6 +21,7 @@
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {
+    "@angular/cdk": "CDK_VER_PLACEHOLDER",
     "@sap-theming/theming-base-content": "THEMING_VER_PLACEHOLDER",
     "focus-trap": "FOCUSTRAP_VER_PLACEHOLDER",
     "fundamental-styles": "FDSTYLES_VER_PLACEHOLDER",

--- a/libs/core/schematics/ng-add/index.ts
+++ b/libs/core/schematics/ng-add/index.ts
@@ -2,13 +2,13 @@ import { Rule, SchematicContext, Tree, chain, SchematicsException } from '@angul
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { getPackageVersionFromPackageJson, hasPackage } from '../utils/package-utils';
 import { addPackageJsonDependency, NodeDependency, NodeDependencyType } from '@schematics/angular/utility/dependencies';
-import { addImportToRootModule, getProjectFromWorkspace, hasModuleImport } from '../utils/ng-module-utils';
-import { getAppModulePath } from '@schematics/angular/utility/ng-ast-utils';
-import { getWorkspace } from '@schematics/angular/utility/config';
+import { hasModuleImport } from '../utils/ng-module-utils';
 import { WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 
 import { cdkVersion } from './versions';
 import { defaultFontStyle } from './styles';
+import { addModuleImportToModule, getProjectFromWorkspace, getProjectMainFile, getAppModulePath } from '@angular/cdk/schematics';
+import { getWorkspace } from '@schematics/angular/utility/config';
 
 const browserAnimationsModuleName = 'BrowserAnimationsModule';
 const noopAnimationsModuleName = 'NoopAnimationsModule';
@@ -71,9 +71,11 @@ function addDependencies(): Rule {
 function addAnimations(options: any): Rule {
     return (tree: Tree) => {
         const workspace = getWorkspace(tree);
-        const modulePath = getAppModulePath(tree, getProjectFromWorkspace(workspace, options.project).architect.build.options.main);
+        const project = getProjectFromWorkspace(workspace);
+        const modulePath = getAppModulePath(tree, getProjectMainFile(project));
 
         if (options.animations) {
+
             if (hasModuleImport(tree, modulePath, noopAnimationsModuleName)) {
                 return console.warn(
                     `Could not set up "${browserAnimationsModuleName}" ` +
@@ -81,17 +83,20 @@ function addAnimations(options: any): Rule {
                         `set up browser animations.`
                 );
             }
-            addImportToRootModule(
+            addModuleImportToModule(
                 tree,
+                modulePath,
                 browserAnimationsModuleName,
-                '@angular/platform-browser/animations',
-                modulePath
+                '@angular/platform-browser/animations'
             );
+
             console.log(`✅️ Added ${browserAnimationsModuleName} to root module.`);
         } else if (!hasModuleImport(tree, modulePath, browserAnimationsModuleName)) {
-            addImportToRootModule(tree, noopAnimationsModuleName, '@angular/platform-browser/animations', modulePath);
+            addModuleImportToModule(tree, modulePath, noopAnimationsModuleName, '@angular/platform-browser/animations');
+
             console.log(`✅️ Added ${noopAnimationsModuleName} to root module.`);
         }
+
         return tree;
     };
 }

--- a/libs/core/schematics/ng-add/index.ts
+++ b/libs/core/schematics/ng-add/index.ts
@@ -5,7 +5,6 @@ import { addPackageJsonDependency, NodeDependency, NodeDependencyType } from '@s
 import { hasModuleImport } from '../utils/ng-module-utils';
 import { WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 
-import { cdkVersion } from './versions';
 import { defaultFontStyle } from './styles';
 import { addModuleImportToModule, getProjectFromWorkspace, getProjectMainFile, getAppModulePath } from '@angular/cdk/schematics';
 import { getWorkspace } from '@schematics/angular/utility/config';
@@ -17,10 +16,10 @@ const fdStylesIconPath = 'node_modules/fundamental-styles/dist/icon.css';
 export function ngAdd(options: any): Rule {
     return chain([
         addDependencies(),
+        endInstallTask(),
         addAnimations(options),
         addStylePathToConfig(options),
-        addFontsToStyles(options),
-        endInstallTask()
+        addFontsToStyles(options)
     ]);
 }
 
@@ -52,10 +51,6 @@ function addDependencies(): Rule {
                 version: `${ngCoreVersionTag}`,
                 name: '@angular/animations'
             });
-        }
-
-        if (!hasPackage(tree, '@angular/cdk')) {
-            dependencies.push({ type: NodeDependencyType.Default, version: `${cdkVersion}`, name: '@angular/cdk' });
         }
 
         dependencies.forEach((dependency) => {

--- a/libs/core/schematics/ng-add/versions.ts
+++ b/libs/core/schematics/ng-add/versions.ts
@@ -1,2 +1,0 @@
-/** Version of cdk, placeholder will is replaced during version synchronization, on `sync-version.sh` script. */
-export const cdkVersion = 'CDK_VER_PLACEHOLDER';

--- a/libs/core/schematics/utils/ng-module-utils.ts
+++ b/libs/core/schematics/utils/ng-module-utils.ts
@@ -1,29 +1,7 @@
 import { Tree, SchematicsException } from '@angular-devkit/schematics';
-import { getSourceFile } from './package-utils';
-import { addImportToModule } from '@schematics/angular/utility/ast-utils';
-import { InsertChange } from '@schematics/angular/utility/change';
 
 import * as ts from 'typescript';
 import { WorkspaceProject, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
-
-// Adds an import to the root module.
-export function addImportToRootModule(tree: Tree, moduleName: string, src: string, modulePath: string): void {
-    const moduleSource = getSourceFile(tree, modulePath);
-    if (!moduleSource) {
-        throw new SchematicsException(`Module not found ${modulePath}`);
-    }
-
-    const changes = addImportToModule(moduleSource as any, modulePath, moduleName, src);
-    const recorder = tree.beginUpdate(modulePath);
-
-    changes.forEach((change) => {
-        if (change instanceof InsertChange) {
-            recorder.insertLeft(change.pos, change.toAdd);
-        }
-    });
-
-    tree.commitUpdate(recorder);
-}
 
 // Checks if an import is included in the module.
 export function hasModuleImport(tree: Tree, modulePath: string, className: string): boolean {

--- a/libs/core/schematics/utils/package-utils.ts
+++ b/libs/core/schematics/utils/package-utils.ts
@@ -8,7 +8,10 @@ export function getSourceFile(host: Tree, path: string): ts.SourceFile {
     if (!buffer) {
         throw new SchematicsException(`Could not find file for path: ${path}`);
     }
-    return ts.createSourceFile(path, buffer.toString(), ts.ScriptTarget.Latest, true);
+
+    const text = buffer.toString('utf-8');
+
+    return ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true);
 }
 
 // Get the version of a package name


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
There were some old methods, that are not supported by angular cli above and equal 10.1 version.
Now some of them are imported from `@schematics/angular` library.

To test it:
- You need testing app with ng@10.1 or above
- Fetch this branch
- run `npm run build-pack-library`
- copy `.tgz` file from `dist/libs/core/` to testing app directory
- Add this version of lib by writing `ng add @fundamental-ngx/core@{{path to tgz file}}`


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

