### PR TITLE
fix: (Platform) i18n remove select, plurals

### DIFF
--- a/PLATFORM_README.md
+++ b/PLATFORM_README.md
@@ -194,6 +194,9 @@ For an existing Angular CLI application,
     When data is provided like this (probably coming from a db or backend server), it is left to the application to provide for the translated
     text. Providing i18n markers as shown in the previous example will not work as this is a limitation of Angular's i18n for now.
 
+    Note: Due to SAP's needs was disabled support of select & plural i18n features (issue [#5098](https://github.com/SAP/fundamental-ngx/issues/5098)).
+    Details how to provide such functionality see in [Wiki](https://github.com/SAP/fundamental-ngx/wiki/Internationalization-Supporting-in-@fundamental-ngx-platform).
+    
 ## Tests
 
 Fundamental Library for Angular makes use of Jasmine and Karma for its unit tests.

--- a/libs/platform/src/lib/components/approval-flow/approval-flow-node/approval-flow-node.component.html
+++ b/libs/platform/src/lib/components/approval-flow/approval-flow-node/approval-flow-node.component.html
@@ -50,13 +50,13 @@
             <div
                 class="approval-flow-node__name"
                 [class.approval-flow-node__name--members-count]="node.approvers.length > 1"
-                i18n="@@platformApprovalFlowNodeMembers">
-                {
-                    node.approvers.length,
-                    plural,
-                    =1 {{{node.approvers[0].name}}}
-                    other {{{node.approvers.length}} members}
-                }
+            >
+                <ng-container *ngIf="node.approvers.length === 1; else multipleApprovers">
+                    {{node.approvers[0].name}}
+                </ng-container>
+                <ng-template #multipleApprovers i18n="@@platformApprovalFlowNodeMembers">
+                    {{node.approvers.length}} members
+                </ng-template>
             </div>
             <div class="approval-flow-node__description">
                 {{ node.approvers.length > 1 ? node.description : node.approvers[0].description }}
@@ -66,25 +66,20 @@
                 inverted="true">
                 <ng-container *ngIf="!checkDueDate || !_showDueDateWarning">{{ node.status }}</ng-container>
                 <ng-container *ngIf="checkDueDate && _showDueDateWarning">
-                    <ng-container *ngIf="_dueIn === dueDateThreshold" i18n="@@platformApprovalFlowNodeStatusDueToday">Due today</ng-container>
-                    <ng-container *ngIf="_dueIn < dueDateThreshold" i18n="@@platformApprovalFlowNodeStatusDueInXDays">
-                        Due in
-                        {{ dueDateThreshold - _dueIn }}
-                        {
-                            dueDateThreshold - _dueIn,
-                            plural,
-                            =1 {day}
-                            other {days}
-                        }
+                    <ng-container
+                        *ngIf="_dueIn === dueDateThreshold"
+                        i18n="@@platformApprovalFlowNodeStatusDueToday">
+                        Due today
                     </ng-container>
-                    <ng-container *ngIf="_dueIn > dueDateThreshold" i18n="@@platformApprovalFlowNodeStatusXDaysOverdue">
-                        {{ _dueIn - dueDateThreshold }}
-                        {
-                            _dueIn - dueDateThreshold,
-                            plural,
-                            =1 {day}
-                            other {days}
-                        } overdue
+                    <ng-container
+                        *ngIf="_dueIn < dueDateThreshold"
+                        i18n="@@platformApprovalFlowNodeStatusDueInXDays">
+                        Due in {{ dueDateThreshold - _dueIn }} days
+                    </ng-container>
+                    <ng-container
+                        *ngIf="_dueIn > dueDateThreshold"
+                        i18n="@@platformApprovalFlowNodeStatusXDaysOverdue">
+                        {{ _dueIn - dueDateThreshold }} days overdue
                     </ng-container>
                 </ng-container>
             </fdp-object-status>

--- a/libs/platform/src/lib/components/approval-flow/approval-flow-user-list/approval-flow-user-list.component.html
+++ b/libs/platform/src/lib/components/approval-flow/approval-flow-user-list/approval-flow-user-list.component.html
@@ -1,6 +1,15 @@
-<div class="approval-flow-user-list__selected-count" i18n="@@platformApprovalFlowSelectedUsers"
-     *ngIf="_selectedItems.length">{{ _selectedItems.length }}
-    {_selectedItems.length, plural, =1 {item} other {items}} selected
+<div
+    class="approval-flow-user-list__selected-count" 
+    *ngIf="_selectedItems.length">
+    {{ _selectedItems.length }}
+    <ng-container
+        *ngIf="_selectedItems.length === 1; else multipleItems"
+        i18n="@@platformApprovalFlowSelectedUser">
+        item selected
+    </ng-container>
+    <ng-template #multipleItems i18n="@@platformApprovalFlowSelectedUsers">
+        items selected
+    </ng-template>
 </div>
 <fdp-list
     [selectionMode]="isSelectable ? 'multi' : 'none'"

--- a/libs/platform/src/lib/components/approval-flow/approval-flow.component.html
+++ b/libs/platform/src/lib/components/approval-flow/approval-flow.component.html
@@ -121,15 +121,15 @@
 </div>
 
 <ng-template let-messageToast #reminderTemplate>
-    <ng-container i18n="@@platformApprovalFlowReminderMessage">
-        Reminder has been sent to
-        {
-            messageToast.data.targets.length,
-            plural,
-            =1 {{{messageToast.data.targets[0].name}}}
-            other {{{messageToast.data.targets.length}} members of {{messageToast.data.node.description}}}
-            }
+    <ng-container
+        *ngIf="messageToast.data.targets.length === 1; else multipleRecievers"
+        i18n="@@platformApprovalFlowReminderMessage">
+        Reminder has been sent to {{messageToast.data.targets[0].name}}
     </ng-container>
+    
+    <ng-template #multipleRecievers i18n="@@platformApprovalFlowReminderMessageMultipleRecievers">
+        Reminder has been sent to {{messageToast.data.targets.length}} members of {{messageToast.data.node.description}}
+    </ng-template>
 </ng-template>
 
 <ng-template #approverAddSuccess>

--- a/libs/platform/src/lib/components/form/text-area/text-area.component.html
+++ b/libs/platform/src/lib/components/form/text-area/text-area.component.html
@@ -22,9 +22,16 @@
 
 <!-- ICU recommends full text in format -->
 <div class="fd-textarea-counter" *ngIf="showExceededText" aria-live="polite" aria-atomic="true" [attr.id]="id+'-counter'">
-    <span i18n="textarea counter|The counter message for this textarea element@@platformI18nTextareaCounterMessage">
-        {{ exceededCharCount | number: '1.0-0' }} {exceededCharCount, plural, =1{ character {counterExcessOrRemaining,
-        select, excess {over the limit} remaining {remaining}} } other { characters {counterExcessOrRemaining, select,
-        excess {over the limit} remaining {remaining}} } }</span
-    >
+    <span>
+        <ng-container
+            *ngIf="counterExcessOrRemaining === 'excess'; else charactersRemaining"
+            i18n="@@platformI18nTextareaCounterMessageCharactersOverTheLimit">
+            {{ exceededCharCount | number: '1.0-0' }} characters over the limit
+        </ng-container>
+        <ng-template
+            #charactersRemaining
+            i18n="@@platformI18nTextareaCounterMessageCharacterseRemaining">
+            {{ exceededCharCount | number: '1.0-0' }} characters remaining
+        </ng-template>
+    </span>
 </div>

--- a/libs/platform/src/lib/components/table/components/table-p13-dialog/columns/columns.component.html
+++ b/libs/platform/src/lib/components/table/components/table-p13-dialog/columns/columns.component.html
@@ -38,10 +38,16 @@
                 fd-button
                 [compact]="true"
                 fdType="transparent"
-                i18n="@@platformTableP13ColumnsDialogShowAllOrSelected"
                 (click)="_toggleShowAll()"
             >
-                {_showAllItemsSubject | async, select, true {Show Selected} other {Show All}}
+                <ng-container
+                    *ngIf="(_showAllItemsSubject | async) === true; else showAll"
+                    i18n="@@platformTableP13ColumnsDialogsShowSelected">
+                    Show Selected
+                </ng-container>
+                <ng-template #showAll i18n="@@platformTableP13ColumnsDialogShowAll">
+                    Show all
+                </ng-template>
             </button>
 
             <!-- Active Button Movement -->

--- a/libs/platform/src/lib/components/table/components/table-p13-dialog/filtering/filter-rule.component.html
+++ b/libs/platform/src/lib/components/table/components/table-p13-dialog/filtering/filter-rule.component.html
@@ -33,24 +33,91 @@
                     *ngFor="let strategy of rule.strategies"
                     [value]="strategy"
                 >
-                    <span i18n="@@platformTableP13FilterStrategyLabel">
-                        { strategy, select,
-                        between {between}
-                        contains {contains}
-                        beginsWith {begins with}
-                        endsWith {ends with}
-                        equalTo {equal to}
-                        greaterThan {greater than}
-                        greaterThanOrEqualTo {greater than or equal to}
-                        lessThan {less than}
-                        lessThanOrEqualTo {less than or equal to}
-                        after {after}
-                        onOrAfter {on or after}
-                        before {before}
-                        beforeOrOn {before or on}
-                        other {Not defined}
-                        }
-                    </span>
+                    <ng-container [ngSwitch]="strategy">
+                        <span 
+                            *ngSwitchCase="'between'" 
+                            i18n="@@platformTableP13FilterStrategyLabelBetween">
+                            between
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'contains'" 
+                            i18n="@@platformTableP13FilterStrategyLabelContains">
+                            contains
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'beginsWith'" 
+                            i18n="@@platformTableP13FilterStrategyLabelBeginsWith">
+                            begins with
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'endsWith'" 
+                            i18n="@@platformTableP13FilterStrategyLabelEndsWith">
+                            ends with
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'equalTo'" 
+                            i18n="@@platformTableP13FilterStrategyLabelEqualTo">
+                            equal to
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'greaterThan'" 
+                            i18n="@@platformTableP13FilterStrategyLabelGreaterThan">
+                            greater than
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'greaterThanOrEqualTo'" 
+                            i18n="@@platformTableP13FilterStrategyLabelGreaterThanOrEqualTo">
+                            greater than or equal to
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'lessThan'" 
+                            i18n="@@platformTableP13FilterStrategyLabelLessThan">
+                            less than
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'lessThanOrEqualTo'" 
+                            i18n="@@platformTableP13FilterStrategyLabelLessThanOrEqualTo">
+                            less than or equal to
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'after'" 
+                            i18n="@@platformTableP13FilterStrategyLabelAfter">
+                            after
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'onOrAfter'" 
+                            i18n="@@platformTableP13FilterStrategyLabelOnOrAfter">
+                            on or after
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'before'" 
+                            i18n="@@platformTableP13FilterStrategyLabelBefore">
+                            before
+                        </span>
+
+                        <span 
+                            *ngSwitchCase="'beforeOrOn'" 
+                            i18n="@@platformTableP13FilterStrategyLabelBeforeOrOn">
+                            before or on
+                        </span>
+
+                        <span
+                            *ngSwitchCaseDefault 
+                            i18n="@@platformTableP13FilterStrategyLabelNotDefined">
+                            Not Defined
+                        </span>
+                    </ng-container>
                 </fd-option>
             </fd-select>
         </div>

--- a/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
+++ b/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
@@ -581,8 +581,10 @@
         <ng-template #filesAndFoldersMovedTo i18n="@@platformUploadCollection.Message.Move.FoldersAndFiles">
             {{ count.folder }} folders and {{ count.file}} files have been moved to
         </ng-template>
-        
-        {{ payload.to ? payload.to.name : 'All files' }}.
+
+        <ng-container *ngIf="payload.to; else allFiles">
+            {{payload.to.name}}
+        </ng-container>.
     </ng-container>
 
     <ng-container
@@ -598,7 +600,9 @@
             {{ count.folder }} folders have been moved to
         </ng-template>
         
-        {{ payload.to ? payload.to.name : 'All files' }}.
+        <ng-container *ngIf="payload.to; else allFiles">
+            {{payload.to.name}}
+        </ng-container>.
     </ng-container>
 
     <ng-container
@@ -614,7 +618,9 @@
             {{ count.file }} files have been moved to
         </ng-template>
         
-        {{ payload.to ? payload.to.name : 'All files' }}.
+        <ng-container *ngIf="payload.to; else allFiles">
+            {{payload.to.name}}
+        </ng-container>.
     </ng-container>
 
     <ng-container *ngIf="payload.items.length === 1">
@@ -628,7 +634,9 @@
             {{ payload.items[0].name }} have been moved to
         </ng-template>
 
-        {{ payload.to ? payload.to.name : 'All files' }}.
+        <ng-container *ngIf="payload.to; else allFiles">
+            {{payload.to.name}}
+        </ng-container>.
     </ng-container>
 </ng-template>
 
@@ -669,4 +677,8 @@
     <ng-container i18n="@@platformUploadCollection.Message.FilenameLength.OneItem" *ngIf="payload.items.length === 1">
         The name "{{ payload.items[0].name }}" exceeded the maximum filename length. Allowed filename length: {{ maxFilenameLength }} characters.
     </ng-container>
+</ng-template>
+
+<ng-template #allFiles i18n="platformUploadCollection.Message.AllFiles">
+    All files
 </ng-template>

--- a/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
+++ b/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
@@ -483,81 +483,151 @@
 </ng-template>
 
 <ng-template #messageNewFolder let-payload="payload" let-messageStripType="messageStripType">
-    <ng-container i18n="@@platformUploadCollection.Message.Create">
-        {{ payload.folder.name }} has been { messageStripType, select, error {failed to create} other {created} }.
+    <ng-container
+        *ngIf="messageStripType === 'error'; else foldersCreated"
+        i18n="@@platformUploadCollection.Message.Create.Failed">
+        {{ payload.folder.name }} has been failed to create.
     </ng-container>
+    <ng-template #foldersCreated i18n="@@platformUploadCollection.Message.Create">
+        {{ payload.folder.name }} has been created.
+    </ng-template>
 </ng-template>
 
 <ng-template #messageUpdateVersion let-payload="payload" let-messageStripType="messageStripType">
-    <ng-container i18n="@@platformUploadCollection.Message.UpdateVersion">
-        {{ payload.item.name }} has been { messageStripType, select, error {failed to update} other {updated} } version.
+    <ng-container
+        *ngIf="messageStripType === 'error'; else versionUpdated"
+        i18n="@@platformUploadCollection.Message.UpdateVersion.Failed">
+        {{ payload.item.name }} has been failed to update version.
     </ng-container>
+    <ng-template #versionUpdated i18n="@@platformUploadCollection.Message.UpdateVersion">
+        {{ payload.item.name }} has been updated version.
+    </ng-template>
 </ng-template>
 
 <ng-template #messageFileRename let-payload="payload" let-messageStripType="messageStripType">
-    <ng-container i18n="@@platformUploadCollection.Message.FileRename">
-        The file "{{ payload.item.name }}" has been { messageStripType, select, error {failed to rename} other { renamed
-        }} to "{{ payload.fileName }}".
+    <ng-container
+        *ngIf="messageStripType === 'error'; else fileRenamed"
+        i18n="@@platformUploadCollection.Message.FileRename.Failed">
+        The file "{{ payload.item.name }}" has been failed to rename to "{{ payload.fileName }}".
     </ng-container>
+    <ng-template #fileRenamed i18n="@@platformUploadCollection.Message.FileRename">
+        The file "{{ payload.item.name }}" has been renamed to "{{ payload.fileName }}".
+    </ng-template>
 </ng-template>
 
 <ng-template #messageRemove let-payload="payload" let-messageStripType="messageStripType" let-count="count">
     <ng-container
         *ngIf="payload.items.length > 1 && count.folder && count.file"
-        i18n="@@platformUploadCollection.Message.Remove.FoldersAndFiles"
     >
-        {{ count.folder }} { count.folder, plural, =1 {folder} other {folders} } and {{ count.file }} { count.file,
-        plural, =1 {file} other {files} } have been { messageStripType, select, error {failed to remove} other {removed}
-        }.
+        <ng-container
+            *ngIf="messageStripType === 'error'; else foldersAndFilesRemoved"
+            i18n="@@platformUploadCollection.Message.Remove.FoldersAndFiles.Failed"
+        >
+            {{ count.folder }} folders and {{ count.file }} files have been failed to remove.
+        </ng-container>
+        <ng-template #foldersAndFilesRemoved i18n="@@platformUploadCollection.Message.Remove.FoldersAndFiles">
+            {{ count.folder }} folders and {{ count.file }} files have been removed.
+        </ng-template>
     </ng-container>
 
     <ng-container
-        i18n="@@platformUploadCollection.Message.Remove.Folders"
         *ngIf="payload.items.length > 1 && count.folder && !count.file"
     >
-        {{ count.folder }} folders have been { messageStripType, select, error {failed to remove} other {removed} }.
+        <ng-container
+            *ngIf="messageStripType === 'error'; else foldersRemoved"
+            i18n="@@platformUploadCollection.Message.Remove.Folders.Failed">
+            {{ count.folder }} folders have been failed to remove.
+        </ng-container>
+        <ng-template #foldersRemoved i18n="@@platformUploadCollection.Message.Remove.Folders">
+            {{ count.folder }} folders have been removed.
+        </ng-template>
     </ng-container>
 
     <ng-container
-        i18n="@@platformUploadCollection.Message.Remove.Files"
         *ngIf="payload.items.length > 1 && count.file && !count.folder"
     >
-        {{ count.file }} files have been { messageStripType, select, error {failed to remove} other {removed} }.
+        <ng-container
+            *ngIf="messageStripType === 'error'; else filesRemoved"
+            i18n="@@platformUploadCollection.Message.Remove.Files.Failed">
+            {{ count.file }} files have been failed to remove.
+        </ng-container>
+        <ng-template #filesRemoved i18n="@@platformUploadCollection.Message.Remove.Files">
+            {{ count.file }} files have been removed.
+        </ng-template>
     </ng-container>
 
-    <ng-container i18n="@@platformUploadCollection.Message.Remove.OneItem" *ngIf="payload.items.length === 1">
-        {{ payload.items[0].name }} has been { messageStripType, select, error {failed to remove} other {removed} }.
+    <ng-container *ngIf="payload.items.length === 1">
+        <ng-container
+            *ngIf="messageStripType === 'error'; else oneItemRemoved"
+            i18n="@@platformUploadCollection.Message.Remove.OneItem.Failed">
+            {{ payload.items[0].name }} has been failed to remove.
+        </ng-container>
+        <ng-template #oneItemRemoved i18n="@@platformUploadCollection.Message.Remove.OneItem">
+            {{ payload.items[0].name }} has been removed.
+        </ng-template>
     </ng-container>
 </ng-template>
 
 <ng-template #messageMove let-payload="payload" let-messageStripType="messageStripType" let-count="count">
     <ng-container
         *ngIf="payload.items.length > 1 && count.folder && count.file"
-        i18n="@@platformUploadCollection.Message.Move.FoldersAndFiles"
     >
-        {{ count.folder }} { count.folder, plural, =1 {folder} other {folders} } and {{ count.file }} { count.file,
-        plural, =1 {file} other {files}} have been { messageStripType, select, error {failed to move to} other {moved
-        to} } {{ payload.to ? payload.to.name : 'All files' }}.
+        <ng-container
+            *ngIf="messageStripType === 'error'; else filesAndFoldersMovedTo"
+            i18n="@@platformUploadCollection.Message.Move.FoldersAndFiles.Failed"
+        >
+            {{ count.folder }} folders and {{ count.file}} files have been failed to move to
+        </ng-container>
+        <ng-template #filesAndFoldersMovedTo i18n="@@platformUploadCollection.Message.Move.FoldersAndFiles">
+            {{ count.folder }} folders and {{ count.file}} files have been moved to
+        </ng-template>
+        
+        {{ payload.to ? payload.to.name : 'All files' }}.
     </ng-container>
 
     <ng-container
-        i18n="@@platformUploadCollection.Message.Move.Folders"
         *ngIf="payload.items.length > 1 && count.folder && !count.file"
     >
-        {{ count.folder }} folders have been { messageStripType, select, error {failed to move to} other {moved to} }
+        <ng-container
+            *ngIf="messageStripType === 'error'; else foldersMovedTo"
+            i18n="@@platformUploadCollection.Message.Move.Folders.Failed"
+        >
+            {{ count.folder }} folders have been failed to move to
+        </ng-container>
+        <ng-template #foldersMovedTo i18n="@@platformUploadCollection.Message.Move.Folders">
+            {{ count.folder }} folders have been moved to
+        </ng-template>
+        
         {{ payload.to ? payload.to.name : 'All files' }}.
     </ng-container>
 
     <ng-container
-        i18n="@@platformUploadCollection.Message.Move.Files"
         *ngIf="payload.items.length > 1 && count.file && !count.folder"
     >
-        {{ count.file }} files have been { messageStripType, select, error {failed to move to} other {moved to}}
+        <ng-container
+            *ngIf="messageStripType === 'error'; else filesMovedTo"
+            i18n="@@platformUploadCollection.Message.Move.Files.Failed"
+        >
+            {{ count.file }} files have been failed to move to
+        </ng-container>
+        <ng-template #filesMovedTo i18n="@@platformUploadCollection.Message.Move.Files">
+            {{ count.file }} files have been moved to
+        </ng-template>
+        
         {{ payload.to ? payload.to.name : 'All files' }}.
     </ng-container>
 
-    <ng-container i18n="@@platformUploadCollection.Message.Move.OneItem" *ngIf="payload.items.length === 1">
-        {{ payload.items[0].name }} has been { messageStripType, select, error {failed to move to} other {moved to} }
+    <ng-container *ngIf="payload.items.length === 1">
+        <ng-container
+            *ngIf="messageStripType === 'error'; else oneItemMovedTo"
+            i18n="@@platformUploadCollection.Message.Move.OneItem.Failed"
+        >
+            {{ payload.items[0].name }} have been failed to move to
+        </ng-container>
+        <ng-template #oneItemMovedTo i18n="@@platformUploadCollection.Message.Move.OneItem">
+            {{ payload.items[0].name }} have been moved to
+        </ng-template>
+
         {{ payload.to ? payload.to.name : 'All files' }}.
     </ng-container>
 </ng-template>

--- a/libs/platform/src/lib/components/value-help-dialog/components/define-tab/define-tab.component.html
+++ b/libs/platform/src/lib/components/value-help-dialog/components/define-tab/define-tab.component.html
@@ -134,21 +134,78 @@
 <ng-template #conditionStrategyOption let-type="type" let-strategy="strategy">
     <ng-container *ngIf="strategyLabels[strategy.key]; else defaultOption">{{ strategyLabels[strategy.key] }}</ng-container>
     <ng-template #defaultOption>
-        <ng-container i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label">
-            {strategy.key, select,
-                contains {contains}
-                equalTo {equal to}
-                between {between}
-                startsWith {starts with}
-                endsWith {ends with}
-                lessThan {less than}
-                lessThanEqual {less than or equal to}
-                greaterThan {greater than}
-                greaterThanEqual {greater than or equal to}
-                empty {empty}
-                not_equalTo {not equal to}
-                not_empty {not empty}
-            }
+        <ng-container [ngSwitch]="strategy.key">
+            <ng-container
+                *ngSwitchCase="'contains'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.Contains">
+                contains
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'equalTo'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.EqualTo">
+                equal to
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'between'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.Between">
+                between
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'startsWith'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.StartsWith">
+                starts with
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'endsWith'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.EndsWith">
+                ends with
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'lessThan'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.LessThan">
+                less than
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'lessThanEqual'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.LessThanEqual">
+                less than equal
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'greaterThan'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.GreaterThan'">
+                greater than
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'greaterThanEqual'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.GreaterThanEqual">
+                greater than equal
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'empty'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.Empty">
+                empty
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'not_equalTo'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.NotEqualTo">
+                not equal to
+            </ng-container>
+
+            <ng-container
+                *ngSwitchCase="'not_empty'"
+                i18n="@@platformI18nValueHelpDialog.Define.Condition.Strategy.Label.NotEmpty">
+                not empty
+            </ng-container>
         </ng-container>
     </ng-template>
 </ng-template>

--- a/libs/platform/src/lib/components/value-help-dialog/models/vhd-strategy.enum.ts
+++ b/libs/platform/src/lib/components/value-help-dialog/models/vhd-strategy.enum.ts
@@ -1,17 +1,3 @@
-export enum VhdDefineStrategy {
-    contains = 'contains',
-    equalTo = 'equalTo',
-    between = 'between',
-    startsWith = 'startsWith',
-    endsWith = 'endsWith',
-    lessThan = 'lessThan',
-    lessThanEqual = 'lessThanEqual',
-    greaterThan = 'greaterThan',
-    greaterThanEqual = 'greaterThanEqual',
-    empty = 'empty',
-    not_equalTo = 'not_equalTo',
-    not_empty = 'not_empty'
-}
 export enum VhdDefineIncludeStrategy {
     contains = 'contains',
     equalTo = 'equalTo',
@@ -24,6 +10,7 @@ export enum VhdDefineIncludeStrategy {
     greaterThanEqual = 'greaterThanEqual',
     empty = 'empty'
 }
+
 export enum VhdDefineExcludeStrategy {
     not_equalTo = 'not_equalTo',
     not_empty = 'not_empty'


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Closes #5098.

#### Please provide a brief summary of this pull request.

Code of the Platform components refactored to get rid of plural & select features of the i18n. The [wiki page](https://github.com/SAP/fundamental-ngx/wiki/Internationalization-Supporting-in-@fundamental-ngx-platform#select--plural) about internationalization updated.

As i18n isn't an Angular directive - we're highly limited in next things:

* Cannot **bind** i18n id - so we cannot implement & use helper component.
* Cannot set i18n markers **inside** of the loops, components code (there exist hacky solution but it isn't applicable as translations extracting isn't working).

#### Please check whether the PR fulfills the following requirements

- [X] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [X] tests for the changes that have been done
- [X] all items on the [PR Review Checklist](https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist) are addressed.
- [X] Run npm run build-pack-library and test in external application

Documentation checklist:
- [X] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [X] Documentation Examples
- [X] Stackblitz works for all examples