### PR TITLE
fix(platform): correct delete behaviour for textarea

### DIFF
--- a/libs/platform/src/lib/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/form/text-area/text-area.component.ts
@@ -168,7 +168,8 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
     private readonly remainingText = 'remaining';
     private readonly excessText = 'excess';
 
-    private get shouldTrackTextLimit(): boolean {
+    /** @hidden */
+    private get _shouldTrackTextLimit(): boolean {
         return this.maxLength > 0 && !this.showExceededText;
     }
 
@@ -206,7 +207,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         this._setMaxHeight();
 
         // don't set any error state if we are not showing counter message
-        if (!this.shouldTrackTextLimit) {
+        if (!this._shouldTrackTextLimit) {
             this.stateType = null;
         }
 
@@ -324,7 +325,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
             this.autoGrowTextArea();
             this.isValueCustomSet = false; // set it to false first time it comes here
         }
-        if (this.shouldTrackTextLimit && KeyUtil.isKeyCode(event, [DELETE, BACKSPACE])) {
+        if (this._shouldTrackTextLimit && KeyUtil.isKeyCode(event, [DELETE, BACKSPACE])) {
             // for the custom value set and showExceededText=false case, on any key press, remove excess characters
             if (this.value) {
                 this._textAreaCharCount = this.value.length;

--- a/libs/platform/src/lib/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/form/text-area/text-area.component.ts
@@ -18,7 +18,7 @@ import {
 import { NgControl, NgForm } from '@angular/forms';
 import { BACKSPACE, DELETE } from '@angular/cdk/keycodes';
 
-import { ContentDensity } from '@fundamental-ngx/core/utils';
+import { ContentDensity, KeyUtil } from '@fundamental-ngx/core/utils';
 import { BaseInput, FormField, FormFieldControl, Status } from '@fundamental-ngx/platform/shared';
 import { TextAreaConfig } from './text-area.config';
 
@@ -168,6 +168,10 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
     private readonly remainingText = 'remaining';
     private readonly excessText = 'excess';
 
+    private get shouldTrackTextLimit(): boolean {
+        return this.maxLength > 0 && !this.showExceededText;
+    }
+
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() ngControl: NgControl,
@@ -202,7 +206,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         this._setMaxHeight();
 
         // don't set any error state if we are not showing counter message
-        if (!this.showExceededText) {
+        if (!this.shouldTrackTextLimit) {
             this.stateType = null;
         }
 
@@ -320,7 +324,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
             this.autoGrowTextArea();
             this.isValueCustomSet = false; // set it to false first time it comes here
         }
-        if (!this.showExceededText && (event.keyCode === DELETE || event.keyCode === BACKSPACE)) {
+        if (this.shouldTrackTextLimit && KeyUtil.isKeyCode(event, [DELETE, BACKSPACE])) {
             // for the custom value set and showExceededText=false case, on any key press, remove excess characters
             if (this.value) {
                 this._textAreaCharCount = this.value.length;


### PR DESCRIPTION
## Related Issue.
Closes #6525 

## Description
Previously backspace/delete keypress caused of the removal of the whole textarea value if no maxlength property was provided. Now if it's not provided, the behaviour of the keypress is native. 

#### Please check whether the PR fulfils the following requirements


##### During Implementation
1. Visual Testing:
- n/a visual misalignments/updates
- n/a check Light/Dark/HCB/HCW themes
- n/a RTL/LTR - proper rendering and labeling
- n/a responsiveness(resize)
- n/a Content Density (Cozy/Compact/(Condensed))
- n/a States - hover/disabled/focused/active/on click/selected/selected hover/press state
- n/a Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- [x] Mouse vs. Keyboard support
- [x] Text Truncation
2. API and functional correctness
- [x] check for console logs (warnings, errors)
- [x] API boundary values
- [x] different combinations of components - free style
- [x] change the API values during testing
3. Documentation and Example validations
- [x] missing API documentation or it is not understandable
- [x] poor examples
- [x] Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox


##### PR Quality
- [x] the commit message(s) follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application
- n/a update `README.md`
- n/a [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)

##### PR Review
2. API and functional correctness
n/a
3. Documentation and Example validations
n/a
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox
