### PR TITLE
chore: increase version to 0.26.1 add necessary stash to hotfix deploy script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.26.1](https://github.com/SAP/fundamental-ngx/compare/v0.26.1-rc.20...v0.26.1) (2021-01-28)
+
 ### [0.26.1-rc.28](https://github.com/SAP/fundamental-ngx/compare/v0.26.1-rc.27...v0.26.1-rc.28) (2021-02-02)
 
 

--- a/ci-scripts/hotfix-publish.sh
+++ b/ci-scripts/hotfix-publish.sh
@@ -69,6 +69,7 @@ fi
 
 # Increment version on main
 if [[ $latest == "true" ]]; then
+  git stash
   git checkout $MASTER_BRANCH
   npm run std-version
   git push "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" $MASTER_BRANCH > /dev/null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fundamental-ngx",
-  "version": "0.26.1-rc.28",
+  "version": "0.26.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fundamental-ngx",
-  "version": "0.26.1-rc.28",
+  "version": "0.26.1",
   "license": "Apache-2.0",
   "main": "dist/libs/core/index.js",
   "description": "Fundamental Library for Angular is a themable Fiori 3 Angular component library.",


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
During running hotfix release script, there was some error:
![image](https://user-images.githubusercontent.com/26483208/106114587-012df880-6150-11eb-8e66-a975db4733a9.png)

That made unable to increment version of current `main`  tag.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

