### PR TITLE
fix(platform): add sameFilenameAllowed

### DIFF
--- a/libs/platform/src/lib/components/upload-collection/models/upload-collection.models.ts
+++ b/libs/platform/src/lib/components/upload-collection/models/upload-collection.models.ts
@@ -1,3 +1,4 @@
+import { MessageStates } from '@fundamental-ngx/core/form';
 import { EventPayload } from './upload-collection-events.models';
 
 export enum UploadCollectionItemStatus {
@@ -20,6 +21,7 @@ export interface UploadCollectionFolder {
     fileSize?: number;
     files: UploadCollectionItem[];
     status?: UploadCollectionItemStatus;
+    sameFilenameState?: MessageStates;
 }
 
 export interface UploadCollectionFile {
@@ -33,6 +35,7 @@ export interface UploadCollectionFile {
     url: string;
     status?: UploadCollectionItemStatus;
     file?: File;
+    sameFilenameState?: MessageStates;
 }
 
 export interface ItemPerPage {

--- a/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
+++ b/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
@@ -183,6 +183,7 @@
                                             fd-form-control
                                             [value]="_getItemName(item)"
                                             (blur)="_fileNameChange($event, item)"
+                                            (input)="_checkName($event, item)"
                                             type="text"
                                             i18n-placeholder
                                             placeholder="Enter a name"

--- a/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
+++ b/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.html
@@ -177,16 +177,25 @@
 
                         <ng-template #editMode>
                             <div fd-form-item>
-                                <input
-                                    fd-form-control
-                                    [value]="_getItemName(item)"
-                                    (blur)="_fileNameChange($event, item)"
-                                    type="text"
-                                    i18n-placeholder
-                                    placeholder="Enter a name"
-                                    compact="true"
-                                />
-                                <span [innerText]="_getItemExtension(item)"></span>
+                                <fd-form-input-message-group [triggers]="[]" [isOpen]="item.sameFilenameState">
+                                    <div class="fdp-upload-collection__vertical-align-center">
+                                        <input
+                                            fd-form-control
+                                            [value]="_getItemName(item)"
+                                            (blur)="_fileNameChange($event, item)"
+                                            type="text"
+                                            i18n-placeholder
+                                            placeholder="Enter a name"
+                                            compact="true"
+                                            [state]="item.sameFilenameState"
+                                        />
+                                        <span [innerText]="_getItemExtension(item)"></span>
+                                    </div>
+
+                                    <fd-form-message [type]="item.sameFilenameState">
+                                        {{ item.type === 'file' ? 'File' : 'Folder' }} already exists with that name.
+                                    </fd-form-message>
+                                </fd-form-input-message-group>
                             </div>
                         </ng-template>
                     </fdp-table-cell>

--- a/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.ts
+++ b/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.ts
@@ -162,7 +162,7 @@ export class UploadCollectionComponent {
      * 'Same name' refers to an already existing file name in the list.
      * */
     @Input()
-    sameFilenameAllowed = false;
+    sameFileNameAllowed = false;
 
     /**
      * The event is triggered when the file type or the MIME type don't match the permitted types
@@ -326,16 +326,9 @@ export class UploadCollectionComponent {
             return;
         }
 
-        if (
-            !this.sameFilenameAllowed &&
-            this._getList().some((item) => currentItem.documentId !== item.documentId && item.name === newName)
-        ) {
-            currentItem.sameFilenameState = 'error';
-
+        if (currentItem.sameFilenameState) {
             return;
         }
-
-        currentItem.sameFilenameState = null;
 
         const data = {
             parentFolderId: this._getCurrentFolderId(),
@@ -367,6 +360,24 @@ export class UploadCollectionComponent {
                     });
                 }
             });
+    }
+
+    /** @hidden */
+    _checkName(e: FocusEvent, currentItem: UploadCollectionItem): void {
+        const input = e.target as HTMLInputElement;
+        const itemName = input.value;
+        const newName = currentItem.type === 'file' ? `${itemName}.${currentItem.name.split('.').pop()}` : itemName;
+
+        if (
+            !this.sameFileNameAllowed &&
+            this._getList().some((item) => currentItem.documentId !== item.documentId && item.name === newName)
+        ) {
+            currentItem.sameFilenameState = 'error';
+
+            return;
+        }
+
+        currentItem.sameFilenameState = null;
     }
 
     /** @hidden
@@ -669,7 +680,7 @@ export class UploadCollectionComponent {
 
     /** @hidden */
     _onRowSelectionChange(data: TableRowSelectionChangeEvent<UploadCollectionItem>): void {
-        if (!this.sameFilenameAllowed) {
+        if (!this.sameFileNameAllowed) {
             const removedItem = data.removed[0];
             this._clearItemSameFilenameState(removedItem);
         }

--- a/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.ts
+++ b/libs/platform/src/lib/components/upload-collection/upload-collection/upload-collection.component.ts
@@ -2,12 +2,13 @@ import { Component, ViewChild, ElementRef, Input, Output, EventEmitter, ViewEnca
 import { Subscription } from 'rxjs';
 import { take, tap } from 'rxjs/operators';
 
-import { DialogService, DialogConfig, uuidv4 } from '@fundamental-ngx/core';
+import { DialogService, DialogConfig } from '@fundamental-ngx/core/dialog';
+import { uuidv4 } from '@fundamental-ngx/core/utils';
 
 import { TableRowSelectionChangeEvent } from '../../table/public_api';
 
 import { NewFolderComponent } from '../dialogs/new-folder/new-folder.component';
-import {  MoveToComponent } from '../dialogs/move-to/move-to.component';
+import { MoveToComponent } from '../dialogs/move-to/move-to.component';
 import { FilesValidatorService, FilesValidatorOutput } from '../services/files-validator.service';
 import {
     UploadCollectionFile,
@@ -157,6 +158,13 @@ export class UploadCollectionComponent {
     showSearch = true;
 
     /**
+     * Allows to use the same name for a file when editing the file name.
+     * 'Same name' refers to an already existing file name in the list.
+     * */
+    @Input()
+    sameFilenameAllowed = false;
+
+    /**
      * The event is triggered when the file type or the MIME type don't match the permitted types
      * (only if the fileTypes property or the mimeTypes property are provided by the application).
      */
@@ -292,14 +300,18 @@ export class UploadCollectionComponent {
     /**@hidden
      * Opens the file selector.
      */
-    _fileNameChange(e: FocusEvent, item: UploadCollectionItem): void {
+    _fileNameChange(e: FocusEvent, currentItem: UploadCollectionItem): void {
         const input = e.target as HTMLInputElement;
         const itemName = input.value;
-        const newName = item.type === 'file' ? `${itemName}.${item.name.split('.').pop()}` : itemName;
+        const newName = currentItem.type === 'file' ? `${itemName}.${currentItem.name.split('.').pop()}` : itemName;
+
+        if (currentItem.name === newName) {
+            return;
+        }
 
         if (itemName.length > this.maxFilenameLength) {
             const reanmedItem = {
-                ...item,
+                ...currentItem,
                 name: newName
             };
             const payload = {
@@ -314,12 +326,23 @@ export class UploadCollectionComponent {
             return;
         }
 
+        if (
+            !this.sameFilenameAllowed &&
+            this._getList().some((item) => currentItem.documentId !== item.documentId && item.name === newName)
+        ) {
+            currentItem.sameFilenameState = 'error';
+
+            return;
+        }
+
+        currentItem.sameFilenameState = null;
+
         const data = {
             parentFolderId: this._getCurrentFolderId(),
             fileName: newName,
-            item: { ...item }
+            item: { ...currentItem }
         };
-        item.status = UploadCollectionItemStatus.LOADING;
+        currentItem.status = UploadCollectionItemStatus.LOADING;
 
         this.dataSource
             .fileRenamed(data)
@@ -646,6 +669,11 @@ export class UploadCollectionComponent {
 
     /** @hidden */
     _onRowSelectionChange(data: TableRowSelectionChangeEvent<UploadCollectionItem>): void {
+        if (!this.sameFilenameAllowed) {
+            const removedItem = data.removed[0];
+            this._clearItemSameFilenameState(removedItem);
+        }
+
         this.selectedItems = data.selection;
     }
 
@@ -995,5 +1023,18 @@ export class UploadCollectionComponent {
         const itemsPerPage = this._itemsPerPage as number;
         this._countShowedItems = this._currentPage * itemsPerPage - itemsPerPage + 1;
         this._countNotShowedItems = this._countShowedItems + this._visibleList.length - 1;
+    }
+
+    /** @hidden */
+    private _clearItemSameFilenameState(currentItem: UploadCollectionItem): void {
+        if (!currentItem) {
+            return;
+        }
+
+        this._getList().forEach((item) => {
+            if (item.documentId === currentItem.documentId) {
+                item.sameFilenameState = null;
+            }
+        });
     }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#4474

#### Please provide a brief summary of this pull request.
Added `sameFilenameAllowed` input that allows using the same name for a file when editing the file name.
'Same name' refers to an already existing file name in the list.
Default value: `false`
#### Please check whether the PR fulfills the following requirements

- [X] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [X] tests for the changes that have been done
- [X] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [X] Run npm run build-pack-library and test in external application

Documentation checklist:
- [X] update `README.md`
- [X] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [X] Documentation Examples
- [X] Stackblitz works for all examples

