### PR TITLE
docs(docs): apply correct headings

### DIFF
--- a/apps/docs/src/app/core/component-docs/layout-grid/layout-grid-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/layout-grid/layout-grid-docs.component.html
@@ -1,4 +1,6 @@
-<h2>Grid columns</h2>
+<fd-docs-section-title id="grid-columns" componentName="layout-grid">
+    Grid columns
+</fd-docs-section-title>
 <description> Grid column width can be set using the <code>fdLayoutGridCol</code> property.</description>
 <component-example>
     <fd-layout-grid-basic-example></fd-layout-grid-basic-example>
@@ -7,7 +9,9 @@
 
 <separator></separator>
 
-<h2>Growing columns</h2>
+<fd-docs-section-title id="growing-columns" componentName="layout-grid">
+    Growing columns
+</fd-docs-section-title>
 <description> Growing column takes all available width in the row. To create a growing column add <code>colGrow</code>
     attribute to <code>fdLayoutGridCol</code> element.
 </description>
@@ -18,7 +22,9 @@
 
 <separator></separator>
 
-<h2>Column offset</h2>
+<fd-docs-section-title id="column-offset" componentName="layout-grid">
+    Column offset
+</fd-docs-section-title>
 <description> Space between columns can be added using the <code>fdLayoutGridColOffset</code> property.</description>
 <component-example>
     <fd-layout-grid-offset-example></fd-layout-grid-offset-example>
@@ -27,7 +33,9 @@
 
 <separator></separator>
 
-<h2>Responsive columns</h2>
+<fd-docs-section-title id="responsive-columns" componentName="layout-grid">
+    Responsive columns
+</fd-docs-section-title>
 <description>
     Responsiveness can be achieved by setting a column width for each size using the
     <code>fdLayoutGridCol fdLayoutGridColM fdLayoutGridColL fdLayoutGridColXl</code> properties. Responsiveness works
@@ -61,7 +69,9 @@
 
 <separator></separator>
 
-<h2>Responsive offset</h2>
+<fd-docs-section-title id="responsive-offset" componentName="layout-grid">
+    Responsive offset
+</fd-docs-section-title>
 <description>Offsets can also be used with the responsive layout grid.</description>
 <component-example>
     <fd-layout-grid-responsive-offset-example></fd-layout-grid-responsive-offset-example>
@@ -70,7 +80,9 @@
 
 <separator></separator>
 
-<h2>Grid row</h2>
+<fd-docs-section-title id="grid-row" componentName="layout-grid">
+    Grid row
+</fd-docs-section-title>
 <description> Rows can be defined by adding divs with the <code>fdLayoutGridRow</code> directive.</description>
 <component-example>
     <fd-layout-grid-row-example></fd-layout-grid-row-example>
@@ -79,7 +91,9 @@
 
 <separator></separator>
 
-<h2>Without gap</h2>
+<fd-docs-section-title id="without-gap" componentName="layout-grid">
+    Without gap
+</fd-docs-section-title>
 <description>
     Rows without gaps can be achieved by inputs:<br/>
     - <code>[noVerticalGap] - to remove vertical gap</code>,<br>
@@ -93,7 +107,9 @@
 
 <separator></separator>
 
-<h2>Nesting columns</h2>
+<fd-docs-section-title id="nesting-columns" componentName="layout-grid">
+    Nesting columns
+</fd-docs-section-title>
 <description> Add a row in between inner rows when using nesting. It will add a gutter in between rows.</description>
 <component-example>
     <fd-layout-grid-nesting-example></fd-layout-grid-nesting-example>

--- a/apps/docs/src/app/core/component-docs/notification/notification-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/notification/notification-docs.component.html
@@ -1,4 +1,6 @@
-<h2>Notification</h2>
+<fd-docs-section-title id="notification-standard" componentName="notification">
+    Notification
+</fd-docs-section-title>
 <description>
     Notification Component can be used with a lot of different types and sizes. Also there is example of container
     usage. It is possible to provide container reference, where should the notification belong. By default it is a
@@ -12,13 +14,15 @@
 
 <separator></separator>
 
-<h2>Template as Content</h2>
+<fd-docs-section-title id="notification-template-content" componentName="notification">
+    Template as Content
+</fd-docs-section-title>
 <description>
     The NotificationService allows passing in a template reference as the content of the notification. Add
     <code>let-notification</code> to the template element to access the injected <code>NotificationRef</code>.
     <br /><br />
     The example also features a confirmation notification. Subscribe to <code>afterClosed</code> to access the returned
-    value. A dismissal will trigger an error on the observable, similar to rejecting a promise. The example notification is dismissed after 4 seconds. 
+    value. A dismissal will trigger an error on the observable, similar to rejecting a promise. The example notification is dismissed after 4 seconds.
 </description>
 <component-example>
     <fd-notification-open-template-example></fd-notification-open-template-example>
@@ -27,7 +31,9 @@
 
 <separator></separator>
 
-<h2>Component as Content</h2>
+<fd-docs-section-title id="notification-component-content" componentName="notification">
+    Component as Content
+</fd-docs-section-title>
 <description>
     A component type can be passed to the NotificationService open method as the content of the notification. Inject
     <code>NotificationRef</code> inside the content component to access methods such as close and dismiss.
@@ -38,9 +44,9 @@
 <code-example [exampleFiles]="componentAsContent"></code-example>
 
 <separator></separator>
-<h2>
+<fd-docs-section-title id="notification-group" componentName="notification">
     Notification Group
-</h2>
+</fd-docs-section-title>
 <description>
     Items are added to a list based on internal events within apps or systems. The list can display various types of notifications, which can differ in terms of appearance, content, and functionality. The list can be ordered by Date (the most recent notification appears first), by Type (notifications appear as grouped notifications ordered from A-Z) and by Priority (from highest to lowest priority).
 </description>

--- a/apps/docs/src/app/core/component-docs/title/title-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/title/title-docs.component.html
@@ -1,4 +1,6 @@
-<h2>Semantic Level</h2>
+<fd-docs-section-title id="semantic-level" componentName="tile">
+    Semantic Level
+</fd-docs-section-title>
 <description>
     There are 6 semantic levels of a heading element. There should only be one H1 on a page, and headings should only
     appear in ascending order without skipping a level; i.e. even if there are only 3 levels on a page, the order must
@@ -9,7 +11,9 @@
 </component-example>
 <code-example [exampleFiles]="titleSemanticExample"></code-example>
 
-<h2>Visual</h2>
+<fd-docs-section-title id="visual" componentName="tile">
+    Visual
+</fd-docs-section-title>
 <description>
     If a design requires it, the visual level can be set to something different than the semantic level. This allows the
     sequential order to be maintained while providing flexibility in appearance. In order to do this, use the optional
@@ -20,14 +24,18 @@
 </component-example>
 <code-example [exampleFiles]="titleVisualExample"></code-example>
 
-<h2>Elision</h2>
+<fd-docs-section-title id="elision" componentName="tile">
+    Elision
+</fd-docs-section-title>
 <description> By default the Title text overflow will be elided when longer than its container. </description>
 <component-example>
     <fd-title-elision-example></fd-title-elision-example>
 </component-example>
 <code-example [exampleFiles]="titleElisionExample"></code-example>
 
-<h2>Wrapping</h2>
+<fd-docs-section-title id="wrapping" componentName="tile">
+    Wrapping
+</fd-docs-section-title>
 <description> Add the <code>[wrap]</code> input to cause the overflow text to wrap instead. </description>
 <component-example>
     <fd-title-wrapping-example></fd-title-wrapping-example>

--- a/apps/docs/src/app/platform/component-docs/platform-approval-flow/platform-approval-flow-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-approval-flow/platform-approval-flow-docs.component.html
@@ -1,4 +1,6 @@
-<h2>Approval Flow</h2>
+<fd-docs-section-title id="approval-flow" componentName="approval-flow">
+    Approval flow
+</fd-docs-section-title>
 <component-example>
     <fdp-platform-approval-flow-example></fdp-platform-approval-flow-example>
 </component-example>

--- a/apps/docs/src/app/platform/component-docs/platform-upload-collection/platform-upload-collection-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-upload-collection/platform-upload-collection-docs.component.html
@@ -1,25 +1,33 @@
-<h2>Default</h2>
+<fd-docs-section-title id="default" componentName="upload-collection">
+    Default
+</fd-docs-section-title>
 <description></description>
 <component-example>
     <fdp-upload-collection-example></fdp-upload-collection-example>
 </component-example>
 <code-example [exampleFiles]="uploadCollection"></code-example>
 
-<h2>Disabled State</h2>
+<fd-docs-section-title id="disabled-state" componentName="upload-collection">
+    Disabled State
+</fd-docs-section-title>
 <description>Use <code class="code-snippet">[disable]="true"</code> to disable all CRUD buttons.</description>
 <component-example>
     <fdp-upload-collection-disabled-example></fdp-upload-collection-disabled-example>
 </component-example>
 <code-example [exampleFiles]="uploadCollectionDisabled"></code-example>
 
-<h2>Readonly State</h2>
+<fd-docs-section-title id="readonly-state" componentName="upload-collection">
+    Readonly State
+</fd-docs-section-title>
 <description>Use <code class="code-snippet">[readonly]="true"</code> to hide all CRUD buttons.</description>
 <component-example>
     <fdp-upload-collection-readonly-example></fdp-upload-collection-readonly-example>
 </component-example>
 <code-example [exampleFiles]="uploadCollectionReadOnly"></code-example>
 
-<h2>Witout Pagination and Search</h2>
+<fd-docs-section-title id="without-pagination-and-seatch" componentName="upload-collection">
+    Witout Pagination and Search
+</fd-docs-section-title>
 <description>
     Use <code class="code-snippet">[showSearch]="false"</code> to hide search input, by default
     <code class="code-snippet">[showSearch]="true"</code>.


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5649 

#### Please provide a brief summary of this pull request.
Added correct heading components instead of h2
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- n/a update `README.md`
- n/a [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- n/a Stackblitz works for all examples

