### PR TITLE
fix: (Core) remove wizard padding logic from dialog body component

### DIFF
--- a/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
+++ b/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
@@ -1,7 +1,6 @@
-import { AfterContentInit, Component, ContentChildren, ElementRef, Optional, QueryList } from '@angular/core';
+import { Component, ElementRef, Optional } from '@angular/core';
 import { DialogConfig } from '../utils/dialog-config.class';
 import { DialogRef } from '../../dialog/utils/dialog-ref.class';
-import { WizardComponent } from '../../wizard/wizard.component';
 
 /**
  * Applies fundamental layout and styling to the contents of a dialog body.
@@ -20,26 +19,11 @@ import { WizardComponent } from '../../wizard/wizard.component';
         '[class.fd-dialog__body--no-vertical-padding]': '!dialogConfig.verticalPadding'
     }
 })
-export class DialogBodyComponent implements AfterContentInit {
-
-    /** @hidden */
-    @ContentChildren(WizardComponent, { descendants: true })
-    _wizard: QueryList<WizardComponent>;
-
+export class DialogBodyComponent {
     /** @hidden */
     constructor(
         private _elRef: ElementRef,
         @Optional() public dialogConfig: DialogConfig,
         @Optional() public dialogRef: DialogRef
     ) {}
-
-    /** @hidden */
-    ngAfterContentInit(): void {
-        if (this._wizard && this._wizard.first) {
-            const style = this._elRef.nativeElement.style;
-            style.paddingTop = '0';
-            style.paddingBottom = '0';
-            style.overflowY = 'hidden';
-        }
-    }
 }

--- a/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
+++ b/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
@@ -26,4 +26,9 @@ export class DialogBodyComponent {
         @Optional() public dialogConfig: DialogConfig,
         @Optional() public dialogRef: DialogRef
     ) {}
+
+    /** @hidden */
+    elementRef(): ElementRef<any> {
+        return this._elRef;
+    }
 }

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -9,6 +9,7 @@ import {
     HostListener,
     Input,
     OnDestroy,
+    Optional,
     QueryList,
     TemplateRef,
     ViewChild,
@@ -19,6 +20,7 @@ import { Subscription } from 'rxjs';
 import { WizardProgressBarDirective } from './wizard-progress-bar/wizard-progress-bar.directive';
 import { scrollTop } from '../utils/functions/scroll';
 import { ACTIVE_STEP_STATUS, CURRENT_STEP_STATUS, UPCOMING_STEP_STATUS, COMPLETED_STEP_STATUS } from './constants';
+import { DialogBodyComponent } from '../dialog/dialog-body/dialog-body.component';
 
 export const STEP_MIN_WIDTH = 168;
 export const STEP_STACKED_TOP_CLASS = 'fd-wizard__step--stacked-top';
@@ -93,7 +95,11 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
     /** @hidden */
     private _previousWidth: number;
 
-    constructor(private _elRef: ElementRef, private readonly _cdRef: ChangeDetectorRef) {}
+    constructor(
+        private _elRef: ElementRef,
+        private readonly _cdRef: ChangeDetectorRef,
+        @Optional() private _dialogBodyComponent: DialogBodyComponent
+    ) {}
 
     /** @hidden */
     @HostListener('window:resize')
@@ -198,18 +204,21 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
 
     /** @hidden */
     private _getDialogOffset(): number {
-        const dialogBody = this._elRef.nativeElement.parentElement;
         let retVal = 0;
-        if (dialogBody.tagName.toLowerCase() === 'fd-dialog-body') {
-            const dialogBodyStyle = this._elRef.nativeElement.parentElement.style;
-            dialogBodyStyle.paddingTop = '0';
-            dialogBodyStyle.paddingBottom = '0';
-            dialogBodyStyle.overflowY = 'hidden';
-            if (dialogBody.querySelector('.' + 'fd-title--h2')) {
-                retVal = dialogBody.querySelector('.' + 'fd-title--h2').offsetHeight;
+        if (this._dialogBodyComponent) {
+            const dialogBody = this._dialogBodyComponent.elementRef().nativeElement;
+            if (dialogBody.tagName.toLowerCase() === 'fd-dialog-body') {
+                const dialogBodyStyle = dialogBody.style;
+                dialogBodyStyle.paddingTop = '0';
+                dialogBodyStyle.paddingBottom = '0';
+                dialogBodyStyle.overflowY = 'hidden';
+                if (dialogBody.querySelector('.' + 'fd-title--h2')) {
+                    retVal = dialogBody.querySelector('.' + 'fd-title--h2').offsetHeight;
+                }
+                retVal = retVal + window.innerHeight - dialogBody.offsetHeight;
             }
-            retVal = retVal + window.innerHeight - dialogBody.offsetHeight;
         }
+
         return retVal;
     }
 

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -208,12 +208,10 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
         if (this._dialogBodyComponent) {
             const dialogBody = this._dialogBodyComponent.elementRef().nativeElement;
             if (dialogBody.tagName.toLowerCase() === 'fd-dialog-body') {
-                const dialogBodyStyle = dialogBody.style;
-                dialogBodyStyle.paddingTop = '0';
-                dialogBodyStyle.paddingBottom = '0';
-                dialogBodyStyle.overflowY = 'hidden';
-                if (dialogBody.querySelector('.' + 'fd-title--h2')) {
-                    retVal = dialogBody.querySelector('.' + 'fd-title--h2').offsetHeight;
+                this._dialogBodyComponent.dialogConfig.verticalPadding = false;
+                const dialogBodyTitle = dialogBody.querySelector('.fd-title--h2');
+                if (dialogBodyTitle) {
+                    retVal = dialogBodyTitle.offsetHeight;
                 }
                 retVal = retVal + window.innerHeight - dialogBody.offsetHeight;
             }

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -201,6 +201,10 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
         const dialogBody = this._elRef.nativeElement.parentElement;
         let retVal = 0;
         if (dialogBody.tagName.toLowerCase() === 'fd-dialog-body') {
+            const dialogBodyStyle = this._elRef.nativeElement.parentElement.style;
+            dialogBodyStyle.paddingTop = '0';
+            dialogBodyStyle.paddingBottom = '0';
+            dialogBodyStyle.overflowY = 'hidden';
             if (dialogBody.querySelector('.' + 'fd-title--h2')) {
                 retVal = dialogBody.querySelector('.' + 'fd-title--h2').offsetHeight;
             }


### PR DESCRIPTION
fixes #5402 

Moves wizard padding logic away from the dialog body to remove circular dependency between components