### PR TITLE
fix: add temporary style fix for action buttons in Timeline

### DIFF
--- a/libs/core/src/lib/timeline/components/timeline-node-footer/timeline-node-footer.component.ts
+++ b/libs/core/src/lib/timeline/components/timeline-node-footer/timeline-node-footer.component.ts
@@ -7,7 +7,10 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
     encapsulation: ViewEncapsulation.None,
     host: {
         'class': 'fd-timeline__post-actions'
-    }
+    },
+    styles: [`.fd-timeline__post-actions button + button { 
+       margin-left: 0.5rem;
+    }`]
 })
 export class TimelineNodeFooterComponent {
 }


### PR DESCRIPTION
## Description

Add a temporary styling for adding space between buttons inside `fd-timeline-node-footer` container. 

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.

### Before:
<img width="433" alt="Screen Shot 2021-09-15 at 11 38 49 AM" src="https://user-images.githubusercontent.com/39598672/133464756-aab0620e-f2b3-43af-b4f1-349aa28dd569.png">

### After:
<img width="442" alt="Screen Shot 2021-09-15 at 11 32 06 AM" src="https://user-images.githubusercontent.com/39598672/133464553-a7884ce0-b997-4071-9f0c-7d8e4a4697d9.png">
