### PR TITLE
docs(core): provide correct size for tablist in Notification Group

### DIFF
--- a/apps/docs/src/app/core/component-docs/notification/examples/notification-group/notification-group-example.component.html
+++ b/apps/docs/src/app/core/component-docs/notification/examples/notification-group/notification-group-example.component.html
@@ -5,7 +5,7 @@
         </fd-popover-control>
         <fd-popover-body>
             <fd-notification-group width="40rem">
-                <fd-tab-list>
+                <fd-tab-list size="s">
                     <fd-tab title="By Date">
                         <fd-notification-group-list>
                             <fd-notification-group-header [(expanded)]="expandedByDate">


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #6296 

#### Please provide a brief summary of this pull request.
Tab list used in Notification Group example should use the `s` size(1rem spacing) to be vertically aligned to other elements as per spec.

#### Please check whether the PR fulfills the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

