### PR TITLE
fix: (Core) Time Component stop scrolling on init

### DIFF
--- a/libs/core/src/lib/time/time-column/time-column.component.scss
+++ b/libs/core/src/lib/time/time-column/time-column.component.scss
@@ -9,7 +9,6 @@
 }
 
 
-
 .fd-time-column-custom-hidden {
     display: none;
 }

--- a/libs/core/src/lib/time/time-column/time-column.component.scss
+++ b/libs/core/src/lib/time/time-column/time-column.component.scss
@@ -9,6 +9,7 @@
 }
 
 
+
 .fd-time-column-custom-hidden {
     display: none;
 }

--- a/libs/core/src/lib/time/time-column/time-column.component.spec.ts
+++ b/libs/core/src/lib/time/time-column/time-column.component.spec.ts
@@ -42,7 +42,7 @@ describe('TimeColumnComponent', () => {
         component.activeValue = rows[2];
         fixture.detectChanges();
 
-        expect((<any>component)._pickTime).toHaveBeenCalledWith(component.items.toArray()[2], true);
+        expect((<any>component)._pickTime).toHaveBeenCalledWith(component.items.toArray()[2], false);
     });
 
     it('should call pick time method with scrollUp', () => {

--- a/libs/core/src/lib/time/time-column/time-column.component.ts
+++ b/libs/core/src/lib/time/time-column/time-column.component.ts
@@ -299,7 +299,6 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
      * after => Defines if value was incremented/decremented, needed for hours to trigger AM/PM change
      */
     private _pickTime(item: CarouselItemDirective, smooth?: boolean, emitEvent?: boolean, after?: boolean): void {
-
         if (!item) {
             return;
         }
@@ -364,9 +363,7 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
                     map((value) => this._getValue(value)),
                     map((value) => this._getItem(value))
                 )
-                .subscribe((item) =>
-                    this._pickTime(item, false, true)
-                )
+                .subscribe((item) => this._pickTime(item, false, true))
         );
     }
 

--- a/libs/core/src/lib/time/time-column/time-column.component.ts
+++ b/libs/core/src/lib/time/time-column/time-column.component.ts
@@ -61,7 +61,7 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
     @Input()
     set activeValue(activeItem: T) {
         if (this._initialized && this._activeValue !== activeItem) {
-            this._pickTime(this._getItem(activeItem), true);
+            this._pickTime(this._getItem(activeItem), false);
         }
         this._activeValue = activeItem;
     }
@@ -299,12 +299,18 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
      * after => Defines if value was incremented/decremented, needed for hours to trigger AM/PM change
      */
     private _pickTime(item: CarouselItemDirective, smooth?: boolean, emitEvent?: boolean, after?: boolean): void {
+
         if (!item) {
             return;
         }
-        this._triggerCarousel(item, smooth);
+
+        if (this.active) {
+            this._triggerCarousel(item, smooth);
+        }
+
         this._activeCarouselItem = item;
         this._activeValue = item.value;
+
         if (emitEvent) {
             this.activeValueChange.emit({
                 value: item.value,
@@ -358,7 +364,9 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
                     map((value) => this._getValue(value)),
                     map((value) => this._getItem(value))
                 )
-                .subscribe((item) => this._pickTime(item, false, true))
+                .subscribe((item) =>
+                    this._pickTime(item, false, true)
+                )
         );
     }
 
@@ -382,6 +390,6 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
         if (!this._activeValue) {
             this._activeValue = this.items.first.value;
         }
-        this._pickTime(this._getItem(this._activeValue), true);
+        this._pickTime(this._getItem(this._activeValue), false);
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3695
#### Please provide a brief summary of this pull request.

Now time component doesn't scroll on popover open/init.
There is no way to speed up switching between columns, because all of them are shown and hidden by css

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

