### PR TITLE
fix: (Core) Text component's more or less label for expand/collapse functionality is not readable for accessibility.

### DIFF
--- a/libs/core/src/lib/text/text.component.html
+++ b/libs/core/src/lib/text/text.component.html
@@ -10,6 +10,7 @@
     </span>
 
     <a fd-link
+       tabindex="0"
        class="fd-text__link--more"
        *ngIf="_expandable && _hasMore"
        (click)="toggleTextView()"

--- a/libs/core/src/lib/text/text.component.html
+++ b/libs/core/src/lib/text/text.component.html
@@ -13,6 +13,7 @@
        tabindex="0"
        class="fd-text__link--more"
        *ngIf="_expandable && _hasMore"
+       (keydown.enter)="toggleTextView()"
        (click)="toggleTextView()"
        [innerText]="isCollapsed ? moreLabel : lessLabel"></a>
 </p>


### PR DESCRIPTION

#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx https://github.com/SAP/fundamental-ngx/issues/5077

#### Please provide a brief summary of this pull request.

Text component more or less label for expand/collapse functionality is not readable for accessibility.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

