### PR TITLE
docs(platform): fix disabled scroll in other pages on back press from Dynamic Page examples

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-docs.component.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
 
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
+import { PlatformDynamicPagePageOverflowService } from './platform-dynamic-page-examples/platform-dynamic-page-page-overflow.service';
 
 import * as dynamicPageBasicExample from '!raw-loader!./platform-dynamic-page-examples/platform-dynamic-page-example.component.html';
 import * as dynamicPageBasicExampleScss from '!raw-loader!./platform-dynamic-page-examples/platform-dynamic-page-example.component.scss';
@@ -26,11 +28,17 @@ import * as dynamicPageFlexibleColumnExample from '!raw-loader!./platform-dynami
 import * as dynamicPageFlexibleColumnExampleScss from '!raw-loader!./platform-dynamic-page-examples/platform-dynamic-page-flexible-column-example.component.scss';
 import * as dynamicPageFlexibleColumnExampleTsCode from '!raw-loader!./platform-dynamic-page-examples/platform-dynamic-page-flexible-column-example.component.ts';
 
+import * as platformDynamicPagePageOverflowServiceTs from '!raw-loader!./platform-dynamic-page-examples/platform-dynamic-page-page-overflow.service.ts';
+
 @Component({
     selector: 'app-dynamic-page',
     templateUrl: './platform-dynamic-page-docs.component.html'
 })
-export class PlatformDynamicPageDocsComponent {
+export class PlatformDynamicPageDocsComponent implements OnInit, OnDestroy {
+    private _subscription: Subscription;
+    // service to change the overflow value for page-content class
+    constructor(private _overflowHandlingService: PlatformDynamicPagePageOverflowService) {}
+
     dynamicPageBasic: ExampleFile[] = [
         {
             language: 'html',
@@ -43,6 +51,14 @@ export class PlatformDynamicPageDocsComponent {
             code: dynamicPageBasicExampleTsCode,
             fileName: 'platform-dynamic-page-example',
             component: 'PlatformDynamicPageExampleComponent'
+        },
+        {
+            language: 'typescript',
+            name: 'platform-dynamic-page-page-overflow.service.ts',
+            code: platformDynamicPagePageOverflowServiceTs,
+            fileName: 'platform-dynamic-page-page-overflow',
+            component: 'PlatformDynamicPagePageOverflowService',
+            service: true
         }
     ];
     dynamicPageSnapScroll: ExampleFile[] = [
@@ -57,6 +73,14 @@ export class PlatformDynamicPageDocsComponent {
             code: dynamicPageSnapScrollExampleTsCode,
             fileName: 'platform-dynamic-page-snap-scroll-example',
             component: 'PlatformDynamicPageSnapScrollExampleComponent'
+        },
+        {
+            language: 'typescript',
+            name: 'platform-dynamic-page-page-overflow.service.ts',
+            code: platformDynamicPagePageOverflowServiceTs,
+            fileName: 'platform-dynamic-page-page-overflow',
+            component: 'PlatformDynamicPagePageOverflowService',
+            service: true
         }
     ];
 
@@ -72,6 +96,14 @@ export class PlatformDynamicPageDocsComponent {
             code: dynamicPageTabbedExampleTsCode,
             fileName: 'platform-dynamic-page-tabbed-example',
             component: 'PlatformDynamicPageTabbedExampleComponent'
+        },
+        {
+            language: 'typescript',
+            name: 'platform-dynamic-page-page-overflow.service.ts',
+            code: platformDynamicPagePageOverflowServiceTs,
+            fileName: 'platform-dynamic-page-page-overflow',
+            component: 'PlatformDynamicPagePageOverflowService',
+            service: true
         }
     ];
 
@@ -87,6 +119,14 @@ export class PlatformDynamicPageDocsComponent {
             code: dynamicPageResponsivePaddingExampleTsCode,
             fileName: 'platform-dynamic-page-responsive-padding-example',
             component: 'PlatformDynamicPageResponsivePaddingExampleComponent'
+        },
+        {
+            language: 'typescript',
+            name: 'platform-dynamic-page-page-overflow.service.ts',
+            code: platformDynamicPagePageOverflowServiceTs,
+            fileName: 'platform-dynamic-page-page-overflow',
+            component: 'PlatformDynamicPagePageOverflowService',
+            service: true
         }
     ];
 
@@ -102,6 +142,14 @@ export class PlatformDynamicPageDocsComponent {
             code: dynamicPageNonCollapsibleExampleTsCode,
             fileName: 'platform-dynamic-page-non-collapsible-example',
             component: 'PlatformDynamicPageNonCollapsibleExampleComponent'
+        },
+        {
+            language: 'typescript',
+            name: 'platform-dynamic-page-page-overflow.service.ts',
+            code: platformDynamicPagePageOverflowServiceTs,
+            fileName: 'platform-dynamic-page-page-overflow',
+            component: 'PlatformDynamicPagePageOverflowService',
+            service: true
         }
     ];
 
@@ -117,6 +165,28 @@ export class PlatformDynamicPageDocsComponent {
             code: dynamicPageFlexibleColumnExampleTsCode,
             fileName: 'platform-dynamic-page-flexible-column-example',
             component: 'PlatformDynamicPageFlexibleColumnExampleComponent'
+        },
+        {
+            language: 'typescript',
+            name: 'platform-dynamic-page-page-overflow.service.ts',
+            code: platformDynamicPagePageOverflowServiceTs,
+            fileName: 'platform-dynamic-page-page-overflow',
+            component: 'PlatformDynamicPagePageOverflowService',
+            service: true
         }
     ];
+
+    ngOnInit(): void {
+        this._subscription = this._overflowHandlingService.isExampleOpened.subscribe((isExampleOpened) => {
+            if (isExampleOpened) {
+                document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
+            } else {
+                document.getElementById('page-content').style.overflowY = '';
+            }
+        });
+    }
+
+    ngOnDestroy(): void {
+      this._subscription.unsubscribe();
+    }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-example.component.ts
@@ -1,5 +1,6 @@
-import { ChangeDetectionStrategy, Component, ElementRef, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { DynamicPageCollapseChangeEvent } from '@fundamental-ngx/platform';
+import { PlatformDynamicPagePageOverflowService } from './platform-dynamic-page-page-overflow.service';
 
 @Component({
     selector: 'fdp-platform-dynamic-page-example',
@@ -7,13 +8,15 @@ import { DynamicPageCollapseChangeEvent } from '@fundamental-ngx/platform';
     styleUrls: ['./platform-dynamic-page-example.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PlatformDynamicPageExampleComponent {
+export class PlatformDynamicPageExampleComponent implements OnDestroy {
     @ViewChild('overlay')
     overlay: ElementRef<HTMLElement>;
 
     fullscreen = false;
 
     pageTitle = 'Balenciaga Tripple S Trainers';
+
+    constructor(private _overflowHandlingService: PlatformDynamicPagePageOverflowService) {}
 
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
@@ -26,13 +29,21 @@ export class PlatformDynamicPageExampleComponent {
     openPage(): void {
         this.fullscreen = true;
         this.overlay.nativeElement.style.width = '100%';
-        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
+        this._overflowHandlingService.isExampleOpened.next(true);
     }
-    
+
     closePage(event: Event): void {
         event.stopPropagation();
+        this.resetPageActions();
+    }
+
+    resetPageActions(): void {
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
-        document.getElementById('page-content').style.overflowY = 'auto';
+        this._overflowHandlingService.isExampleOpened.next(false);
+    }
+
+    ngOnDestroy(): void {
+        this.resetPageActions();
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-flexible-column-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-flexible-column-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ViewChild, ElementRef, ChangeDetectorRef } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewChild, ElementRef, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { BreadcrumbComponent } from '@fundamental-ngx/core/breadcrumb';
 import { FlexibleColumnLayout } from '@fundamental-ngx/core/flexible-column-layout';
 import {
@@ -6,6 +6,7 @@ import {
     DynamicPageComponent,
     DynamicPageTabChangeEvent
 } from '@fundamental-ngx/platform';
+import { PlatformDynamicPagePageOverflowService } from './platform-dynamic-page-page-overflow.service';
 
 @Component({
     selector: 'fdp-platform-dynamic-page-flexible-column-example',
@@ -13,7 +14,7 @@ import {
     styleUrls: ['./platform-dynamic-page-flexible-column-example.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PlatformDynamicPageFlexibleColumnExampleComponent {
+export class PlatformDynamicPageFlexibleColumnExampleComponent implements OnDestroy {
     /**
      * documentation related property
      * provides access to the HTML element with "overlay" reference
@@ -48,7 +49,10 @@ export class PlatformDynamicPageFlexibleColumnExampleComponent {
      */
     localLayout = 'OneColumnStartFullScreen';
 
-    constructor(private _cd: ChangeDetectorRef) {}
+    constructor(
+        private _cd: ChangeDetectorRef,
+        private _overflowHandlingService: PlatformDynamicPagePageOverflowService
+    ) {}
 
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
@@ -75,7 +79,7 @@ export class PlatformDynamicPageFlexibleColumnExampleComponent {
     openPage(): void {
         this.fullscreen = true;
         this.overlay.nativeElement.style.width = '100%';
-        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
+        this._overflowHandlingService.isExampleOpened.next(true);
     }
 
     /**
@@ -84,9 +88,13 @@ export class PlatformDynamicPageFlexibleColumnExampleComponent {
      */
     closePage(event: Event): void {
         event.stopPropagation();
+        this.resetPageActions();
+    }
+
+    resetPageActions(): void {
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
-        document.getElementById('page-content').style.overflowY = 'auto';
+        this._overflowHandlingService.isExampleOpened.next(false);
     }
 
     onTabChanged(event: DynamicPageTabChangeEvent): void {
@@ -103,5 +111,9 @@ export class PlatformDynamicPageFlexibleColumnExampleComponent {
         setTimeout(() => {
             this.breadCrumbComponent.onResize();
         }, 800);
+    }
+
+    ngOnDestroy(): void {
+        this.resetPageActions();
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-non-collapsible-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-non-collapsible-example.component.ts
@@ -1,5 +1,6 @@
-import { Component, ChangeDetectionStrategy, ElementRef, ViewChild } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ElementRef, ViewChild, OnDestroy } from '@angular/core';
 import { DynamicPageCollapseChangeEvent } from '@fundamental-ngx/platform';
+import { PlatformDynamicPagePageOverflowService } from './platform-dynamic-page-page-overflow.service';
 
 @Component({
     selector: 'fdp-platform-dynamic-page-non-collapsible-example',
@@ -7,13 +8,15 @@ import { DynamicPageCollapseChangeEvent } from '@fundamental-ngx/platform';
     styleUrls: ['./platform-dynamic-page-non-collapsible-example.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PlatformDynamicPageNonCollapsibleExampleComponent {
+export class PlatformDynamicPageNonCollapsibleExampleComponent implements OnDestroy {
     @ViewChild('overlay')
     overlay: ElementRef<HTMLElement>;
 
     fullscreen = false;
 
     pageTitle = 'Balenciaga Tripple S Trainers';
+
+    constructor(private _overflowHandlingService: PlatformDynamicPagePageOverflowService) {}
 
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
@@ -26,12 +29,20 @@ export class PlatformDynamicPageNonCollapsibleExampleComponent {
     openPage(): void {
         this.fullscreen = true;
         this.overlay.nativeElement.style.width = '100%';
-        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
+        this._overflowHandlingService.isExampleOpened.next(true);
     }
     closePage(event: Event): void {
         event.stopPropagation();
+        this.resetPageActions();
+    }
+
+    resetPageActions(): void {
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
-        document.getElementById('page-content').style.overflowY = 'auto';
+        this._overflowHandlingService.isExampleOpened.next(false);
+    }
+
+    ngOnDestroy(): void {
+        this.resetPageActions();
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-page-overflow.service.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-page-overflow.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class PlatformDynamicPagePageOverflowService {
+    isExampleOpened = new BehaviorSubject<boolean>(false);
+}

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-responsive-padding-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-responsive-padding-example.component.ts
@@ -1,5 +1,6 @@
-import { Component, ChangeDetectionStrategy, ElementRef, ViewChild } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ElementRef, ViewChild, OnDestroy } from '@angular/core';
 import { DynamicPageCollapseChangeEvent } from '@fundamental-ngx/platform';
+import { PlatformDynamicPagePageOverflowService } from './platform-dynamic-page-page-overflow.service';
 
 @Component({
     selector: 'fdp-platform-dynamic-page-responsive-padding-example',
@@ -7,13 +8,15 @@ import { DynamicPageCollapseChangeEvent } from '@fundamental-ngx/platform';
     styleUrls: ['./platform-dynamic-page-responsive-padding-example.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PlatformDynamicPageResponsivePaddingExampleComponent {
+export class PlatformDynamicPageResponsivePaddingExampleComponent implements OnDestroy {
     @ViewChild('overlay')
     overlay: ElementRef<HTMLElement>;
 
     fullscreen = false;
 
     pageTitle = 'Balenciaga Tripple S Trainers';
+
+    constructor(private _overflowHandlingService: PlatformDynamicPagePageOverflowService) {}
 
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
@@ -26,12 +29,20 @@ export class PlatformDynamicPageResponsivePaddingExampleComponent {
     openPage(): void {
         this.fullscreen = true;
         this.overlay.nativeElement.style.width = '100%';
-        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
+        this._overflowHandlingService.isExampleOpened.next(true);
     }
     closePage(event: Event): void {
         event.stopPropagation();
+        this.resetPageActions();
+    }
+
+    resetPageActions(): void {
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
-        document.getElementById('page-content').style.overflowY = 'auto';
+        this._overflowHandlingService.isExampleOpened.next(false);
+    }
+
+    ngOnDestroy(): void {
+        this.resetPageActions();
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-snap-scroll-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-snap-scroll-example.component.ts
@@ -1,5 +1,6 @@
-import { Component, ChangeDetectionStrategy, ElementRef, ViewChild } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ElementRef, ViewChild, OnDestroy } from '@angular/core';
 import { DynamicPageCollapseChangeEvent } from '@fundamental-ngx/platform';
+import { PlatformDynamicPagePageOverflowService } from './platform-dynamic-page-page-overflow.service';
 
 @Component({
     selector: 'fdp-platform-dynamic-page-snap-scroll-example',
@@ -7,13 +8,15 @@ import { DynamicPageCollapseChangeEvent } from '@fundamental-ngx/platform';
     styleUrls: ['./platform-dynamic-page-snap-scroll-example.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PlatformDynamicPageSnapScrollExampleComponent {
+export class PlatformDynamicPageSnapScrollExampleComponent implements OnDestroy {
     @ViewChild('overlay')
     overlay: ElementRef<HTMLElement>;
 
     fullscreen = false;
 
     pageTitle = 'Balenciaga Tripple S Trainers';
+
+    constructor(private _overflowHandlingService: PlatformDynamicPagePageOverflowService) {}
 
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
@@ -26,12 +29,20 @@ export class PlatformDynamicPageSnapScrollExampleComponent {
     openPage(): void {
         this.fullscreen = true;
         this.overlay.nativeElement.style.width = '100%';
-        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
+        this._overflowHandlingService.isExampleOpened.next(true);
     }
     closePage(event: Event): void {
         event.stopPropagation();
+        this.resetPageActions();
+    }
+
+    resetPageActions(): void {
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
-        document.getElementById('page-content').style.overflowY = 'auto';
+        this._overflowHandlingService.isExampleOpened.next(false);
+    }
+
+    ngOnDestroy(): void {
+        this.resetPageActions();
     }
 }

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.ts
@@ -1,9 +1,10 @@
-import { Component, ChangeDetectionStrategy, ViewChild, ElementRef } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewChild, ElementRef, OnDestroy } from '@angular/core';
 import {
     DynamicPageCollapseChangeEvent,
     DynamicPageComponent,
     DynamicPageTabChangeEvent
 } from '@fundamental-ngx/platform';
+import { PlatformDynamicPagePageOverflowService } from './platform-dynamic-page-page-overflow.service';
 
 @Component({
     selector: 'fdp-platform-dynamic-page-tabbed-example',
@@ -11,7 +12,7 @@ import {
     styleUrls: ['./platform-dynamic-page-tabbed-example.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PlatformDynamicPageTabbedExampleComponent {
+export class PlatformDynamicPageTabbedExampleComponent implements OnDestroy {
     @ViewChild('overlay')
     overlay: ElementRef<HTMLElement>;
 
@@ -22,6 +23,8 @@ export class PlatformDynamicPageTabbedExampleComponent {
 
     pageTitle = 'Balenciaga Tripple S Trainers';
 
+    constructor(private _overflowHandlingService: PlatformDynamicPagePageOverflowService) {}
+
     onCollapseChange(event: DynamicPageCollapseChangeEvent): void {
         console.log('collapse changed');
     }
@@ -29,13 +32,17 @@ export class PlatformDynamicPageTabbedExampleComponent {
     openPage(): void {
         this.overlay.nativeElement.style.width = '100%';
         this.fullscreen = true;
-        document.getElementById('page-content').style.overflowY = 'hidden'; // hide the underlying page scrollbars
+        this._overflowHandlingService.isExampleOpened.next(true);
     }
     closePage(event: Event): void {
         event.stopPropagation();
+        this.resetPageActions();
+    }
+
+    resetPageActions(): void {
         this.fullscreen = false;
         this.overlay.nativeElement.style.width = '0%';
-        document.getElementById('page-content').style.overflowY = 'auto';
+        this._overflowHandlingService.isExampleOpened.next(false);
     }
 
     onTabChanged(event: DynamicPageTabChangeEvent): void {
@@ -44,5 +51,9 @@ export class PlatformDynamicPageTabbedExampleComponent {
 
     switchTab(id: string): void {
         this.dynamicPageComponent.setSelectedTab(id);
+    }
+
+    ngOnDestroy(): void {
+        this.resetPageActions();
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#4619

#### Please provide a brief summary of this pull request.
The documentation page class `page-content` overflow styles are changed in the documentation examples to hide multiple scrollbar visibility in some browsers when dynamic page examples are opened in full screen. When back pressed, this class's overflow styles were not being reset, due to which the scroll would get disabled in the previous documentation page. This PR resets the styles of `page-content` to fix this issue.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

