### PR TITLE
fix: (Core) remove responsive paddings when Shellbar is used with Side Nav

### DIFF
--- a/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav/shellbar-side-nav-example.component.html
+++ b/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav/shellbar-side-nav-example.component.html
@@ -1,4 +1,4 @@
-<fd-shellbar class="fd-shellbar-navigation-custom">
+<fd-shellbar [sideNav]="true">
     <button
         fd-shellbar-side-nav
         fd-button

--- a/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav/shellbar-side-nav-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav/shellbar-side-nav-example.component.scss
@@ -2,12 +2,6 @@
     display: none;
 }
 
-.fd-shellbar-navigation-custom {
-    .fd-shellbar {
-        padding: 0;
-    }
-}
-
 .shellbar-sidenav-content-example {
     display: flex;
     align-items: flex-start;

--- a/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.component.html
@@ -35,8 +35,8 @@
     Shellbar with SideNavigation
 </fd-docs-section-title>
 <description>
-    There is used <code>sideNavigation</code> in the <code>Shellbar</code> component. To add some control button, it is
-    mandatory to use <code>fd-shellbar-side-nav</code>, which will be placed in the left side of shellbar.
+    When Shellbar is used together with Vertical Navigation (aka Side Navigation) set the 
+    <code>sideNav</code> property to <b>true</b>. This will remove the responsive paddings applied on different screen sizes and will align vertically the control button with the items in the Side Navigation. The control button, situated on the far left hand-side of the Shellbar, is responsible for switching the modes of the Side Navigation (expanded, condensed and off-screen) and requires the <code>fd-shellbar-side-nav</code> directive.
 </description>
 <component-example>
     <fd-shellbar-side-nav-example></fd-shellbar-side-nav-example>

--- a/libs/core/src/lib/shellbar/shellbar.component.html
+++ b/libs/core/src/lib/shellbar/shellbar.component.html
@@ -1,4 +1,7 @@
-<div class="fd-shellbar" [ngClass]="'fd-shellbar--' + size">
+<div 
+    class="fd-shellbar" 
+    [ngClass]="'fd-shellbar--' + size"
+    [class.fd-shellbar--side-nav]="sideNav">
     <div class="fd-shellbar__group fd-shellbar__group--product">
         <ng-content select="[fd-shellbar-side-nav]"></ng-content>
         <ng-content select="fd-shellbar-logo"></ng-content>

--- a/libs/core/src/lib/shellbar/shellbar.component.scss
+++ b/libs/core/src/lib/shellbar/shellbar.component.scss
@@ -21,5 +21,21 @@
 
 	.fd-shellbar__group {
 		flex-basis: auto;
-	}
+    }
+    
+    &--side-nav {
+        &.fd-shellbar--s,
+        &.fd-shellbar--m,
+        &.fd-shellbar--l,
+        &.fd-shellbar--xl {
+            padding: 0 0.5rem 0 0;
+
+            @at-root {
+                [dir="rtl"] &,
+                &[dir="rtl"] {
+                    padding: 0 0 0 0.5rem;
+                }
+            }   
+        }
+    }
 }

--- a/libs/core/src/lib/shellbar/shellbar.component.ts
+++ b/libs/core/src/lib/shellbar/shellbar.component.ts
@@ -33,6 +33,13 @@ export class ShellbarComponent implements AfterContentInit {
     @Input()
     size: ShellbarSizes = 'm';
 
+    /** 
+     * Whether the Shellbar is used with Side Navigation 
+     * When set to true, the responsive paddings are not applied
+     */
+    @Input()
+    sideNav: boolean = false;
+
     /** @hidden */
     @ContentChild(ComboboxComponent, { static: false })
     comboboxComponent: ComboboxComponent;

--- a/libs/core/src/lib/shellbar/shellbar.component.ts
+++ b/libs/core/src/lib/shellbar/shellbar.component.ts
@@ -38,7 +38,7 @@ export class ShellbarComponent implements AfterContentInit {
      * When set to true, the responsive paddings are not applied
      */
     @Input()
-    sideNav: boolean = false;
+    sideNav = false;
 
     /** @hidden */
     @ContentChild(ComboboxComponent, { static: false })


### PR DESCRIPTION

#### Please provide a link to the associated issue.
closes https://github.com/SAP/fundamental-ngx/issues/4556

#### Please provide a brief summary of this pull request.
This PR removes the responsive paddings which are applied based on the screen size so that the control button (hamburger ) is aligned vertically with the icons/text in the Side Nav. This is achieved by introducing a modifier class `fd-shellbar--side-nav` which applies `0 0.5rem 0 0` paddings on the Shellbar.  

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [na] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

