### PR TITLE
fix(platform): remove anchor from list item for multi-input value help

### DIFF
--- a/libs/platform/src/lib/components/form/multi-input/multi-input.component.html
+++ b/libs/platform/src/lib/components/form/multi-input/multi-input.component.html
@@ -84,7 +84,6 @@
         [selectionMode]="selectionMode"
         [contentDensity]="contentDensity"
         *ngIf="_suggestions && _suggestions.length"
-        [navigated]="true"
     >
         <ng-container *ngIf="!isGroup">
             <fdp-standard-list-item


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes https://github.com/SAP/fundamental-ngx/issues/6005

#### Please provide a brief summary of this pull request.
Currently platform multi-input value help list items are created with anchor link. So it displays underscore below the text.
It is not needed, as fiori does not mention it to be navigable list item.

https://wiki.wdf.sap.corp/wiki/pages/viewpage.action?pageId=2059233657
https://wiki.wdf.sap.corp/wiki/pages/viewpage.action?pageId=2059233657

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [NA] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

