### PR TITLE
fix(core): adding accessability label to the inline help component

### DIFF
--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-example.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-example.component.html
@@ -1,26 +1,26 @@
 <div class="fd-inline-help-example">
     <span>Default</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" tabindex="0" ariaLabel="Default Inline Help Tooltip"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Left Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" tabindex="0" ariaLabel="Left Position Inline Help Tooltip"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Right Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" tabindex="0" ariaLabel="Inline Help Tooltip" ></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" tabindex="0" ariaLabel="Left Position Inline Help Tooltip" ></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Top Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" tabindex="0" ariaLabel="Top Position Inline Help Tooltip"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Bottom Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="bottom" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="bottom" tabindex="0" ariaLabel="Bottom Position Inline Help Tooltip"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">

--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-example.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-example.component.html
@@ -1,29 +1,30 @@
 <div class="fd-inline-help-example">
     <span>Default</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" tabindex="0" ariaLabel="Default Inline Help Tooltip"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Left Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" tabindex="0" ariaLabel="Left Position Inline Help Tooltip"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" tabindex="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Right Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" tabindex="0" ariaLabel="Left Position Inline Help Tooltip" ></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" tabindex="0" ariaLabel="Inline Help Tooltip" ></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Top Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" tabindex="0" ariaLabel="Top Position Inline Help Tooltip"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Bottom Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="bottom" tabindex="0" ariaLabel="Bottom Position Inline Help Tooltip"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="bottom" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Inline Help in Input</span>
-    <input fd-form-control fd-inline-help="Inline Help Tooltip" placement="right" placeholder="Inline tooltip inside input" aria-label="Inline Help Tooltip"/>
+    <input fd-form-control fd-inline-help="Inline Help Tooltip" placement="right" placeholder="Inline tooltip inside input" ariaLabel="Inline Help Tooltip"/>
 </div>
+

--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-example.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-example.component.html
@@ -1,30 +1,30 @@
 <div class="fd-inline-help-example">
-    <span>Default</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
+    <span id="fd-inline-help-default">Default</span>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" tabindex="0" aria-describedby="fd-inline-help-default" ariaLabel="Inline Help Tooltip"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
-    <span>Left Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" tabindex="0"></fd-icon>
+    <span id="fd-inline-help-left">Left Position</span>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" tabindex="0" ariaLabel="Inline Help Tooltip" aria-describedby="fd-inline-help-left"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
-    <span>Right Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" tabindex="0" ariaLabel="Inline Help Tooltip" ></fd-icon>
+    <span id="fd-inline-help-right">Right Position</span>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" tabindex="0" ariaLabel="Inline Help Tooltip" aria-describedby="fd-inline-help-right"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
-    <span>Top Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
+    <span id="fd-inline-help-top">Top Position</span>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" tabindex="0" ariaLabel="Inline Help Tooltip" aria-describedby="fd-inline-help-top"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
-    <span>Bottom Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="bottom" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
+    <span id="fd-inline-help-bottom">Bottom Position</span>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="bottom" tabindex="0" ariaLabel="Inline Help Tooltip" aria-describedby="fd-inline-help-bottom"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
-    <span>Inline Help in Input</span>
-    <input fd-form-control fd-inline-help="Inline Help Tooltip" placement="right" placeholder="Inline tooltip inside input" ariaLabel="Inline Help Tooltip"/>
+    <span id="fd-inline-help-input">Inline Help in Input</span>
+    <input fd-form-control fd-inline-help="Inline Help Tooltip" placement="right" placeholder="Inline tooltip inside input" ariaLabel="Inline Help Tooltip" aria-describedby="fd-inline-help-input"/>
 </div>
 

--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-styled-example.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-styled-example.component.html
@@ -1,1 +1,1 @@
-<fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" additionalBodyClass="fd-custom-inline-help-body" tabindex="0" ariaLabel="Inline Help Tooltip text color Red"></fd-icon>
+<fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" additionalBodyClass="fd-custom-inline-help-body" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>

--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-styled-example.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-styled-example.component.html
@@ -1,1 +1,1 @@
-<fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" additionalBodyClass="fd-custom-inline-help-body" tabindex="0" ariaLabel="Inline Help Tooltip"></fd-icon>
+<fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" additionalBodyClass="fd-custom-inline-help-body" tabindex="0" ariaLabel="Inline Help Tooltip text color Red"></fd-icon>

--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-template-example/inline-help-template-example.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-template-example/inline-help-template-example.component.html
@@ -1,4 +1,4 @@
-<span [fd-inline-help-template]="templateRef" placement="bottom" aria-describedby="tooltip-message1">Hover on me to see inline help</span>
+<a fd-object-status clickable="true" label="Hover on me to see inline help" [fd-inline-help-template]="templateRef" placement="bottom" aria-describedby="tooltip-message1"></a>
 
 <ng-template #templateRef>
     <div style="display: flex; align-items: center;">

--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-template-example/inline-help-template-example.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-template-example/inline-help-template-example.component.html
@@ -1,4 +1,4 @@
-<a fd-object-status clickable="true" label="Hover on me to see inline help" [fd-inline-help-template]="templateRef" placement="bottom" aria-describedby="tooltip-message1"></a>
+<a fd-object-status clickable="true" label="Hover on me to see inline help" [fd-inline-help-template]="templateRef" placement="bottom" aria-labelledby="tooltip-message1"></a>
 
 <ng-template #templateRef>
     <div style="display: flex; align-items: center;">

--- a/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-trigger-example.component.html
+++ b/apps/docs/src/app/core/component-docs/inline-help/examples/inline-help-trigger-example.component.html
@@ -1,4 +1,4 @@
-<button fd-button fd-inline-help="Inline Help Tooltip" [triggers]="['click']" [closeOnOutsideClick]="true" aria-describedby="tooltipmsg">
+<button role="button" fd-button fd-inline-help="Inline Help Tooltip" [triggers]="['click']" [closeOnOutsideClick]="true" aria-describedby="tooltipmsg">
     Click on me, to display inline help
 </button>
 <span id="tooltipmsg" style="display:none">Inline Help Tooltip.</span>

--- a/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/inline-help/inline-help-docs.module.ts
@@ -11,6 +11,7 @@ import { InlineHelpTriggerExampleComponent } from './examples/inline-help-trigge
 import { InlineHelpTemplateExampleComponent } from './examples/inline-help-template-example/inline-help-template-example.component';
 import { FormModule } from '@fundamental-ngx/core/form';
 import { InlineHelpModule } from '@fundamental-ngx/core/inline-help';
+import { ObjectStatusModule } from '@fundamental-ngx/core/object-status';
 
 const routes: Routes = [
     {
@@ -24,7 +25,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-    imports: [RouterModule.forChild(routes), SharedDocumentationPageModule, FormModule, InlineHelpModule],
+    imports: [RouterModule.forChild(routes), SharedDocumentationPageModule, FormModule, InlineHelpModule, ObjectStatusModule],
     exports: [RouterModule],
     declarations: [
         InlineHelpDocsComponent,

--- a/libs/core/src/lib/inline-help/inline-help.directive.ts
+++ b/libs/core/src/lib/inline-help/inline-help.directive.ts
@@ -12,7 +12,10 @@ const INLINE_HELP_CLASS = 'fd-inline-help__content';
     // tslint:disable-next-line:directive-selector
     selector: '[fd-inline-help], [fd-inline-help-template]',
     providers: [PopoverService],
-    host: { '[class.fd-inline-help__trigger]': 'true' }
+    host: {
+        '[class.fd-inline-help__trigger]': 'true',
+        '[attr.aria-label]': 'ariaLabel !== null ? placement !== null ? placement +","+ariaLabel : ariaLabel : " "'
+    }
 })
 export class InlineHelpDirective extends BasePopoverClass implements OnInit, OnChanges {
     /** The trigger events that will open/close the inline help component.
@@ -39,6 +42,9 @@ export class InlineHelpDirective extends BasePopoverClass implements OnInit, OnC
     /** Inline help template to display inside generated popover */
     @Input('fd-inline-help-template')
     inlineHelpTemplate: TemplateRef<any> = null;
+
+    @Input()
+    ariaLabel: string = null;
 
     constructor(
         private _popoverService: PopoverService,

--- a/libs/core/src/lib/inline-help/inline-help.directive.ts
+++ b/libs/core/src/lib/inline-help/inline-help.directive.ts
@@ -14,7 +14,7 @@ const INLINE_HELP_CLASS = 'fd-inline-help__content';
     providers: [PopoverService],
     host: {
         '[class.fd-inline-help__trigger]': 'true',
-        '[attr.aria-label]': 'ariaLabel !== null ? placement !== null ? placement +","+ariaLabel : ariaLabel : " "'
+        '[attr.aria-label]': 'ariaLabel !== null ? placement !== null ? placement +","+ariaLabel : ariaLabel : placement '
     }
 })
 export class InlineHelpDirective extends BasePopoverClass implements OnInit, OnChanges {

--- a/libs/core/src/lib/inline-help/inline-help.directive.ts
+++ b/libs/core/src/lib/inline-help/inline-help.directive.ts
@@ -13,8 +13,7 @@ const INLINE_HELP_CLASS = 'fd-inline-help__content';
     selector: '[fd-inline-help], [fd-inline-help-template]',
     providers: [PopoverService],
     host: {
-        '[class.fd-inline-help__trigger]': 'true',
-        '[attr.aria-label]': 'ariaLabel !== null ? placement !== null ? placement +","+ariaLabel : ariaLabel : placement '
+        '[class.fd-inline-help__trigger]': 'true'
     }
 })
 export class InlineHelpDirective extends BasePopoverClass implements OnInit, OnChanges {
@@ -42,9 +41,6 @@ export class InlineHelpDirective extends BasePopoverClass implements OnInit, OnC
     /** Inline help template to display inside generated popover */
     @Input('fd-inline-help-template')
     inlineHelpTemplate: TemplateRef<any> = null;
-
-    @Input()
-    ariaLabel: string = null;
 
     constructor(
         private _popoverService: PopoverService,


### PR DESCRIPTION
#### Please provide a link to the associated issue.
Closes: https://github.com/SAP/fundamental-ngx/issues/6219

#### Please provide a brief summary of this pull request.

adding accessability label and  removing the hardcoded background

- [x] the commit message follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application

Documentation checklist:
- [x] update `README.md`
- [NA] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
- [x] Documentation Examples
- [x] Stackblitz works for all examples

