### PR TITLE
docs(platform): update cozy button example in sizes section

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-button/platform-button-examples/platform-button-sizes-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-button/platform-button-examples/platform-button-sizes-example.component.html
@@ -1,2 +1,2 @@
-<fdp-button label="Normal Button"></fdp-button>
+<fdp-button label="Normal Button" contentDensity="cozy"></fdp-button>
 <fdp-button contentDensity="compact" label="Compact Button"></fdp-button>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5752 

#### Please provide a brief summary of this pull request.
When we change the content density from the central select to compact then the normal button should not become compact. 

The normal example has explicit contentDensity input set to cozy in order to be valid as an example.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [n/a] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

