### PR TITLE
feat(platform): add automatic colons for the labels

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.html
@@ -85,6 +85,8 @@
 </component-example>
 <code-example [exampleFiles]="customErrors"></code-example>
 
+<separator></separator>
+
 <fd-docs-section-title id="field-layout" componentName="form-generator">
     Form Generator with form field column layout and inline layout
 </fd-docs-section-title>
@@ -95,3 +97,17 @@
     <fdp-platform-form-generator-field-layout-example></fdp-platform-form-generator-field-layout-example>
 </component-example>
 <code-example [exampleFiles]="defaultFormGenerator"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="no-colons" componentName="form-generator">
+    Form Generator labels without colons
+</fd-docs-section-title>
+<description>
+    By default, form generator labels rendered with colon at the end of the label.
+    To disable this behaviour please specify <code>appendColon: false</code> in <code>guiOptions</code> object.
+</description>
+<component-example>
+    <fdp-platform-form-generator-no-colons-example></fdp-platform-form-generator-no-colons-example>
+</component-example>
+<code-example [exampleFiles]="noLabelColonsFiles"></code-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.component.ts
@@ -17,6 +17,9 @@ import * as customErrorsSrc from '!raw-loader!./platform-form-generator-examples
 import * as formFieldLayoutGeneratorhtml from '!raw-loader!./platform-form-generator-examples/platform-form-generator-field-layout-example.component.html';
 import * as formFieldLayoutGeneratorSrc from '!raw-loader!./platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts';
 
+import * as noColonsForLabelHtml from '!raw-loader!./platform-form-generator-examples/platform-form-generator-no-colons-example.component.html';
+import * as noColonsForLabelSrc from '!raw-loader!./platform-form-generator-examples/platform-form-generator-no-colons-example.component.ts';
+
 import { ExampleFile } from '../../../../documentation/core-helpers/code-example/example-file';
 
 @Component({
@@ -105,6 +108,20 @@ export class PlatformFormGeneratorDocsComponent {
             code: formFieldLayoutGeneratorSrc,
             fileName: 'platform-form-generator-field-layout-example',
             component: 'PlatformFormGeneratorFieldLayoutExampleComponent'
+        }
+    ];
+
+    noLabelColonsFiles: ExampleFile[] = [
+        {
+            language: 'html',
+            code: noColonsForLabelHtml,
+            fileName: 'platform-form-generator-no-colons-example'
+        },
+        {
+            language: 'typescript',
+            code: noColonsForLabelSrc,
+            fileName: 'platform-form-generator-no-colons-example',
+            component: 'PlatformFormGeneratorNoColonsExampleComponent'
         }
     ];
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-docs.module.ts
@@ -20,6 +20,7 @@ import { PlatformFormGeneratorObservableExampleComponent } from './platform-form
 import { PlatformFormGeneratorProgramaticSubmitComponent } from './platform-form-generator-examples/platform-form-generator-programatic-submit.component';
 import { PlatformFormGeneratorCustomErrorExampleComponent } from './platform-form-generator-examples/platform-form-generator-custom-error-example.component';
 import { PlatformFormGeneratorFieldLayoutExampleComponent } from './platform-form-generator-examples/platform-form-generator-field-layout-example.component';
+import { PlatformFormGeneratorNoColonsExampleComponent } from './platform-form-generator-examples/platform-form-generator-no-colons-example.component';
 
 const routes: Routes = [
     {
@@ -54,6 +55,7 @@ const routes: Routes = [
         PlatformFormGeneratorProgramaticSubmitComponent,
         PlatformFormGeneratorCustomErrorExampleComponent,
         PlatformFormGeneratorFieldLayoutExampleComponent,
+        PlatformFormGeneratorNoColonsExampleComponent,
     ]
 })
 export class PlatformFormGeneratorDocsModule {}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-no-colons-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-no-colons-example.component.html
@@ -1,0 +1,10 @@
+<fdp-form-generator columnLayout="XL2-L2-M2-S1" mainTitle="Form Generator example without colons in label" [formItems]="questions" (formSubmitted)="onFormSubmitted($event)" (formCreated)="onFormCreated()">
+</fdp-form-generator>
+
+<fdp-button *ngIf="formCreated" (click)="submitForm()" type="submit" label="Submit form"></fdp-button>
+
+<p>Form created: {{ formCreated }}</p>
+
+<p *ngIf="formValue">
+    Form value: {{ formValue|json }}
+</p>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-no-colons-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-no-colons-example.component.ts
@@ -1,0 +1,69 @@
+import { Component, ViewChild } from '@angular/core';
+import { Validators } from '@angular/forms';
+
+import { DynamicFormItem, DynamicFormValue, FormGeneratorComponent } from '@fundamental-ngx/platform/form';
+
+export const dummyAwaitablePromise = (timeout = 200) => {
+    return new Promise<boolean>((resolve) => {
+        setTimeout(() => {
+            resolve(true);
+        }, timeout);
+    });
+};
+
+@Component({
+  selector: 'fdp-platform-form-generator-no-colons-example',
+  templateUrl: './platform-form-generator-no-colons-example.component.html'
+})
+export class PlatformFormGeneratorNoColonsExampleComponent {
+
+    @ViewChild(FormGeneratorComponent) formGenerator: FormGeneratorComponent;
+
+    loading = false;
+
+    formCreated = false;
+    formValue: DynamicFormValue;
+
+    questions: DynamicFormItem[] = [
+        {
+            type: 'input',
+            name: 'labelWithoutColon',
+            message: 'Label without colon',
+            guiOptions: {
+                hint: 'Some contextual hint',
+                column: 1,
+                appendColon: false
+            }
+        },
+        {
+            type: 'input',
+            name: 'labelWithColon',
+            message: 'Label with colon',
+            guiOptions: {
+                hint: 'Some contextual hint',
+                column: 1,
+                appendColon: true
+            }
+        },
+    ];
+
+    onFormCreated(): void {
+        this.formCreated = true;
+    }
+
+    async onFormSubmitted(value: DynamicFormValue): Promise<void> {
+        this.formValue = value;
+
+        this.loading = true;
+
+        // Simulate API request
+        await dummyAwaitablePromise(5000);
+
+        this.loading = false;
+    }
+
+    submitForm(): void {
+        this.formGenerator.submit();
+    }
+
+}

--- a/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.html
+++ b/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.html
@@ -31,7 +31,7 @@
                         [i18Strings]="i18n"
                         [column]="field.formItem?.guiOptions?.column || 1"
                         [columnLayout]="field.formItem?.guiOptions?.columnLayout"
-                        [label]="field.formItem?.message"
+                        [label]="field.formItem?.message + (field.formItem?.guiOptions?.appendColon !== false ? ':' : '')"
                         [validators]="field.formItem?.validators"
                         [required]="field.formItem?.required"
                         [rank]="i"

--- a/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
+++ b/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
@@ -185,6 +185,9 @@ export interface DynamicFormItemGuiOptions {
      * @description Object contains additional payload. Useful for custom elements to manipulate it's view.
      */
     additionalData?: any;
+
+    /** If label should be appended with colon. True by default */
+    appendColon?: boolean;
 }
 
 export interface DynamicFormValue {


### PR DESCRIPTION
## Related Issue.
Closes #6526

## Description
Previously form generator rendered label value "as is". Now by default it will add colon at the end of the text. This can be changed with GuiOptions property per the form generator control.

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.

### Before:
![image](https://user-images.githubusercontent.com/6586561/133249700-96cf65a7-708c-41dc-a741-1aed46a697d0.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/133249729-9e1f1344-9bc1-469d-a6af-71d10040a710.png)

#### Please check whether the PR fulfills the following requirements


##### During Implementation
1. Visual Testing:
- n/a visual misalignments/updates
- n/a check Light/Dark/HCB/HCW themes
- n/a RTL/LTR - proper rendering and labeling
- n/a responsiveness(resize)
- n/a Content Density (Cozy/Compact/(Condensed))
- n/a States - hover/disabled/focused/active/on click/selected/selected hover/press state
- n/a Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- n/a Mouse vs. Keyboard support
- n/a Text Truncation
2. API and functional correctness
- [x] check for console logs (warnings, errors)
- [x] API boundary values
- [x] different combinations of components - free style
- [x] change the API values during testing
3. Documentation and Example validations
- [x] missing API documentation or it is not understandable
- [x] poor examples
- [x] Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox


##### PR Quality
- [x] the commit message(s) follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application
- n/a update `README.md`
- n/a [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)

##### PR Review
2. API and functional correctness
- [x] check for console logs (warnings, errors)
- [x] API boundary values
- [x] different combinations of components - free style
- [x] change the API values during testing
3. Documentation and Example validations
- [x] missing API documentation or it is not understandable
- [x] poor examples
- [x] Stackblitz works for all examples
5. Browser Testing - Edge, Safari, Chrome, Firefox
