### PR TITLE
chore: (Platform)css cleanup hardcoded styles from multi Input component

### DIFF
--- a/e2e/wdio/platform/pages/multi-input.po.ts
+++ b/e2e/wdio/platform/pages/multi-input.po.ts
@@ -8,7 +8,7 @@ export class MultiInputPo extends BaseComponentPo {
     activeDropdownButtons = '[ng-reflect-disabled="false"] button[ng-reflect-glyph="value-help"]';
     allDropdownButtons = 'button[ng-reflect-glyph="value-help"]';
     disabledDropdownButtons = '[ng-reflect-disabled="true"] button[ng-reflect-glyph="value-help"]';
-    activeInputs = '.fd-multi-input-field [ng-reflect-disabled="false"] input';
+    activeInputs = '.fd-multi-input [ng-reflect-disabled="false"] input';
     mobileInput = 'div[role="dialog"] input';
     disabledInputs = '.fdp-multi-input [ng-reflect-disabled="true"] input';
     filledInput = '[ng-reflect-disabled="false"] .fd-tokenizer__inner';

--- a/libs/platform/src/lib/components/form/multi-input/multi-input.component.html
+++ b/libs/platform/src/lib/components/form/multi-input/multi-input.component.html
@@ -45,7 +45,7 @@
             [class]="contentDensity === 'compact' ? 'fd-multi-input-tokenizer-custom--compact' : ''"
             (moreClickedEvent)="moreClicked()"
         >
-            <fd-token [readOnly]="disabled" (onCloseClick)="removeToken(token)" *ngFor="let token of selected">{{
+            <fd-token [readOnly]="disabled" [compact]="contentDensity === 'compact'" (onCloseClick)="removeToken(token)" *ngFor="let token of selected">{{
                 token.label
             }}</fd-token>
             <input

--- a/libs/platform/src/lib/components/form/multi-input/multi-input.component.html
+++ b/libs/platform/src/lib/components/form/multi-input/multi-input.component.html
@@ -1,7 +1,5 @@
-<div class="fd-multi-input fd-multi-input-custom">
-    <div class="fd-multi-input-field">
+<div class="fd-multi-input">
         <ng-container *ngTemplateOutlet="mobile ? mobileTemplate : desktopTemplate"></ng-container>
-    </div>
 </div>
 <ng-template #desktopTemplate>
     <div class="fdp-multi-input" cdkOverlayOrigin #selectTrigger="cdkOverlayOrigin">
@@ -28,7 +26,6 @@
 
 <ng-template #controlTemplate>
     <fd-input-group
-        class="fd-multi-input-input-group-custom"
         [button]="!readonly"
 		[buttonFocusable]="false"
 		[isControl]="true"

--- a/libs/platform/src/lib/components/form/multi-input/multi-input.component.scss
+++ b/libs/platform/src/lib/components/form/multi-input/multi-input.component.scss
@@ -1,4 +1,4 @@
-//TODO evaluate whether this should be in fd-styles
+//Cutomization based on the width of the input used
 
 .fd-multi-input-tokenizer-custom {
     width: calc(100% - 2.25rem);
@@ -6,96 +6,14 @@
         width: calc(100% - 2rem);
     }
 }
-
-.fd-multi-input-input-group-custom {
-    max-width: 100%;
-}
-
-.fd-multi-input-custom {
-    display: block;
-}
-
-.fd-multi-input-item {
-    cursor: pointer;
-    padding: 0;
-}
-
-.fd-multi-input-popover-size {
-    overflow: auto;
-    display: block;
-}
-
-.fd-multi-input-popover-custom.fd-popover-custom {
-	max-width: 100%;
-	display: block;
-
-    .fd-tokenizer {
-        height: 100%;
-    }
-}
-
-.fd-multi-input-menu-overflow {
-    max-width: 37.5rem;
-    overflow: auto;
-
-    // TODO: Remove after adjusting in styles
-    &:not(.fd-list--compact) {
-        .fd-list__item {
-            height: 2.5rem;
-
-            .fd-checkbox__label {
-                padding-top: 0.5625rem;
-                padding-bottom: 0.5625rem;
-            }
-        }
-    }
-}
-
-.fd-input {
-    &.fd-multi-input-tokenizer-input {
-        margin-top: 0;
-        margin-bottom: 0;
-        padding-left: 0;
-        background-color: transparent;
-		min-width: 150px !important;
-    }
-}
-
-.fd-multi-input-show-all {
-    float: right;
-    background-color: transparent;
-    .fd-link:active {
-        color: inherit;
-    }
-}
-
-.fd-multi-input-checkbox {
-    width: 100%;
-    cursor: pointer;
-
-    .fd-checkbox__label {
-        color: inherit;
-    }
-}
-
-.fd-list--multi-input {
-    max-width: 100%;
-}
+// code to adjust to the parent width
 
 .fdp-multi-input {
     &__list-container {
         &.fd-popover__popper {
-            width: 100% !important;
-            position: absolute !important;
+            width: 100% ;
             overflow: hidden;
-
-            .fd-list--dropdown {
-                max-width: 100%;
-            }
+			position: relative;
         }
-    }
-
-    &__list {
-        overflow: auto;
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.

styles Migrated to latest version and removed the styles from ngx component scss file.

part of: https://github.com/SAP/fundamental-ngx/issues/5025

#### Please provide a brief summary of this pull request.

style clean up post the migration. since its a patterned component few customisable css is retained as part of the clean up.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] Documentation Examples
- [x] Stackblitz works for all examples

