### PR TITLE
docs: (Core) fix overlapping of icon labels in Icon component documentation

### DIFF
--- a/apps/docs/src/app/core/component-docs/icon/examples/icon-businessSuiteInAppSymbols-example.component.html
+++ b/apps/docs/src/app/core/component-docs/icon/examples/icon-businessSuiteInAppSymbols-example.component.html
@@ -1,6 +1,6 @@
-<div class="grid">
-    <div *ngFor="let icon of icons">
-        <fd-icon style="font-size:2rem" font="BusinessSuiteInAppSymbols" [glyph]="icon"></fd-icon>
+<div class="fd-docs-icon-container">
+    <div class="fd-docs-icons" *ngFor="let icon of icons">
+        <fd-icon font="BusinessSuiteInAppSymbols" [glyph]="icon"></fd-icon>
         <span>{{ icon }}</span>
     </div>
 </div>

--- a/apps/docs/src/app/core/component-docs/icon/examples/icon-example.component.html
+++ b/apps/docs/src/app/core/component-docs/icon/examples/icon-example.component.html
@@ -1,6 +1,6 @@
-<div class="grid">
-    <div *ngFor="let icon of icons">
-        <fd-icon style="font-size:2rem" [glyph]="icon"></fd-icon>
+<div class="fd-docs-icon-container">
+    <div class="fd-docs-icons" *ngFor="let icon of icons">
+        <fd-icon [glyph]="icon"></fd-icon>
         <span>{{ icon }}</span>
     </div>
 </div>

--- a/apps/docs/src/app/core/component-docs/icon/examples/icon-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/icon/examples/icon-example.component.scss
@@ -1,6 +1,7 @@
 .fd-docs-icon-container {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
 }
 
 .fd-docs-icons {

--- a/apps/docs/src/app/core/component-docs/icon/examples/icon-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/icon/examples/icon-example.component.scss
@@ -1,24 +1,21 @@
-.grid {
+.fd-docs-icon-container {
     display: flex;
     flex-wrap: wrap;
 }
 
-.grid > * {
-    width: calc(100% / 6);
-    margin-bottom: 1rem;
-}
+.fd-docs-icons {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    word-break: break-all;
+    padding: 1rem;
+    width: 9rem;
 
-.grid * {
-    text-align: center;
-    display: block;
-}
+    fd-icon {
+        font-size: 2rem;
+    }
 
-.grid fd-icon {
-    margin-bottom: 0.25rem;
-}
-
-@media (max-width: 36rem) {
-    .grid > * {
-        width: calc(100% / 4);
+    span {
+        text-align: center;
     }
 }

--- a/apps/docs/src/app/core/component-docs/icon/examples/icon-tnt-example.component.html
+++ b/apps/docs/src/app/core/component-docs/icon/examples/icon-tnt-example.component.html
@@ -1,6 +1,6 @@
-<div class="grid">
-    <div *ngFor="let icon of icons">
-        <fd-icon style="font-size:2rem" font="SAP-icons-TNT" [glyph]="icon"></fd-icon>
+<div class="fd-docs-icon-container">
+    <div class="fd-docs-icons" *ngFor="let icon of icons">
+        <fd-icon font="SAP-icons-TNT" [glyph]="icon"></fd-icon>
         <span>{{ icon }}</span>
     </div>
 </div>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#3152

#### Please provide a brief summary of this pull request.
This PR modifies the documentation classes to show the icons properly in smaller screen sizes.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

