### PR TITLE
fix(core): fix Pagination component a11y to announce currently chosen page

### DIFF
--- a/libs/core/src/lib/pagination/pagination.component.html
+++ b/libs/core/src/lib/pagination/pagination.component.html
@@ -28,7 +28,7 @@
                         (keypress)="onKeypressHandler(page, $event)"
                         (click)="goToPage(page, $event)"
                         *ngIf="page !== -1; else more"
-                        [attr.aria-current]="currentPage == page"
+                        [attr.aria-current]="currentPage === page ? 'page': undefined"
                         [attr.aria-label]="pageLabel +' '+ page"
                     >
                         {{ page }}

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -97,9 +97,14 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     itemsPerPageTemplate: TemplateRef<any>;
 
-    /** Label for options for items per page. */
+    /**
+     * Label for options for items per page.
+     * This property is mainly provided to support reading in the right language for screen reader.
+     * Here, Angular i18n's `$localize` tag is used with a default text of `Results per page`.
+     * Application developer is expected to pass in their own value if they use any other localization tool.
+     */
     @Input()
-    itemsPerPageLabel = 'Results per page';
+    itemsPerPageLabel = $localize`:@@corePaginationItemsPerPageLabel:Results per page`;
 
     /** Represents the options for items per page. */
     @Input()
@@ -129,21 +134,50 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     displayTextTemplate: TemplateRef<any>;
 
-    /** Label for the 'previous' page button. */
+    /**
+     * Label for the 'previous' page button.
+     * This property is mainly provided to support reading in the right language for screen reader.
+     * Here, Angular i18n's `$localize` tag is used with a default text of `Previous`.
+     * Application developer is expected to pass in their own value if they use any other localization tool.
+     */
     @Input()
-    previousLabel = 'Previous';
+    previousLabel = $localize`:@@corePaginationPreviousLabel:Previous`;
 
-    /** Label for the 'next' page button. */
+    /**
+     * Label for the 'next' page button.
+     * This property is mainly provided to support reading in the right language for screen reader.
+     * Here, Angular i18n's `$localize` tag is used with a default text of `Next`.
+     * Application developer is expected to pass in their own value if they use any other localization tool.
+     */
     @Input()
-    nextLabel = 'Next';
+    nextLabel = $localize`:@@corePaginationNextLabel:Next`;
 
-    /** Label for the 'Page' page button. */
+    /**
+     * Label for the 'Page' page button.
+     * This property is mainly provided to support reading in the right language for screen reader.
+     * Here, Angular i18n's `$localize` tag is used with a default text of `Page`.
+     * Application developer is expected to pass in their own value if they use any other localization tool.
+     */
     @Input()
-    pageLabel = 'Page';
+    pageLabel = $localize`:@@corePaginationPageLabel:Page `;
 
-    /** Aria label for the navigation element */
+    /**
+     * Aria label for the navigation element
+     * This property is mainly provided to support reading in the right language for screen reader.
+     * Here, Angular i18n's `$localize` tag is used with a default text of `Pagination`.
+     * Application developer is expected to pass in their own value if they use any other localization tool.
+     */
     @Input()
-    ariaLabel = 'Pagination';
+    ariaLabel = $localize`:@@corePaginationAriaLabel:Pagination`;
+
+    /**
+     * The current page label that should be read when a page is selected.
+     * This property is mainly provided to support reading in the right language for screen reader.
+     * Here, Angular i18n's `$localize` tag is used with a default text of `Current page`.
+     * Application developer is expected to pass in their own value if they use any other localization tool.
+     */
+    @Input()
+    currentPageLabel = $localize`:@@corePaginationCurrentPageLabel: Current page`;
 
     /** Event fired when the page is changed. */
     @Output()
@@ -262,8 +296,7 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
         }
         this._refreshPages();
 
-        const currentPageMessage = $localize`:@@corePaginationCurrentPage:Current page`;
-        this._liveAnnouncer.announce(this.pageLabel + ' ' + page + currentPageMessage);
+        this._liveAnnouncer.announce(this.pageLabel + page + this.currentPageLabel);
 
         this.pageChangeStart.emit(page);
     }

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -16,6 +16,7 @@ import {
     TemplateRef,
     ViewEncapsulation
 } from '@angular/core';
+import '@angular/localize/init';
 import { KeyUtil, RtlService } from '@fundamental-ngx/core/utils';
 import { Subscription } from 'rxjs';
 import { Pagination } from './pagination.model';
@@ -261,7 +262,8 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
         }
         this._refreshPages();
 
-        this._liveAnnouncer.announce('Page ' + page + ', current page');
+        const currentPageMessage = $localize`:@@corePaginationCurrentPage:Current page`;
+        this._liveAnnouncer.announce(this.pageLabel + ' ' + page + currentPageMessage);
 
         this.pageChangeStart.emit(page);
     }

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -177,7 +177,7 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
      * Application developer is expected to pass in their own value if they use any other localization tool.
      */
     @Input()
-    currentPageLabel = $localize`:@@corePaginationCurrentPageLabel: Current page`;
+    currentPageAriaLabel = $localize`:@@corePaginationCurrentPageAriaLabel: Page ${this.currentPage}:page: is current page`;
 
     /** Event fired when the page is changed. */
     @Output()
@@ -296,9 +296,9 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
         }
         this._refreshPages();
 
-        this._liveAnnouncer.announce(this.pageLabel + page + this.currentPageLabel);
-
         this.pageChangeStart.emit(page);
+
+        this._liveAnnouncer.announce(this.currentPageAriaLabel);
     }
 
     /**

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -1,27 +1,26 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { coerceArray, coerceNumberProperty } from '@angular/cdk/coercion';
+import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import {
     ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     EventEmitter,
     Input,
     OnChanges,
+    OnDestroy,
     OnInit,
     Optional,
     Output,
     SimpleChanges,
-    ViewEncapsulation,
-    TemplateRef, OnDestroy, ChangeDetectorRef
+    TemplateRef,
+    ViewEncapsulation
 } from '@angular/core';
-import {
-    ENTER,
-    SPACE
-} from '@angular/cdk/keycodes';
-import { coerceNumberProperty, coerceArray } from '@angular/cdk/coercion';
+import { KeyUtil, RtlService } from '@fundamental-ngx/core/utils';
 import { Subscription } from 'rxjs';
-
-import { KeyUtil } from '@fundamental-ngx/core/utils';
-import { PaginationService } from './pagination.service';
-import { RtlService } from '@fundamental-ngx/core/utils';
 import { Pagination } from './pagination.model';
+import { PaginationService } from './pagination.service';
+
 
 /** Constant representing the default number of items per page. */
 const DEFAULT_ITEMS_PER_PAGE = 10;
@@ -190,6 +189,7 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
     constructor (
         private readonly paginationService: PaginationService,
         private readonly _cd: ChangeDetectorRef,
+        private readonly _liveAnnouncer: LiveAnnouncer,
         @Optional() private readonly _rtlService: RtlService
     ) {}
 
@@ -260,6 +260,8 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
             return;
         }
         this._refreshPages();
+
+        this._liveAnnouncer.announce('Page ' + page + ', current page');
 
         this.pageChangeStart.emit(page);
     }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #6096 

#### Please provide a brief summary of this pull request.
This PR modifies the `aria-current` attribute value and uses LiveAnnouncer from CDK to announce the currently selected page.

Unfortunately, `aria-current` does not announce `"current page"` each time the page is changed; it seems to only announce the actively(or first time) selected `aria-current` element and doesn’t announce on page switch when handled dynamically. For this, there were two ways to handle this:
1. To add `current page` to the element’s aria-label attribute itself. This works okay for the pages themselves, but when we try to associate the previous and next buttons to also announce the page navigated to, it announces something like `Previous, Page 4, current page; button`; including the page’s aria-label before completely describing the previous button.
2. To use CDK’s LiveAnnouncer and announce the current page from code, in the method `goToPage` which is also called by previous and next buttons, thereby eliminating the problem explained in point 1. 

I have chosen to use LiveAnnouncer for its clarity of announcing the message in the correct order. It may seem that on selecting a page, it reads `Page 2, link; Page 2, current page`, but this is okay in my opinion because if you just tab through the pages instead, it reads `Page 2, link` first and only on pressing enter/space, it reads `Page 2, current page`(which isn’t happening currently in the latest netlify )

For the other two issues described in the issue, it has been clarified with the issue reporter that this is expected behaviour.
#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

