### PR TITLE
chore: (AppShell) bump to 0.2.37

### DIFF
--- a/libs/app-shell/package.json
+++ b/libs/app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundamental-ngx/app-shell",
-    "version": "0.2.36",
+    "version": "0.2.37",
   "schematics": "./schematics/collection.json",
   "description": "Fundamentals App Shell for microfrontend.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bump version to 0.2.37 by https://github.com/SAP/fundamental-ngx/pull/4124