### PR TITLE
fix(platform): remove hardcoded styles for step-input as part of style cleanup

### DIFF
--- a/libs/platform/src/lib/components/form/step-input/step-input.scss
+++ b/libs/platform/src/lib/components/form/step-input/step-input.scss
@@ -1,24 +1,2 @@
 @import '~fundamental-styles/dist/input';
 @import '~fundamental-styles/dist/step-input';
-
-.fd-input {
-
-    &.fd-step-input__input.is-hover,
-    &.fd-step-input__input:hover {
-        z-index: auto;
-    }
-}
-
-.fd-step-input {
-    &--without-buttons {
-        &>.fd-input {
-            margin-bottom: 0;
-        }
-
-        &>.fd-step-input__button {
-            width: auto;
-            padding-left: 6px;
-            padding-right: 6px;
-        }
-    }
-}


### PR DESCRIPTION

#### Please provide a link to the associated issue.
Part of SAP/fundamental-ngx#5025

#### Please provide a brief summary of this pull request.
Remove hardcoded styles for step-input as part of style cleanup

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [NA] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

