### PR TITLE
fix(core): set real disabled state for button-bar element

### DIFF
--- a/libs/core/src/lib/bar/button-bar/button-bar.component.ts
+++ b/libs/core/src/lib/bar/button-bar/button-bar.component.ts
@@ -51,6 +51,11 @@ export class ButtonBarComponent extends BaseButton implements OnInit, OnDestroy 
     @HostBinding('class.fd-bar__element')
     _barElement = true;
 
+    @HostBinding('style.pointer-events')
+    get pointerEvents(): string {
+        return this._disabled ? 'none' : 'auto';
+    }
+
     /** @hidden */
     @ViewChild(ButtonComponent)
     _buttonComponent: ButtonComponent;
@@ -58,7 +63,10 @@ export class ButtonBarComponent extends BaseButton implements OnInit, OnDestroy 
     /** @hidden */
     private _subscriptions = new Subscription();
 
-    constructor(@Optional() private _contentDensityService: ContentDensityService, private _cdRef: ChangeDetectorRef) {
+    constructor(
+        @Optional() private _contentDensityService: ContentDensityService,
+        private _cdRef: ChangeDetectorRef,
+        ) {
         super();
     }
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#5457

#### Please provide a brief summary of this pull request.
Users expect that if disabled state set on fd-button-bar, any clicks wouldn't work on element, but it didn't work because disabled attribute works only for specific html elements. So I set real disabled state for fd-button-bar element if disabled is true.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

