### PR TITLE
fix(platform): fix Platform ng-add schematics failing in Angular12 apps

### DIFF
--- a/libs/platform/ng-package.json
+++ b/libs/platform/ng-package.json
@@ -4,5 +4,5 @@
     "lib": {
         "entryFile": "src/index.ts"
     },
-    "allowedNonPeerDependencies": ["@fundamental-ngx/core"]
+    "allowedNonPeerDependencies": ["@fundamental-ngx/core", "xml2js"]
 }

--- a/libs/platform/package.json
+++ b/libs/platform/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/SAP/fundamental-ngx"
   },
   "dependencies": {
-    "@fundamental-ngx/core": "VERSION_PLACEHOLDER"
+    "@fundamental-ngx/core": "VERSION_PLACEHOLDER",
+    "xml2js":"0.4.23"
   }
 }

--- a/libs/platform/schematics/utils/translation-utils.ts
+++ b/libs/platform/schematics/utils/translation-utils.ts
@@ -119,7 +119,7 @@ export async function writeToAngularConfig(
 
         // adding serve configurations
         const serveConfigObject = projectObject.architect.serve.configurations;
-        const defaultServeConfig = projectObject.architect.serve.options.browserTarget;
+        const defaultServeConfig = projectObject.architect['extract-i18n'].options.browserTarget;
         languageServeObj = {
             [language]: {
                 browserTarget: defaultServeConfig + ':' + language


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5941 

#### Please provide a brief summary of this pull request.
On creating a new Ang12 project, the `angular.json` configuration does not add `options` field to the `serve` configuration like in previous versions. Also, there is probably stricter checking of how modules/external libraries are used due to which `xml2js` library was not being found. This PR:
- targets the `extract-i18n` config of angular.json instead which shows the correct `browserTarget` path as before
- adds `xml2js` as platform lib dependency to overcome `module not found` errors on Angular12.

The changes have been verified against both Ang12 and Ang10 projects and work fine for both `ng-add` and `ng-update`.
To verify, 
- take this branch and run `npm run build-pack-library`. Copy the path to the `fundamental-ngx-platform-0.31.0-rc.xyz.tgz`  file from the platform dist folder.
- create a new ang12 project
- in the ang12 project terminal, run the command `ng add @fundamental-ngx/platform@<path-to-platform-dist-tgz>` 
- it should run the schematic successfully.

![image](https://user-images.githubusercontent.com/53509521/125610611-fca63ecb-6248-446f-89f6-6c0a5715f95b.png)

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

