### PR TITLE
fix: (Platform) Empty table filtering options

### DIFF
--- a/libs/platform/src/lib/components/table/components/table-p13-dialog/filtering/filter-rule.component.html
+++ b/libs/platform/src/lib/components/table/components/table-p13-dialog/filtering/filter-rule.component.html
@@ -33,7 +33,7 @@
                     *ngFor="let strategy of rule.strategies"
                     [value]="strategy"
                 >
-                    <ng-container i18n="@@platformTableP13FilterStrategyLabel">
+                    <span i18n="@@platformTableP13FilterStrategyLabel">
                         { strategy, select,
                         between {between}
                         contains {contains}
@@ -50,7 +50,7 @@
                         beforeOrOn {before or on}
                         other {Not defined}
                         }
-                    </ng-container>
+                    </span>
                 </fd-option>
             </fd-select>
         </div>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes #4602 

#### Please provide a brief summary of this pull request.
due to latest refactoring in Core: Select, `<ng-container>` can no longer be used as a content of `fd-option`, replaced with `span` to fix this

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

