### PR TITLE
fix: (Platform) Dynamic Content Page overflow

### DIFF
--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
@@ -24,3 +24,10 @@
         cursor: default;
     }
 }
+
+// TODO: remove after migrating 0.15.0 styles
+.fd-dynamic-page {
+	.fd-dynamic-page__content {
+		overflow-y: auto;
+	}
+}


### PR DESCRIPTION
This is temporary fix for scrollbar, which shouldn't be shown all the time