### PR TITLE
feat(core): shellbar - product menu - open item in new tab

### DIFF
--- a/libs/core/src/lib/shellbar/model/shellbar-menu-item.ts
+++ b/libs/core/src/lib/shellbar/model/shellbar-menu-item.ts
@@ -17,4 +17,9 @@ export interface ShellbarMenuItem {
     /* The icon to include in shellbar menu item See the icon page for the list of icons.
     */
     glyph?: string;
+
+    /**
+    /* If true open the link in a new tab.
+    */
+    newTab?: boolean;
 }

--- a/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
+++ b/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
@@ -20,7 +20,7 @@
         [closeOnOutsideClick]="closeOnOutsideClick"
     >
         <li *ngFor="let item of items" (click)="itemClicked(item, $event)" fd-menu-item>
-            <a [attr.href]="item.link ? item.link : null" fd-menu-interactive>
+            <a [attr.href]="item.link ? item.link : null" [attr.target]="item.newTab ? '_blank' : '_self'" fd-menu-interactive>
                 <span fd-menu-title>{{ item.name }}</span>
                 <fd-icon *ngIf="item.glyph" fd-menu-addon position="after" [glyph]="item.glyph"></fd-icon>
             </a>


### PR DESCRIPTION
Add support for opening shellbar's product menu items in a new tab

#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#5685

#### Please provide a brief summary of this pull request.
add support of optional newTab property of type boolean to the ShellbarMenuItem interface which in case if provided and equals true will trigger opening product menu item in a new tab.

#### Please check whether the PR fulfills the following requirements

- [ ] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [ ] tests for the changes that have been done
- [ ] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [ ] Run npm run build-pack-library and test in external application

Documentation checklist:
- [ ] update `README.md`
- [ ] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [ ] Documentation Examples
- [ ] Stackblitz works for all examples

