### PR TITLE
fix(core): fix extra onChange event in the TimePicker component

### DIFF
--- a/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-form-example.component.html
+++ b/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-form-example.component.html
@@ -2,9 +2,9 @@
     <div fd-form-item>
         <label fd-form-label required="true">TimePicker</label>
         <fd-time-picker formControlName="time"
-                        [state]="isValid() ? 'success' : 'error'"
+                        [state]="customForm.get('time').valid ? 'success' : 'error'"
                         required="true"
-                        [message]="isValid() ? 'Valid Time' : 'Invalid Time'">
+                        [message]="customForm.get('time').valid ? 'Valid Time' : 'Invalid Time'">
         </fd-time-picker>
         <br />
         Selected Time:

--- a/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-form-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-form-example.component.ts
@@ -22,8 +22,4 @@ export class TimePickerFormExampleComponent {
         time: new FormControl(),
         disabledTime: new FormControl({ value: new FdDate().setTime(12, 34, 10), disabled: true })
     });
-
-    isValid(): boolean {
-        return this.customForm.get('time').valid;
-    }
 }

--- a/e2e/wdio/core/tests/time-picker.e2e-spec.ts
+++ b/e2e/wdio/core/tests/time-picker.e2e-spec.ts
@@ -173,7 +173,7 @@ describe('Time-picker component test', function () {
         sendKeys('Enter');
 
         if (section === formattingExample) {
-            expect(getValue(section + timeInput)).toEqual('00:34:00');
+            expect(getValue(section + timeInput)).toEqual(`${value}`);
         }
         if (section !== formattingExample) {
             expect(getValue(section + timeInput)).toEqual(`${value}`);

--- a/libs/core/src/lib/time-picker/time-picker.component.html
+++ b/libs/core/src/lib/time-picker/time-picker.component.html
@@ -12,7 +12,7 @@
         <fd-input-group
             #inputGroupComponent
             [compact]="compact"
-            (addOnButtonClicked)="addOnButtonClicked()"
+            (addOnButtonClicked)="_addOnButtonClicked()"
             [button]="true"
             [state]="state"
             [disabled]="disabled"
@@ -26,15 +26,15 @@
                 class="fd-input"
                 fd-input-group-input
                 #inputElement
-                [value]="getFormattedTime()"
                 [compact]="compact"
-                (focusout)="timeInputChanged(inputElement.value)"
+                [value]="_inputTimeValue"
+                (focusout)="_timeInputChanged(inputElement.value)"
+                (keyup.enter)="_timeInputChanged($event.currentTarget.value)"
                 [disabled]="disabled"
                 [attr.id]="inputId"
                 [placeholder]="_placeholder"
                 [attr.aria-label]="timePickerInputLabel"
                 [attr.aria-required]="required"
-                (keyup.enter)="timeInputChanged($event.currentTarget.value)"
             />
         </fd-input-group>
     </fd-popover-control>
@@ -48,9 +48,9 @@
             [tablet]="tablet"
             [compact]="compact"
             [disabled]="disabled"
-            [(ngModel)]="time"
             [keepTwoDigits]="keepTwoDigitsTime"
-            (ngModelChange)="timeFromTimeComponentChanged($event)"
+            [ngModel]="time"
+            (ngModelChange)="_timeComponentValueChanged($event)"
             [meridian]="_meridian"
             [displayHours]="_displayHours"
             [displayMinutes]="_displayMinutes"

--- a/libs/platform/src/lib/components/form/time-picker/time-picker.component.ts
+++ b/libs/platform/src/lib/components/form/time-picker/time-picker.component.ts
@@ -112,7 +112,7 @@ export class PlatformTimePickerComponent<D> extends BaseInput implements OnInit,
     }
 
     get state(): Status {
-        if (this.timePickerComponent && this.timePickerComponent.isInvalidTimeInput) {
+        if (this.timePickerComponent && this.timePickerComponent._isInvalidTimeInput) {
             // if any other error from core timePicker
             return 'error';
         }
@@ -183,7 +183,7 @@ export class PlatformTimePickerComponent<D> extends BaseInput implements OnInit,
      */
     handleTimeChange(value: D): void {
         if (this.timePickerComponent) {
-            if (this.timePickerComponent.isInvalidTimeInput) {
+            if (this.timePickerComponent._isInvalidTimeInput) {
                 this.state = 'error';
             } else {
                 this.state = !this.timePickerComponent.time && !this.allowNull ? 'error' : undefined;


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes: https://github.com/SAP/fundamental-ngx/issues/5126

#### Please provide a brief summary of this pull request.
This PR brings fix not to fire extra FormControl.onChange event if the input element wasn't changed.
Also, this brings some code formatting according to the code styles rules
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [na] update `README.md`
- [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [na] Documentation Examples
- [x] Stackblitz works for all examples

