### PR TITLE
fix: (Core) add fix for checkbox focus inside Multi Input

### DIFF
--- a/libs/core/src/lib/multi-input/multi-input.component.scss
+++ b/libs/core/src/lib/multi-input/multi-input.component.scss
@@ -37,18 +37,6 @@
 .fd-multi-input-menu-overflow {
     max-width: 37.5rem;
     overflow: auto;
-
-    // TODO: Remove after adjusting in styles
-    &:not(.fd-list--compact) {
-        .fd-list__item {
-            height: 2.5rem;
-
-            .fd-checkbox__label {
-                padding-top: 0.5625rem;
-                padding-bottom: 0.5625rem;
-            }
-        }
-    }
 }
 
 .fd-input {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/4483

#### Please provide a brief summary of this pull request.
remove custom styling in fund-ngx that was causing problems with the focus outline in Multi Input

Before:
<img width="1355" alt="Screen Shot 2021-02-16 at 11 04 22 AM" src="https://user-images.githubusercontent.com/39598672/108088780-d9db9480-7046-11eb-8902-568ed91d0bf3.png">


After:
<img width="858" alt="Screen Shot 2021-02-16 at 11 03 47 AM" src="https://user-images.githubusercontent.com/39598672/108088800-dd6f1b80-7046-11eb-8576-48a07cc15c59.png">


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [na] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [na] Documentation Examples
- [na] Stackblitz works for all examples

