### PR TITLE
fix(core): fix access modifier for method in Input Group

### DIFF
--- a/libs/core/src/lib/input-group/input-group.component.ts
+++ b/libs/core/src/lib/input-group/input-group.component.ts
@@ -211,18 +211,6 @@ export class InputGroupComponent implements ControlValueAccessor, OnInit, OnDest
         }
     }
 
-    /** @hidden
-     * calculate the correct ids for input aria-labelledby
-     */
-    private _getAriaLabelledbyIdsForInput(): string {
-      let ariaLabelledByIds = this.ariaLabelledby ? this.ariaLabelledby + ' ' : '';
-      if (!this.button) {
-          ariaLabelledByIds += this._addOnNonButtonId;
-      }
-
-      return ariaLabelledByIds;
-    }
-
     /** @hidden */
     ngOnDestroy(): void {
         this._subscriptions.unsubscribe();
@@ -269,6 +257,19 @@ export class InputGroupComponent implements ControlValueAccessor, OnInit, OnDest
             event.preventDefault();
         }
     }
+
+    /** @hidden
+     * calculate the correct ids for input aria-labelledby
+     */
+     _getAriaLabelledbyIdsForInput(): string {
+      let ariaLabelledByIds = this.ariaLabelledby ? this.ariaLabelledby + ' ' : '';
+      if (!this.button) {
+          ariaLabelledByIds += this._addOnNonButtonId;
+      }
+
+      return ariaLabelledByIds;
+    }
+
     /** @hidden */
     private _listenElementEvents(): void {
         fromEvent(this.elementRef.nativeElement, 'focus', { capture: true }).pipe(


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #6003 

#### Please provide a brief summary of this pull request.
This PR removes `private` modifier from the method `_getAriaLabelledbyIdsForInput`.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [n/a] Documentation Examples
- [x] Stackblitz works for all examples

