### PR TITLE
fix(core): checkbox parent element focus fix

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -20,13 +20,15 @@
     (click)="$event.stopPropagation()"
 />
 
-<label class="fd-checkbox__label"
-       #labelElement
-       [for]="inputId"
-       [ngClass]="labelClass"
-       [attr.title]="title"
-       [class.fd-checkbox__label--compact]="compact"
-       (click)="checkByClick($event)">
+<label
+    class="fd-checkbox__label"
+    #labelElement
+    [for]="inputId"
+    [ngClass]="labelClass"
+    [attr.title]="title"
+    [class.fd-checkbox__label--compact]="compact"
+    (click)="checkByClick($event)">
+
     <ng-container *ngIf="label">
             <span class="fd-checkbox__text">
                 {{ label }}

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -1,39 +1,44 @@
-<input
-    #inputLabel
-    type="checkbox"
-    class="fd-checkbox"
-    [id]="inputId"
-    [name]="name"
-    [disabled]="disabled"
-    [indeterminate]="isIndeterminate"
-    [attr.tabindex]="tabIndexValue"
-    [attr.aria-label]="ariaLabel"
-    [attr.aria-labelledby]="ariaLabelledBy"
-    [attr.aria-describedby]="ariaDescribedBy"
-    [attr.aria-disabled]="disabled"
-    [class.fd-checkbox--compact]="compact"
-    [ngClass]="state ? 'is-' + state : ''"
-    [ngModel]="isChecked"
-    (ngModelChange)="nextValue()"
-    (keydown)="checkByKey($event)"
-    (keyup)="handleInputKeyUp($event)"
-    (click)="$event.stopPropagation()"
-/>
-<label class="fd-checkbox__label"
-       #labelElement
-       [for]="inputId"
-       [ngClass]="labelClass"
-       [attr.title]="title"
-       [class.fd-checkbox__label--compact]="compact"
-       (click)="checkByClick($event)">
-    <ng-container *ngIf="label">
-        <span class="fd-checkbox__text">
-            {{ label }}
-        </span>
-    </ng-container>
-    <ng-container *ngIf="!label">
-        <span class="fd-checkbox__text">
-            <ng-content></ng-content>
-        </span>
-    </ng-container>
-</label>
+<!-- To prevent from focusing parent elements -->
+<span tabindex="-1">
+    <input
+        #inputLabel
+        type="checkbox"
+        class="fd-checkbox"
+        [id]="inputId"
+        [name]="name"
+        [disabled]="disabled"
+        [indeterminate]="isIndeterminate"
+        [attr.tabindex]="tabIndexValue"
+        [attr.aria-label]="ariaLabel"
+        [attr.aria-labelledby]="ariaLabelledBy"
+        [attr.aria-describedby]="ariaDescribedBy"
+        [attr.aria-disabled]="disabled"
+        [class.fd-checkbox--compact]="compact"
+        [ngClass]="state ? 'is-' + state : ''"
+        [ngModel]="isChecked"
+        (ngModelChange)="nextValue()"
+        (keydown)="checkByKey($event)"
+        (keyup)="handleInputKeyUp($event)"
+        (click)="$event.stopPropagation()"
+    />
+
+    <label class="fd-checkbox__label"
+           #labelElement
+           [for]="inputId"
+           [ngClass]="labelClass"
+           [attr.title]="title"
+           [class.fd-checkbox__label--compact]="compact"
+           (click)="checkByClick($event)">
+        <ng-container *ngIf="label">
+            <span class="fd-checkbox__text">
+                {{ label }}
+            </span>
+        </ng-container>
+
+        <ng-container *ngIf="!label">
+            <span class="fd-checkbox__text">
+                <ng-content></ng-content>
+            </span>
+        </ng-container>
+    </label>
+</span>

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -1,44 +1,41 @@
-<!-- To prevent from focusing parent elements -->
-<span tabindex="-1">
-    <input
-        #inputLabel
-        type="checkbox"
-        class="fd-checkbox"
-        [id]="inputId"
-        [name]="name"
-        [disabled]="disabled"
-        [indeterminate]="isIndeterminate"
-        [attr.tabindex]="tabIndexValue"
-        [attr.aria-label]="ariaLabel"
-        [attr.aria-labelledby]="ariaLabelledBy"
-        [attr.aria-describedby]="ariaDescribedBy"
-        [attr.aria-disabled]="disabled"
-        [class.fd-checkbox--compact]="compact"
-        [ngClass]="state ? 'is-' + state : ''"
-        [ngModel]="isChecked"
-        (ngModelChange)="nextValue()"
-        (keydown)="checkByKey($event)"
-        (keyup)="handleInputKeyUp($event)"
-        (click)="$event.stopPropagation()"
-    />
+<input
+    #inputLabel
+    type="checkbox"
+    class="fd-checkbox"
+    [id]="inputId"
+    [name]="name"
+    [disabled]="disabled"
+    [indeterminate]="isIndeterminate"
+    [attr.tabindex]="tabIndexValue"
+    [attr.aria-label]="ariaLabel"
+    [attr.aria-labelledby]="ariaLabelledBy"
+    [attr.aria-describedby]="ariaDescribedBy"
+    [attr.aria-disabled]="disabled"
+    [class.fd-checkbox--compact]="compact"
+    [ngClass]="state ? 'is-' + state : ''"
+    [ngModel]="isChecked"
+    (ngModelChange)="nextValue()"
+    (keydown)="checkByKey($event)"
+    (keyup)="handleInputKeyUp($event)"
+    (click)="$event.stopPropagation()"
+/>
 
-    <label class="fd-checkbox__label"
-           #labelElement
-           [for]="inputId"
-           [ngClass]="labelClass"
-           [attr.title]="title"
-           [class.fd-checkbox__label--compact]="compact"
-           (click)="checkByClick($event)">
-        <ng-container *ngIf="label">
+<label class="fd-checkbox__label"
+       #labelElement
+       [for]="inputId"
+       [ngClass]="labelClass"
+       [attr.title]="title"
+       [class.fd-checkbox__label--compact]="compact"
+       (click)="checkByClick($event)">
+    <ng-container *ngIf="label">
             <span class="fd-checkbox__text">
                 {{ label }}
             </span>
-        </ng-container>
+    </ng-container>
 
-        <ng-container *ngIf="!label">
+    <ng-container *ngIf="!label">
             <span class="fd-checkbox__text">
                 <ng-content></ng-content>
             </span>
-        </ng-container>
-    </label>
-</span>
+    </ng-container>
+</label>

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -116,6 +116,10 @@ export class CheckboxComponent implements ControlValueAccessor, OnInit, OnDestro
     @HostBinding('style.position')
     readonly position = 'relative';
 
+    /** @hidden */
+    @HostBinding('style.outline')
+    readonly outline = 'none';
+
     /** Values returned by control. */
     public values: FdCheckboxValues = { trueValue: true, falseValue: false, thirdStateValue: null };
     /** Stores current checkbox value. */

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -39,7 +39,8 @@ export type fdCheckboxTypes = 'checked' | 'unchecked' | 'indeterminate' | 'force
             useExisting: forwardRef(() => CheckboxComponent),
             multi: true
         }
-    ]
+    ],
+    host: { '[attr.tabindex]': '-1' }
 })
 export class CheckboxComponent implements ControlValueAccessor, OnInit, OnDestroy {
     /** @hidden */

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -127,7 +127,7 @@ export class CheckboxComponent implements ControlValueAccessor, OnInit, OnDestro
     /** @hidden Reference to callback provided by FormControl.*/
     public onTouched = () => {};
     /** @hidden Reference to callback provided by FormControl.*/
-    public onValueChange = (newValue) => {};
+    public onValueChange = (_) => {};
 
     /** @hidden */
     constructor(
@@ -203,7 +203,7 @@ export class CheckboxComponent implements ControlValueAccessor, OnInit, OnDestro
         this.muteKey(event);
     }
 
-    /** @hidden Updates checkbox Indeterminate state on spacebar key on IE11 */
+    /** @hidden Updates checkbox Indeterminate state on space bar key on IE11 */
     public checkByKey(event: KeyboardEvent): void {
         if (this._isSpaceBarEvent(event) && this._platform.TRIDENT) {
             this._nextValueEvent();


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Closes  #5120.

#### Please provide a brief summary of this pull request.

If checkbox placed inside the element with `tabindex` set (even `-1`) that element gets focus when checkbox got clicked. So checkbox wrapped with element with `tabindex="-1"` to avoid that.

#### Please check whether the PR fulfills the following requirements

- [X] the commit message follows the guideline: https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [X] tests for the changes that have been done
- [X] all items on the PR Review Checklist are addressed: https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [X] Run npm run build-pack-library and test in external application

Documentation checklist:
- [X] update `README.md`
- [X] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [X] Documentation Examples
- [X] Stackblitz works for all examples