### PR TITLE
fix(platform): table - content density bugs

### DIFF
--- a/libs/platform/src/lib/table/table.component.scss
+++ b/libs/platform/src/lib/table/table.component.scss
@@ -188,11 +188,18 @@ $fd-table-border-var: var(--sapList_BorderWidth, 0.0625rem) solid var(--sapList_
         width: auto;
     }
 
-    &.fd-table--condensed  {
-        .fd-table__row,
-        .fd-table__cell {
-            // this is required to fix the small difference in height between selection and other columns 
-            height: 1.563rem !important;
+    &.fd-table--condensed {
+        .fd-table__body {
+            .fd-table__row, .fd-table__cell {
+                // such specific value is required to fix the small difference in height between selection and other columns 
+                height: 1.563rem;
+            }
+        }
+
+        .fd-table__header {
+            .fd-table__row, .fd-table__cell {
+                height: 2rem;
+            }
         }
     }
 


### PR DESCRIPTION
## Related Issue.
Closes SAP/fundamental-ngx/#6543

## Description
Adjusted header and body cells' heights as follows:
Content density "condensed":
- header 2 rem
- body 1.563rem
Content density "compact":
- header 2 rem
- body 2rem
