### PR TITLE
fix(platform): table imports fix

### DIFF
--- a/libs/platform/src/lib/components/table/table.module.ts
+++ b/libs/platform/src/lib/components/table/table.module.ts
@@ -60,7 +60,7 @@ import { FdpViewSettingsFilterCustomDef } from './directives/table-view-settings
 import { TableScrollableDirective } from './directives/table-scrollable.directive';
 import { TableScrollerDirective } from './directives/table-scroller.directive';
 import { FdpCellSelectableDirective } from './directives/table-cell-selectable.directive';
-import { PlatformTableCellResizableDirective } from './directives';
+import { PlatformTableCellResizableDirective } from './directives/table-cell-resizable.directive';
 import { PlatformTableColumnResizerComponent } from './components/table-column-resizer/table-column-resizer.component';
 
 @NgModule({


### PR DESCRIPTION
#### Please provide a link to the associated issue.

Closes https://github.wdf.sap.corp/Ariba-Sourcing/minerva/pull/8737

#### Please provide a brief summary of this pull request.

In the `TableModule` was used relative import which refers to the barrel files, it breaks customer's app when using View Engine (not Ivy).

#### Please check whether the PR fulfills the following requirements

- [X] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [X] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [X] Run npm run build-pack-library and test in external application

Documentation checklist:
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [n/a] Documentation Examples
- [n/a] Stackblitz works for all examples

#### How to test (how Minerva folks found this bug)

1 Create an app using Angular 10
2 Import `FundamentalNgxPlatformModule`
3 Try to run `ng xi18n`