### PR TITLE
fix: (Core|Platform) core dialog body min height (ie11 fix)

### DIFF
--- a/libs/core/src/lib/dialog/base/dialog-config-base.class.ts
+++ b/libs/core/src/lib/dialog/base/dialog-config-base.class.ts
@@ -73,7 +73,7 @@ export class DialogConfigBase<T> implements DynamicComponentConfig {
     /** Whether the dialog should have vertical padding. */
     verticalPadding?: boolean = true;
 
-    /** Workaround for IE11, as `flex-grow: 1` on dialog body won't work when 'min-width' for dialog set
+    /** Workaround for IE11, as `flex-grow: 1` on dialog body won't work when 'min-height' for dialog set
      * There is another way to get dialog of wanted height by setting `min-height` for dialog body.
      */
     bodyMinHeight?: string;

--- a/libs/core/src/lib/dialog/base/dialog-config-base.class.ts
+++ b/libs/core/src/lib/dialog/base/dialog-config-base.class.ts
@@ -73,6 +73,9 @@ export class DialogConfigBase<T> implements DynamicComponentConfig {
     /** Whether the dialog should have vertical padding. */
     verticalPadding?: boolean = true;
 
+    /** Workaround for IE11, as `flex-grow: 1` on dialog body won't work, setting `min-height` for body is required */
+    bodyMinHeight?: string;
+
     /** Whether the dialog should have responsive horizontal padding changing with Dialogs window width.
      * max-width: 599px                         - .fd-dialog__content--s
      * min-width: 600px and max-width: 1023px   - .fd-dialog__content--m

--- a/libs/core/src/lib/dialog/base/dialog-config-base.class.ts
+++ b/libs/core/src/lib/dialog/base/dialog-config-base.class.ts
@@ -73,7 +73,9 @@ export class DialogConfigBase<T> implements DynamicComponentConfig {
     /** Whether the dialog should have vertical padding. */
     verticalPadding?: boolean = true;
 
-    /** Workaround for IE11, as `flex-grow: 1` on dialog body won't work, setting `min-height` for body is required */
+    /** Workaround for IE11, as `flex-grow: 1` on dialog body won't work when 'min-width' for dialog set
+     * There is another way to get dialog of wanted height by setting `min-height` for dialog body.
+     */
     bodyMinHeight?: string;
 
     /** Whether the dialog should have responsive horizontal padding changing with Dialogs window width.

--- a/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
+++ b/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
@@ -17,7 +17,8 @@ import { WizardComponent } from '../../wizard/wizard.component';
     templateUrl: 'dialog-body.component.html',
     host: {
         '[class.fd-dialog__body]': 'true',
-        '[class.fd-dialog__body--no-vertical-padding]': '!dialogConfig.verticalPadding'
+        '[class.fd-dialog__body--no-vertical-padding]': '!dialogConfig.verticalPadding',
+        '[style.min-height]': 'dialogConfig.bodyMinHeight'
     }
 })
 export class DialogBodyComponent implements AfterContentInit {

--- a/libs/platform/src/lib/components/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/src/lib/components/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -22,7 +22,6 @@ const dialogConfig: DialogConfig = {
     responsivePadding: true,
     verticalPadding: true,
     minWidth: '30rem',
-    minHeight: '50%',
     /** 88px it's the header + footer height */
     bodyMinHeight: 'calc(50vh - 88px)'
 };
@@ -189,9 +188,9 @@ export class TableP13DialogComponent implements OnDestroy {
 
         const dialogRef = this._dialogService.open(P13ColumnsDialogComponent, {
             ...dialogConfig,
-            minWidth: '35rem',
             responsivePadding: false,
             verticalPadding: false,
+            minWidth: '35rem',
             data: dialogData
         });
 

--- a/libs/platform/src/lib/components/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/src/lib/components/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -22,7 +22,9 @@ const dialogConfig: DialogConfig = {
     responsivePadding: true,
     verticalPadding: true,
     minWidth: '30rem',
-    minHeight: '50%'
+    minHeight: '50%',
+    /** 88px it's the header + footer height */
+    bodyMinHeight: 'calc(50vh - 88px)'
 };
 
 /**
@@ -132,12 +134,12 @@ export class TableP13DialogComponent implements OnDestroy {
         };
 
         const dialogRef = this._dialogService.open(P13FilteringDialogComponent, {
+            ...dialogConfig,
             responsivePadding: false,
             verticalPadding: false,
             width: '50rem',
-            minHeight: '50%',
             data: dialogData
-        } as DialogConfig);
+        });
 
         this._subscriptions.add(
             dialogRef.afterClosed

--- a/libs/platform/src/lib/components/table/components/table-view-settings-dialog/table-view-settings-dialog.component.ts
+++ b/libs/platform/src/lib/components/table/components/table-view-settings-dialog/table-view-settings-dialog.component.ts
@@ -28,7 +28,6 @@ const dialogConfig: DialogConfig = {
     responsivePadding: false,
     verticalPadding: false,
     minWidth: '30%',
-    minHeight: '50%',
     /** 88px it's the header + footer height */
     bodyMinHeight: 'calc(50vh - 88px)'
 };
@@ -129,12 +128,9 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
         };
 
         const dialogRef = this._dialogService.open(FiltersComponent, {
-            responsivePadding: false,
-            verticalPadding: false,
-            minWidth: '30%',
-            minHeight: '50%',
+            ...dialogConfig,
             data: dialogData
-        } as DialogConfig);
+        });
 
         this._subscriptions.add(
             dialogRef.afterClosed

--- a/libs/platform/src/lib/components/table/components/table-view-settings-dialog/table-view-settings-dialog.component.ts
+++ b/libs/platform/src/lib/components/table/components/table-view-settings-dialog/table-view-settings-dialog.component.ts
@@ -28,7 +28,9 @@ const dialogConfig: DialogConfig = {
     responsivePadding: false,
     verticalPadding: false,
     minWidth: '30%',
-    minHeight: '50%'
+    minHeight: '50%',
+    /** 88px it's the header + footer height */
+    bodyMinHeight: 'calc(50vh - 88px)'
 };
 
 /**


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Closes #4411, #4412, #5465.

#### Please provide a brief summary of this pull request.

`flex-grow: 1` isn't working in IE11 for the dialog body (container has `flex-direction: column`). Instead of having CSS in several places, as we have `DialogConfig` class it makes sense to just extend it - that will lead to smaller code changes for every dialog where we want to fix that IE11 issue.

#### Please check whether the PR fulfills the following requirements

- [X] the commit message follows the guideline: https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [X] tests for the changes that have been done
- [X] all items on the PR Review Checklist are addressed : https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [X] Run npm run build-pack-library and test in external application

Documentation checklist:
- [X] update `README.md`
- [X] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [X] Documentation Examples
- [X] Stackblitz works for all examples