### PR TITLE
fix: (Core) Add setTimeout for IE11 on InitialFocusDirective

### DIFF
--- a/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.spec.ts
+++ b/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.spec.ts
@@ -1,6 +1,6 @@
 import { InitialFocusDirective } from './initial-focus.directive';
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 @Component({
     template: `
@@ -33,14 +33,16 @@ describe('InitialFocusDirective', () => {
         component = fixture.componentInstance;
     });
 
-    it('should focus element', () => {
+    it('should focus element', fakeAsync(() => {
         fixture.detectChanges();
+        tick(10);
         expect(document.activeElement).toBe(component.elementToFocus.nativeElement);
-    });
+    }));
 
-    it('should focus nested element', () => {
+    it('should focus nested element', fakeAsync(() => {
         component.rootElementTabIndex = -1;
         fixture.detectChanges();
+        tick(10);
         expect(document.activeElement).toBe(component.nestedElementToFocus.nativeElement);
-    });
+    }));
 });

--- a/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.ts
+++ b/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.ts
@@ -18,7 +18,7 @@ export class InitialFocusDirective implements AfterViewInit {
     /** @hidden */
     ngAfterViewInit(): void {
         if (this.enabled) {
-            this._focusFirstTabbableElement();
+            setTimeout(() => this._focusFirstTabbableElement())
         }
     }
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/4483
#### Please provide a brief summary of this pull request.
It fixes issue with IE11 and initial focus, for some reason there is a need to wait for all synchronous jobs, before the focus method is being called.


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

