### PR TITLE
fix(core): remove style from ngx to reuse the style from fundamental-style lib for file uploader component

### DIFF
--- a/libs/core/src/lib/file-uploader/file-uploader.component.html
+++ b/libs/core/src/lib/file-uploader/file-uploader.component.html
@@ -13,7 +13,6 @@
 >
     <input
         #textInput
-        readonly
         [ngClass]="state ? ' is-' + state : ''"
         class="fd-input fd-file-uploader__input"
         aria-live="polite"

--- a/libs/core/src/lib/file-uploader/file-uploader.component.scss
+++ b/libs/core/src/lib/file-uploader/file-uploader.component.scss
@@ -1,6 +1,2 @@
 @import '~fundamental-styles/dist/input';
 @import '~fundamental-styles/dist/file-uploader';
-
-.fd-file-uploader .fd-input.is-error {
-    border-color: var(--sapField_InvalidColor, #b00) !important;
-}


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Part of #5025

#### Please provide a brief summary of this pull request.
PR change contains remove style from ngx to reuse the style from fundamental-style lib for file uploader component.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [NA] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

