### PR TITLE
fix: (Core) add fix for empty checkbox focus

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.scss
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.scss
@@ -1,1 +1,5 @@
 @import '~fundamental-styles/dist/checkbox';
+
+.fd-checkbox__text:empty {
+    margin: 0;
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/4316

#### Please provide a brief summary of this pull request.
Due to a recent change in Checkbox introduced in https://github.com/SAP/fundamental-ngx/pull/4192 the span with class `fd-checkbox__text` is always present even when the checkbox is "empty" (has no label). This element brings a margin left of 0.6875rem which causes the issue. I added css to remove this margin when the span element has no content inside (is empty).

Before:
<img width="1880" alt="Screen Shot 2021-01-12 at 2 47 09 PM" src="https://user-images.githubusercontent.com/39598672/104364768-11ee3580-54e5-11eb-96e2-b3a79f292ddc.png">

Now:
<img width="1891" alt="Screen Shot 2021-01-12 at 2 43 35 PM" src="https://user-images.githubusercontent.com/39598672/104364797-1a467080-54e5-11eb-9c30-ccdf52017b79.png">


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [na] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [na] Documentation Examples
- [na] Stackblitz works for all examples

