### PR TITLE
fix: (Platform) Open Menu on click for Internet explorer

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-menu-button/platform-menu-button-examples/platform-menu-button-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-menu-button/platform-menu-button-examples/platform-menu-button-example.component.html
@@ -1,16 +1,5 @@
 <div>Menu Button Disabled</div>
 <fdp-menu-button
-    [id]="'menu-button-14'"
-    [contentDensity]="'cozy'"
-    label="Default Button"
-    [icon]="'world'"
-    [disabled]="false"
-    [fdpMenuTriggerFor]="basicMenu"
->
-</fdp-menu-button>
-
-<span>&nbsp;&nbsp;&nbsp;&nbsp;</span>
-<fdp-menu-button
     [id]="'menu-button-15'"
     [contentDensity]="'cozy'"
     label="Default Disabled Button"

--- a/apps/docs/src/app/platform/component-docs/platform-menu/platform-menu-examples/platform-menu-x-position-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-menu/platform-menu-examples/platform-menu-x-position-example.component.html
@@ -3,7 +3,7 @@
     <fdp-button buttonType="menu" [fdpMenuTriggerFor]="basicMenu" label="Menu Button" title="menu button"></fdp-button>
     <fdp-button glyph="menu" [fdpMenuTriggerFor]="basicMenu" title="icon menu"></fdp-button>
     <fd-avatar style="margin-right: 10px;" title="avatar menu" size="m" image="http://picsum.photos/id/1018/400"
-        [fdpMenuTriggerFor]="basicMenu"></fd-avatar>
+        [fdpMenuTriggerFor]="basicMenu" tabindex="0"></fd-avatar>
     <div style="margin-top: 1rem;"><label>Item Selected:</label> {{ item }}</div>
 
     <fdp-menu #basicMenu [xPosition]="'before'" id="basic-menu">

--- a/e2e/wdio/platform/tests/menu-button.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/menu-button.e2e-spec.ts
@@ -56,11 +56,6 @@ describe('Menu button test suite', function() {
         });
 
         it('should check selected menu option and close menu', () => {
-            // skip for IE https://github.com/SAP/fundamental-ngx/issues/4058
-            if (browserIsIEorSafari()) {
-                console.log('Skip for Safari and IE');
-                return;
-            }
             click(cozyBtnArr);
             click(menuItemArr);
 
@@ -69,32 +64,17 @@ describe('Menu button test suite', function() {
         });
 
         it('should check menu items visible', () => {
-            // skip for IE https://github.com/SAP/fundamental-ngx/issues/4058
-            if (browserIsIE()) {
-                console.log('Skip for IE');
-                return;
-            }
             click(cozyBtnArr);
             expect(isElementDisplayed(menuItemOverlay)).toBe(true);
         });
 
         it('should check close menu by clicking menu btn', () => {
-            // skip for IE https://github.com/SAP/fundamental-ngx/issues/4058
-            if (browserIsIE()) {
-                console.log('Skip for IE');
-                return;
-            }
             doubleClick(cozyBtnArr);
             expect(isElementDisplayed(menuItemOverlay)).toBe(false);
 
         });
 
         it('should check closing menu when clicking outside of menu', () => {
-            // skip for IE https://github.com/SAP/fundamental-ngx/issues/4058
-            if (browserIsIE()) {
-                console.log('Skip for IE');
-                return;
-            }
             waitForPresent(cozyBtnArr);
             click(cozyBtnArr);
             waitForElDisplayed(menuItemOverlay);
@@ -161,43 +141,42 @@ describe('Menu button test suite', function() {
     describe('Check types of menu buttons', function() {
 
         it('should check disabled buttons', () => {
-            // https://github.com/SAP/fundamental-ngx/issues/3757 first btn is enabled, start from 0 after fix
-            for (let i = 1; 6 > i; i++) {
+            for (let i = 0; 5 > i; i++) {
                 expect(getAttributeByName(menuTypeBtnAttrArr, disabledState, i)).toEqual('true');
             }
         });
 
         it('should check btn with and without icon', () => {
             waitForElDisplayed(menuTypeBtnArr, 0);
-            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 6)).toBe(icon);
+            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 5)).toBe(icon);
+            expect(getText(menuTypeBtnArr, 5).trim()).toEqual(cozyAndCompactBtnTextArr[0]);
+            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 6)).toBe(null);
             expect(getText(menuTypeBtnArr, 6).trim()).toEqual(cozyAndCompactBtnTextArr[0]);
-            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 7)).toBe(null);
-            expect(getText(menuTypeBtnArr, 7).trim()).toEqual(cozyAndCompactBtnTextArr[0]);
-            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 8)).toBe(icon);
-            expect(getText(menuTypeBtnArr, 8).trim()).toBe('');
+            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 7)).toBe(icon);
+            expect(getText(menuTypeBtnArr, 7).trim()).toBe('');
         });
 
         it('should check compact btn with and without icon', () => {
-            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 9)).toBe(icon);
+            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 8)).toBe(icon);
+            expect(getText(menuTypeBtnArr, 8).trim()).toEqual(cozyAndCompactBtnTextArr[0]);
+            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 9)).toBe(null);
             expect(getText(menuTypeBtnArr, 9).trim()).toEqual(cozyAndCompactBtnTextArr[0]);
-            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 10)).toBe(null);
-            expect(getText(menuTypeBtnArr, 10).trim()).toEqual(cozyAndCompactBtnTextArr[0]);
-            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 11)).toBe(icon);
-            expect(getText(menuTypeBtnArr, 11).trim()).toBe('');
+            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 10)).toBe(icon);
+            expect(getText(menuTypeBtnArr, 10).trim()).toBe('');
 
-            for (let i = 9; 12 > i; i++) {
+            for (let i = 8; 11 > i; i++) {
                 expect(getAttributeByName(menuTypeBtnArr, compactAttr, i)).toBe('true');
             }
         });
 
         it('should check long text menu btn with and without icon', () => {
-            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 12)).toContain(icon);
+            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 11)).toContain(icon);
+            expect(getText(menuTypeBtnArr, 11).trim()).toEqual(truncatedBtnText);
+            expect(getAttributeByName(menuTypeBtnArr, tooltipAttr, 11))
+                .toContain(truncatedBtnTooltipText);
+            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 12)).toBe(null);
             expect(getText(menuTypeBtnArr, 12).trim()).toEqual(truncatedBtnText);
             expect(getAttributeByName(menuTypeBtnArr, tooltipAttr, 12))
-                .toContain(truncatedBtnTooltipText);
-            expect(getAttributeByName(menuTypeBtnArr, iconAttr, 13)).toBe(null);
-            expect(getText(menuTypeBtnArr, 13).trim()).toEqual(truncatedBtnText);
-            expect(getAttributeByName(menuTypeBtnArr, tooltipAttr, 13))
                 .toBe(truncatedBtnNoIconTooltipText);
         });
     });

--- a/libs/platform/src/lib/components/menu/menu-trigger.directive.ts
+++ b/libs/platform/src/lib/components/menu/menu-trigger.directive.ts
@@ -95,8 +95,9 @@ export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
             $event.preventDefault();
             $event.stopPropagation();
         }
-        // filter out clicks initiated by keyboard enter
-        if ($event.detail > 0) {
+        // filter out clicks initiated by keyboard enter.
+        // For IE 11, MouseEvent fires a MSPointerEvent object instead of MouseEvent.
+        if ($event.detail > 0 || ($event instanceof PointerEvent && $event.detail === 0)) {
             this.toggleMenu();
         }
     }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#3734
Closes SAP/fundamental-ngx#3757
Closes SAP/fundamental-ngx#4058

#### Please provide a brief summary of this pull request.
This PR fixes following issues:
1. #3734 : applied tab focus on avatar-menu - documentation change.
2. #3757 : removed example for non-disable menu-button from disabled section.
3. #4058: fixes IE 11 issue, where menu is not opening on click.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

