### PR TITLE
fix(platform): correct imports for checkbox group module

### DIFF
--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.module.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { FormModule as FdFormModule } from '@fundamental-ngx/core';
+import { FormsModule } from '@angular/forms';
+import { FormGroupModule } from '@fundamental-ngx/core';
 import { CheckboxGroupComponent } from './checkbox-group.component';
 import { PlatformCheckboxModule } from '../checkbox/checkbox.module';
 
 @NgModule({
-    imports: [CommonModule, PlatformCheckboxModule, FormsModule, FdFormModule, ReactiveFormsModule],
+    imports: [CommonModule, PlatformCheckboxModule, FormsModule, FormGroupModule],
     exports: [CheckboxGroupComponent],
     declarations: [CheckboxGroupComponent]
 })

--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.module.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { FormGroupModule } from '@fundamental-ngx/core';
+import { FormGroupModule } from '@fundamental-ngx/core/form';
 import { CheckboxGroupComponent } from './checkbox-group.component';
 import { PlatformCheckboxModule } from '../checkbox/checkbox.module';
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes https://github.com/SAP/fundamental-ngx/issues/3999

#### Please provide a brief summary of this pull request.
This PR optimises the import for checkbox-group.
instead of importing entire core/formModule, importing only required `formgroup`.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [NA] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

