### PR TITLE
fix(core,platform): replace name with attr.name for taborder to work correctly

### DIFF
--- a/libs/core/src/lib/radio/radio-button/radio-button.component.html
+++ b/libs/core/src/lib/radio/radio-button/radio-button.component.html
@@ -3,7 +3,7 @@
     class="fd-radio"
     [disabled]="disabled"
     [id]="id"
-    [name]="name"
+    [attr.name]="name"
     [attr.tabindex]="tabIndex"
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="ariaLabelledBy"

--- a/libs/platform/src/lib/components/form/radio-group/radio-group.component.html
+++ b/libs/platform/src/lib/components/form/radio-group/radio-group.component.html
@@ -1,7 +1,6 @@
 <fd-form-group
     [isInline]="isInline"
     role="radiogroup"
-    [attr.tabindex]="0"
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="ariaLabelledBy"
     [attr.aria-orientation]="isInline ? 'horizontal' : 'vertical'"

--- a/libs/platform/src/lib/components/form/radio-group/radio/radio.component.spec.ts
+++ b/libs/platform/src/lib/components/form/radio-group/radio/radio.component.spec.ts
@@ -44,7 +44,7 @@ class TestRadioButtonComponent {
     @ViewChild('radio2') radioButton2: RadioButtonComponent;
     @ViewChild('radio3') radioButton3: RadioButtonComponent;
 }
-describe('RadioButtonComponent', () => {
+fdescribe('RadioButtonComponent', () => {
     let component: TestRadioButtonComponent;
     let fixture: ComponentFixture<TestRadioButtonComponent>;
 
@@ -76,7 +76,7 @@ describe('RadioButtonComponent', () => {
         expect(inputElem.nativeElement.type).toEqual('radio');
         expect(inputElem.nativeElement.getAttribute('id')).toBeTruthy();
         expect(inputElem.nativeElement.getAttribute('ng-reflect-is-disabled')).toEqual('false');
-        expect(inputElem.nativeElement.getAttribute('ng-reflect-name')).toEqual('radio');
+        expect(inputElem.nativeElement.getAttribute('name')).toEqual('radio');
         expect(inputElem.nativeElement.getAttribute('ng-reflect-value')).toEqual('1');
 
         expect(inputElem.nativeElement.classList.contains('fd-radio')).toBeTruthy();
@@ -88,7 +88,7 @@ describe('RadioButtonComponent', () => {
         expect(inputElems[1].nativeElement.type).toEqual('radio');
         expect(inputElems[1].nativeElement.getAttribute('id')).toBeTruthy();
         expect(inputElems[2].nativeElement.getAttribute('ng-reflect-is-disabled')).toBeTruthy();
-        expect(inputElems[1].nativeElement.getAttribute('ng-reflect-name')).toEqual('radio');
+        expect(inputElems[1].nativeElement.getAttribute('name')).toEqual('radio');
         expect(inputElems[1].nativeElement.getAttribute('ng-reflect-value')).toEqual('2');
 
         expect(inputElems[1].nativeElement.classList.contains('fd-radio')).toBeTruthy();


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes https://github.com/SAP/fundamental-ngx/issues/5656

#### Please provide a brief summary of this pull request.
currently tab order is not working on radio button examples. Tab does not take you from one example to another, but it skips.
Same behaviour is in Platform Radio and Platform radio-group. fix is provided in core radio by replacing [name]="name" to [attr.name]="name".

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [NA] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [NA] Documentation Examples
- [x] Stackblitz works for all examples

