### PR TITLE
docs(core): fix displayFormat option for Time Picker example

### DIFF
--- a/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-format-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-format-example.component.ts
@@ -8,5 +8,5 @@ import { FdDate } from '@fundamental-ngx/core/datetime';
 export class TimePickerFormatExampleComponent {
     time = new FdDate().setTime(12, 0, 0);
     // FdDatetimeAdapter is based on Intl.DateTimeFormat.
-    displayFormat = { hour: 'numeric', minute: '2-digit', second: '2-digit', hour12: false };
+    displayFormat = { hour: 'numeric', minute: '2-digit', second: '2-digit', hourCycle: 'h23'};
 }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5750 

#### Please provide a brief summary of this pull request.
This is a known issue with the Intl.DateTimeFormat class. This example uses the option `hour12:false` :
<img src="https://user-images.githubusercontent.com/53509521/125029810-cee1d900-e0a7-11eb-8825-d3f221353a37.png" width="500">
[This option returns strange results at times as seen in this stackoverflow post.](https://stackoverflow.com/questions/65604554/intl-datetimeformat-returns-an-hour-over-24)
This PR uses the suggested solution of using the `hourCycle` option instead to fix this issue. 

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

