### PR TITLE
fix: (Core|Platform) remove deps from packages nx builder improvement

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -234,7 +234,8 @@
           "builder": "@nrwl/angular:package",
           "options": {
             "tsConfig": "libs/core/tsconfig.lib.json",
-            "project": "libs/core/ng-package.json"
+            "project": "libs/core/ng-package.json",
+            "updateBuildableProjectDepsInPackageJson": false
           },
           "configurations": {
             "production": {
@@ -282,7 +283,8 @@
           "builder": "@nrwl/angular:package",
           "options": {
             "tsConfig": "libs/platform/tsconfig.lib.json",
-            "project": "libs/platform/ng-package.json"
+            "project": "libs/platform/ng-package.json",
+            "updateBuildableProjectDepsInPackageJson": false
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Closes #5356.

#### Please provide a brief summary of this pull request.

Since we've switched to the nrwl/nx builder we started adding dependencies to the packages - it's the default for that builder (and the situation is the opposite for angular/package builder). 

In that case `@fundamental-ngx/core` & `@fundamental-ngx/platform` packages have their own angular package dependencies and their versions may be different from the respective packages provided by the host application - it leads to the various errors (at least the ones described in #5356).

The goal is to disable including packages to avoid any mismatching and use only the packages provided by the host application.

#### Please check whether the PR fulfills the following requirements

- [X] the commit message follows the guideline: https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [X] all items on the PR Review Checklist are addressed : https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [X] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [n/a] Documentation Examples
- [n/a] Stackblitz works for all examples