### PR TITLE
fix: (Core) add fix for content text in Feed Tile truncation

### DIFF
--- a/libs/core/src/lib/tile/tile.component.scss
+++ b/libs/core/src/lib/tile/tile.component.scss
@@ -1,3 +1,8 @@
 @import '~fundamental-styles/dist/tile';
 @import '~fundamental-styles/dist/numeric-content';
 @import '~fundamental-styles/dist/badge';
+
+// temp fix until the new version of fundamental-styles is released
+.fd-tile--feed .fd-tile__content-text {
+    max-height: 2.125rem;
+}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/4483

#### Please provide a brief summary of this pull request.
Temp fix for truncation of content text in Feed Tile not working in IE11
