### PR TITLE
fix(core): multi-input, disable browser native autocomplete

### DIFF
--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -47,7 +47,7 @@
                       [tokenizerFocusable]="false"
                       (moreClickedEvent)="_moreClicked()"
                       class="fd-multi-input-tokenizer-custom"
-                      [class]="compact ? 'fd-multi-input-tokenizer-custom--compact' : ''"
+                      [class.fd-multi-input-tokenizer-custom--compact]="compact"
                       tabindex="-1"
         >
             <fd-token
@@ -61,6 +61,7 @@
             </fd-token>
             <input type="text"
                    class="fd-input fd-tokenizer__input fd-multi-input-tokenizer-input"
+                   autocomplete="off"
                    fd-form-control
                    fd-input-group-input
                    fd-auto-complete
@@ -74,7 +75,7 @@
                    [compact]="compact"
                    [disabled]="disabled"
                    [attr.aria-required]="required"
-                   [ngClass]="{ 'fd-input--compact': compact }"
+                   [class.fd-input--compact]="compact"
                    (ngModelChange)="_handleSearchTermChange($event)"
                    (keydown)="_handleInputKeydown($event)"
                    [ngModelOptions]="{standalone: true}"


### PR DESCRIPTION
## Related Issue.
Closes SAP/fundamental-ngx/#5987

## Description

Disabled browser native autocomplete for multi-input

##### During Implementation
1. Visual Testing:
- [n/a] visual misalignments/updates
- [n/a] check Light/Dark/HCB/HCW themes
- [n/a] RTL/LTR - proper rendering and labeling
- [n/a] responsiveness(resize)
- [n/a] Content Density (Cozy/Compact/(Condensed))
- [n/a] States - hover/disabled/focused/active/on click/selected/selected hover/press state
- [n/a] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- [n/a] Mouse vs. Keyboard support
- [n/a] Text Truncation
2. API and functional correctness
- [n/a] check for console logs (warnings, errors)
- [n/a] API boundary values
- [n/a] different combinations of components - free style
- [n/a] change the API values during testing
3. Documentation and Example validations
- [n/a] missing API documentation or it is not understandable
- [n/a] poor examples
- [n/a] Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox


##### PR Quality
- [X] the commit message(s) follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [X] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [n/a] Run npm run build-pack-library and test in external application
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
