### PR TITLE
fix(core): access popover on image using keyboard

### DIFF
--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.html
@@ -9,7 +9,7 @@
     [focusAutoCapture]="true"
 >
     <fd-popover-control>
-        <fd-avatar size="s" [circle]="true" ariaLabel="photo 1" image="http://picsum.photos/id/1018/400"></fd-avatar>
+        <fd-avatar size="s" [circle]="true" ariaLabel="photo 1" image="http://picsum.photos/id/1018/400" tabindex="0"></fd-avatar>
     </fd-popover-control>
     <fd-popover-body>
         <ul fd-list>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.scss
@@ -12,9 +12,12 @@ $fd-focus-outline-offset: 0.0625rem;
     &:focus,
     &.is-focus {
       outline-offset: $offset;
-      outline-width: var(--sapContent_FocusWidth);
-      outline-color: var(--sapContent_FocusColor);
-      outline-style: var(--sapContent_FocusStyle);
+      outline-width: .0625rem;
+      outline-width: var(--sapContent_FocusWidth, .0625rem);
+      outline-color: #000;
+      outline-color: var(--sapContent_FocusColor, #000);
+      outline-style: dotted;
+      outline-style: var(--sapContent_FocusStyle, dotted);
     }
   }
 

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.scss
@@ -6,12 +6,10 @@
 .fd-button {
     margin: 10px;
 }
-$fd-focus-outline-offset: 0.0625rem;
 
-@mixin fd-fiori-focus($offset: -0.1875rem) {
+@mixin fd-fiori-focus() {
     &:focus,
     &.is-focus {
-      outline-offset: $offset;
       outline-width: .0625rem;
       outline-width: var(--sapContent_FocusWidth, .0625rem);
       outline-color: #000;
@@ -22,6 +20,6 @@ $fd-focus-outline-offset: 0.0625rem;
   }
 
   fd-avatar{
-    @include fd-fiori-focus($fd-focus-outline-offset);
+    @include fd-fiori-focus();
     cursor: pointer;
   }

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-programmatic/popover-programmatic-open-example.component.scss
@@ -6,3 +6,19 @@
 .fd-button {
     margin: 10px;
 }
+$fd-focus-outline-offset: 0.0625rem;
+
+@mixin fd-fiori-focus($offset: -0.1875rem) {
+    &:focus,
+    &.is-focus {
+      outline-offset: $offset;
+      outline-width: var(--sapContent_FocusWidth);
+      outline-color: var(--sapContent_FocusColor);
+      outline-style: var(--sapContent_FocusStyle);
+    }
+  }
+
+  fd-avatar{
+    @include fd-fiori-focus($fd-focus-outline-offset);
+    cursor: pointer;
+  }

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
@@ -1,11 +1,12 @@
 <div class="fd-docs-flex-display-helper">
     <fd-popover [focusTrapped]="true" [focusAutoCapture]="true" title="photo 1 in circle">
         <fd-popover-control>
-            <fd-avatar size="s" [circle]="true" ariaLabel="photo 1 in circle" image="http://picsum.photos/id/1018/400"></fd-avatar>
+            <fd-avatar size="s" [circle]="true" ariaLabel="photo 1 in circle" image="http://picsum.photos/id/1018/400"
+            tabindex="0"></fd-avatar>
         </fd-popover-control>
         <fd-popover-body *ngIf="list1 && list1.length">
             <ul fd-list>
-                <li fd-list-item *ngFor="let option of list1">
+                <li fd-list-item *ngFor="let option of list1" (click)="navigate(this)" (keydown)="navigate(this)">
                     <a [attr.href]="option.url" fd-list-title>{{ option.text }}</a>
                 </li>
             </ul>
@@ -14,7 +15,7 @@
 
     <fd-popover placement="top" [focusTrapped]="true" [focusAutoCapture]="true" title="menu2">
         <fd-popover-control>
-            <fd-icon [glyph]="'menu2'" ariaLabel="menu2"></fd-icon>
+            <fd-icon [glyph]="'menu2'" ariaLabel="menu2" tabindex="0"></fd-icon>
         </fd-popover-control>
         <fd-popover-body *ngIf="list1 && list1.length">
             <ul fd-list>
@@ -27,7 +28,7 @@
 
     <fd-popover placement="bottom" [focusTrapped]="true" [focusAutoCapture]="true" title="money-bills">
         <fd-popover-control>
-            <fd-avatar size="m" [glyph]="'money-bills'" ariaLabel="money-bills" colorAccent="3"></fd-avatar>
+            <fd-avatar size="m" [glyph]="'money-bills'" ariaLabel="money-bills" colorAccent="3" tabindex = "0"></fd-avatar>
         </fd-popover-control>
         <fd-popover-body *ngIf="list1 && list1.length" style="min-width: 400px">
             <div fd-popover-body-header>
@@ -83,7 +84,7 @@
 
     <fd-popover placement="bottom" [focusTrapped]="true" [focusAutoCapture]="true" title="circle photo">
         <fd-popover-control>
-            <fd-avatar size="s" [circle]="true" ariaLabel="circle photo" image="https://picsum.photos/id/2/400/400"></fd-avatar>
+            <fd-avatar size="s" [circle]="true" ariaLabel="circle photo" image="https://picsum.photos/id/2/400/400" tabindex="0"></fd-avatar>
         </fd-popover-control>
         <fd-popover-body *ngIf="list1 && list1.length">
             <ul fd-list>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
@@ -6,7 +6,7 @@
         </fd-popover-control>
         <fd-popover-body *ngIf="list1 && list1.length">
             <ul fd-list>
-                <li fd-list-item *ngFor="let option of list1" (click)="navigate(this)" (keydown)="navigate(this)">
+                <li fd-list-item *ngFor="let option of list1">
                     <a [attr.href]="option.url" fd-list-title>{{ option.text }}</a>
                 </li>
             </ul>
@@ -47,7 +47,7 @@
         </fd-popover-body>
     </fd-popover>
 
-    <fd-popover [focusTrapped]="true" [focusAutoCapture]="true">
+    <fd-popover [focusTrapped]="true" [focusAutoCapture]="true" [(isOpen)]="isOpen">
         <fd-popover-control>
             <button fd-button label="Sample"></button>
         </fd-popover-control>
@@ -74,8 +74,8 @@
             <div fd-popover-body-footer>
                 <div fd-bar [barDesign]="'footer'" [cozy]="true">
                     <div fd-bar-right>
-                        <fd-button-bar label="Save" fdType="emphasized"></fd-button-bar>
-                        <fd-button-bar label="Cancel"></fd-button-bar>
+                        <fd-button-bar label="Save" fdType="emphasized" (click)="this.isOpen = false"></fd-button-bar>
+                        <fd-button-bar label="Cancel" (click)="this.isOpen = false"></fd-button-bar>
                     </div>
                 </div>
             </div>

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.scss
@@ -1,9 +1,6 @@
-$fd-focus-outline-offset: 0.0625rem;
-
-@mixin fd-fiori-focus($offset: -0.1875rem) {
+@mixin fd-fiori-focus() {
     &:focus,
     &.is-focus {
-      outline-offset: $offset;
       outline-width: .0625rem;
       outline-width: var(--sapContent_FocusWidth, .0625rem);
       outline-color: #000;
@@ -13,12 +10,11 @@ $fd-focus-outline-offset: 0.0625rem;
     }
   }
 
-  // temporary will be removed once respective component styles are updated
   fd-avatar,
   fd-icon,
  .fd-list,
  a {
-    @include fd-fiori-focus($fd-focus-outline-offset);
+    @include fd-fiori-focus();
     cursor: pointer;
   }
 

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.scss
@@ -1,4 +1,26 @@
-.fd-docs-flex-display-helper {
+$fd-focus-outline-offset: 0.0625rem;
+
+@mixin fd-fiori-focus($offset: -0.1875rem) {
+    &:focus,
+    &.is-focus {
+      outline-offset: $offset;
+      outline-width: var(--sapContent_FocusWidth);
+      outline-color: var(--sapContent_FocusColor);
+      outline-style: var(--sapContent_FocusStyle);
+    }
+  }
+
+  // temporary will be removed once respective component styles are updated
+  fd-avatar,
+  fd-icon,
+ .fd-list,
+ a {
+    @include fd-fiori-focus($fd-focus-outline-offset);
+    cursor: pointer;
+  }
+
+
+  .fd-docs-flex-display-helper {
     display: flex;
     align-items: center;
     justify-content: space-around;

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.scss
@@ -4,9 +4,12 @@ $fd-focus-outline-offset: 0.0625rem;
     &:focus,
     &.is-focus {
       outline-offset: $offset;
-      outline-width: var(--sapContent_FocusWidth);
-      outline-color: var(--sapContent_FocusColor);
-      outline-style: var(--sapContent_FocusStyle);
+      outline-width: .0625rem;
+      outline-width: var(--sapContent_FocusWidth, .0625rem);
+      outline-color: #000;
+      outline-color: var(--sapContent_FocusColor, #000);
+      outline-style: dotted;
+      outline-style: var(--sapContent_FocusStyle, dotted);
     }
   }
 

--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.ts
@@ -7,6 +7,8 @@ import { Component, ViewEncapsulation } from '@angular/core';
     encapsulation: ViewEncapsulation.None
 })
 export class PopoverExampleComponent {
+    isOpen = false;
+
     list1 = [
         { text: 'Option 1', url: '#' },
         { text: 'Option 2', url: '#' },

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -147,7 +147,7 @@ export class PopoverComponent extends BasePopoverClass implements AfterViewInit,
     /** Handler for alt + arrow down keydown */
     triggerKeyDownHandler(event: KeyboardEvent): void {
         if ((KeyUtil.isKeyCode(event, DOWN_ARROW) && event.altKey && !this.disabled) ||
-         (KeyUtil.isKeyCode(event, ENTER) || KeyUtil.isKeyCode(event, SPACE))) {
+         (KeyUtil.isKeyCode(event, [ENTER, SPACE]))) {
             this.open();
             event.preventDefault();
             event.stopPropagation();

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -18,7 +18,7 @@ import {
     CdkOverlayOrigin,
     ConnectedPosition,
 } from '@angular/cdk/overlay';
-import { DOWN_ARROW } from '@angular/cdk/keycodes';
+import { DOWN_ARROW, ENTER, SPACE } from '@angular/cdk/keycodes';
 
 import { BasePopoverClass } from './base/base-popover.class';
 import { KeyUtil } from '@fundamental-ngx/core/utils';
@@ -146,7 +146,8 @@ export class PopoverComponent extends BasePopoverClass implements AfterViewInit,
 
     /** Handler for alt + arrow down keydown */
     triggerKeyDownHandler(event: KeyboardEvent): void {
-        if (KeyUtil.isKeyCode(event, DOWN_ARROW) && event.altKey && !this.disabled) {
+        if ((KeyUtil.isKeyCode(event, DOWN_ARROW) && event.altKey && !this.disabled) ||
+         (KeyUtil.isKeyCode(event, ENTER) || KeyUtil.isKeyCode(event, SPACE))) {
             this.open();
             event.preventDefault();
             event.stopPropagation();


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx #3139 

#### Please provide a brief summary of this pull request.

The ‘image’ buttons highlighted in popover will be reachable by keyboard as well.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

