### PR TITLE
test: (e2e) fix flaky calendar e2e tests

### DIFF
--- a/e2e/wdio/core/fixtures/appData/calendar-contents.ts
+++ b/e2e/wdio/core/fixtures/appData/calendar-contents.ts
@@ -9,3 +9,4 @@ export const compactAttribute = 'compact';
 export const mondayStartDate = 'M';
 export const currentDayClass = 'current';
 export const otherMonth = 'fd-calendar__item ng-star-inserted fd-calendar__item--other-month';
+export const fullCurrentDayClass = 'fd-calendar__item ng-star-inserted is-active fd-calendar__item--current';

--- a/e2e/wdio/core/tests/calendar.e2e-spec.ts
+++ b/e2e/wdio/core/tests/calendar.e2e-spec.ts
@@ -23,7 +23,7 @@ import {
     landscapeAttribute,
     mondayStartDate,
     portraitAttribute,
-    otherMonth
+    otherMonth, fullCurrentDayClass
 } from '../fixtures/appData/calendar-contents';
 
 describe('calendar test suite', function() {
@@ -360,7 +360,8 @@ describe('calendar test suite', function() {
     function checkSingleSelection(calendar: string, selector: string, index: number = 0): void {
         scrollIntoView(calendar + selector, index);
         while (getAttributeByName(calendar + selector, disabledAttribute, index) === 'true' ||
-        getAttributeByName(calendar + selector, classAttribute, index) === otherMonth) {
+        getAttributeByName(calendar + selector, classAttribute, index) === otherMonth ||
+        getAttributeByName(calendar + selector, classAttribute, index) === fullCurrentDayClass ) {
             index++;
         }
         click(calendar + selector, index);


### PR DESCRIPTION
#### Please provide a brief summary of this pull request.
add fix for calendar (core) e2e tests where the test on the 1st of the month tries to choose the 1st as a new date and fails.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

