### PR TITLE
fix: (Core) Add another way to put resize boundaries

### DIFF
--- a/libs/core/src/lib/dialog/dialog.component.html
+++ b/libs/core/src/lib/dialog/dialog.component.html
@@ -4,9 +4,9 @@
     tabindex="-1"
     aria-modal="true"
     fdResize
-    fdResizeBoundary=".fd-dialog"
     cdkDrag
     cdkDragBoundary=".fd-dialog"
+    [fdResizeBoundary]="elementRef()?.nativeElement"
     [class]="dialogConfig.dialogPanelClass"
     [ngClass]="{
         'fd-dialog__content': true,

--- a/libs/core/src/lib/utils/directives/resize/resize.directive.ts
+++ b/libs/core/src/lib/utils/directives/resize/resize.directive.ts
@@ -26,7 +26,7 @@ interface ResizeMove {
 export class ResizeDirective implements OnChanges, AfterContentInit, OnDestroy {
     /** Element limiting resizable container growth */
     // tslint:disable-next-line:no-input-rename
-    @Input('fdResizeBoundary') resizeBoundary = 'body';
+    @Input('fdResizeBoundary') resizeBoundary: string | HTMLElement = 'body';
 
     /** Whether resizable behaviour should be disabled */
     // tslint:disable-next-line:no-input-rename
@@ -155,7 +155,14 @@ export class ResizeDirective implements OnChanges, AfterContentInit, OnDestroy {
 
     /** @hidden Return boundary container */
     private _findResizeContainer(): Element {
-        const resizeContainer = closestElement(this.resizeBoundary, this._elementRef.nativeElement);
+        let resizeContainer: Element | null
+        if (typeof this.resizeBoundary === 'string') {
+            resizeContainer = closestElement(this.resizeBoundary, this._elementRef.nativeElement);
+        } else {
+            resizeContainer = this.resizeBoundary
+        }
+
+
         if (resizeContainer) {
             return resizeContainer;
         } else {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes: https://github.com/SAP/fundamental-ngx/issues/3618
#### Please provide a brief summary of this pull request.
There is added anohter way to pass element for `resize` directive.

Because of `shadowRoot` there was no way to select (by `querySelctor`) mandatory element. This element is now provided directly.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

