### PR TITLE
fix: (Core) change touched state on focus for Datepickers

### DIFF
--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -21,6 +21,7 @@
                 [attr.aria-label]="dateInputLabel"
                 [(ngModel)]="_inputFieldDate"
                 (ngModelChange)="handleInputChange($event)"
+                (focus)="onTouched()"
             />
             <span fd-input-group-addon [button]="true" [compact]="compact">
                 <button

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -27,6 +27,7 @@
                     [ngClass]="{ 'is-error': _isInvalidDateInput && useValidation }"
                     [disabled]="disabled"
                     (ngModelChange)="handleInputChange($event)"
+                    (focus)="onTouched()"
                 />
                 <span
                     fd-input-group-addon


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of https://github.com/SAP/fundamental-ngx/issues/4482

#### Please provide a brief summary of this pull request.
Added `(focus)="onTouched()"` to the inputs of Date-picker and Datetime-picker so that the `touched` control changes to true when the input is focused.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [na] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [na] Documentation Examples
- [na] Stackblitz works for all examples

