### PR TITLE
fix(core): make no date message optional

### DIFF
--- a/libs/core/src/lib/datetime/datetime-format.pipes.ts
+++ b/libs/core/src/lib/datetime/datetime-format.pipes.ts
@@ -11,7 +11,7 @@ export class DateFormatPipe<D> implements PipeTransform {
         @Optional() @Inject(DATE_TIME_FORMATS) private _dateTimeFormats: DateTimeFormats
     ) {}
 
-    transform(date: D, noDateMessage: string): string {
+    transform(date: D, noDateMessage?: string): string {
         if (date) {
             return this._dateTimeAdapter.format(date, this._dateTimeFormats.display.dateInput);
         } else {
@@ -29,7 +29,7 @@ export class DateTimeFormatPipe<D> implements PipeTransform {
         @Optional() @Inject(DATE_TIME_FORMATS) private _dateTimeFormats: DateTimeFormats
     ) {}
 
-    transform(date: D, noDateMessage: string): string {
+    transform(date: D, noDateMessage?: string): string {
         if (date) {
             return this._dateTimeAdapter.format(date, this._dateTimeFormats.display.dateTimeInput);
         } else {
@@ -46,7 +46,7 @@ export class DateFromNowPipe<D> implements PipeTransform {
         private _dateTimeAdapter: DatetimeAdapter<D>
     ) {}
 
-    transform(date: D, noDateMessage: string): string {
+    transform(date: D, noDateMessage?: string): string {
         if (this._dateTimeAdapter.fromNow && typeof this._dateTimeAdapter.fromNow !== 'undefined') {
             if (date) {
                 return this._dateTimeAdapter.fromNow(date);


### PR DESCRIPTION
Quick fix for the datetime pipes, making the error message string parameter optional