### PR TITLE
fix: (Store) Exporting additional types for QueryAdapter

### DIFF
--- a/libs/store/src/index.ts
+++ b/libs/store/src/index.ts
@@ -27,10 +27,16 @@ export {
     QueryAdapter,
     DefaultQueryAdapter,
     QueryAdapterService,
-    DefaultQueryAdapterService
+    DefaultQueryAdapterService,
+    QueryAdapterFactory
 } from './lib/infrastructure/persistence/query/query-adapter';
-export { Query } from './lib/infrastructure/persistence/query/query';
+export {
+    Query,
+    QuerySnapshot,
+    OrderBy
+} from './lib/infrastructure/persistence/query/query';
 export * from './lib/infrastructure/persistence/query/grammar/query-expressions';
+export * from './lib/infrastructure/persistence/query/grammar/predicate';
 export {
     FundamentalRootStoreModule,
     FundamentalStoreModule,

--- a/libs/store/src/lib/infrastructure/persistence/query/query-adapter.ts
+++ b/libs/store/src/lib/infrastructure/persistence/query/query-adapter.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BaseEntity, EntityType } from '../../../domain/public_api';
+import { EntityType } from '../../../domain/public_api';
 import {
     Predicate,
     EqPredicate,


### PR DESCRIPTION
#### Please provide a link to the associated issue.
n/a

#### Please provide a brief summary of this pull request.

In order for the end user to develop their own customized QueryAdapter, they need query and predicate types which are currently not exported.

Adding exports for
* QueryAdapterFactory
* QuerySnapshot
* OrderBy
* collection of Predicate types

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md


