### PR TITLE
fix(core): fix Quick View Accessibility issues

### DIFF
--- a/apps/docs/src/app/core/api-files.ts
+++ b/apps/docs/src/app/core/api-files.ts
@@ -233,7 +233,8 @@ export const API_FILES = {
         'QuickViewGroupTitleComponent',
         'QuickViewGroupItemComponent',
         'QuickViewGroupItemLabelComponent',
-        'QuickViewGroupItemContentComponent'
+        'QuickViewGroupItemContentComponent',
+        'QuickViewGroupItemContentElementDirective'
     ],
     scrollSpy: ['ScrollSpyDirective'],
     select: ['SelectComponent', 'OptionComponent'],

--- a/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-base-example.component.html
+++ b/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-base-example.component.html
@@ -10,8 +10,9 @@
             </fd-quick-view-subheader-subtitle>
         </fd-quick-view-subheader>
 
-        <fd-quick-view-group *ngFor="let group of data.groups">
-            <fd-quick-view-group-title>
+        <fd-quick-view-group *ngFor="let group of data.groups; let i = index"
+                             [attr.aria-labelledby]="getGroupId(i, group)">
+            <fd-quick-view-group-title [id]="getGroupId(i, group)">
                 {{ group.title }}
             </fd-quick-view-group-title>
             <fd-quick-view-group-item *ngFor="let item of group.items">
@@ -24,9 +25,18 @@
                            [href]="'tel:' + item.value"
                            [innerText]="item.value"
                            fd-link
+                           fd-quick-view-group-item-content-element
                         ></a>
-                        <a *ngSwitchCase="'Email'" [href]="'mailto:' + item.value" [innerText]="item.value" fd-link></a>
-                        <div *ngSwitchDefault [innerText]="item.value"></div>
+                        <a *ngSwitchCase="'Email'"
+                           [href]="'mailto:' + item.value"
+                           [innerText]="item.value"
+                           fd-link
+                           fd-quick-view-group-item-content-element
+                        ></a>
+                        <div *ngSwitchDefault
+                             [innerText]="item.value"
+                             fd-quick-view-group-item-content-element
+                        ></div>
                     </ng-container>
                 </fd-quick-view-group-item-content>
             </fd-quick-view-group-item>

--- a/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-base-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-base-example.component.ts
@@ -37,4 +37,8 @@ export class QuickViewBaseExampleComponent {
             }]
         }]
     };
+
+    getGroupId(idx: number, group: any): string {
+        return `${this.data.id}-${idx}-${group.title.split(' ').join('-')}`
+    }
 }

--- a/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-dialog-example.component.html
+++ b/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-dialog-example.component.html
@@ -4,7 +4,7 @@
             <ng-template fdTemplate="header">
                 <div fd-bar-middle>
                     <fd-bar-element>
-                        <h1 fd-title>Details</h1>
+                        <h1 fd-title [id]="data.id+'-header'">Details</h1>
                     </fd-bar-element>
                 </div>
             </ng-template>
@@ -22,8 +22,9 @@
                     </fd-quick-view-subheader-subtitle>
                 </fd-quick-view-subheader>
 
-                <fd-quick-view-group *ngFor="let group of data.groups">
-                    <fd-quick-view-group-title>
+                <fd-quick-view-group *ngFor="let group of data.groups; let i = index"
+                                     [attr.aria-labelledby]="getGroupId(i, group)">
+                    <fd-quick-view-group-title [id]="getGroupId(i, group)">
                         {{ group.title }}
                     </fd-quick-view-group-title>
                     <fd-quick-view-group-item *ngFor="let item of group.items">
@@ -36,9 +37,18 @@
                                    [href]="'tel:' + item.value"
                                    [innerText]="item.value"
                                    fd-link
+                                   fd-quick-view-group-item-content-element
                                 ></a>
-                                <a *ngSwitchCase="'Email'" [href]="'mailto:' + item.value" [innerText]="item.value" fd-link></a>
-                                <div *ngSwitchDefault [innerText]="item.value"></div>
+                                <a *ngSwitchCase="'Email'"
+                                   [href]="'mailto:' + item.value"
+                                   [innerText]="item.value"
+                                   fd-link
+                                   fd-quick-view-group-item-content-element
+                                ></a>
+                                <div *ngSwitchDefault
+                                     [innerText]="item.value"
+                                     fd-quick-view-group-item-content-element
+                                ></div>
                             </ng-container>
                         </fd-quick-view-group-item-content>
                     </fd-quick-view-group-item>
@@ -55,7 +65,6 @@
             </fd-button-bar>
 
             <fd-button-bar
-                fd-initial-focus
                 fdType="transparent"
                 label="Cancel"
                 [compact]="true"

--- a/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-dialog-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-dialog-example.component.ts
@@ -38,9 +38,17 @@ export class QuickViewDialogExampleComponent {
         }]
     };
 
+    get isOpened(): boolean {
+        return !!document.querySelector(`#${this.data.id}`);
+    }
+
     constructor(private readonly dialogService: DialogService) {}
 
     openDialog(dialog: TemplateRef<any>): void {
-        this.dialogService.open(dialog);
+        this.dialogService.open(dialog, { id: this.data.id, ariaLabelledBy: `${this.data.id}-header` });
+    }
+
+    getGroupId(idx: number, group: any): string {
+        return `${this.data.id}-${idx}-${group.title.split(' ').join('-')}`
     }
 }

--- a/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-popover-example.component.html
+++ b/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-popover-example.component.html
@@ -1,10 +1,16 @@
 <div class="fd-docs-flex-display-helper">
-    <fd-popover placement="right-start" [noArrow]="false">
+    <fd-popover placement="right-start"
+                [noArrow]="false"
+                [focusAutoCapture]="true"
+                (isOpenChange)="isOpenChangePopover1($event)">
         <fd-popover-control>
-            <button fd-button label="Open Popover"></button>
+            <button fd-button label="Open Popover"
+                    [attr.aria-controls]="data.id+'-1'"
+                    [attr.aria-expanded]="isOpened1"
+                    [attr.aria-haspopup]="true"></button>
         </fd-popover-control>
 
-        <fd-popover-body>
+        <fd-popover-body [id]="data.id+'-1'" role="tooltip">
             <fd-quick-view [id]="data.id">
                 <fd-quick-view-title align="middle">{{ data.title }}</fd-quick-view-title>
 
@@ -18,8 +24,9 @@
                     </fd-quick-view-subheader-subtitle>
                 </fd-quick-view-subheader>
 
-                <fd-quick-view-group *ngFor="let group of data.groups">
-                    <fd-quick-view-group-title>
+                <fd-quick-view-group *ngFor="let group of data.groups; let i = index;"
+                                     [attr.aria-labelledby]="getGroupId(i, group)">
+                    <fd-quick-view-group-title [id]="getGroupId(i, group)">
                         {{ group.title }}
                     </fd-quick-view-group-title>
                     <fd-quick-view-group-item *ngFor="let item of group.items">
@@ -32,9 +39,18 @@
                                    [href]="'tel:' + item.value"
                                    [innerText]="item.value"
                                    fd-link
+                                   fd-quick-view-group-item-content-element
                                 ></a>
-                                <a *ngSwitchCase="'Email'" [href]="'mailto:' + item.value" [innerText]="item.value" fd-link></a>
-                                <div *ngSwitchDefault [innerText]="item.value"></div>
+                                <a *ngSwitchCase="'Email'"
+                                   [href]="'mailto:' + item.value"
+                                   [innerText]="item.value"
+                                   fd-link
+                                   fd-quick-view-group-item-content-element
+                                ></a>
+                                <div *ngSwitchDefault
+                                     [innerText]="item.value"
+                                     fd-quick-view-group-item-content-element
+                                ></div>
                             </ng-container>
                         </fd-quick-view-group-item-content>
                     </fd-quick-view-group-item>
@@ -43,12 +59,18 @@
         </fd-popover-body>
     </fd-popover>
 
-    <fd-popover placement="right-start" [noArrow]="false">
+    <fd-popover placement="right-start"
+                [noArrow]="false"
+                [focusAutoCapture]="true"
+                (isOpenChange)="isOpenChangePopover2($event)">
         <fd-popover-control>
-            <button fd-button label="Open Popover Without Heading"></button>
+            <button fd-button label="Open Popover Without Heading"
+                    [attr.aria-controls]="data.id+'-2'"
+                    [attr.aria-expanded]="isOpened2"
+                    [attr.aria-haspopup]="true"></button>
         </fd-popover-control>
 
-        <fd-popover-body>
+        <fd-popover-body [id]="data.id+'-2'" role="tooltip">
             <fd-quick-view [id]="data.id+'-without-heading'">
                 <fd-quick-view-subheader>
                     <fd-avatar [image]="data.subHeader.avatar" size="s"></fd-avatar>
@@ -60,8 +82,9 @@
                     </fd-quick-view-subheader-subtitle>
                 </fd-quick-view-subheader>
 
-                <fd-quick-view-group *ngFor="let group of data.groups">
-                    <fd-quick-view-group-title>
+                <fd-quick-view-group *ngFor="let group of data.groups; let i = index"
+                                     [attr.aria-labelledby]="getGroupId(i, group)">
+                    <fd-quick-view-group-title [id]="getGroupId(i, group)">
                         {{ group.title }}
                     </fd-quick-view-group-title>
                     <fd-quick-view-group-item *ngFor="let item of group.items">
@@ -74,9 +97,18 @@
                                    [href]="'tel:' + item.value"
                                    [innerText]="item.value"
                                    fd-link
+                                   fd-quick-view-group-item-content-element
                                 ></a>
-                                <a *ngSwitchCase="'Email'" [href]="'mailto:' + item.value" [innerText]="item.value" fd-link></a>
-                                <div *ngSwitchDefault [innerText]="item.value"></div>
+                                <a *ngSwitchCase="'Email'"
+                                   [href]="'mailto:' + item.value"
+                                   [innerText]="item.value"
+                                   fd-link
+                                   fd-quick-view-group-item-content-element
+                                ></a>
+                                <div *ngSwitchDefault
+                                     [innerText]="item.value"
+                                     fd-quick-view-group-item-content-element
+                                ></div>
                             </ng-container>
                         </fd-quick-view-group-item-content>
                     </fd-quick-view-group-item>

--- a/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-popover-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/quick-view/examples/quick-view-popover-example.component.ts
@@ -44,4 +44,19 @@ export class QuickViewPopoverExampleComponent {
             }]
         }]
     };
+
+    isOpened1 = false;
+    isOpened2 = false;
+
+    isOpenChangePopover1(isOpen: boolean): void {
+        this.isOpened1 = isOpen;
+    }
+
+    isOpenChangePopover2(isOpen: boolean): void {
+        this.isOpened2 = isOpen;
+    }
+
+    getGroupId(idx: number, group: any): string {
+        return `${this.data.id}-${idx}-${group.title.split(' ').join('-')}`
+    }
 }

--- a/libs/core/src/lib/quick-view/public_api.ts
+++ b/libs/core/src/lib/quick-view/public_api.ts
@@ -9,3 +9,4 @@ export * from './quick-view-group-title/quick-view-group-title.component';
 export * from './quick-view-group-item/quick-view-group-item.component';
 export * from './quick-view-group-item-label/quick-view-group-item-label.component';
 export * from './quick-view-group-item-content/quick-view-group-item-content.component';
+export * from './quick-view-group-item-content/quick-view-group-item-content-element.directive';

--- a/libs/core/src/lib/quick-view/quick-view-group-item-content/quick-view-group-item-content-element.directive.spec.ts
+++ b/libs/core/src/lib/quick-view/quick-view-group-item-content/quick-view-group-item-content-element.directive.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { Component, ElementRef, ViewChild } from '@angular/core';
+import { QuickViewGroupItemContentElementDirective } from './quick-view-group-item-content-element.directive';
+
+@Component({
+    template: ` <div #directiveElement fd-quick-view-group-item-content-element> Element </div> `
+})
+class TestComponent {
+    @ViewChild('directiveElement')
+    ref: ElementRef;
+}
+
+describe('QuickViewGroupItemContentElementDirective', () => {
+    let component: TestComponent;
+    let fixture: ComponentFixture<TestComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestComponent, QuickViewGroupItemContentElementDirective]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should assign class', () => {
+        expect(component.ref.nativeElement.classList).toContain('fd-quick-view__group-item__content-element');
+    });
+});

--- a/libs/core/src/lib/quick-view/quick-view-group-item-content/quick-view-group-item-content-element.directive.ts
+++ b/libs/core/src/lib/quick-view/quick-view-group-item-content/quick-view-group-item-content-element.directive.ts
@@ -1,0 +1,13 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-quick-view-group-item-content-element]',
+    host: {
+        class: `${QuickViewGroupItemContentElementDirective.class} fd-input`
+    }
+})
+export class QuickViewGroupItemContentElementDirective {
+    /** @hidden */
+    static class = 'fd-quick-view__group-item__content-element';
+}

--- a/libs/core/src/lib/quick-view/quick-view-group-item-content/quick-view-group-item-content.component.ts
+++ b/libs/core/src/lib/quick-view/quick-view-group-item-content/quick-view-group-item-content.component.ts
@@ -1,11 +1,32 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef } from '@angular/core';
+
+import { QuickViewGroupItemContentElementDirective } from './quick-view-group-item-content-element.directive';
+import { getClosest } from '@fundamental-ngx/core/utils';
 
 @Component({
     selector: 'fd-quick-view-group-item-content',
     templateUrl: './quick-view-group-item-content.component.html',
-    host: {
-        '[class.fd-input]': 'true'
-    },
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class QuickViewGroupItemContentComponent {}
+export class QuickViewGroupItemContentComponent implements AfterViewInit {
+    /** @hidden */
+    constructor(private readonly _elRef: ElementRef) {}
+
+    /** @hidden */
+    ngAfterViewInit(): void {
+        this._bindElementAttributes();
+    }
+
+    /** @hidden
+     * Needed for binding the id of the element and id of the proper label to aria-labelledby. */
+    private _bindElementAttributes(): void {
+        const parentId = getClosest('.fd-form-item', this._elRef.nativeElement)?.id;
+        const id = `${parentId}-content`;
+
+        const element = this._elRef.nativeElement.querySelector(`.${QuickViewGroupItemContentElementDirective.class}`);
+        if (element && parentId) {
+            element.setAttribute('id', id);
+            element.setAttribute('aria-labelledby', `${parentId}-label ${id}`);
+        }
+    }
+}

--- a/libs/core/src/lib/quick-view/quick-view-group-item-label/quick-view-group-item-label.component.ts
+++ b/libs/core/src/lib/quick-view/quick-view-group-item-label/quick-view-group-item-label.component.ts
@@ -1,8 +1,27 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef } from '@angular/core';
+import { getClosest } from '@fundamental-ngx/core/utils';
 
 @Component({
     selector: 'fd-quick-view-group-item-label',
     templateUrl: './quick-view-group-item-label.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class QuickViewGroupItemLabelComponent {}
+export class QuickViewGroupItemLabelComponent implements AfterViewInit {
+    /** @hidden */
+    constructor(private readonly _elRef: ElementRef) {}
+
+    /** @hidden */
+    ngAfterViewInit(): void {
+        this._bindElementAttributes();
+    }
+
+    /** @hidden
+     * Needed for binding the id to the label element (and this id needed for aria-labelledby of proper element). */
+    private _bindElementAttributes(): void {
+        const parentId = getClosest('.fd-form-item', this._elRef.nativeElement)?.id;
+
+        if (this._elRef.nativeElement.firstChild && parentId) {
+            this._elRef.nativeElement.firstChild.setAttribute('id', `${parentId}-label`);
+        }
+    }
+}

--- a/libs/core/src/lib/quick-view/quick-view-group-item/quick-view-group-item.component.html
+++ b/libs/core/src/lib/quick-view/quick-view-group-item/quick-view-group-item.component.html
@@ -1,3 +1,3 @@
-<div fd-form-item>
+<div fd-form-item [id]="id">
     <ng-content></ng-content>
 </div>

--- a/libs/core/src/lib/quick-view/quick-view-group-item/quick-view-group-item.component.ts
+++ b/libs/core/src/lib/quick-view/quick-view-group-item/quick-view-group-item.component.ts
@@ -1,8 +1,14 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+let quickViewGroupItemUniqueId = 0;
 
 @Component({
     selector: 'fd-quick-view-group-item',
     templateUrl: './quick-view-group-item.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class QuickViewGroupItemComponent {}
+export class QuickViewGroupItemComponent {
+    /** Id of the quick view element. */
+    @Input()
+    id: string = 'fd-quick-view-group-item-' + quickViewGroupItemUniqueId++;
+}

--- a/libs/core/src/lib/quick-view/quick-view.module.ts
+++ b/libs/core/src/lib/quick-view/quick-view.module.ts
@@ -11,13 +11,11 @@ import { QuickViewGroupTitleComponent } from './quick-view-group-title/quick-vie
 import { QuickViewGroupItemComponent } from './quick-view-group-item/quick-view-group-item.component';
 import { QuickViewGroupItemLabelComponent } from './quick-view-group-item-label/quick-view-group-item-label.component';
 import { QuickViewGroupItemContentComponent } from './quick-view-group-item-content/quick-view-group-item-content.component';
+import { QuickViewGroupItemContentElementDirective } from './quick-view-group-item-content/quick-view-group-item-content-element.directive';
 import { TitleModule } from '@fundamental-ngx/core/title';
 import { BarModule } from '@fundamental-ngx/core/bar';
-import { FormGroupModule } from '@fundamental-ngx/core/form';
-import { FormItemModule } from '@fundamental-ngx/core/form';
-import { FormLabelModule } from '@fundamental-ngx/core/form';
 import { PopoverModule } from '@fundamental-ngx/core/popover';
-
+import { FormGroupModule, FormItemModule, FormLabelModule } from '@fundamental-ngx/core/form';
 
 @NgModule({
     imports: [CommonModule, TitleModule, BarModule, FormGroupModule, FormItemModule, FormLabelModule, PopoverModule],
@@ -31,7 +29,8 @@ import { PopoverModule } from '@fundamental-ngx/core/popover';
         QuickViewGroupTitleComponent,
         QuickViewGroupItemComponent,
         QuickViewGroupItemLabelComponent,
-        QuickViewGroupItemContentComponent
+        QuickViewGroupItemContentComponent,
+        QuickViewGroupItemContentElementDirective
     ],
     exports: [
         QuickViewComponent,
@@ -43,7 +42,8 @@ import { PopoverModule } from '@fundamental-ngx/core/popover';
         QuickViewGroupTitleComponent,
         QuickViewGroupItemComponent,
         QuickViewGroupItemLabelComponent,
-        QuickViewGroupItemContentComponent
+        QuickViewGroupItemContentComponent,
+        QuickViewGroupItemContentElementDirective
     ]
 })
 export class QuickViewModule {}

--- a/libs/core/src/lib/utils/functions/closest-element.ts
+++ b/libs/core/src/lib/utils/functions/closest-element.ts
@@ -23,3 +23,20 @@ export function closestElement(selector, element): Element | null {
 
     return element;
 }
+
+/** Alternative way to get closes element. */
+export function getClosest(selector, elem): Element | null {
+    // .matches polyfill
+    if (!Element.prototype.matches) {
+        /** @ts-ignore */
+        Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
+    }
+
+    // get the closest matching element
+    for ( ; elem && elem !== document; elem = elem.parentNode) {
+        if (elem.matches(selector)) {
+            return elem;
+        }
+    }
+    return null;
+}


### PR DESCRIPTION
BREAKING CHANGE:
 added `QuickViewGroupItemContentElementDirective` (`fd-quick-view-group-item-content-element`) needed for bind the corresponding label to the element (email, phone, link, etc.)

#### Please provide a link to the associated issue.
Closes: SAP/fundamental-ngx#4963

#### Please provide a brief summary of this pull request.
- readable corresponding label
- focus trap & close on ESC for popover and dialog variants 
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [n/a] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

