### PR TITLE
Fix/tabbable popover controls

### DIFF
--- a/libs/core/src/lib/popover/popover-control/popover-control.component.scss
+++ b/libs/core/src/lib/popover/popover-control/popover-control.component.scss
@@ -1,0 +1,3 @@
+.fd-popover-outline:focus-visible {
+    outline: var(--sapContent_FocusWidth) dotted var(--sapContent_FocusColor)
+}

--- a/libs/core/src/lib/popover/popover-control/popover-control.component.ts
+++ b/libs/core/src/lib/popover/popover-control/popover-control.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation } from '@angular/core';
 
 /**
  * A component used to enforce a certain layout for the popover.
@@ -12,7 +12,18 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 @Component({
     selector: 'fd-popover-control',
     templateUrl: './popover-control.component.html',
+    styleUrls: ['./popover-control.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PopoverControlComponent {}
+export class PopoverControlComponent implements AfterContentInit {
+    constructor(public elRef: ElementRef) {}
+
+    ngAfterContentInit(): void {
+        const elemChild = this.elRef.nativeElement.children[0];
+        if (elemChild?.getAttribute('tabindex') !== '-1') {
+            elemChild.tabIndex = '0';
+            elemChild.classList.add('fd-popover-outline');
+        }
+    }
+}

--- a/libs/core/src/lib/popover/popover-control/popover-control.component.ts
+++ b/libs/core/src/lib/popover/popover-control/popover-control.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, ViewEncapsulation } from '@angular/core';
 
 /**
  * A component used to enforce a certain layout for the popover.
@@ -16,10 +16,11 @@ import { AfterContentInit, ChangeDetectionStrategy, Component, ElementRef, ViewE
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PopoverControlComponent implements AfterContentInit {
+export class PopoverControlComponent {
     constructor(public elRef: ElementRef) {}
 
-    ngAfterContentInit(): void {
+    /** @hidden */
+    makeTabbable(): void {
         const elemChild = this.elRef.nativeElement.children[0];
         if (elemChild?.getAttribute('tabindex') !== '-1') {
             elemChild.tabIndex = '0';

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -4,6 +4,7 @@ import {
     Component,
     ContentChild,
     ElementRef,
+    HostListener,
     Input,
     OnChanges,
     OnDestroy,
@@ -18,12 +19,13 @@ import {
     CdkOverlayOrigin,
     ConnectedPosition,
 } from '@angular/cdk/overlay';
-import { DOWN_ARROW } from '@angular/cdk/keycodes';
+import { DOWN_ARROW, ENTER, SPACE } from '@angular/cdk/keycodes';
 
 import { BasePopoverClass } from './base/base-popover.class';
 import { KeyUtil } from '@fundamental-ngx/core/utils';
 import { PopoverBodyComponent } from './popover-body/popover-body.component';
 import { PopoverService } from './popover-service/popover.service';
+import { PopoverControlComponent } from './popover-control/popover-control.component';
 
 let cdkPopoverUniqueId = 0;
 
@@ -74,8 +76,13 @@ export class PopoverComponent extends BasePopoverClass implements AfterViewInit,
     @ViewChild(CdkOverlayOrigin)
     triggerOrigin: CdkOverlayOrigin;
 
+    /** @hidden */
     @ContentChild(PopoverBodyComponent)
-    popoverBody: PopoverBodyComponent
+    popoverBody: PopoverBodyComponent;
+
+    /** @hidden */
+    @ContentChild(PopoverControlComponent)
+    popoverControl: PopoverControlComponent;
 
     /** @deprecated
      * Left for backward compatibility
@@ -112,6 +119,18 @@ export class PopoverComponent extends BasePopoverClass implements AfterViewInit,
     /** @hidden */
     ngOnDestroy(): void {
         this._popoverService.onDestroy();
+    }
+
+    /** @hidden */
+    @HostListener('keydown', ['$event'])
+    onKeyDown(event: KeyboardEvent): void {
+        if (this.popoverControl.elRef.nativeElement.children[0] === document.activeElement) {
+            if (KeyUtil.isKeyCode(event, SPACE) || KeyUtil.isKeyCode(event, ENTER)) {
+                // prevent page scrolling on Space keydown
+                event.preventDefault();
+                this._popoverService.toggle();
+            }
+        }
     }
 
     /** Closes the popover. */

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -1,4 +1,5 @@
 import {
+    AfterContentInit,
     AfterViewInit,
     ChangeDetectionStrategy,
     Component,
@@ -46,7 +47,7 @@ let cdkPopoverUniqueId = 0;
     styleUrls: ['./popover.component.scss'],
     providers: [PopoverService]
 })
-export class PopoverComponent extends BasePopoverClass implements AfterViewInit, OnDestroy, OnChanges {
+export class PopoverComponent extends BasePopoverClass implements AfterViewInit, AfterContentInit, OnDestroy, OnChanges {
 
     /** Tooltip for popover */
     @Input()
@@ -109,6 +110,13 @@ export class PopoverComponent extends BasePopoverClass implements AfterViewInit,
             popoverBody: this.popoverBody,
         } : null);
 
+    }
+
+    /** @hidden */
+    ngAfterContentInit(): void {
+        if (this.popoverControl && this.triggers.includes('click')) {
+            this.popoverControl.makeTabbable();
+        }
     }
 
     /** @hidden */


### PR DESCRIPTION
fixes #5816 

Makes all clickable popover controls tab-able (unless `tabindex="-1"`) and adds a focus outline to them (but only when they've received focus via the tab key, by using `:focus-visible`).