### PR TITLE
fix: (Core) Split Buton 0.16.1 migration

### DIFF
--- a/libs/core/src/lib/split-button/split-button.component.html
+++ b/libs/core/src/lib/split-button/split-button.component.html
@@ -6,9 +6,7 @@
             [compact]="compact"
             [disabled]="disabled"
             (click)="onMainButtonClick($event)">
-
         <ng-container *ngTemplateOutlet="titleTemplate"></ng-container>
-
     </button>
 
     <button fd-button

--- a/libs/core/src/lib/split-button/split-button.component.scss
+++ b/libs/core/src/lib/split-button/split-button.component.scss
@@ -1,14 +1,9 @@
 @import '~fundamental-styles/dist/button-split';
 
-// TODO: Remove after fix on styles https://github.com/SAP/fundamental-styles/issues/1721
-.fd-button-split {
-    .fd-button {
-        display: flex;
-        align-items: center;
-        justify-content: flex-start;
-
-        &__text {
-            display: inline-block;
-        }
-    }
+// Remove after merging https://github.com/SAP/fundamental-styles/issues/2163
+.fd-button-split,
+.fd-button-split > :first-child:hover {
+	.fd-button-split__text {
+		color: inherit;
+	}
 }

--- a/libs/core/src/lib/split-button/split-button.component.spec.ts
+++ b/libs/core/src/lib/split-button/split-button.component.spec.ts
@@ -1,8 +1,9 @@
-import { SplitButtonComponent } from './split-button.component';
 import { Component, DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { SplitButtonComponent, splitButtonTextClass, splitButtonTextCompactClass } from './split-button.component';
 import { MenuModule } from '../menu/menu.module';
+import { ButtonModule } from '../button/button.module';
 import createSpy = jasmine.createSpy;
 
 @Component({
@@ -33,7 +34,7 @@ describe('SplitButtonComponent', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            imports: [MenuModule],
+            imports: [MenuModule, ButtonModule],
             declarations: [SplitButtonComponent, TestComponent]
         });
     }));
@@ -101,4 +102,15 @@ describe('SplitButtonComponent', () => {
         expect(mouseEvent.stopPropagation).toHaveBeenCalled();
         expect(componentInstance.selected.elementRef.nativeElement.click).toHaveBeenCalled();
     });
+
+    it('should add button text class', () => {
+        fixture.detectChanges();
+        componentInstance.ngAfterViewInit();
+        const textElement = componentInstance.mainActionBtn?.nativeElement.querySelector('.fd-button__text');
+        expect(textElement.classList.contains(splitButtonTextClass));
+        componentInstance.compact = true;
+        componentInstance.ngOnChanges(<any>{'compact': true});
+        expect(textElement.classList.contains(splitButtonTextCompactClass));
+
+    })
 });


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.com/SAP/fundamental-ngx/issues/3684
#### Please provide a brief summary of this pull request.
- There are added split button text classes.
- Removed unnecessary styling
- Added another styling, that should be removed after migrating next versions of styles 

