### PR TITLE
test: (e2e) add radio button group e2e tests

### DIFF
--- a/e2e/wdio/platform/fixtures/testData/radio-button-group.ts
+++ b/e2e/wdio/platform/fixtures/testData/radio-button-group.ts
@@ -50,6 +50,8 @@ const springValue = 'spring';
 const springIndex = 1;
 const marchIndex = 2;
 const autumnIndex = 3;
+const ariaChecked = 'aria-checked';
+const ngReflectIsDisabled = 'ng-reflect-is-disabled';
 
 export {
     radioButtonWithDefaultStateAndSelectionIndex,
@@ -103,5 +105,7 @@ export {
     radioButtonWithDisabledItemsCreatedFromSelectItem,
     submitDisabledRadioButtonWithValidationErrorIndex,
     submitRadioButtonHaveValidationError,
-    submitRadioButtonWithListOfSelectItemObjects
+    submitRadioButtonWithListOfSelectItemObjects,
+    ariaChecked,
+    ngReflectIsDisabled
 };

--- a/e2e/wdio/platform/fixtures/testData/radio-button-group.ts
+++ b/e2e/wdio/platform/fixtures/testData/radio-button-group.ts
@@ -1,0 +1,107 @@
+const radioButtonWithDefaultStateAndSelectionIndex = 0;
+const radioButtonInlineCozyRadioGroup = 1;
+const radioButtonWithDefaultPropertyValues = 2;
+const radioButtonWithDisabledButtonAndValidationError = 3;
+const radioButtonUsingFormGroupAndFormControl = 4;
+const radioButtonInlineWithDefaultSelection = 5;
+const radioButtonInlineCompact = 6;
+const radioButtonWithDisabledItem = 7;
+const radioButtonHaveValidationError = 8;
+const radioButtonWithNoSelectionValue = 9;
+const radioButtonWithFormGroupAndFormControl = 10;
+const radioButtonWithPreSelection = 11;
+const radioButtonWithGivenListOfStringValues = 12;
+const radioButtonWithListOfSelectItemObjects = 13;
+const radioButtonVertical = 14;
+const radioButtonVerticalQualificationForm = 15;
+const radioButtonWithSelectItemsFormGroupAndFormControl = 18;
+const radioButtonWithPreSelectionOnObjectDataPassed = 19;
+const radioButtonWithPreSelectionBasedOnControlValue = 21;
+const platformRadioButtonWithSelectiemObject = 22;
+const radioButtonWithLookupKeyAndDisplayKey = 23;
+const radioButtonWithDisabledContentAndFormcontrol = 24;
+const radioButtonWithSomeDisabledButtons = 25;
+const radioButtonCreatedFromList = 26;
+const radioButtonDisabledWithSelectedItem = 27;
+const radioButtonWithDisabledButtonsFromSelectitemObject = 28;
+const radioButtonWithDisabledButtonsDrivenForm = 29;
+const radioButtonWithIndividualButtonDisabled = 30;
+const radioButtonDisabledCreatedFromList = 31;
+const radioButtonDisabledCreatedFromSelectItem = 32;
+const radioButtonWithDisabledItemsCreatedFromSelectItem = 33;
+const resetDisabledValidationGroupButtonIndex = 21;
+const resetHaveValidationErrorIndex = 44;
+const resetListOfSelectitemObjectIndex = 51;
+const resetVerticalRadioGroupButtonIndex = 54;
+const resetQualificationFormButtonIndex = 59;
+const submitDisabledRadioButtonWithValidationErrorIndex = 20;
+const submitRadioButtonHaveValidationError = 43;
+const submitRadioButtonWithListOfSelectItemObjects = 50;
+const orientation = ['vertical', 'horizontal'];
+const monthNames = ['january', 'february', 'march', 'april'];
+const seasonsNames = ['winter', 'spring', 'summer', 'autumn'];
+const winterValue = 'winter';
+const januaryValue = 'january';
+const autumnValue = 'autumn';
+const noneValue = 'none';
+const marchValue = 'march';
+const samsungValue = 'samsung';
+const springValue = 'spring';
+const springIndex = 1;
+const marchIndex = 2;
+const autumnIndex = 3;
+
+export {
+    radioButtonWithDefaultStateAndSelectionIndex,
+    orientation,
+    winterValue,
+    radioButtonInlineCozyRadioGroup,
+    radioButtonWithDefaultPropertyValues,
+    radioButtonWithDisabledButtonAndValidationError,
+    januaryValue,
+    monthNames,
+    resetDisabledValidationGroupButtonIndex,
+    marchIndex,
+    radioButtonUsingFormGroupAndFormControl,
+    marchValue,
+    radioButtonInlineWithDefaultSelection,
+    radioButtonInlineCompact,
+    radioButtonWithDisabledItem,
+    radioButtonHaveValidationError,
+    resetHaveValidationErrorIndex,
+    radioButtonWithNoSelectionValue,
+    noneValue,
+    radioButtonWithFormGroupAndFormControl,
+    radioButtonWithPreSelection,
+    radioButtonWithGivenListOfStringValues,
+    radioButtonWithListOfSelectItemObjects,
+    resetListOfSelectitemObjectIndex,
+    seasonsNames,
+    radioButtonVertical,
+    resetVerticalRadioGroupButtonIndex,
+    resetQualificationFormButtonIndex,
+    radioButtonWithSelectItemsFormGroupAndFormControl,
+    radioButtonVerticalQualificationForm,
+    autumnIndex,
+    autumnValue,
+    radioButtonWithPreSelectionOnObjectDataPassed,
+    springIndex,
+    springValue,
+    radioButtonWithPreSelectionBasedOnControlValue,
+    platformRadioButtonWithSelectiemObject,
+    samsungValue,
+    radioButtonWithLookupKeyAndDisplayKey,
+    radioButtonWithDisabledContentAndFormcontrol,
+    radioButtonWithSomeDisabledButtons,
+    radioButtonCreatedFromList,
+    radioButtonDisabledWithSelectedItem,
+    radioButtonWithDisabledButtonsFromSelectitemObject,
+    radioButtonWithDisabledButtonsDrivenForm,
+    radioButtonWithIndividualButtonDisabled,
+    radioButtonDisabledCreatedFromList,
+    radioButtonDisabledCreatedFromSelectItem,
+    radioButtonWithDisabledItemsCreatedFromSelectItem,
+    submitDisabledRadioButtonWithValidationErrorIndex,
+    submitRadioButtonHaveValidationError,
+    submitRadioButtonWithListOfSelectItemObjects
+};

--- a/e2e/wdio/platform/fixtures/testData/radio-button-group.ts
+++ b/e2e/wdio/platform/fixtures/testData/radio-button-group.ts
@@ -1,111 +1,54 @@
-const radioButtonWithDefaultStateAndSelectionIndex = 0;
-const radioButtonInlineCozyRadioGroup = 1;
-const radioButtonWithDefaultPropertyValues = 2;
-const radioButtonWithDisabledButtonAndValidationError = 3;
-const radioButtonUsingFormGroupAndFormControl = 4;
-const radioButtonInlineWithDefaultSelection = 5;
-const radioButtonInlineCompact = 6;
-const radioButtonWithDisabledItem = 7;
-const radioButtonHaveValidationError = 8;
-const radioButtonWithNoSelectionValue = 9;
-const radioButtonWithFormGroupAndFormControl = 10;
-const radioButtonWithPreSelection = 11;
-const radioButtonWithGivenListOfStringValues = 12;
-const radioButtonWithListOfSelectItemObjects = 13;
-const radioButtonVertical = 14;
-const radioButtonVerticalQualificationForm = 15;
-const radioButtonWithSelectItemsFormGroupAndFormControl = 18;
-const radioButtonWithPreSelectionOnObjectDataPassed = 19;
-const radioButtonWithPreSelectionBasedOnControlValue = 21;
-const platformRadioButtonWithSelectiemObject = 22;
-const radioButtonWithLookupKeyAndDisplayKey = 23;
-const radioButtonWithDisabledContentAndFormcontrol = 24;
-const radioButtonWithSomeDisabledButtons = 25;
-const radioButtonCreatedFromList = 26;
-const radioButtonDisabledWithSelectedItem = 27;
-const radioButtonWithDisabledButtonsFromSelectitemObject = 28;
-const radioButtonWithDisabledButtonsDrivenForm = 29;
-const radioButtonWithIndividualButtonDisabled = 30;
-const radioButtonDisabledCreatedFromList = 31;
-const radioButtonDisabledCreatedFromSelectItem = 32;
-const radioButtonWithDisabledItemsCreatedFromSelectItem = 33;
-const resetDisabledValidationGroupButtonIndex = 21;
-const resetHaveValidationErrorIndex = 44;
-const resetListOfSelectitemObjectIndex = 51;
-const resetVerticalRadioGroupButtonIndex = 54;
-const resetQualificationFormButtonIndex = 59;
-const submitDisabledRadioButtonWithValidationErrorIndex = 20;
-const submitRadioButtonHaveValidationError = 43;
-const submitRadioButtonWithListOfSelectItemObjects = 50;
-const orientation = ['vertical', 'horizontal'];
-const monthNames = ['january', 'february', 'march', 'april'];
-const seasonsNames = ['winter', 'spring', 'summer', 'autumn'];
-const winterValue = 'winter';
-const januaryValue = 'january';
-const autumnValue = 'autumn';
-const noneValue = 'none';
-const marchValue = 'march';
-const samsungValue = 'samsung';
-const springValue = 'spring';
-const springIndex = 1;
-const marchIndex = 2;
-const autumnIndex = 3;
-const ariaChecked = 'aria-checked';
-const ngReflectIsDisabled = 'ng-reflect-is-disabled';
-
-export {
-    radioButtonWithDefaultStateAndSelectionIndex,
-    orientation,
-    winterValue,
-    radioButtonInlineCozyRadioGroup,
-    radioButtonWithDefaultPropertyValues,
-    radioButtonWithDisabledButtonAndValidationError,
-    januaryValue,
-    monthNames,
-    resetDisabledValidationGroupButtonIndex,
-    marchIndex,
-    radioButtonUsingFormGroupAndFormControl,
-    marchValue,
-    radioButtonInlineWithDefaultSelection,
-    radioButtonInlineCompact,
-    radioButtonWithDisabledItem,
-    radioButtonHaveValidationError,
-    resetHaveValidationErrorIndex,
-    radioButtonWithNoSelectionValue,
-    noneValue,
-    radioButtonWithFormGroupAndFormControl,
-    radioButtonWithPreSelection,
-    radioButtonWithGivenListOfStringValues,
-    radioButtonWithListOfSelectItemObjects,
-    resetListOfSelectitemObjectIndex,
-    seasonsNames,
-    radioButtonVertical,
-    resetVerticalRadioGroupButtonIndex,
-    resetQualificationFormButtonIndex,
-    radioButtonWithSelectItemsFormGroupAndFormControl,
-    radioButtonVerticalQualificationForm,
-    autumnIndex,
-    autumnValue,
-    radioButtonWithPreSelectionOnObjectDataPassed,
-    springIndex,
-    springValue,
-    radioButtonWithPreSelectionBasedOnControlValue,
-    platformRadioButtonWithSelectiemObject,
-    samsungValue,
-    radioButtonWithLookupKeyAndDisplayKey,
-    radioButtonWithDisabledContentAndFormcontrol,
-    radioButtonWithSomeDisabledButtons,
-    radioButtonCreatedFromList,
-    radioButtonDisabledWithSelectedItem,
-    radioButtonWithDisabledButtonsFromSelectitemObject,
-    radioButtonWithDisabledButtonsDrivenForm,
-    radioButtonWithIndividualButtonDisabled,
-    radioButtonDisabledCreatedFromList,
-    radioButtonDisabledCreatedFromSelectItem,
-    radioButtonWithDisabledItemsCreatedFromSelectItem,
-    submitDisabledRadioButtonWithValidationErrorIndex,
-    submitRadioButtonHaveValidationError,
-    submitRadioButtonWithListOfSelectItemObjects,
-    ariaChecked,
-    ngReflectIsDisabled
-};
+export const radioButtonWithDefaultStateAndSelectionIndex = 0;
+export const radioButtonInlineCozyRadioGroup = 1;
+export const radioButtonWithDefaultPropertyValues = 2;
+export const radioButtonWithDisabledButtonAndValidationError = 3;
+export const radioButtonUsingFormGroupAndFormControl = 4;
+export const radioButtonInlineWithDefaultSelection = 5;
+export const radioButtonInlineCompact = 6;
+export const radioButtonWithDisabledItem = 7;
+export const radioButtonHaveValidationError = 8;
+export const radioButtonWithNoSelectionValue = 9;
+export const radioButtonWithFormGroupAndFormControl = 10;
+export const radioButtonWithPreSelection = 11;
+export const radioButtonWithGivenListOfStringValues = 12;
+export const radioButtonWithListOfSelectItemObjects = 13;
+export const radioButtonVertical = 14;
+export const radioButtonVerticalQualificationForm = 15;
+export const radioButtonWithSelectItemsFormGroupAndFormControl = 18;
+export const radioButtonWithPreSelectionOnObjectDataPassed = 19;
+export const radioButtonWithPreSelectionBasedOnControlValue = 21;
+export const platformRadioButtonWithSelectiemObject = 22;
+export const radioButtonWithLookupKeyAndDisplayKey = 23;
+export const radioButtonWithDisabledContentAndFormcontrol = 24;
+export const radioButtonWithSomeDisabledButtons = 25;
+export const radioButtonCreatedFromList = 26;
+export const radioButtonDisabledWithSelectedItem = 27;
+export const radioButtonWithDisabledButtonsFromSelectitemObject = 28;
+export const radioButtonWithDisabledButtonsDrivenForm = 29;
+export const radioButtonWithIndividualButtonDisabled = 30;
+export const radioButtonDisabledCreatedFromList = 31;
+export const radioButtonDisabledCreatedFromSelectItem = 32;
+export const radioButtonWithDisabledItemsCreatedFromSelectItem = 33;
+export const resetDisabledValidationGroupButtonIndex = 21;
+export const resetHaveValidationErrorIndex = 44;
+export const resetListOfSelectitemObjectIndex = 51;
+export const resetVerticalRadioGroupButtonIndex = 54;
+export const resetQualificationFormButtonIndex = 59;
+export const submitDisabledRadioButtonWithValidationErrorIndex = 20;
+export const submitRadioButtonHaveValidationError = 43;
+export const submitRadioButtonWithListOfSelectItemObjects = 50;
+export const orientation = ['vertical', 'horizontal'];
+export const monthNames = ['january', 'february', 'march', 'april'];
+export const seasonsNames = ['winter', 'spring', 'summer', 'autumn'];
+export const winterValue = 'winter';
+export const januaryValue = 'january';
+export const autumnValue = 'autumn';
+export const noneValue = 'none';
+export const marchValue = 'march';
+export const samsungValue = 'samsung';
+export const springValue = 'spring';
+export const springIndex = 1;
+export const marchIndex = 2;
+export const autumnIndex = 3;
+export const ariaChecked = 'aria-checked';
+export const ngReflectIsDisabled = 'ng-reflect-is-disabled';

--- a/e2e/wdio/platform/pages/radio-button-group.po.ts
+++ b/e2e/wdio/platform/pages/radio-button-group.po.ts
@@ -1,0 +1,28 @@
+import { BaseComponentPo } from './base-component.po';
+import { waitForElDisplayed, waitForPresent } from '../../driver/wdio';
+
+export class RadioButtonGroupPage extends BaseComponentPo {
+    url = '/radio-group';
+    root = '#page-content';
+    containersArr = 'component-example .fd-container';
+    selectedValueLabel = '//p[contains(text(), "Selected")]';
+    preferredBrandLabel = '//p[contains(text(), "Preferred Brand:")]';
+    radioButtonForm = '.fd-form-group fdp-input-message-group';
+    radioButtons = 'fd-form-group .fd-form-item label.fd-radio__label';
+    formGroup = 'fd-form-group[role=radiogroup]';
+    errorMessage = '.is-error';
+
+    radioButtonInputByName = (name: number = 0) => {
+        return `[id="fd-popover-${name}"] input`;
+    };
+
+    actionButtonByName = (name: number = 8) => {
+        return `#fdp-id-${name}`;
+    };
+
+    open(): void {
+        super.open(this.url);
+        waitForElDisplayed(this.root);
+        waitForPresent(this.formGroup);
+    }
+}

--- a/e2e/wdio/platform/pages/radio-button-group.po.ts
+++ b/e2e/wdio/platform/pages/radio-button-group.po.ts
@@ -12,16 +12,16 @@ export class RadioButtonGroupPage extends BaseComponentPo {
     formGroup = 'fd-form-group[role=radiogroup]';
     errorMessage = '.is-error';
 
-    radioButtonInputByName = (name: number = 0) => {
-        return `[id="fd-popover-${name}"] input`;
+    radioButtonInputByIndex = (index: number = 0) => {
+        return `[id="fd-popover-${index}"] input`;
     };
 
-    radioButtonLabelByName = (name: number = 0) => {
-        return `[id="fd-popover-${name}"] label`;
+    radioButtonLabelByIndex = (index: number = 0) => {
+        return `[id="fd-popover-${index}"] label`;
     };
 
-    actionButtonByName = (name: number = 8) => {
-        return `#fdp-id-${name}`;
+    actionButtonByIndex = (index: number = 8) => {
+        return `#fdp-id-${index}`;
     };
 
     open(): void {

--- a/e2e/wdio/platform/pages/radio-button-group.po.ts
+++ b/e2e/wdio/platform/pages/radio-button-group.po.ts
@@ -16,6 +16,10 @@ export class RadioButtonGroupPage extends BaseComponentPo {
         return `[id="fd-popover-${name}"] input`;
     };
 
+    radioButtonLabelByName = (name: number = 0) => {
+        return `[id="fd-popover-${name}"] label`;
+    };
+
     actionButtonByName = (name: number = 8) => {
         return `#fdp-id-${name}`;
     };

--- a/e2e/wdio/platform/tests/radio-button-group.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/radio-button-group.e2e-spec.ts
@@ -1,0 +1,440 @@
+import { RadioButtonGroupPage } from '../pages/radio-button-group.po';
+import {
+    click, elementArray,
+    getAttributeByName,
+    getElementArrayLength, getText,
+    refreshPage,
+    scrollIntoView,
+    waitForElDisplayed
+} from '../../driver/wdio';
+
+import {
+    radioButtonWithDefaultStateAndSelectionIndex,
+    orientation,
+    winterValue,
+    radioButtonInlineCozyRadioGroup,
+    radioButtonWithDefaultPropertyValues,
+    radioButtonWithDisabledButtonAndValidationError,
+    januaryValue,
+    monthNames,
+    resetDisabledValidationGroupButtonIndex,
+    marchIndex,
+    radioButtonUsingFormGroupAndFormControl,
+    marchValue,
+    radioButtonInlineWithDefaultSelection,
+    radioButtonInlineCompact,
+    radioButtonWithDisabledItem,
+    radioButtonHaveValidationError,
+    resetHaveValidationErrorIndex,
+    radioButtonWithNoSelectionValue,
+    noneValue,
+    radioButtonWithFormGroupAndFormControl,
+    radioButtonWithPreSelection,
+    radioButtonWithGivenListOfStringValues,
+    radioButtonWithListOfSelectItemObjects,
+    resetListOfSelectitemObjectIndex,
+    seasonsNames,
+    radioButtonVertical,
+    resetVerticalRadioGroupButtonIndex,
+    resetQualificationFormButtonIndex,
+    radioButtonWithSelectItemsFormGroupAndFormControl,
+    radioButtonVerticalQualificationForm,
+    autumnIndex,
+    autumnValue,
+    radioButtonWithPreSelectionOnObjectDataPassed,
+    springIndex,
+    springValue,
+    radioButtonWithPreSelectionBasedOnControlValue,
+    platformRadioButtonWithSelectiemObject,
+    samsungValue,
+    radioButtonWithLookupKeyAndDisplayKey,
+    radioButtonWithDisabledContentAndFormcontrol,
+    radioButtonWithSomeDisabledButtons,
+    radioButtonCreatedFromList,
+    radioButtonDisabledWithSelectedItem,
+    radioButtonWithDisabledButtonsFromSelectitemObject,
+    radioButtonWithDisabledButtonsDrivenForm,
+    radioButtonWithIndividualButtonDisabled,
+    radioButtonDisabledCreatedFromList,
+    radioButtonDisabledCreatedFromSelectItem,
+    radioButtonWithDisabledItemsCreatedFromSelectItem,
+    submitDisabledRadioButtonWithValidationErrorIndex,
+    submitRadioButtonHaveValidationError,
+    submitRadioButtonWithListOfSelectItemObjects
+
+} from '../fixtures/testData/radio-button-group';
+
+describe('Radio button group  Test Suite', function() {
+    const radioButtonGroupPage: RadioButtonGroupPage = new RadioButtonGroupPage();
+    const {
+        formGroup, selectedValueLabel, preferredBrandLabel
+    } = radioButtonGroupPage;
+
+    beforeAll(() => {
+        radioButtonGroupPage.open();
+    }, 1);
+
+    afterEach(() => {
+        refreshPage();
+    });
+
+    it('Verify Radio button buttons can be aligned vertically and horizontally.', () => {
+        const groupButtons = elementArray(formGroup);
+        for (let i = 1; i < groupButtons.length; i++) {
+            expect(orientation).toContain(getAttributeByName(formGroup, 'aria-orientation', i));
+        }
+
+    });
+
+    it('Compact radio group with "default" state and with default selection', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultStateAndSelectionIndex));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultStateAndSelectionIndex));
+        expect(getText(selectedValueLabel)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName()
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify Inline cozy radio group', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCozyRadioGroup));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCozyRadioGroup));
+        expect(getText(selectedValueLabel, radioButtonInlineCozyRadioGroup)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCozyRadioGroup)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify radio group with default property values', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultPropertyValues));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultPropertyValues));
+        expect(getText(selectedValueLabel, radioButtonWithDefaultPropertyValues)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultPropertyValues)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify radio group with disabled button and validation error', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
+        expect(getText(selectedValueLabel, radioButtonWithDisabledButtonAndValidationError)).toContain(januaryValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError)
+            , 'aria-checked')).toBe('true');
+        click(radioButtonGroupPage.actionButtonByName(resetDisabledValidationGroupButtonIndex));
+        expect(monthNames).not.toContain(getText(selectedValueLabel, radioButtonWithDisabledButtonAndValidationError));
+    });
+
+
+    it('Verify radio group using FormGroup and FormControl', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl), marchIndex);
+        expect(getText(selectedValueLabel, radioButtonUsingFormGroupAndFormControl)).toContain(marchValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl)
+            , 'ng-reflect-is-disabled')).toBe('true');
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl)
+            , 'aria-checked', marchIndex)).toBe('true');
+    });
+
+    it('Verify inline compact radio group with default selection', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineWithDefaultSelection));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineWithDefaultSelection));
+        expect(getText(selectedValueLabel, radioButtonInlineWithDefaultSelection)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineWithDefaultSelection)
+            , 'aria-checked')).toBe('true');
+
+    });
+
+    it('Verify inline compact radio group', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCompact));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCompact));
+        expect(getText(selectedValueLabel, radioButtonInlineCompact)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCompact)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify radio group using FormGroup and FormControl', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem), marchIndex);
+        expect(getText(selectedValueLabel, radioButtonWithDisabledItem)).toContain(marchValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem)
+            , 'ng-reflect-is-disabled')).toBe('true');
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem)
+            , 'aria-checked', marchIndex)).toBe('true');
+    });
+
+    it('Verify radio group with disabled button and validation error', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError));
+        expect(getText(selectedValueLabel, radioButtonHaveValidationError).toLowerCase()).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError)
+            , 'aria-checked')).toBe('true');
+        click(radioButtonGroupPage.actionButtonByName(resetHaveValidationErrorIndex));
+        expect(monthNames).not.toContain(getText(selectedValueLabel, radioButtonHaveValidationError));
+    });
+
+    it('Verify platform radio button with None (No selection) value created as an Option', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue));
+        expect(getText(selectedValueLabel, radioButtonWithNoSelectionValue).toLowerCase()).toContain(noneValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue)
+            , 'aria-checked')).toBe('true');
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue), 1);
+        expect(getText(selectedValueLabel, radioButtonWithNoSelectionValue).toLowerCase()).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue)
+            , 'aria-checked', 1)).toBe('true');
+    });
+
+    it('Verify radio group using FormGroup and FormControl with List of String Values', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithFormGroupAndFormControl));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithFormGroupAndFormControl));
+        expect(getText(selectedValueLabel, radioButtonWithFormGroupAndFormControl).toLowerCase()).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithFormGroupAndFormControl)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify Creating platform radio button with list of string values also pre-selection based on control value', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelection));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelection));
+        expect(getText(selectedValueLabel, radioButtonWithPreSelection).toLowerCase()).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelection)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify Creating platform radio button with given list of string values', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithGivenListOfStringValues));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithGivenListOfStringValues));
+        expect(getText(selectedValueLabel, radioButtonWithGivenListOfStringValues).toLowerCase()).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithGivenListOfStringValues)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify platform radio buttons created with given list of SelectItem objects and have validation error', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
+        expect(getText(selectedValueLabel, radioButtonWithListOfSelectItemObjects)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects)
+            , 'aria-checked')).toBe('true');
+        click(radioButtonGroupPage.actionButtonByName(resetListOfSelectitemObjectIndex));
+        expect(seasonsNames).not.toContain(getText(selectedValueLabel, radioButtonWithListOfSelectItemObjects));
+    });
+
+    it('Verify Vertical radio group', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonVertical));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonVertical));
+        expect(getText(selectedValueLabel, radioButtonVertical)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonVertical)
+            , 'aria-checked')).toBe('true');
+        click(radioButtonGroupPage.actionButtonByName(resetVerticalRadioGroupButtonIndex));
+        expect(seasonsNames).not.toContain(getText(selectedValueLabel, radioButtonVertical));
+    });
+
+    it('Verify qualification form', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonVerticalQualificationForm));
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonVerticalQualificationForm));
+        for (let i = 0; i < radioButtonsLength; i++) {
+            click(radioButtonGroupPage.radioButtonInputByName(radioButtonVerticalQualificationForm), i);
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonVerticalQualificationForm)
+                , 'aria-checked', i)).toBe('true');
+        }
+        click(radioButtonGroupPage.actionButtonByName(resetQualificationFormButtonIndex));
+    });
+
+    it('Verify compact platform radio button created with given list of SelectItem objects.Using FormGroup and FormControl', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl), autumnIndex);
+        expect(getText(selectedValueLabel, radioButtonWithSelectItemsFormGroupAndFormControl - 4)).toContain(autumnValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl)
+            , 'aria-checked', autumnIndex)).toBe('true');
+    });
+
+    it('Verify platform radio button creation and pre-selection based on object data passed.', () => {
+        expect(getText(selectedValueLabel, 15)).toContain(springValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
+            , 'aria-checked', springIndex)).toBe('true');
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed));
+        expect(getText(selectedValueLabel, radioButtonWithPreSelectionOnObjectDataPassed - 4)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify platform radio buttons created with given list of SelectItem objects also pre-selection based on control value', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue));
+        expect(getText(selectedValueLabel, radioButtonWithPreSelectionBasedOnControlValue - 5)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify platform radio button created with given list of SelectItem objects', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject));
+        click(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject));
+        expect(getText(selectedValueLabel, platformRadioButtonWithSelectiemObject - 5)).toContain(winterValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify platform Radio Button created from Invoice objects. Using LookupKey and DisplayKey.', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey));
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey));
+        expect(getText(preferredBrandLabel)).toContain(samsungValue);
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify platform radio buttons Passed as content projection and some radio buttons are disabled', () => {
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol));
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol));
+        for (let i = 0; i < radioButtonsLength; i++) {
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol)
+                , 'ng-reflect-is-disabled', i)).toBe('true');
+        }
+    });
+
+    it('Verify platform radio buttons Passed as content projection and some radio buttons are disabled', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSomeDisabledButtons));
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSomeDisabledButtons)
+            , 'ng-reflect-is-disabled', 2)).toBe('true');
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSomeDisabledButtons)
+            , 'ng-reflect-is-disabled', 3)).toBe('true');
+        click(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject));
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify platform radio button created from list of string values', () => {
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonCreatedFromList));
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonCreatedFromList));
+        for (let i = 0; i < radioButtonsLength; i++) {
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonCreatedFromList)
+                , 'ng-reflect-is-disabled', i)).toBe('true');
+        }
+    });
+
+    it('Verify platform radio buttons created from list of SelectItem objects and FormContol is disabled', () => {
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonDisabledWithSelectedItem));
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem));
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem)
+            , 'ng-reflect-is-disabled')).toBe('true');
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem)
+            , 'aria-checked')).toBe('true');
+        for (let i = 1; i < radioButtonsLength; i++) {
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem)
+                , 'ng-reflect-is-disabled', i)).toBe('true');
+        }
+    });
+
+    it('Verify platform radio buttons created from list of SelectItem objects and some items are disabled', () => {
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject));
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject));
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+            , 'ng-reflect-is-disabled')).toBe('false');
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+            , 'ng-reflect-is-disabled', 1)).toBe('false');
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+            , 'aria-checked', 1)).toBe('true');
+        for (let i = 2; i < radioButtonsLength; i++) {
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+                , 'ng-reflect-is-disabled', i)).toBe('true');
+        }
+    });
+
+    it('Verify platform radio buttons passed as content projection and group is disabled', () => {
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm));
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm));
+        for (let i = 0; i < radioButtonsLength; i++) {
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm)
+                , 'ng-reflect-is-disabled', i)).toBe('true');
+        }
+    });
+
+    it('Verify platform radio buttons passed as content projection and individual radio button is disabled', () => {
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonWithIndividualButtonDisabled));
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled));
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+            , 'ng-reflect-is-disabled')).toBe('false');
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+            , 'ng-reflect-is-disabled', 1)).toBe('false');
+        for (let i = 2; i < radioButtonsLength; i++) {
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+                , 'ng-reflect-is-disabled', i)).toBe('true');
+        }
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled));
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify platform radio buttons created from list of string values and group is disabled', () => {
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonDisabledCreatedFromList));
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledCreatedFromList));
+        for (let i = 0; i < radioButtonsLength; i++) {
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledCreatedFromList)
+                , 'ng-reflect-is-disabled', i)).toBe('true');
+        }
+    });
+
+    it('Verify platform radio buttons created from list of SelectItem and group is disabled', () => {
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem));
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem));
+        for (let i = 0; i < radioButtonsLength; i++) {
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem)
+                , 'ng-reflect-is-disabled', i)).toBe('true');
+        }
+    });
+
+    it('Verify platform radio buttons created from list of SelectItem and individual item has disabled property', () => {
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+            , 'ng-reflect-is-disabled')).toBe('false');
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+            , 'ng-reflect-is-disabled', 1)).toBe('false');
+        for (let i = 2; i < radioButtonsLength; i++) {
+            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+                , 'ng-reflect-is-disabled', i)).toBe('true');
+        }
+        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
+        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+            , 'aria-checked')).toBe('true');
+    });
+
+    it('Verify validation for radio group with disabled button and validation error', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError));
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonHaveValidationError));
+        click(radioButtonGroupPage.actionButtonByName(submitRadioButtonHaveValidationError));
+        for (let i = 0; i < radioButtonsLength; i++) {
+            waitForElDisplayed(radioButtonGroupPage.errorMessage, i);
+        }
+    });
+
+    it('Verify validation for radio group with disabled button and validation error', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
+        click(radioButtonGroupPage.actionButtonByName(submitDisabledRadioButtonWithValidationErrorIndex));
+        for (let i = 0; i < radioButtonsLength; i++) {
+            waitForElDisplayed(radioButtonGroupPage.errorMessage, i);
+        }
+    });
+
+    it('Verify validation for radio buttons created with given list of SelectItem objects and have validation error', () => {
+        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
+        const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
+            .radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
+        click(radioButtonGroupPage.actionButtonByName(submitRadioButtonWithListOfSelectItemObjects));
+        for (let i = 0; i < radioButtonsLength; i++) {
+            waitForElDisplayed(radioButtonGroupPage.errorMessage, i);
+        }
+    });
+
+    it('should be able to switch to rtl', () => {
+        radioButtonGroupPage.checkRtlSwitch();
+    });
+});

--- a/e2e/wdio/platform/tests/radio-button-group.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/radio-button-group.e2e-spec.ts
@@ -88,7 +88,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Compact radio group with "default" state and with default selection', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultStateAndSelectionIndex));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultStateAndSelectionIndex));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDefaultStateAndSelectionIndex));
         expect(getText(selectedValueLabel)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName()
             , 'aria-checked')).toBe('true');
@@ -96,7 +96,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify Inline cozy radio group', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCozyRadioGroup));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCozyRadioGroup));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonInlineCozyRadioGroup));
         expect(getText(selectedValueLabel, radioButtonInlineCozyRadioGroup)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCozyRadioGroup)
             , 'aria-checked')).toBe('true');
@@ -104,7 +104,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify radio group with default property values', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultPropertyValues));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultPropertyValues));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDefaultPropertyValues));
         expect(getText(selectedValueLabel, radioButtonWithDefaultPropertyValues)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultPropertyValues)
             , 'aria-checked')).toBe('true');
@@ -112,7 +112,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify radio group with disabled button and validation error', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDisabledButtonAndValidationError));
         expect(getText(selectedValueLabel, radioButtonWithDisabledButtonAndValidationError)).toContain(januaryValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError)
             , 'aria-checked')).toBe('true');
@@ -123,7 +123,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify radio group using FormGroup and FormControl', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl), marchIndex);
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonUsingFormGroupAndFormControl), marchIndex);
         expect(getText(selectedValueLabel, radioButtonUsingFormGroupAndFormControl)).toContain(marchValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl)
             , 'ng-reflect-is-disabled')).toBe('true');
@@ -133,7 +133,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify inline compact radio group with default selection', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineWithDefaultSelection));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineWithDefaultSelection));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonInlineWithDefaultSelection));
         expect(getText(selectedValueLabel, radioButtonInlineWithDefaultSelection)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineWithDefaultSelection)
             , 'aria-checked')).toBe('true');
@@ -142,7 +142,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify inline compact radio group', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCompact));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCompact));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonInlineCompact));
         expect(getText(selectedValueLabel, radioButtonInlineCompact)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCompact)
             , 'aria-checked')).toBe('true');
@@ -150,7 +150,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify radio group using FormGroup and FormControl', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem), marchIndex);
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDisabledItem), marchIndex);
         expect(getText(selectedValueLabel, radioButtonWithDisabledItem)).toContain(marchValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem)
             , 'ng-reflect-is-disabled')).toBe('true');
@@ -160,7 +160,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify radio group with disabled button and validation error', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonHaveValidationError));
         expect(getText(selectedValueLabel, radioButtonHaveValidationError).toLowerCase()).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError)
             , 'aria-checked')).toBe('true');
@@ -170,11 +170,11 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify platform radio button with None (No selection) value created as an Option', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithNoSelectionValue));
         expect(getText(selectedValueLabel, radioButtonWithNoSelectionValue).toLowerCase()).toContain(noneValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue)
             , 'aria-checked')).toBe('true');
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue), 1);
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithNoSelectionValue), 1);
         expect(getText(selectedValueLabel, radioButtonWithNoSelectionValue).toLowerCase()).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue)
             , 'aria-checked', 1)).toBe('true');
@@ -182,7 +182,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify radio group using FormGroup and FormControl with List of String Values', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithFormGroupAndFormControl));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithFormGroupAndFormControl));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithFormGroupAndFormControl));
         expect(getText(selectedValueLabel, radioButtonWithFormGroupAndFormControl).toLowerCase()).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithFormGroupAndFormControl)
             , 'aria-checked')).toBe('true');
@@ -190,7 +190,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify Creating platform radio button with list of string values also pre-selection based on control value', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelection));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelection));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithPreSelection));
         expect(getText(selectedValueLabel, radioButtonWithPreSelection).toLowerCase()).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelection)
             , 'aria-checked')).toBe('true');
@@ -198,7 +198,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify Creating platform radio button with given list of string values', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithGivenListOfStringValues));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithGivenListOfStringValues));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithGivenListOfStringValues));
         expect(getText(selectedValueLabel, radioButtonWithGivenListOfStringValues).toLowerCase()).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithGivenListOfStringValues)
             , 'aria-checked')).toBe('true');
@@ -206,7 +206,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify platform radio buttons created with given list of SelectItem objects and have validation error', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithListOfSelectItemObjects));
         expect(getText(selectedValueLabel, radioButtonWithListOfSelectItemObjects)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects)
             , 'aria-checked')).toBe('true');
@@ -216,7 +216,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify Vertical radio group', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonVertical));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonVertical));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonVertical));
         expect(getText(selectedValueLabel, radioButtonVertical)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonVertical)
             , 'aria-checked')).toBe('true');
@@ -229,7 +229,7 @@ describe('Radio button group  Test Suite', function() {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonVerticalQualificationForm));
         for (let i = 0; i < radioButtonsLength; i++) {
-            click(radioButtonGroupPage.radioButtonInputByName(radioButtonVerticalQualificationForm), i);
+            click(radioButtonGroupPage.radioButtonLabelByName(radioButtonVerticalQualificationForm), i);
             expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonVerticalQualificationForm)
                 , 'aria-checked', i)).toBe('true');
         }
@@ -238,7 +238,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify compact platform radio button created with given list of SelectItem objects.Using FormGroup and FormControl', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl), autumnIndex);
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithSelectItemsFormGroupAndFormControl), autumnIndex);
         expect(getText(selectedValueLabel, radioButtonWithSelectItemsFormGroupAndFormControl - 4)).toContain(autumnValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl)
             , 'aria-checked', autumnIndex)).toBe('true');
@@ -249,7 +249,7 @@ describe('Radio button group  Test Suite', function() {
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
             , 'aria-checked', springIndex)).toBe('true');
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithPreSelectionOnObjectDataPassed));
         expect(getText(selectedValueLabel, radioButtonWithPreSelectionOnObjectDataPassed - 4)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
             , 'aria-checked')).toBe('true');
@@ -257,7 +257,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify platform radio buttons created with given list of SelectItem objects also pre-selection based on control value', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithPreSelectionBasedOnControlValue));
         expect(getText(selectedValueLabel, radioButtonWithPreSelectionBasedOnControlValue - 5)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue)
             , 'aria-checked')).toBe('true');
@@ -265,7 +265,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify platform radio button created with given list of SelectItem objects', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject));
-        click(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject));
+        click(radioButtonGroupPage.radioButtonLabelByName(platformRadioButtonWithSelectiemObject));
         expect(getText(selectedValueLabel, platformRadioButtonWithSelectiemObject - 5)).toContain(winterValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject)
             , 'aria-checked')).toBe('true');
@@ -273,7 +273,7 @@ describe('Radio button group  Test Suite', function() {
 
     it('Verify platform Radio Button created from Invoice objects. Using LookupKey and DisplayKey.', () => {
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey));
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithLookupKeyAndDisplayKey));
         expect(getText(preferredBrandLabel)).toContain(samsungValue);
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey)
             , 'aria-checked')).toBe('true');
@@ -295,7 +295,7 @@ describe('Radio button group  Test Suite', function() {
             , 'ng-reflect-is-disabled', 2)).toBe('true');
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSomeDisabledButtons)
             , 'ng-reflect-is-disabled', 3)).toBe('true');
-        click(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject));
+        click(radioButtonGroupPage.radioButtonLabelByName(platformRadioButtonWithSelectiemObject));
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject)
             , 'aria-checked')).toBe('true');
     });
@@ -314,11 +314,7 @@ describe('Radio button group  Test Suite', function() {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonDisabledWithSelectedItem));
         scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem));
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem)
-            , 'ng-reflect-is-disabled')).toBe('true');
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem)
-            , 'aria-checked')).toBe('true');
-        for (let i = 1; i < radioButtonsLength; i++) {
+        for (let i = 0; i < radioButtonsLength; i++) {
             expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem)
                 , 'ng-reflect-is-disabled', i)).toBe('true');
         }
@@ -362,7 +358,7 @@ describe('Radio button group  Test Suite', function() {
             expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
                 , 'ng-reflect-is-disabled', i)).toBe('true');
         }
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithIndividualButtonDisabled));
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
             , 'aria-checked')).toBe('true');
     });
@@ -399,7 +395,7 @@ describe('Radio button group  Test Suite', function() {
             expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
                 , 'ng-reflect-is-disabled', i)).toBe('true');
         }
-        click(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
+        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
         expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
             , 'aria-checked')).toBe('true');
     });

--- a/e2e/wdio/platform/tests/radio-button-group.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/radio-button-group.e2e-spec.ts
@@ -70,7 +70,7 @@ import {
 describe('Radio button group  Test Suite', function() {
     const radioButtonGroupPage: RadioButtonGroupPage = new RadioButtonGroupPage();
     const {
-        formGroup, selectedValueLabel, preferredBrandLabel, radioButtonInputByName, radioButtonLabelByName, actionButtonByName
+        formGroup, selectedValueLabel, preferredBrandLabel, radioButtonInputByIndex, radioButtonLabelByIndex, actionButtonByIndex
     } = radioButtonGroupPage;
 
     beforeAll(() => {
@@ -90,251 +90,251 @@ describe('Radio button group  Test Suite', function() {
     });
 
     it('Compact radio group with "default" state and with default selection', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithDefaultStateAndSelectionIndex));
-        click(radioButtonLabelByName(radioButtonWithDefaultStateAndSelectionIndex));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithDefaultStateAndSelectionIndex));
+        click(radioButtonLabelByIndex(radioButtonWithDefaultStateAndSelectionIndex));
         expect(getText(selectedValueLabel)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName()
+        expect(getAttributeByName(radioButtonInputByIndex()
             , ariaChecked)).toBe('true');
     });
 
     it('Verify Inline cozy radio group', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonInlineCozyRadioGroup));
-        click(radioButtonLabelByName(radioButtonInlineCozyRadioGroup));
+        scrollIntoView(radioButtonInputByIndex(radioButtonInlineCozyRadioGroup));
+        click(radioButtonLabelByIndex(radioButtonInlineCozyRadioGroup));
         expect(getText(selectedValueLabel, radioButtonInlineCozyRadioGroup)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonInlineCozyRadioGroup)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonInlineCozyRadioGroup)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify radio group with default property values', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithDefaultPropertyValues));
-        click(radioButtonLabelByName(radioButtonWithDefaultPropertyValues));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithDefaultPropertyValues));
+        click(radioButtonLabelByIndex(radioButtonWithDefaultPropertyValues));
         expect(getText(selectedValueLabel, radioButtonWithDefaultPropertyValues)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDefaultPropertyValues)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDefaultPropertyValues)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify radio group with disabled button and validation error', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
-        click(radioButtonLabelByName(radioButtonWithDisabledButtonAndValidationError));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithDisabledButtonAndValidationError));
+        click(radioButtonLabelByIndex(radioButtonWithDisabledButtonAndValidationError));
         expect(getText(selectedValueLabel, radioButtonWithDisabledButtonAndValidationError)).toContain(januaryValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledButtonAndValidationError)
             , ariaChecked)).toBe('true');
-        click(actionButtonByName(resetDisabledValidationGroupButtonIndex));
+        click(actionButtonByIndex(resetDisabledValidationGroupButtonIndex));
         expect(monthNames).not.toContain(getText(selectedValueLabel, radioButtonWithDisabledButtonAndValidationError));
     });
 
 
     it('Verify radio group using FormGroup and FormControl', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonUsingFormGroupAndFormControl));
-        click(radioButtonLabelByName(radioButtonUsingFormGroupAndFormControl), marchIndex);
+        scrollIntoView(radioButtonInputByIndex(radioButtonUsingFormGroupAndFormControl));
+        click(radioButtonLabelByIndex(radioButtonUsingFormGroupAndFormControl), marchIndex);
         expect(getText(selectedValueLabel, radioButtonUsingFormGroupAndFormControl)).toContain(marchValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonUsingFormGroupAndFormControl)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonUsingFormGroupAndFormControl)
             , ngReflectIsDisabled)).toBe('true');
-        expect(getAttributeByName(radioButtonInputByName(radioButtonUsingFormGroupAndFormControl)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonUsingFormGroupAndFormControl)
             , ariaChecked, marchIndex)).toBe('true');
     });
 
     it('Verify inline compact radio group with default selection', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonInlineWithDefaultSelection));
-        click(radioButtonLabelByName(radioButtonInlineWithDefaultSelection));
+        scrollIntoView(radioButtonInputByIndex(radioButtonInlineWithDefaultSelection));
+        click(radioButtonLabelByIndex(radioButtonInlineWithDefaultSelection));
         expect(getText(selectedValueLabel, radioButtonInlineWithDefaultSelection)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonInlineWithDefaultSelection)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonInlineWithDefaultSelection)
             , ariaChecked)).toBe('true');
 
     });
 
     it('Verify inline compact radio group', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonInlineCompact));
-        click(radioButtonLabelByName(radioButtonInlineCompact));
+        scrollIntoView(radioButtonInputByIndex(radioButtonInlineCompact));
+        click(radioButtonLabelByIndex(radioButtonInlineCompact));
         expect(getText(selectedValueLabel, radioButtonInlineCompact)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonInlineCompact)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonInlineCompact)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify radio group using FormGroup and FormControl', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledItem));
-        click(radioButtonLabelByName(radioButtonWithDisabledItem), marchIndex);
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithDisabledItem));
+        click(radioButtonLabelByIndex(radioButtonWithDisabledItem), marchIndex);
         expect(getText(selectedValueLabel, radioButtonWithDisabledItem)).toContain(marchValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItem)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledItem)
             , ngReflectIsDisabled)).toBe('true');
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItem)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledItem)
             , ariaChecked, marchIndex)).toBe('true');
     });
 
     it('Verify radio group with disabled button and validation error', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonHaveValidationError));
-        click(radioButtonLabelByName(radioButtonHaveValidationError));
+        scrollIntoView(radioButtonInputByIndex(radioButtonHaveValidationError));
+        click(radioButtonLabelByIndex(radioButtonHaveValidationError));
         expect(getText(selectedValueLabel, radioButtonHaveValidationError).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonHaveValidationError)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonHaveValidationError)
             , ariaChecked)).toBe('true');
-        click(actionButtonByName(resetHaveValidationErrorIndex));
+        click(actionButtonByIndex(resetHaveValidationErrorIndex));
         expect(monthNames).not.toContain(getText(selectedValueLabel, radioButtonHaveValidationError));
     });
 
     it('Verify platform radio button with None (No selection) value created as an Option', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithNoSelectionValue));
-        click(radioButtonLabelByName(radioButtonWithNoSelectionValue));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithNoSelectionValue));
+        click(radioButtonLabelByIndex(radioButtonWithNoSelectionValue));
         expect(getText(selectedValueLabel, radioButtonWithNoSelectionValue).toLowerCase()).toContain(noneValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithNoSelectionValue)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithNoSelectionValue)
             , ariaChecked)).toBe('true');
-        click(radioButtonLabelByName(radioButtonWithNoSelectionValue), 1);
+        click(radioButtonLabelByIndex(radioButtonWithNoSelectionValue), 1);
         expect(getText(selectedValueLabel, radioButtonWithNoSelectionValue).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithNoSelectionValue)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithNoSelectionValue)
             , ariaChecked, 1)).toBe('true');
     });
 
     it('Verify radio group using FormGroup and FormControl with List of String Values', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithFormGroupAndFormControl));
-        click(radioButtonLabelByName(radioButtonWithFormGroupAndFormControl));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithFormGroupAndFormControl));
+        click(radioButtonLabelByIndex(radioButtonWithFormGroupAndFormControl));
         expect(getText(selectedValueLabel, radioButtonWithFormGroupAndFormControl).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithFormGroupAndFormControl)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithFormGroupAndFormControl)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify Creating platform radio button with list of string values also pre-selection based on control value', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithPreSelection));
-        click(radioButtonLabelByName(radioButtonWithPreSelection));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithPreSelection));
+        click(radioButtonLabelByIndex(radioButtonWithPreSelection));
         expect(getText(selectedValueLabel, radioButtonWithPreSelection).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithPreSelection)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithPreSelection)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify Creating platform radio button with given list of string values', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithGivenListOfStringValues));
-        click(radioButtonLabelByName(radioButtonWithGivenListOfStringValues));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithGivenListOfStringValues));
+        click(radioButtonLabelByIndex(radioButtonWithGivenListOfStringValues));
         expect(getText(selectedValueLabel, radioButtonWithGivenListOfStringValues).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithGivenListOfStringValues)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithGivenListOfStringValues)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio buttons created with given list of SelectItem objects and have validation error', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
-        click(radioButtonLabelByName(radioButtonWithListOfSelectItemObjects));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithListOfSelectItemObjects));
+        click(radioButtonLabelByIndex(radioButtonWithListOfSelectItemObjects));
         expect(getText(selectedValueLabel, radioButtonWithListOfSelectItemObjects)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithListOfSelectItemObjects)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithListOfSelectItemObjects)
             , ariaChecked)).toBe('true');
-        click(actionButtonByName(resetListOfSelectitemObjectIndex));
+        click(actionButtonByIndex(resetListOfSelectitemObjectIndex));
         expect(seasonsNames).not.toContain(getText(selectedValueLabel, radioButtonWithListOfSelectItemObjects));
     });
 
     it('Verify Vertical radio group', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonVertical));
-        click(radioButtonLabelByName(radioButtonVertical));
+        scrollIntoView(radioButtonInputByIndex(radioButtonVertical));
+        click(radioButtonLabelByIndex(radioButtonVertical));
         expect(getText(selectedValueLabel, radioButtonVertical)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonVertical)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonVertical)
             , ariaChecked)).toBe('true');
-        click(actionButtonByName(resetVerticalRadioGroupButtonIndex));
+        click(actionButtonByIndex(resetVerticalRadioGroupButtonIndex));
         expect(seasonsNames).not.toContain(getText(selectedValueLabel, radioButtonVertical));
     });
 
     it('Verify qualification form', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonVerticalQualificationForm));
+        scrollIntoView(radioButtonInputByIndex(radioButtonVerticalQualificationForm));
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonVerticalQualificationForm));
+            .radioButtonInputByIndex(radioButtonVerticalQualificationForm));
         for (let i = 0; i < radioButtonsLength; i++) {
-            click(radioButtonLabelByName(radioButtonVerticalQualificationForm), i);
-            expect(getAttributeByName(radioButtonInputByName(radioButtonVerticalQualificationForm)
+            click(radioButtonLabelByIndex(radioButtonVerticalQualificationForm), i);
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonVerticalQualificationForm)
                 , ariaChecked, i)).toBe('true');
         }
-        click(actionButtonByName(resetQualificationFormButtonIndex));
+        click(actionButtonByIndex(resetQualificationFormButtonIndex));
     });
 
     it('Verify compact platform radio button created with given list of SelectItem objects.Using FormGroup and FormControl', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl));
-        click(radioButtonLabelByName(radioButtonWithSelectItemsFormGroupAndFormControl), autumnIndex);
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithSelectItemsFormGroupAndFormControl));
+        click(radioButtonLabelByIndex(radioButtonWithSelectItemsFormGroupAndFormControl), autumnIndex);
         expect(getText(selectedValueLabel, radioButtonWithSelectItemsFormGroupAndFormControl - 4)).toContain(autumnValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithSelectItemsFormGroupAndFormControl)
             , ariaChecked, autumnIndex)).toBe('true');
     });
 
     it('Verify platform radio button creation and pre-selection based on object data passed.', () => {
         expect(getText(selectedValueLabel, 15)).toContain(springValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithPreSelectionOnObjectDataPassed)
             , ariaChecked, springIndex)).toBe('true');
-        scrollIntoView(radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed));
-        click(radioButtonLabelByName(radioButtonWithPreSelectionOnObjectDataPassed));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithPreSelectionOnObjectDataPassed));
+        click(radioButtonLabelByIndex(radioButtonWithPreSelectionOnObjectDataPassed));
         expect(getText(selectedValueLabel, radioButtonWithPreSelectionOnObjectDataPassed - 4)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithPreSelectionOnObjectDataPassed)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio buttons created with given list of SelectItem objects also pre-selection based on control value', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue));
-        click(radioButtonLabelByName(radioButtonWithPreSelectionBasedOnControlValue));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithPreSelectionBasedOnControlValue));
+        click(radioButtonLabelByIndex(radioButtonWithPreSelectionBasedOnControlValue));
         expect(getText(selectedValueLabel, radioButtonWithPreSelectionBasedOnControlValue - 5)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithPreSelectionBasedOnControlValue)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio button created with given list of SelectItem objects', () => {
-        scrollIntoView(radioButtonInputByName(platformRadioButtonWithSelectiemObject));
-        click(radioButtonLabelByName(platformRadioButtonWithSelectiemObject));
+        scrollIntoView(radioButtonInputByIndex(platformRadioButtonWithSelectiemObject));
+        click(radioButtonLabelByIndex(platformRadioButtonWithSelectiemObject));
         expect(getText(selectedValueLabel, platformRadioButtonWithSelectiemObject - 5)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonInputByName(platformRadioButtonWithSelectiemObject)
+        expect(getAttributeByName(radioButtonInputByIndex(platformRadioButtonWithSelectiemObject)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify platform Radio Button created from Invoice objects. Using LookupKey and DisplayKey.', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey));
-        click(radioButtonLabelByName(radioButtonWithLookupKeyAndDisplayKey));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithLookupKeyAndDisplayKey));
+        click(radioButtonLabelByIndex(radioButtonWithLookupKeyAndDisplayKey));
         expect(getText(preferredBrandLabel)).toContain(samsungValue);
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithLookupKeyAndDisplayKey)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio buttons Passed as content projection and some radio buttons are disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol));
-        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol));
+            .radioButtonInputByIndex(radioButtonWithDisabledContentAndFormcontrol));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithDisabledContentAndFormcontrol));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol)
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledContentAndFormcontrol)
                 , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons Passed as content projection and some radio buttons are disabled', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithSomeDisabledButtons));
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithSomeDisabledButtons)
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithSomeDisabledButtons));
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithSomeDisabledButtons)
             , ngReflectIsDisabled, 2)).toBe('true');
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithSomeDisabledButtons)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithSomeDisabledButtons)
             , ngReflectIsDisabled, 3)).toBe('true');
-        click(radioButtonLabelByName(platformRadioButtonWithSelectiemObject));
-        expect(getAttributeByName(radioButtonInputByName(platformRadioButtonWithSelectiemObject)
+        click(radioButtonLabelByIndex(platformRadioButtonWithSelectiemObject));
+        expect(getAttributeByName(radioButtonInputByIndex(platformRadioButtonWithSelectiemObject)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio button created from list of string values', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonCreatedFromList));
-        scrollIntoView(radioButtonInputByName(radioButtonCreatedFromList));
+            .radioButtonInputByIndex(radioButtonCreatedFromList));
+        scrollIntoView(radioButtonInputByIndex(radioButtonCreatedFromList));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonInputByName(radioButtonCreatedFromList)
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonCreatedFromList)
                 , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons created from list of SelectItem objects and FormContol is disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonDisabledWithSelectedItem));
-        scrollIntoView(radioButtonInputByName(radioButtonDisabledWithSelectedItem));
+            .radioButtonInputByIndex(radioButtonDisabledWithSelectedItem));
+        scrollIntoView(radioButtonInputByIndex(radioButtonDisabledWithSelectedItem));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonInputByName(radioButtonDisabledWithSelectedItem)
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonDisabledWithSelectedItem)
                 , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons created from list of SelectItem objects and some items are disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject));
-        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject));
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+            .radioButtonInputByIndex(radioButtonWithDisabledButtonsFromSelectitemObject));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithDisabledButtonsFromSelectitemObject));
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledButtonsFromSelectitemObject)
             , ngReflectIsDisabled)).toBe('false');
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledButtonsFromSelectitemObject)
             , ngReflectIsDisabled, 1)).toBe('false');
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledButtonsFromSelectitemObject)
             , ariaChecked, 1)).toBe('true');
         for (let i = 2; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledButtonsFromSelectitemObject)
                 , ngReflectIsDisabled, i)).toBe('true');
         }
     });
@@ -345,93 +345,93 @@ describe('Radio button group  Test Suite', function() {
             return
         }
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm));
-        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm));
+            .radioButtonInputByIndex(radioButtonWithDisabledButtonsDrivenForm));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithDisabledButtonsDrivenForm));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm)
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledButtonsDrivenForm)
                 , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons passed as content projection and individual radio button is disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonWithIndividualButtonDisabled));
-        scrollIntoView(radioButtonInputByName(radioButtonWithIndividualButtonDisabled));
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+            .radioButtonInputByIndex(radioButtonWithIndividualButtonDisabled));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithIndividualButtonDisabled));
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithIndividualButtonDisabled)
             , ngReflectIsDisabled)).toBe('false');
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithIndividualButtonDisabled)
             , ngReflectIsDisabled, 1)).toBe('false');
         for (let i = 2; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithIndividualButtonDisabled)
                 , ngReflectIsDisabled, i)).toBe('true');
         }
-        click(radioButtonLabelByName(radioButtonWithIndividualButtonDisabled));
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+        click(radioButtonLabelByIndex(radioButtonWithIndividualButtonDisabled));
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithIndividualButtonDisabled)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio buttons created from list of string values and group is disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonDisabledCreatedFromList));
-        scrollIntoView(radioButtonInputByName(radioButtonDisabledCreatedFromList));
+            .radioButtonInputByIndex(radioButtonDisabledCreatedFromList));
+        scrollIntoView(radioButtonInputByIndex(radioButtonDisabledCreatedFromList));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonInputByName(radioButtonDisabledCreatedFromList)
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonDisabledCreatedFromList)
                 , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons created from list of SelectItem and group is disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem));
-        scrollIntoView(radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem));
+            .radioButtonInputByIndex(radioButtonDisabledCreatedFromSelectItem));
+        scrollIntoView(radioButtonInputByIndex(radioButtonDisabledCreatedFromSelectItem));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem)
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonDisabledCreatedFromSelectItem)
                 , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons created from list of SelectItem and individual item has disabled property', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
-        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+            .radioButtonInputByIndex(radioButtonWithDisabledItemsCreatedFromSelectItem));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithDisabledItemsCreatedFromSelectItem));
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledItemsCreatedFromSelectItem)
             , ngReflectIsDisabled)).toBe('false');
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledItemsCreatedFromSelectItem)
             , ngReflectIsDisabled, 1)).toBe('false');
         for (let i = 2; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+            expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledItemsCreatedFromSelectItem)
                 , ngReflectIsDisabled, i)).toBe('true');
         }
-        click(radioButtonLabelByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
-        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+        click(radioButtonLabelByIndex(radioButtonWithDisabledItemsCreatedFromSelectItem));
+        expect(getAttributeByName(radioButtonInputByIndex(radioButtonWithDisabledItemsCreatedFromSelectItem)
             , ariaChecked)).toBe('true');
     });
 
     it('Verify validation for radio group with disabled button and validation error', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonHaveValidationError));
+        scrollIntoView(radioButtonInputByIndex(radioButtonHaveValidationError));
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonHaveValidationError));
-        click(actionButtonByName(submitRadioButtonHaveValidationError));
+            .radioButtonInputByIndex(radioButtonHaveValidationError));
+        click(actionButtonByIndex(submitRadioButtonHaveValidationError));
         for (let i = 0; i < radioButtonsLength; i++) {
             waitForElDisplayed(radioButtonGroupPage.errorMessage, i);
         }
     });
 
     it('Verify validation for radio group with disabled button and validation error', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithDisabledButtonAndValidationError));
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
-        click(actionButtonByName(submitDisabledRadioButtonWithValidationErrorIndex));
+            .radioButtonInputByIndex(radioButtonWithDisabledButtonAndValidationError));
+        click(actionButtonByIndex(submitDisabledRadioButtonWithValidationErrorIndex));
         for (let i = 0; i < radioButtonsLength; i++) {
             waitForElDisplayed(radioButtonGroupPage.errorMessage, i);
         }
     });
 
     it('Verify validation for radio buttons created with given list of SelectItem objects and have validation error', () => {
-        scrollIntoView(radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
+        scrollIntoView(radioButtonInputByIndex(radioButtonWithListOfSelectItemObjects));
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
-            .radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
-        click(actionButtonByName(submitRadioButtonWithListOfSelectItemObjects));
+            .radioButtonInputByIndex(radioButtonWithListOfSelectItemObjects));
+        click(actionButtonByIndex(submitRadioButtonWithListOfSelectItemObjects));
         for (let i = 0; i < radioButtonsLength; i++) {
             waitForElDisplayed(radioButtonGroupPage.errorMessage, i);
         }

--- a/e2e/wdio/platform/tests/radio-button-group.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/radio-button-group.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { RadioButtonGroupPage } from '../pages/radio-button-group.po';
 import {
+    browserIsFirefox,
     click, elementArray,
     getAttributeByName,
     getElementArrayLength, getText,
@@ -60,14 +61,16 @@ import {
     radioButtonWithDisabledItemsCreatedFromSelectItem,
     submitDisabledRadioButtonWithValidationErrorIndex,
     submitRadioButtonHaveValidationError,
-    submitRadioButtonWithListOfSelectItemObjects
+    submitRadioButtonWithListOfSelectItemObjects,
+    ariaChecked,
+    ngReflectIsDisabled
 
 } from '../fixtures/testData/radio-button-group';
 
 describe('Radio button group  Test Suite', function() {
     const radioButtonGroupPage: RadioButtonGroupPage = new RadioButtonGroupPage();
     const {
-        formGroup, selectedValueLabel, preferredBrandLabel
+        formGroup, selectedValueLabel, preferredBrandLabel, radioButtonInputByName, radioButtonLabelByName, actionButtonByName
     } = radioButtonGroupPage;
 
     beforeAll(() => {
@@ -76,7 +79,7 @@ describe('Radio button group  Test Suite', function() {
 
     afterEach(() => {
         refreshPage();
-    });
+    }, 1);
 
     it('Verify Radio button buttons can be aligned vertically and horizontally.', () => {
         const groupButtons = elementArray(formGroup);
@@ -87,344 +90,348 @@ describe('Radio button group  Test Suite', function() {
     });
 
     it('Compact radio group with "default" state and with default selection', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultStateAndSelectionIndex));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDefaultStateAndSelectionIndex));
+        scrollIntoView(radioButtonInputByName(radioButtonWithDefaultStateAndSelectionIndex));
+        click(radioButtonLabelByName(radioButtonWithDefaultStateAndSelectionIndex));
         expect(getText(selectedValueLabel)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName()
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName()
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify Inline cozy radio group', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCozyRadioGroup));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonInlineCozyRadioGroup));
+        scrollIntoView(radioButtonInputByName(radioButtonInlineCozyRadioGroup));
+        click(radioButtonLabelByName(radioButtonInlineCozyRadioGroup));
         expect(getText(selectedValueLabel, radioButtonInlineCozyRadioGroup)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCozyRadioGroup)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonInlineCozyRadioGroup)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify radio group with default property values', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultPropertyValues));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDefaultPropertyValues));
+        scrollIntoView(radioButtonInputByName(radioButtonWithDefaultPropertyValues));
+        click(radioButtonLabelByName(radioButtonWithDefaultPropertyValues));
         expect(getText(selectedValueLabel, radioButtonWithDefaultPropertyValues)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDefaultPropertyValues)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDefaultPropertyValues)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify radio group with disabled button and validation error', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDisabledButtonAndValidationError));
+        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
+        click(radioButtonLabelByName(radioButtonWithDisabledButtonAndValidationError));
         expect(getText(selectedValueLabel, radioButtonWithDisabledButtonAndValidationError)).toContain(januaryValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError)
-            , 'aria-checked')).toBe('true');
-        click(radioButtonGroupPage.actionButtonByName(resetDisabledValidationGroupButtonIndex));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError)
+            , ariaChecked)).toBe('true');
+        click(actionButtonByName(resetDisabledValidationGroupButtonIndex));
         expect(monthNames).not.toContain(getText(selectedValueLabel, radioButtonWithDisabledButtonAndValidationError));
     });
 
 
     it('Verify radio group using FormGroup and FormControl', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonUsingFormGroupAndFormControl), marchIndex);
+        scrollIntoView(radioButtonInputByName(radioButtonUsingFormGroupAndFormControl));
+        click(radioButtonLabelByName(radioButtonUsingFormGroupAndFormControl), marchIndex);
         expect(getText(selectedValueLabel, radioButtonUsingFormGroupAndFormControl)).toContain(marchValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl)
-            , 'ng-reflect-is-disabled')).toBe('true');
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonUsingFormGroupAndFormControl)
-            , 'aria-checked', marchIndex)).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonUsingFormGroupAndFormControl)
+            , ngReflectIsDisabled)).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonUsingFormGroupAndFormControl)
+            , ariaChecked, marchIndex)).toBe('true');
     });
 
     it('Verify inline compact radio group with default selection', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineWithDefaultSelection));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonInlineWithDefaultSelection));
+        scrollIntoView(radioButtonInputByName(radioButtonInlineWithDefaultSelection));
+        click(radioButtonLabelByName(radioButtonInlineWithDefaultSelection));
         expect(getText(selectedValueLabel, radioButtonInlineWithDefaultSelection)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineWithDefaultSelection)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonInlineWithDefaultSelection)
+            , ariaChecked)).toBe('true');
 
     });
 
     it('Verify inline compact radio group', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCompact));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonInlineCompact));
+        scrollIntoView(radioButtonInputByName(radioButtonInlineCompact));
+        click(radioButtonLabelByName(radioButtonInlineCompact));
         expect(getText(selectedValueLabel, radioButtonInlineCompact)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonInlineCompact)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonInlineCompact)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify radio group using FormGroup and FormControl', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDisabledItem), marchIndex);
+        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledItem));
+        click(radioButtonLabelByName(radioButtonWithDisabledItem), marchIndex);
         expect(getText(selectedValueLabel, radioButtonWithDisabledItem)).toContain(marchValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem)
-            , 'ng-reflect-is-disabled')).toBe('true');
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItem)
-            , 'aria-checked', marchIndex)).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItem)
+            , ngReflectIsDisabled)).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItem)
+            , ariaChecked, marchIndex)).toBe('true');
     });
 
     it('Verify radio group with disabled button and validation error', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonHaveValidationError));
+        scrollIntoView(radioButtonInputByName(radioButtonHaveValidationError));
+        click(radioButtonLabelByName(radioButtonHaveValidationError));
         expect(getText(selectedValueLabel, radioButtonHaveValidationError).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError)
-            , 'aria-checked')).toBe('true');
-        click(radioButtonGroupPage.actionButtonByName(resetHaveValidationErrorIndex));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonHaveValidationError)
+            , ariaChecked)).toBe('true');
+        click(actionButtonByName(resetHaveValidationErrorIndex));
         expect(monthNames).not.toContain(getText(selectedValueLabel, radioButtonHaveValidationError));
     });
 
     it('Verify platform radio button with None (No selection) value created as an Option', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithNoSelectionValue));
+        scrollIntoView(radioButtonInputByName(radioButtonWithNoSelectionValue));
+        click(radioButtonLabelByName(radioButtonWithNoSelectionValue));
         expect(getText(selectedValueLabel, radioButtonWithNoSelectionValue).toLowerCase()).toContain(noneValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue)
-            , 'aria-checked')).toBe('true');
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithNoSelectionValue), 1);
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithNoSelectionValue)
+            , ariaChecked)).toBe('true');
+        click(radioButtonLabelByName(radioButtonWithNoSelectionValue), 1);
         expect(getText(selectedValueLabel, radioButtonWithNoSelectionValue).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithNoSelectionValue)
-            , 'aria-checked', 1)).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithNoSelectionValue)
+            , ariaChecked, 1)).toBe('true');
     });
 
     it('Verify radio group using FormGroup and FormControl with List of String Values', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithFormGroupAndFormControl));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithFormGroupAndFormControl));
+        scrollIntoView(radioButtonInputByName(radioButtonWithFormGroupAndFormControl));
+        click(radioButtonLabelByName(radioButtonWithFormGroupAndFormControl));
         expect(getText(selectedValueLabel, radioButtonWithFormGroupAndFormControl).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithFormGroupAndFormControl)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithFormGroupAndFormControl)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify Creating platform radio button with list of string values also pre-selection based on control value', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelection));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithPreSelection));
+        scrollIntoView(radioButtonInputByName(radioButtonWithPreSelection));
+        click(radioButtonLabelByName(radioButtonWithPreSelection));
         expect(getText(selectedValueLabel, radioButtonWithPreSelection).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelection)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithPreSelection)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify Creating platform radio button with given list of string values', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithGivenListOfStringValues));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithGivenListOfStringValues));
+        scrollIntoView(radioButtonInputByName(radioButtonWithGivenListOfStringValues));
+        click(radioButtonLabelByName(radioButtonWithGivenListOfStringValues));
         expect(getText(selectedValueLabel, radioButtonWithGivenListOfStringValues).toLowerCase()).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithGivenListOfStringValues)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithGivenListOfStringValues)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio buttons created with given list of SelectItem objects and have validation error', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithListOfSelectItemObjects));
+        scrollIntoView(radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
+        click(radioButtonLabelByName(radioButtonWithListOfSelectItemObjects));
         expect(getText(selectedValueLabel, radioButtonWithListOfSelectItemObjects)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects)
-            , 'aria-checked')).toBe('true');
-        click(radioButtonGroupPage.actionButtonByName(resetListOfSelectitemObjectIndex));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithListOfSelectItemObjects)
+            , ariaChecked)).toBe('true');
+        click(actionButtonByName(resetListOfSelectitemObjectIndex));
         expect(seasonsNames).not.toContain(getText(selectedValueLabel, radioButtonWithListOfSelectItemObjects));
     });
 
     it('Verify Vertical radio group', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonVertical));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonVertical));
+        scrollIntoView(radioButtonInputByName(radioButtonVertical));
+        click(radioButtonLabelByName(radioButtonVertical));
         expect(getText(selectedValueLabel, radioButtonVertical)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonVertical)
-            , 'aria-checked')).toBe('true');
-        click(radioButtonGroupPage.actionButtonByName(resetVerticalRadioGroupButtonIndex));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonVertical)
+            , ariaChecked)).toBe('true');
+        click(actionButtonByName(resetVerticalRadioGroupButtonIndex));
         expect(seasonsNames).not.toContain(getText(selectedValueLabel, radioButtonVertical));
     });
 
     it('Verify qualification form', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonVerticalQualificationForm));
+        scrollIntoView(radioButtonInputByName(radioButtonVerticalQualificationForm));
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonVerticalQualificationForm));
         for (let i = 0; i < radioButtonsLength; i++) {
-            click(radioButtonGroupPage.radioButtonLabelByName(radioButtonVerticalQualificationForm), i);
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonVerticalQualificationForm)
-                , 'aria-checked', i)).toBe('true');
+            click(radioButtonLabelByName(radioButtonVerticalQualificationForm), i);
+            expect(getAttributeByName(radioButtonInputByName(radioButtonVerticalQualificationForm)
+                , ariaChecked, i)).toBe('true');
         }
-        click(radioButtonGroupPage.actionButtonByName(resetQualificationFormButtonIndex));
+        click(actionButtonByName(resetQualificationFormButtonIndex));
     });
 
     it('Verify compact platform radio button created with given list of SelectItem objects.Using FormGroup and FormControl', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithSelectItemsFormGroupAndFormControl), autumnIndex);
+        scrollIntoView(radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl));
+        click(radioButtonLabelByName(radioButtonWithSelectItemsFormGroupAndFormControl), autumnIndex);
         expect(getText(selectedValueLabel, radioButtonWithSelectItemsFormGroupAndFormControl - 4)).toContain(autumnValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl)
-            , 'aria-checked', autumnIndex)).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithSelectItemsFormGroupAndFormControl)
+            , ariaChecked, autumnIndex)).toBe('true');
     });
 
     it('Verify platform radio button creation and pre-selection based on object data passed.', () => {
         expect(getText(selectedValueLabel, 15)).toContain(springValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
-            , 'aria-checked', springIndex)).toBe('true');
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithPreSelectionOnObjectDataPassed));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
+            , ariaChecked, springIndex)).toBe('true');
+        scrollIntoView(radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed));
+        click(radioButtonLabelByName(radioButtonWithPreSelectionOnObjectDataPassed));
         expect(getText(selectedValueLabel, radioButtonWithPreSelectionOnObjectDataPassed - 4)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithPreSelectionOnObjectDataPassed)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio buttons created with given list of SelectItem objects also pre-selection based on control value', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithPreSelectionBasedOnControlValue));
+        scrollIntoView(radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue));
+        click(radioButtonLabelByName(radioButtonWithPreSelectionBasedOnControlValue));
         expect(getText(selectedValueLabel, radioButtonWithPreSelectionBasedOnControlValue - 5)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithPreSelectionBasedOnControlValue)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio button created with given list of SelectItem objects', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject));
-        click(radioButtonGroupPage.radioButtonLabelByName(platformRadioButtonWithSelectiemObject));
+        scrollIntoView(radioButtonInputByName(platformRadioButtonWithSelectiemObject));
+        click(radioButtonLabelByName(platformRadioButtonWithSelectiemObject));
         expect(getText(selectedValueLabel, platformRadioButtonWithSelectiemObject - 5)).toContain(winterValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(platformRadioButtonWithSelectiemObject)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify platform Radio Button created from Invoice objects. Using LookupKey and DisplayKey.', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey));
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithLookupKeyAndDisplayKey));
+        scrollIntoView(radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey));
+        click(radioButtonLabelByName(radioButtonWithLookupKeyAndDisplayKey));
         expect(getText(preferredBrandLabel)).toContain(samsungValue);
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey)
-            , 'aria-checked')).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithLookupKeyAndDisplayKey)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio buttons Passed as content projection and some radio buttons are disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol));
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol));
+        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol)
-                , 'ng-reflect-is-disabled', i)).toBe('true');
+            expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledContentAndFormcontrol)
+                , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons Passed as content projection and some radio buttons are disabled', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSomeDisabledButtons));
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSomeDisabledButtons)
-            , 'ng-reflect-is-disabled', 2)).toBe('true');
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithSomeDisabledButtons)
-            , 'ng-reflect-is-disabled', 3)).toBe('true');
-        click(radioButtonGroupPage.radioButtonLabelByName(platformRadioButtonWithSelectiemObject));
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(platformRadioButtonWithSelectiemObject)
-            , 'aria-checked')).toBe('true');
+        scrollIntoView(radioButtonInputByName(radioButtonWithSomeDisabledButtons));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithSomeDisabledButtons)
+            , ngReflectIsDisabled, 2)).toBe('true');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithSomeDisabledButtons)
+            , ngReflectIsDisabled, 3)).toBe('true');
+        click(radioButtonLabelByName(platformRadioButtonWithSelectiemObject));
+        expect(getAttributeByName(radioButtonInputByName(platformRadioButtonWithSelectiemObject)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio button created from list of string values', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonCreatedFromList));
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonCreatedFromList));
+        scrollIntoView(radioButtonInputByName(radioButtonCreatedFromList));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonCreatedFromList)
-                , 'ng-reflect-is-disabled', i)).toBe('true');
+            expect(getAttributeByName(radioButtonInputByName(radioButtonCreatedFromList)
+                , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons created from list of SelectItem objects and FormContol is disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonDisabledWithSelectedItem));
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem));
+        scrollIntoView(radioButtonInputByName(radioButtonDisabledWithSelectedItem));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledWithSelectedItem)
-                , 'ng-reflect-is-disabled', i)).toBe('true');
+            expect(getAttributeByName(radioButtonInputByName(radioButtonDisabledWithSelectedItem)
+                , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons created from list of SelectItem objects and some items are disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject));
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject));
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
-            , 'ng-reflect-is-disabled')).toBe('false');
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
-            , 'ng-reflect-is-disabled', 1)).toBe('false');
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
-            , 'aria-checked', 1)).toBe('true');
+        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+            , ngReflectIsDisabled)).toBe('false');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+            , ngReflectIsDisabled, 1)).toBe('false');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+            , ariaChecked, 1)).toBe('true');
         for (let i = 2; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
-                , 'ng-reflect-is-disabled', i)).toBe('true');
+            expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsFromSelectitemObject)
+                , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons passed as content projection and group is disabled', () => {
+        if (browserIsFirefox()) {
+            console.log('Skip for FF');
+            return
+        }
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm));
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm));
+        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm)
-                , 'ng-reflect-is-disabled', i)).toBe('true');
+            expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledButtonsDrivenForm)
+                , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons passed as content projection and individual radio button is disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonWithIndividualButtonDisabled));
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled));
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
-            , 'ng-reflect-is-disabled')).toBe('false');
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
-            , 'ng-reflect-is-disabled', 1)).toBe('false');
+        scrollIntoView(radioButtonInputByName(radioButtonWithIndividualButtonDisabled));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+            , ngReflectIsDisabled)).toBe('false');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+            , ngReflectIsDisabled, 1)).toBe('false');
         for (let i = 2; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
-                , 'ng-reflect-is-disabled', i)).toBe('true');
+            expect(getAttributeByName(radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+                , ngReflectIsDisabled, i)).toBe('true');
         }
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithIndividualButtonDisabled));
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
-            , 'aria-checked')).toBe('true');
+        click(radioButtonLabelByName(radioButtonWithIndividualButtonDisabled));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithIndividualButtonDisabled)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify platform radio buttons created from list of string values and group is disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonDisabledCreatedFromList));
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledCreatedFromList));
+        scrollIntoView(radioButtonInputByName(radioButtonDisabledCreatedFromList));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledCreatedFromList)
-                , 'ng-reflect-is-disabled', i)).toBe('true');
+            expect(getAttributeByName(radioButtonInputByName(radioButtonDisabledCreatedFromList)
+                , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons created from list of SelectItem and group is disabled', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem));
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem));
+        scrollIntoView(radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem));
         for (let i = 0; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem)
-                , 'ng-reflect-is-disabled', i)).toBe('true');
+            expect(getAttributeByName(radioButtonInputByName(radioButtonDisabledCreatedFromSelectItem)
+                , ngReflectIsDisabled, i)).toBe('true');
         }
     });
 
     it('Verify platform radio buttons created from list of SelectItem and individual item has disabled property', () => {
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
-            , 'ng-reflect-is-disabled')).toBe('false');
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
-            , 'ng-reflect-is-disabled', 1)).toBe('false');
+        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+            , ngReflectIsDisabled)).toBe('false');
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+            , ngReflectIsDisabled, 1)).toBe('false');
         for (let i = 2; i < radioButtonsLength; i++) {
-            expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
-                , 'ng-reflect-is-disabled', i)).toBe('true');
+            expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+                , ngReflectIsDisabled, i)).toBe('true');
         }
-        click(radioButtonGroupPage.radioButtonLabelByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
-        expect(getAttributeByName(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
-            , 'aria-checked')).toBe('true');
+        click(radioButtonLabelByName(radioButtonWithDisabledItemsCreatedFromSelectItem));
+        expect(getAttributeByName(radioButtonInputByName(radioButtonWithDisabledItemsCreatedFromSelectItem)
+            , ariaChecked)).toBe('true');
     });
 
     it('Verify validation for radio group with disabled button and validation error', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonHaveValidationError));
+        scrollIntoView(radioButtonInputByName(radioButtonHaveValidationError));
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonHaveValidationError));
-        click(radioButtonGroupPage.actionButtonByName(submitRadioButtonHaveValidationError));
+        click(actionButtonByName(submitRadioButtonHaveValidationError));
         for (let i = 0; i < radioButtonsLength; i++) {
             waitForElDisplayed(radioButtonGroupPage.errorMessage, i);
         }
     });
 
     it('Verify validation for radio group with disabled button and validation error', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
+        scrollIntoView(radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonWithDisabledButtonAndValidationError));
-        click(radioButtonGroupPage.actionButtonByName(submitDisabledRadioButtonWithValidationErrorIndex));
+        click(actionButtonByName(submitDisabledRadioButtonWithValidationErrorIndex));
         for (let i = 0; i < radioButtonsLength; i++) {
             waitForElDisplayed(radioButtonGroupPage.errorMessage, i);
         }
     });
 
     it('Verify validation for radio buttons created with given list of SelectItem objects and have validation error', () => {
-        scrollIntoView(radioButtonGroupPage.radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
+        scrollIntoView(radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
         const radioButtonsLength = getElementArrayLength(radioButtonGroupPage
             .radioButtonInputByName(radioButtonWithListOfSelectItemObjects));
-        click(radioButtonGroupPage.actionButtonByName(submitRadioButtonWithListOfSelectItemObjects));
+        click(actionButtonByName(submitRadioButtonWithListOfSelectItemObjects));
         for (let i = 0; i < radioButtonsLength; i++) {
             waitForElDisplayed(radioButtonGroupPage.errorMessage, i);
         }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
[4172](https://app.zenhub.com/workspaces/fundamental-library-5f32933d64202b0012e3572e/issues/sap/fundamental-ngx/4172)
#### Please provide a brief summary of this pull request.
Added e2e tests for radio button group component (platform)
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

