### PR TITLE
fix: (Platform) provide programmatic tab selection for Dynamic Page

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-docs.component.html
@@ -27,7 +27,8 @@
     Tabbed Dynamic Page
 </fd-docs-section-title>
 <description> Specify the <code>[tabLabel]</code> option to internally set up tabbed content for the page. 
-    Use <code>(tabChange)</code> property to do something on tab change.</description>
+    Use <code>(tabChange)</code> property to do something on tab change. 
+    To programmatically switch/set the dynamic page tab, call <code>setSelectedTab(id)</code> on the <code>DynamicPageComponent</code> and pass in the id of the tab to switch/set to.</description>
 <component-example>
     <fdp-platform-dynamic-page-tabbed-example></fdp-platform-dynamic-page-tabbed-example>
 </component-example>

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.html
@@ -231,7 +231,7 @@
                     <button
                         fd-button
                         (click)="switchTab('tab_1')"
-                        title="Switch  to tab 1"
+                        title="Switch to tab 1"
                         label="Switch to Tab 1"
                     ></button>
                     <br />

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.html
@@ -228,6 +228,13 @@
                     debitis. Similique vel ipsam debitis fuga sequi eveniet perspiciatis?
                     <br />
                     <br />
+                    <button
+                        fd-button
+                        (click)="switchTab('tab_1')"
+                        title="Switch  to tab 1"
+                        label="Switch to Tab 1"
+                    ></button>
+                    <br />
                     <br />
                     Lorem ipsum dolor sit, amet consectetur adipisicing elit. Quaerat veniam libero nostrum explicabo
                     sed odit? Recusandae praesentium voluptatum cum omnis, placeat beatae quasi eum odio doloribus

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
@@ -1,5 +1,9 @@
 import { Component, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
-import { DynamicPageCollapseChangeEvent, DynamicPageTabChangeEvent } from '@fundamental-ngx/platform';
+import {
+    DynamicPageCollapseChangeEvent,
+    DynamicPageComponent,
+    DynamicPageTabChangeEvent
+} from '@fundamental-ngx/platform';
 
 @Component({
     selector: 'fdp-platform-dynamic-page-tabbed-example',
@@ -10,6 +14,9 @@ import { DynamicPageCollapseChangeEvent, DynamicPageTabChangeEvent } from '@fund
 export class PlatformDynamicPageTabbedExampleComponent {
     @ViewChild('overlay')
     overlay: ElementRef<HTMLElement>;
+
+    @ViewChild(DynamicPageComponent)
+    dynamicPageComponent: DynamicPageComponent;
 
     fullscreen = false;
 
@@ -33,5 +40,9 @@ export class PlatformDynamicPageTabbedExampleComponent {
 
     onTabChanged(event: DynamicPageTabChangeEvent): void {
         console.log('tab changed to ' + event.payload.id);
+    }
+
+    switchTab(id: string): void {
+        this.dynamicPageComponent.setSelectedTab(id);
     }
 }

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
@@ -35,6 +35,12 @@ export class DynamicPageContentComponent implements OnInit {
     tabLabel: string;
 
     /**
+     * a unique identifier for this content
+     */
+    @Input()
+    id: string;
+
+    /**
      * sets background for content to `list`, `transparent`, or `solid` background color.
      * Default is `solid`.
      */

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.html
@@ -9,9 +9,9 @@
     </header>
 
     <div class="fd-dynamic-page__tabs--overflow" *ngIf="isTabbed" #contentContainer>
-        <fd-tab-list (selectedTabChange)="_handleTabChange($event)">
+        <fd-tab-list (selectedTabChange)="_handleTabChange($event)" #dynamicPageTabs>
             <ng-container *ngFor="let tab of tabs; let i = index">
-                <fd-tab [title]="tab.tabLabel">
+                <fd-tab [title]="tab.tabLabel" [id]="tab.id">
                     <fdp-dynamic-page-tabbed-content
                         [background]="background"
                         [size]="size"

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.spec.ts
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.spec.ts
@@ -1,9 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { TabPanelComponent, TabsModule, ToolbarModule } from '@fundamental-ngx/core';
+import { TabsModule, ToolbarModule } from '@fundamental-ngx/core';
 import {
     CLASS_NAME,
     DynamicPageComponent,
@@ -191,8 +191,12 @@ describe('DynamicPageComponent default values', () => {
     template: `<fdp-dynamic-page [size]="size" [background]="background">
         <fdp-dynamic-page-title></fdp-dynamic-page-title>
         <fdp-dynamic-page-header></fdp-dynamic-page-header>
-        <fdp-dynamic-page-content id="tab1" [tabLabel]="tabLabel1">DynamicPage Content Tabbed 1 Text</fdp-dynamic-page-content>
-        <fdp-dynamic-page-content id="tab2" [tabLabel]="tabLabel2">DynamicPage Content Tabbed 2 Text</fdp-dynamic-page-content>
+        <fdp-dynamic-page-content id="tab1" [tabLabel]="tabLabel1"
+            >DynamicPage Content Tabbed 1 Text</fdp-dynamic-page-content
+        >
+        <fdp-dynamic-page-content id="tab2" [tabLabel]="tabLabel2"
+            >DynamicPage Content Tabbed 2 Text</fdp-dynamic-page-content
+        >
     </fdp-dynamic-page>`
 })
 class TestTabbedComponent {
@@ -243,15 +247,13 @@ describe('DynamicPageComponent tabbed values', () => {
         fixture.detectChanges();
         const tab2: HTMLElement = fixture.debugElement.query(By.css('#tab2')).nativeElement;
         expect(tab2.getAttribute('aria-expanded')).toBe('true');
-    })
+    });
 });
 
 @Component({
     template: `<fdp-dynamic-page [size]="size" [background]="background">
         <fdp-dynamic-page-title></fdp-dynamic-page-title>
-        <fdp-dynamic-page-header
-            [collapsible]="false"
-            [pinnable]="false"></fdp-dynamic-page-header>
+        <fdp-dynamic-page-header [collapsible]="false" [pinnable]="false"></fdp-dynamic-page-header>
         <fdp-dynamic-page-content>DynamicPage Content</fdp-dynamic-page-content>
     </fdp-dynamic-page>`
 })
@@ -298,5 +300,4 @@ describe('DynamicPageComponent with collapsible set to false', () => {
             .nativeElement;
         expect(contentEl.getAttribute('aria-hidden')).toBe('false');
     });
-
 });

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.spec.ts
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.spec.ts
@@ -1,10 +1,9 @@
-import { ScrollingModule } from '@angular/cdk/scrolling';
 import { CommonModule } from '@angular/common';
-import { Component, ViewChild } from '@angular/core';
+import { Component, QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { TabsModule, ToolbarModule } from '@fundamental-ngx/core';
+import { TabPanelComponent, TabsModule, ToolbarModule } from '@fundamental-ngx/core';
 import {
     CLASS_NAME,
     DynamicPageComponent,
@@ -63,7 +62,7 @@ describe('DynamicPageComponent default values', () => {
     beforeEach(async(() => {
         const scrollableSpy = jasmine.createSpyObj('DynamicPageService', ['expandHeader', 'collapseHeader']);
         TestBed.configureTestingModule({
-            imports: [CommonModule, PlatformDynamicPageModule, ToolbarModule, ScrollingModule],
+            imports: [CommonModule, PlatformDynamicPageModule, ToolbarModule],
             declarations: [TestComponent],
             providers: [{ provide: DynamicPageService, useValue: scrollableSpy }]
         }).compileComponents();
@@ -192,8 +191,8 @@ describe('DynamicPageComponent default values', () => {
     template: `<fdp-dynamic-page [size]="size" [background]="background">
         <fdp-dynamic-page-title></fdp-dynamic-page-title>
         <fdp-dynamic-page-header></fdp-dynamic-page-header>
-        <fdp-dynamic-page-content [tabLabel]="tabLabel1">DynamicPage Content Tabbed 1 Text</fdp-dynamic-page-content>
-        <fdp-dynamic-page-content [tabLabel]="tabLabel2">DynamicPage Content Tabbed 2 Text</fdp-dynamic-page-content>
+        <fdp-dynamic-page-content id="tab1" [tabLabel]="tabLabel1">DynamicPage Content Tabbed 1 Text</fdp-dynamic-page-content>
+        <fdp-dynamic-page-content id="tab2" [tabLabel]="tabLabel2">DynamicPage Content Tabbed 2 Text</fdp-dynamic-page-content>
     </fdp-dynamic-page>`
 })
 class TestTabbedComponent {
@@ -210,7 +209,7 @@ describe('DynamicPageComponent tabbed values', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, PlatformDynamicPageModule, TabsModule, ScrollingModule],
+            imports: [CommonModule, PlatformDynamicPageModule, TabsModule],
             declarations: [TestTabbedComponent],
             providers: [{ provide: DynamicPageService }]
         }).compileComponents();
@@ -238,6 +237,13 @@ describe('DynamicPageComponent tabbed values', () => {
         const tabsContainer = fixture.debugElement.query(By.css('.fd-tabs'));
         expect(tabsContainer.nativeElement.classList.contains(CLASS_NAME.dynamicPageTabsMedium)).toBeTruthy();
     });
+
+    it('should switch tabs', async () => {
+        dynamicPageComponent.setSelectedTab('tab2');
+        fixture.detectChanges();
+        const tab2: HTMLElement = fixture.debugElement.query(By.css('#tab2')).nativeElement;
+        expect(tab2.getAttribute('aria-expanded')).toBe('true');
+    })
 });
 
 @Component({
@@ -261,7 +267,7 @@ describe('DynamicPageComponent with collapsible set to false', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, PlatformDynamicPageModule, TabsModule, ScrollingModule],
+            imports: [CommonModule, PlatformDynamicPageModule, TabsModule],
             declarations: [TestNonCollapsibleComponent],
             providers: [{ provide: DynamicPageService }]
         }).compileComponents();

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.ts
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.ts
@@ -89,6 +89,9 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
     @ViewChildren(DynamicPageTabbedContentComponent)
     tabContents: QueryList<DynamicPageTabbedContentComponent>;
 
+    @ViewChildren(TabPanelComponent)
+    dynamicPageTabs: QueryList<TabPanelComponent>;
+
     /**
      * @hidden
      * reference to header container
@@ -211,6 +214,19 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
     toggleCollapse(): void {
         if (this.headerCollapsible) {
             this._dynamicPageService.toggleHeader();
+        }
+    }
+
+    /**
+     * marks the dynamic page tab as selected when the id of the tab is passed
+     */
+    setSelectedTab(id: string): void {
+        if (id && this.dynamicPageTabs) {
+            this.dynamicPageTabs.forEach((element) => {
+                if (element.id === id) {
+                    element.open(true);
+                }
+            });
         }
     }
 

--- a/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.ts
+++ b/libs/platform/src/lib/components/dynamic-page/dynamic-page.component.ts
@@ -221,13 +221,15 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
      * marks the dynamic page tab as selected when the id of the tab is passed
      */
     setSelectedTab(id: string): void {
-        if (id && this.dynamicPageTabs) {
-            this.dynamicPageTabs.forEach((element) => {
-                if (element.id === id) {
-                    element.open(true);
-                }
-            });
+        if (!(id && this.dynamicPageTabs)) {
+            return;
         }
+
+        this.dynamicPageTabs.forEach((element) => {
+            if (element.id === id) {
+                element.open(true);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes #4530 
#### Please provide a brief summary of this pull request.
This PR allows one to programmatically set the Dynamic Page's tabs as the selected one. To see this in action, check the example `Tabbed Dynamic Page`, switch over to Tab 2 and click the button `Switch to Tab 1`. This should switch the tab to Tab 1.
![image](https://user-images.githubusercontent.com/53509521/106720730-cfbe9c80-6629-11eb-97cf-44df21a713ea.png)

To programmatically switch/set the dynamic page tab, call `setSelectedTab(id)` on the DynamicPageComponent and pass in the id of the tab to switch/set to.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

