### PR TITLE
fix: (Store) Fixing data returned by getWithQuery

### DIFF
--- a/libs/store/src/lib/infrastructure/persistence/store/entity-store-builder.ts
+++ b/libs/store/src/lib/infrastructure/persistence/store/entity-store-builder.ts
@@ -138,7 +138,9 @@ export class DefaultQueryService<TModel> extends QueryService<TModel> {
 
     getWithQuery(query: QuerySnapshot<TModel>): Observable<TModel[]> {
         return this.service.getWithQuery(query as any).pipe(
-            map(dto => instanceForType(this.entity, dto))
+            map((data: TModel[]) => {
+                return data.map(dto => instanceForType(this.entity, dto));
+            })
         );
     }
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
n/a

#### Please provide a brief summary of this pull request.

`DefaultQueryService.getWithQuery` is supposed to return a observable with an array of proxied entity objects. Instead it was  returning a proxied array of entities.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist

