### PR TITLE
feat: (Platform) approval flow adjustments

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-approval-flow/platform-approval-flow-examples/approval-flow-example-data-source.class.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-approval-flow/platform-approval-flow-examples/approval-flow-example-data-source.class.ts
@@ -2,6 +2,7 @@ import {
     ApprovalDataSource,
     ApprovalNode,
     ApprovalProcess,
+    ApprovalStatus,
     ApprovalTeam,
     ApprovalUser
 } from '@fundamental-ngx/platform';
@@ -361,6 +362,7 @@ type GraphTypes = 'simple' | 'medium' | 'complex';
 
 export class ApprovalFlowExampleDataSource implements ApprovalDataSource {
     selectedGraph: GraphTypes;
+    defaultStatus: ApprovalStatus | null = null;
 
     readonly state: BehaviorSubject<ApprovalProcess>;
 
@@ -369,9 +371,23 @@ export class ApprovalFlowExampleDataSource implements ApprovalDataSource {
         this.state = new BehaviorSubject<ApprovalProcess>(graphs[this.selectedGraph]);
     }
 
+    setDefaultStatus(status: ApprovalStatus | null): void {
+        this.defaultStatus = status;
+        this.selectGraph(this.selectedGraph);
+    }
+
     selectGraph(selectedGraph: string = 'complex'): void {
         this.selectedGraph = selectedGraph as GraphTypes;
-        this.state.next(graphs[this.selectedGraph]);
+        const graph = { ...graphs[this.selectedGraph] };
+        graph.nodes = graph.nodes.map(n => {
+            const nodeCopy = { ...n };
+            if (this.defaultStatus) {
+                nodeCopy.status = this.defaultStatus;
+            }
+
+            return nodeCopy;
+        });
+        this.state.next(graph);
     }
 
     fetch(): Observable<ApprovalProcess> {

--- a/apps/docs/src/app/platform/component-docs/platform-approval-flow/platform-approval-flow-examples/platform-approval-flow-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-approval-flow/platform-approval-flow-examples/platform-approval-flow-example.component.ts
@@ -37,6 +37,7 @@ import { ApprovalFlowExampleDataSource } from './approval-flow-example-data-sour
         </p>
         <p>Enable "Edit mode": <input type="checkbox" [(ngModel)]="editModeEnabled"></p>
         <p>Show due date warnings: <input type="checkbox" [(ngModel)]="checkDueDate"></p>
+        <p>Set all statuses to "Not Started": <input type="checkbox" [(ngModel)]="setNotStartedStatuses" (ngModelChange)="setNotStarted()"></p>
         <p style="display: flex;align-items: center;">Allow sending reminders to approvers with statuses: 
             <fd-multi-input 
                 style="margin-left: .5rem;"
@@ -52,11 +53,16 @@ export class PlatformApprovalFlowExampleComponent {
     examples = ['simple', 'medium', 'complex'];
     selectedExample = 'complex';
     checkDueDate = false;
+    setNotStartedStatuses = false;
     editModeEnabled = true;
     allStatuses = ['in progress', 'not started', 'approved', 'rejected'];
     sendReminderStatuses: ApprovalStatus[] = ['in progress', 'not started'];
 
     nodeClick(node: ApprovalNode): void {
         console.log('Node click handler', node);
+    }
+
+    setNotStarted(): void {
+        this.dataSource.setDefaultStatus(this.setNotStartedStatuses ? 'not started' : null);
     }
 }

--- a/libs/platform/src/lib/components/approval-flow/approval-flow-node/approval-flow-node.component.scss
+++ b/libs/platform/src/lib/components/approval-flow/approval-flow-node/approval-flow-node.component.scss
@@ -71,6 +71,7 @@ $carousel-marker-top--edit-mode: $node-height--edit-mode / 2 - $carousel-marker-
             border-top-style: solid;
             border-top-width: 1px;
             left: -2.2rem;
+            width: 2.2rem;
         }
     }
 
@@ -158,6 +159,12 @@ $carousel-marker-top--edit-mode: $node-height--edit-mode / 2 - $carousel-marker-
             right: auto;
             left: -2rem;
             width: 2rem;
+        }
+
+        &.#{$block}--parent-approved {
+            &.#{$block}--line-before:before {
+                width: 2rem;
+            }
         }
 
         .#{$block}__name.#{$block}__name--members-count {

--- a/libs/platform/src/lib/components/approval-flow/approval-flow.component.html
+++ b/libs/platform/src/lib/components/approval-flow/approval-flow.component.html
@@ -12,7 +12,7 @@
                 <ng-container *ngSwitchCase="'nodesRemove'" [ngTemplateOutlet]="nodesRemove"></ng-container>
                 <ng-container *ngSwitchCase="'teamRemove'" [ngTemplateOutlet]="teamRemove"></ng-container>
             </span>
-            <a href="#" (click)="$event.preventDefault();_dismissMessage(i);_undoLastAction()">Undo</a>
+            <a href="#" (click)="$event.preventDefault();_dismissMessage(i);_undoLastAction()" i18n="@@platformApprovalFlowUndo">Undo</a>
         </bdi>
     </fd-message-strip>
 </div>
@@ -30,8 +30,8 @@
     </div>
 </fd-toolbar>
 
-<div class="approval-flow__watchers" [attr.dir]="_dir" *ngIf=" _approvalProcess?.watchers.length">
-    <p class="approval-flow__watchers-title" i18n="@@platformApprovalFlowWatchers">Watchers</p>
+<div class="approval-flow__watchers" [attr.dir]="_dir" *ngIf="_approvalProcess?.watchers.length || _isEditMode">
+    <p class="approval-flow__watchers-title" i18n="@@platformApprovalFlowWatchers">{{ watchersLabel }}</p>
     <ng-container *ngIf="!_isEditMode">
         <fd-avatar
             *ngFor="let watcher of _approvalProcess?.watchers; trackBy: _trackByFn"
@@ -96,7 +96,7 @@
                         [checkDueDate]="checkDueDate"
                         [dueDateThreshold]="dueDateThreshold"
                         [renderArrow]="columnIndex > 0"
-                        [renderLineBefore]="(_isCarousel && firstColumn && firstNode) || !!_nodeParentsMap[node.id] && !_graph[columnIndex - 1]?.nodes[nodeIndex]?.blank"
+                        [renderLineBefore]="(_isCarousel && firstColumn) || !!_nodeParentsMap[node.id] && !_graph[columnIndex - 1]?.nodes[nodeIndex]?.blank"
                         [renderLineAfter]="(_isCarousel && lastColumn && lastNode) || !lastColumn && !node.blank && !_graph[columnIndex + 1]?.nodes[nodeIndex]?.blank"
                         [renderCarouselStartMarker]="(_isCarousel && _metaMap[node.id].isRoot)"
                         [renderCarouselEndMarker]="(_isCarousel && _metaMap[node.id].isLast)"


### PR DESCRIPTION
#### Please provide a link to the associated issue.
issue hasn't been created yet, these tasks were discussed on a call with Kevin and application developers

#### Please provide a brief summary of this pull request.
- added ability to start the approval flow from a bunch of parallel nodes (previously only 1 root node was supported)
- fixed issue with missing watchers input in edit mode if there were no watchers in the beginning
- added input `watchersLabel` to customize text label near watchers block
- added ability to set all statuses in demo examples to `not started` to see how the graph responds to that 

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

