### PR TITLE
docs(core): apply required mark for label  and remove inline help class in compact example for text area component 

### DIFF
--- a/apps/docs/src/app/core/component-docs/textarea/examples/textarea-example.component.html
+++ b/apps/docs/src/app/core/component-docs/textarea/examples/textarea-example.component.html
@@ -9,7 +9,7 @@
     <textarea fd-form-control id="textarea-2" placeholder="Field placeholder text" aria-required="true"></textarea>
 </div>
 <div fd-form-item>
-    <label fd-form-label for="compact-textarea">Compact textarea</label>
+    <label fd-form-label [required]="true" for="compact-textarea">Compact and Required textarea</label>
     <textarea
         fd-form-control
         id="compact-textarea"

--- a/apps/docs/src/app/core/component-docs/textarea/examples/textarea-example.component.html
+++ b/apps/docs/src/app/core/component-docs/textarea/examples/textarea-example.component.html
@@ -1,7 +1,7 @@
 <h4 fd-form-header>Form Header</h4>
 <br>
 <div fd-form-item>
-    <label fd-form-label for="textarea-1">Default textarea</label>
+    <label fd-form-label colon="true" for="textarea-1">Default textarea</label>
     <textarea fd-form-control id="textarea-1" placeholder="Field placeholder text"></textarea>
 </div>
 <div fd-form-item>

--- a/apps/docs/src/app/core/component-docs/textarea/examples/textarea-example.component.html
+++ b/apps/docs/src/app/core/component-docs/textarea/examples/textarea-example.component.html
@@ -9,7 +9,7 @@
     <textarea fd-form-control id="textarea-2" placeholder="Field placeholder text" aria-required="true"></textarea>
 </div>
 <div fd-form-item>
-    <label fd-form-label [required]="true" for="compact-textarea">Compact and Required textarea</label>
+    <label fd-form-label [required]="true" for="compact-textarea">Compact and Required textarea:</label>
     <textarea
         fd-form-control
         id="compact-textarea"

--- a/apps/docs/src/app/core/component-docs/textarea/examples/textarea-form-group-example.component.html
+++ b/apps/docs/src/app/core/component-docs/textarea/examples/textarea-form-group-example.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="customForm">
     <fieldset fd-fieldset>
         <div fd-form-item>
-            <label fd-form-label for="textarea-1">Textarea:</label>
+            <label fd-form-label colon="true" for="textarea-1">Textarea</label>
             <textarea
                 formControlName="textAreaControl"
                 fd-form-control
@@ -11,7 +11,7 @@
             Textarea Value: {{ customForm.controls.textAreaControl.value }}
         </div>
         <div fd-form-item>
-            <label fd-form-label for="textarea-2">Disabled Textarea:</label>
+            <label fd-form-label colon="true" for="textarea-2">Disabled Textarea</label>
             <textarea
                 formControlName="disabledTextAreaControl"
                 fd-form-control

--- a/apps/docs/src/app/core/component-docs/textarea/examples/textarea-inline-help-example.component.html
+++ b/apps/docs/src/app/core/component-docs/textarea/examples/textarea-inline-help-example.component.html
@@ -1,5 +1,5 @@
 <div fd-form-item>
-    <label fd-form-label for="textarea-41" inlineHelpTitle="Inline Help">
+    <label fd-form-label colon="true" for="textarea-41" inlineHelpTitle="Inline Help">
         Textarea with inline help
     </label>
     <textarea fd-form-control placeholder="Field placeholder text" id="textarea-41"></textarea>

--- a/apps/docs/src/app/core/component-docs/textarea/examples/textarea-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/textarea/examples/textarea-state-example.component.html
@@ -1,5 +1,5 @@
 <div fd-form-item>
-    <label fd-form-label for="input-52">
+    <label fd-form-label colon="true" for="input-52">
         Valid(Success) Textarea
     </label>
     <fd-form-input-message-group>
@@ -11,7 +11,7 @@
 </div>
 
 <div fd-form-item>
-    <label fd-form-label for="input-53">
+    <label fd-form-label colon="true" for="input-53">
         Invalid(Error) Textarea
     </label>
     <fd-form-input-message-group>
@@ -22,7 +22,7 @@
     </fd-form-input-message-group>
 </div>
 <div fd-form-item>
-    <label fd-form-label for="input-54">
+    <label fd-form-label colon="true" for="input-54">
         Warning Textarea
     </label>
     <fd-form-input-message-group>
@@ -34,7 +34,7 @@
 </div>
 
 <div fd-form-item>
-    <label fd-form-label for="input-55">
+    <label fd-form-label colon="true" for="input-55">
         Information Textarea
     </label>
     <fd-form-input-message-group>
@@ -52,13 +52,13 @@
 </div>
 
 <div fd-form-item>
-    <label fd-form-label for="textarea-55">
+    <label fd-form-label colon="true" for="textarea-55">
         Disabled Textarea
     </label>
     <textarea fd-form-control id="textarea-55" placeholder="Field placeholder text" disabled></textarea>
 </div>
 <div fd-form-item>
-    <label fd-form-label for="textarea-56">
+    <label fd-form-label colon="true" for="textarea-56">
         Readonly Textarea
     </label>
     <textarea fd-form-control id="textarea-56" placeholder="Field placeholder text" readonly></textarea>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes https://github.com/SAP/fundamental-ngx/issues/5899,
Closes https://github.com/SAP/fundamental-ngx/issues/5907

#### Please provide a brief summary of this pull request.
This PR change contains applying the required mark for label in compact example for text area component.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [NA] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

