### PR TITLE
feat(platform): introduce feature to change column and inline value based on form container layout

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
@@ -66,6 +66,11 @@
     it shows that on <code>L</code> size screen, field should be dispalyed in 2nd column and when scren size changes to
     <code>XL</code> size then the field will be displayed in 3rd Column(defaults to <code>L</code> layout value when
     value for <code>XL</code> not provided).
+    <br />
+    <br />
+    In this example, we have used custom break-points for screen sizes. <code>XL screen size >= 1540px</code>,
+    <code>L screen size is between 1224px and 1540px</code>,
+    <code>M screen size is between 800px and 1224px</code>, <code>S screen size is less than 800px</code>.
 </description>
 <component-example>
     <fdp-platform-form-column-change-example></fdp-platform-form-column-change-example>
@@ -82,6 +87,11 @@
     be dispalyed in vertical mode and when scren size changes to
     <code>XL</code> size then the field will be displayed inline(defaults to <code>L</code> layout value when value for
     <code>XL</code> not provided).
+    <br />
+    <br />
+    In this example, we have used custom break-points for screen sizes. <code>XL screen size >= 1540px</code>,
+    <code>L screen size is between 1224px and 1540px</code>,
+    <code>M screen size is between 800px and 1224px</code>, <code>S screen size is less than 800px</code>.
 </description>
 <component-example>
     <fdp-platform-form-isinline-change-example></fdp-platform-form-isinline-change-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
@@ -23,8 +23,9 @@
 <fd-docs-section-title id="not-recommended" componentName="form-container">
     Not recommended form layouts
 </fd-docs-section-title>
-<description>This example shows more possible layout combinations for form container usage that are not recommended
-</description>
+<description
+    >This example shows more possible layout combinations for form container usage that are not recommended</description
+>
 <component-example>
     <fdp-platform-form-container-not-recommended-example></fdp-platform-form-container-not-recommended-example>
 </component-example>
@@ -42,26 +43,23 @@
 <separator></separator>
 
 <fd-docs-section-title id="column-binding" componentName="form-container"> Column Binding </fd-docs-section-title>
-<description>To bind column use the <code>[column]</code> attribute. The column attribute specify the respective layout
-    for XL size, the rest automatically wrap according to layout pattern.</description>
+<description>To bind column use the <code>[column]</code> attribute. The column attribute specify the respective layout for XL size, the rest automatically wrap according to layout pattern.</description>
 <component-example>
     <fdp-platform-form-basic-example></fdp-platform-form-basic-example>
 </component-example>
 <code-example [exampleFiles]="formContainerColumn"></code-example>
 
 <fd-docs-section-title id="group" componentName="form-container"> Form Field Group </fd-docs-section-title>
-<description>Wrap fields with the <code>[form-field-group]</code> component to group them. You can use
-    <code>[column]</code> and <code>[rank]</code> attribute
-</description>
+<description>Wrap fields with the <code>[form-field-group]</code> component to group them. You can use <code>[column]</code> and <code>[rank]</code> attribute</description>
 <component-example>
     <fdp-platform-form-group-example></fdp-platform-form-group-example>
 </component-example>
 <code-example [exampleFiles]="formContainerGroup"></code-example>
 
 <separator></separator>
-<fd-docs-section-title id="field-column-change" componentName="form-container"> Change of column number for a field
-</fd-docs-section-title>
-<description>To change the column number in form-group-container for a field while screen size changes, property
+<fd-docs-section-title id="field-column-change" componentName="form-container">Change of column number for a field</fd-docs-section-title>
+<description>
+    To change the column number in form-group-container for a field while screen size changes, property
     <code>[columnLayout]</code> can be used. it takes object in the form of <code>XL: 3, L: 2, M: 1, S: 1</code>. Here
     it shows that on <code>L</code> size screen, field should be dispalyed in 2nd column and when scren size changes to
     <code>XL</code> size then the field will be displayed in 3rd Column(defaults to <code>L</code> layout value when
@@ -69,8 +67,8 @@
     <br />
     <br />
     In this example, we have used custom break-points for screen sizes. <code>XL screen size >= 1540px</code>,
-    <code>L screen size is between 1224px and 1540px</code>,
-    <code>M screen size is between 800px and 1224px</code>, <code>S screen size is less than 800px</code>.
+    <code>L screen size is between 1224px and 1540px</code>, <code>M screen size is between 800px and 1224px</code>,
+    <code>S screen size is less than 800px</code>.
 </description>
 <component-example>
     <fdp-platform-form-column-change-example></fdp-platform-form-column-change-example>
@@ -79,19 +77,18 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="field-inline-change" componentName="form-container"> Change of isInline value for a field
-</fd-docs-section-title>
-<description>To change the isInline value in form-group-container for a field while screen size changes, property
+<fd-docs-section-title id="field-inline-change" componentName="form-container">Change of isInline value for a field</fd-docs-section-title>
+<description>
+    To change the isInline value in form-group-container for a field while screen size changes, property
     <code>[isInlineLayout]</code> can be used. it takes object in the form of
     <code>XL: true, L: false, M: true, S: false</code>. Here it shows that on <code>L</code> size screen, field should
-    be dispalyed in vertical mode and when scren size changes to
-    <code>XL</code> size then the field will be displayed inline(defaults to <code>L</code> layout value when value for
-    <code>XL</code> not provided).
+    be dispalyed in vertical mode and when scren size changes to <code>XL</code> size then the field will be displayed
+    inline(defaults to <code>L</code> layout value when value for <code>XL</code> not provided).
     <br />
     <br />
     In this example, we have used custom break-points for screen sizes. <code>XL screen size >= 1540px</code>,
-    <code>L screen size is between 1224px and 1540px</code>,
-    <code>M screen size is between 800px and 1224px</code>, <code>S screen size is less than 800px</code>.
+    <code>L screen size is between 1224px and 1540px</code>, <code>M screen size is between 800px and 1224px</code>,
+    <code>S screen size is less than 800px</code>.
 </description>
 <component-example>
     <fdp-platform-form-isinline-change-example></fdp-platform-form-isinline-change-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
@@ -23,9 +23,8 @@
 <fd-docs-section-title id="not-recommended" componentName="form-container">
     Not recommended form layouts
 </fd-docs-section-title>
-<description
-    >This example shows more possile layout combinations for form container usage that are not recommended</description
->
+<description>This example shows more possile layout combinations for form container usage that are not recommended
+</description>
 <component-example>
     <fdp-platform-form-container-not-recommended-example></fdp-platform-form-container-not-recommended-example>
 </component-example>
@@ -43,15 +42,42 @@
 <separator></separator>
 
 <fd-docs-section-title id="column-binding" componentName="form-container"> Column Binding </fd-docs-section-title>
-<description>To bind column use the <code>[column]</code> attribute. The column attribute specify the respective layout for XL size, the rest automatically wrap according to layout pattern.</description>
+<description>To bind column use the <code>[column]</code> attribute. The column attribute specify the respective layout
+    for XL size, the rest automatically wrap according to layout pattern.</description>
 <component-example>
     <fdp-platform-form-basic-example></fdp-platform-form-basic-example>
 </component-example>
 <code-example [exampleFiles]="formContainerColumn"></code-example>
 
 <fd-docs-section-title id="group" componentName="form-container"> Form Field Group </fd-docs-section-title>
-<description>Wrap fields with the <code>[form-field-group]</code> component to group them. You can use <code>[column]</code> and <code>[rank]</code> attribute</description>
+<description>Wrap fields with the <code>[form-field-group]</code> component to group them. You can use
+    <code>[column]</code> and <code>[rank]</code> attribute</description>
 <component-example>
     <fdp-platform-form-group-example></fdp-platform-form-group-example>
 </component-example>
 <code-example [exampleFiles]="formContainerGroup"></code-example>
+
+<separator></separator>
+<fd-docs-section-title id="field-column-change" componentName="form-container"> Change of column number for a field
+</fd-docs-section-title>
+<description>To change the column number in form-group-container for a field while screen size changes, property
+    <code>[columnLayout]</code> can be used. it takes object in the form of <code>XL: 3, L: 2, M: 1</code>. Here it
+    shows that on <code>XL</code> size screen, field should be dispalyed in 3rd column and when scren size to <code>L</code> size then the
+    field will be displayed in 2nd Column.</description>
+<component-example>
+    <fdp-platform-form-column-change-example></fdp-platform-form-column-change-example>
+</component-example>
+<code-example [exampleFiles]="formFieldColumnLayout"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="field-isInline-change" componentName="form-container"> Change of isInline value for a field
+</fd-docs-section-title>
+<description>To change the isInline value in form-group-container for a field while screen size changes, property
+    <code>[isInlineLayout]</code> can be used. it takes object in the form of <code>XL: true, L: false, M: true, S: false</code>. Here it
+    shows that on <code>XL</code> size screen, field should be dispalyed in inLine mode and when scren size to <code>L</code> size then the
+    field will be displayed in vertical.</description>
+<component-example>
+    <fdp-platform-form-isinline-change-example></fdp-platform-form-isinline-change-example>
+</component-example>
+<code-example [exampleFiles]="formFieldInlineLayout"></code-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 <fd-docs-section-title id="recommended" componentName="form-container">
+=======
+<fd-docs-section-title id="form-container-recommended" componentName="form-container">
+>>>>>>> 3f1f23324 (fix(platform): use enum for breakpoints, subscription destroy, review comments)
     Recommended form layouts
 </fd-docs-section-title>
 <description>This example shows recommended layouts for form container</description>
@@ -9,7 +13,11 @@
 
 <separator></separator>
 
+<<<<<<< HEAD
 <fd-docs-section-title id="possible" componentName="form-container">
+=======
+<fd-docs-section-title id="form-container-possible" componentName="form-container">
+>>>>>>> 3f1f23324 (fix(platform): use enum for breakpoints, subscription destroy, review comments)
     Possible form layouts
 </fd-docs-section-title>
 <description>This example shows other possible layout combinations for form container</description>
@@ -20,10 +28,14 @@
 
 <separator></separator>
 
+<<<<<<< HEAD
 <fd-docs-section-title id="not-recommended" componentName="form-container">
+=======
+<fd-docs-section-title id="form-container-not-recommended" componentName="form-container">
+>>>>>>> 3f1f23324 (fix(platform): use enum for breakpoints, subscription destroy, review comments)
     Not recommended form layouts
 </fd-docs-section-title>
-<description>This example shows more possile layout combinations for form container usage that are not recommended
+<description>This example shows more possible layout combinations for form container usage that are not recommended
 </description>
 <component-example>
     <fdp-platform-form-container-not-recommended-example></fdp-platform-form-container-not-recommended-example>
@@ -32,7 +44,11 @@
 
 <separator></separator>
 
+<<<<<<< HEAD
 <fd-docs-section-title id="complex" componentName="form-container"> Complex form </fd-docs-section-title>
+=======
+<fd-docs-section-title id="form-container-complex" componentName="form-container"> Complex form </fd-docs-section-title>
+>>>>>>> 3f1f23324 (fix(platform): use enum for breakpoints, subscription destroy, review comments)
 <description>This example shows visualizes various Platform Form components in the form container</description>
 <component-example>
     <fdp-platform-form-container-complex-example></fdp-platform-form-container-complex-example>
@@ -62,8 +78,8 @@
 </fd-docs-section-title>
 <description>To change the column number in form-group-container for a field while screen size changes, property
     <code>[columnLayout]</code> can be used. it takes object in the form of <code>XL: 3, L: 2, M: 1</code>. Here it
-    shows that on <code>XL</code> size screen, field should be dispalyed in 3rd column and when scren size to <code>L</code> size then the
-    field will be displayed in 2nd Column.</description>
+    shows that on <code>L</code> size screen, field should be dispalyed in 2nd column and when scren size to <code>XL</code> size then the
+    field will be displayed in 3rd Column(defaults to <code>L</code> layout value when value for <code>XL</code> not provided).</description>
 <component-example>
     <fdp-platform-form-column-change-example></fdp-platform-form-column-change-example>
 </component-example>
@@ -71,12 +87,12 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="field-isInline-change" componentName="form-container"> Change of isInline value for a field
+<fd-docs-section-title id="field-inline-change" componentName="form-container"> Change of isInline value for a field
 </fd-docs-section-title>
 <description>To change the isInline value in form-group-container for a field while screen size changes, property
     <code>[isInlineLayout]</code> can be used. it takes object in the form of <code>XL: true, L: false, M: true, S: false</code>. Here it
-    shows that on <code>XL</code> size screen, field should be dispalyed in inLine mode and when scren size to <code>L</code> size then the
-    field will be displayed in vertical.</description>
+    shows that on <code>L</code> size screen, field should be dispalyed in vertical mode and when scren size to <code>XL</code> size then the
+    field will be displayed inline(defaults to <code>L</code> layout value when value for <code>XL</code> not provided).</description>
 <component-example>
     <fdp-platform-form-isinline-change-example></fdp-platform-form-isinline-change-example>
 </component-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.html
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 <fd-docs-section-title id="recommended" componentName="form-container">
-=======
-<fd-docs-section-title id="form-container-recommended" componentName="form-container">
->>>>>>> 3f1f23324 (fix(platform): use enum for breakpoints, subscription destroy, review comments)
     Recommended form layouts
 </fd-docs-section-title>
 <description>This example shows recommended layouts for form container</description>
@@ -13,11 +9,7 @@
 
 <separator></separator>
 
-<<<<<<< HEAD
 <fd-docs-section-title id="possible" componentName="form-container">
-=======
-<fd-docs-section-title id="form-container-possible" componentName="form-container">
->>>>>>> 3f1f23324 (fix(platform): use enum for breakpoints, subscription destroy, review comments)
     Possible form layouts
 </fd-docs-section-title>
 <description>This example shows other possible layout combinations for form container</description>
@@ -28,11 +20,7 @@
 
 <separator></separator>
 
-<<<<<<< HEAD
 <fd-docs-section-title id="not-recommended" componentName="form-container">
-=======
-<fd-docs-section-title id="form-container-not-recommended" componentName="form-container">
->>>>>>> 3f1f23324 (fix(platform): use enum for breakpoints, subscription destroy, review comments)
     Not recommended form layouts
 </fd-docs-section-title>
 <description>This example shows more possible layout combinations for form container usage that are not recommended
@@ -44,11 +32,7 @@
 
 <separator></separator>
 
-<<<<<<< HEAD
 <fd-docs-section-title id="complex" componentName="form-container"> Complex form </fd-docs-section-title>
-=======
-<fd-docs-section-title id="form-container-complex" componentName="form-container"> Complex form </fd-docs-section-title>
->>>>>>> 3f1f23324 (fix(platform): use enum for breakpoints, subscription destroy, review comments)
 <description>This example shows visualizes various Platform Form components in the form container</description>
 <component-example>
     <fdp-platform-form-container-complex-example></fdp-platform-form-container-complex-example>
@@ -67,7 +51,8 @@
 
 <fd-docs-section-title id="group" componentName="form-container"> Form Field Group </fd-docs-section-title>
 <description>Wrap fields with the <code>[form-field-group]</code> component to group them. You can use
-    <code>[column]</code> and <code>[rank]</code> attribute</description>
+    <code>[column]</code> and <code>[rank]</code> attribute
+</description>
 <component-example>
     <fdp-platform-form-group-example></fdp-platform-form-group-example>
 </component-example>
@@ -77,9 +62,11 @@
 <fd-docs-section-title id="field-column-change" componentName="form-container"> Change of column number for a field
 </fd-docs-section-title>
 <description>To change the column number in form-group-container for a field while screen size changes, property
-    <code>[columnLayout]</code> can be used. it takes object in the form of <code>XL: 3, L: 2, M: 1</code>. Here it
-    shows that on <code>L</code> size screen, field should be dispalyed in 2nd column and when scren size to <code>XL</code> size then the
-    field will be displayed in 3rd Column(defaults to <code>L</code> layout value when value for <code>XL</code> not provided).</description>
+    <code>[columnLayout]</code> can be used. it takes object in the form of <code>XL: 3, L: 2, M: 1, S: 1</code>. Here
+    it shows that on <code>L</code> size screen, field should be dispalyed in 2nd column and when scren size changes to
+    <code>XL</code> size then the field will be displayed in 3rd Column(defaults to <code>L</code> layout value when
+    value for <code>XL</code> not provided).
+</description>
 <component-example>
     <fdp-platform-form-column-change-example></fdp-platform-form-column-change-example>
 </component-example>
@@ -90,9 +77,12 @@
 <fd-docs-section-title id="field-inline-change" componentName="form-container"> Change of isInline value for a field
 </fd-docs-section-title>
 <description>To change the isInline value in form-group-container for a field while screen size changes, property
-    <code>[isInlineLayout]</code> can be used. it takes object in the form of <code>XL: true, L: false, M: true, S: false</code>. Here it
-    shows that on <code>L</code> size screen, field should be dispalyed in vertical mode and when scren size to <code>XL</code> size then the
-    field will be displayed inline(defaults to <code>L</code> layout value when value for <code>XL</code> not provided).</description>
+    <code>[isInlineLayout]</code> can be used. it takes object in the form of
+    <code>XL: true, L: false, M: true, S: false</code>. Here it shows that on <code>L</code> size screen, field should
+    be dispalyed in vertical mode and when scren size changes to
+    <code>XL</code> size then the field will be displayed inline(defaults to <code>L</code> layout value when value for
+    <code>XL</code> not provided).
+</description>
 <component-example>
     <fdp-platform-form-isinline-change-example></fdp-platform-form-isinline-change-example>
 </component-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.component.ts
@@ -11,6 +11,10 @@ import * as platformComplexFormContainerSrc from '!raw-loader!./platform-form-co
 import * as platformComplexFormContainerTsCode from '!raw-loader!./platform-form-container-examples/platform-form-container-complex-example.component.ts';
 import * as platformColFormContainerSrc from '!raw-loader!./platform-form-container-examples/platform-form-basic/platform-form-basic-example.component.html';
 import * as platformGFormContainerSrc from '!raw-loader!./platform-form-container-examples/platform-form-group/platform-form-group-example.component.html';
+import * as platformFormFieldLayoutSrc from '!raw-loader!./platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.html';
+import * as platformFormFieldLayoutTsCode from '!raw-loader!./platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.ts';
+import * as platformFormFieldInlineLayoutSrc from '!raw-loader!./platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.html';
+import * as platformFormFieldInlineLayoutTsCode from '!raw-loader!./platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.ts';
 
 @Component({
     selector: 'app-form-container',
@@ -79,7 +83,7 @@ export class PlatformFormContainerDocsComponent {
             fileName: 'platform-form-container-columns-example',
             component: 'PlatformFormContainerBasicExampleComponent'
         }
-    ]
+    ];
 
     formContainerGroup: ExampleFile[] = [
         {
@@ -88,7 +92,35 @@ export class PlatformFormContainerDocsComponent {
             fileName: 'platform-form-container-grouping-example',
             component: 'PlatformFormContainerGroupExampleComponent'
         }
-    ]
+    ];
 
+    formFieldColumnLayout: ExampleFile[] = [
+        {
+            language: 'html',
+            code: platformFormFieldLayoutSrc,
+            fileName: 'platform-field-column-change-example',
+            component: 'PlatformFieldColumnChangeExampleComponent'
+        },
+        {
+            language: 'typescript',
+            code: platformFormFieldLayoutTsCode,
+            fileName: 'platform-field-column-change-example',
+            component: 'PlatformFieldColumnChangeExampleComponent'
+        }
+    ];
 
+    formFieldInlineLayout: ExampleFile[] = [
+        {
+            language: 'html',
+            code: platformFormFieldInlineLayoutSrc,
+            fileName: 'platform-field-isinline-change-example',
+            component: 'PlatformFieldIsInlineChangeExampleComponent'
+        },
+        {
+            language: 'typescript',
+            code: platformFormFieldInlineLayoutTsCode,
+            fileName: 'platform-field-isinline-change-example',
+            component: 'PlatformFieldIsInlineChangeExampleComponent'
+        }
+    ];
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.module.ts
@@ -13,7 +13,9 @@ import {
     PlatformCheckboxGroupModule,
     PlatformStepInputModule,
     PlatformInputGroupModule,
-    PlatformSwitchModule
+    PlatformSwitchModule,
+    PlatformComboboxModule,
+    PlatformSelectModule
 } from '@fundamental-ngx/platform';
 import { PlatformFormContainerDocsComponent } from './platform-form-container-docs.component';
 import { PlatformFormContainerRecommendedExampleComponent } from './platform-form-container-examples/platform-form-container-recommended-example.component';
@@ -49,6 +51,8 @@ const routes: Routes = [
         PlatformStepInputModule,
         PlatformInputGroupModule,
         PlatformSwitchModule,
+        PlatformComboboxModule,
+        PlatformSelectModule,
         FdpFormGroupModule
     ],
     exports: [RouterModule],

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-docs.module.ts
@@ -23,6 +23,8 @@ import { PlatformFormContainerComplexExampleComponent } from './platform-form-co
 import { PlatformFormContainerHeaderComponent } from './platform-form-container-header/platform-form-container-header.component';
 import { PlatformFormBasicExampleComponent } from './platform-form-container-examples/platform-form-basic/platform-form-basic-example.component';
 import { PlatformFormGroupExampleComponent } from './platform-form-container-examples/platform-form-group/platform-form-group-example.component';
+import { PlatformFieldColumnChangeExampleComponent } from './platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component';
+import { PlatformFieldIsInlineChangeExampleComponent } from './platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component';
 
 const routes: Routes = [
     {
@@ -59,7 +61,10 @@ const routes: Routes = [
         PlatformFormContainerComplexExampleComponent,
 
         PlatformFormBasicExampleComponent,
-        PlatformFormGroupExampleComponent
+        PlatformFormGroupExampleComponent,
+
+        PlatformFieldColumnChangeExampleComponent,
+        PlatformFieldIsInlineChangeExampleComponent
     ]
 })
 export class PlatformFormContainerDocsModule {}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.html
@@ -1,64 +1,66 @@
 <fdp-form-group #fg1 [formGroup]="form" mainTitle="XL2-L2-M2-S1" columnLayout="XL2-L2-M2-S1">
-    <fdp-form-field
-        #ff1
-        id="basicTextarea"
-        label="XL: 1, L: 2, M: 1, S: 1"
-        placeholder="XL: 1, L: 2, M: 1, S: 1"
-        hint="XL: 1, L: 2, M: 1, S: 1"
-        [columnLayout]="{ XL: 1, L: 2, M: 1, S: 1 }"
-        rank="1"
-        hintPlacement="left"
-    >
-        <fdp-textarea name="basicTextarea" [formControl]="ff1.formControl"></fdp-textarea>
-    </fdp-form-field>
-    <fdp-form-field
-        #ff2
-        id="seasons0"
-        label="XL: 1, L: 1, M: 2, S: 1"
-        hint="XL: 1, L: 1, M: 2, S: 1"
-        hintPlacement="left"
-        [columnLayout]="{ XL: 1, L: 1, M: 2, S: 1 }"
-        rank="2"
-    >
-        <fdp-checkbox-group
-            [list]="seasons"
-            name="seasons0"
-            [isInline]="true"
-            ariaLabel="My favourite Seasons"
-            [formControl]="ff2.formControl"
-        ></fdp-checkbox-group>
-    </fdp-form-field>
-    <fdp-form-field
-        #ff3
-        id="basicTextarea2"
-        label="XL: 2, L: 2, M: 1, S: 1"
-        placeholder="XL: 2, L: 2, M: 1, S: 1"
-        hint="XL: 2, L: 2, M: 1, S: 1"
-        [columnLayout]="{ XL: 2, L: 2, M: 1, S: 1 }"
-        rank="3"
-    >
-        <fdp-textarea name="basicTextarea2" [formControl]="ff3.formControl"></fdp-textarea>
-    </fdp-form-field>
-    <fdp-form-field
-        #ff5
-        id="basicTextarea3"
-        label="XL: 2, L: 2, M: 2, S: 1"
-        placeholder="XL: 2, L: 2, M: 2, S: 1"
-        hint="XL: 2, L: 2, M: 2, S: 1"
-        [columnLayout]="{ XL: 2, L: 2, M: 2, S: 1 }"
-        rank="5"
-    >
-        <fdp-textarea name="basicTextarea3" [formControl]="ff5.formControl"></fdp-textarea>
-    </fdp-form-field>
-    <fdp-form-field
-        #ff6
-        id="basicTextarea6"
-        label="XL: 2, L: 1, M: 1, S: 1"
-        placeholder="XL: 2, L: 1, M: 1, S: 1"
-        hint="XL: 2, L: 1, M: 1, S: 1"
-        [columnLayout]="{ XL: 2, L: 1, M: 1, S: 1 }"
-        rank="6"
-    >
-        <fdp-textarea name="basicTextarea6" [formControl]="ff6.formControl"></fdp-textarea>
-    </fdp-form-field>
+    <fdp-form-field-group label="Form field column layout">
+        <fdp-form-field
+            #ff1
+            id="basicTextarea-ex1"
+            label="XL: 1, L: 2, M: 1, S: 1"
+            placeholder="XL: 1, L: 2, M: 1, S: 1"
+            hint="XL: 1, L: 2, M: 1, S: 1"
+            [columnLayout]="{ XL: 1, L: 2, M: 1, S: 1 }"
+            rank="1"
+            hintPlacement="left"
+        >
+            <fdp-textarea name="basicTextarea-ex1" [formControl]="ff1.formControl"></fdp-textarea>
+        </fdp-form-field>
+        <fdp-form-field
+            #ff2
+            id="seasons0-ex1"
+            label="XL: 1, L: 1, M: 2, S: 1"
+            hint="XL: 1, L: 1, M: 2, S: 1"
+            hintPlacement="left"
+            [columnLayout]="{ XL: 1, L: 1, M: 2, S: 1 }"
+            rank="2"
+        >
+            <fdp-checkbox-group
+                [list]="seasons"
+                name="seasons0-ex1"
+                [isInline]="true"
+                ariaLabel="My favourite Seasons"
+                [formControl]="ff2.formControl"
+            ></fdp-checkbox-group>
+        </fdp-form-field>
+        <fdp-form-field
+            #ff3
+            id="basicTextarea2-ex1"
+            label="XL: 2, L: 2, M: 1, S: 1"
+            placeholder="XL: 2, L: 2, M: 1, S: 1"
+            hint="XL: 2, L: 2, M: 1, S: 1"
+            [columnLayout]="{ XL: 2, L: 2, M: 1, S: 1 }"
+            rank="3"
+        >
+            <fdp-textarea name="basicTextarea2-ex1" [formControl]="ff3.formControl"></fdp-textarea>
+        </fdp-form-field>
+        <fdp-form-field
+            #ff5
+            id="basicTextarea3-ex1"
+            label="XL: 2, L: 2, M: 2, S: 1"
+            placeholder="XL: 2, L: 2, M: 2, S: 1"
+            hint="XL: 2, L: 2, M: 2, S: 1"
+            [columnLayout]="{ XL: 2, L: 2, M: 2, S: 1 }"
+            rank="5"
+        >
+            <fdp-textarea name="basicTextarea3-ex1" [formControl]="ff5.formControl"></fdp-textarea>
+        </fdp-form-field>
+        <fdp-form-field
+            #ff6
+            id="basicTextarea6-ex1"
+            label="XL: 2, L: 1, M: 1, S: 1"
+            placeholder="XL: 2, L: 1, M: 1, S: 1"
+            hint="XL: 2, L: 1, M: 1, S: 1"
+            [columnLayout]="{ XL: 2, L: 1, M: 1, S: 1 }"
+            rank="6"
+        >
+            <fdp-textarea name="basicTextarea6-ex1" [formControl]="ff6.formControl"></fdp-textarea>
+        </fdp-form-field>
+    </fdp-form-field-group>
 </fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.html
@@ -1,0 +1,64 @@
+<fdp-form-group #fg1 [formGroup]="form" mainTitle="XL2-L2-M2-S1" columnLayout="XL2-L2-M2-S1">
+    <fdp-form-field
+        #ff1
+        id="basicTextarea"
+        label="XL: 1, L: 2, M: 1, S: 1"
+        placeholder="XL: 1, L: 2, M: 1, S: 1"
+        hint="XL: 1, L: 2, M: 1, S: 1"
+        [columnLayout]="{ XL: 1, L: 2, M: 1, S: 1 }"
+        rank="1"
+        hintPlacement="left"
+    >
+        <fdp-textarea name="basicTextarea" [formControl]="ff1.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff2
+        id="seasons0"
+        label="XL: 1, L: 1, M: 2, S: 1"
+        hint="XL: 1, L: 1, M: 2, S: 1"
+        hintPlacement="left"
+        [columnLayout]="{ XL: 1, L: 1, M: 2, S: 1 }"
+        rank="2"
+    >
+        <fdp-checkbox-group
+            [list]="seasons"
+            name="seasons0"
+            [isInline]="true"
+            ariaLabel="My favourite Seasons"
+            [formControl]="ff2.formControl"
+        ></fdp-checkbox-group>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff3
+        id="basicTextarea2"
+        label="XL: 2, L: 2, M: 1, S: 1"
+        placeholder="XL: 2, L: 2, M: 1, S: 1"
+        hint="XL: 2, L: 2, M: 1, S: 1"
+        [columnLayout]="{ XL: 2, L: 2, M: 1, S: 1 }"
+        rank="3"
+    >
+        <fdp-textarea name="basicTextarea2" [formControl]="ff3.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff5
+        id="basicTextarea3"
+        label="XL: 2, L: 2, M: 2, S: 1"
+        placeholder="XL: 2, L: 2, M: 2, S: 1"
+        hint="XL: 2, L: 2, M: 2, S: 1"
+        [columnLayout]="{ XL: 2, L: 2, M: 2, S: 1 }"
+        rank="5"
+    >
+        <fdp-textarea name="basicTextarea3" [formControl]="ff5.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff6
+        id="basicTextarea6"
+        label="XL: 2, L: 1, M: 1, S: 1"
+        placeholder="XL: 2, L: 1, M: 1, S: 1"
+        hint="XL: 2, L: 1, M: 1, S: 1"
+        [columnLayout]="{ XL: 2, L: 1, M: 1, S: 1 }"
+        rank="6"
+    >
+        <fdp-textarea name="basicTextarea6" [formControl]="ff6.formControl"></fdp-textarea>
+    </fdp-form-field>
+</fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+    selector: 'fdp-platform-form-column-change-example',
+    templateUrl: './platform-field-column-change-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None
+})
+export class PlatformFieldColumnChangeExampleComponent {
+    form: FormGroup = new FormGroup({});
+
+    seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-column-change-example.component.ts
@@ -1,11 +1,24 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { FormGroup } from '@angular/forms';
+import { RESPONSIVE_BREAKPOINTS_CONFIG } from '@fundamental-ngx/platform';
+
+const DEFAULT_NEW_BREAKPOINTS_CONFIG = {
+    S: 800,
+    M: 1224,
+    L: 1540
+};
 
 @Component({
     selector: 'fdp-platform-form-column-change-example',
     templateUrl: './platform-field-column-change-example.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    providers: [
+        {
+            provide: RESPONSIVE_BREAKPOINTS_CONFIG,
+            useValue: DEFAULT_NEW_BREAKPOINTS_CONFIG
+        }
+    ]
 })
 export class PlatformFieldColumnChangeExampleComponent {
     form: FormGroup = new FormGroup({});

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.html
@@ -25,7 +25,7 @@
         #ff3
         id="basicTextarea2"
         label="Basic Textarea with Platform Forms 2"
-        [placeholder]="'Start entering detailed description'"
+        placeholder="Start entering detailed description"
         hint="This is tooltip help"
         column="1"
         rank="3"
@@ -36,7 +36,7 @@
         #ff5
         id="basicTextarea3"
         label="Basic Textarea with Platform Forms 5"
-        [placeholder]="'Start entering detailed description'"
+        placeholder="Start entering detailed description"
         hint="This is tooltip help"
         column="1"
         rank="5"
@@ -47,7 +47,7 @@
         #ff6
         id="basicTextarea6"
         label="Basic Textarea with Platform Forms 6"
-        [placeholder]="'Start entering detailed description'"
+        placeholder="Start entering detailed description"
         hint="This is tooltip help"
         column="1"
         rank="6"

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.html
@@ -1,0 +1,57 @@
+<fdp-form-group #fg1 [formGroup]="form" mainTitle="XL1-L1-M1-S1" columnLayout="XL1-L1-M1-S1">
+    <fdp-form-field
+        #ff1
+        id="basicTextarea"
+        label="Basic Textarea with Platform Forms"
+        placeholder="Start entering detailed description"
+        hint="This is tooltip help"
+        column="1"
+        rank="1"
+        hintPlacement="left"
+    >
+        <fdp-textarea name="basicTextarea" [formControl]="ff1.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field #ff2 id="seasons0" label="XL: true, L: false, M: true, S: false" column="1" rank="2">
+        <fdp-checkbox-group
+            [list]="seasons"
+            name="seasons0"
+            [inlineLayout]="{ XL: true, L: false, M: true, S: false }"
+            [isInline]="true"
+            ariaLabel="My favourite Seasons"
+            [formControl]="ff2.formControl"
+        ></fdp-checkbox-group>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff3
+        id="basicTextarea2"
+        label="Basic Textarea with Platform Forms 2"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        column="1"
+        rank="3"
+    >
+        <fdp-textarea name="basicTextarea2" [formControl]="ff3.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff5
+        id="basicTextarea3"
+        label="Basic Textarea with Platform Forms 5"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        column="1"
+        rank="5"
+    >
+        <fdp-textarea name="basicTextarea3" [formControl]="ff5.formControl"></fdp-textarea>
+    </fdp-form-field>
+    <fdp-form-field
+        #ff6
+        id="basicTextarea6"
+        label="Basic Textarea with Platform Forms 6"
+        [placeholder]="'Start entering detailed description'"
+        hint="This is tooltip help"
+        column="1"
+        rank="6"
+    >
+        <fdp-textarea name="basicTextarea6" [formControl]="ff6.formControl"></fdp-textarea>
+    </fdp-form-field>
+</fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.html
@@ -1,57 +1,79 @@
 <fdp-form-group #fg1 [formGroup]="form" mainTitle="XL1-L1-M1-S1" columnLayout="XL1-L1-M1-S1">
-    <fdp-form-field
-        #ff1
-        id="basicTextarea"
-        label="Basic Textarea with Platform Forms"
-        placeholder="Start entering detailed description"
-        hint="This is tooltip help"
-        column="1"
-        rank="1"
-        hintPlacement="left"
-    >
-        <fdp-textarea name="basicTextarea" [formControl]="ff1.formControl"></fdp-textarea>
-    </fdp-form-field>
-    <fdp-form-field #ff2 id="seasons0" label="XL: true, L: false, M: true, S: false" column="1" rank="2">
-        <fdp-checkbox-group
-            [list]="seasons"
-            name="seasons0"
-            [inlineLayout]="{ XL: true, L: false, M: true, S: false }"
-            [isInline]="true"
-            ariaLabel="My favourite Seasons"
-            [formControl]="ff2.formControl"
-        ></fdp-checkbox-group>
-    </fdp-form-field>
-    <fdp-form-field
-        #ff3
-        id="basicTextarea2"
-        label="Basic Textarea with Platform Forms 2"
-        placeholder="Start entering detailed description"
-        hint="This is tooltip help"
-        column="1"
-        rank="3"
-    >
-        <fdp-textarea name="basicTextarea2" [formControl]="ff3.formControl"></fdp-textarea>
-    </fdp-form-field>
-    <fdp-form-field
-        #ff5
-        id="basicTextarea3"
-        label="Basic Textarea with Platform Forms 5"
-        placeholder="Start entering detailed description"
-        hint="This is tooltip help"
-        column="1"
-        rank="5"
-    >
-        <fdp-textarea name="basicTextarea3" [formControl]="ff5.formControl"></fdp-textarea>
-    </fdp-form-field>
-    <fdp-form-field
-        #ff6
-        id="basicTextarea6"
-        label="Basic Textarea with Platform Forms 6"
-        placeholder="Start entering detailed description"
-        hint="This is tooltip help"
-        column="1"
-        rank="6"
-    >
-        <fdp-textarea name="basicTextarea6" [formControl]="ff6.formControl"></fdp-textarea>
-    </fdp-form-field>
+    <fdp-form-field-group label="Form field inline layout">
+        <fdp-form-field
+            #ff1
+            id="basicTextarea-ex2"
+            label="Basic Textarea with Platform Forms"
+            placeholder="Start entering detailed description"
+            hint="This is tooltip help"
+            column="1"
+            rank="1"
+            hintPlacement="left"
+        >
+            <fdp-textarea name="basicTextarea-ex2" [formControl]="ff1.formControl"></fdp-textarea>
+        </fdp-form-field>
+        <fdp-form-field
+            #ff2
+            id="seasons0-ex2"
+            hint="XL: true, L: false, M: true, S: false"
+            label="Checkbox group inline value: XL: true, L: false, M: true, S: false"
+            column="1"
+            rank="2"
+        >
+            <fdp-checkbox-group
+                [list]="seasons"
+                name="seasons0-ex2"
+                [inlineLayout]="{ XL: true, L: false, M: true, S: false }"
+                ariaLabel="My favourite Seasons"
+                [formControl]="ff2.formControl"
+            ></fdp-checkbox-group>
+        </fdp-form-field>
+        <fdp-form-field
+            #ff3
+            id="basicTextarea2-ex2"
+            label="Select an option"
+            placeholder="Select your choice"
+            hint="This is tooltip help"
+            column="1"
+            rank="3"
+        >
+            <fdp-select placeholder="Select an option" [list]="option"></fdp-select>
+        </fdp-form-field>
+        <fdp-form-field
+            #ff5
+            id="basicTextarea3-ex2"
+            label="Basic Textarea with Platform Forms 2"
+            placeholder="Start entering detailed description"
+            hint="This is tooltip help"
+            column="1"
+            rank="5"
+        >
+            <fdp-textarea name="basicTextarea3-ex2" [formControl]="ff5.formControl"></fdp-textarea>
+        </fdp-form-field>
+        <fdp-form-field
+            #ff6
+            id="basicRadioGroup-ex2"
+            label="Radio group button: XL: false, L: true, M: false, S: true"
+            hint="XL: false, L: true, M: false, S: true"
+            column="1"
+            rank="6"
+        >
+            <fdp-radio-group
+                [inlineLayout]="{ XL: false, L: true, M: false, S: true }"
+                name="radio-ex2"
+                [list]="seasons"
+                ariaLabel="select favourite Season"
+                [formControl]="ff6.formControl"
+            ></fdp-radio-group>
+        </fdp-form-field>
+
+        <fdp-form-field #ff7 id="combobox" label="Combobox" column="1" rank="7">
+            <fdp-combobox
+                name="combobox"
+                placeholder="Type some text..."
+                [dataSource]="dataSource"
+                [formControl]="ff7.formControl"
+            ></fdp-combobox>
+        </fdp-form-field>
+    </fdp-form-field-group>
 </fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.ts
@@ -1,7 +1,13 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
-import { OptionItem } from '@fundamental-ngx/platform';
+import { OptionItem, RESPONSIVE_BREAKPOINTS_CONFIG } from '@fundamental-ngx/platform';
+
+const DEFAULT_NEW_BREAKPOINTS_CONFIG = {
+    S: 800,
+    M: 1224,
+    L: 1540
+};
 
 export class Fruit {
     id: string;
@@ -19,7 +25,13 @@ export class Fruit {
     selector: 'fdp-platform-form-isinline-change-example',
     templateUrl: './platform-field-isinline-change-example.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    providers: [
+        {
+            provide: RESPONSIVE_BREAKPOINTS_CONFIG,
+            useValue: DEFAULT_NEW_BREAKPOINTS_CONFIG
+        }
+    ]
 })
 export class PlatformFieldIsInlineChangeExampleComponent {
     form: FormGroup = new FormGroup({});

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.ts
@@ -1,6 +1,20 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
+import { OptionItem } from '@fundamental-ngx/platform';
+
+export class Fruit {
+    id: string;
+    name: string;
+    age: number;
+
+    constructor(id: string, name: string, age: number) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+    }
+}
+
 @Component({
     selector: 'fdp-platform-form-isinline-change-example',
     templateUrl: './platform-field-isinline-change-example.component.html',
@@ -11,4 +25,23 @@ export class PlatformFieldIsInlineChangeExampleComponent {
     form: FormGroup = new FormGroup({});
 
     seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
+
+    dataSource = ['Apple', 'Banana', 'Pineapple', 'Strawberry', 'Broccoli', 'Carrot', 'Jalapeño', 'Spinach'];
+
+    userList = [
+        new Fruit('A', 'Apple', 10),
+        new Fruit('B', 'orange', 70),
+        new Fruit('C', 'Plums', 10),
+        new Fruit('D', 'pineapple', 11),
+        new Fruit('E', 'watermelon', 10)
+    ];
+    option = this.userList.map<OptionItem>((item) => {
+        return {
+            label: item.name + item.id,
+            value: item,
+            triggerValue: `(${item.id})`,
+            disabled: item.id === 'B',
+            icon: ''
+        };
+    });
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-field-layout/platform-field-isinline-change-example.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+    selector: 'fdp-platform-form-isinline-change-example',
+    templateUrl: './platform-field-isinline-change-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None
+})
+export class PlatformFieldIsInlineChangeExampleComponent {
+    form: FormGroup = new FormGroup({});
+
+    seasons: string[] = ['Winter', 'Spring', 'Summer', 'Autumn'];
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-header/platform-form-container-header.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-header/platform-form-container-header.component.html
@@ -19,6 +19,13 @@
                     column)
                 </li>
                 <li>Responsible for change detection and UI updates</li>
+                <li>
+                    Form field can be placed to different columns based on available screen size.
+                </li>
+                <li>
+                    <code>[columnLayout]</code> value can be passed in form of <code>XL: 3, L: 2, M: 1, S: 1</code> to
+                    acheive this.
+                </li>
             </ul>
         </li>
         <li>
@@ -36,6 +43,13 @@
     <br />
     <br />
 
+    <h3>React with custom screen-size breakpoints</h3>
+    We have default breakpoints of screen sizes. on change of that, layout of form-container changes based on
+    specification provided.
+    Further we also have option to inject custom breakpoints as well. Please check component file of example
+    <strong>Change of column number for a field</strong> for reference.
+    <br />
+    <br />
     <import module="FdpFormGroupModule"></import>
 </description>
 

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.html
@@ -84,3 +84,14 @@
     <fdp-platform-form-generator-custom-error-example></fdp-platform-form-generator-custom-error-example>
 </component-example>
 <code-example [exampleFiles]="customErrors"></code-example>
+
+<fd-docs-section-title id="def6" componentName="form-generator-component">
+    Form Generator with form field column layout and inline layout
+</fd-docs-section-title>
+<description>
+    This example shows arrangement of form-field based on <code>columnLayout</code> values and <code>inLineLayout</code> values.
+</description>
+<component-example>
+    <fdp-platform-form-generator-field-layout-example></fdp-platform-form-generator-field-layout-example>
+</component-example>
+<code-example [exampleFiles]="defaultFormGenerator"></code-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.html
@@ -85,7 +85,7 @@
 </component-example>
 <code-example [exampleFiles]="customErrors"></code-example>
 
-<fd-docs-section-title id="def6" componentName="form-generator-component">
+<fd-docs-section-title id="field-layout" componentName="form-generator">
     Form Generator with form field column layout and inline layout
 </fd-docs-section-title>
 <description>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.ts
@@ -14,6 +14,9 @@ import * as programaticSubmitSrc from '!raw-loader!./platform-form-generator-exa
 import * as customErrorsHtml from '!raw-loader!./platform-form-generator-examples/platform-form-generator-custom-error-example.component.html';
 import * as customErrorsSrc from '!raw-loader!./platform-form-generator-examples/platform-form-generator-custom-error-example.component.ts';
 
+import * as formFieldLayoutGeneratorhtml from '!raw-loader!./platform-form-generator-examples/platform-form-generator-field-layout-example.component.html';
+import * as formFieldLayoutGeneratorSrc from '!raw-loader!./platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts';
+
 import { ExampleFile } from '../../../../documentation/core-helpers/code-example/example-file';
 
 @Component({
@@ -88,6 +91,20 @@ export class PlatformFormGeneratorDocsComponent {
             code: customErrorsSrc,
             fileName: 'platform-form-generator-custom-error-example',
             component: 'PlatformFormGeneratorCustomErrorExampleComponent'
+        }
+    ];
+
+    formFieldLayoutGenerator: ExampleFile[] = [
+        {
+            language: 'html',
+            code: formFieldLayoutGeneratorhtml,
+            fileName: 'platform-form-generator-field-layout-example'
+        },
+        {
+            language: 'typescript',
+            code: formFieldLayoutGeneratorSrc,
+            fileName: 'platform-form-generator-field-layout-example',
+            component: 'PlatformFormGeneratorFieldLayoutExampleComponent'
         }
     ];
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.module.ts
@@ -15,6 +15,7 @@ import {
 import { PlatformFormGeneratorObservableExampleComponent } from './platform-form-generator-examples/platform-form-generator-observable-example.component';
 import { PlatformFormGeneratorProgramaticSubmitComponent } from './platform-form-generator-examples/platform-form-generator-programatic-submit.component';
 import { PlatformFormGeneratorCustomErrorExampleComponent } from './platform-form-generator-examples/platform-form-generator-custom-error-example.component';
+import { PlatformFormGeneratorFieldLayoutExampleComponent } from './platform-form-generator-examples/platform-form-generator-field-layout-example.component';
 
 const routes: Routes = [
     {
@@ -48,6 +49,7 @@ const routes: Routes = [
         PlatformFormGeneratorObservableExampleComponent,
         PlatformFormGeneratorProgramaticSubmitComponent,
         PlatformFormGeneratorCustomErrorExampleComponent,
+        PlatformFormGeneratorFieldLayoutExampleComponent,
     ]
 })
 export class PlatformFormGeneratorDocsModule {}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.html
@@ -1,0 +1,10 @@
+<fdp-form-generator columnLayout="XL2-L2-M2-S1" mainTitle="Form Generator with field layout example" [formItems]="questions" (formSubmitted)="onFormSubmitted($event)" (formCreated)="onFormCreated()">
+</fdp-form-generator>
+
+<fdp-button *ngIf="formCreated" (click)="submitForm()" type="submit" label="Submit form"></fdp-button>
+
+<p>Form created: {{ formCreated }}</p>
+
+<p *ngIf="formValue">
+    Form value: {{ formValue|json }}
+</p>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
@@ -45,7 +45,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
     questions: DynamicFormItem[] = [
         {
             type: 'input',
-            name: 'name',
+            name: 'name1',
             message: 'Your name: XL: 1, L: 2, M: 1, S: 2',
             default: 'John',
             guiOptions: {
@@ -66,7 +66,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'password',
             controlType: 'password',
-            name: 'password',
+            name: 'password1',
             message: 'Password: XL: 1, L: 2, M: 2, S: 1',
             validators: [Validators.required],
             validate: (value: string) => {
@@ -82,7 +82,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         },
         {
             type: 'number',
-            name: 'age',
+            name: 'age1',
             message: () => 'Your age: XL: 1, L: 2, M: 1, S: 1',
             default: '18',
             validators: [Validators.required],
@@ -93,7 +93,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         },
         {
             type: 'editor',
-            name: 'bio',
+            name: 'bio1',
             message: 'Your biography: XL: 2, L: 1, M: 2, S: 1',
             guiOptions: {
                 columnLayout: { XL: 2, L: 1, M: 2, S: 1 },
@@ -102,7 +102,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         },
         {
             type: 'checkbox',
-            name: 'citizenship',
+            name: 'citizenship1',
             message: 'Your citizenship: XL: 2 true, L: 1 false, M: 2 true, S: 1 false',
             guiOptions: {
                 inline: true,
@@ -126,7 +126,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         },
         {
             type: 'list',
-            name: 'department',
+            name: 'department1',
             message: 'Department you work in: column: 2',
             validators: [Validators.required],
             default: 'IT',
@@ -138,7 +138,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         },
         {
             type: 'list',
-            name: 'main_speciality',
+            name: 'main_speciality1',
             message: 'Main speciality: XL: 2, L: 1, M: 1, S: 1',
             validators: [Validators.required],
             choices: async () => {
@@ -156,7 +156,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         },
         {
             type: 'confirm',
-            name: 'agree',
+            name: 'agree1',
             message: 'Do you agree with terms and conditions?: XL: 2, L: 1, M: 2, S: 1',
             choices: ['Yes', 'No'],
             validate: async (value) => {
@@ -170,7 +170,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         },
         {
             type: 'radio',
-            name: 'choose_best_option',
+            name: 'choose_best_option1',
             message: 'Primary front-end framework: XL: 2 false, L: 1 true, M: 1 false, S: 1 true',
             choices: ['Angular', 'React', 'VueJS'],
             guiOptions: {
@@ -184,7 +184,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         },
         {
             type: 'datepicker',
-            name: 'birthday',
+            name: 'birthday1',
             message: 'Your birthday: XL: 1, L: 2, M: 1, S: 1',
             guiOptions: {
                 columnLayout: { XL: 1, L: 2, M: 1, S: 1 },
@@ -200,7 +200,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         },
         {
             type: 'switch',
-            name: 'enable_feature',
+            name: 'enable_feature1',
             message: 'Enable some analytics',
             default: false,
             guiOptions: {

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
@@ -1,0 +1,232 @@
+import { Component, ViewChild } from '@angular/core';
+import { Validators } from '@angular/forms';
+import {
+    DatetimeAdapter,
+    DATE_TIME_FORMATS,
+    FdDate,
+    FdDatetimeAdapter,
+    FD_DATETIME_FORMATS
+} from '@fundamental-ngx/core/datetime';
+
+import { DynamicFormItem, DynamicFormValue, FormGeneratorComponent } from '@fundamental-ngx/platform';
+
+export const dummyAwaitablePromise = (timeout = 200) => {
+    return new Promise<boolean>((resolve) => {
+        setTimeout(() => {
+            resolve(true);
+        }, timeout);
+    });
+};
+
+@Component({
+    selector: 'fdp-platform-form-generator-field-layout-example',
+    templateUrl: './platform-form-generator-field-layout-example.component.html',
+    providers: [
+        // Note that this is usually provided in the root of your application.
+        // Due to the limit of this example we must provide it on this level.
+        {
+            provide: DatetimeAdapter,
+            useClass: FdDatetimeAdapter
+        },
+        {
+            provide: DATE_TIME_FORMATS,
+            useValue: FD_DATETIME_FORMATS
+        }
+    ]
+})
+export class PlatformFormGeneratorFieldLayoutExampleComponent {
+    @ViewChild(FormGeneratorComponent) formGenerator: FormGeneratorComponent;
+
+    loading = false;
+
+    formCreated = false;
+    formValue: DynamicFormValue;
+
+    questions: DynamicFormItem[] = [
+        {
+            type: 'input',
+            name: 'name',
+            message: 'Your name: XL: 1, L: 2, M: 1, S: 2',
+            default: 'John',
+            guiOptions: {
+                hint: 'Some contextual hint: XL: 1, L: 2, M: 1, S: 2',
+                columnLayout: { XL: 1, L: 2, M: 1, S: 1 },
+            },
+            validate: async (value) => {
+                await dummyAwaitablePromise();
+
+                return value === 'John' ? null : 'Your name should be John';
+            },
+            transformer: async (value: any) => {
+                await dummyAwaitablePromise();
+                return `${value}777`;
+            },
+            validators: [Validators.required]
+        },
+        {
+            type: 'password',
+            controlType: 'password',
+            name: 'password',
+            message: 'Password: XL: 1, L: 2, M: 2, S: 1',
+            validators: [Validators.required],
+            validate: (value: string) => {
+                const passwordPattern = new RegExp('^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[^\\w\\s]).{8,}$');
+                return passwordPattern.test(value)
+                    ? null
+                    : 'Minimum eight characters, at least one letter, one number and one special character';
+            },
+            guiOptions: {
+                hint: 'XL: 1, L: 2, M: 2, S: 1',
+                columnLayout: { XL: 1, L: 2, M: 2, S: 1 },
+            }
+        },
+        {
+            type: 'number',
+            name: 'age',
+            message: () => 'Your age: XL: 1, L: 2, M: 1, S: 1',
+            default: '18',
+            validators: [Validators.required],
+            guiOptions: {
+                columnLayout: { XL: 1, L: 2, M: 1, S: 1 },
+                hint: 'XL: 1, L: 2, M: 1, S: 1',
+            }
+        },
+        {
+            type: 'editor',
+            name: 'bio',
+            message: 'Your biography: XL: 2, L: 1, M: 2, S: 1',
+            guiOptions: {
+                columnLayout: { XL: 2, L: 1, M: 2, S: 1 },
+                hint: 'XL: 2, L: 1, M: 2, S: 1',
+            }
+        },
+        {
+            type: 'checkbox',
+            name: 'citizenship',
+            message: 'Your citizenship: XL: 2 true, L: 1 false, M: 2 true, S: 1 false',
+            guiOptions: {
+                inline: true,
+                columnLayout: { XL: 2, L: 1, M: 2, S: 1 },
+                inlineLayout: { XL: true, L: false, M: true, S: false },
+                hint: 'XL: 2 true, L: 1 false, M: 2 true, S: 1 false',
+            },
+            choices: (formValue) => {
+                return [
+                    'USA',
+                    'Germany',
+                    {
+                        label: 'Ukraine',
+                        value: 'Ukraine'
+                    }
+                ];
+            },
+            validate: (input, formValue) => {
+                return input?.length > 0 ? null : 'You need to select some country';
+            }
+        },
+        {
+            type: 'list',
+            name: 'department',
+            message: 'Department you work in: column: 2',
+            validators: [Validators.required],
+            default: 'IT',
+            choices: ['IT', 'Accounting', 'Management'],
+            guiOptions: {
+                column: 2,
+                hint: 'column: 2',
+            }
+        },
+        {
+            type: 'list',
+            name: 'main_speciality',
+            message: 'Main speciality: XL: 2, L: 1, M: 1, S: 1',
+            validators: [Validators.required],
+            choices: async () => {
+                await dummyAwaitablePromise();
+                return ['Front-end', 'Back-end'];
+            },
+            when: async (formValue: any) => {
+                await dummyAwaitablePromise();
+                return formValue.department === 'IT';
+            },
+            guiOptions: {
+                columnLayout: { XL: 2, L: 1, M: 1, S: 1 },
+                hint: 'XL: 2, L: 1, M: 1, S: 1',
+            }
+        },
+        {
+            type: 'confirm',
+            name: 'agree',
+            message: 'Do you agree with terms and conditions?: XL: 2, L: 1, M: 2, S: 1',
+            choices: ['Yes', 'No'],
+            validate: async (value) => {
+                await dummyAwaitablePromise();
+                return value === 'Yes' ? null : 'You must agree';
+            },
+            guiOptions: {
+                columnLayout: { XL: 2, L: 1, M: 2, S: 1 },
+                hint: 'XL: 2, L: 1, M: 2, S: 1',
+            }
+        },
+        {
+            type: 'radio',
+            name: 'choose_best_option',
+            message: 'Primary front-end framework: XL: 2 false, L: 1 true, M: 1 false, S: 1 true',
+            choices: ['Angular', 'React', 'VueJS'],
+            guiOptions: {
+                columnLayout: { XL: 2, L: 1, M: 1 },
+                inlineLayout: { XL: false, L: true, M: false, S: true },
+                hint: 'XL: 2 false, L: 1 true, M: 1 false, S: 1 true'
+            },
+            validate: (result: string) => {
+                return result === 'Angular' ? null : 'You should pick Angular';
+            }
+        },
+        {
+            type: 'datepicker',
+            name: 'birthday',
+            message: 'Your birthday: XL: 1, L: 2, M: 1, S: 1',
+            guiOptions: {
+                columnLayout: { XL: 1, L: 2, M: 1, S: 1 },
+                hint: 'XL: 1, L: 2, M: 1, S: 1'
+            },
+            validators: [Validators.required],
+            validate: (value: FdDate) => {
+                return value !== null && value.year < 2020 ? null : 'You need to be born before 2020';
+            },
+            transformer: (value: FdDate) => {
+                return value?.toDateString();
+            }
+        },
+        {
+            type: 'switch',
+            name: 'enable_feature',
+            message: 'Enable some analytics',
+            default: false,
+            guiOptions: {
+                additionalData: {
+                    semantic: true
+                }
+            }
+        }
+    ];
+
+    onFormCreated(): void {
+        this.formCreated = true;
+    }
+
+    async onFormSubmitted(value: DynamicFormValue): Promise<void> {
+        this.formValue = value;
+
+        this.loading = true;
+
+        // Simulate API request
+        await dummyAwaitablePromise(5000);
+
+        this.loading = false;
+    }
+
+    submitForm(): void {
+        this.formGenerator.submit();
+    }
+}

--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
@@ -13,7 +13,8 @@ import {
     Optional,
     Self,
     SkipSelf,
-    Host
+    Host,
+    NgZone
 } from '@angular/core';
 import { NgForm, NgControl } from '@angular/forms';
 
@@ -83,9 +84,10 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
         @Optional() @Self() ngControl: NgControl,
         @Optional() @SkipSelf() ngForm: NgForm,
         @Optional() @SkipSelf() @Host() formField: FormField,
-        @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>
+        @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>,
+        _ngZone: NgZone
     ) {
-        super(cd, ngControl, ngForm, formField, formControl);
+        super(cd, ngControl, ngForm, formField, formControl, _ngZone);
     }
 
     writeValue(value: any): void {

--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
@@ -13,7 +13,8 @@ import {
     Optional,
     Self,
     SkipSelf,
-    Host
+    Host,
+    OnInit
 } from '@angular/core';
 import { NgForm, NgControl } from '@angular/forms';
 
@@ -37,7 +38,7 @@ import { FormField } from '../form-field';
     encapsulation: ViewEncapsulation.None,
     providers: [{ provide: FormFieldControl, useExisting: forwardRef(() => CheckboxGroupComponent), multi: true }]
 })
-export class CheckboxGroupComponent extends CollectionBaseInput {
+export class CheckboxGroupComponent extends CollectionBaseInput implements OnInit {
     /**
      * value for selected checkboxes.
      */
@@ -47,12 +48,6 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
     set value(selectedValue: any) {
         super.setValue(selectedValue);
     }
-
-    /**
-     * To Display multiple checkboxes in a line
-     */
-    @Input()
-    isInline = false;
 
     /**
      * Establishes two way binding, when checkbox group used outside form.
@@ -92,6 +87,10 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
         @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>
     ) {
         super(cd, ngControl, ngForm, formField, formControl);
+    }
+
+    ngOnInit(): void {
+        super.ngOnInit();
     }
 
     writeValue(value: any): void {

--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
@@ -17,11 +17,13 @@ import {
     NgZone
 } from '@angular/core';
 import { NgForm, NgControl } from '@angular/forms';
+import { distinctUntilChanged } from 'rxjs/operators';
 
 import { CollectionBaseInput } from '../collection-base.input';
 import { CheckboxComponent } from '../checkbox/checkbox.component';
 import { PlatformCheckboxChange } from '../checkbox/checkbox.component';
 import { FormFieldControl } from '../form-control';
+import { InlineLayout } from '../form-options';
 import { FormField } from '../form-field';
 
 /**
@@ -47,6 +49,31 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
     }
     set value(selectedValue: any) {
         super.setValue(selectedValue);
+    }
+
+    /**
+     * To Display multiple checkboxes in a line
+     */
+    @Input()
+    get isInline(): boolean {
+        return this._isInline;
+    }
+
+    set isInline(inline: boolean) {
+        this._isInline = inline;
+        this._cd.markForCheck();
+    }
+
+    /** object to change isInline property based on screen size */
+    @Input()
+    get inlineLayout(): InlineLayout {
+        return this._inlineLayout;
+    }
+
+    set inlineLayout(layout: InlineLayout) {
+        this._inlineLayout = layout;
+        this._setFieldLayout(layout);
+        this.isInline = this._isInlineCurrent;
     }
 
     /**
@@ -79,6 +106,12 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
     /** @hidden used for two way binding, when used outside form */
     private _checked: string[];
 
+    /** @hidden */
+    private _inlineLayout: InlineLayout;
+
+    /** @hidden */
+    private _isInline: boolean;
+
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() ngControl: NgControl,
@@ -88,6 +121,10 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
         _ngZone: NgZone
     ) {
         super(cd, ngControl, ngForm, formField, formControl, _ngZone);
+        // subscribe to _inlineCurrentValue in collection-base-input
+        this._inlineCurrentValue
+            .pipe(distinctUntilChanged())
+            .subscribe((currentInline) => (this.isInline = currentInline));
     }
 
     writeValue(value: any): void {

--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
@@ -17,7 +17,6 @@ import {
     Inject
 } from '@angular/core';
 import { NgForm, NgControl } from '@angular/forms';
-import { BreakpointObserver } from '@angular/cdk/layout';
 import { distinctUntilChanged } from 'rxjs/operators';
 
 import {
@@ -105,7 +104,6 @@ export class CheckboxGroupComponent extends InLineLayoutCollectionBaseInput {
     constructor(
         cd: ChangeDetectorRef,
         readonly _responsiveBreakpointsService: ResponsiveBreakpointsService,
-        readonly _breakpointObserver: BreakpointObserver,
         @Optional() @Self() ngControl: NgControl,
         @Optional() @SkipSelf() ngForm: NgForm,
         @Optional() @SkipSelf() @Host() formField: FormField,
@@ -114,9 +112,7 @@ export class CheckboxGroupComponent extends InLineLayoutCollectionBaseInput {
         @Inject(RESPONSIVE_BREAKPOINTS_CONFIG)
         readonly _defaultResponsiveBreakPointConfig: ResponsiveBreakPointConfig
     ) {
-        super(cd, _responsiveBreakpointsService, _breakpointObserver, ngControl, ngForm, formField, formControl);
-
-        this._responsiveBreakPointConfig = _defaultResponsiveBreakPointConfig || new ResponsiveBreakPointConfig();
+        super(cd, _responsiveBreakpointsService, ngControl, ngForm, formField, formControl, _defaultResponsiveBreakPointConfig);
 
         // subscribe to _inlineCurrentValue in collection-form-field-inline-layout
         this._inlineCurrentValue

--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
@@ -13,8 +13,7 @@ import {
     Optional,
     Self,
     SkipSelf,
-    Host,
-    OnInit
+    Host
 } from '@angular/core';
 import { NgForm, NgControl } from '@angular/forms';
 
@@ -38,7 +37,7 @@ import { FormField } from '../form-field';
     encapsulation: ViewEncapsulation.None,
     providers: [{ provide: FormFieldControl, useExisting: forwardRef(() => CheckboxGroupComponent), multi: true }]
 })
-export class CheckboxGroupComponent extends CollectionBaseInput implements OnInit {
+export class CheckboxGroupComponent extends CollectionBaseInput {
     /**
      * value for selected checkboxes.
      */
@@ -87,10 +86,6 @@ export class CheckboxGroupComponent extends CollectionBaseInput implements OnIni
         @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>
     ) {
         super(cd, ngControl, ngForm, formField, formControl);
-    }
-
-    ngOnInit(): void {
-        super.ngOnInit();
     }
 
     writeValue(value: any): void {

--- a/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
+++ b/libs/platform/src/lib/components/form/checkbox-group/checkbox-group.component.ts
@@ -14,16 +14,21 @@ import {
     Self,
     SkipSelf,
     Host,
-    NgZone
+    Inject
 } from '@angular/core';
 import { NgForm, NgControl } from '@angular/forms';
+import { BreakpointObserver } from '@angular/cdk/layout';
 import { distinctUntilChanged } from 'rxjs/operators';
 
-import { CollectionBaseInput } from '../collection-base.input';
+import {
+    InLineLayoutCollectionBaseInput,
+    ResponsiveBreakPointConfig,
+    ResponsiveBreakpointsService,
+    RESPONSIVE_BREAKPOINTS_CONFIG
+} from '../inline-layout-collection-base.input';
 import { CheckboxComponent } from '../checkbox/checkbox.component';
 import { PlatformCheckboxChange } from '../checkbox/checkbox.component';
 import { FormFieldControl } from '../form-control';
-import { InlineLayout } from '../form-options';
 import { FormField } from '../form-field';
 
 /**
@@ -40,7 +45,7 @@ import { FormField } from '../form-field';
     encapsulation: ViewEncapsulation.None,
     providers: [{ provide: FormFieldControl, useExisting: forwardRef(() => CheckboxGroupComponent), multi: true }]
 })
-export class CheckboxGroupComponent extends CollectionBaseInput {
+export class CheckboxGroupComponent extends InLineLayoutCollectionBaseInput {
     /**
      * value for selected checkboxes.
      */
@@ -62,18 +67,6 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
     set isInline(inline: boolean) {
         this._isInline = inline;
         this._cd.markForCheck();
-    }
-
-    /** object to change isInline property based on screen size */
-    @Input()
-    get inlineLayout(): InlineLayout {
-        return this._inlineLayout;
-    }
-
-    set inlineLayout(layout: InlineLayout) {
-        this._inlineLayout = layout;
-        this._setFieldLayout(layout);
-        this.isInline = this._isInlineCurrent;
     }
 
     /**
@@ -107,21 +100,25 @@ export class CheckboxGroupComponent extends CollectionBaseInput {
     private _checked: string[];
 
     /** @hidden */
-    private _inlineLayout: InlineLayout;
-
-    /** @hidden */
     private _isInline: boolean;
 
     constructor(
         cd: ChangeDetectorRef,
+        readonly _responsiveBreakpointsService: ResponsiveBreakpointsService,
+        readonly _breakpointObserver: BreakpointObserver,
         @Optional() @Self() ngControl: NgControl,
         @Optional() @SkipSelf() ngForm: NgForm,
         @Optional() @SkipSelf() @Host() formField: FormField,
         @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>,
-        _ngZone: NgZone
+        @Optional()
+        @Inject(RESPONSIVE_BREAKPOINTS_CONFIG)
+        readonly _defaultResponsiveBreakPointConfig: ResponsiveBreakPointConfig
     ) {
-        super(cd, ngControl, ngForm, formField, formControl, _ngZone);
-        // subscribe to _inlineCurrentValue in collection-base-input
+        super(cd, _responsiveBreakpointsService, _breakpointObserver, ngControl, ngForm, formField, formControl);
+
+        this._responsiveBreakPointConfig = _defaultResponsiveBreakPointConfig || new ResponsiveBreakPointConfig();
+
+        // subscribe to _inlineCurrentValue in collection-form-field-inline-layout
         this._inlineCurrentValue
             .pipe(distinctUntilChanged())
             .subscribe((currentInline) => (this.isInline = currentInline));

--- a/libs/platform/src/lib/components/form/collection-base.input.ts
+++ b/libs/platform/src/lib/components/form/collection-base.input.ts
@@ -1,12 +1,12 @@
 import { Input, Directive, OnInit } from '@angular/core';
-import { BaseInput } from './base.input';
-import { isSelectItem } from '../../domain/data-model';
-import { isFunction, isJsObject, isString } from '../../utils/lang';
-import { SelectItem } from '../../domain/data-model';
-import { fromEvent } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { InlineLayout } from './../form/form-options';
+import { fromEvent } from 'rxjs';
 
+import { InlineLayout, RESPONSIVE_BREAKPOINTS } from './../form/form-options';
+import { isFunction, isJsObject, isString } from '../../utils/lang';
+import { isSelectItem } from '../../domain/data-model';
+import { SelectItem } from '../../domain/data-model';
+import { BaseInput } from './base.input';
 
 /**
  * Defines specific behavior for Input controls which deals with list of values including:
@@ -68,16 +68,31 @@ export abstract class CollectionBaseInput extends BaseInput implements OnInit {
         this._inlineLayout = layout;
     }
 
+    /** @hidden */
     private _inlineLayout: InlineLayout;
+
+    /** @hidden */
     private _isInline: boolean;
+
+    /** @hidden */
     private _xlIsInline: boolean;
+
+    /** @hidden */
     private _lgIsInline: boolean;
+
+    /** @hidden */
     private _mdIsInline: boolean;
+
+    /** @hidden */
     private _sIsInline: boolean;
+
+    /** @hidden */
     private _isInLineLayoutEnabled = true;
 
+    /** @hidden */
     ngOnInit(): void {
         this._setFieldLayout();
+        super.ngOnInit();
     }
 
     protected lookupValue(item: any): string {
@@ -112,12 +127,13 @@ export abstract class CollectionBaseInput extends BaseInput implements OnInit {
         }
     }
 
+    /** set values of inline for each screen layout */
     protected _setFieldLayout(): void {
         try {
-            this._xlIsInline = this.inlineLayout['XL'];
-            this._lgIsInline = this.inlineLayout['L'];
+            this._sIsInline = this.inlineLayout['S'] || false;
             this._mdIsInline = this.inlineLayout['M'];
-            this._sIsInline = this.inlineLayout['S'];
+            this._lgIsInline = this.inlineLayout['L'];
+            this._xlIsInline = this.inlineLayout['XL'];
             this._updateLayout();
         } catch (error) {
             this._isInLineLayoutEnabled = false;
@@ -135,13 +151,21 @@ export abstract class CollectionBaseInput extends BaseInput implements OnInit {
         const width = window.innerWidth;
 
         // check if value has changed, then only assign new value.
-        if (width > 0 && width < 600 && this.isInline !== this._sIsInline) {
+        if (width > 0 && width < RESPONSIVE_BREAKPOINTS['S'] && this.isInline !== this._sIsInline) {
             this.isInline = this._sIsInline;
-        } else if (width >= 600 && width < 1024 && this.isInline !== this._mdIsInline) {
+        } else if (
+            width >= RESPONSIVE_BREAKPOINTS['S'] &&
+            width < RESPONSIVE_BREAKPOINTS['M'] &&
+            this.isInline !== this._mdIsInline
+        ) {
             this.isInline = this._mdIsInline;
-        } else if (width >= 1024 && width < 1440 && this.isInline !== this._lgIsInline) {
+        } else if (
+            width >= RESPONSIVE_BREAKPOINTS['M'] &&
+            width < RESPONSIVE_BREAKPOINTS['L'] &&
+            this.isInline !== this._lgIsInline
+        ) {
             this.isInline = this._lgIsInline;
-        } else if (width >= 1440 && this.isInline !== this._xlIsInline) {
+        } else if (width >= RESPONSIVE_BREAKPOINTS['L'] && this.isInline !== this._xlIsInline) {
             this.isInline = this._xlIsInline;
         }
     }

--- a/libs/platform/src/lib/components/form/form-generator/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.html
+++ b/libs/platform/src/lib/components/form/form-generator/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.html
@@ -2,6 +2,7 @@
     <fdp-checkbox-group
         [contentDensity]="formItem.guiOptions?.contentDensity"
         [isInline]="formItem.guiOptions?.inline || false"
+        [inlineLayout]="formItem.guiOptions?.inlineLayout"
         [name]="name"
         [list]="formItem.choices"
         [formControlName]="name"

--- a/libs/platform/src/lib/components/form/form-generator/dynamic-form-generator-radio/dynamic-form-generator-radio.component.html
+++ b/libs/platform/src/lib/components/form/form-generator/dynamic-form-generator-radio/dynamic-form-generator-radio.component.html
@@ -2,6 +2,7 @@
     <fdp-radio-group
         [contentDensity]="formItem.guiOptions?.contentDensity"
         [isInline]="formItem.guiOptions?.inline || false"
+        [inlineLayout]="formItem.guiOptions?.inlineLayout"
         [name]="name"
         [list]="formItem.choices"
         [formControlName]="name"

--- a/libs/platform/src/lib/components/form/form-generator/form-generator/form-generator.component.html
+++ b/libs/platform/src/lib/components/form/form-generator/form-generator/form-generator.component.html
@@ -17,6 +17,7 @@
                     [id]="field.formItem?.name"
                     [i18Strings]="i18n"
                     [column]="field.formItem?.guiOptions?.column || 1"
+                    [columnLayout]="field.formItem?.guiOptions?.columnLayout"
                     [label]="field.formItem?.message"
                     [validators]="field.formItem?.validators"
                     [required]="field.formItem?.required"

--- a/libs/platform/src/lib/components/form/form-generator/interfaces/dynamic-form-item.ts
+++ b/libs/platform/src/lib/components/form/form-generator/interfaces/dynamic-form-item.ts
@@ -3,7 +3,8 @@ import { Observable } from 'rxjs';
 
 import { SelectItem } from '../../../../domain/data-model';
 import { InputType } from '../../input/input.component';
-import { ColumnLayout, HintPlacement, InlineLayout, LabelLayout } from '../../form-options';
+import { ColumnLayout, HintPlacement, LabelLayout } from '../../form-options';
+import { InlineLayout } from '../../inline-layout-collection-base.input';
 import { ContentDensity } from '../../form-control';
 
 export type DynamicFormItemChoices = number | string | SelectItem;
@@ -55,17 +56,18 @@ export interface DynamicFormItem {
      * @description
      * Default value of the form item.
      */
-    default?: any | ((formValue?: DynamicFormValue) => any | Promise<any>| Observable<any>);
+    default?: any | ((formValue?: DynamicFormValue) => any | Promise<any> | Observable<any>);
 
     /**
      * @description
      * The list of available options to select.
      * @param formValue raw form item value.
      */
-    choices?: DynamicFormItemChoices[] |
-    ((formValue?: DynamicFormValue) => DynamicFormItemChoices[]
-    | Promise<DynamicFormItemChoices[]>
-    | Observable<DynamicFormItemChoices[]>);
+    choices?:
+        | DynamicFormItemChoices[]
+        | ((
+              formValue?: DynamicFormValue
+          ) => DynamicFormItemChoices[] | Promise<DynamicFormItemChoices[]> | Observable<DynamicFormItemChoices[]>);
 
     /**
      * @description
@@ -76,8 +78,13 @@ export interface DynamicFormItem {
      * @param formValue the form value hash.
      * @returns null or String
      */
-    validate?: (formItemValue?: any, formValue?: DynamicFormValue) =>
-    DynamicFormItemValidationResult | Promise<DynamicFormItemValidationResult> | Observable<DynamicFormItemValidationResult>;
+    validate?: (
+        formItemValue?: any,
+        formValue?: DynamicFormValue
+    ) =>
+        | DynamicFormItemValidationResult
+        | Promise<DynamicFormItemValidationResult>
+        | Observable<DynamicFormItemValidationResult>;
 
     /**
      * @description
@@ -127,7 +134,6 @@ export interface DynamicFormItem {
 }
 
 export interface DynamicFormItemGuiOptions {
-
     /**
      * @description
      * Index of column if form has multi-column layout

--- a/libs/platform/src/lib/components/form/form-generator/interfaces/dynamic-form-item.ts
+++ b/libs/platform/src/lib/components/form/form-generator/interfaces/dynamic-form-item.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 
 import { SelectItem } from '../../../../domain/data-model';
 import { InputType } from '../../input/input.component';
-import { HintPlacement, LabelLayout } from '../../form-options';
+import { ColumnLayout, HintPlacement, InlineLayout, LabelLayout } from '../../form-options';
 import { ContentDensity } from '../../form-control';
 
 export type DynamicFormItemChoices = number | string | SelectItem;
@@ -133,6 +133,12 @@ export interface DynamicFormItemGuiOptions {
      * Index of column if form has multi-column layout
      */
     column?: number;
+
+    /** column arrangement for form-field based on screen size */
+    columnLayout?: ColumnLayout;
+
+    /** inline layout for list based form item */
+    inlineLayout?: InlineLayout;
 
     /**
      * @description

--- a/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.ts
+++ b/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.ts
@@ -24,7 +24,7 @@ import { debounceTime, startWith, takeUntil } from 'rxjs/operators';
 
 import { FormFieldControl } from '../../form-control';
 import { FormField } from '../../form-field';
-import { Column, LabelLayout, HintPlacement, ColumnLayout } from '../../form-options';
+import { Column, ColumnLayout, HintPlacement, LabelLayout, RESPONSIVE_BREAKPOINTS } from '../../form-options';
 import { FormGroupContainer } from '../../form-group';
 import { FormFieldGroup } from '../../form-field-group';
 import { FORM_GROUP_CHILD_FIELD_TOKEN } from '../constants';
@@ -397,10 +397,10 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
     /** @hidden */
     private _setColumnNumber(): void {
         try {
-            this._xlColumnNumber = this.columnLayout['XL'];
-            this._lgColumnNumber = this.columnLayout['L'];
-            this._mdColumnNumber = this.columnLayout['M'];
             this._sColumnNumber = this.columnLayout['S'] || 1;
+            this._mdColumnNumber = this.columnLayout['M'] || this._sColumnNumber;
+            this._lgColumnNumber = this.columnLayout['L'] || this._mdColumnNumber;
+            this._xlColumnNumber = this.columnLayout['XL'] || this._lgColumnNumber;
         } catch (error) {
             this._isColumnLayoutEnabled = false;
         }
@@ -425,16 +425,24 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
 
         if (this._isColumnLayoutEnabled) {
             // check if value has changed, then only assign new value.
-            if (width > 0 && width < 600 && this._sColumnNumber !== this.column) {
+            if (width > 0 && width < RESPONSIVE_BREAKPOINTS['S'] && this._sColumnNumber !== this.column) {
                 this.column = this._sColumnNumber;
                 columnUpdated = true;
-            } else if (width >= 600 && width < 1024 && this._mdColumnNumber !== this.column) {
+            } else if (
+                width >= RESPONSIVE_BREAKPOINTS['S'] &&
+                width < RESPONSIVE_BREAKPOINTS['M'] &&
+                this._mdColumnNumber !== this.column
+            ) {
                 this.column = this._mdColumnNumber;
                 columnUpdated = true;
-            } else if (width >= 1024 && width < 1440 && this._lgColumnNumber !== this.column) {
+            } else if (
+                width >= RESPONSIVE_BREAKPOINTS['M'] &&
+                width < RESPONSIVE_BREAKPOINTS['L'] &&
+                this._lgColumnNumber !== this.column
+            ) {
                 this.column = this._lgColumnNumber;
                 columnUpdated = true;
-            } else if (width >= 1440 && this._xlColumnNumber !== this.column) {
+            } else if (width >= RESPONSIVE_BREAKPOINTS['L'] && this._xlColumnNumber !== this.column) {
                 this.column = this._xlColumnNumber;
                 columnUpdated = true;
             }

--- a/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.ts
+++ b/libs/platform/src/lib/components/form/form-group/form-field/form-field.component.ts
@@ -20,7 +20,6 @@ import {
 } from '@angular/core';
 import { FormControl, FormGroup, ValidatorFn, Validators, AbstractControl } from '@angular/forms';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
-import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
 import { Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 
@@ -209,7 +208,6 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
     /** @hidden */
     constructor(
         private _cd: ChangeDetectorRef,
-        private _breakpointObserver: BreakpointObserver,
         @Optional() formGroupContainer: FormGroupContainer,
         @Optional() @SkipSelf() @Host() readonly formFieldGroup: FormFieldGroup,
         @Optional()
@@ -236,9 +234,9 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
         }
 
         if (this._isColumnLayoutEnabled) {
-            this._breakpointObserver
-                .observe(this._responsiveBreakpointsService.getBreakpoints(this._responsiveBreakPointConfig))
-                .subscribe((result) => this._breakPointMeet(result));
+            this._responsiveBreakpointsService
+                .observeBreakpointByConfig(this._responsiveBreakPointConfig)
+                .subscribe((breakPointName) => this._updateLayout(breakPointName));
         }
 
         this.addToFormGroup();
@@ -461,17 +459,5 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
 
         // emit column change, so form-group knows it and re-arranges the fields
         this.onColumnChange.emit(true);
-    }
-
-    /** @hidden when screen size changes from one breakpoint to another */
-    private _breakPointMeet(breakPoints: BreakpointState): void {
-        if (breakPoints.matches) {
-            for (const breakpoint in breakPoints.breakpoints) {
-                if (breakPoints.breakpoints[breakpoint]) {
-                    const breakPointName = this._responsiveBreakpointsService.getBreakpointName(breakpoint);
-                    this._updateLayout(breakPointName);
-                }
-            }
-        }
     }
 }

--- a/libs/platform/src/lib/components/form/form-group/form-group.component.ts
+++ b/libs/platform/src/lib/components/form/form-group/form-group.component.ts
@@ -48,7 +48,7 @@ import { HintPlacement, LabelLayout } from '../form-options';
 import { FormFieldGroup } from '../form-field-group';
 import { Field, FieldGroup, FieldColumn, isFieldChild, isFieldGroupChild, getField } from '../form-helpers';
 import { FORM_GROUP_CHILD_FIELD_TOKEN } from './constants';
-import { filter, map, startWith } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 
 export const formGroupProvider: Provider = {
     provide: FormGroupContainer,
@@ -354,7 +354,7 @@ export class FormGroupComponent implements FormGroupContainer, OnInit, AfterCont
     /** @hidden */
     private _listenFormFieldColumnChange(): void {
         this.formGroupChildren.forEach((field: FormFieldComponent) =>
-            field.onColumnChange?.subscribe((_) => {
+            field.onColumnChange?.pipe(takeUntil(this._destroyed)).subscribe((_) => {
                 this._updateFieldByColumn();
                 this._cd.markForCheck();
             })

--- a/libs/platform/src/lib/components/form/form-group/form-group.component.ts
+++ b/libs/platform/src/lib/components/form/form-group/form-group.component.ts
@@ -42,6 +42,7 @@ import { Subject } from 'rxjs';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
 import { FormField } from '../form-field';
+import { FormFieldComponent } from './form-field/form-field.component';
 import { FormGroupContainer } from '../form-group';
 import { HintPlacement, LabelLayout } from '../form-options';
 import { FormFieldGroup } from '../form-field-group';
@@ -284,7 +285,7 @@ export class FormGroupComponent implements FormGroupContainer, OnInit, AfterCont
         this._updateFieldByColumn();
         this._updateFormFieldsProperties();
         this._listenToFormGroupChildren();
-
+        this._listenFormFieldColumnChange();
         this._cd.markForCheck();
     }
 
@@ -348,6 +349,16 @@ export class FormGroupComponent implements FormGroupContainer, OnInit, AfterCont
             this._updateFieldByColumn();
             this._cd.markForCheck();
         });
+    }
+
+    /** @hidden */
+    private _listenFormFieldColumnChange(): void {
+        this.formGroupChildren.forEach((field: FormFieldComponent) =>
+            field.onColumnChange?.subscribe((_) => {
+                this._updateFieldByColumn();
+                this._cd.markForCheck();
+            })
+        );
     }
 
     /**

--- a/libs/platform/src/lib/components/form/form-group/form-group.component.ts
+++ b/libs/platform/src/lib/components/form/form-group/form-group.component.ts
@@ -37,18 +37,18 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { AbstractControl, ControlContainer, FormGroup } from '@angular/forms';
-import { KeyValue } from '@angular/common';
-import { Subject } from 'rxjs';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { KeyValue } from '@angular/common';
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 
-import { FormField } from '../form-field';
+import { Field, FieldGroup, FieldColumn, isFieldChild, isFieldGroupChild, getField } from '../form-helpers';
 import { FormFieldComponent } from './form-field/form-field.component';
 import { FormGroupContainer } from '../form-group';
+import { FormField } from '../form-field';
 import { HintPlacement, LabelLayout } from '../form-options';
 import { FormFieldGroup } from '../form-field-group';
-import { Field, FieldGroup, FieldColumn, isFieldChild, isFieldGroupChild, getField } from '../form-helpers';
 import { FORM_GROUP_CHILD_FIELD_TOKEN } from './constants';
-import { takeUntil } from 'rxjs/operators';
 
 export const formGroupProvider: Provider = {
     provide: FormGroupContainer,

--- a/libs/platform/src/lib/components/form/form-options.ts
+++ b/libs/platform/src/lib/components/form/form-options.ts
@@ -7,3 +7,17 @@ export type FormZone = 'zTop' | 'zBottom' | 'zLeft' | 'zRight';
 export type Column = 1 | 2 | 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export type Status = 'success' | 'error' | 'warning' | 'default' | 'information';
+
+export interface ColumnLayout {
+    XL: number;
+    L: number;
+    M: number;
+    S: number;
+}
+
+export interface InlineLayout {
+    XL: boolean;
+    L: boolean;
+    M: boolean;
+    S: boolean;
+}

--- a/libs/platform/src/lib/components/form/form-options.ts
+++ b/libs/platform/src/lib/components/form/form-options.ts
@@ -21,3 +21,9 @@ export interface InlineLayout {
     M: boolean;
     S: boolean;
 }
+
+export enum RESPONSIVE_BREAKPOINTS {
+    S = 600,
+    M = 1024,
+    L = 1440
+}

--- a/libs/platform/src/lib/components/form/form-options.ts
+++ b/libs/platform/src/lib/components/form/form-options.ts
@@ -9,17 +9,17 @@ export type Column = 1 | 2 | 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 export type Status = 'success' | 'error' | 'warning' | 'default' | 'information';
 
 export interface ColumnLayout {
-    XL: number;
-    L: number;
-    M: number;
-    S: number;
+    XL?: number;
+    L?: number;
+    M?: number;
+    S?: number;
 }
 
 export interface InlineLayout {
-    XL: boolean;
-    L: boolean;
-    M: boolean;
-    S: boolean;
+    XL?: boolean;
+    L?: boolean;
+    M?: boolean;
+    S?: boolean;
 }
 
 export enum RESPONSIVE_BREAKPOINTS {

--- a/libs/platform/src/lib/components/form/form-options.ts
+++ b/libs/platform/src/lib/components/form/form-options.ts
@@ -14,16 +14,3 @@ export interface ColumnLayout {
     M?: number;
     S?: number;
 }
-
-export interface InlineLayout {
-    XL?: boolean;
-    L?: boolean;
-    M?: boolean;
-    S?: boolean;
-}
-
-export enum RESPONSIVE_BREAKPOINTS {
-    S = 600,
-    M = 1024,
-    L = 1440
-}

--- a/libs/platform/src/lib/components/form/inline-layout-collection-base.input.ts
+++ b/libs/platform/src/lib/components/form/inline-layout-collection-base.input.ts
@@ -1,0 +1,210 @@
+import {
+    ChangeDetectorRef,
+    Directive,
+    Host,
+    Inject,
+    Injectable,
+    InjectionToken,
+    Input,
+    OnInit,
+    Optional,
+    Self,
+    SkipSelf
+} from '@angular/core';
+import { NgControl, NgForm } from '@angular/forms';
+import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
+import { BehaviorSubject } from 'rxjs';
+
+import { CollectionBaseInput } from './collection-base.input';
+import { FormFieldControl } from './form-control';
+import { FormField } from './form-field';
+
+export interface InlineLayout {
+    XL?: boolean;
+    L?: boolean;
+    M?: boolean;
+    S?: boolean;
+}
+
+export enum RESPONSIVE_BREAKPOINTS {
+    S = 600,
+    M = 1024,
+    L = 1440
+}
+
+export const RESPONSIVE_BREAKPOINTS_CONFIG = new InjectionToken<ResponsiveBreakPointConfig>(
+    'Default Responsive breakpoint config'
+);
+
+@Injectable()
+export class ResponsiveBreakPointConfig {
+    L: number = RESPONSIVE_BREAKPOINTS['L'];
+    M: number = RESPONSIVE_BREAKPOINTS['M'];
+    S: number = RESPONSIVE_BREAKPOINTS['S'];
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ResponsiveBreakpointsService {
+    breakpoints: object = {};
+    activeBreakpoints: string[];
+    minWidth = 'min-width';
+    maxWidth = 'max-width';
+    unit = 'px';
+
+    getBreakpoints(config: ResponsiveBreakPointConfig): string[] {
+        let breakPointStr: string;
+        this.activeBreakpoints = [];
+
+        for (const screenSize of Object.keys(config)) {
+            switch (screenSize) {
+                case 'S':
+                    breakPointStr = `(max-width: ${config[screenSize]}${this.unit})`;
+                    this.activeBreakpoints.push(breakPointStr);
+                    this.breakpoints[breakPointStr] = screenSize;
+                    break;
+                case 'M':
+                    breakPointStr = `(min-width: ${config['S']}${this.unit}) and (max-width: ${config[screenSize]}${this.unit})`;
+                    this.activeBreakpoints.push(breakPointStr);
+                    this.breakpoints[breakPointStr] = screenSize;
+                    break;
+                case 'L':
+                    breakPointStr = `(min-width: ${config['M']}${this.unit}) and (max-width: ${config[screenSize]}${this.unit})`;
+                    this.activeBreakpoints.push(breakPointStr);
+                    this.breakpoints[breakPointStr] = screenSize;
+
+                    // create entry for XL screen
+                    breakPointStr = `(min-width: ${config[screenSize]}${this.unit})`;
+                    this.activeBreakpoints.push(breakPointStr);
+                    this.breakpoints[breakPointStr] = 'XL';
+                    break;
+            }
+        }
+        return this.activeBreakpoints;
+    }
+
+    getBreakpointName(breakpointValue): string {
+        return this.breakpoints[breakpointValue];
+    }
+}
+
+@Directive()
+export abstract class InLineLayoutCollectionBaseInput extends CollectionBaseInput implements OnInit {
+    /** object to change isInline property based on screen size */
+    @Input()
+    get inlineLayout(): InlineLayout {
+        return this._inlineLayout;
+    }
+
+    set inlineLayout(layout: InlineLayout) {
+        this._inlineLayout = layout;
+        this._isInLineLayoutEnabled = true;
+        this._setFieldLayout(layout);
+    }
+
+    /** @hidden */
+    protected _inlineCurrentValue = new BehaviorSubject<boolean>(false);
+
+    /** @hidden */
+    protected _responsiveBreakPointConfig: ResponsiveBreakPointConfig;
+
+    /** @hidden */
+    private _inlineLayout: InlineLayout;
+
+    /** @hidden */
+    private _isInlineCurrent: boolean;
+
+    /** @hidden */
+    private _xlIsInline: boolean;
+
+    /** @hidden */
+    private _lgIsInline: boolean;
+
+    /** @hidden */
+    private _mdIsInline: boolean;
+
+    /** @hidden */
+    private _sIsInline: boolean;
+
+    /** @hidden */
+    private _isInLineLayoutEnabled = false;
+
+    constructor(
+        cd: ChangeDetectorRef,
+        readonly _responsiveBreakpointsService: ResponsiveBreakpointsService,
+        readonly _breakpointObserver: BreakpointObserver,
+        @Optional() @Self() readonly ngControl: NgControl,
+        @Optional() @SkipSelf() readonly ngForm: NgForm,
+        @Optional() @SkipSelf() @Host() formField: FormField,
+        @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>,
+        @Optional()
+        @Inject(RESPONSIVE_BREAKPOINTS_CONFIG)
+        readonly _defaultResponsiveBreakPointConfig?: ResponsiveBreakPointConfig
+    ) {
+        super(cd, ngControl, ngForm, formField, formControl);
+
+        this._responsiveBreakPointConfig = _defaultResponsiveBreakPointConfig || new ResponsiveBreakPointConfig();
+    }
+
+    ngOnInit(): void {
+        super.ngOnInit();
+
+        if (this._isInLineLayoutEnabled) {
+            this._breakpointObserver
+                .observe(this._responsiveBreakpointsService.getBreakpoints(this._responsiveBreakPointConfig))
+                .subscribe((result) => this._breakPointMeet(result));
+        }
+    }
+
+    /** set values of inline for each screen layout */
+    private _setFieldLayout(inlineLayout: InlineLayout): void {
+        try {
+            this._sIsInline = !!inlineLayout['S'];
+            this._mdIsInline = !!inlineLayout['M'];
+            this._lgIsInline = !!inlineLayout['L'];
+            this._xlIsInline = !!inlineLayout['XL'];
+        } catch (error) {
+            this._isInLineLayoutEnabled = false;
+        }
+    }
+
+    /** @hidden */
+    private _updateLayout(currentBreakingPointName: string): void {
+        if (this._isInLineLayoutEnabled) {
+            switch (currentBreakingPointName) {
+                case 'S':
+                    this._isInlineCurrent = this._sIsInline;
+                    this._inlineCurrentValue.next(this._isInlineCurrent);
+                    break;
+                case 'M':
+                    this._isInlineCurrent = this._mdIsInline;
+                    this._inlineCurrentValue.next(this._isInlineCurrent);
+                    break;
+                case 'L':
+                    this._isInlineCurrent = this._lgIsInline;
+                    this._inlineCurrentValue.next(this._isInlineCurrent);
+                    break;
+                case 'XL':
+                    this._isInlineCurrent = this._xlIsInline;
+                    this._inlineCurrentValue.next(this._isInlineCurrent);
+                    break;
+                default:
+                    this._isInlineCurrent = this._xlIsInline;
+                    this._inlineCurrentValue.next(this._isInlineCurrent);
+            }
+        }
+    }
+
+    /** @hidden when screen size changes from one breakpoint to another */
+    private _breakPointMeet(breakPoints: BreakpointState): void {
+        if (breakPoints.matches) {
+            for (const breakpoint in breakPoints.breakpoints) {
+                if (breakPoints.breakpoints[breakpoint]) {
+                    const breakPointName = this._responsiveBreakpointsService.getBreakpointName(breakpoint);
+                    this._updateLayout(breakPointName);
+                }
+            }
+        }
+    }
+}

--- a/libs/platform/src/lib/components/form/public_api.ts
+++ b/libs/platform/src/lib/components/form/public_api.ts
@@ -21,6 +21,7 @@ export * from './form-group/form-field/form-field.component';
 export * from './form-group/form-group.component';
 export * from './form-helpers';
 export * from './form-options';
+export * from './inline-layout-collection-base.input';
 export * from './input-group/public_api';
 export * from './input-message-group-with-template/input-message-group-with-template.component';
 export * from './input/fdp-input.module';

--- a/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
+++ b/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
@@ -58,12 +58,6 @@ export class RadioGroupComponent extends CollectionBaseInput implements AfterVie
     }
 
     /**
-     * To Display Radio buttons in a line
-     */
-    @Input()
-    isInline = false;
-
-    /**
      * None value radio button created
      */
     @Input()

--- a/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
+++ b/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
@@ -23,12 +23,13 @@ import {
 import { NgControl, NgForm } from '@angular/forms';
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import { UP_ARROW, DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
-import { takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
 import { RadioButtonComponent } from './radio/radio.component';
 import { CollectionBaseInput } from '../collection-base.input';
 import { FormFieldControl } from '../form-control';
+import { InlineLayout } from '../form-options';
 import { FormField } from '../form-field';
 
 /**
@@ -57,6 +58,37 @@ export class RadioGroupComponent extends CollectionBaseInput implements AfterVie
     set value(newValue: any) {
         super.setValue(newValue);
     }
+
+    /**
+     * To Display Radio buttons in a line
+     */
+    @Input()
+    get isInline(): boolean {
+        return this._isInline;
+    }
+
+    set isInline(inline: boolean) {
+        this._isInline = inline;
+        this._cd.markForCheck();
+    }
+
+    /** object to change isInline property based on screen size */
+    @Input()
+    get inlineLayout(): InlineLayout {
+        return this._inlineLayout;
+    }
+
+    set inlineLayout(layout: InlineLayout) {
+        this._inlineLayout = layout;
+        this._setFieldLayout(layout);
+        this.isInline = this._isInlineCurrent;
+    }
+
+    /** @hidden */
+    private _inlineLayout: InlineLayout;
+
+    /** @hidden */
+    private _isInline: boolean;
 
     /**
      * None value radio button created
@@ -103,6 +135,10 @@ export class RadioGroupComponent extends CollectionBaseInput implements AfterVie
     ) {
         super(_changeDetector, ngControl, ngForm, formField, formControl, _ngZone);
         this.id = `radio-group-${nextUniqueId++}`;
+        // subscribe to _inlineCurrentValue in collection-base-input
+        this._inlineCurrentValue
+            .pipe(distinctUntilChanged())
+            .subscribe((currentInline) => (this.isInline = currentInline));
     }
 
     /**

--- a/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
+++ b/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
@@ -23,7 +23,6 @@ import {
 import { NgControl, NgForm } from '@angular/forms';
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import { UP_ARROW, DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
-import { BreakpointObserver } from '@angular/cdk/layout';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
@@ -120,7 +119,6 @@ export class RadioGroupComponent
     constructor(
         protected _cd: ChangeDetectorRef,
         readonly _responsiveBreakpointsService: ResponsiveBreakpointsService,
-        readonly _breakpointObserver: BreakpointObserver,
         @Optional() @Self() ngControl: NgControl,
         @Optional() @SkipSelf() ngForm: NgForm,
         @Optional() @SkipSelf() @Host() formField: FormField,
@@ -129,10 +127,8 @@ export class RadioGroupComponent
         @Inject(RESPONSIVE_BREAKPOINTS_CONFIG)
         readonly _defaultResponsiveBreakPointConfig: ResponsiveBreakPointConfig
     ) {
-        super(_cd, _responsiveBreakpointsService, _breakpointObserver, ngControl, ngForm, formField, formControl);
+        super(_cd, _responsiveBreakpointsService, ngControl, ngForm, formField, formControl, _defaultResponsiveBreakPointConfig);
         this.id = `radio-group-${nextUniqueId++}`;
-
-        this._responsiveBreakPointConfig = _defaultResponsiveBreakPointConfig || new ResponsiveBreakPointConfig();
 
         // subscribe to _inlineCurrentValue in inline-layout-collection-base-input
         this._inlineCurrentValue

--- a/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
+++ b/libs/platform/src/lib/components/form/radio-group/radio-group.component.ts
@@ -17,7 +17,8 @@ import {
     ViewChildren,
     forwardRef,
     SkipSelf,
-    Host
+    Host,
+    NgZone
 } from '@angular/core';
 import { NgControl, NgForm } from '@angular/forms';
 import { FocusKeyManager } from '@angular/cdk/a11y';
@@ -97,9 +98,10 @@ export class RadioGroupComponent extends CollectionBaseInput implements AfterVie
         @Optional() @Self() ngControl: NgControl,
         @Optional() @SkipSelf() ngForm: NgForm,
         @Optional() @SkipSelf() @Host() formField: FormField,
-        @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>
+        @Optional() @SkipSelf() @Host() formControl: FormFieldControl<any>,
+        _ngZone: NgZone
     ) {
-        super(_changeDetector, ngControl, ngForm, formField, formControl);
+        super(_changeDetector, ngControl, ngForm, formField, formControl, _ngZone);
         this.id = `radio-group-${nextUniqueId++}`;
     }
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
closes https://github.com/SAP/fundamental-ngx/issues/5900

#### Please provide a brief summary of this pull request.
1. This PR introduces property `columnLayout` in `fdp-form-field` for placing a field in certain column whenever layout changes. It takes an object as input in the form of `{ XL: 1, L: 2, M: 1, S: 1 }`.
2. It also introduces property `inlineLayout` for collection-based-input fields, so this field layout can change from `inline` to `vertical` or vice-versa based on layout.

created example inside `platform/form-container` and `platform/form-generator`.
1. Change of column number for a field
2. Change of isInline value for a field

Form generator:
1. Form Generator with form field column layout and inline layout

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [NA] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

