### PR TITLE
fix: import form label styling and update facet examples

### DIFF
--- a/apps/docs/src/app/core/component-docs/facets/facet-examples/facet-group-example.component.html
+++ b/apps/docs/src/app/core/component-docs/facets/facet-examples/facet-group-example.component.html
@@ -1,19 +1,19 @@
 <fd-facet-group ariaLabel="Facet Group">
     <fd-facet type="form" facetTitle="Technical Data" id="facet1">
         <fd-facet-content>
-            <label class="fd-form-label" for="form-value-10">Base unit:</label>
+            <label fd-form-label colon="true" for="form-value-10">Base unit</label>
             <fd-text text="Each" id="form-value-10"></fd-text>
         </fd-facet-content>
         <fd-facet-content>
-            <label class="fd-form-label" for="form-value-11">Length:</label>
+            <label fd-form-label colon="true" for="form-value-11">Length</label>
             <fd-text text="23.24 Centimeter" id="form-value-11"></fd-text>
         </fd-facet-content>
         <fd-facet-content>
-            <label class="fd-form-label" for="form-value-12">Width:</label>
+            <label fd-form-label colon="true" for="form-value-12">Width</label>
             <fd-text text="86.1 Centimeter" id="form-value-12"></fd-text>
         </fd-facet-content>
         <fd-facet-content>
-            <label class="fd-form-label" for="form-value-13">Height:</label>
+            <label fd-form-label colon="true" for="form-value-13">Height</label>
             <fd-text text="20.8 Centimeter" id="form-value-13"></fd-text>
         </fd-facet-content>
     </fd-facet>

--- a/apps/docs/src/app/core/component-docs/facets/facet-examples/form-facet-example.component.html
+++ b/apps/docs/src/app/core/component-docs/facets/facet-examples/form-facet-example.component.html
@@ -1,18 +1,18 @@
 <fd-facet type="form" facetTitle="Technical Data" id="formFacetExample">
     <fd-facet-content>
-        <label class="fd-form-label" for="form-value-1">Base unit:</label>
+        <label fd-form-label colon="true"  for="form-value-1">Base unit</label>
         <fd-text text="Each" id="form-value-1"></fd-text>
     </fd-facet-content>
     <fd-facet-content>
-        <label class="fd-form-label" for="form-value-2">Length:</label>
+        <label fd-form-label colon="true"  for="form-value-2">Length</label>
         <fd-text text="23.24 Centimeter" id="form-value-2"></fd-text>
     </fd-facet-content>
     <fd-facet-content>
-        <label class="fd-form-label" for="form-value-3">Width:</label>
+        <label fd-form-label colon="true" for="form-value-3">Width</label>
         <fd-text text="86.1 Centimeter" id="form-value-3"></fd-text>
     </fd-facet-content>
     <fd-facet-content>
-        <label class="fd-form-label" for="form-value-4">Height:</label>
+        <label fd-form-label colon="true" for="form-value-4">Height</label>
         <fd-text text="20.8 Centimeter" id="form-value-4"></fd-text>
     </fd-facet-content>
 </fd-facet>

--- a/libs/core/src/lib/facets/facet-group.component.scss
+++ b/libs/core/src/lib/facets/facet-group.component.scss
@@ -1,7 +1,3 @@
-@import '~fundamental-styles/dist/facet';
-@import '~fundamental-styles/dist/paddings';
-@import '~fundamental-styles/dist/margins';
-
 // this style is specifically for the `alignEnd` modifier
 .fd-facet-align-end {
   order: 1;

--- a/libs/core/src/lib/facets/facet/facet.component.scss
+++ b/libs/core/src/lib/facets/facet/facet.component.scss
@@ -1,0 +1,3 @@
+@import '~fundamental-styles/dist/facet';
+@import '~fundamental-styles/dist/paddings';
+@import '~fundamental-styles/dist/margins';

--- a/libs/core/src/lib/facets/facet/facet.component.ts
+++ b/libs/core/src/lib/facets/facet/facet.component.ts
@@ -17,6 +17,7 @@ let randomTitleId = 0;
 @Component({
     selector: 'fd-facet',
     templateUrl: './facet.component.html',
+    styleUrls: ['./facet.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {


### PR DESCRIPTION
fixes #5016 

#### Please provide a brief summary of this pull request.
1. move the css import to facet component
2. update the examples to use form-label directives


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

