### PR TITLE
test: disable card and object status e2e tests

### DIFF
--- a/e2e/wdio/core/tests/card.e2e-spec.ts
+++ b/e2e/wdio/core/tests/card.e2e-spec.ts
@@ -116,7 +116,7 @@ describe('Card test suite:', function() {
             checkElArrIsClickable(tableCardItems);
         });
 
-        it('should check status colors', () => {
+        xit('should check status colors', () => {
             const statusesCount = getElementArrayLength(tableCardItemStatuses);
             for (let i = 0; statusesCount > i; i++) {
                 expect(getCSSPropertyByName(tableCardItemStatuses, colorAttr, i).value)

--- a/e2e/wdio/core/tests/object-status.e2e-spec.ts
+++ b/e2e/wdio/core/tests/object-status.e2e-spec.ts
@@ -32,20 +32,20 @@ describe('Object Status test suite', function() {
             }
         });
 
-        it('should check semantic colors', () => {
+        xit('should check semantic colors', () => {
             checkObjectColors(iconExamples + status, iconExamples + text, statusAttr, colorAttr, semanticColors);
         });
     });
 
     describe('object status text only examples', function() {
-        it('should check text value and colors', () => {
+        xit('should check text value and colors', () => {
             checkObjectValues(textExamples + text, semanticText);
             checkObjectColors(textExamples + status, textExamples + text, statusAttr, colorAttr, semanticColors);
         });
     });
 
     describe('object status with text and icon examples', function() {
-        it('should check text value and colors', () => {
+        xit('should check text value and colors', () => {
             checkObjectValues(textAndIconExamples + text, semanticText);
             checkObjectColors(textAndIconExamples + status, textAndIconExamples + text, statusAttr, colorAttr, semanticColors);
             // skip until issue fixed https://github.com/SAP/fundamental-ngx/issues/4493
@@ -54,14 +54,14 @@ describe('Object Status test suite', function() {
     });
 
     describe('object status with generic indication colors examples', function() {
-        it('should check text value and colors', () => {
+        xit('should check text value and colors', () => {
             checkObjectValues(colorsExamples + text, genericColorText);
             checkObjectColors(colorsExamples + status, colorsExamples + text, indicatorAttr, colorAttr, genericColors);
         });
     });
 
     describe('clickable object status examples', function() {
-        it('should check text value and colors', () => {
+        xit('should check text value and colors', () => {
             const objTextValues = semanticText.concat(genericColorText);
             const objectCount = getElementArrayLength(clickableExamples + status);
 
@@ -83,14 +83,14 @@ describe('Object Status test suite', function() {
     });
 
     describe('inverted object status examples', function() {
-        it('should check text value and colors', () => {
+        xit('should check text value and colors', () => {
             checkObjectValues(invertedExamples + text, objStatusText);
             checkObjectColors(invertedExamples + status, invertedExamples + status, statusAttr, backgroundColorAttr, invertedSemanticColors);
         });
     });
 
     describe('inverted object status with generic indication colors examples', function() {
-        it('should check text value and inverted colors', () => {
+        xit('should check text value and inverted colors', () => {
             checkObjectValues(invertedColorExamples + text, genericColorText);
             checkObjectColors(invertedColorExamples + status, invertedColorExamples + status, indicatorAttr, backgroundColorAttr, genericColors);
 
@@ -109,7 +109,7 @@ describe('Object Status test suite', function() {
             }
         });
 
-        it('should check text value and color', () => {
+        xit('should check text value and color', () => {
             const objectCount = getElementArrayLength(largeExamples);
 
             for (let i = 0; i < objectCount; i++) {
@@ -140,7 +140,7 @@ describe('Object Status test suite', function() {
     });
 
     describe('Check visual regression', function() {
-        it('should check examples visual regression', () => {
+        xit('should check examples visual regression', () => {
             objectStatusPage.saveExampleBaselineScreenshot();
             expect(objectStatusPage.compareWithBaseline()).toBeLessThan(1);
         });

--- a/e2e/wdio/platform/tests/object-status.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/object-status.e2e-spec.ts
@@ -50,7 +50,7 @@ describe('object status test suite', function() {
     });
 
     describe('object status text only example', function() {
-        it('should check text colors and text values', () => {
+        xit('should check text colors and text values', () => {
             scrollIntoView(textOnlyExamples + text);
             checkStatusColors(textOnlyExamples + text, colorAttribute, semanticColors);
             checkElementTextValue(textOnlyExamples + text, semanticStatusText);
@@ -58,7 +58,7 @@ describe('object status test suite', function() {
     });
 
     describe('object status with text and icon example', function() {
-        it('should check text colors and text values', () => {
+        xit('should check text colors and text values', () => {
             scrollIntoView(textAndIconExamples + text);
             checkStatusColors(textAndIconExamples + text, colorAttribute, semanticColors);
             checkElementTextValue(textAndIconExamples + text, semanticStatusText);
@@ -72,7 +72,7 @@ describe('object status test suite', function() {
     });
 
     describe('object status with generic indication colors example', function() {
-        it('should check text colors and text values', () => {
+        xit('should check text colors and text values', () => {
             scrollIntoView(indicationColorExamples + text);
             checkStatusColors(indicationColorExamples + text, colorAttribute, indicationColors);
             checkElementTextValue(indicationColorExamples + text, indicationColorText);
@@ -104,7 +104,7 @@ describe('object status test suite', function() {
             checkAttributeValueTrue(invertedIndicationColorExamples + status, invertedAttribute);
         });
 
-        it('should check inverted colors', () => {
+        xit('should check inverted colors', () => {
             checkStatusColors(invertedIndicationColorExamples + text, colorAttr, invertedTextColor);
             checkStatusColors(invertedIndicationColorExamples + status, backgroundColorAttribute, indicationColors);
         });
@@ -123,7 +123,7 @@ describe('object status test suite', function() {
     });
 
     describe('Visual regression', function() {
-        it('should check examples visual regression', () => {
+        xit('should check examples visual regression', () => {
             refreshPage();
             waitForPresent(defaultExamples + status);
             objectStatusPage.saveExampleBaselineScreenshot();


### PR DESCRIPTION
disable card and object status e2e tests

disabling visual regression testing against hardcoded colors

to be addressed in #4939 