### PR TITLE
docs: (Platform) fix underlying documentation page scroll in Dynamic Page

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-example.component.ts
@@ -26,10 +26,12 @@ export class PlatformDynamicPageExampleComponent {
     openPage(): void {
         this.fullscreen = true;
         this.overlay.nativeElement.style.width = '100%';
+        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
     }
     closePage(event: Event): void {
         event.stopPropagation();
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
+        document.getElementById('page-content').style.overflowY = 'auto';
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-non-collapsible-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-non-collapsible-example.component.ts
@@ -24,10 +24,12 @@ export class PlatformDynamicPageNonCollapsibleExampleComponent {
     openPage(): void {
         this.fullscreen = true;
         this.overlay.nativeElement.style.width = '100%';
+        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
     }
     closePage(event: Event): void {
         event.stopPropagation();
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
+        document.getElementById('page-content').style.overflowY = 'auto';
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-responsive-padding-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-responsive-padding-example.component.ts
@@ -26,10 +26,12 @@ export class PlatformDynamicPageResponsivePaddingExampleComponent {
     openPage(): void {
         this.fullscreen = true;
         this.overlay.nativeElement.style.width = '100%';
+        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
     }
     closePage(event: Event): void {
         event.stopPropagation();
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
+        document.getElementById('page-content').style.overflowY = 'auto';
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-snap-scroll-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-snap-scroll-example.component.ts
@@ -26,10 +26,12 @@ export class PlatformDynamicPageSnapScrollExampleComponent {
     openPage(): void {
         this.fullscreen = true;
         this.overlay.nativeElement.style.width = '100%';
+        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
     }
     closePage(event: Event): void {
         event.stopPropagation();
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
+        document.getElementById('page-content').style.overflowY = 'auto';
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
@@ -22,11 +22,13 @@ export class PlatformDynamicPageTabbedExampleComponent {
     openPage(): void {
         this.overlay.nativeElement.style.width = '100%';
         this.fullscreen = true;
+        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
     }
     closePage(event: Event): void {
         event.stopPropagation();
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
+        document.getElementById('page-content').style.overflowY = 'auto';
     }
 
     onTabChanged(event: DynamicPageTabChangeEvent): void {

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
@@ -24,3 +24,7 @@
         cursor: default;
     }
 }
+
+.fd-dynamic-page__content {
+    overflow: auto;
+}

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
@@ -24,7 +24,3 @@
         cursor: default;
     }
 }
-
-.fd-dynamic-page__content {
-    overflow: auto;
-}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #4311 

#### Please provide a brief summary of this pull request.
- In Firefox, the PR fixes an issue where a secondary scrollbar would appear behind the dynamic page scrollbar, and scrolling the secondary one and closing the dynamic page example would have scrolled the underlying page examples. It also happens in other browsers but the two scrollbars don't appear together. This is a documentation examples pages issue.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

