### PR TITLE
fix(docs): add resettable flag for playground and reset message strip

### DIFF
--- a/apps/docs/src/app/core/component-docs/message-strip/message-strip-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/message-strip/message-strip-docs.component.html
@@ -38,8 +38,8 @@
 </component-example>
 <code-example [exampleFiles]="messageStripWidthExample"></code-example>
 
-<playground [schema]="schema" [schemaInitialValues]="data" (onFormChanges)="onSchemaValues($event)">
-    <fd-message-strip
+<playground [schema]="schema" [schemaInitialValues]="data" [resettable]="true" (onReset)="reset()" (onFormChanges)="onSchemaValues($event)">
+    <fd-message-strip *ngIf="shouldShow"
         [type]="data.modifier.type"
         [dismissible]="data.properties.dismissible"
         [noIcon]="data.properties.noIcon"

--- a/apps/docs/src/app/core/component-docs/message-strip/message-strip-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/message-strip/message-strip-docs.component.ts
@@ -13,6 +13,7 @@ import { ExampleFile } from '../../../documentation/core-helpers/code-example/ex
     templateUrl: './message-strip-docs.component.html'
 })
 export class MessageStripDocsComponent {
+
     static schema: any = {
         properties: {
             properties: {
@@ -86,11 +87,32 @@ export class MessageStripDocsComponent {
 
     schema: Schema;
 
+    /**
+     * Should show message strip component in playground.
+     */
+     shouldShow = true;
+
+    /**
+     * @hidden
+     */
+    private _originalSchemaValues = Object.assign({}, this.data);
+
     constructor(private schemaFactory: SchemaFactoryService) {
         this.schema = this.schemaFactory.getComponent('messageStrip');
     }
 
     onSchemaValues(data): void {
         this.data = data;
+    }
+
+    /**
+     * Resets message strip playground component and it's configuration
+     */
+    reset(): void {
+        this.shouldShow = false;
+        setTimeout(() => {
+            this.data = Object.assign({}, this._originalSchemaValues);
+            this.shouldShow = true;
+        });
     }
 }

--- a/apps/docs/src/app/documentation/core-helpers/playground/playground.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/playground/playground.component.html
@@ -10,8 +10,10 @@
             <schema
                 class="fd-playground__schema"
                 [schema]="schema"
+                [resettable]="resettable"
                 [initialValues]="schemaInitialValues"
                 (onSchemaValues)="onSchemaValueChanges($event)"
+                (onReset)="reset()"
             ></schema>
         </div>
     </div>

--- a/apps/docs/src/app/documentation/core-helpers/playground/playground.component.ts
+++ b/apps/docs/src/app/documentation/core-helpers/playground/playground.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Schema } from '../../../schema/models/schema.model';
 
 @Component({
@@ -6,18 +6,33 @@ import { Schema } from '../../../schema/models/schema.model';
     templateUrl: './playground.component.html',
     styleUrls: ['./playground.components.scss']
 })
-export class PlayGroundComponent implements OnInit {
+export class PlayGroundComponent {
     @Input() schema: Schema;
 
-    @Input() schemaInitialValues;
+    @Input() schemaInitialValues: any;
 
     @Input() displayBlock: boolean;
 
+    /**
+     * Is current playground can be resetted to defaults.
+     */
+    @Input() resettable = false;
+
     @Output() onFormChanges: EventEmitter<any> = new EventEmitter<any>();
 
-    ngOnInit(): void {}
+    /**
+     * Emits event when playground was resetted.
+     */
+    @Output() onReset: EventEmitter<void> = new EventEmitter<void>();
 
-    onSchemaValueChanges($event): void {
+    onSchemaValueChanges($event: any): void {
         this.onFormChanges.emit($event);
+    }
+
+    /**
+     * Emits event when playground was resetted.
+     */
+    reset(): void {
+        this.onReset.emit();
     }
 }

--- a/apps/docs/src/app/schema/containers/schema-group/schema-group.component.html
+++ b/apps/docs/src/app/schema/containers/schema-group/schema-group.component.html
@@ -66,4 +66,11 @@
             </fieldset>
         </ng-template>
     </ng-container>
+
+    <ng-container *ngIf="resettable">
+        <fieldset fd-fieldset class="schema--inner-group">
+            <button fd-button (click)="reset()">Reset</button>
+        </fieldset>
+
+    </ng-container>
 </div>

--- a/apps/docs/src/app/schema/containers/schema-group/schema-group.component.ts
+++ b/apps/docs/src/app/schema/containers/schema-group/schema-group.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormGroup, FormControl, AbstractControl } from '@angular/forms';
 import { Property } from '../../models/schema.model';
 
@@ -11,6 +11,11 @@ export class SchemaGroupComponent implements OnInit {
     @Input() schemaGroup: FormGroup;
     @Input() properties: Property;
 
+    /**
+     * Is current playground can be resetted.
+     */
+    @Input() resettable = false;
+
     controls: Array<{
         key: string;
         control: AbstractControl;
@@ -18,9 +23,14 @@ export class SchemaGroupComponent implements OnInit {
         enum: [any];
     }> = [];
 
+    /**
+     * Emits when playground needs to be resetted.
+     */
+    @Output() onReset: EventEmitter<void> = new EventEmitter<void>();
+
     ngOnInit(): void {
         const controls = this.schemaGroup.controls;
-        
+
         for (const key in controls) {
             if (controls.hasOwnProperty(key)) {
                 this.controls.push({
@@ -36,5 +46,12 @@ export class SchemaGroupComponent implements OnInit {
     /** @hidden */
     _isFormControl(form: FormControl | FormGroup): boolean {
         return form instanceof FormControl;
+    }
+
+    /**
+     * Emits reset event.
+     */
+    reset(): void {
+        this.onReset.emit()
     }
 }

--- a/apps/docs/src/app/schema/containers/schema/schema.component.html
+++ b/apps/docs/src/app/schema/containers/schema/schema.component.html
@@ -1,1 +1,1 @@
-<schema-group [schemaGroup]="schemaGroup" [properties]="schema.properties"></schema-group>
+<schema-group [schemaGroup]="schemaGroup" [properties]="schema.properties" [resettable]="resettable" (onReset)="reset()"></schema-group>

--- a/apps/docs/src/app/schema/containers/schema/schema.component.ts
+++ b/apps/docs/src/app/schema/containers/schema/schema.component.ts
@@ -1,30 +1,91 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { Properties, Schema } from '../../models/schema.model';
 import { FormControl, FormGroup } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { takeWhile } from 'rxjs/operators';
 
 @Component({
     selector: 'schema',
     templateUrl: 'schema.component.html',
     styleUrls: ['schema.component.scss']
 })
-export class SchemaComponent implements OnInit {
+export class SchemaComponent implements OnInit, OnChanges, OnDestroy {
     @Input() schema: Schema;
 
     @Input() initialValues: any;
 
+    /**
+     * Is current playground can be resetted.
+     */
+    @Input() resettable = false;
+
     @Output() onSchemaValues: EventEmitter<any> = new EventEmitter<any>();
+
+    /**
+     * Emits when playground needs to be resetted.
+     */
+    @Output() onReset: EventEmitter<void> = new EventEmitter<void>();
 
     schemaGroup: FormGroup;
 
+    /**
+     * @hidden
+     */
+    private _resetted = false;
+
+    /**
+     * @hidden
+     */
+    private _allowSubscribe = true;
+
+    /**
+     * @hidden
+     */
+    ngOnDestroy(): void {
+        this._allowSubscribe = false;
+    }
+
+    /**
+     * @hidden
+     */
     ngOnInit(): void {
+        this._constructSchemaGroup();
+    }
+
+    /**
+     * Resets the form and emits event.
+     */
+    reset(): void {
+        this._resetted = true;
+        this.onReset.emit();
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+
+        if (this._resetted && changes.initialValues) {
+            this.initialValues = changes.initialValues.currentValue;
+            this._resetted = false;
+            this.schemaGroup.patchValue(this.initialValues);
+        }
+    }
+
+    /**
+     * @hidden
+     */
+    private _constructSchemaGroup(): void {
         this.schemaGroup = this._constructProperties(this.schema.properties);
+
         this.schemaGroup.patchValue(this.initialValues);
 
-        this.schemaGroup.valueChanges.subscribe((values) => {
+        this.schemaGroup.valueChanges
+        .pipe(takeWhile(() => this._allowSubscribe)).subscribe((values) => {
             this.onSchemaValues.emit(values);
         });
     }
 
+    /**
+     * @hidden
+     */
     private _constructProperties(properties: Properties): FormGroup {
         const formGroup = {};
         for (const property in properties) {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5795 

#### Please provide a brief summary of this pull request.
Add reset button for playground component and reset components inside playground when button being pressed.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- n/a tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- n/a Run npm run build-pack-library and test in external application

Documentation checklist:
- n/a update `README.md`
- n/a [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- n/a Stackblitz works for all examples

