### PR TITLE
chore: update tsconfig to not include spec files on build

### DIFF
--- a/apps/docs/tsconfig.app.json
+++ b/apps/docs/tsconfig.app.json
@@ -7,7 +7,8 @@
         "types": ["node"]
     },
     "files": ["src/main.ts", "src/polyfills.ts"],
-    "include": ["src/*.d.ts"],
+    "include": ["src/*.d.ts",  "**/*.ts"],
+    "exclude": ["**/*.spec.ts"],
     "angularCompilerOptions": {
       "enableIvy": true
     }

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -8,7 +8,5 @@
   "angularCompilerOptions": {
     "enableIvy": true
   },
-  "include": [
-    "**/*.ts"
-  ]
+  "include": []
 }

--- a/apps/docs/tsconfig.netlify.json
+++ b/apps/docs/tsconfig.netlify.json
@@ -5,5 +5,7 @@
         "esModuleInterop": true,
         "outDir": "../../dist/out-tsc",
         "types": ["node"]
-    }
+    },
+    "exclude": ["**/*.spec.ts"],
+    "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Related Issue.
Closes SAP/fundamental-ngx/#6671

## Description
Currently docs application's `.spec` files are included in build process, that results in that build to fail. This is fixed by properly placing `include`/`exclude` statements in tsconfigs
