### PR TITLE
fix: (Core) make Form's Input Message readable by screen readers

### DIFF
--- a/e2e/wdio/platform/tests/checkbox.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/checkbox.e2e-spec.ts
@@ -233,27 +233,27 @@ describe('Checkbox test suite', () => {
 
     describe('Checkbox With Form and State Change on Error', () => {
         it('should check error handling examples', () => {
-            if (!browserIsIEorSafari()) {
-                const errorCheckboxesLength = getElementArrayLength(errorCheckboxes);
-
-                for (let i = 0; errorCheckboxesLength > i; i++) {
-                    checkIfDisabled(errorCheckboxes, 'ng-reflect-is-disabled', 'false', i);
-                }
-
-                clickNextElement(presenceCheckbox);
-                expect(getCSSPropertyByName(presenceCheckbox, 'border-bottom-color').value)
-                    .toContain(checkboxGPData.checkboxErrorState);
-                scrollIntoView(checkboxPage.errorExampleTitle);
-                click(checkboxPage.errorExampleTitle);
-                mouseHoverElement(presenceCheckbox);
-                expect(getText(checkboxPage.errorTooltip).trim()).toEqual(checkboxData.checkboxErrorTooltip);
-
-                checkHoverState(errorCheckboxes, 1);
-                checkFocusState(errorCheckboxes, 1);
+            if (browserIsIEorSafari()) {
+                console.log('Skip for Safari and IE');
                 return;
             }
-            console.log('Skip for Safari and IE');
-        });
+            const errorCheckboxesLength = getElementArrayLength(errorCheckboxes);
+
+            for (let i = 0; errorCheckboxesLength > i; i++) {
+                checkIfDisabled(errorCheckboxes, 'ng-reflect-is-disabled', 'false', i);
+            }
+
+            scrollIntoView(checkboxPage.submitBtn);
+            clickNextElement(presenceCheckbox);
+            expect(getCSSPropertyByName(presenceCheckbox, 'border-bottom-color').value)
+                .toContain(checkboxGPData.checkboxErrorState);
+            scrollIntoView(checkboxPage.submitBtn);
+            mouseHoverElement(checkboxPage.submitBtn);
+            waitForElDisplayed(checkboxPage.errorTooltip);
+            expect(getText(checkboxPage.errorTooltip).trim()).toEqual(checkboxData.checkboxErrorTooltip);
+            checkHoverState(errorCheckboxes, 1);
+            checkFocusState(errorCheckboxes, 1);
+        }, 1);
 
         it('should check error handling form submission', () => {
             if (!browserIsIEorSafari()) {
@@ -271,6 +271,7 @@ describe('Checkbox test suite', () => {
                 click(checkboxPage.submitBtn);
 
                 expect(getAlertText()).toEqual('Status: INVALID');
+                acceptAlert();
                 return;
             }
             console.log('Skip for Safari and IE');

--- a/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.ts
+++ b/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.ts
@@ -29,7 +29,7 @@ export class FormInputMessageGroupComponent {
      *  Whether the popover should close when a click is made outside its boundaries.
      */
     @Input()
-    closeOnOutsideClick = true;
+    closeOnOutsideClick = false;
 
     /**
      * Preset options for the message body width.
@@ -46,7 +46,7 @@ export class FormInputMessageGroupComponent {
 
     /** Whether the popover should close when the escape key is pressed. */
     @Input()
-    closeOnEscapeKey = true;
+    closeOnEscapeKey = false;
 
     /** The placement of the popover. It can be one of: top, top-start, top-end, bottom,
      *  bottom-start, bottom-end, right, right-start, right-end, left, left-start, left-end. */

--- a/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.ts
+++ b/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.ts
@@ -22,7 +22,7 @@ export class FormInputMessageGroupComponent {
      * Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp).
      */
     @Input()
-    triggers: string[] = ['click'];
+    triggers: string[] = ['focusin', 'focusout'];
 
     /*
      * Allows the user to decide if he wants to keep the error message after they click outside

--- a/libs/core/src/lib/form/form-message/form-message.component.ts
+++ b/libs/core/src/lib/form/form-message/form-message.component.ts
@@ -21,8 +21,8 @@ export type MessageStates = 'success' | 'error' | 'warning' | 'information';
     templateUrl: './form-message.component.html',
     styleUrls: ['./form-message.component.scss'],
     host: {
-        '[attr.aria-live]': '"assertive"',
-        '[attr.aria-atomic]': 'true'
+        'aria-live': 'assertive',
+        'aria-atomic': 'true'
     },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/libs/core/src/lib/form/form-message/form-message.component.ts
+++ b/libs/core/src/lib/form/form-message/form-message.component.ts
@@ -20,6 +20,10 @@ export type MessageStates = 'success' | 'error' | 'warning' | 'information';
     selector: 'fd-form-message',
     templateUrl: './form-message.component.html',
     styleUrls: ['./form-message.component.scss'],
+    host: {
+        '[attr.aria-live]': '"assertive"',
+        '[attr.aria-atomic]': 'true'
+    },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes: https://github.com/SAP/fundamental-ngx/issues/4229
#### Please provide a brief summary of this pull request.
Form Message become readable by screen readers like VoiceOver
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [n/a] Stackblitz works for all examples

