### PR TITLE
fix: (Core) byline list content typo

### DIFF
--- a/libs/core/src/lib/list/directives/byline/list-content.directive.ts
+++ b/libs/core/src/lib/list/directives/byline/list-content.directive.ts
@@ -10,6 +10,6 @@ export class ListContentDirective {
 
     /** Whether or not this is a 2-column content. */
     @Input()
-    @HostBinding('fd-list__content--2-col')
+    @HostBinding('class.fd-list__content--2-col')
     twoCol = false;
 }


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
There is wrong `@hostbinding` in list content directive 
![image](https://user-images.githubusercontent.com/26483208/105173321-23f15900-5b21-11eb-9d86-c314a531dc0b.png)


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

