### PR TITLE
fix: (core) added text component fixes for ie11

### DIFF
--- a/libs/core/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
+++ b/libs/core/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
@@ -132,7 +132,7 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
 
     reset(): void {
         if (this._lineClampTarget && this._originalText) {
-            this._lineClampTarget.innerText = this._originalText;
+            this._lineClampTarget.textContent = this._originalText;
         }
         if (this._isNativeSupport) {
             this._resetNative();
@@ -167,7 +167,7 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
         const ellipsisText = () => {
             if (this.rootElement.scrollHeight > lineClampHeight) {
                 ellipsisTextArray.pop();
-                this._lineClampTarget.innerText = ellipsisTextArray.join(' ') + '...';
+                this._lineClampTarget.textContent = ellipsisTextArray.join(' ') + '...';
                 ellipsisText.call(this);
             }
         };
@@ -218,7 +218,9 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
             return;
         }
         const style = window.getComputedStyle(this.rootElement, null);
-        this._resetNative();
+
+        this.reset();
+
         const fontSize = parseInt(style.getPropertyValue('font-size'), 10);
         const boxSizing = style.getPropertyValue('box-sizing');
         let height = parseInt(style.getPropertyValue('height'), 10);


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#4870 
#### Please provide a brief summary of this pull request.
Both fixes are for the LineClamp directive.
- Changed `innerText` parameter to `textContent`, because of empty spaces in ie11
- Added reset fix for ie on resize
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] Documentation Examples

