### PR TITLE
fix(platform): rename title input to remove native tooltip in wizard generator

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-condition-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-condition-example.component.ts
@@ -176,7 +176,7 @@ export class WizardGeneratorConditionExampleComponent implements OnDestroy {
                 appendToWizard: false,
                 addSummary: false,
                 responsivePaddings: true,
-                title: this.wizardTitle
+                wizardTitle: this.wizardTitle
             }
         }).afterClosed.pipe(takeUntil(this._onDestroy$))
         .subscribe((wizardValue: WizardGeneratorFormsValue) => {

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-customizable-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-customizable-example.component.ts
@@ -135,7 +135,7 @@ export class WizardGeneratorCustomizableExampleComponent implements OnDestroy {
                 appendToWizard: false,
                 addSummary: false,
                 responsivePaddings: false,
-                title: this.wizardTitle,
+                wizardTitle: this.wizardTitle,
                 goNextButtonTemplate: this.goNextTemplate,
                 goBackButtonTemplate: this.goBackTemplate,
                 finishButtonTemplate: this.finishTemplate,

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-default-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-default-example.component.html
@@ -1,4 +1,4 @@
-<fdp-wizard-generator [items]="stepItems" [title]="wizardTitle" (wizardFinished)="wizardFinished($event)"></fdp-wizard-generator>
+<fdp-wizard-generator [items]="stepItems" (wizardFinished)="wizardFinished($event)"></fdp-wizard-generator>
 
 <p *ngIf="wizardValue">
     Wizard value: {{ wizardValue | json }}

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-default-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-default-example.component.ts
@@ -1,17 +1,12 @@
 import { Component } from '@angular/core';
 import { Validators } from '@angular/forms';
-import { WizardGeneratorFormsValue, WizardGeneratorItem, WizardTitle } from '@fundamental-ngx/platform';
+import { WizardGeneratorFormsValue, WizardGeneratorItem } from '@fundamental-ngx/platform';
 
 @Component({
   selector: 'fdp-wizard-generator-default-example',
   templateUrl: './wizard-generator-default-example.component.html'
 })
 export class WizardGeneratorDefaultExampleComponent {
-
-    wizardTitle: WizardTitle = {
-        size: 2,
-        text: 'Checkout'
-    };
 
     wizardValue: WizardGeneratorFormsValue;
 

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-dialog-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-dialog-example.component.ts
@@ -128,7 +128,7 @@ export class WizardGeneratorDialogExampleComponent implements OnDestroy {
                 appendToWizard: false,
                 addSummary: true,
                 responsivePaddings: false,
-                title: this.wizardTitle
+                wizardTitle: this.wizardTitle
             }
         }).afterClosed.pipe(takeUntil(this._onDestroy$))
         .subscribe((wizardValue: WizardGeneratorFormsValue) => {

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-responsive-dialog-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-responsive-dialog-example.component.ts
@@ -125,7 +125,7 @@ export class WizardGeneratorResponsiveDialogExampleComponent implements OnDestro
                 appendToWizard: false,
                 addSummary: true,
                 responsivePaddings: true,
-                title: this.wizardTitle
+                wizardTitle: this.wizardTitle
             }
         }).afterClosed.pipe(takeUntil(this._onDestroy$))
         .subscribe((wizardValue: WizardGeneratorFormsValue) => {

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-responsive-paddings-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-responsive-paddings-example.component.html
@@ -1,4 +1,4 @@
-<fdp-wizard-generator [items]="stepItems" [responsivePaddings]="true" [title]="wizardTitle" (wizardFinished)="wizardFinished($event)"></fdp-wizard-generator>
+<fdp-wizard-generator [items]="stepItems" [responsivePaddings]="true" (wizardFinished)="wizardFinished($event)"></fdp-wizard-generator>
 
 <p *ngIf="wizardValue">
     Wizard value: {{ wizardValue | json }}

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-responsive-paddings-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-responsive-paddings-example.component.ts
@@ -1,18 +1,12 @@
 import { Component } from '@angular/core';
 import { Validators } from '@angular/forms';
-import { WizardGeneratorFormsValue, WizardGeneratorItem, WizardTitle } from '@fundamental-ngx/platform';
+import { WizardGeneratorFormsValue, WizardGeneratorItem } from '@fundamental-ngx/platform';
 
 @Component({
   selector: 'fdp-wizard-generator-responsive-paddings-example',
   templateUrl: './wizard-generator-responsive-paddings-example.component.html'
 })
 export class WizardGeneratorResponsivePaddingsExampleComponent {
-
-    wizardTitle: WizardTitle = {
-        size: 2,
-        text: 'Checkout'
-    };
-
     wizardValue: WizardGeneratorFormsValue;
 
     stepItems: WizardGeneratorItem[] = [

--- a/libs/platform/src/lib/components/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.html
+++ b/libs/platform/src/lib/components/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.html
@@ -1,6 +1,6 @@
 <fd-dialog>
     <fd-dialog-header>
-        <h2 fd-title [headerSize]="title.size">{{ title.text }}</h2>
+        <h2 fd-title [headerSize]="wizardTitle.size">{{ wizardTitle.text }}</h2>
     </fd-dialog-header>
     <fd-dialog-body>
         <fdp-wizard-body [responsivePaddings]="responsivePaddings" [navigationButtonLabels]="navigationButtonLabels" [hidden]="!_wizardCreated" (statusChange)="stepStatusChanged($event.id, $event.status)" [appendToWizard]="appendToWizard" [contentHeight]="contentHeight"></fdp-wizard-body>

--- a/libs/platform/src/lib/components/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.ts
+++ b/libs/platform/src/lib/components/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.ts
@@ -20,7 +20,7 @@ export class DialogWizardGeneratorComponent extends BaseWizardGenerator {
     /**
      * @description Wizards dialog title configuration.
      */
-    title: WizardTitle;
+    wizardTitle: WizardTitle;
 
     /**
      * @description Confirmation message when wizard dialog close button has been clicked.
@@ -70,7 +70,7 @@ export class DialogWizardGeneratorComponent extends BaseWizardGenerator {
         super(_wizardGeneratorService, _cd);
 
         this.items = this._dialogRef.data.items;
-        this.title = this._dialogRef.data.title;
+        this.wizardTitle = this._dialogRef.data.wizardTitle;
         this.appendToWizard = this._dialogRef.data.appendToWizard;
         this.addSummary = this._dialogRef.data.addSummary;
         this.navigationButtonLabels = this._dialogRef.data.navigationButtonLabels;

--- a/libs/platform/src/lib/components/wizard-generator/interfaces/wizard-dialog-data.interface.ts
+++ b/libs/platform/src/lib/components/wizard-generator/interfaces/wizard-dialog-data.interface.ts
@@ -39,7 +39,7 @@ export interface WizardDialogData {
     /**
      * @description Wizards dialog title configuration.
      */
-    title: WizardTitle;
+    wizardTitle: WizardTitle;
 
     /**
      * @description Text that will be displayed if user clicks on Cancel button.

--- a/libs/platform/src/lib/components/wizard-generator/wizard-dialog-generator.service.spec.ts
+++ b/libs/platform/src/lib/components/wizard-generator/wizard-dialog-generator.service.spec.ts
@@ -125,7 +125,7 @@ describe('WizardDialogGeneratorService', () => {
                 appendToWizard: false,
                 addSummary: false,
                 responsivePaddings: false,
-                title: wizardTitle
+                wizardTitle: wizardTitle
             }
         });
         expect(dialogService.hasOpenDialogs()).toBeTrue();


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #6111

#### Please provide a brief summary of this pull request.
Renamed title input property so it won't render as title attribute.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- n/a update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

