### PR TITLE
fix: (Platform) make formcontrol non mandatory  in checkbox group for non form cases

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-checkbox-group/platform-checkbox-group-examples/platform-checkbox-group-list-object.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-checkbox-group/platform-checkbox-group-examples/platform-checkbox-group-list-object.component.html
@@ -96,3 +96,17 @@
         </fdp-checkbox-group>
     </fdp-form-field>
 </fdp-form-group>
+
+<h3>Checkbox group outside form</h3>
+<fdp-checkbox-group [list]="languages" name="languages" [isInline]="true" ariaLabel="My known languages"
+    [(checked)]="selectedDishes">
+</fdp-checkbox-group>
+
+<span style="margin-left: 2rem;">Selected dishes: {{ selectedDishes }}</span>
+
+<h3>Checkbox group outside form using displayKey and lookupKey:</h3>
+<fdp-checkbox-group [list]="invoiceItems" name="invoices" lookupKey="item" displayKey="itemType"
+    ariaLabel="Purchased Items" [(checked)]="selectedInvoices">
+</fdp-checkbox-group>
+
+<span style="margin-left: 2rem;">Selected invoices: {{ selectedInvoices }}</span>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-checkbox-group/platform-checkbox-group-examples/platform-checkbox-group-list-object.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-checkbox-group/platform-checkbox-group-examples/platform-checkbox-group-list-object.component.ts
@@ -37,6 +37,10 @@ export class PlatformCheckboxGroupListObjectComponent {
     languagesKnown = '';
     currencies = ['INR', 'USD'];
     itemsData = ['pen'];
+
+    // outside form
+    selectedDishes = ['java', 'javascript'];
+    selectedInvoices = ['pen'];
 }
 
 class Country implements SelectItem {

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-checkbox-group/platform-checkbox-group-examples/platform-checkbox-group-list.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-checkbox-group/platform-checkbox-group-examples/platform-checkbox-group-list.component.html
@@ -75,3 +75,9 @@
         </fdp-checkbox-group>
     </fdp-form-field>
 </fdp-form-group>
+
+<h3>Checkbox group outside form</h3>
+<fdp-checkbox-group [list]="dishes" name="fav-dishes" [isInline]="true" ariaLabel="My favorite dishes"
+    [(checked)]="selectedDishes"></fdp-checkbox-group>
+
+<span style="margin-left: 2rem;">Selected dishes: {{ selectedDishes }}</span>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-checkbox-group/platform-checkbox-group-examples/platform-checkbox-group-list.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-checkbox-group/platform-checkbox-group-examples/platform-checkbox-group-list.component.ts
@@ -7,6 +7,7 @@ import { FormGroup, FormControl } from '@angular/forms';
 })
 export class PlatformCheckboxGroupListComponent {
     seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
+    dishes: string[] = ['Italian', 'Chinese', 'Indian', 'Japanese'];
     sports: string[] = ['cycling', 'running', 'visit gym', 'swimming'];
     phonesList: string[] = ['Samsung', 'Apple', 'OnePlus', 'Redmi'];
 
@@ -22,4 +23,7 @@ export class PlatformCheckboxGroupListComponent {
     // template driven
     countrySeason = '';
     selectedSports = ['running', 'swimming'];
+
+    // outside form
+    selectedDishes = ['Chinese', 'Italian'];
 }

--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
@@ -54,6 +54,18 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
     @Input()
     isInline = false;
 
+    /**
+     * Establishes two way binding, when checkbox group used outside form.
+     */
+    @Input()
+    get checked(): string[] {
+        return this._checked;
+    }
+    set checked(checkedValues: string[]) {
+        this._checked = checkedValues;
+        this.value = checkedValues;
+    }
+
     /** Children checkboxes passed as content */
     @ContentChildren(CheckboxComponent)
     contentCheckboxes: QueryList<CheckboxComponent>;
@@ -64,6 +76,13 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
 
     @Output()
     readonly valueChange: EventEmitter<PlatformCheckboxChange> = new EventEmitter<PlatformCheckboxChange>();
+
+    /** Emits checked change event */
+    @Output()
+    readonly checkedChange: EventEmitter<String[]> = new EventEmitter<String[]>();
+
+    /** @hidden used for two way binding, when used outside form */
+    private _checked: string[];
 
     constructor(
         cd: ChangeDetectorRef,
@@ -87,8 +106,12 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
      * @param event: contains checkbox and event in a PlatformCheckboxChange class object.
      */
     public groupValueChanges(event: PlatformCheckboxChange): void {
-        this.onTouched();
-        this.valueChange.emit(event);
+        if (event instanceof PlatformCheckboxChange) {
+            this.checked = event.checked;
+            this.onTouched();
+            this.valueChange.emit(event);
+            this.checkedChange.emit(this.checked);
+        }
     }
 
     /**

--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
@@ -79,7 +79,7 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
 
     /** Emits checked change event */
     @Output()
-    readonly checkedChange: EventEmitter<String[]> = new EventEmitter<String[]>();
+    readonly checkedChange: EventEmitter<string[]> = new EventEmitter<string[]>();
 
     /** @hidden used for two way binding, when used outside form */
     private _checked: string[];


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5173 

#### Please provide a brief summary of this pull request.

Not able is use non template driven checkbox group outside form fields.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a ] update `README.md`
- [n/a ] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

