### PR TITLE
fix(platform): use placeholder property for form generator

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-example.component.ts
@@ -43,6 +43,7 @@ export class PlatformFormGeneratorExampleComponent {
             name: 'name',
             message: 'Your name',
             default: 'John',
+            placeholder: 'Please provide your name',
             guiOptions: {
                 hint: 'Some contextual hint',
                 column: 1

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
@@ -47,6 +47,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
             name: 'name1',
             message: 'Your name: XL: 1, L: 2, M: 1, S: 2',
             default: 'John',
+            placeholder: 'Please provide your name',
             guiOptions: {
                 hint: 'Some contextual hint: XL: 1, L: 2, M: 1, S: 2',
                 columnLayout: { XL: 1, L: 2, M: 1, S: 1 },

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-observable-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-observable-example.component.ts
@@ -45,6 +45,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
             name: 'name2',
             message: 'Your name',
             default: 'John',
+            placeholder: () => of('Please provide your name').pipe(delay(400)),
             guiOptions: {
                 hint: 'Some contextual hint',
                 column: 1

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.html
@@ -1,7 +1,7 @@
 <ng-container [formGroup]="form">
     <fdp-date-picker
         [contentDensity]="formItem.guiOptions?.contentDensity"
-        [placeholder]="formItem.message"
+        [placeholder]="formItem.placeholder || formItem.message"
         [name]="name"
         [formControlName]="name"
         [allowNull]="false"

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-editor/dynamic-form-generator-editor.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-editor/dynamic-form-generator-editor.component.html
@@ -1,7 +1,7 @@
 <ng-container [formGroup]="form">
     <fdp-textarea
         [contentDensity]="formItem.guiOptions?.contentDensity"
-        [placeholder]="formItem.message"
+        [placeholder]="formItem.placeholder || formItem.message"
         [name]="name"
         [formControlName]="name"
     ></fdp-textarea>

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-select/dynamic-form-generator-select.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-select/dynamic-form-generator-select.component.html
@@ -1,7 +1,7 @@
 <ng-container [formGroup]="form">
 <fdp-select
     [contentDensity]="formItem.guiOptions?.contentDensity"
-    [placeholder]="formItem.message"
+    [placeholder]="formItem.placeholder || formItem.message"
     [name]="name"
     [list]="formItem.choices"
     [formControlName]="name"


### PR DESCRIPTION
## Related Issue.
Closes #6725 

## Description
Added usage of placeholder property of form generator metadata

#### Please check whether the PR fulfills the following requirements

##### During Implementation
1. Visual Testing:
- [x] visual misalignments/updates
- [x] check Light/Dark/HCB/HCW themes
- [x] RTL/LTR - proper rendering and labeling
- [x] responsiveness(resize)
- [x] Content Density (Cozy/Compact/(Condensed))
- [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
- [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- [x] Mouse vs. Keyboard support
- [x] Text Truncation
2. API and functional correctness
- [x] check for console logs (warnings, errors)
- [x] API boundary values
- [x] different combinations of components - free style
- [x] change the API values during testing
3. Documentation and Example validations
- [x] missing API documentation or it is not understandable
- [x] poor examples
- [x] Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox


##### PR Quality
- [X] the commit message(s) follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [X] tests for the changes that have been done
- [X] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [X] Run npm run build-pack-library and test in external application
- [X] update `README.md`
- [X] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)

