### PR TITLE
fix(core): bug when first typing in combobox that uses objects

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -460,7 +460,7 @@ export class ComboboxComponent implements ComboboxInterface, ControlValueAccesso
     }
 
     get isEmptyValue(): boolean {
-        return this.inputText.trim().length === 0;
+        return !this.inputText || this.inputText?.trim().length === 0;
     }
 
     /** Get the input text of the input. */


### PR DESCRIPTION
Closes #6305 

Fixes a bug where user could not type in to combobox that uses objects instead of strings for values