### PR TITLE
fix(platform): correct order for summary items

### DIFF
--- a/libs/platform/src/lib/components/wizard-generator/components/wizard-summary-step/wizard-summary-section/wizard-summary-section.component.ts
+++ b/libs/platform/src/lib/components/wizard-generator/components/wizard-summary-step/wizard-summary-section/wizard-summary-section.component.ts
@@ -69,6 +69,7 @@ export class WizardSummarySectionComponent implements OnInit {
         this._wizardGeneratorService.editStep(this.step.id);
     }
 
+    /** @hidden */
     private _formatStepValue(): void {
 
         if (!this._componentForms) {
@@ -77,7 +78,15 @@ export class WizardSummarySectionComponent implements OnInit {
 
         const formattedStepValue = [];
 
-        for (const [formId, form] of Object.entries(this._componentForms)) {
+        this.step.formGroups.forEach((formGroup) => {
+            const formId = formGroup.id;
+
+            const form = this._componentForms[formId];
+
+            // Form might be skipped due to conditional rendering
+            if (!form) {
+                return;
+            }
 
             const formattedForm: FormattedFormStep = {
                 title: form.title,
@@ -90,7 +99,7 @@ export class WizardSummarySectionComponent implements OnInit {
             };
 
             formattedStepValue.push(formattedForm);
-        }
+        });
 
         this._formattedStepValue = formattedStepValue;
     }


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #6120 

#### Please provide a brief summary of this pull request.
Changed logic of gathering summary section items to reflect original order of the form groups in wizard generator steps.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- n/a update `README.md`
- n/a [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- n/a Documentation Examples
- [x] Stackblitz works for all examples

