### PR TITLE
fix: add GridListModule to the exports

### DIFF
--- a/libs/core/src/lib/fundamental-ngx-core.module.ts
+++ b/libs/core/src/lib/fundamental-ngx-core.module.ts
@@ -87,6 +87,7 @@ import { OnlyDigitsModule } from './utils/directives/only-digits/only-digits.mod
 import { IllustratedMessageModule } from './illustrated-message/illustrated-message.module';
 import { DynamicPageModule } from './dynamic-page/dynamic-page.module';
 import { StatusIndicatorModule } from './status-indicator/status-indicator.module';
+import { GridListModule } from './grid-list/grid-list.module';
 
 @NgModule({
     imports: [CommonModule, FormsModule],
@@ -174,7 +175,8 @@ import { StatusIndicatorModule } from './status-indicator/status-indicator.modul
         SliderModule,
         OnlyDigitsModule,
         IllustratedMessageModule,
-        StatusIndicatorModule
+        StatusIndicatorModule,
+        GridListModule
     ],
     providers: [AlertService, DialogService, NotificationService, MessageToastService, ThemesService]
 })


### PR DESCRIPTION
The GridListModule is not currently added in fundamental-ngx-core.module.ts
