### PR TITLE
fix: (Core) set is-disabled class to disabled button

### DIFF
--- a/libs/core/src/lib/button/base-button.ts
+++ b/libs/core/src/lib/button/base-button.ts
@@ -1,4 +1,5 @@
 import { Directive, Input } from '@angular/core';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
 export type GlyphPosition = 'before' | 'after';
 
@@ -61,4 +62,26 @@ export class BaseButton {
      */
     @Input()
     fdMenu = false;
+
+    /**
+     * Native disabled attribute of button element
+     */
+    @Input()
+    get disabled(): boolean { return this._disabled; }
+
+    set disabled(value: boolean) { this._disabled = coerceBooleanProperty(value); }
+
+    /**
+     * Native aria-disabled attribute of button element
+     */
+    @Input('aria-disabled')
+    get ariaDisabled(): boolean { return this._ariaDisabled; }
+
+    set ariaDisabled(value: boolean) { this._ariaDisabled = coerceBooleanProperty(value); }
+
+    /** @hidden */
+    _disabled: boolean;
+
+    /** @hidden */
+    _ariaDisabled: boolean;
 }

--- a/libs/core/src/lib/button/button.component.spec.ts
+++ b/libs/core/src/lib/button/button.component.spec.ts
@@ -1,7 +1,8 @@
-import { ButtonComponent } from './button.component';
 import { Component, DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+
+import { ButtonComponent } from './button.component';
 
 @Component({
     selector: 'fd-test-component',
@@ -33,7 +34,7 @@ describe('ButtonComponent', () => {
         expect(component).toBeTruthy();
     });
 
-   it('should add appropriate classes', () => {
+    it('should add appropriate classes', () => {
         componentInstance.compact = true;
         componentInstance.fdType = 'standard';
         componentInstance.fdMenu = true;
@@ -43,5 +44,58 @@ describe('ButtonComponent', () => {
         expect(cssClass).toContain('standard');
         expect(cssClass).toContain('fd-button--menu');
         expect(cssClass).toContain('compact');
+    });
+});
+
+@Component({
+    selector: 'fd-disabled-test-component',
+    template: '<button fd-button label="Button" disabled></button>'
+})
+export class DisabledTestComponent {}
+
+@Component({
+    selector: 'fd-aria-disabled-test-component',
+    template: '<button fd-button label="Button" aria-disabled="true"></button>'
+})
+export class AriaDisabledTestComponent {}
+
+describe('ButtonComponent – Disabled', () => {
+    let disabledFixture: ComponentFixture<DisabledTestComponent>,
+        ariaDisabledFixture: ComponentFixture<AriaDisabledTestComponent>,
+        debugElement: DebugElement,
+        element: HTMLElement;
+
+    let component, componentInstance: ButtonComponent;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [ButtonComponent, DisabledTestComponent, AriaDisabledTestComponent]
+        });
+    }));
+
+    it('should add is-disabled class to [disabled] button', () => {
+        disabledFixture = TestBed.createComponent(DisabledTestComponent);
+        debugElement = disabledFixture.debugElement;
+        element = debugElement.nativeElement;
+        disabledFixture.detectChanges();
+        component = debugElement.query(By.directive(ButtonComponent));
+        componentInstance = component.injector.get(ButtonComponent);
+        componentInstance.buildComponentCssClass();
+
+        const cssClass = componentInstance.buildComponentCssClass().join(' ');
+        expect(cssClass).toContain('is-disabled');
+    });
+
+    it('should add is-disabled class to [aria-disabled="true"] button', () => {
+        ariaDisabledFixture = TestBed.createComponent(AriaDisabledTestComponent);
+        debugElement = ariaDisabledFixture.debugElement;
+        element = debugElement.nativeElement;
+        ariaDisabledFixture.detectChanges();
+        component = debugElement.query(By.directive(ButtonComponent));
+        componentInstance = component.injector.get(ButtonComponent);
+        componentInstance.buildComponentCssClass();
+
+        const cssClass = componentInstance.buildComponentCssClass().join(' ');
+        expect(cssClass).toContain('is-disabled');
     });
 });

--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -31,7 +31,8 @@ import { BaseButton } from './base-button';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
-        '[attr.type]': 'type'
+        '[attr.type]': 'type',
+        '[attr.disabled]': '_disabled || null'
     }
 })
 export class ButtonComponent extends BaseButton implements OnChanges, CssClassBuilder, OnInit {
@@ -70,7 +71,7 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
             this.fdType ? `fd-button--${this.fdType}` : '',
             this.compact ? 'fd-button--compact' : '',
             this.fdMenu ? 'fd-button--menu' : '',
-            this._isDisabled() ? 'is-disabled' : '',
+            this._disabled || this._ariaDisabled ? 'is-disabled' : '',
             this.class
         ];
     }
@@ -84,10 +85,5 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
 
     detectChanges(): void {
         this._changeDetectorRef.detectChanges();
-    }
-
-    /** @hidden */
-    private _isDisabled(): boolean {
-        return this.elementRef().nativeElement.hasAttribute('disabled') || this.elementRef().nativeElement.getAttribute('aria-disabled');
     }
 }

--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -1,7 +1,9 @@
 import {
-    ChangeDetectionStrategy, ChangeDetectorRef,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
-    ElementRef, Input,
+    ElementRef,
+    Input,
     OnChanges,
     OnInit,
     ViewEncapsulation
@@ -33,8 +35,7 @@ import { BaseButton } from './base-button';
     }
 })
 export class ButtonComponent extends BaseButton implements OnChanges, CssClassBuilder, OnInit {
-
-    /** The property allows user to pass additional css classes*/
+    /** The property allows user to pass additional css classes. */
     @Input()
     class = '';
 
@@ -69,6 +70,7 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
             this.fdType ? `fd-button--${this.fdType}` : '',
             this.compact ? 'fd-button--compact' : '',
             this.fdMenu ? `fd-button--menu` : '',
+            this._isDisabled() ? `is-disabled` : '',
             this.class
         ];
     }
@@ -82,5 +84,9 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
 
     detectChanges(): void {
         this._changeDetectorRef.detectChanges();
+    }
+
+    private _isDisabled(): boolean {
+        return this.elementRef().nativeElement.hasAttribute('disabled') || this.elementRef().nativeElement.getAttribute('aria-disabled');
     }
 }

--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -69,8 +69,8 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
             'fd-button',
             this.fdType ? `fd-button--${this.fdType}` : '',
             this.compact ? 'fd-button--compact' : '',
-            this.fdMenu ? `fd-button--menu` : '',
-            this._isDisabled() ? `is-disabled` : '',
+            this.fdMenu ? 'fd-button--menu' : '',
+            this._isDisabled() ? 'is-disabled' : '',
             this.class
         ];
     }
@@ -86,6 +86,7 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
         this._changeDetectorRef.detectChanges();
     }
 
+    /** @hidden */
     private _isDisabled(): boolean {
         return this.elementRef().nativeElement.hasAttribute('disabled') || this.elementRef().nativeElement.getAttribute('aria-disabled');
     }

--- a/libs/platform/src/lib/components/menu-button/menu-button.component.spec.ts
+++ b/libs/platform/src/lib/components/menu-button/menu-button.component.spec.ts
@@ -89,7 +89,7 @@ describe('Menu Button Disabled test and Type, size test', () => {
 
     it('button should be disabled', () => {
         const menubuttonElement = fixture.debugElement.query(By.css('button'));
-        expect(menubuttonElement.nativeElement.getAttribute('disabled')).toEqual('');
+        expect(menubuttonElement.nativeElement.hasAttribute('disabled')).toEqual(true);
     });
 
     it('button should be standard and contain Menu', () => {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/4391
#### Please provide a brief summary of this pull request.
Set `is-disabled` class to `disabled` or `aria-disabled="true"` buttons.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples


#### Note:
Don't understand why, but this test case not working on the default test case. That's why I've added a new test case.
```
    it('should add is-disabled class to disabled button', () => {
        element.setAttribute('disabled', null);
        fixture.detectChanges(); // or componentInstance.ngOnChanges();
        componentInstance.buildComponentCssClass();

        let cssClass = componentInstance.buildComponentCssClass().join(' ');
        expect(cssClass).toContain('is-disabled');

        element.removeAttribute('disabled');
        element.setAttribute('aria-disabled', 'true');
        fixture.detectChanges(); // or componentInstance.ngOnChanges();
        componentInstance.buildComponentCssClass();

        cssClass = componentInstance.buildComponentCssClass().join(' ');
        expect(cssClass).toContain('is-disabled');
    });
```