### PR TITLE
fix(platform): associate both label and inline help with Textarea component for a11y

### DIFF
--- a/e2e/wdio/platform/pages/combobox.po.ts
+++ b/e2e/wdio/platform/pages/combobox.po.ts
@@ -34,19 +34,19 @@ export class ComboBoxPo extends BaseComponentPo {
     };
 
     comboBoxButtons = (name: string) => {
-        return `//label[@for='${name}']/../../fdp-input-message-group//button`;
+        return `//label[@id='fdp-form-label-${name}']/../../fdp-input-message-group//button`;
     };
 
     comboBoxExpandedButtons = (name: string) => {
-        return `//label[@for='${name}']/../../fdp-input-message-group//button[contains (@class,"is-expanded")]`;
+        return `//label[@id='fdp-form-label-${name}']/../../fdp-input-message-group//button[contains (@class,"is-expanded")]`;
     };
 
     comboBoxInputs = (name: string) => {
-        return `//label[@for='${name}']/../../fdp-input-message-group//input`;
+        return `//label[@id='fdp-form-label-${name}']/../../fdp-input-message-group//input`;
     };
 
     filledComboBoxInputs = (name: string, option: string) => {
-        return `//label[@for='${name}']/../../fdp-input-message-group//input[@ng-reflect-model='${option}']`;
+        return `//label[@id='fdp-form-label-${name}']/../../fdp-input-message-group//input[@ng-reflect-model='${option}']`;
     };
 
     expandDropdown(type: string): void {

--- a/e2e/wdio/platform/pages/textarea.po.ts
+++ b/e2e/wdio/platform/pages/textarea.po.ts
@@ -6,14 +6,14 @@ export class TextareaPo extends BaseComponentPo {
     root = '#page-content';
 
     basicTextArea = '#basicTextarea';
-    basicTextAreaLabel = '[for="basicTextarea"] > span';
-    basicTextAreaPopoverIcon = '[for="basicTextarea"] fd-popover-control span';
+    basicTextAreaLabel = '#fdp-form-label-basicTextarea';
+    basicTextAreaPopoverIcon = '#fdp-form-label-basicTextarea fd-popover-control span';
     basicTextAreaPopoverBody = 'fd-popover-body';
 
-    readOnlyTextAreaLabel = '[for="readonlyDescription"] > span';
+    readOnlyTextAreaLabel = '#fdp-form-label-readonlyDescription > span';
 
     disabledTextArea = '#disabledDescription';
-    disabledTextAreaLabel = '[for="disabledDescription"] > span';
+    disabledTextAreaLabel = '#fdp-form-label-disabledDescription > span';
 
     growingDisabledTextarea = '#growingDisabledTextarea';
     growingMaxLinesTextarea = '#growingMaxLinesTextarea';
@@ -22,13 +22,12 @@ export class TextareaPo extends BaseComponentPo {
     withCharactersMaxNumberTextarea = '#noCounterMessageInteraction';
 
     compactTextArea = '#compactTextarea';
-    compactTextAreaLabel = '[for="compactTextarea"] > span';
+    compactTextAreaLabel = '#fdp-form-label-compactTextarea > span';
 
-    detailedTextAreaLabel = '[for="detailedDescription"] > span';
+    detailedTextAreaLabel = '#fdp-form-label-detailedDescription > span';
     detailedTextArea = '#detailedDescription';
     detailedTextAreaErrorMessage = '[type="error"]';
-    detailedTextAreaCharacterCounter = '//div[label[@for="detailedDescription"]]//div[@role="alert"]//span';
-
+    detailedTextAreaCharacterCounter = `//div[label[@id='fdp-form-label-detailedDescription']]//div[@role="alert"]//span`;
     noPlatformsFormTextAreaLabel = '[for="textarea-1"]';
 
     open(): void {

--- a/libs/platform/src/lib/components/form/base.input.ts
+++ b/libs/platform/src/lib/components/form/base.input.ts
@@ -207,7 +207,16 @@ export abstract class BaseInput extends BaseComponent
         }
     }
 
+    /** @hidden */
     ngAfterViewInit(): void {
+        const labelAndHelpId = `fdp-form-label-${this.id} fdp-form-hint-${this.id}`;
+        // if not specified, associate label and inline help ids with the input,
+        // else add these ids to the specified ones
+        if (!this.ariaLabelledBy) {
+            this.ariaLabelledBy = labelAndHelpId;
+        } else {
+            this.ariaLabelledBy += ' ' + labelAndHelpId;
+        }
         this._cd.detectChanges();
     }
 

--- a/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.html
+++ b/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.html
@@ -1,7 +1,7 @@
 <ng-template #renderer>
     <div [horizontal]="labelLayout === 'horizontal'" fd-form-item class="fd-row">
         <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
-            <label [attr.for]="id"
+            <label [id]="'fdp-form-label-' + id"
                    [required]="editable && required"
                    fd-form-label
                    [inlineHelpTitle]="hint"
@@ -11,6 +11,7 @@
         </div>
         <ng-container *ngTemplateOutlet="withFormMessage"></ng-container>
     </div>
+    <span aria-hidden="true" style="display: none" [id]="'fdp-form-hint-' + id">{{ hint }}</span>
 </ng-template>
 
 <ng-template #withFormMessage>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes SAP/fundamental-ngx#3440

#### Please provide a brief summary of this pull request.
Inline help is being used with `fd-form-label` and its contents are passed as attributes. So the normal way of associating through `for` and `id` does not read out the inline help content. This PR replaces `for` and `id` with `aria-labelledby` at the base-input class to fix this issue.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

