### PR TITLE
fix(core): added existed instance of dialog to injector of component

### DIFF
--- a/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
+++ b/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
@@ -36,7 +36,8 @@ export class DialogService extends DialogBaseService<DialogContainerComponent> {
             providers: [
                 { provide: DialogConfig, useValue: dialogConfig },
                 { provide: DialogRef, useValue: dialogRef },
-                { provide: RtlService, useValue: this._rtlService }
+                { provide: RtlService, useValue: this._rtlService },
+                { provide: DialogService, useValue: this },
             ]
         });
 


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #6106

#### Please provide a brief summary of this pull request.
The root of the problem was that the injector was redefined to the subsequent dialog, and the connection with the parent DialogService service was lost.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

