### PR TITLE
docs(core): fix a11y for Facets component

### DIFF
--- a/apps/docs/src/app/core/component-docs/facets/facet-examples/facet-group-example.component.html
+++ b/apps/docs/src/app/core/component-docs/facets/facet-examples/facet-group-example.component.html
@@ -23,7 +23,7 @@
         </fd-facet-content>
     </fd-facet>
     <fd-facet type="image" id="facet3">
-        <fd-avatar image="http://picsum.photos/id/1018/400" size="l"></fd-avatar>
+        <fd-avatar title="Nature" image="http://picsum.photos/id/1018/400" size="l"></fd-avatar>
     </fd-facet>
     <fd-facet type="key-value" facetTitle="Status" id="facet4">
         <span

--- a/apps/docs/src/app/core/component-docs/facets/facet-examples/form-link-facet-example.component.html
+++ b/apps/docs/src/app/core/component-docs/facets/facet-examples/form-link-facet-example.component.html
@@ -1,14 +1,29 @@
 <fd-facet type="form" facetTitle="Contact Information" id="formFacetLinkExample">
     <fd-facet-content>
-        <fd-icon glyph="add-employee"></fd-icon>
-        <a [routerLink]="['./']" fd-link tabindex="0">John Miller</a>
+        <fd-icon id="fd-facet-icon-1" ariaLabel="Primary number" title="Primary number" glyph="call"></fd-icon>
+        <a fd-link aria-labelledby="fd-facet-icon-1 fd-facet-text-1" id="fd-facet-text-1" href="tel:+91 98765 43210">
+            +91 98765 43210
+        </a>
     </fd-facet-content>
     <fd-facet-content>
-        <fd-icon glyph="outgoing-call"></fd-icon>
-        <a [routerLink]="['./']" fd-link tabindex="0"> +1 234 5678 </a>
+        <fd-icon
+            id="fd-facet-icon-2"
+            ariaLabel="Secondary number"
+            title="Secondary number"
+            glyph="outgoing-call"
+        ></fd-icon>
+        <a fd-link aria-labelledby="fd-facet-icon-2 fd-facet-text-2" id="fd-facet-text-2" href="tel:+1 234 5678">
+            +1 234 5678
+        </a>
     </fd-facet-content>
     <fd-facet-content>
-        <fd-icon glyph="email"></fd-icon>
-        <a [routerLink]="['./']" fd-link tabindex="0">john.miller@company.com</a>
+        <fd-icon id="fd-facet-icon-3" ariaLabel="Email" title="Email" glyph="email"></fd-icon>
+        <a
+            fd-link
+            aria-labelledby="fd-facet-icon-3 fd-facet-text-3"
+            id="fd-facet-text-3"
+            href="mailto:john.miller@company.com"
+            >john.miller@company.com
+        </a>
     </fd-facet-content>
 </fd-facet>

--- a/apps/docs/src/app/core/component-docs/facets/facet-examples/image-facet-example.component.html
+++ b/apps/docs/src/app/core/component-docs/facets/facet-examples/image-facet-example.component.html
@@ -1,8 +1,8 @@
 <fd-facet-group ariaLabel="Image Facets">
     <fd-facet type="image">
-        <fd-avatar image="http://picsum.photos/id/1018/400" size="l"></fd-avatar>
+        <fd-avatar title="Nature" image="http://picsum.photos/id/1018/400" size="l"></fd-avatar>
     </fd-facet>
     <fd-facet type="image">
-        <fd-avatar size="l" glyph="money-bills"></fd-avatar>
+        <fd-avatar title="Money" size="l" glyph="money-bills"></fd-avatar>
     </fd-facet>
 </fd-facet-group>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#5577

#### Please provide a brief summary of this pull request.
This PR fixes:
- missing tooltip on image facets- added title attribute
- missing focus is a separate issue that is already being worked on in Styles; this is elaborated in the issue 5577 comments
- incorrect reading of form facet with links example- added appropriate aria tags
- incorrect reading of rating indicator facet example- related to rating indicator component, a11y/qa to raise separate issue

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

