### PR TITLE
fix: (Core) add fix for incorrect Shellbar overflowed counter position

### DIFF
--- a/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions-mobile.component.html
+++ b/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions-mobile.component.html
@@ -15,12 +15,12 @@
     </div>
 
     <fd-menu #menu [options]="{ placement: 'bottom-end' }" [fillControlMode]="null">
-        <li fd-menu-item *ngFor="let action of shellbarActions" (click)="actionClicked(action, $event)">
+        <li fd-menu-item *ngFor="let action of shellbarActions" (click)="actionClicked(action, $event)" class="fd-shellbar__action">
             <div fd-menu-interactive>
                 <fd-menu-addon position="before" [glyph]="action.glyph"></fd-menu-addon>
                 <span fd-menu-title>{{ action.label }}</span>
                 <span *ngIf="action.notificationCount"
-                      class="fd-counter fd-counter--notification fd-shellbar__counter--notification">
+                      class="fd-counter fd-shellbar__counter--overflowed">
                 {{ action.notificationCount }}
             </span>
             </div>

--- a/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions-mobile.component.ts
+++ b/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions-mobile.component.ts
@@ -12,7 +12,15 @@ import { ShellbarActionComponent } from '../shellbar-action/shellbar-action.comp
     selector: 'fd-shellbar-actions-mobile',
     templateUrl: './shellbar-actions-mobile.component.html',
     encapsulation: ViewEncapsulation.None,
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    // TODO: remove hardcoded styles
+    styles: [`
+        .fd-shellbar__counter--overflowed {
+            position: absolute;
+            right: 0.25rem;
+            top: -0.25rem;
+        }
+    `]
 })
 export class ShellbarActionsMobileComponent implements AfterContentChecked {
     /** @hidden */


### PR DESCRIPTION
part of #4482 

depends on https://github.com/SAP/fundamental-styles/pull/2094 but contains hardcoded styling for now

The shellbar notifications, when moved into the overflow menu on small screens, were not positioned correctly.  This was not known in the styles library because we had only seen it in ngx thus far.  This PR fixes the positioning and adds an example

Before:
![Screen Shot 2021-01-27 at 11 44 40 AM](https://user-images.githubusercontent.com/2471874/106038322-0bd78780-6095-11eb-9d47-d31bb7584551.png)

After:
![Screen Shot 2021-01-27 at 2 07 39 PM](https://user-images.githubusercontent.com/2471874/106054297-08e69200-60a9-11eb-9c98-abe38142b808.png)
