### PR TITLE
fix: (Core) do not use fdScrollSpy when appendToWizard=false

### DIFF
--- a/libs/core/src/lib/wizard/wizard.component.html
+++ b/libs/core/src/lib/wizard/wizard.component.html
@@ -1,12 +1,17 @@
 <section class="fd-wizard">
     <ng-content select="fd-wizard-navigation"></ng-content>
-    <div
+    <div *ngIf="appendToWizard"
         class="fd-wizard-container-wrapper"
         #wrapperContainer
         fdScrollSpy
         [trackedTags]="['div']"
         (spyChange)="scrollSpyChange($event)"
     >
+        <div *ngFor="let contentTemplate of contentTemplates">
+            <ng-container *ngTemplateOutlet="contentTemplate"></ng-container>
+        </div>
+    </div>
+    <div *ngIf="!appendToWizard" class="fd-wizard-container-wrapper">
         <div *ngFor="let contentTemplate of contentTemplates">
             <ng-container *ngTemplateOutlet="contentTemplate"></ng-container>
         </div>


### PR DESCRIPTION
fixes #5428 

Fixes a bug where a console error would be thrown after scrolling wizard content when `appendToWizard="false"`