### PR TITLE
fix: (Core) asterisk not in a proper place in IE11 for form field

### DIFF
--- a/libs/core/src/lib/form/form-label/form-label.component.scss
+++ b/libs/core/src/lib/form/form-label/form-label.component.scss
@@ -22,7 +22,7 @@ $form-label-inline-help-placement-space: 1.25rem;
 }
 
 .fd-form-label {
-	display: block;
+	display: inline-block;
 }
 
 .fd-form-label__wrapper {


### PR DESCRIPTION
asterisk not in a proper place in IE11 for form field

#### Please provide a link to the associated issue.

https://github.com/SAP/fundamental-ngx/issues/4234

#### Please provide a brief summary of this pull request.

<img width="832" alt="Screenshot 2021-01-08 at 2 26 17 PM" src="https://user-images.githubusercontent.com/53534379/103994805-87909380-51bd-11eb-90ed-95a17a399ae6.png">

Fixed 

![image](https://user-images.githubusercontent.com/53534379/104002676-6765d200-51c7-11eb-9896-55a4703d70db.png)



#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

