### PR TITLE
fix(platform): baseInput CVAs emit extra event

### DIFF
--- a/libs/platform/src/lib/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/form/text-area/text-area.component.ts
@@ -132,7 +132,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
             // when custom value not set, we should set/reset counter to maxlength value when it becomes undefined
             this.exceededCharCount = this.maxLength ? this.maxLength : 0;
             // reset state by resetting value
-            super.writeValue('');
+            super.setValue('');
         }
     }
 

--- a/libs/platform/src/lib/shared/form/base.input.ts
+++ b/libs/platform/src/lib/shared/form/base.input.ts
@@ -260,8 +260,8 @@ export abstract class BaseInput extends BaseComponent
      */
     writeValue(value: any): void {
         this._value = value;
-        this.onChange(value);
         this.stateChanges.next('writeValue');
+        this._cd.markForCheck();
     }
 
     get status(): Status {
@@ -322,9 +322,18 @@ export abstract class BaseInput extends BaseComponent
         }
     }
 
-    protected setValue(value: any): void {
+    /**
+     * Used to change the value of a control. 
+     * @param value the value to be applied
+     * @param emitOnChange whether to emit "onChange" event. 
+     * Should be "false", if the change is made programmatically (internally) by the control, "true" otherwise
+     */
+    protected setValue(value: any, emitOnChange = true): void {
         if (value !== this._value) {
             this.writeValue(value);
+            if (emitOnChange) {
+                this.onChange(value);
+            }
             this._cd.markForCheck();
         }
     }


### PR DESCRIPTION
## Related Issue.
Closes SAP/fundamental-ngx/#3013

## Description
There is an extra ngModelChange event for all components based on BaseInput class: 
- when value is set by reactive form with `emitEvent: true`, there was 2 emissions of valueChanges (should be 1)
- when value is set with `emitEvent: false`, it still emitted once (while it should not)

Although the change is pretty simple, it affected a lot of platform CVAs. The following components were tested to be working correctly:
- checkbox-group
- date-picker
- datetime-picker
- input
- input-group
- base-multi-input
- radio
- time-picker
- combobox
- multi-combobox
- multi-input
- platform-file-uploader
- radio-group
- select
- number-step-input
- switch
- text-area
- list
- slider

#### Please check whether the PR fulfills the following requirements


##### During Implementation
1. Visual Testing:
- [n/a] visual misalignments/updates
- [n/a] check Light/Dark/HCB/HCW themes
- [n/a] RTL/LTR - proper rendering and labeling
- [n/a] responsiveness(resize)
- [n/a] Content Density (Cozy/Compact/(Condensed))
- [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
- [n/a] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- [n/a] Mouse vs. Keyboard support
- [n/a] Text Truncation
2. API and functional correctness
- [x] check for console logs (warnings, errors)
- [x] API boundary values
- [n/a] different combinations of components - free style
- [x] change the API values during testing
3. Documentation and Example validations
- [n/a] missing API documentation or it is not understandable
- [n/a] poor examples
- [n/a] Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox


##### PR Quality
- [x] the commit message(s) follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [x] Run npm run build-pack-library and test in external application
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)

##### PR Review
- [ ] visual misalignments/updates
- [ ] check Light/Dark/HCB/HCW themes
- [ ] RTL/LTR - proper rendering and labeling
- [ ] responsiveness(resize)
- [ ] Content Density (Cozy/Compact/(Condensed))
- [ ] States - hover/disabled/focused/active/on click/selected/selected hover/press state
- [ ] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- [ ] Mouse vs. Keyboard support
- [ ] Text Truncation
2. API and functional correctness
- [ ] check for console logs (warnings, errors)
- [ ] API boundary values
- [ ] different combinations of components - free style
- [ ] change the API values during testing
3. Documentation and Example validations
- [ ] missing API documentation or it is not understandable
- [ ] poor examples
- [ ] Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox
