### PR TITLE
fix(platform): fix content density in select component with no predefined value

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-select/platform-select-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-select/platform-select-docs.component.html
@@ -3,6 +3,7 @@
 </fd-docs-section-title>
 <description>
     Following examples presents different modes of the Select control.
+    Use <code>contentDensity="compact"</code> to explicitly set compact mode.
 </description>
 <component-example>
     <fdp-select-mode-example></fdp-select-mode-example>
@@ -30,6 +31,7 @@
 </fd-docs-section-title>
 <description>
     Use semantic states to visually highlight current <code>state</code> of the Select.
+    Use <code>contentDensity="compact"</code> to explicitly set compact mode.
 </description>
 <component-example>
     <fdp-select-semantic-state-example></fdp-select-semantic-state-example>
@@ -49,7 +51,7 @@
         <li>Reference to selected option - <code>selected</code></li>
     </ul>
     Selected option as a context to custom template. Setting <code>[AutoResize]=true</code> with
-     no specific width helps to resize the select control based on option selected. 
+     no specific width helps to resize the select control based on option selected.
 </description>
 <component-example>
     <fdp-select-custom-trigger></fdp-select-custom-trigger>
@@ -116,7 +118,7 @@
    Do not Wrap the Options
 </fd-docs-section-title>
 <description>
-    We use <code>noWrapText= true</code> by which 
+    We use <code>noWrapText= true</code> by which
     long text in options won't get wrapped on overflow.
     They get truncated with ellipsis.
 </description>

--- a/libs/platform/src/lib/components/form/select/commons/base-select.ts
+++ b/libs/platform/src/lib/components/form/select/commons/base-select.ts
@@ -181,14 +181,8 @@ export abstract class BaseSelect extends CollectionBaseInput implements OnInit, 
      */
     @Input()
     set contentDensity(contentDensity: ContentDensity) {
-        if (contentDensity === undefined && this._contentDensityService) {
-            this._subscriptions.add(this._contentDensityService._contentDensityListener.subscribe(density => {
-                this._isCompact = density !== 'cozy';
-                this.cd.markForCheck();
-            }))
-        } else {
-            this._isCompact = contentDensity !== 'cozy';
-        }
+        this._contentDensity = contentDensity;
+        this._isCompact = this.contentDensity !== 'cozy';
     }
 
     /** Data for suggestion list */
@@ -294,9 +288,7 @@ export abstract class BaseSelect extends CollectionBaseInput implements OnInit, 
                 this._isCompact = density !== 'cozy';
                 this.cd.markForCheck();
             }))
-        } else {
-            this._isCompact = this.contentDensity !== 'cozy';
-        }
+         }
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/components/form/select/commons/base-select.ts
+++ b/libs/platform/src/lib/components/form/select/commons/base-select.ts
@@ -28,7 +28,8 @@ import {
     ListComponent,
     MobileModeConfig,
     TemplateDirective,
-    PopoverFillMode
+    PopoverFillMode,
+    ContentDensityService
 } from '@fundamental-ngx/core';
 import {
     isOptionItem,
@@ -54,7 +55,7 @@ export class FdpSelectionChangeEvent {
 
 @Directive()
 export abstract class BaseSelect extends CollectionBaseInput implements AfterViewInit, OnDestroy {
-   
+
     /** Provides maximum default height for the optionPanel */
     @Input()
     maxHeight = '250px';
@@ -111,7 +112,7 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
     @Input()
     readonly = false;
 
-    /** Placeholder for the select. Appears in the 
+    /** Placeholder for the select. Appears in the
     * triggerbox if no option is selected. */
     @Input()
     placeholder: string;
@@ -177,12 +178,17 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
     maxWidth?: number;
 
     /**
-     * content Density of element. 'cozy' | 'compact'
+     * content Density of element. 'cozy' | 'compact'| 'condensed'
      */
     @Input()
     set contentDensity(contentDensity: ContentDensity) {
-        this._contentDensity = contentDensity;
-        this.isCompact = contentDensity === 'compact';
+
+        if (this.isCompact === undefined && this._contentDensityService) {
+            this._subscriptions.add(this._contentDensityService._contentDensityListener.subscribe(density => {
+                this.isCompact = density !== 'cozy';
+                this._cd.markForCheck();
+            }))
+        }
     }
 
     /** Data for suggestion list */
@@ -229,13 +235,16 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
     searchInputElement: ElementRef;
 
     /** @hidden */
-    _contentDensity: ContentDensity = this.selectConfig.contentDensity;
+   // _contentDensity: ContentDensity = this.selectConfig.contentDensity;
+
+    /** @hidden */
+    _contentDensityService: ContentDensityService;
 
     /**
      * @hidden
      * Whether "contentDensity" is "compact"
      */
-    isCompact: boolean = this._contentDensity === 'compact';
+    isCompact: boolean;
 
     /** Whether the select is opened. */
     isOpen = false;
@@ -442,7 +451,7 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
     private _convertObjectsToOptionItems(items: any[]): OptionItem[] {
         // if (this.group && this.groupKey) {
         //     return this._convertObjectsToGroupOptionItems(items);
-        // } else 
+        // } else
         if (this.showSecondaryText && this.secondaryKey) {
             return this._convertObjectsToSecondaryOptionItems(items);
         } else {

--- a/libs/platform/src/lib/components/form/select/select/select.component.html
+++ b/libs/platform/src/lib/components/form/select/select/select.component.html
@@ -1,6 +1,6 @@
 <fd-select [placeholder]="placeholder"
 [glyph]="glyph"
-[compact]="isCompact"
+[compact]="_isCompact"
 [disabled]="disabled"
 [readonly]="readonly"
 [closeOnOutsideClick]="closeOnOutsideClick"

--- a/libs/platform/src/lib/components/form/select/select/select.component.ts
+++ b/libs/platform/src/lib/components/form/select/select/select.component.ts
@@ -19,7 +19,7 @@ import {
 import { NgControl, NgForm } from '@angular/forms';
 
 
-import { SelectComponent as CoreSelect} from '@fundamental-ngx/core';
+import { SelectComponent as CoreSelect } from '@fundamental-ngx/core';
 
 import { DynamicComponentService, FdSelectChange, SelectControlState } from '@fundamental-ngx/core';
 import { OptionItem } from '../../../../domain';

--- a/libs/platform/src/lib/components/form/select/select/select.component.ts
+++ b/libs/platform/src/lib/components/form/select/select/select.component.ts
@@ -19,7 +19,7 @@ import {
 import { NgControl, NgForm } from '@angular/forms';
 
 
-import { SelectComponent as CoreSelect } from '@fundamental-ngx/core';
+import { SelectComponent as CoreSelect} from '@fundamental-ngx/core';
 
 import { DynamicComponentService, FdSelectChange, SelectControlState } from '@fundamental-ngx/core';
 import { OptionItem } from '../../../../domain';


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5650 

#### Please provide a brief summary of this pull request.

When user changes the content density option in documentation. Detect the changed option and display accordingly when no contentDensity value is set for select component.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

