### PR TITLE
fix: (Core) add fix for Inline Help icon-text misalignment

### DIFF
--- a/libs/core/src/lib/form/form-label/form-label.component.scss
+++ b/libs/core/src/lib/form/form-label/form-label.component.scss
@@ -31,6 +31,7 @@ $form-label-inline-help-placement-space: 1.25rem;
 	overflow: hidden;
 
 	&--inline-help {
+		display: flex;
 		padding-left: $form-label-inline-help-placement-space;
 
 		@include rtl() {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/4316

#### Please provide a brief summary of this pull request.
The icon and the text of the Inline Help were not vertically aligned. Provided a css fix for the issue.
Before:
<img width="1222" alt="Screen Shot 2021-01-12 at 3 15 51 PM" src="https://user-images.githubusercontent.com/39598672/104367634-187eac00-54e9-11eb-8e10-165a734d7213.png">

After:
<img width="1248" alt="Screen Shot 2021-01-12 at 3 15 34 PM" src="https://user-images.githubusercontent.com/39598672/104367650-22a0aa80-54e9-11eb-9f01-9a091cf9d17a.png">


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [na] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [na] Documentation Examples
- [na] Stackblitz works for all examples

