### PR TITLE
fix(platform): adjust Datetime Picker width to container width when used with Platform Forms

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-docs.component.html
@@ -1,8 +1,8 @@
 <fd-docs-section-title id="datetimePickerBasic" componentName="datetimePicker"
     >Basic Datetime Picker</fd-docs-section-title
 >
-<description
-    >Basic usage of Datetime Picker without Forms and with options like <code>meredian</code>, <code>allowNull</code>,
+<description>
+    Basic usage of Datetime Picker without Forms and with options like <code>meridian</code>, <code>allowNull</code>,
     <code>disabled</code>, pre-populating and changing dates.</description
 >
 <component-example>
@@ -15,7 +15,10 @@
 <fd-docs-section-title id="datetimePickerReactive" componentName="datetimePicker"
     >Datetime Picker with Reactive Forms</fd-docs-section-title
 >
-<description>Usage of Datetime Picker with Platform Forms using Reactive Forms.</description>
+<description>
+    Usage of Datetime Picker with Platform Forms using Reactive Forms. When used with Platform Forms, the Datetime
+    Picker will take 100% of its parent container width depending on the chosen column layout.
+</description>
 <component-example>
     <fdp-platform-datetime-picker-reactive-example></fdp-platform-datetime-picker-reactive-example>
 </component-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-disable-function-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-disable-function-example.component.html
@@ -1,8 +1,12 @@
-<fdp-form-group #ffg [formGroup]="datetimePickerForm">
+<fdp-form-group
+    #ffg
+    [formGroup]="datetimePickerForm"
+    mainTitle="Datetime Picker with XL2-L2-M1-S1 form layout"
+    columnLayout="XL2-L2-M1-S1">
     <fdp-form-field
         #ffl1
         id="simple"
-        rank="1"
+        column="1"
         required="true"
         [validators]="requiredDateValidator"
         label="Date:"
@@ -16,7 +20,7 @@
         </fdp-datetime-picker>
     </fdp-form-field>
 
-    <fdp-form-field id="disabledDatetime" rank="2" label="Disabled Datetime Picker:">
+    <fdp-form-field id="disabledDatetime" column="2" label="Disabled Datetime Picker:">
         <fdp-datetime-picker name="disabledDatetime" [disabled]="true" [value]="date"> </fdp-datetime-picker>
     </fdp-form-field>
 

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-reactive-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-reactive-example.component.html
@@ -3,11 +3,13 @@
     [formGroup]="datetimePickerForm"
     [object]="formData"
     (onSubmit)="onSubmit()"
+    mainTitle="Datetime Picker with XL3-L1-M1-S1 form layout"
+    columnLayout="XL3-L1-M1-S1"
 >
     <fdp-form-field
         #ffl1
         id="simple"
-        rank="1"
+        column="1"
         required="true"
         [validators]="requiredDateValidator"
         placeholder="MM/dd/YYYY, hh:mm"
@@ -22,7 +24,7 @@
     <fdp-form-field
         #ffl3
         id="withAllowNull"
-        rank="3"
+        column="2"
         label="With allowNull not enabled to disallow input from taking null value:"
     >
         <fdp-datetime-picker
@@ -37,7 +39,7 @@
     <fdp-form-field
         #ffl6
         id="storedDate"
-        rank="7"
+        column="3"
         required="true"
         label="Passing datetime through form object:"
     >
@@ -49,18 +51,7 @@
         </fdp-datetime-picker>
     </fdp-form-field>
 
-    <fdp-form-field
-        id="submitBtn"
-        rank="8"
-    >
-        <button
-            fd-button
-            name="submitBtn"
-            (click)="onSubmit()"
-        >Submit</button>
-    </fdp-form-field>
-
-    <ng-template
+    <ng-template 
         #i18n
         let-errors
     >
@@ -70,6 +61,7 @@
     </ng-template>
 </fdp-form-group>
 
+<button fd-button name="submitBtn" (click)="onSubmit()">Submit</button>
 <div>form valid: {{ datetimePickerForm?.valid }}</div>
 
 <div *ngIf="stringValue">form value: {{ stringValue }}</div>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-template-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-template-example.component.html
@@ -1,9 +1,11 @@
 <fdp-form-group
     #fdpForm
+    mainTitle="Datetime Picker with XL2-L2-M1-S1 form layout"
+    columnLayout="XL2-L2-M1-S1"
 >
     <fdp-form-field
         id="simple"
-        rank="1"
+        column="1"
         required="true"
         placeholder="Enter a date"
         label="Date:"

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-header/platform-datetime-picker-header.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-header/platform-datetime-picker-header.component.html
@@ -12,7 +12,7 @@
     </p>
 </description>
 <description>
-    The Time Picker component <strong>relies on provided datetime implementation</strong> (<code>DatetimeAdapter</code>)
+    The DatetimePicker component <strong>relies on provided datetime implementation</strong> (<code>DatetimeAdapter</code>)
     and <strong>datetime formats</strong> (<code>DateTimeFormats</code>).
 </description>
 

--- a/libs/platform/src/lib/components/form/datetime-picker/datetime-picker.component.spec.ts
+++ b/libs/platform/src/lib/components/form/datetime-picker/datetime-picker.component.spec.ts
@@ -173,4 +173,9 @@ describe('PlatformDatetimePickerComponent', () => {
 
         expect(inputGroupEl.nativeElement.classList.contains('is-error')).toBeTrue();
     });
+
+    it('should take 100% of container width', async () => {
+      const customPopoverEl = fixture.debugElement.query(By.css('.fd-datetime .fd-popover-custom'));
+      expect(customPopoverEl.nativeElement.style.display).toBe('inline');
+    });
 });

--- a/libs/platform/src/lib/components/form/datetime-picker/datetime-picker.component.spec.ts
+++ b/libs/platform/src/lib/components/form/datetime-picker/datetime-picker.component.spec.ts
@@ -174,7 +174,7 @@ describe('PlatformDatetimePickerComponent', () => {
         expect(inputGroupEl.nativeElement.classList.contains('is-error')).toBeTrue();
     });
 
-    it('should take 100% of container width', async () => {
+    it('should take 100% of container width', () => {
       const customPopoverEl = fixture.debugElement.query(By.css('.fd-datetime .fd-popover-custom'));
       expect(customPopoverEl.nativeElement.style.display).toBe('inline');
     });

--- a/libs/platform/src/lib/components/form/datetime-picker/datetime-picker.component.ts
+++ b/libs/platform/src/lib/components/form/datetime-picker/datetime-picker.component.ts
@@ -1,4 +1,5 @@
 import {
+    AfterViewInit,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -14,21 +15,13 @@ import {
     ViewChild
 } from '@angular/core';
 import { NgControl, NgForm } from '@angular/forms';
-import {
-    CalendarYearGrid,
-    DatetimeAdapter,
-    DateTimeFormats,
-    DatetimePickerComponent,
-    DATE_TIME_FORMATS,
-    DaysOfWeek,
-    FdCalendarView,
-    Placement,
-    SpecialDayRule
-} from '@fundamental-ngx/core';
-
+import { CalendarYearGrid, DaysOfWeek, FdCalendarView } from '@fundamental-ngx/core/calendar';
+import { DatetimeAdapter, DateTimeFormats, DATE_TIME_FORMATS } from '@fundamental-ngx/core/datetime';
+import { DatetimePickerComponent } from '@fundamental-ngx/core/datetime-picker';
+import { Placement, SpecialDayRule } from '@fundamental-ngx/core/shared';
 import { BaseInput } from '../base.input';
-import { FormField } from '../form-field';
 import { FormFieldControl, Status } from '../form-control';
+import { FormField } from '../form-field';
 import { createMissingDateImplementationError } from './errors';
 
 @Component({
@@ -37,7 +30,7 @@ import { createMissingDateImplementationError } from './errors';
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [{ provide: FormFieldControl, useExisting: PlatformDatetimePickerComponent, multi: true }]
 })
-export class PlatformDatetimePickerComponent<D> extends BaseInput {
+export class PlatformDatetimePickerComponent<D> extends BaseInput implements AfterViewInit {
     /**
      * value for datetime
      */
@@ -252,6 +245,16 @@ export class PlatformDatetimePickerComponent<D> extends BaseInput {
         this.value = _dateTimeAdapter.now();
     }
 
+    /**
+     * @hidden
+     */
+    ngAfterViewInit(): void {
+        // if used with platform forms, adjust width of datetimepicker to take 100% container space
+        if (this.formField) {
+            this._adjustPickerWidth();
+        }
+    }
+
     /** @hidden */
     writeValue(value: D): void {
         super.writeValue(value);
@@ -308,4 +311,16 @@ export class PlatformDatetimePickerComponent<D> extends BaseInput {
     handleActiveViewChange = (fdCalendarView: FdCalendarView): void => {
         this.activeViewChange.emit(fdCalendarView);
     };
+
+    /**
+     * @hidden
+     * method that adjusts width of datetimepicker to take 100% container space
+     */
+    private _adjustPickerWidth(): void {
+        const customPopoverEl = this._elRef.nativeElement.querySelector('.fd-datetime .fd-popover-custom');
+        if (!customPopoverEl) {
+            return;
+        }
+        customPopoverEl.style.display = 'inline';
+    }
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#4442 #3973

#### Please provide a brief summary of this pull request.
This PR adjusts the width of DatetimePicker when used along with Platform Forms such that it takes up 100% of its container space and looks consistent with other form controls.
Before:
![image](https://user-images.githubusercontent.com/53509521/123222807-f2285800-d4ed-11eb-9eb3-42fe8bd29b04.png)
After:
![image](https://user-images.githubusercontent.com/53509521/123222967-184df800-d4ee-11eb-830b-6adb7a1417c8.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

