### PR TITLE
fix(platform): display default content density  as core for components

### DIFF
--- a/libs/platform/src/lib/components/button/button.component.html
+++ b/libs/platform/src/lib/components/button/button.component.html
@@ -1,6 +1,6 @@
 <button #fdButton fd-button [attr.id]="id" [attr.title]="title" [attr.name]="name" [attr.aria-label]="ariaLabel"
     [glyphPosition]="glyphPosition" [label]="label" [type]="type" [attr.value]="value"
-    [attr.aria-selected]="ariaSelected" [attr.aria-disabled]="ariaDisabled" [compact]="contentDensity !== 'cozy'"
+    [attr.aria-selected]="ariaSelected" [attr.aria-disabled]="ariaDisabled" [compact]="contentDensity ? contentDensity !== 'cozy' : ''"
     [glyph]="glyph" [disabled]="disabled" (click)="onBtnClick($event)" [fdType]="buttonType" [class.is-disabled]="ariaDisabled"
     [ngStyle]="{ width: width }">
 </button>


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5877

#### Please provide a brief summary of this pull request.
When platform button is used in any user angular application the button should have a content density as cozy by default.

Before:
<img width="1680" alt="2021-07-16_19-14-45" src="https://user-images.githubusercontent.com/53487468/126117798-2849bdea-4d95-456d-9730-40a2b212e29a.png">


After:

<img width="1675" alt="2021-07-19_12-38-53" src="https://user-images.githubusercontent.com/53487468/126117890-96fb983d-547f-4628-82c5-5b81c92f8965.png">
<img width="1737" alt="2021-07-19_12-39-13" src="https://user-images.githubusercontent.com/53487468/126118003-7b340983-d88d-43ab-b17a-4b461a505ff4.png">


#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [n/a] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

