### PR TITLE
fix(platform): add styles for extra space of fixed-height table

### DIFF
--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -258,6 +258,7 @@
         fdpTableScrollable
         #verticalScrollable="tableScrollable"
         [style.height]="bodyHeight"
+        [class.fixed-height]="!!bodyHeight"
     >
         <div
             *ngIf="_tableRowsVisible.length || loading; else emptyTableTemplate"

--- a/libs/platform/src/lib/table/table.component.scss
+++ b/libs/platform/src/lib/table/table.component.scss
@@ -357,10 +357,15 @@ $fd-table-border-var: var(--sapList_BorderWidth, 0.0625rem) solid var(--sapList_
             @include hide-scrollbar();
         }
 
-        .fd-table__row:last-of-type {
+        &:not(.fixed-height) .fd-table__row:last-of-type {
             .fd-table__cell {
                 border-bottom: 0;
             }
+        }
+
+        &.fixed-height {
+            background-color: #fff;
+            background-color: var(--sapList_Background, #fff);
         }
     }
 


### PR DESCRIPTION
## Related Issue.
Closes SAP/fundamental-ngx/#6547

## Description
add styles for extra space of fixed-height table

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.

### Before:
![image](https://user-images.githubusercontent.com/33101123/135122144-cd319fe6-f30e-4946-9b66-d46659572756.png)


### After:
![image](https://user-images.githubusercontent.com/33101123/135122098-0b719d56-d55d-4c9a-b7d4-da07ce77421b.png)

