### PR TITLE
fix: (Core) hide Shellbar custom elements in mobile mode

### DIFF
--- a/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions.component.html
+++ b/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions.component.html
@@ -9,7 +9,10 @@
     ></fd-shellbar-actions-mobile>
 </div>
 
-<ng-content></ng-content>
+<div class="fd-shellbar__action fd-shellbar__action--desktop">
+    <ng-content></ng-content>
+</div>
+
 <ng-content select="fd-shellbar-action"></ng-content>
 <ng-container *ngIf="userItem">
     <ng-container *ngIf="!userComponent">


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes https://github.com/SAP/fundamental-ngx/issues/4557

#### Please provide a brief summary of this pull request.
Currently elements passed through content projection to the Shellbar were not hiding "hiding" in mobile mode. 

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [na] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [na] Documentation Examples
- [na] Stackblitz works for all examples

