### PR TITLE
fix: (Platform) Add ability to use fdp-form-field out of fdp-form-group-content

### DIFF
--- a/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.ts
+++ b/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.ts
@@ -23,7 +23,6 @@ import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coerci
 import { Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 
-
 import { FormFieldControl } from '../../form-control';
 import { FormField } from '../../form-field';
 import { Column, LabelLayout, HintPlacement } from '../../form-options';
@@ -127,6 +126,13 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
     @Input()
     disabled = false;
 
+    /**
+     * Form Group Container to bind the Form-Field to.
+     * This will override default value injected by constructor
+     */
+    @Input()
+    formGroupContainer: FormGroupContainer;
+
     @Output()
     onChange: EventEmitter<string> = new EventEmitter<string>();
 
@@ -155,12 +161,18 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
     /** @hidden */
     constructor(
         private _cd: ChangeDetectorRef,
-        private _elementRef: ElementRef,
-        @Optional() readonly formGroupContainer: FormGroupContainer,
-        @Optional() @SkipSelf() @Host() readonly formFieldGroup: FormFieldGroup) {
+        @Optional() formGroupContainer: FormGroupContainer,
+        @Optional() @SkipSelf() @Host() readonly formFieldGroup: FormFieldGroup
+    ) {
         // provides capability to make a field disabled. useful in reactive form approach.
         this.formControl = new FormControl({ value: null, disabled: this.disabled });
-
+        // formGroupContainer can be injected only if current form-field is located
+        // insight formGroupContainer content.
+        // If this is not the case the formGroupContainer
+        // will be undefined (known angular issue),
+        // in such case formGroupContainer can be pointed explicitly using
+        // component input annotation
+        this.formGroupContainer = formGroupContainer;
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/components/form/form.spec.ts
+++ b/libs/platform/src/lib/components/form/form.spec.ts
@@ -3,7 +3,6 @@ import { TestBed, ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ReactiveFormsModule, FormGroup } from '@angular/forms';
 
-import { ContentDensityService } from '../../../../../core/src';
 import { FormGroupComponent } from './form-group/form-group.component';
 import { FdpFormGroupModule } from './form-group/fdp-form.module';
 import { PlatformInputModule } from './input/fdp-input.module';
@@ -349,7 +348,6 @@ describe('fdp-form-field out of fdp-form-group', () => {
             TestBed.configureTestingModule({
                 imports: [ReactiveFormsModule, FdpFormGroupModule, PlatformInputModule],
                 declarations: [HostFormComponent],
-                providers: [ContentDensityService]
             }).compileComponents();
         })
     );


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes:  https://github.com/SAP/fundamental-ngx/issues/5121
#### Please provide a brief summary of this pull request.
This PR adds optional input to the `fdp-form-field` component.
Currently `fdp-form-field` injects `fdp-form-group` instance through the component constructor, which means this injection doesn't work when `fdp-form-field` is defined out of `fdp-form-group` content.
New optional input gives the possibility to define parent FormGroupContainer explicitly through component input.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

