### PR TITLE
docs(core): remove multiple overflow options from action bar

### DIFF
--- a/apps/docs/src/app/core/component-docs/action-bar/examples/action-bar-mobile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/action-bar/examples/action-bar-mobile-example.component.html
@@ -49,44 +49,6 @@
                         </div>
                     </li>
                 </fd-menu>
-
-                <button
-                    fd-button
-                    aria-label="More"
-                    aria-haspopup="true"
-                    glyph="overflow"
-                    fdType="transparent"
-                    [fdMenuTrigger]="menu2"
-                    [compact]="true"
-                ></button>
-
-                <fd-menu #menu2 placement="bottom-end" [compact]="true">
-                    <li fd-menu-item>
-                        <div fd-menu-interactive>
-                            <span fd-menu-title>Edit</span>
-                        </div>
-                    </li>
-                    <li fd-menu-item>
-                        <div fd-menu-interactive>
-                            <span fd-menu-title>Delete</span>
-                        </div>
-                    </li>
-                    <li fd-menu-item>
-                        <div fd-menu-interactive>
-                            <span fd-menu-title>Assign</span>
-                        </div>
-                    </li>
-                    <li fd-menu-item>
-                        <div fd-menu-interactive>
-                            <span fd-menu-title>Expire</span>
-                        </div>
-                    </li>
-                    <li fd-menu-item>
-                        <div fd-menu-interactive>
-                            <span fd-menu-title>Archive</span>
-                        </div>
-                    </li>
-                </fd-menu>
             </div>
         </div>
         <p fd-action-bar-description [withBackBtn]="true">Action bar Description</p>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5679

#### Please provide a brief summary of this pull request.

Removed multiple overflow options from action bar examples to avoid duplication.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

