### PR TITLE
fix(core): dialog z-index fix

### DIFF
--- a/libs/core/src/lib/dialog/dialog.component.scss
+++ b/libs/core/src/lib/dialog/dialog.component.scss
@@ -1,7 +1,7 @@
 @import '~fundamental-styles/dist/dialog';
 
 .fd-dialog {
-    z-index: 1000;
+    z-index: 999;
 }
 
 .fd-dialog__resize-handle {


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Closes #4518

#### Please provide a brief summary of this pull request.

`z-index` for the dialog fix to be available to have an overlay on top of the dialog.

#### Please check whether the PR fulfills the following requirements

- [X] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [X] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [X] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [n/a] Documentation Examples
- [X] Stackblitz works for all examples

