### PR TITLE
docs(core): fix placeholder not being read by JAWS for Feed Input

### DIFF
--- a/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-disabled-example/feed-input-disabled-example.component.html
+++ b/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-disabled-example/feed-input-disabled-example.component.html
@@ -1,6 +1,6 @@
 <fd-feed-input
     [disabled]="true"
-    aria-label="Feed input example">
+    aria-label="Feed input">
 
     <fd-avatar
         fdFeedInputAvatar
@@ -14,7 +14,6 @@
         fd-form-control
         fdFeedInputTextarea
         placeholder="Post something here"
-        aria-label="Feed message"
         [disabled]="true"></textarea>
 
     <button

--- a/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-example/feed-input-example.component.html
+++ b/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-example/feed-input-example.component.html
@@ -1,5 +1,5 @@
 <fd-feed-input
-    aria-label="Feed input example">
+    aria-label="Feed input">
 
     <fd-avatar
         fdFeedInputAvatar
@@ -12,8 +12,7 @@
     <textarea
         fd-form-control
         fdFeedInputTextarea
-        placeholder="Post something here"
-        aria-label="Feed message"></textarea>
+        placeholder="Post something here"></textarea>
 
     <button
         fdFeedInputButton

--- a/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-grow-example/feed-input-grow-example.component.html
+++ b/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-grow-example/feed-input-grow-example.component.html
@@ -1,5 +1,5 @@
 <fd-feed-input
-    aria-label="Feed input example">
+    aria-label="Feed input">
 
     <fd-avatar
         fdFeedInputAvatar
@@ -13,8 +13,7 @@
         fd-form-control
         fdFeedInputTextarea
         [fdFeedInputTextareaMaxRows]="7"
-        placeholder="Post something here"
-        aria-label="Feed message"></textarea>
+        placeholder="Post something here"></textarea>
 
     <button
         fdFeedInputButton

--- a/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-no-avatar-example/feed-input-no-avatar-example.component.html
+++ b/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-no-avatar-example/feed-input-no-avatar-example.component.html
@@ -1,11 +1,10 @@
 <fd-feed-input
-    aria-label="Feed input example">
+    aria-label="Feed input">
 
     <textarea
         fd-form-control
         fdFeedInputTextarea
-        placeholder="Post something here"
-        aria-label="Feed message"></textarea>
+        placeholder="Post something here"></textarea>
 
     <button
         fdFeedInputButton

--- a/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-placeholder-example/feed-input-placeholder-example.component.html
+++ b/apps/docs/src/app/core/component-docs/feed-input/examples/feed-input-placeholder-example/feed-input-placeholder-example.component.html
@@ -1,5 +1,5 @@
 <fd-feed-input
-    aria-label="Feed input example">
+    aria-label="Feed input">
 
     <fd-avatar
         fdFeedInputAvatar
@@ -13,8 +13,7 @@
     <textarea
         fd-form-control
         fdFeedInputTextarea
-        placeholder="Post something here"
-        aria-label="Feed message"></textarea>
+        placeholder="Post something here"></textarea>
 
     <button
         fdFeedInputButton


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #6216 

#### Please provide a brief summary of this pull request.
It seems that in textarea, when `aria-label` is present, `placeholder` is not given significance and won't be read out at all([w3 link describing the computation for element accessible name](https://www.w3.org/TR/html-aam-1.0/#input-type-text-input-type-password-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation), `placeholder` comes at fourth place in priority). 
To get the screen reader to announce `placeholder`, we have removed `aria-label`. 
As suggested in 6216 issue, we have also removed `example` word from the feed-input element's `aria-label`.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

