### PR TITLE
test(e2e): fix notification e2e test

### DIFF
--- a/e2e/wdio/core/tests/notification.e2e-spec.ts
+++ b/e2e/wdio/core/tests/notification.e2e-spec.ts
@@ -126,13 +126,12 @@ describe('Notification component test', function () {
         notificationPage.checkRtlSwitch();
     });
 
-    function checkActions(action: string, button: string, index: number): void {
+    function checkActions(action: string, buttonChoice: string, index: number): void {
         scrollIntoView(defaultExample + overflowButton, index);
         click(defaultExample + overflowButton, index);
-        click(button);
+        click(buttonChoice);
         expect(isElementDisplayed(messageToast)).toBe(true);
         expect(getText(messageToast)).toBe(`${action} action performed`)
         waitForNotDisplayed(messageToast);
     }
-
 });


### PR DESCRIPTION
## Related Issue.
Closes none

## Description

fixes broken test - selector and variable both named 'button' caused test to click on the wrong button, renamed var button to buttonChoice.

#### Please check whether the PR fulfills the following requirements

##### PR Quality
- [x] the commit message(s) follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [n/a ] Run npm run build-pack-library and test in external application
- [ n/a] update `README.md`
- [ n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)

