### PR TITLE
fix(platform): remove the readonly prop from combobox

### DIFF
--- a/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.html
+++ b/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.html
@@ -35,7 +35,6 @@
         [state]="status === 'error' ? 'error' : state"
         [buttonFocusable]="false"
         [disabled]="disabled"
-        [readOnly]="readonly"
         [isControl]="true"
         (addOnButtonClicked)="!mobile && onPrimaryButtonClick(_connectedOverlay.open)"
         [isExpanded]="!mobile && isOpen && _suggestions.length > 0"


### PR DESCRIPTION
`fd-input-group` does not have a `[readOnly]` input property. Temporary remove it from the template until it's introduced properly.
