### PR TITLE
fix: (Core) Fixed Card Layout Change focus target to header

### DIFF
--- a/libs/core/src/lib/fixed-card-layout/fixed-card-layout-item/fixed-card-layout-item.component.ts
+++ b/libs/core/src/lib/fixed-card-layout/fixed-card-layout-item/fixed-card-layout-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ChangeDetectionStrategy, HostBinding } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef } from '@angular/core';
 import { FocusableOption } from '@angular/cdk/a11y';
 
 @Component({
@@ -10,14 +10,13 @@ import { FocusableOption } from '@angular/cdk/a11y';
     }
 })
 export class FixedCardLayoutItemComponent implements FocusableOption {
-    /** @hidden */
-    @HostBinding()
-    tabindex = 0;
-
     constructor(private _elementRef: ElementRef) {}
 
     /** Set focus on the element. */
     focus(): void {
-        this._elementRef.nativeElement.focus();
+        const header = this._elementRef.nativeElement.querySelector('.fd-card__header')
+        if (header) {
+            header.focus();
+        }
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
fixes https://github.com/SAP/fundamental-ngx/issues/4498
#### Please provide a brief summary of this pull request.
There is removed tabindex from card item inside fixed card layout. Now it will focus header

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

