### PR TITLE
fix(core): remove duplicated css imports

### DIFF
--- a/libs/core/src/lib/slider/slider.component.scss
+++ b/libs/core/src/lib/slider/slider.component.scss
@@ -1,6 +1,5 @@
 @import '~fundamental-styles/dist/slider';
 @import '~fundamental-styles/dist/input';
-@import '~fundamental-styles/dist/popover';
 
 .fd-popover__popper--cdk-custom.fd-slider--tooltip-popover {
     top: -7px !important;

--- a/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.scss
+++ b/libs/platform/src/lib/components/form/combobox/combobox/combobox.component.scss
@@ -1,5 +1,4 @@
 @import '~@angular/cdk/overlay-prebuilt';
-@import '~fundamental-styles/dist/popover';
 
 .fdp-combobox {
     &__list-container {

--- a/libs/platform/src/lib/components/form/select/select/select.component.scss
+++ b/libs/platform/src/lib/components/form/select/select/select.component.scss
@@ -1,5 +1,4 @@
 @import "~@angular/cdk/overlay-prebuilt";
-@import '~fundamental-styles/dist/popover';
 @import "~fundamental-styles/dist/select";
 
 // tem fix, its a bug a fd-form-layout.css file


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5657 

#### Please provide a brief summary of this pull request.
Removed duplicated css imports from select, combobox and slider components.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- n/a update `README.md`
- n/a [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- n/a Documentation Examples
- n/a Stackblitz works for all examples

