### PR TITLE
fix: (Core) Break word in every component under fixed card layout

### DIFF
--- a/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
+++ b/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.scss
@@ -2,10 +2,15 @@ $fd-namespace: 'fd';
 $fixedCardGroup: #{$fd-namespace}-fixed-card-group;
 
 .#{$fixedCardGroup} {
+
     &--card-layout {
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
+
+		* {
+			word-break: break-all;
+		}
     }
 
     &--card-layout-column {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
part of https://github.tools.sap/dxp/jukebox/issues/420
#### Please provide a brief summary of this pull request.
Issue with card resize exist only on cards that are bigger than should be.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

