### PR TITLE
fix(core,platform): fix weird selection behaviour because of using attr.name in radio button

### DIFF
--- a/apps/docs/src/app/core/component-docs/radio/examples/radio-example.component.html
+++ b/apps/docs/src/app/core/component-docs/radio/examples/radio-example.component.html
@@ -9,7 +9,7 @@
             </fd-radio-button>
         </div>
         <div fd-form-item>
-            <fd-radio-button value="'val2" id="radio-2" name="radio-name-1" [(ngModel)]="optionVariable">
+            <fd-radio-button value="val2" id="radio-2" name="radio-name-1" [(ngModel)]="optionVariable">
                 Option One
             </fd-radio-button>
         </div>

--- a/libs/core/src/lib/radio/radio-button/radio-button.component.html
+++ b/libs/core/src/lib/radio/radio-button/radio-button.component.html
@@ -3,7 +3,7 @@
     class="fd-radio"
     [disabled]="disabled"
     [id]="id"
-    [attr.name]="name"
+    [name]="name"
     [attr.tabindex]="tabIndex"
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="ariaLabelledBy"

--- a/libs/core/src/lib/radio/radio-button/radio-button.component.html
+++ b/libs/core/src/lib/radio/radio-button/radio-button.component.html
@@ -3,6 +3,7 @@
     class="fd-radio"
     [disabled]="disabled"
     [id]="id"
+    [attr.name]="name"
     [name]="name"
     [attr.tabindex]="tabIndex"
     [attr.aria-label]="ariaLabel"

--- a/libs/platform/src/lib/components/form/radio-group/radio/radio.component.spec.ts
+++ b/libs/platform/src/lib/components/form/radio-group/radio/radio.component.spec.ts
@@ -76,7 +76,7 @@ describe('RadioButtonComponent', () => {
         expect(inputElem.nativeElement.type).toEqual('radio');
         expect(inputElem.nativeElement.getAttribute('id')).toBeTruthy();
         expect(inputElem.nativeElement.getAttribute('ng-reflect-is-disabled')).toEqual('false');
-        expect(inputElem.nativeElement.getAttribute('name')).toEqual('radio');
+        expect(inputElem.nativeElement.getAttribute('ng-reflect-name')).toEqual('radio');
         expect(inputElem.nativeElement.getAttribute('ng-reflect-value')).toEqual('1');
 
         expect(inputElem.nativeElement.classList.contains('fd-radio')).toBeTruthy();
@@ -88,7 +88,7 @@ describe('RadioButtonComponent', () => {
         expect(inputElems[1].nativeElement.type).toEqual('radio');
         expect(inputElems[1].nativeElement.getAttribute('id')).toBeTruthy();
         expect(inputElems[2].nativeElement.getAttribute('ng-reflect-is-disabled')).toBeTruthy();
-        expect(inputElems[1].nativeElement.getAttribute('name')).toEqual('radio');
+        expect(inputElems[1].nativeElement.getAttribute('ng-reflect-name')).toEqual('radio');
         expect(inputElems[1].nativeElement.getAttribute('ng-reflect-value')).toEqual('2');
 
         expect(inputElems[1].nativeElement.classList.contains('fd-radio')).toBeTruthy();


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes https://github.com/SAP/fundamental-ngx/issues/6055
Closes https://github.com/SAP/fundamental-ngx/issues/5656

#### Please provide a brief summary of this pull request.
Because of change made in PR https://github.com/SAP/fundamental-ngx/pull/5895, selection behaviour of radio button became buggy. It is changing the selection is another radio group as well.
This issue is happening in **Core radio button** as well.
Reverting the change, so it can be fixed.
Opening original issue https://github.com/SAP/fundamental-ngx/issues/5656 for tab order behaviour.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [NA] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

Before:
![before-radio](https://user-images.githubusercontent.com/57661487/126592177-dd0368c2-fef3-4686-ad2d-b1ac94c32b58.gif)

After:
![after-radio](https://user-images.githubusercontent.com/57661487/126592192-2ba29f18-da8d-4a40-9058-b7aed77291d4.gif)
