### PR TITLE
fix: (Platform) fix tabChange event not emitting in Dynamic Page 

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-flexible-column-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-flexible-column-example.component.ts
@@ -89,7 +89,7 @@ export class PlatformDynamicPageFlexibleColumnExampleComponent {
     }
 
     onTabChanged(event: DynamicPageTabChangeEvent): void {
-        console.log('tab changed to ' + event.payload);
+        console.log('tab changed to ' + event.payload.id);
     }
 
     onLayoutChanged(layout: FlexibleColumnLayout): void {

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-non-collapsible-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-non-collapsible-example.component.html
@@ -4,7 +4,7 @@
         <div class="overlay-content">
             <fdp-dynamic-page size="large" ariaLabel="Example Dynamic Page">
                 <fdp-dynamic-page-title
-                    title="Balenciaga Tripple S Trainers"
+                    [title]="pageTitle"
                     subtitle="Oversized multimaterial sneakers with quilted effect"
                 >
                     <!-- breadcrumb content -->
@@ -37,6 +37,7 @@
                                 fdType="positive"
                                 (click)="closePage($event)"
                                 label="Accept"
+                                title="Accept"
                             ></button>
                             <button
                                 fd-toolbar-item
@@ -45,6 +46,7 @@
                                 fdType="negative"
                                 (click)="closePage($event)"
                                 label="Reject"
+                                title="Reject"
                             ></button>
                             <fd-toolbar-separator></fd-toolbar-separator>
                         </fd-toolbar>
@@ -52,7 +54,7 @@
                     <fdp-dynamic-page-layout-actions>
                         <!-- layout actions -->
                         <fd-toolbar fdType="transparent" [clearBorder]="true">
-                            <button fd-button fdType="transparent" aria-label="Resize" (click)="resizeClicked($event)">
+                            <button fd-button fdType="transparent" aria-label="Resize" (click)="resizeClicked($event)" title="Resize">
                                 <i class="sap-icon--resize"></i>
                             </button>
                             <button
@@ -60,10 +62,11 @@
                                 fdType="transparent"
                                 aria-label="Exit Fullscreen"
                                 (click)="closePage($event)"
+                                title="Exit Fullscreen"
                             >
                                 <i class="sap-icon--exitfullscreen"></i>
                             </button>
-                            <button fd-button fdType="transparent" aria-label="Close" (click)="closePage($event)">
+                            <button fd-button fdType="transparent" aria-label="Close" (click)="closePage($event)" title="Close">
                                 <i class="sap-icon--decline"></i>
                             </button>
                         </fd-toolbar>

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-non-collapsible-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-non-collapsible-example.component.ts
@@ -13,6 +13,8 @@ export class PlatformDynamicPageNonCollapsibleExampleComponent {
 
     fullscreen = false;
 
+    pageTitle = 'Balenciaga Tripple S Trainers';
+
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
     }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
@@ -32,6 +32,6 @@ export class PlatformDynamicPageTabbedExampleComponent {
     }
 
     onTabChanged(event: DynamicPageTabChangeEvent): void {
-        console.log('tab changed to ' + event.payload);
+        console.log('tab changed to ' + event.payload.id);
     }
 }

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
@@ -11,13 +11,14 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
+import { TabPanelComponent } from '@fundamental-ngx/core';
 
 import { DynamicPageBackgroundType, CLASS_NAME, DynamicPageResponsiveSize } from '../constants';
 import { addClassNameToElement } from '../utils';
 
 /** Dynamic Page tab change event */
 export class DynamicPageTabChangeEvent {
-    constructor(public source: DynamicPageContentComponent, public payload: number) {}
+    constructor(public source: DynamicPageContentComponent, public payload: TabPanelComponent) {}
 }
 @Component({
     selector: 'fdp-dynamic-page-content',

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.html
@@ -9,7 +9,7 @@
     </header>
 
     <div class="fd-dynamic-page__tabs--overflow" *ngIf="isTabbed" #contentContainer>
-        <fd-tab-list (selectedIndexChange)="_handleTabChange($event)">
+        <fd-tab-list (selectedTabChange)="_handleTabChange($event)">
             <ng-container *ngFor="let tab of tabs; let i = index">
                 <fd-tab [title]="tab.tabLabel">
                     <fdp-dynamic-page-tabbed-content

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.scss
@@ -9,15 +9,8 @@
 }
 
 .fd-dynamic-page__header--not-collapsible {
-
-    .fd-dynamic-page__title-area.is-focus,
-    .fd-dynamic-page__title-area:focus {
-        outline: none;
-    }
-
     .fd-dynamic-page__title-area.is-hover,
     .fd-dynamic-page__title-area:hover {
-        background: inherit;
         cursor: default;
     }
 }

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.ts
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.ts
@@ -16,6 +16,7 @@ import {
     ViewChildren,
     ViewEncapsulation
 } from '@angular/core';
+import { TabPanelComponent } from '@fundamental-ngx/core';
 import { fromEvent, Subscription } from 'rxjs';
 import { debounceTime, startWith, throttleTime } from 'rxjs/operators';
 import { BaseComponent } from '../base';
@@ -441,8 +442,8 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
     /** @hidden
      * handle tab changes and emit event
      */
-    _handleTabChange(index: number): void {
-        const event = new DynamicPageTabChangeEvent(this.contentComponent, index);
+    _handleTabChange(tabPanel: TabPanelComponent): void {
+        const event = new DynamicPageTabChangeEvent(this.contentComponent, tabPanel);
         this.contentComponent.tabChange.emit(event);
         this._cd.detectChanges();
     }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #4514 
fixes #4495 

#### Please provide a brief summary of this pull request.
Core tab had some breaking changes, where selectedIndexChange was replaced with selectedTabChange. This was not changed in Dynamic Page implementation which uses this output event, due to which the `tabChange` event was not being emitted. This PR makes the necessary changes. You can see the console.log message appear now when the tab is changed.

It also refactors 'disable header' example and fixes a theming related issue for the same example.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

