### PR TITLE
fix: (core) chaged text examples selectors to fix stackblitz

### DIFF
--- a/apps/docs/src/app/core/component-docs/text/examples/text-basic.component.ts
+++ b/apps/docs/src/app/core/component-docs/text/examples/text-basic.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'text-basic',
+    selector: 'fd-text-basic',
     templateUrl: './text-basic.component.html'
 })
 export class TextBasicComponent {}

--- a/apps/docs/src/app/core/component-docs/text/examples/text-expandable.component.ts
+++ b/apps/docs/src/app/core/component-docs/text/examples/text-expandable.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'text-expandable',
+    selector: 'fd-text-expandable',
     templateUrl: './text-expandable.component.html'
 })
 export class TextExpandableComponent {

--- a/apps/docs/src/app/core/component-docs/text/examples/text-hyphenation.component.ts
+++ b/apps/docs/src/app/core/component-docs/text/examples/text-hyphenation.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'text-hyphenation',
+    selector: 'fd-text-hyphenation',
     templateUrl: './text-hyphenation.component.html',
     styleUrls: ['./text-hyphenation.component.scss']
 })

--- a/apps/docs/src/app/core/component-docs/text/examples/text-max-lines.component.ts
+++ b/apps/docs/src/app/core/component-docs/text/examples/text-max-lines.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'text-max-lines',
+    selector: 'fd-text-max-lines',
     templateUrl: './text-max-lines.component.html'
 })
 export class TextMaxLinesComponent {

--- a/apps/docs/src/app/core/component-docs/text/examples/text-whitespaces.component.ts
+++ b/apps/docs/src/app/core/component-docs/text/examples/text-whitespaces.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'text-whitespaces',
+    selector: 'fd-text-whitespaces',
     templateUrl: './text-whitespaces.component.html'
 })
 export class TextWhitespacesComponent {

--- a/apps/docs/src/app/core/component-docs/text/text-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/text/text-docs.component.html
@@ -2,7 +2,7 @@
     Text basic example
 </fd-docs-section-title>
 <component-example>
-    <text-basic></text-basic>
+    <fd-text-basic></fd-text-basic>
 </component-example>
 <code-example [exampleFiles]="textBasic"></code-example>
 
@@ -12,7 +12,7 @@
     Text whitespaces example
 </fd-docs-section-title>
 <component-example>
-    <text-whitespaces></text-whitespaces>
+    <fd-text-whitespaces></fd-text-whitespaces>
 </component-example>
 <code-example [exampleFiles]="textWhitespaces"></code-example>
 
@@ -22,7 +22,7 @@
     Text Max lines example
 </fd-docs-section-title>
 <component-example>
-    <text-max-lines></text-max-lines>
+    <fd-text-max-lines></fd-text-max-lines>
 </component-example>
 <code-example [exampleFiles]="textMaxLines"></code-example>
 
@@ -36,7 +36,7 @@
     <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens">MDN hyphens</a>
 </description>
 <component-example>
-    <text-hyphenation></text-hyphenation>
+    <fd-text-hyphenation></fd-text-hyphenation>
 </component-example>
 <code-example [exampleFiles]="textHyphenation"></code-example>
 
@@ -46,7 +46,7 @@
     Text Expandable example
 </fd-docs-section-title>
 <component-example>
-    <text-expandable></text-expandable>
+    <fd-text-expandable></fd-text-expandable>
 </component-example>
 <code-example [exampleFiles]="textExpandable"></code-example>
 

--- a/apps/docs/src/app/core/component-docs/text/text-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/text/text-docs.component.ts
@@ -57,17 +57,13 @@ export class TextDocsComponent {
         {
             language: 'html',
             code: textHyphenationHtml,
-            fileName: 'text-hyphenation'
+            fileName: 'text-hyphenation',
+            scssFileCode: textHyphenationScss
         },
         {
             language: 'typescript',
             code: textHyphenationTs,
             component: 'TextHyphenationComponent',
-            fileName: 'text-hyphenation'
-        },
-        {
-            language: 'scss',
-            code: textHyphenationScss,
             fileName: 'text-hyphenation'
         }
     ];


### PR DESCRIPTION
#### Please provide a link to the associated issue.
#4867 
#### Please provide a brief summary of this pull request.
- Changed selectors of the text examples
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] Documentation Examples
- [x] Stackblitz works for all examples

