### PR TITLE
fix(docs): add missing required validators

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-error-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-error-example.component.ts
@@ -17,6 +17,7 @@ export class PlatformFormGeneratorCustomErrorExampleComponent {
             type: 'input',
             message: 'Custom validation error example',
             name: 'custom_validation_error_example',
+            required: true,
             validate: (value) => value ? null : 'This field needs to be filled',
             guiOptions: {
                 hint: 'Keep it empty to see validation error on submit'

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-example.component.ts
@@ -109,6 +109,7 @@ export class PlatformFormGeneratorExampleComponent {
                     }
                 ];
             },
+            validators: [Validators.required],
             validate: (input, formValue) => {
                 return input?.length > 0 ? null : 'You need to select some country';
             }
@@ -146,6 +147,7 @@ export class PlatformFormGeneratorExampleComponent {
             name: 'agree',
             message: 'Do you agree with terms and conditions?',
             choices: ['Yes', 'No'],
+            validators: [Validators.required],
             validate: async (value) => {
                 await dummyAwaitablePromise();
                 return value === 'Yes' ? null : 'You must agree';
@@ -162,6 +164,7 @@ export class PlatformFormGeneratorExampleComponent {
             guiOptions: {
                 column: 2
             },
+            validators: [Validators.required],
             validate: (result: string) => {
                 return result === 'Angular' ? null : 'You should pick Angular';
             }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
@@ -120,6 +120,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
                     }
                 ];
             },
+            validators: [Validators.required],
             validate: (input, formValue) => {
                 return input?.length > 0 ? null : 'You need to select some country';
             }
@@ -159,6 +160,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
             name: 'agree1',
             message: 'Do you agree with terms and conditions?: XL: 2, L: 1, M: 2, S: 1',
             choices: ['Yes', 'No'],
+            validators: [Validators.required],
             validate: async (value) => {
                 await dummyAwaitablePromise();
                 return value === 'Yes' ? null : 'You must agree';
@@ -178,6 +180,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
                 inlineLayout: { XL: false, L: true, M: false, S: true },
                 hint: 'XL: 2 false, L: 1 true, M: 1 false, S: 1 true'
             },
+            validators: [Validators.required],
             validate: (result: string) => {
                 return result === 'Angular' ? null : 'You should pick Angular';
             }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-observable-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-observable-example.component.ts
@@ -93,6 +93,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
             type: 'checkbox',
             name: 'citizenship2',
             message: 'Your citizenship',
+            validators: [Validators.required],
             guiOptions: {
                 inline: true,
                 column: 2
@@ -136,6 +137,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
             name: 'agree2',
             message: 'Do you agree with terms and conditions?',
             choices: ['Yes', 'No'],
+            validators: [Validators.required],
             validate: (value) => of(value === 'Yes' ? null : 'You must agree'),
             guiOptions: {
                 column: 2
@@ -149,6 +151,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
             guiOptions: {
                 column: 2
             },
+            validators: [Validators.required],
             validate: (result: string) => of(result === 'Angular' ? null : 'You should pick Angular')
         },
         {

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-programatic-submit.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-programatic-submit.component.ts
@@ -105,6 +105,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
                     value: 'Ukraine'
                 }
             ]),
+            validators: [Validators.required],
             validate: (input, formValue) => {
                 return input?.length > 0 ? null : 'You need to select some country';
             }
@@ -136,6 +137,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
             name: 'agree3',
             message: 'Do you agree with terms and conditions?',
             choices: ['Yes', 'No'],
+            validators: [Validators.required],
             validate: (value) => of(value === 'Yes' ? null : 'You must agree'),
             guiOptions: {
                 column: 2
@@ -149,6 +151,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
             guiOptions: {
                 column: 2
             },
+            validators: [Validators.required],
             validate: (result: string) => of(result === 'Angular' ? null : 'You should pick Angular')
         },
         {


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes #6274

#### Please provide a brief summary of this pull request.
Added missing required validators for documentation examples.

#### Please check whether the PR fulfils the following requirements

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- n/a update `README.md`
- n/a [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

