### PR TITLE
fix: (Platform) drop not unique i18n custom ids

### DIFF
--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
@@ -20,7 +20,7 @@
         [class.fd-grid-list__highlight--negative]="status === 'warning'"
         [class.fd-grid-list__highlight--critical]="status === 'error'"
         [class.fd-grid-list__highlight--neutral]="status === 'neutral'"
-        i18n-aria-label="@@coreGridList.Item.Status|Status aria-label attribute"
+        i18n-aria-label="coreGridList.Item.Status|Status aria-label attribute"
         [attr.aria-label]="'Item has status. Status: ' + status + '.'"
     ></span>
 

--- a/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
+++ b/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
@@ -64,9 +64,9 @@
                     [compact]="true"
                     fdType="ghost"
                     [disabled]="disabled"
-                    i18n-label="@@platformUploadCollection.Btn.Add"
+                    i18n-label="platformUploadCollection.Btn.Add"
                     label="Add"
-                    i18n-title="@@platformUploadCollection.Btn.Add"
+                    i18n-title="platformUploadCollection.Btn.Add|Title"
                     title="Add"
                 ></button>
 
@@ -78,9 +78,9 @@
                     *ngIf="hierarchy"
                     [disabled]="disabled"
                     fdType="transparent"
-                    i18n-label="@@platformUploadCollection.Btn.NewFolder"
+                    i18n-label="platformUploadCollection.Btn.NewFolder"
                     label="New Folder"
-                    i18n-title="@@platformUploadCollection.Btn.NewFolder"
+                    i18n-title="platformUploadCollection.Btn.NewFolder|Title attribute"
                     title="New Folder"
                 ></button>
             </ng-container>
@@ -94,9 +94,9 @@
                 [compact]="true"
                 fdType="ghost"
                 [disabled]="disabled"
-                i18n-label="@@platformUploadCollection.Btn.MoveTo"
+                i18n-label="platformUploadCollection.Btn.MoveTo"
                 label="Move to"
-                i18n-title="@@platformUploadCollection.Btn.MoveTo"
+                i18n-title="platformUploadCollection.Btn.MoveTo|Title attribute"
                 title="Move to"
             ></button>
             <button
@@ -107,9 +107,9 @@
                 [compact]="true"
                 [disabled]="disabled"
                 *ngIf="_showIfSelectedOnlyFiles()"
-                i18n-label="@@platformUploadCollection.Btn.Download"
+                i18n-label="platformUploadCollection.Btn.Download"
                 label="Download"
-                i18n-title="@@platformUploadCollection.Btn.Download"
+                i18n-title="platformUploadCollection.Btn.Download|Title attribute"
                 title="Download"
             ></button>
             <button
@@ -119,9 +119,9 @@
                 [compact]="true"
                 fdType="ghost"
                 [disabled]="disabled"
-                i18n-label="@@platformUploadCollection.Btn.Remove"
+                i18n-label="platformUploadCollection.Btn.Remove"
                 label="Remove"
-                i18n-title="@@platformUploadCollection.Btn.Remove"
+                i18n-title="platformUploadCollection.Btn.Remove|Title attribute"
                 title="Remove"
             ></button>
         </ng-container>
@@ -244,9 +244,9 @@
                             <div class="fdp-upload-collection__actions--status">
                                 <button
                                     fd-button
-                                    i18n-label="@@platformUploadCollection.Btn.Run"
+                                    i18n-label="platformUploadCollection.Btn.Run"
                                     label="Run"
-                                    i18n-title="@@platformUploadCollection.Btn.Run"
+                                    i18n-title="platformUploadCollection.Btn.Run|Title attribute"
                                     title="Run"
                                     (click)="_runUploadNewFileAfterFail(item)"
                                     [compact]="true"
@@ -257,9 +257,9 @@
 
                                 <button
                                     fd-button
-                                    i18n-label="@@platformUploadCollection.Btn.Cancel"
+                                    i18n-label="platformUploadCollection.Btn.Cancel"
                                     label="Cancel"
-                                    i18n-title="@@platformUploadCollection.Btn.Cancel"
+                                    i18n-title="platformUploadCollection.Btn.Cancel|Title attribute"
                                     title="Cancel"
                                     fdType="negative"
                                     [compact]="true"
@@ -357,21 +357,21 @@
 <fdp-menu #menuActions xPosition="before" contentDensity="compact">
     <fdp-menu-item (itemSelect)="_moveToClicked()">
         <fd-icon class="fdp-upload-collection__fd-icon" glyph="folder-blank"></fd-icon>
-        <span i18n="@@platformUploadCollection.Btn.MoveTo">Move to</span>
+        <span i18n="platformUploadCollection.Btn.MoveTo|Menu Action">Move to</span>
     </fdp-menu-item>
     <ng-container *ngIf="_activeItem?.type === 'file'">
         <fdp-menu-item (itemSelect)="_downloadClicked()">
             <fd-icon class="fdp-upload-collection__fd-icon" glyph="download"></fd-icon>
-            <span i18n="@@platformUploadCollection.Btn.Download">Download</span>
+            <span i18n="platformUploadCollection.Btn.Download|Menu Action">Download</span>
         </fdp-menu-item>
         <fdp-menu-item (itemSelect)="_openUpdateFileVersion()">
             <fd-icon class="fdp-upload-collection__fd-icon" glyph="drill-up"></fd-icon>
-            <span i18n="@@platformUploadCollection.Btn.UpdateVersion">Update version</span>
+            <span i18n="platformUploadCollection.Btn.UpdateVersion|Menu Action">Update version</span>
         </fdp-menu-item>
     </ng-container>
     <fdp-menu-item (itemSelect)="_remove()">
         <fd-icon class="fdp-upload-collection__fd-icon" glyph="delete"></fd-icon>
-        <span i18n="@@platformUploadCollection.Btn.Remove">Remove</span>
+        <span i18n="platformUploadCollection.Btn.Remove|Menu Action">Remove</span>
     </fdp-menu-item>
 </fdp-menu>
 

--- a/libs/platform/src/lib/components/value-help-dialog/components/define-tab/define-tab.component.html
+++ b/libs/platform/src/lib/components/value-help-dialog/components/define-tab/define-tab.component.html
@@ -15,7 +15,7 @@
             <div fdLayoutGridRow>
                 <div fdLayoutGridCol colGrow>&nbsp;</div>
                 <div fdLayoutGridCol class="action-col">
-                    <button fd-button i18n-aria-label="@@platformI18nValueHelpDialog.AddDefineCondition" aria-label="Add new define condition" glyph="add" (click)="addEmptyCondition(_defineTypes.include)"></button>
+                    <button fd-button i18n-aria-label="@@platformI18nValueHelpDialog.IncludeConditionBtnAddNew" aria-label="Add new define condition" glyph="add" (click)="addEmptyCondition(_defineTypes.include)"></button>
                 </div>
             </div>
         </fd-layout-grid>
@@ -39,7 +39,7 @@
             <div fdLayoutGridRow>
                 <div fdLayoutGridCol colGrow>&nbsp;</div>
                 <div fdLayoutGridCol class="action-col">
-                    <button fd-button i18n-aria-label="@@platformI18nValueHelpDialog.AddDefineCondition" aria-label="Add new define condition" glyph="add" (click)="addEmptyCondition(_defineTypes.exclude)"></button>
+                    <button fd-button i18n-aria-label="@@platformI18nValueHelpDialog.ExcludeConditionBtnAddNew" aria-label="Add new define condition" glyph="add" (click)="addEmptyCondition(_defineTypes.exclude)"></button>
                 </div>
             </div>
         </fd-layout-grid>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes: https://github.com/SAP/fundamental-ngx/issues/4911
#### Please provide a brief summary of this pull request.
Remove i18n custom id duplicates in upload-collection and value-help-dialog modules
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

