### PR TITLE
fix(core): set default ariaLabel to Message Strip for screen reader a11y

### DIFF
--- a/apps/docs/src/app/core/component-docs/message-strip/examples/message-strip-example.component.html
+++ b/apps/docs/src/app/core/component-docs/message-strip/examples/message-strip-example.component.html
@@ -1,13 +1,13 @@
-<fd-message-strip [type]="'warning'">
+<fd-message-strip type="warning">
     A dismissible warning message strip.
 </fd-message-strip>
-<fd-message-strip [type]="'success'" [dismissible]="false">
+<fd-message-strip type="success" [dismissible]="false">
     A non-dismissible success message strip.
 </fd-message-strip>
-<fd-message-strip [type]="'information'">
+<fd-message-strip type="information">
     A dismissible information message strip.
 </fd-message-strip>
-<fd-message-strip [type]="'error'" [dismissible]="false">
+<fd-message-strip type="error" [dismissible]="false">
     A non-dismissible error message strip.
 </fd-message-strip>
 <fd-message-strip>

--- a/apps/docs/src/app/core/component-docs/message-strip/examples/message-strip-noicon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/message-strip/examples/message-strip-noicon-example.component.html
@@ -1,12 +1,17 @@
-<fd-message-strip [type]="'warning'" [noIcon]="true">
+<fd-message-strip type="warning" [noIcon]="true">
     A dismissible warning message strip.
 </fd-message-strip>
-<fd-message-strip [type]="'success'" [dismissible]="false" [noIcon]="true">
+<fd-message-strip
+    type="success"
+    [dismissible]="false"
+    [noIcon]="true"
+    ariaLabel="A non-dismissible success message strip."
+>
     A non-dismissible success message strip.
 </fd-message-strip>
-<fd-message-strip [type]="'information'" [noIcon]="true">
+<fd-message-strip type="information" [noIcon]="true">
     A dismissible information message strip.
 </fd-message-strip>
-<fd-message-strip [type]="'error'" [dismissible]="false" [noIcon]="true">
+<fd-message-strip type="error" [dismissible]="false" [noIcon]="true">
     A non-dismissible error message strip.
 </fd-message-strip>

--- a/apps/docs/src/app/core/component-docs/message-strip/examples/message-strip-width-example.component.html
+++ b/apps/docs/src/app/core/component-docs/message-strip/examples/message-strip-width-example.component.html
@@ -1,15 +1,28 @@
-<fd-message-strip [type]="'warning'" [noIcon]="true" [minWidth]="'200px'">
+<fd-message-strip
+    type="warning"
+    [noIcon]="true"
+    minWidth="200px"
+>
     A dismissible warning message strip.
 </fd-message-strip>
-<fd-message-strip [type]="'success'" [dismissible]="false" [width]="'70%'">
-    A non-dismissible success message strip.
+<fd-message-strip
+    type="success"
+    [dismissible]="false"
+    width="70%"
+    ariaLabel="A non-dismissible success message strip."
+>
+    A non-dismissible success message strip with custom aria label.
 </fd-message-strip>
-<fd-message-strip [type]="'information'" [width]="'50%'">
+<fd-message-strip type="information" width="50%">
     A dismissible information message strip.
 </fd-message-strip>
-<fd-message-strip [type]="'error'" [dismissible]="false" [width]="'200px'">
+<fd-message-strip
+    type="error"
+    [dismissible]="false"
+    width="200px"
+>
     A non-dismissible error message strip.
 </fd-message-strip>
-<fd-message-strip [width]="'200px'">
+<fd-message-strip width="200px">
     A dismissible normal message strip.
 </fd-message-strip>

--- a/apps/docs/src/app/core/component-docs/message-strip/message-strip-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/message-strip/message-strip-docs.component.html
@@ -44,6 +44,7 @@
         [dismissible]="data.properties.dismissible"
         [noIcon]="data.properties.noIcon"
         [width]="data.properties.width"
+        [ariaLabel]="data.properties.message"
     >
         {{ data.properties.message }}
     </fd-message-strip>

--- a/libs/core/src/lib/message-strip/message-strip.component.html
+++ b/libs/core/src/lib/message-strip/message-strip.component.html
@@ -1,3 +1,6 @@
+<p class="fd-message-strip__text" #messageStripContent role="alert">
+    <ng-content></ng-content>
+</p>
 <button
     class="fd-message-strip__close"
     fd-button
@@ -10,6 +13,3 @@
     [attr.aria-label]="dismissLabel"
     [attr.title]="dismissLabel"
 ></button>
-<p class="fd-message-strip__text">
-    <ng-content></ng-content>
-</p>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#3123

#### Please provide a brief summary of this pull request.
This PR adds the `ariaLabel` property to some of the examples for the screen readers to properly convey the message strip content. PR also handles logic for when `ariaLabel` property is not specified, the library will set the text of the message strip as the aria-label.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

