### PR TITLE
fix(docs): add ability to include assets to examples

### DIFF
--- a/apps/docs/src/app/core/component-docs/illustrated-message/illustrated-message-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/illustrated-message/illustrated-message-docs.component.ts
@@ -11,6 +11,13 @@ import * as illustratedMessageDialogTsCode from '!raw-loader!./examples/illustra
 import * as illustratedMessageSpotSrc from '!raw-loader!./examples/illustrated-message-spot-example.component.html';
 import * as illustratedMessageSpotTsCode from '!raw-loader!./examples/illustrated-message-spot-example.component.ts';
 
+import * as illustration from '!raw-loader!../../../../assets/images/sapIllus-Dialog-NoMail.svg';
+import * as illustrationSceneNoMail from '!raw-loader!../../../../assets/images/sapIllus-Scene-NoMail.svg';
+
+import * as illustrationDialogNoMail from '!raw-loader!../../../../assets/images/sapIllus-Dialog-NoMail.svg';
+
+import * as illustrationSpotNoMail from '!raw-loader!../../../../assets/images/sapIllus-Spot-NoMail.svg';
+
 @Component({
     selector: 'app-illustrated-message',
     templateUrl: './illustrated-message-docs.component.html'
@@ -28,6 +35,18 @@ export class IllustratedMessageDocsComponent {
             code: illustratedMessageTsCode,
             fileName: 'illustrated-message-example',
             component: 'IllustratedMessageExampleComponent'
+        },
+        {
+            language: 'svg',
+            code: illustration,
+            fileName: 'sapIllus-Dialog-NoMail',
+            path: 'src/assets/images'
+        },
+        {
+            language: 'svg',
+            code: illustrationSceneNoMail,
+            fileName: 'sapIllus-Scene-NoMail',
+            path: 'src/assets/images'
         }
     ];
 
@@ -42,6 +61,12 @@ export class IllustratedMessageDocsComponent {
             code: illustratedMessageDialogTsCode,
             fileName: 'illustrated-message-dialog-example',
             component: 'IllustratedMessageDialogExampleComponent'
+        },
+        {
+            language: 'svg',
+            code: illustrationDialogNoMail,
+            fileName: 'sapIllus-Dialog-NoMail',
+            path: 'src/assets/images'
         }
     ];
 
@@ -56,6 +81,12 @@ export class IllustratedMessageDocsComponent {
             code: illustratedMessageSpotTsCode,
             fileName: 'illustrated-message-spot-example',
             component: 'IllustratedMessageSpotExampleComponent'
+        },
+        {
+            language: 'svg',
+            code: illustrationSpotNoMail,
+            fileName: 'sapIllus-Spot-NoMail',
+            path: 'src/assets/images'
         }
     ];
 }

--- a/apps/docs/src/app/documentation/core-helpers/code-example/example-file.ts
+++ b/apps/docs/src/app/documentation/core-helpers/code-example/example-file.ts
@@ -17,4 +17,5 @@ export interface ExampleFile {
     };
     service?: boolean;
     pipe?: boolean;
+    path?: string;
 }

--- a/apps/docs/src/app/documentation/core-helpers/stackblitz/stackblitz-dependencies.ts
+++ b/apps/docs/src/app/documentation/core-helpers/stackblitz/stackblitz-dependencies.ts
@@ -68,16 +68,17 @@ export class StackblitzDependencies {
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "assets": [
-            {
+              "src/assets",
+              {
                 "glob": "**/css_variables.css",
                 "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/",
                 "output": "./assets/theming-base/"
-            },
-            {
+              },
+              {
                 "glob": "**/*",
                 "input": "./node_modules/fundamental-styles/dist/theming/",
                 "output": "./assets/fundamental-styles-theming/"
-            }
+              }
             ],
             "styles": [
               "src/styles.scss"

--- a/apps/docs/src/app/documentation/core-helpers/stackblitz/stackblitz.service.ts
+++ b/apps/docs/src/app/documentation/core-helpers/stackblitz/stackblitz.service.ts
@@ -59,6 +59,9 @@ export class StackblitzService {
                 generatedFiles = this.handleTsFile(example);
             } else if (example.language === 'scss') {
                 generatedFiles = this.handleScssFile(example);
+            } else if (example.path !== undefined) {
+                defaultProjectInfo.files[`${example.path}/${example.fileName}.${example.language}`] = example.code.default;
+                return;
             }
 
             if (generatedFiles.html) {
@@ -88,10 +91,17 @@ export class StackblitzService {
             : stackBlitzFiles[0].selector;
 
         defaultProjectInfo.files['src/index.html'] = `
-            <link rel="stylesheet" href="node_modules/fundamental-styles/dist/fonts.css"></link>
-            <link rel="stylesheet" href="node_modules/fundamental-styles/dist/icon.css"></link>
-            <${mainFileSelector}></${mainFileSelector}>
-        `;
+<html>
+    <head>
+        <link rel="stylesheet"
+        href="node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_fiori_3/css_variables.css" />
+        <link rel="stylesheet" href="node_modules/fundamental-styles/dist/fonts.css" />
+        <link rel="stylesheet" href="node_modules/fundamental-styles/dist/icon.css" />
+    </head>
+    <body>
+        <${mainFileSelector}></${mainFileSelector}>
+    </body>
+</html>`;
 
         sdk.openProject(<any>defaultProjectInfo);
     }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #5178 #6008

#### Please provide a brief summary of this pull request.
Added ability to include assets into stackblitz project.
NOTE: assets are rendering after stackblitz project has been forked. I might be a problem on stackblitz side itself and not on ours.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- n/a update `README.md`
- n/a [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

