### PR TITLE
fix(core): fix meridian switch changing hour display in Time component

### DIFF
--- a/libs/core/src/lib/time/time.component.ts
+++ b/libs/core/src/lib/time/time.component.ts
@@ -258,8 +258,17 @@ export class TimeComponent<D> implements OnInit, OnChanges, OnDestroy, AfterView
      * This implicitly changes hours by +/- 12
      */
     handleMeridianChange(meridian: Meridian): void {
-        const hourOffset: number = meridian === Meridian.AM ? -12 : 12;
-        const currentHour = this._getModelHour();
+        let hourOffset: number = meridian === Meridian.AM ? -12 : 12;
+        let currentHour = this._getModelHour();
+
+        if (currentHour > 12 && meridian === Meridian.PM) {
+            currentHour -= 12;
+        } else if (currentHour === 12) {
+            currentHour = 0;
+        } else if (currentHour < 12 && meridian === Meridian.AM) {
+            hourOffset = 0;
+        }
+        
         const newHour = Math.max(0, Math.min(23, currentHour + hourOffset));
 
         this.handleHourChange(newHour);


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#4428

#### Please provide a brief summary of this pull request.
This PR fixes the logic on changing the meridian. It was miscalculating the display hours and adding/subtracting 12 hours extra. For eg: if time set was 1 PM and user clicked on PM again, it would calculate 13hrs+12hrs= 25hrs and take `Math.min` of 23hrs and set time as 11 PM.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [n/a] Documentation Examples
- [x] Stackblitz works for all examples

