### PR TITLE
fix(core): fix Avatar Group's popover control styles & enhance a11y

### DIFF
--- a/apps/docs/src/app/core/api-files.ts
+++ b/apps/docs/src/app/core/api-files.ts
@@ -26,6 +26,7 @@ export const API_FILES = {
         'AvatarGroupComponent',
         'AvatarGroupItemDirective',
         'AvatarGroupFocusableAvatarDirective',
+        'AvatarGroupPopoverControlDirective',
         'AvatarGroupOverflowBodyDirective',
         'AvatarGroupOverflowItemDirective',
         'AvatarGroupOverflowButtonDirective',

--- a/apps/docs/src/app/core/component-docs/avatar-group/avatar-group-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/avatar-group/avatar-group-docs.module.ts
@@ -16,6 +16,7 @@ import { PopoverModule } from '@fundamental-ngx/core/popover';
 import { QuickViewModule } from '@fundamental-ngx/core/quick-view';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { TitleModule } from '@fundamental-ngx/core/title';
+import { LinkModule } from '@fundamental-ngx/core/link';
 
 const routes: Routes = [
     {
@@ -38,6 +39,7 @@ const routes: Routes = [
         PopoverModule,
         QuickViewModule,
         BarModule,
+        LinkModule,
         TitleModule
     ],
     exports: [RouterModule],

--- a/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-group-type-example.component.html
+++ b/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-group-type-example.component.html
@@ -46,13 +46,14 @@
                     fd-button
                     fd-avatar-group-overflow-button
                     tabindex="-1"
+                    [compact]="false"
                     [size]="size">
                 <bdi fd-avatar-group-overflow-button-text>
                     +{{ avatarGroup_GroupType.overflowItemsCount }}
                 </bdi>
             </button>
         </fd-popover-control>
-        <fd-popover-body #overflowPopoverBody>
+        <fd-popover-body #overflowPopoverBody aria-labelledby="avatar-group-1-popover-header" role="tooltip">
             <div class="fd-popover__wrapper">
                 <div fd-popover-body-header>
                     <div fd-bar barDesign="header">
@@ -64,7 +65,7 @@
                                            aria-label="Back"
                                            title="Back"
                             ></fd-button-bar>
-                            <fd-bar-element>
+                            <fd-bar-element id="avatar-group-1-popover-header">
                                 {{ isDetailStage ? 'Business Card' : 'Team Members (' + people.length + ')' }}
                             </fd-bar-element>
                             <fd-bar-element *ngIf="isDetailStage">&nbsp;</fd-bar-element>

--- a/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-group-type-example.component.html
+++ b/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-group-type-example.component.html
@@ -9,13 +9,16 @@
                 placement="bottom"
                 maxWidth="312"
                 #overflowPopover>
-        <fd-popover-control tabindex="0"
+        <fd-popover-control fd-avatar-group-popover-control
+                            [attr.aria-label]="'Has popup type dialog Conjoined avatars, ' + (people?.length - avatarGroup_GroupType?.overflowItemsCount)
+            + ' avatars displayed, ' + avatarGroup_GroupType?.overflowItemsCount + ' avatars hidden, activate for complete list'"
                             (click)="handleControlClick($event, overflowPopover)"
                             (keydown)="handleControlKeydown($event, overflowPopover)">
             <div *ngFor="let person of people" fd-avatar-group-item>
                 <fd-avatar *ngIf="!person.imageUrl && !person.glyph"
                            [label]="person.firstName + ' ' + person.lastName"
                            [title]="person.firstName + ' ' + person.lastName"
+                           [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"
                            role="img"
                            [circle]="true"
                            [border]="true"
@@ -24,6 +27,7 @@
                 <fd-avatar *ngIf="person.imageUrl"
                            role="img"
                            [title]="person.firstName + ' ' + person.lastName"
+                           [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"
                            [circle]="true"
                            [border]="true"
                            [size]="size"
@@ -32,6 +36,7 @@
                 <fd-avatar *ngIf="person.glyph"
                            role="img"
                            [title]="person.firstName + ' ' + person.lastName"
+                           [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"
                            [circle]="true"
                            [border]="true"
                            [size]="size"
@@ -81,6 +86,7 @@
                                            size="s"
                                            [label]="person.firstName + ' ' + person.lastName"
                                            [title]="person.firstName + ' ' + person.lastName"
+                                           [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"
                                            role="img"
                                            (click)="openOverflowDetails(idx)"
                                            (keydown.enter)="openOverflowDetails(idx)"
@@ -90,6 +96,7 @@
                                            fd-avatar-group-focusable-avatar
                                            role="img"
                                            [title]="person.firstName + ' ' + person.lastName"
+                                           [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"
                                            [circle]="true"
                                            size="s"
                                            [image]="person.imageUrl"
@@ -101,6 +108,7 @@
                                            fd-avatar-group-focusable-avatar
                                            role="img"
                                            [title]="person.firstName + ' ' + person.lastName"
+                                           [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"
                                            [circle]="true"
                                            size="s"
                                            [glyph]="person.glyph"
@@ -118,20 +126,23 @@
                                 <fd-avatar *ngIf="!personDetails.imageUrl && !personDetails.glyph"
                                            [circle]="true"
                                            size="s"
-                                           [label]="personDetails.firstName + ' ' + personDetails.lastName"
                                            role="img"
-                                           [title]="personDetails.firstName + ' ' + personDetails.lastName"></fd-avatar>
+                                           [label]="personDetails.firstName + ' ' + personDetails.lastName"
+                                           [title]="personDetails.firstName + ' ' + personDetails.lastName"
+                                           [ariaLabel]="personDetails.firstName + ' ' + personDetails.lastName + ' avatar'"></fd-avatar>
                                 <fd-avatar *ngIf="personDetails.imageUrl"
                                            [circle]="true"
                                            size="s"
                                            role="img"
                                            [title]="personDetails.firstName + ' ' + personDetails.lastName"
+                                           [ariaLabel]="personDetails.firstName + ' ' + personDetails.lastName + ' avatar'"
                                            [image]="personDetails.imageUrl"></fd-avatar>
                                 <fd-avatar *ngIf="personDetails.glyph"
                                            [circle]="true"
                                            size="s"
                                            role="img"
                                            [title]="personDetails.firstName + ' ' + personDetails.lastName"
+                                           [ariaLabel]="personDetails.firstName + ' ' + personDetails.lastName + ' avatar'"
                                            [glyph]="personDetails.glyph"></fd-avatar>
                                 <fd-quick-view-subheader-title>{{ personDetails.firstName }} {{ personDetails.lastName }}</fd-quick-view-subheader-title>
                                 <fd-quick-view-subheader-subtitle>{{ personDetails.position }}</fd-quick-view-subheader-subtitle>

--- a/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-group-type-example.component.html
+++ b/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-group-type-example.component.html
@@ -153,21 +153,21 @@
                                 <fd-quick-view-group-item>
                                     <fd-quick-view-group-item-label>Phone</fd-quick-view-group-item-label>
                                     <fd-quick-view-group-item-content>
-                                        <a [href]="'tel:' + personDetails.phone" [innerText]="personDetails.phone"></a>
+                                        <a fd-link [href]="'tel:' + personDetails.phone" [innerText]="personDetails.phone"></a>
                                     </fd-quick-view-group-item-content>
                                 </fd-quick-view-group-item>
 
                                 <fd-quick-view-group-item>
                                     <fd-quick-view-group-item-label>Mobile</fd-quick-view-group-item-label>
                                     <fd-quick-view-group-item-content>
-                                        <a [href]="'tel:' + personDetails.mobile" [innerText]="personDetails.mobile"></a>
+                                        <a fd-link [href]="'tel:' + personDetails.mobile" [innerText]="personDetails.mobile"></a>
                                     </fd-quick-view-group-item-content>
                                 </fd-quick-view-group-item>
 
                                 <fd-quick-view-group-item>
                                     <fd-quick-view-group-item-label>Email</fd-quick-view-group-item-label>
                                     <fd-quick-view-group-item-content>
-                                        <a [href]="'mailto:' + personDetails.email" [innerText]="personDetails.email"></a>
+                                        <a fd-link [href]="'mailto:' + personDetails.email" [innerText]="personDetails.email"></a>
                                     </fd-quick-view-group-item-content>
                                 </fd-quick-view-group-item>
                             </fd-quick-view-group>

--- a/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-individual-type-example.component.html
+++ b/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-individual-type-example.component.html
@@ -45,9 +45,9 @@
                 </div>
             </fd-popover-control>
 
-            <fd-popover-body>
+            <fd-popover-body [attr.aria-labelledby]="person.id+'-popover-header'" role="tooltip">
                 <fd-quick-view [id]="person.id">
-                    <fd-quick-view-title align="left">Business card</fd-quick-view-title>
+                    <fd-quick-view-title align="left" [id]="person.id+'-popover-header'">Business card</fd-quick-view-title>
                     <fd-quick-view-subheader>
                         <fd-avatar *ngIf="!person.imageUrl && !person.glyph"
                                    [circle]="true"
@@ -119,6 +119,7 @@
         <fd-popover-control>
             <button fd-button
                     fd-avatar-group-overflow-button
+                    [compact]="false"
                     [size]="size"
                     (click)="handleControlClick($event, overflowPopover)"
                     (keydown)="handleControlKeydown($event, overflowPopover)">
@@ -127,7 +128,7 @@
                 </bdi>
             </button>
         </fd-popover-control>
-        <fd-popover-body #overflowPopoverBody>
+        <fd-popover-body #overflowPopoverBody aria-labelledby="avatar-group-0-popover-header" role="tooltip">
             <div class="fd-popover__wrapper">
                 <div fd-popover-body-header>
                     <div fd-bar barDesign="header">
@@ -139,7 +140,7 @@
                                            aria-label="Back"
                                            title="Back"
                             ></fd-button-bar>
-                            <fd-bar-element>
+                            <fd-bar-element id="avatar-group-0-popover-header">
                                 {{ isDetailStage ? 'Business Card' : 'Team Members (' + avatarGroup_IndividualType.overflowItemsCount + ')' }}
                             </fd-bar-element>
                             <fd-bar-element *ngIf="isDetailStage">&nbsp;</fd-bar-element>

--- a/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-individual-type-example.component.html
+++ b/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-individual-type-example.component.html
@@ -8,6 +8,8 @@
                     [triggers]="[]"
                     [closeOnOutsideClick]="true"
                     [closeOnEscapeKey]="true"
+                    [focusAutoCapture]="true"
+                    [focusTrapped]="true"
                     #individualPopover>
             <fd-popover-control>
                 <div fd-avatar-group-item
@@ -79,21 +81,21 @@
                         <fd-quick-view-group-item>
                             <fd-quick-view-group-item-label>Phone</fd-quick-view-group-item-label>
                             <fd-quick-view-group-item-content>
-                                <a [href]="'tel:' + person.phone" [innerText]="person.phone"></a>
+                                <a fd-link [href]="'tel:' + person.phone" [innerText]="person.phone"></a>
                             </fd-quick-view-group-item-content>
                         </fd-quick-view-group-item>
 
                         <fd-quick-view-group-item>
                             <fd-quick-view-group-item-label>Mobile</fd-quick-view-group-item-label>
                             <fd-quick-view-group-item-content>
-                                <a [href]="'tel:' + person.mobile" [innerText]="person.mobile"></a>
+                                <a fd-link [href]="'tel:' + person.mobile" [innerText]="person.mobile"></a>
                             </fd-quick-view-group-item-content>
                         </fd-quick-view-group-item>
 
                         <fd-quick-view-group-item>
                             <fd-quick-view-group-item-label>Email</fd-quick-view-group-item-label>
                             <fd-quick-view-group-item-content>
-                                <a [href]="'mailto:' + person.email" [innerText]="person.email"></a>
+                                <a fd-link [href]="'mailto:' + person.email" [innerText]="person.email"></a>
                             </fd-quick-view-group-item-content>
                         </fd-quick-view-group-item>
                     </fd-quick-view-group>
@@ -229,21 +231,21 @@
                                 <fd-quick-view-group-item>
                                     <fd-quick-view-group-item-label>Phone</fd-quick-view-group-item-label>
                                     <fd-quick-view-group-item-content>
-                                        <a [href]="'tel:' + personDetails.phone" [innerText]="personDetails.phone"></a>
+                                        <a fd-link [href]="'tel:' + personDetails.phone" [innerText]="personDetails.phone"></a>
                                     </fd-quick-view-group-item-content>
                                 </fd-quick-view-group-item>
 
                                 <fd-quick-view-group-item>
                                     <fd-quick-view-group-item-label>Mobile</fd-quick-view-group-item-label>
                                     <fd-quick-view-group-item-content>
-                                        <a [href]="'tel:' + personDetails.mobile" [innerText]="personDetails.mobile"></a>
+                                        <a fd-link [href]="'tel:' + personDetails.mobile" [innerText]="personDetails.mobile"></a>
                                     </fd-quick-view-group-item-content>
                                 </fd-quick-view-group-item>
 
                                 <fd-quick-view-group-item>
                                     <fd-quick-view-group-item-label>Email</fd-quick-view-group-item-label>
                                     <fd-quick-view-group-item-content>
-                                        <a [href]="'mailto:' + personDetails.email" [innerText]="personDetails.email"></a>
+                                        <a fd-link [href]="'mailto:' + personDetails.email" [innerText]="personDetails.email"></a>
                                     </fd-quick-view-group-item-content>
                                 </fd-quick-view-group-item>
                             </fd-quick-view-group>

--- a/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-individual-type-example.component.html
+++ b/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-individual-type-example.component.html
@@ -20,7 +20,8 @@
                                [size]="size"
                                role="img"
                                [title]="person.firstName + ' ' + person.lastName"
-                               [label]="person.firstName + ' ' + person.lastName"></fd-avatar>
+                               [label]="person.firstName + ' ' + person.lastName"
+                               [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"></fd-avatar>
 
                     <fd-avatar *ngIf="person.imageUrl"
                                [circle]="true"
@@ -28,7 +29,8 @@
                                [size]="size"
                                [image]="person.imageUrl"
                                role="img"
-                               [title]="person.firstName + ' ' + person.lastName"></fd-avatar>
+                               [title]="person.firstName + ' ' + person.lastName"
+                               [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"></fd-avatar>
 
                     <fd-avatar *ngIf="person.glyph"
                                [circle]="true"
@@ -36,7 +38,8 @@
                                [size]="size"
                                [glyph]="person.glyph"
                                role="img"
-                               [title]="person.firstName + ' ' + person.lastName"></fd-avatar>
+                               [title]="person.firstName + ' ' + person.lastName"
+                               [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"></fd-avatar>
                 </div>
             </fd-popover-control>
 
@@ -47,23 +50,26 @@
                         <fd-avatar *ngIf="!person.imageUrl && !person.glyph"
                                    [circle]="true"
                                    size="s"
-                                   [label]="person.firstName + ' ' + person.lastName"
                                    role="img"
-                                   [title]="person.firstName + ' ' + person.lastName"></fd-avatar>
+                                   [label]="person.firstName + ' ' + person.lastName"
+                                   [title]="person.firstName + ' ' + person.lastName"
+                                   [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"></fd-avatar>
 
                         <fd-avatar *ngIf="person.imageUrl"
                                    [circle]="true"
                                    size="s"
-                                   [image]="person.imageUrl"
                                    role="img"
-                                   [title]="person.firstName + ' ' + person.lastName"></fd-avatar>
+                                   [image]="person.imageUrl"
+                                   [title]="person.firstName + ' ' + person.lastName"
+                                   [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"></fd-avatar>
 
                         <fd-avatar *ngIf="person.glyph"
                                    [circle]="true"
                                    size="s"
-                                   [glyph]="person.glyph"
                                    role="img"
-                                   [title]="person.firstName + ' ' + person.lastName"></fd-avatar>
+                                   [glyph]="person.glyph"
+                                   [title]="person.firstName + ' ' + person.lastName"
+                                   [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"></fd-avatar>
                         <fd-quick-view-subheader-title>{{ person.firstName }} {{ person.lastName }}</fd-quick-view-subheader-title>
                         <fd-quick-view-subheader-subtitle>{{ person.position }}</fd-quick-view-subheader-subtitle>
                     </fd-quick-view-subheader>
@@ -151,9 +157,10 @@
                                        fd-avatar-group-focusable-avatar
                                        [circle]="true"
                                        size="s"
-                                       [label]="person.firstName + ' ' + person.lastName"
                                        role="img"
+                                       [label]="person.firstName + ' ' + person.lastName"
                                        [title]="person.firstName + ' ' + person.lastName"
+                                       [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"
                                        (click)="openOverflowDetails(idx)"
                                        (keydown.enter)="openOverflowDetails(idx)"
                                        (keydown.space)="openOverflowDetails(idx)"
@@ -163,9 +170,10 @@
                                        fd-avatar-group-focusable-avatar
                                        [circle]="true"
                                        size="s"
-                                       [image]="person.imageUrl"
                                        role="img"
+                                       [image]="person.imageUrl"
                                        [title]="person.firstName + ' ' + person.lastName"
+                                       [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"
                                        (click)="openOverflowDetails(idx)"
                                        (keydown.enter)="openOverflowDetails(idx)"
                                        (keydown.space)="openOverflowDetails(idx)"
@@ -175,9 +183,10 @@
                                        fd-avatar-group-focusable-avatar
                                        [circle]="true"
                                        size="s"
-                                       [glyph]="person.glyph"
                                        role="img"
+                                       [glyph]="person.glyph"
                                        [title]="person.firstName + ' ' + person.lastName"
+                                       [ariaLabel]="person.firstName + ' ' + person.lastName + ' avatar'"
                                        (click)="openOverflowDetails(idx)"
                                        (keydown.enter)="openOverflowDetails(idx)"
                                        (keydown.space)="openOverflowDetails(idx)"
@@ -193,21 +202,24 @@
                                            size="s"
                                            [label]="personDetails.firstName + ' ' + personDetails.lastName"
                                            role="img"
-                                           [title]="personDetails.firstName + ' ' + personDetails.lastName"></fd-avatar>
+                                           [title]="personDetails.firstName + ' ' + personDetails.lastName"
+                                           [ariaLabel]="personDetails.firstName + ' ' + personDetails.lastName + ' avatar'"></fd-avatar>
 
                                 <fd-avatar *ngIf="personDetails.imageUrl"
                                            [circle]="true"
                                            size="s"
                                            [image]="personDetails.imageUrl"
                                            role="img"
-                                           [title]="personDetails.firstName + ' ' + personDetails.lastName"></fd-avatar>
+                                           [title]="personDetails.firstName + ' ' + personDetails.lastName"
+                                           [ariaLabel]="personDetails.firstName + ' ' + personDetails.lastName + ' avatar'"></fd-avatar>
 
                                 <fd-avatar *ngIf="personDetails.glyph"
                                            [circle]="true"
                                            size="s"
                                            [glyph]="personDetails.glyph"
                                            role="img"
-                                           [title]="personDetails.firstName + ' ' + personDetails.lastName"></fd-avatar>
+                                           [title]="personDetails.firstName + ' ' + personDetails.lastName"
+                                           [ariaLabel]="personDetails.firstName + ' ' + personDetails.lastName + ' avatar'"></fd-avatar>
                                 <fd-quick-view-subheader-title>{{ personDetails.firstName }} {{ personDetails.lastName }}</fd-quick-view-subheader-title>
                                 <fd-quick-view-subheader-subtitle>{{ personDetails.position }}</fd-quick-view-subheader-subtitle>
                             </fd-quick-view-subheader>

--- a/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-individual-type-example.component.html
+++ b/apps/docs/src/app/core/component-docs/avatar-group/examples/avatar-group-individual-type-example.component.html
@@ -45,10 +45,13 @@
                 </div>
             </fd-popover-control>
 
-            <fd-popover-body [attr.aria-labelledby]="person.id+'-popover-header'" role="tooltip">
+            <fd-popover-body
+                [attr.aria-labelledby]="person.id+'-popover-header'"
+                [attr.aria-describedby]="person.id+'-popover-subheader'"
+                role="tooltip">
                 <fd-quick-view [id]="person.id">
                     <fd-quick-view-title align="left" [id]="person.id+'-popover-header'">Business card</fd-quick-view-title>
-                    <fd-quick-view-subheader>
+                    <fd-quick-view-subheader [id]="person.id+'-popover-subheader'">
                         <fd-avatar *ngIf="!person.imageUrl && !person.glyph"
                                    [circle]="true"
                                    size="s"
@@ -76,8 +79,8 @@
                         <fd-quick-view-subheader-subtitle>{{ person.position }}</fd-quick-view-subheader-subtitle>
                     </fd-quick-view-subheader>
 
-                    <fd-quick-view-group>
-                        <fd-quick-view-group-title>Contact Details</fd-quick-view-group-title>
+                    <fd-quick-view-group [attr.aria-labelledby]="person.id+'-group-title'">
+                        <fd-quick-view-group-title [id]="person.id+'-group-title'">Contact Details</fd-quick-view-group-title>
                         <fd-quick-view-group-item>
                             <fd-quick-view-group-item-label>Phone</fd-quick-view-group-item-label>
                             <fd-quick-view-group-item-content>

--- a/libs/core/src/lib/avatar-group/avatar-group.component.ts
+++ b/libs/core/src/lib/avatar-group/avatar-group.component.ts
@@ -5,7 +5,6 @@ import {
     ContentChildren,
     ElementRef,
     forwardRef,
-    HostBinding,
     Input,
     OnChanges,
     OnDestroy,
@@ -37,7 +36,6 @@ let avatarGroupUniqueId = 0;
 export class AvatarGroupComponent implements OnChanges, OnInit, AfterViewInit, OnDestroy {
     /** Id of the Avatar Group. */
     @Input()
-    @HostBinding('attr.id')
     id = `fd-avatar-group-${avatarGroupUniqueId++}`;
 
     /** Apply user custom class. */

--- a/libs/core/src/lib/avatar-group/avatar-group.module.ts
+++ b/libs/core/src/lib/avatar-group/avatar-group.module.ts
@@ -8,6 +8,7 @@ import { AvatarGroupOverflowItemDirective } from './directives/avatar-group-over
 import { AvatarGroupOverflowButtonDirective } from './directives/avatar-group-overflow-button.directive';
 import { AvatarGroupOverflowButtonTextDirective } from './directives/avatar-group-overflow-button-text.directive';
 import { AvatarGroupFocusableAvatarDirective } from './directives/avatar-group-focusable-avatar.directive';
+import { AvatarGroupPopoverControlDirective } from './directives/avatar-group-popover-control.directive';
 
 @NgModule({
     imports: [CommonModule],
@@ -15,6 +16,7 @@ import { AvatarGroupFocusableAvatarDirective } from './directives/avatar-group-f
         AvatarGroupComponent,
         AvatarGroupItemDirective,
         AvatarGroupFocusableAvatarDirective,
+        AvatarGroupPopoverControlDirective,
         AvatarGroupOverflowBodyDirective,
         AvatarGroupOverflowItemDirective,
         AvatarGroupOverflowButtonDirective,
@@ -24,6 +26,7 @@ import { AvatarGroupFocusableAvatarDirective } from './directives/avatar-group-f
         AvatarGroupComponent,
         AvatarGroupItemDirective,
         AvatarGroupFocusableAvatarDirective,
+        AvatarGroupPopoverControlDirective,
         AvatarGroupOverflowBodyDirective,
         AvatarGroupOverflowItemDirective,
         AvatarGroupOverflowButtonDirective,

--- a/libs/core/src/lib/avatar-group/directives/avatar-group-popover-control.directive.spec.ts
+++ b/libs/core/src/lib/avatar-group/directives/avatar-group-popover-control.directive.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { Component, ElementRef, ViewChild } from '@angular/core';
+
+import { AvatarGroupModule } from '../avatar-group.module';
+
+@Component({
+    template: `<fd-avatar #directiveElement fd-avatar-group-popover-control></fd-avatar>`
+})
+class TestComponent {
+    @ViewChild('directiveElement', { static: false })
+    ref: ElementRef;
+}
+
+describe('AvatarGroupPopoverControlDirective', () => {
+    let component: TestComponent;
+    let fixture: ComponentFixture<TestComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestComponent],
+            imports: [AvatarGroupModule]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should assign class', () => {
+        expect(component.ref.nativeElement).toHaveClass('fd-avatar-group__popover-control');
+    });
+});

--- a/libs/core/src/lib/avatar-group/directives/avatar-group-popover-control.directive.ts
+++ b/libs/core/src/lib/avatar-group/directives/avatar-group-popover-control.directive.ts
@@ -1,0 +1,19 @@
+import { Directive, HostBinding, Input } from '@angular/core';
+
+/** Needed to bind specific class to group type popover control. */
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-avatar-group-popover-control]',
+    host: { class: 'fd-avatar-group__popover-control' }
+})
+export class AvatarGroupPopoverControlDirective {
+    /** Tabindex of the popover control. */
+    @Input()
+    @HostBinding('attr.tabindex')
+    tabindex = 0;
+
+    /** Role of the popover control. */
+    @Input()
+    @HostBinding('attr.role')
+    role = 'button';
+}

--- a/libs/core/src/lib/avatar-group/public_api.ts
+++ b/libs/core/src/lib/avatar-group/public_api.ts
@@ -2,6 +2,7 @@ export * from './avatar-group.module';
 export * from './avatar-group.component';
 export * from './directives/avatar-group-item.directive';
 export * from './directives/avatar-group-focusable-avatar.directive';
+export * from './directives/avatar-group-popover-control.directive';
 export * from './directives/avatar-group-overflow-body.directive';
 export * from './directives/avatar-group-overflow-item.directive';
 export * from './directives/avatar-group-overflow-button.directive';


### PR DESCRIPTION
BREAKING CHANGE:
 added `AvatarGroupPopoverControlDirective` (`fd-avatar-group-popover-control`) needed to bind the corresponding CSS class and attributes to group type overflow popover control.


#### Please provide a link to the associated issue.
Closes https://github.com/SAP/fundamental-ngx/issues/5575

#### Please provide a brief summary of this pull request.
- a11y issues in examples
- new directive for styling group type popover control

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [N/A] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

