### PR TITLE
fix: (core) FdDatetimeAdapter: add time parsing

### DIFF
--- a/libs/core/src/lib/datetime/fd-date-formats.ts
+++ b/libs/core/src/lib/datetime/fd-date-formats.ts
@@ -1,21 +1,25 @@
 import { DateTimeFormats } from './datetime-formats';
 
+const dateInput = { year: 'numeric', month: 'numeric', day: 'numeric' };
+const timeInput = { hour: 'numeric', minute: '2-digit' };
+const dateTimeInput = {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+};
+
 export const FD_DATETIME_FORMATS: DateTimeFormats = {
     parse: {
-        dateInput: null,
-        timeInput: null,
-        dateTimeInput: null
+        dateInput: dateInput,
+        timeInput: timeInput,
+        dateTimeInput: dateTimeInput
     },
     display: {
-        dateInput: { year: 'numeric', month: 'numeric', day: 'numeric' },
-        timeInput: { hour: 'numeric', minute: '2-digit' },
-        dateTimeInput: {
-            year: 'numeric',
-            month: 'numeric',
-            day: 'numeric',
-            hour: 'numeric',
-            minute: '2-digit'
-        },
+        dateInput: dateInput,
+        timeInput: timeInput,
+        dateTimeInput: dateTimeInput,
 
         dateA11yLabel: { year: 'numeric', month: 'long', day: 'numeric' },
         monthA11yLabel: { month: 'long' },

--- a/libs/core/src/lib/datetime/fd-datetime-adapter.spec.ts
+++ b/libs/core/src/lib/datetime/fd-datetime-adapter.spec.ts
@@ -298,8 +298,17 @@ describe('FdDatetimeAdapter', () => {
         expect(adapter.datesEqual(adapter.now(), new FdDate())).toBe(true, `should be equal to now date moment`);
     });
 
-    it('should parse string', () => {
+    it('should parse "en" date string', () => {
         expect(adapter.parse('1/1/2017')).toEqual(new FdDate(2017, 1, 1));
+    });
+
+    it('should parse "en" time string', () => {
+        expect(adapter.parse('10:30 PM', { hour: 'numeric', minute: '2-digit', hour12: true })).toEqual(
+            FdDate.getNow().setTime(22, 30, 0)
+        );
+        expect(adapter.parse('10:30', { hour: 'numeric', minute: '2-digit' })).toEqual(
+            FdDate.getNow().setTime(10, 30, 0)
+        );
     });
 
     it('should parse number', () => {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes https://github.com/SAP/fundamental-ngx/issues/4334
#### Please provide a brief summary of this pull request.
This PR is adding ability to parse "en" time string
So time picker examples where locale is "en" should start working.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

