### PR TITLE
fix(core): grid list a11y for voice over

### DIFF
--- a/libs/core/src/lib/grid-list/components/grid-list/grid-list.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list/grid-list.component.html
@@ -8,7 +8,7 @@
     [class.fd-grid-list--mode-single-select-right]="selectionMode === 'singleSelectRight'"
     [class.fd-grid-list--mode-multi-select]="selectionMode === 'multiSelect'"
 >
-    <div class="fd-container" role="listbox" [attr.aria-label]="ariaLabel">
+    <form class="fd-container" role="listbox" [attr.aria-label]="ariaLabel">
         <ng-content></ng-content>
-    </div>
+    </form>
 </div>


### PR DESCRIPTION
## Related Issue.
Closes SAP/fundamental-ngx/#5774

## Description
VoiceOver doesn't bind radio buttons to the parent div with `role="listbox"`. Because of this all radio buttons exist in the single scope and are included in shared total count. To overcome this, changing parent element tag from `div` to `form`
