### PR TITLE
fix(platform): replace duplicate i18n ids

### DIFF
--- a/libs/platform/src/lib/approval-flow/approval-flow-select-type/approval-flow-select-type.component.html
+++ b/libs/platform/src/lib/approval-flow/approval-flow-select-type/approval-flow-select-type.component.html
@@ -15,7 +15,7 @@
         <fd-form-group class="fdp-approval-flow-select-type__form">
             <div fd-form-item>
                 <fd-radio-button
-                    i18n="@@platformApprovalFlowAddNodeDialogNodeTypeParallel"
+                    i18n="@@platformApprovalFlowSelectTypeDialogNodeTypeParallel"
                     [value]="_nodeTypes.PARALLEL"
                     [(ngModel)]="_nodeType"
                     [compact]="true"
@@ -27,7 +27,7 @@
 
             <div fd-form-item>
                 <fd-radio-button
-                    i18n="@@platformApprovalFlowAddNodeDialogNodeTypeSerial"
+                    i18n="@@platformApprovalFlowSelectTypeDialogNodeTypeSerial"
                     [value]="_nodeTypes.SERIAL"
                     [(ngModel)]="_nodeType"
                     [compact]="true"


### PR DESCRIPTION
## Related Issue.
Closes SAP/fundamental-ngx/#6467

## Description
Replace duplicate i18n ids with a new unique id, because the localized strings are different from the first usage of the previous ids.
