### PR TITLE
docs: (Core) update object status icon to the latest version

### DIFF
--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-clickable-and-icon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-clickable-and-icon-example.component.html
@@ -1,8 +1,8 @@
-<a fd-object-status status="negative" glyph="status-negative" [clickable]="true" label="Negative" aria-label="Object Status Negative"></a>
-<a fd-object-status status="critical" glyph="status-critical" [clickable]="true" label="Critical" aria-label="Object Status Critical"></a>
-<a fd-object-status status="positive" glyph="status-positive" [clickable]="true" label="Positive" aria-label="Object Status Positive"></a>
-<a fd-object-status status="informative" glyph="hint" [clickable]="true" label="Informative" aria-label="Object Status Informative"></a>
-<a fd-object-status glyph="to-be-reviewed" [clickable]="true" label="Default" aria-label="Object Status Default"></a>
+<a fd-object-status status="negative" glyph="message-error" [clickable]="true" label="Negative" aria-label="Object Status Negative"></a>
+<a fd-object-status status="critical" glyph="message-warning" [clickable]="true" label="Critical" aria-label="Object Status Critical"></a>
+<a fd-object-status status="positive" glyph="message-success" [clickable]="true" label="Positive" aria-label="Object Status Positive"></a>
+<a fd-object-status status="informative" glyph="message-information" [clickable]="true" label="Informative" aria-label="Object Status Informative"></a>
+<a fd-object-status [clickable]="true" label="Default" aria-label="Object Status Default"></a>
 <br />
 <br />
 <ng-container *ngFor="let item of [1, 2, 3, 4, 5, 6, 7, 8]">

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-default-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-default-example.component.html
@@ -1,5 +1,5 @@
-<span fd-object-status glyph="to-be-reviewed" glyphAriaLabel="Check for review" title="To Be Reviewed"></span>
-<span fd-object-status status="negative" glyph="status-negative" glyphAriaLabel="Negative" title="Negative"></span>
-<span fd-object-status status="critical" glyph="status-critical" glyphAriaLabel="Critical" title="Critical"></span>
-<span fd-object-status status="positive" glyph="status-positive" glyphAriaLabel="Positive" title="Positive"></span>
-<span fd-object-status status="informative" glyph="hint" glyphAriaLabel="Show More" title="Informative"></span>
+<span fd-object-status glyphAriaLabel="Check for review" title="Default"></span>
+<span fd-object-status status="negative" glyph="message-error" glyphAriaLabel="Negative" title="Negative"></span>
+<span fd-object-status status="critical" glyph="message-warning" glyphAriaLabel="Critical" title="Critical"></span>
+<span fd-object-status status="positive" glyph="message-success" glyphAriaLabel="Positive" title="Positive"></span>
+<span fd-object-status status="informative" glyph="message-information" glyphAriaLabel="Show More" title="Informative"></span>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-icon-text-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-icon-text-example.component.html
@@ -1,5 +1,5 @@
-<span fd-object-status status="negative" glyph="status-negative" label="Negative" aria-label="Object status Negative"></span>
-<span fd-object-status status="critical" glyph="status-critical" label="Critical" aria-label="Object status Critical"></span>
-<span fd-object-status status="positive" glyph="status-positive" label="Positive" aria-label="Object status Positive"></span>
-<span fd-object-status status="informative" glyph="hint" label="Informative" aria-label="Object status Informative"></span>
-<span fd-object-status glyph="to-be-reviewed" label="Default" aria-label="Object status Default"></span>
+<span fd-object-status status="negative" glyph="message-error"  label="Negative" aria-label="Object status Negative"></span>
+<span fd-object-status status="critical" glyph="message-warning"  label="Critical" aria-label="Object status Critical"></span>
+<span fd-object-status status="positive" glyph="message-success"  label="Positive" aria-label="Object status Positive"></span>
+<span fd-object-status status="informative" glyph="message-information"  label="Informative" aria-label="Object status Informative"></span>
+<span fd-object-status label="Default" aria-label="Object status Default"></span>

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-inverted-example.component.html
@@ -1,7 +1,7 @@
 <span
     fd-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     [inverted]="true"
     title="Negative"
     aria-label="Object status Negative Inverted"
@@ -9,7 +9,7 @@
 <span
     fd-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     [inverted]="true"
     title="Critical"
     aria-label="Object status Critical Inverted"
@@ -17,7 +17,7 @@
 <span
     fd-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     [inverted]="true"
     title="Positive"
     aria-label="Object status Positive Inverted"
@@ -25,17 +25,10 @@
 <span
     fd-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     [inverted]="true"
     title="Informative"
     aria-label="Object status Informative Inverted"
-></span>
-<span
-    fd-object-status
-    glyph="to-be-reviewed"
-    [inverted]="true"
-    title="To Be Reviewed"
-    aria-label="Object status Reviewed Inverted"
 ></span>
 
 <br /><br />
@@ -127,7 +120,7 @@
 <span
     fd-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     [inverted]="true"
     label="Negative"
     aria-label="Object status Negative Icon and Text Inverted"
@@ -135,7 +128,7 @@
 <span
     fd-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     [inverted]="true"
     label="Critical"
     aria-label="Object status Critical Icon and Text Inverted"
@@ -143,7 +136,7 @@
 <span
     fd-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     [inverted]="true"
     label="Positive"
     aria-label="Object status Positive Icon and Text Inverted"
@@ -151,14 +144,13 @@
 <span
     fd-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     [inverted]="true"
     label="Informative"
     aria-label="Object status Informative Icon and Text Inverted"
 ></span>
 <span
     fd-object-status
-    glyph="to-be-reviewed"
     [inverted]="true"
     label="Default"
     aria-label="Object status Default Icon and Text Inverted"
@@ -169,7 +161,7 @@
 <a
     fd-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     [clickable]="true"
     [inverted]="true"
     label="Negative"
@@ -178,7 +170,7 @@
 <a
     fd-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     [clickable]="true"
     [inverted]="true"
     label="Critical"
@@ -187,7 +179,7 @@
 <a
     fd-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     [clickable]="true"
     [inverted]="true"
     label="Positive"
@@ -196,7 +188,7 @@
 <a
     fd-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     [clickable]="true"
     [inverted]="true"
     label="Informative"
@@ -204,7 +196,6 @@
 ></a>
 <a
     fd-object-status
-    glyph="to-be-reviewed"
     [clickable]="true"
     [inverted]="true"
     label="Default"

--- a/apps/docs/src/app/core/component-docs/object-status/examples/object-status-large-example.component.html
+++ b/apps/docs/src/app/core/component-docs/object-status/examples/object-status-large-example.component.html
@@ -1,7 +1,7 @@
 <span
     fd-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     [inverted]="true"
     [large]="true"
     title="Negative"
@@ -10,7 +10,7 @@
 <span
     fd-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     [inverted]="true"
     [large]="true"
     title="Critical"
@@ -19,7 +19,7 @@
 <span
     fd-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     [inverted]="true"
     [large]="true"
     title="Positive"
@@ -28,19 +28,11 @@
 <span
     fd-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     [inverted]="true"
     [large]="true"
     title="Informative"
     aria-label="Object Status Informative Inverted and large"
-></span>
-<span
-    fd-object-status
-    glyph="to-be-reviewed"
-    [inverted]="true"
-    [large]="true"
-    title="To Be Reviewed"
-    aria-label="Object Status Default Inverted and large"
 ></span>
 
 <br /><br />
@@ -126,7 +118,7 @@
 <span
     fd-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     [large]="true"
     label="Negative"
     aria-label="Object Status Informative icon and large text"
@@ -134,7 +126,7 @@
 <span
     fd-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     [large]="true"
     label="Critical"
     aria-label="Object Status Critical icon and large text"
@@ -142,7 +134,7 @@
 <span
     fd-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     [large]="true"
     label="Positive"
     aria-label="Object Status Positive icon and large text"
@@ -150,14 +142,13 @@
 <span
     fd-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     [large]="true"
     label="Informative"
     aria-label="Object Status Informative icon and large text"
 ></span>
 <span
     fd-object-status
-    glyph="to-be-reviewed"
     [large]="true"
     label="Default"
     aria-label="Object Status Default icon and large text"
@@ -168,7 +159,7 @@
 <a
     fd-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -178,7 +169,7 @@
 <a
     fd-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -188,7 +179,7 @@
 <a
     fd-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -198,7 +189,7 @@
 <a
     fd-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -207,7 +198,6 @@
 ></a>
 <a
     fd-object-status
-    glyph="to-be-reviewed"
     [clickable]="true"
     [large]="true"
     [inverted]="true"

--- a/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-clickable-and-icon-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-clickable-and-icon-example.component.html
@@ -1,6 +1,6 @@
 <fdp-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-information"
     clickable="true"
     (click)="showObjectStatus()"
     label="Negative"
@@ -8,7 +8,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     clickable="true"
     (click)="showObjectStatus()"
     label="Critical"
@@ -16,7 +16,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     clickable="true"
     (click)="showObjectStatus()"
     label="Positive"
@@ -24,14 +24,13 @@
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     clickable="true"
     (click)="showObjectStatus()"
     label="Informative"
     ariaLabel="Object status Informative Clickable"
 ></fdp-object-status>
 <fdp-object-status
-    glyph="to-be-reviewed"
     clickable="true"
     (click)="showObjectStatus()"
     label="Default"

--- a/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-example.component.html
@@ -1,5 +1,4 @@
 <fdp-object-status
-    glyph="hide"
     title="Default status"
     label="Object Status"
     ariaLabel="Object status Default"

--- a/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-icon-text-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-icon-text-example.component.html
@@ -1,33 +1,32 @@
 <fdp-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     label="Negative"
     title="Negative"
     ariaLabel="Object status Negative"
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     label="Critical"
     title="Critical"
     ariaLabel="Object status Critical"
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     label="Positive"
     title="Positive"
     ariaLabel="Object status Positive"
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     label="Informative"
     title="Informative"
     ariaLabel="Object status Informative"
 ></fdp-object-status>
 <fdp-object-status
-    glyph="to-be-reviewed"
     label="Default"
     title="Default"
     ariaLabel="Object status Default"

--- a/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-inverted-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-inverted-example.component.html
@@ -1,36 +1,30 @@
 <fdp-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     inverted="true"
     title="Status Negative"
     ariaLabel="Object status Negative inverted"
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     inverted="true"
     title="Status Critical"
     ariaLabel="Object status Critical inverted"
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     inverted="true"
     title="Status Positive"
     ariaLabel="Object status Positive inverted"
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     inverted="true"
     title="Status Informative"
     ariaLabel="Object status Informative inverted"
-></fdp-object-status>
-<fdp-object-status
-    glyph="to-be-reviewed"
-    inverted="true"
-    title="Status Reviewed"
-    ariaLabel="Object status default inverted"
 ></fdp-object-status>
 
 <br /><br />
@@ -102,34 +96,33 @@
 
 <fdp-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     inverted="true"
     ariaLabel="Object status Negative inverted"
     label="Negative"
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     inverted="true"
     ariaLabel="Object status Critical inverted"
     label="Critical"
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     inverted="true"
     ariaLabel="Object status Positive inverted"
     label="Positive"
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     inverted="true"
     ariaLabel="Object status Informative inverted"
     label="Informative"
 ></fdp-object-status>
 <fdp-object-status
-    glyph="to-be-reviewed"
     inverted="true"
     ariaLabel="Object status Default inverted"
     label="Default"
@@ -139,7 +132,7 @@
 
 <fdp-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     clickable="true"
     inverted="true"
     label="Negative"
@@ -147,7 +140,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     clickable="true"
     inverted="true"
     label="Critical"
@@ -155,7 +148,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     clickable="true"
     inverted="true"
     label="Positive"
@@ -163,14 +156,13 @@
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     clickable="true"
     inverted="true"
     label="Informative"
     ariaLabel="Object status Informative inverted clickable"
 ></fdp-object-status>
 <fdp-object-status
-    glyph="to-be-reviewed"
     clickable="true"
     inverted="true"
     label="Default"

--- a/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-large-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-object-status/platform-object-status-example/platform-object-status-large-example.component.html
@@ -1,6 +1,6 @@
 <fdp-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     inverted="true"
     large="true"
     title="Status Negative"
@@ -8,7 +8,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     inverted="true"
     large="true"
     title="Status Critical"
@@ -16,7 +16,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     inverted="true"
     large="true"
     title="Status Positive"
@@ -24,18 +24,11 @@
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     inverted="true"
     large="true"
     title="Status Informative"
     ariaLabel="Object status Informative large"
-></fdp-object-status>
-<fdp-object-status
-    glyph="to-be-reviewed"
-    inverted="true"
-    large="true"
-    title="Status Reviewd"
-    ariaLabel="Object status Default large"
 ></fdp-object-status>
 
 <br /><br />
@@ -107,34 +100,33 @@
 
 <fdp-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     large="true"
     label="Negative"
     ariaLabel="Object status Negative large"
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     large="true"
     label="Critical"
     ariaLabel="Object status Critical large"
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     large="true"
     label="Positive"
     ariaLabel="Object status Positive large"
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     large="true"
     label="Informative"
     ariaLabel="Object status Informative large"
 ></fdp-object-status>
 <fdp-object-status
-    glyph="to-be-reviewed"
     large="true"
     label="Default"
     ariaLabel="Object status Default large"
@@ -144,7 +136,7 @@
 
 <fdp-object-status
     status="negative"
-    glyph="status-negative"
+    glyph="message-error"
     clickable="true"
     large="true"
     inverted="true"
@@ -154,7 +146,7 @@
 >
 <fdp-object-status
     status="critical"
-    glyph="status-critical"
+    glyph="message-warning"
     clickable="true"
     large="true"
     inverted="true"
@@ -164,7 +156,7 @@
 >
 <fdp-object-status
     status="positive"
-    glyph="status-positive"
+    glyph="message-success"
     clickable="true"
     large="true"
     inverted="true"
@@ -174,7 +166,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="hint"
+    glyph="message-information"
     clickable="true"
     large="true"
     inverted="true"
@@ -182,7 +174,6 @@
     ariaLabel="Object status Informative large inverted"
 ></fdp-object-status>
 <fdp-object-status
-    glyph="to-be-reviewed"
     clickable="true"
     large="true"
     inverted="true"


### PR DESCRIPTION
updatig the object status icon to the latest version

#### Please provide a link to the associated issue.
https://github.com/SAP/fundamental-ngx/issues/3533

#### Please provide a brief summary of this pull request.
Object status icon, we still use the old version.
<img width="850" alt="Screenshot 2021-01-05 at 10 34 29 PM" src="https://user-images.githubusercontent.com/53534379/103675670-39ee0e00-4fa6-11eb-8574-d86992232a3c.png">


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

