### PR TITLE
fix(core): extended example, label for the busy indicator

### DIFF
--- a/apps/docs/src/app/core/api-files.ts
+++ b/apps/docs/src/app/core/api-files.ts
@@ -55,7 +55,7 @@ export const API_FILES = {
         'DynamicSideContentMainComponent'
     ],
     breadcrumb: ['BreadcrumbComponent', 'BreadcrumbItemDirective', 'BreadcrumbLinkDirective'],
-    busyIndicator: ['BusyIndicatorComponent'],
+    busyIndicator: ['BusyIndicatorComponent', 'BusyIndicatorExtendedDirective'],
     button: ['ButtonComponent'],
     segmentedButton: ['SegmentedButtonComponent'],
     calendar: [

--- a/apps/docs/src/app/core/component-docs/busy-indicator/busy-indicator-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/busy-indicator-docs.component.html
@@ -1,6 +1,4 @@
-<fd-docs-section-title id="default" componentName="busy-indicator">
-    Default Busy Indicator
-</fd-docs-section-title>
+<fd-docs-section-title id="default" componentName="busy-indicator"> Default Busy Indicator </fd-docs-section-title>
 <description>
     Busy Indicator displays loading animation depending on its state. To set Busy Indicator state use
     <code>[loading]</code> property.
@@ -9,10 +7,9 @@
     <fd-busy-indicator-basic-example></fd-busy-indicator-basic-example>
 </component-example>
 <code-example [exampleFiles]="busyIndicatorBasicExample"></code-example>
+<separator></separator>
 
-<fd-docs-section-title id="size" componentName="busy-indicator">
-    Busy Indicator sizes
-</fd-docs-section-title>
+<fd-docs-section-title id="size" componentName="busy-indicator"> Busy Indicator sizes </fd-docs-section-title>
 <description>
     Busy Indicator can be displayed in three different sizes. To change the size use <code>[size]</code> property.
 </description>
@@ -23,12 +20,36 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="wrapper" componentName="busy-indicator">
-    Busy Indicator as wrapper
+<fd-docs-section-title id="label" componentName="busy-indicator"> Busy Indicator with label </fd-docs-section-title>
+<description>
+    Busy Indicator can be displayed with label when loading the content. To add the label use
+    <code>[label]</code> string property.
+</description>
+<component-example>
+    <fd-busy-indicator-label-example></fd-busy-indicator-label-example>
+</component-example>
+<code-example [exampleFiles]="busyIndicatorLabelExample"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="extended" componentName="busy-indicator">
+    Busy Indicator with message toast
 </fd-docs-section-title>
 <description>
-    Busy Indicator might be used as a wrapper to display elements or sections of the page behind an overflow.
-    Depending of the wrapped element type, use <code>[block]</code> property to manipulate the <code>display</code>
+    Busy Indicator can be displayed with message toast when loading the content. To add the extended busy indicator wrap
+    the <code>fd-busy-indicator</code> component with in <code>fd-busy-indicator-extended</code> directive.
+</description>
+<component-example>
+    <fd-busy-indicator-extended-example></fd-busy-indicator-extended-example>
+</component-example>
+<code-example [exampleFiles]="busyIndicatorExtendedExample"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="wrapper" componentName="busy-indicator"> Busy Indicator as wrapper </fd-docs-section-title>
+<description>
+    Busy Indicator might be used as a wrapper to display elements or sections of the page behind an overflow. Depending
+    of the wrapped element type, use <code>[block]</code> property to manipulate the <code>display</code>
     property of the Busy Indicator.
 </description>
 <component-example>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/busy-indicator-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/busy-indicator-docs.component.ts
@@ -2,6 +2,9 @@ import { Component } from '@angular/core';
 
 import * as BusyIndicatorHtml from '!raw-loader!./examples/busy-indicator-basic-example.component.html';
 import * as BusyIndicatorSizeHtml from '!raw-loader!./examples/busy-indicator-size-example.component.html';
+import * as BusyIndicatorLabelHtml from '!raw-loader!./examples/busy-indicator-label-example.component.html';
+import * as BusyIndicatorExtendedHtml from '!raw-loader!./examples/busy-indicator-extended-example.component.html';
+import * as BusyIndicatorExtendedTs from '!raw-loader!./examples/busy-indicator-extended-example.component.ts';
 import * as BusyIndicatorWrapperTs from '!raw-loader!./examples/busy-indicator-wrapper-example.component.ts';
 import * as BusyIndicatorWrapperHtml from '!raw-loader!./examples/busy-indicator-wrapper-example.component.html';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
@@ -23,6 +26,26 @@ export class BusyIndicatorDocsComponent {
             language: 'html',
             code: BusyIndicatorSizeHtml,
             fileName: 'busy-indicator-size-example'
+        }
+    ];
+    busyIndicatorLabelExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: BusyIndicatorLabelHtml,
+            fileName: 'busy-indicator-label-example'
+        }
+    ];
+    busyIndicatorExtendedExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: BusyIndicatorExtendedHtml,
+            fileName: 'busy-indicator-extended-example'
+        },
+        {
+            language: 'typescript',
+            code: BusyIndicatorExtendedTs,
+            fileName: 'busy-indicator-extended-example',
+            component: 'BusyIndicatorExtendedExampleComponent'
         }
     ];
     busyIndicatorWrapperExample: ExampleFile[] = [

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-basic-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-basic-example.component.html
@@ -1,3 +1,3 @@
 <div style="text-align: center">
-    <fd-busy-indicator [loading]="true" ariaLabel="loading" title="Loading"></fd-busy-indicator>
+    <fd-busy-indicator [loading]="true" ariaLabel="loading" title="Please Wait"></fd-busy-indicator>
 </div>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-basic-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-basic-example.component.html
@@ -1,3 +1,3 @@
 <div style="text-align: center">
-    <fd-busy-indicator [loading]="true"></fd-busy-indicator>
+    <fd-busy-indicator [loading]="true" ariaLabel="loading" title="Loading"></fd-busy-indicator>
 </div>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
@@ -3,6 +3,6 @@
 
 <ng-template #template>
     <div fd-busy-indicator-extended>
-        <fd-busy-indicator [loading]="true" label="Please Wait..." ariaLabel="Please wait" title="Please wait"></fd-busy-indicator>
+        <fd-busy-indicator [loading]="true" label="Please Wait..." title="Please wait"></fd-busy-indicator>
     </div>
 </ng-template>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
@@ -1,4 +1,4 @@
-<button fd-button label="Open from Component" (click)="openFromTemplate(template)"></button>
+<button fd-button label="Open from Template" (click)="openFromTemplate(template)"></button>
 <button fd-button label="Hide All" fdType="emphasized" (click)="messageToastService.hideAll()"></button>
 
 <ng-template #template>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
@@ -3,6 +3,6 @@
 
 <ng-template #template>
     <div fd-busy-indicator-extended>
-        <fd-busy-indicator [loading]="true" label="Please Wait..." ariaLabel="Please wait"></fd-busy-indicator>
+        <fd-busy-indicator [loading]="true" label="Please Wait..." ariaLabel="Please wait" title="Please wait"></fd-busy-indicator>
     </div>
 </ng-template>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
@@ -1,0 +1,8 @@
+<button fd-button label="Open from Component" (click)="openFromTemplate(template)"></button>
+<button fd-button label="Hide All" fdType="emphasized" (click)="messageToastService.hideAll()"></button>
+
+<ng-template #template>
+    <div fd-busy-indicator-extended>
+        <fd-busy-indicator [loading]="true" label="Please Wait..." ariaLabel="Please wait"></fd-busy-indicator>
+    </div>
+</ng-template>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { MessageToastService } from '@fundamental-ngx/core';
+
+@Component({
+    selector: 'fd-busy-indicator-extended-example',
+    templateUrl: './busy-indicator-extended-example.component.html'
+})
+export class BusyIndicatorExtendedExampleComponent {
+    /** @hidden */
+    constructor(public messageToastService: MessageToastService) {}
+
+    openFromTemplate(template): void {
+        this.messageToastService.open(template, {
+            mousePersist: true,
+            duration: -1
+        });
+    }
+}

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-label-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-label-example.component.html
@@ -1,0 +1,3 @@
+<div style="text-align: center" fd-busy-indicator-extended>
+    <fd-busy-indicator [loading]="true" label="Please wait" ariaLabel="Please wait"></fd-busy-indicator>
+</div>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-label-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-label-example.component.html
@@ -1,3 +1,3 @@
 <div style="text-align: center" fd-busy-indicator-extended>
-    <fd-busy-indicator [loading]="true" label="Please wait" ariaLabel="Please wait"></fd-busy-indicator>
+    <fd-busy-indicator [loading]="true" label="Please wait" ariaLabel="Please wait" title="Please wait"></fd-busy-indicator>
 </div>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-label-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-label-example.component.html
@@ -1,3 +1,3 @@
-<div style="text-align: center" fd-busy-indicator-extended>
-    <fd-busy-indicator [loading]="true" label="Please wait" ariaLabel="Please wait" title="Please wait"></fd-busy-indicator>
+<div fd-busy-indicator-extended>
+    <fd-busy-indicator [loading]="true" label="Please wait" title="Please wait"></fd-busy-indicator>
 </div>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-label-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-label-example.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'fd-busy-indicator-label-example',
+    templateUrl: './busy-indicator-label-example.component.html'
+})
+export class BusyIndicatorLabelExampleComponent {}

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-size-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-size-example.component.html
@@ -1,3 +1,3 @@
 <div style="text-align: center;" *ngFor="let size of ['s', 'm', 'l']">
-    <fd-busy-indicator [loading]="true" [size]="size"></fd-busy-indicator>
+    <fd-busy-indicator [loading]="true" [size]="size"  [ariaLabel]="size+' '+ 'size loading'" [title]="size+' '+ 'size loading'"></fd-busy-indicator>
 </div>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-size-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-size-example.component.html
@@ -1,3 +1,3 @@
 <div style="text-align: center;" *ngFor="let size of ['s', 'm', 'l']">
-    <fd-busy-indicator [loading]="true" [size]="size"  [ariaLabel]="size+' '+ 'size loading'" [title]="size+' '+ 'size loading'"></fd-busy-indicator>
+    <fd-busy-indicator [loading]="true" [size]="size" [title]="size+' '+ 'size loading'"></fd-busy-indicator>
 </div>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-wrapper-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-wrapper-example.component.html
@@ -20,7 +20,7 @@
 
 
 <h5>Use Busy Indicator as a inline wrapper</h5>
-<fd-busy-indicator [loading]="loading" size="s" ariaLabel="Loading" title="Inline Wrapper">
+<fd-busy-indicator [loading]="loading" size="s" title="Inline Wrapper">
     <button fd-button label="Save"></button>
 </fd-busy-indicator>
 

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-wrapper-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-wrapper-example.component.html
@@ -1,5 +1,5 @@
-<h5>Use Busy Indicator as a block wrapper</h5>
-<fd-busy-indicator [loading]="loading" block="true">
+<h5 id="fd-busy-indicator-label-1">Use Busy Indicator as a block wrapper</h5>
+<fd-busy-indicator [loading]="loading" block="true" aria-labelledby="fd-busy-indicator-label-1">
     <form>
         <div fd-form-item>
             <label fd-form-label for="name">Name:</label>

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-wrapper-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-wrapper-example.component.html
@@ -1,5 +1,5 @@
 <h5 id="fd-busy-indicator-label-1">Use Busy Indicator as a block wrapper</h5>
-<fd-busy-indicator [loading]="loading" block="true" aria-labelledby="fd-busy-indicator-label-1">
+<fd-busy-indicator [loading]="loading" block="true" aria-labelledby="fd-busy-indicator-label-1" title="Block Wrapper">
     <form>
         <div fd-form-item>
             <label fd-form-label for="name">Name:</label>
@@ -20,7 +20,7 @@
 
 
 <h5>Use Busy Indicator as a inline wrapper</h5>
-<fd-busy-indicator [loading]="loading" size="s">
+<fd-busy-indicator [loading]="loading" size="s" ariaLabel="Loading" title="Inline Wrapper">
     <button fd-button label="Save"></button>
 </fd-busy-indicator>
 

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/index.ts
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/index.ts
@@ -1,13 +1,19 @@
 import { BusyIndicatorBasicExampleComponent } from './busy-indicator-basic-example.component';
+import { BusyIndicatorExtendedExampleComponent } from './busy-indicator-extended-example.component';
+import { BusyIndicatorLabelExampleComponent } from './busy-indicator-label-example.component';
 import { BusyIndicatorSizeExampleComponent } from './busy-indicator-size-example.component';
 import { BusyIndicatorWrapperExampleComponent } from './busy-indicator-wrapper-example.component';
 
 export * from './busy-indicator-basic-example.component';
 export * from './busy-indicator-size-example.component';
 export * from './busy-indicator-wrapper-example.component';
+export * from './busy-indicator-label-example.component';
+export * from './busy-indicator-extended-example.component';
 
 export const examples = [
     BusyIndicatorSizeExampleComponent,
     BusyIndicatorBasicExampleComponent,
-    BusyIndicatorWrapperExampleComponent
+    BusyIndicatorWrapperExampleComponent,
+    BusyIndicatorLabelExampleComponent,
+    BusyIndicatorExtendedExampleComponent
 ];

--- a/libs/core/src/lib/busy-indicator/busy-indicator-extended/busy-indicator-extended.directive.spec.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator-extended/busy-indicator-extended.directive.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { Component, TemplateRef, ViewChild, NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { BusyIndicatorExtendedDirective } from './busy-indicator-extended.directive';
+import { MessageToastService } from '../../message-toast/message-toast-service/message-toast.service';
+import { MessageToastComponent } from '../../message-toast/message-toast.component';
+import { MessageToastContainerComponent } from '../../message-toast/message-toast-utils/message-toast-container.component';
+import { BusyIndicatorComponent } from '../busy-indicator.component';
+
+@Component({
+    template: `<ng-template #testTemplate let-messageToast>
+        <div fd-busy-indicator-extended>
+            <fd-busy-indicator [loading]="true" label="Please wait" ariaLabel="Please wait"></fd-busy-indicator>
+        </div>
+    </ng-template>`
+})
+class TestComponent {
+    @ViewChild('testTemplate', { static: true }) templateRef: TemplateRef<any>;
+}
+
+@NgModule({
+    declarations: [
+        MessageToastComponent,
+        MessageToastContainerComponent,
+        BusyIndicatorComponent,
+        BusyIndicatorExtendedDirective,
+        TestComponent
+    ],
+    imports: [CommonModule, BrowserModule],
+    providers: [MessageToastService],
+    entryComponents: [
+        MessageToastComponent,
+        MessageToastContainerComponent,
+        BusyIndicatorComponent,
+        BusyIndicatorExtendedDirective,
+        TestComponent
+    ]
+})
+class TestModule {}
+
+describe('BusyIndicatorExtenedDirective', () => {
+    let messageComponent: MessageToastComponent;
+    let fixture: ComponentFixture<MessageToastComponent>;
+
+    beforeEach(
+        waitForAsync(() => {
+            TestBed.configureTestingModule({
+                imports: [TestModule]
+            }).compileComponents();
+        })
+    );
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(MessageToastComponent);
+        messageComponent = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(messageComponent).toBeTruthy();
+    });
+
+    it('should assign classes', () => {
+        messageComponent.open();
+        spyOn<any>(messageComponent, '_loadFromComponent').and.callThrough();
+        messageComponent.childContent = TestBed.createComponent(TestComponent).componentInstance.templateRef;
+        messageComponent.ngOnInit();
+        messageComponent.ngAfterViewInit();
+        console.log('message component', fixture.nativeElement.classList);
+        expect(fixture.nativeElement.classList.contains('fd-busy-indicator-extended--message-toast')).toBe(true);
+        expect(fixture.nativeElement.classList.contains('fd-busy-indicator-extended')).toBe(true);
+    });
+});

--- a/libs/core/src/lib/busy-indicator/busy-indicator-extended/busy-indicator-extended.directive.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator-extended/busy-indicator-extended.directive.ts
@@ -30,10 +30,10 @@ export class BusyIndicatorExtendedDirective implements AfterContentInit {
         const hasLabel = this.busyIndicator.label;
         if (hasLabel !== undefined) {
             this.elementRef().nativeElement.parentElement.classList.add('fd-busy-indicator-extended');
-            if (this.elementRef().nativeElement.parentElement.classList.contains(messageToastClass)) {
-                this.elementRef().nativeElement.parentElement.classList.add(
-                    'fd-busy-indicator-extended--message-toast'
-                );
+            const { classList } = this.elementRef().nativeElement.parentElement;
+            classList.add('fd-busy-indicator-extended');
+            if (classList.contains(messageToastClass)) {
+                classList.add('fd-busy-indicator-extended--message-toast');
             }
         }
     }

--- a/libs/core/src/lib/busy-indicator/busy-indicator-extended/busy-indicator-extended.directive.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator-extended/busy-indicator-extended.directive.ts
@@ -1,0 +1,40 @@
+import { AfterContentInit, ContentChild, Directive, ElementRef } from '@angular/core';
+import { BusyIndicatorComponent } from '../busy-indicator.component';
+
+const messageToastClass = 'fd-message-toast';
+
+@Directive({
+    // tslint:disable-next-line:directive-selector
+    selector: '[fd-busy-indicator-extended]'
+})
+export class BusyIndicatorExtendedDirective implements AfterContentInit {
+    /** @hidden */
+    @ContentChild(BusyIndicatorComponent)
+    busyIndicator: BusyIndicatorComponent;
+
+    /** @hidden */
+    constructor(private _eleRef: ElementRef) {}
+
+    /** @hidden */
+    ngAfterContentInit(): void {
+        this._appendCssToParent();
+    }
+
+    /** @hidden */
+    elementRef(): ElementRef<HTMLElement> {
+        return this._eleRef;
+    }
+
+    /** @hidden */
+    private _appendCssToParent(): void {
+        const hasLabel = this.busyIndicator.label;
+        if (hasLabel !== undefined) {
+            this.elementRef().nativeElement.parentElement.classList.add('fd-busy-indicator-extended');
+            if (this.elementRef().nativeElement.parentElement.classList.contains(messageToastClass)) {
+                this.elementRef().nativeElement.parentElement.classList.add(
+                    'fd-busy-indicator-extended--message-toast'
+                );
+            }
+        }
+    }
+}

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.html
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.html
@@ -1,25 +1,25 @@
 <ng-content></ng-content>
 
 <ng-container *ngIf="loading">
-
     <div
         #busyIndicator
         class="fd-busy-indicator"
-        [ngClass]="{
-        'fd-busy-indicator--l': size === 'l',
-        'fd-busy-indicator--m': size === 'm',
-        'fd-busy-indicator--s': size === 's',
-        'fd-busy-indicator--absolute': busyIndicator?.previousElementSibling
-    }">
+        [class.fd-busy-indicator--l] = "size === 'l'"
+        [class.fd-busy-indicator--m] = "size === 'm'"
+        [class.fd-busy-indicator--s] = "size === 's'"
+        [class.fd-busy-indicator--absolute] = "busyIndicator?.previousElementSibling"
+    >
         <div class="fd-busy-indicator--circle-0"></div>
         <div class="fd-busy-indicator--circle-1"></div>
         <div class="fd-busy-indicator--circle-2"></div>
     </div>
 
-    <div class="fd-busy-indicator__overlay"
-         [class.fd-busy-indicator__overlay--transparent]="!busyIndicator?.previousElementSibling">
-    </div>
+    <span *ngIf="label" class="fd-busy-indicator-extended__label">{{ label }}</span>
+
+    <div
+        class="fd-busy-indicator__overlay"
+        [class.fd-busy-indicator__overlay--transparent]="!busyIndicator?.previousElementSibling"
+    ></div>
 
     <div #fakeFocusElement tabindex="0" aria-hidden="true" (focusin)="fakeElementFocusHandler($event)"></div>
-
 </ng-container>

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
@@ -21,7 +21,7 @@
             outline-style: var(--sapContent_FocusStyle, dotted);
         }
 
-        &[tabindex="-1"] {
+        &[tabindex='-1'] {
             outline: none;
         }
 

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
@@ -24,6 +24,7 @@ export type BusyIndicatorSize = 's' | 'm' | 'l';
         '[attr.aria-busy]': 'loading',
         '[attr.aria-live]': 'ariaLive',
         '[attr.aria-label]': 'ariaLabel',
+        '[attr.title]': 'title',
         '[class.fd-busy-indicator__container]': 'true',
         '[class.fd-busy-indicator__container--inline]': '!block'
     }
@@ -44,6 +45,10 @@ export class BusyIndicatorComponent {
     /** Aria label attribute value. */
     @Input()
     ariaLabel: string;
+
+    /** title attribute value for tooltip. */
+    @Input()
+    title: string;
 
     /** add loading label value */
     @Input()

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
@@ -19,7 +19,7 @@ export type BusyIndicatorSize = 's' | 'm' | 'l';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
-        'aria-role': 'progressbar',
+        'role': 'progressbar',
         '[attr.tabindex]': 'loading ? 0 : -1',
         '[attr.aria-busy]': 'loading',
         '[attr.aria-live]': 'ariaLive',

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
@@ -43,7 +43,11 @@ export class BusyIndicatorComponent {
 
     /** Aria label attribute value. */
     @Input()
-    ariaLabel = 'Loading';
+    ariaLabel: string;
+
+    /** add loading label value */
+    @Input()
+    label: string;
 
     /** Aria live attribute value. */
     @Input()
@@ -53,7 +57,8 @@ export class BusyIndicatorComponent {
     @ViewChild('fakeFocusElement')
     fakeFocusElement: ElementRef;
 
-    constructor(private _elementRef: ElementRef) { }
+    /** @hidden */
+    constructor(private _elementRef: ElementRef) {}
 
     /** @hidden If focus escapes busy container focus element after wrapped content */
     @HostListener('keydown', ['$event'])

--- a/libs/core/src/lib/busy-indicator/busy-indicator.module.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BusyIndicatorComponent } from './busy-indicator.component';
+import { BusyIndicatorExtendedDirective } from './busy-indicator-extended/busy-indicator-extended.directive';
 
 @NgModule({
-    declarations: [BusyIndicatorComponent],
-    exports: [BusyIndicatorComponent],
+    declarations: [BusyIndicatorComponent, BusyIndicatorExtendedDirective],
+    exports: [BusyIndicatorComponent, BusyIndicatorExtendedDirective],
     imports: [CommonModule]
 })
 export class BusyIndicatorModule {}

--- a/libs/core/src/lib/busy-indicator/public_api.ts
+++ b/libs/core/src/lib/busy-indicator/public_api.ts
@@ -1,2 +1,3 @@
 export * from './busy-indicator.module';
 export * from './busy-indicator.component';
+export * from './busy-indicator-extended/busy-indicator-extended.directive';


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes: https://github.com/SAP/fundamental-ngx/issues/3111, https://github.com/SAP/fundamental-ngx/issues/3112

#### Please provide a brief summary of this pull request.

adding extened example and adding extended label to the component

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [] Run npm run build-pack-library and test in external application

Documentation checklist:
- [NA] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

