### PR TITLE
fix(docs): add appropriate anchors to the documentation

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-icon-tab-bar/platform-icon-tab-bar-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-icon-tab-bar/platform-icon-tab-bar-docs.component.html
@@ -1,4 +1,6 @@
-<h2>Text type tabs</h2>
+<fd-docs-section-title id="text-type" componentName="icon-tab-bar">
+    Text type tabs
+</fd-docs-section-title>
 <description>
   <p>
       The text-only variant is one of the most common types. It allows longer labels, and can also display counters next to the text to indicate the number of items on the tab page.
@@ -11,7 +13,11 @@
 </component-example>
 <code-example [exampleFiles]="iconTabBarTextTypeFiles"></code-example>
 
-<h2>Text type tabs (column mode)</h2>
+<separator></separator>
+
+<fd-docs-section-title id="text-type-column-mode" componentName="icon-tab-bar">
+    Text type tabs (column mode)
+</fd-docs-section-title>
 <description>
     <p>
         To use this mode you need to pass input<code class="code-snippet">[layoutMode]="'column'"</code>
@@ -22,9 +28,11 @@
 </component-example>
 <code-example [exampleFiles]="iconTabBarTextTypeFiles"></code-example>
 
+<separator></separator>
 
-
-<h2>Icon type tabs</h2>
+<fd-docs-section-title id="icon-type" componentName="icon-tab-bar">
+    Icon type tabs
+</fd-docs-section-title>
 <description>
     Icon tabs are also common tab types. These round tabs can be populated with any icon from the SAP icon font.
     Labels are optional. If you decide to use labels, use them for all tabs. You can use counters as needed.
@@ -36,8 +44,11 @@
 </component-example>
 <code-example [exampleFiles]="iconTabBarIconOnlyTypeFiles"></code-example>
 
+<separator></separator>
 
-<h2>Icon type tabs with labels</h2>
+<fd-docs-section-title id="icon-type-labels" componentName="icon-tab-bar">
+    Icon type tabs with labels
+</fd-docs-section-title>
 <description>
     To use the icon type of the tabs you must pass input <code class="code-snippet">[type]="'icon'"</code>
 </description>
@@ -46,8 +57,11 @@
 </component-example>
 <code-example [exampleFiles]="iconTabBarIconTypeFiles"></code-example>
 
+<separator></separator>
 
-<h2>Filter type tabs</h2>
+<fd-docs-section-title id="filter-type" componentName="icon-tab-bar">
+    Filter type tabs
+</fd-docs-section-title>
 <description>
     If you build the tab bar as a filter, it can comprise two parts:
 
@@ -70,8 +84,11 @@
 </component-example>
 <code-example [exampleFiles]="iconTabBarFilterTypeFiles"></code-example>
 
+<separator></separator>
 
-<h2>Process type tabs</h2>
+<fd-docs-section-title id="process-type" componentName="icon-tab-bar">
+    Process type tabs
+</fd-docs-section-title>
 <description>
     You can also use the tab bar to depict a process. In this case, each tab stands for one step.
     To use the process type of the tabs you must pass input <code class="code-snippet">[type]="'process'"</code>
@@ -81,10 +98,11 @@
 </component-example>
 <code-example [exampleFiles]="iconTabBarProcessTypeFiles"></code-example>
 
+<separator></separator>
 
-
-
-<h2>Nested tabs</h2>
+<fd-docs-section-title id="nested" componentName="icon-tab-bar">
+    Nested tabs
+</fd-docs-section-title>
 <description>
     <p>
         Nesting allows deeper hierarchies with indentations to indicate the level of each tab.
@@ -101,7 +119,11 @@
 </component-example>
 <code-example [exampleFiles]="iconTabBarTextTypeFiles"></code-example>
 
-<h2>Reordering</h2>
+<separator></separator>
+
+<fd-docs-section-title id="reordering" componentName="icon-tab-bar">
+    Reordering
+</fd-docs-section-title>
 <description>
    <p>
        You can allow users to rearrange the tab order in a desktop environment (property: enableTabReordering). If this feature is enabled, users can drag and drop tabs to reorder them, either directly on the tab bar or inside the overflow menu.
@@ -116,7 +138,11 @@
 </component-example>
 <code-example [exampleFiles]="iconTabBarTextTypeFiles"></code-example>
 
-<h2>Overflowing</h2>
+<separator></separator>
+
+<fd-docs-section-title id="overflow" componentName="icon-tab-bar">
+    Overflowing
+</fd-docs-section-title>
 <description>
     <p>
         When the screen space does not allow to show all tabs on the main tab bar, an overflow appears on the far right, containing all remaining tabs that do not fit on the screen.
@@ -127,7 +153,11 @@
 </component-example>
 <code-example [exampleFiles]="iconTabBarIconTypeFiles"></code-example>
 
-<h2>Configurable paddings</h2>
+<separator></separator>
+
+<fd-docs-section-title id="paddings" componentName="icon-tab-bar">
+    Configurable paddings
+</fd-docs-section-title>
 <description>
     <p>
         You can set horizontal paddings by adding a specifying the size of the paddings.


### PR DESCRIPTION
## Related Issue.
Closes #6761 

## Description
Added appropriate anchors and separators to the documentation page

#### Please check whether the PR fulfills the following requirements


##### During Implementation
1. Visual Testing:
- n/a visual misalignments/updates
- n/a check Light/Dark/HCB/HCW themes
- n/a RTL/LTR - proper rendering and labeling
- n/a responsiveness(resize)
- n/a Content Density (Cozy/Compact/(Condensed))
- [n/aStates - hover/disabled/focused/active/on click/selected/selected hover/press state
- n/a Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- n/a Mouse vs. Keyboard support
- n/a Text Truncation
2. API and functional correctness
- n/a check for console logs (warnings, errors)
- n/a API boundary values
- n/a different combinations of components - free style
- n/a change the API values during testing
3. Documentation and Example validations
- n/a missing API documentation or it is not understandable
- n/a poor examples
- n/a Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox


