### PR TITLE
docs: (Core) refactor dialog example to remove box shadow issue

### DIFF
--- a/apps/docs/src/app/core/component-docs/wizard/examples/wizard-dialog-example.component.html
+++ b/apps/docs/src/app/core/component-docs/wizard/examples/wizard-dialog-example.component.html
@@ -1,7 +1,9 @@
 <ng-template let-dialog let-dialogConfig="dialogConfig" #confirmationDialog>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog" class="fd-wizard-example">
+        <fd-dialog-header>
+            <h2 fd-title headerSize="2">Checkout</h2>
+        </fd-dialog-header>
         <fd-dialog-body>
-            <h2 fd-title>Checkout</h2>
             <fd-wizard [appendToWizard]="false">
                 <fd-wizard-navigation>
                     <ul fd-wizard-progress-bar>

--- a/apps/docs/src/app/core/component-docs/wizard/examples/wizard-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/wizard/examples/wizard-example.component.scss
@@ -4,12 +4,16 @@
         margin-bottom: 12px !important;
     }
 
+    .fd-dialog__header .fd-bar, .fd-bar--header {
+        box-shadow: none;
+    }
+
     .fd-title--h3 {
         margin-bottom: 12px !important;
     }
 
     .fd-title--h2 {
-        padding: 8px 0 8px 32px;
+        padding: 16px 0 8px 16px;
     }
 
     .fd-wizard__content {


### PR DESCRIPTION
fixes #4692 

Moves the wizard title into a dialog header and adds some custom styles to remove the unwanted box-shadow between the title and the progress bar.