### PR TITLE
fix: (Core) proper alignment of the Split Button text

### DIFF
--- a/libs/core/src/lib/split-button/split-button.component.scss
+++ b/libs/core/src/lib/split-button/split-button.component.scss
@@ -5,6 +5,7 @@
     .fd-button {
         display: flex;
         align-items: center;
+        justify-content: flex-start;
 
         &__text {
             display: inline-block;


### PR DESCRIPTION

#### Please provide a brief summary of this pull request.
The text of the Split button should not be centered but left-aligned.
Css was provided as a temporary solution until the new version of fund-styles is released.

