### PR TITLE
fix: (Core) wizard step indicator stacking bugs on narrow screens

### DIFF
--- a/libs/core/src/lib/action-sheet/action-sheet-item/action-sheet-item.component.html
+++ b/libs/core/src/lib/action-sheet/action-sheet-item/action-sheet-item.component.html
@@ -4,5 +4,6 @@
         [class.fd-button--compact]="compact"
         [label]="label"
         [glyph]="glyph"
+        [disabled]="disabled"
 >
 </button>

--- a/libs/core/src/lib/action-sheet/action-sheet-item/action-sheet-item.component.ts
+++ b/libs/core/src/lib/action-sheet/action-sheet-item/action-sheet-item.component.ts
@@ -62,6 +62,10 @@ export class ActionSheetItemComponent implements KeyboardSupportItemInterface {
     @Input()
     isCloseButton = false;
 
+    /** Whether or not the action sheet item is disabled. */
+    @Input()
+    disabled = false;
+
     /** @hidden */
     @ViewChild(ButtonComponent)
     buttonComponent: ButtonComponent;

--- a/libs/core/src/lib/wizard/wizard-step-indicator/wizard-step-indicator.component.html
+++ b/libs/core/src/lib/wizard/wizard-step-indicator/wizard-step-indicator.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="stackedItems && stackedItems.length > 1">
-    <fd-action-sheet [compact]="compact">
+    <fd-action-sheet [compact]="compact" style="pointer-events: all">
         <fd-action-sheet-control>
             <span class="fd-wizard__step-indicator">
                 <ng-container *ngTemplateOutlet="stepIndicatorContent"></ng-container>
@@ -11,6 +11,7 @@
                 *ngFor="let step of stackedItems"
                 [label]="step.label"
                 [glyph]="step.glyph"
+                [disabled]="!step.visited"
                 (click)="stepItemClicked(step, $event)"
             ></li>
         </fd-action-sheet-body>

--- a/libs/core/src/lib/wizard/wizard-step-indicator/wizard-step-indicator.component.ts
+++ b/libs/core/src/lib/wizard/wizard-step-indicator/wizard-step-indicator.component.ts
@@ -44,11 +44,13 @@ export class WizardStepIndicatorComponent {
 
     /** @hidden */
     stepItemClicked(step?: WizardStepComponent, event?: MouseEvent): void {
-        if (this.actionSheet) {
-            this.actionSheet.close();
+        if (step && step.visited) {
+            if (this.actionSheet) {
+                this.actionSheet.close();
+            }
+            event.preventDefault();
+            this.stepIndicatorItemClicked.emit(step);
         }
-        event.preventDefault();
-        this.stepIndicatorItemClicked.emit(step);
     }
 
     /** @hidden */

--- a/libs/core/src/lib/wizard/wizard-step/wizard-step.component.html
+++ b/libs/core/src/lib/wizard/wizard-step/wizard-step.component.html
@@ -21,7 +21,7 @@
     <span
         *ngIf="!_finalStep || (status === 'current' && branching)"
         class="fd-wizard__connector"
-        [class.fd-wizard__connector--active]="status === 'completed'"
+        [class.fd-wizard__connector--active]="completed"
         [class.fd-wizard__connector--branching]="branching"
     >
     </span>

--- a/libs/core/src/lib/wizard/wizard-step/wizard-step.component.html
+++ b/libs/core/src/lib/wizard/wizard-step/wizard-step.component.html
@@ -19,7 +19,7 @@
         </div>
     </a>
     <span
-        *ngIf="!finalStep || (status === 'current' && branching)"
+        *ngIf="!_finalStep || (status === 'current' && branching)"
         class="fd-wizard__connector"
         [class.fd-wizard__connector--active]="status === 'completed'"
         [class.fd-wizard__connector--branching]="branching"

--- a/libs/core/src/lib/wizard/wizard-step/wizard-step.component.ts
+++ b/libs/core/src/lib/wizard/wizard-step/wizard-step.component.ts
@@ -1,6 +1,7 @@
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     ContentChild,
     ElementRef,
@@ -106,9 +107,6 @@ export class WizardStepComponent implements OnChanges, AfterViewInit, OnDestroy 
     wizardLabel: ElementRef;
 
     /** @hidden */
-    finalStep = false;
-
-    /** @hidden */
     visited = false;
 
     /** @hidden */
@@ -121,7 +119,10 @@ export class WizardStepComponent implements OnChanges, AfterViewInit, OnDestroy 
     _stepId: number;
 
     /** @hidden */
-    constructor(private _elRef: ElementRef) {}
+    _finalStep = false;
+
+    /** @hidden */
+    constructor(private _elRef: ElementRef, private _cdRef: ChangeDetectorRef) {}
 
     /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
@@ -148,6 +149,12 @@ export class WizardStepComponent implements OnChanges, AfterViewInit, OnDestroy 
     /** @hidden */
     ngOnDestroy(): void {
         this._subscriptions.unsubscribe();
+    }
+
+    /** @hidden */
+    setFinalStep(val: boolean): void {
+        this._finalStep = val;
+        this._cdRef.detectChanges();
     }
 
     /** @hidden */

--- a/libs/core/src/lib/wizard/wizard.component.scss
+++ b/libs/core/src/lib/wizard/wizard.component.scss
@@ -7,3 +7,12 @@
 .fd-wizard-container-wrapper {
     overflow: auto;
 }
+// TODO: remove when fundamental-styles version 0.16.1 is merged
+.fd-wizard__step--stacked:last-child {
+    padding-right: 2.375rem;
+}
+.fd-wizard__step--stacked:last-child[dir=rtl],
+[dir=rtl] .fd-wizard__step--stacked:last-child {
+    padding-right: 0;
+    padding-left: 2.375rem;
+}

--- a/libs/core/src/lib/wizard/wizard.component.spec.ts
+++ b/libs/core/src/lib/wizard/wizard.component.spec.ts
@@ -127,7 +127,7 @@ describe('WizardComponent', () => {
         expect(component.steps.last._stepId).toBe(3);
         expect(component.steps.first.content.wizardContentId).toBe('0');
         expect(component.steps.first.visited).toBeTruthy();
-        expect(component.steps.last.finalStep).toBeTruthy();
+        expect(component.steps.last._finalStep).toBeTruthy();
     });
 
     it('should handleStepOrStatusChanges', fakeAsync(() => {

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -364,14 +364,13 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
                 : (stepToHide = stepsArray[stepsArray.length - 1]);
             stepToHide.getClassList().add(STEP_NO_LABEL_CLASS);
             stepToHide.getClassList().add(STEP_STACKED_CLASS);
-            if (stepsArray.indexOf(stepToHide) < currentStepIndex) {
+            if (stepsArray.indexOf(stepToHide) < currentStepIndex && !this.stackedStepsLeft.includes(stepToHide)) {
                 this.stackedStepsLeft.push(stepToHide);
-            } else if (stepsArray.indexOf(stepToHide) > currentStepIndex) {
+            } else if (stepsArray.indexOf(stepToHide) > currentStepIndex && !this.stackedStepsRight.includes(stepToHide)) {
                 this.stackedStepsRight.unshift(stepToHide);
             }
-            if (this.stackedStepsLeft.length) {
-                this._setStackedTop(currentStep);
-            }
+            this._cdRef.detectChanges();
+            this._setStackedTop(currentStep);
         }
     }
 
@@ -383,6 +382,9 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
                 if (this.steps.toArray()[index + 1] === currentStep) {
                     if (this.steps.length > 1) {
                         step.getClassList().add(STEP_STACKED_TOP_CLASS);
+                        if (!this.stackedStepsLeft.includes(step) && this.stackedStepsLeft.length > 1) {
+                            this.stackedStepsLeft.push(step);
+                        }
                     }
                     step.stepIndicator.setStackedItems(this.stackedStepsLeft);
                 } else {

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -301,6 +301,7 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
                 step.visited ||
                 ((step.status === CURRENT_STEP_STATUS || step.status === COMPLETED_STEP_STATUS) && step.content)
             ) {
+                step.visited = true;
                 if (step.status === CURRENT_STEP_STATUS && (!step.completed || !this.appendToWizard)) {
                     step.content.tallContent = true;
                 }
@@ -312,7 +313,6 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
                 } else if (this.appendToWizard && !step.isSummary) {
                     this.contentTemplates.push(step.content.contentTemplate);
                 }
-                step.visited = true;
             }
         }
         const lastVisibleTemplate = this.steps.toArray()[this.contentTemplates.length - 1];

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -282,7 +282,7 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
             }
             step._stepId = _stepId;
             _stepId++;
-            step.finalStep = false;
+            step.setFinalStep(false);
             /*
              If the step is completed and appendToWizard is true, hide the nextStep button, unless it's the last step,
              or if there's a summary and it is the second to last step
@@ -317,7 +317,7 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
         if (lastVisibleTemplate && lastVisibleTemplate.content) {
             lastVisibleTemplate.content.tallContent = true;
         }
-        this.steps.last.finalStep = true;
+        this._setFinalStep();
     }
 
     /** @hidden */
@@ -427,20 +427,24 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
     /** @hidden */
     private _setFinalStep(): void {
         const lastNonSummaryStep = this._getLastNonSummaryStep();
-        if (this.steps.last.isSummary && lastNonSummaryStep) {
-            lastNonSummaryStep.content.tallContent = true;
-            lastNonSummaryStep.finalStep = true;
-            this.steps.last.removeFromDom();
-        } else if (lastNonSummaryStep) {
+        if (lastNonSummaryStep) {
+            if (this.steps.last.isSummary) {
+                this.steps.last.removeFromDom();
+            }
             if (lastNonSummaryStep.content) {
                 lastNonSummaryStep.content.tallContent = true;
             }
-            lastNonSummaryStep.finalStep = true;
+            lastNonSummaryStep.setFinalStep(true);
         }
     }
 
     /** @hidden */
     private _showSummary(): void {
+        this.steps.forEach(step => {
+            if (!step.isSummary) {
+                step.completed = true;
+            }
+        });
         const summary = this.steps.find((step) => step.isSummary);
         summary.content.tallContent = true;
         this.contentTemplates = [summary.content.contentTemplate];

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -457,9 +457,11 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
 
     /** @hidden */
     private _shrinkWhileAnyStepIsTooNarrow(): void {
-        this._resetStepClasses();
         this.stackedStepsLeft = [];
         this.stackedStepsRight = [];
+        this.steps.first.stepIndicator.setStackedItems(this.stackedStepsLeft);
+        this._getLastNonSummaryStep().stepIndicator.setStackedItems(this.stackedStepsRight);
+        this._resetStepClasses();
         let i = 0;
         while (this._anyStepIsTooNarrow() && i < this.steps.length - 1) {
             i++;


### PR DESCRIPTION
fixes #4420 

Fixes a number of bugs where the stacked step indicator action sheet would be missing steps it should have, or clicking the step indicator would change to a step rather than open the action sheet

Before
![Screen Shot 2021-03-10 at 9 32 34 AM](https://user-images.githubusercontent.com/2471874/110663330-8d85ff00-8183-11eb-80ff-b0217423d511.png)

After
![Screen Shot 2021-03-10 at 9 31 01 AM](https://user-images.githubusercontent.com/2471874/110663215-79420200-8183-11eb-8d2f-967db515dbb8.png)
