### PR TITLE
fix(platform): should be able to reset form components

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-examples/platform-textarea-counter-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-examples/platform-textarea-counter-example.component.html
@@ -11,11 +11,10 @@
                 [validators]="textareaValidator"
             >
                 <fdp-textarea
-                    [formControl]="ff2.formControl"
+                    formControlName="detailedDescription"
                     name="detailedDescription"
                     [maxLength]="10"
                     [showExceededText]="true"
-                    [value]="value"
                 >
                 </fdp-textarea>
             </fdp-form-field>
@@ -30,7 +29,7 @@
                 [validators]="textareaNoCounterMessageValidator"
             >
                 <fdp-textarea
-                    [formControl]="ff3.formControl"
+                    formControl="noCounterMessageInteraction"
                     name="noCounterMessageInteraction"
                     [maxLength]="10"
                     [showExceededText]="false"

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-examples/platform-textarea-counter-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-textarea/platform-textarea-examples/platform-textarea-counter-example.component.ts
@@ -1,5 +1,5 @@
 import { Component, AfterViewInit, ChangeDetectorRef, ChangeDetectionStrategy } from '@angular/core';
-import { ValidatorFn, Validators, FormGroup } from '@angular/forms';
+import { ValidatorFn, Validators, FormGroup, FormControl } from '@angular/forms';
 
 @Component({
     selector: 'fdp-platform-textarea-counter-example',
@@ -8,11 +8,13 @@ import { ValidatorFn, Validators, FormGroup } from '@angular/forms';
 })
 export class PlatformTextareaCounterExampleComponent implements AfterViewInit {
     form: FormGroup;
-    value = 'Lorem ipsum, dolor sit amet';
-    private textareaValidator: ValidatorFn[];
-    private textareaNoCounterMessageValidator: ValidatorFn[];
+    textareaValidator: ValidatorFn[];
+    textareaNoCounterMessageValidator: ValidatorFn[];
     constructor(private _cd: ChangeDetectorRef) {
-        this.form = new FormGroup({});
+        this.form = new FormGroup({
+            detailedDescription: new FormControl('Lorem ipsum, dolor sit amet'),
+            noCounterMessageInteraction: new FormControl()
+        });
 
         this.textareaValidator = [Validators.maxLength(10), Validators.required];
         this.textareaNoCounterMessageValidator = [Validators.required];

--- a/libs/platform/src/lib/form/combobox/commons/base-combobox.ts
+++ b/libs/platform/src/lib/form/combobox/commons/base-combobox.ts
@@ -38,6 +38,7 @@ import { ListComponent } from '@fundamental-ngx/core/list';
 import { MobileModeConfig } from '@fundamental-ngx/core/mobile-mode';
 import {
     ArrayComboBoxDataSource,
+    coerceArraySafe,
     CollectionBaseInput,
     ComboBoxDataSource,
     FormField,
@@ -143,11 +144,7 @@ export abstract class BaseCombobox extends CollectionBaseInput implements AfterV
     }
 
     set value(value: any) {
-        if (!value) {
-            return;
-        }
-
-        const selectedItems = Array.isArray(value) ? value : [value];
+        const selectedItems = coerceArraySafe(value);
         this.setAsSelected(this._convertToOptionItems(selectedItems));
         super.setValue(value);
     }
@@ -348,11 +345,7 @@ export abstract class BaseCombobox extends CollectionBaseInput implements AfterV
 
     /** write value for ControlValueAccessor */
     writeValue(value: any): void {
-        if (!value) {
-            return;
-        }
-
-        const selectedItems = Array.isArray(value) ? value : [value];
+        const selectedItems = coerceArraySafe(value);
         this.setAsSelected(this._convertToOptionItems(selectedItems));
         super.writeValue(value);
     }

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -538,7 +538,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
             }
         }
 
-        this._cd.markForCheck();
+        this._cd.detectChanges();
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -253,6 +253,9 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
      * */
     _flatSuggestions: SelectableOptionItem[];
 
+    /** @hidden */
+    _fullFlatSuggestions: SelectableOptionItem[];
+
     /** @hidden
      * List of selected suggestions
      * */
@@ -529,12 +532,12 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
 
         for (let i = 0; i <= this.selectedItems.length; i++) {
             const selectedItem = this.selectedItems[i];
-            const idx = this._flatSuggestions.findIndex(
+            const idx = this._fullFlatSuggestions.findIndex(
                 (item) => item.label === selectedItem || item.value === selectedItem
             );
             if (idx !== -1) {
-                this._selectedSuggestions.push(this._flatSuggestions[idx]);
-                this._flatSuggestions[idx].selected = true;
+                this._selectedSuggestions.push(this._fullFlatSuggestions[idx]);
+                this._fullFlatSuggestions[idx].selected = true;
             }
         }
 
@@ -605,6 +608,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
     /** @hidden */
     private _openDataStream(ds: FdpMultiComboboxDataSource<any>): MultiComboBoxDataSource<any> {
         const initDataSource = this._toDataStream(ds);
+        let isInitDataSource = true;
 
         if (initDataSource === undefined) {
             throw new Error(`[dataSource] source did not match an array, Observable, or DataSource`);
@@ -624,6 +628,11 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
             .subscribe((data) => {
                 this._suggestions = this._convertToOptionItems(data);
                 this._flatSuggestions = this.isGroup ? this._flattenGroups(this._suggestions) : this._suggestions;
+
+                if (isInitDataSource) {
+                    this._fullFlatSuggestions = this._flatSuggestions;
+                    isInitDataSource = false;
+                }
 
                 this.stateChanges.next('initDataSource.open().');
 

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -57,8 +57,6 @@ import {
     ObservableMultiComboBoxDataSource,
     SelectableOptionItem
 } from '@fundamental-ngx/platform/shared';
-import { MultiComboboxComponent } from '../multi-combobox/multi-combobox.component';
-import { ListConfig } from '@fundamental-ngx/platform/list';
 import { TextAlignment } from '../../combobox';
 import { MultiComboboxConfig } from '../multi-combobox.config';
 
@@ -505,6 +503,12 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
         this.selectionChange.emit(event);
     }
 
+    /**
+     * Used to change the value of a control.
+     * @param value the value to be applied
+     * @param emitOnChange whether to emit "onChange" event.
+     * Should be "false", if the change is made programmatically (internally) by the control, "true" otherwise
+     */
     protected setValue(value: any, emitOnChange = true): void {
         this.selectedItems = coerceArraySafe(value);
         super.setValue(this.selectedItems, emitOnChange);

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -146,10 +146,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
 
     @Input()
     set value(value: any) {
-        this.selectedItems = coerceArraySafe(value);
-        super.setValue(this.selectedItems);
-        this._setSelectedSuggestions();
-        this.emitChangeEvent();
+        this.setValue(value, true);
     }
     get value(): any {
         return super.getValue();
@@ -381,10 +378,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
 
     /** write value for ControlValueAccessor */
     writeValue(value: any): void {
-        this.selectedItems = coerceArraySafe(value);
-        super.writeValue(this.selectedItems);
-        this._setSelectedSuggestions();
-        this.emitChangeEvent();
+        this.setValue(value, false);
     }
 
     /** @hidden */
@@ -505,10 +499,17 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
      * @hidden
      * Method to emit change event
      */
-    emitChangeEvent(): void {
+    _emitChangeEvent(): void {
         const event = new MultiComboboxSelectionChangeEvent(this, this.value);
 
         this.selectionChange.emit(event);
+    }
+
+    protected setValue(value: any, emitOnChange = true): void {
+        this.selectedItems = coerceArraySafe(value);
+        super.setValue(this.selectedItems, emitOnChange);
+        this._setSelectedSuggestions();
+        this._emitChangeEvent();
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -144,7 +144,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
 
     @Input()
     set value(value: any) {
-        this.setValue(value, true);
+        super.setValue(value, true);
     }
     get value(): any {
         return super.getValue();
@@ -376,7 +376,10 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements A
 
     /** write value for ControlValueAccessor */
     writeValue(value: any): void {
-        this.setValue(value, false);
+        this.selectedItems = coerceArraySafe(value);
+        super.writeValue(this.selectedItems);
+        this._setSelectedSuggestions();
+        this._emitChangeEvent();
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox-mobile/multi-combobox/multi-combobox-mobile.component.html
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox-mobile/multi-combobox/multi-combobox-mobile.component.html
@@ -1,7 +1,7 @@
 <ng-template let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
         <fd-dialog-header>
-            <h1 fd-title *ngIf="mobileConfig?.title" [innerText]="mobileConfig.title"></h1>
+            <h1 fd-title fd-dialog-title *ngIf="mobileConfig?.title" [innerText]="mobileConfig.title"></h1>
             <button
                 fd-dialog-close-button
                 *ngIf="mobileConfig?.hasCloseButton"

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox-mobile/multi-combobox/multi-combobox-mobile.component.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox-mobile/multi-combobox/multi-combobox-mobile.component.ts
@@ -96,7 +96,7 @@ export class MultiComboboxMobileComponent extends MobileModeBase<MultiComboboxIn
             return;
         }
 
-        this._selectedBackup = this._component._selected?.length ? [...this._component._selected] : [];
+        this._selectedBackup = this._component._selectedSuggestions?.length ? [...this._component._selectedSuggestions] : [];
         if (!this._dialogService.hasOpenDialogs()) {
             this._open();
         }

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox-mobile/multi-combobox/multi-combobox-mobile.component.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox-mobile/multi-combobox/multi-combobox-mobile.component.ts
@@ -96,7 +96,9 @@ export class MultiComboboxMobileComponent extends MobileModeBase<MultiComboboxIn
             return;
         }
 
-        this._selectedBackup = this._component._selectedSuggestions?.length ? [...this._component._selectedSuggestions] : [];
+        this._selectedBackup = this._component._selectedSuggestions?.length
+            ? [...this._component._selectedSuggestions]
+            : [];
         if (!this._dialogService.hasOpenDialogs()) {
             this._open();
         }

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox.interface.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox.interface.ts
@@ -12,7 +12,7 @@ export const MULTICOMBOBOX_COMPONENT = new InjectionToken<string[]>('MultiCombob
  */
 export interface MultiComboboxInterface extends MobileMode {
     _suggestions: SelectableOptionItem[];
-    _selected: SelectableOptionItem[];
+    _selectedSuggestions: SelectableOptionItem[];
     selectedShown$: BehaviorSubject<boolean>;
     openChange: Subject<boolean>;
 

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.html
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.html
@@ -45,7 +45,7 @@
         (keydown)="navigateByTokens($event)"
     >
         <fd-tokenizer
-            *ngIf="_selected"
+            *ngIf="_selectedSuggestions"
             [compact]="isCompact"
             [tokenizerFocusable]="false"
             class="fdp-multi-combobox-tokenizer-custom"
@@ -56,7 +56,7 @@
                 [compact]="isCompact"
                 [readOnly]="disabled"
                 (onCloseClick)="removeToken(token, $event)"
-                *ngFor="let token of _selected"
+                *ngFor="let token of _selectedSuggestions"
             >
                 {{ token.label }}
             </fd-token>

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.spec.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.spec.ts
@@ -177,14 +177,14 @@ describe('MultiComboboxComponent default values', () => {
         fixture.detectChanges();
 
         expect(item.selected).toBeTrue();
-        expect(multiCombobox._selected.length).toEqual(1);
+        expect(multiCombobox._selectedSuggestions.length).toEqual(1);
         expect(propagateChangeSpy).toHaveBeenCalled();
 
         multiCombobox.toggleSelection(item);
         fixture.detectChanges();
 
         expect(item.selected).toBeFalse();
-        expect(multiCombobox._selected.length).toEqual(0);
+        expect(multiCombobox._selectedSuggestions.length).toEqual(0);
         expect(propagateChangeSpy).toHaveBeenCalled();
     });
 
@@ -204,11 +204,11 @@ describe('MultiComboboxComponent default values', () => {
         overlayContainerEl.querySelector('.fd-list__item').dispatchEvent(selectEvent);
         fixture.detectChanges();
 
-        expect(multiCombobox._selected.length).toEqual(component.dataSource.length);
+        expect(multiCombobox._selectedSuggestions.length).toEqual(component.dataSource.length);
 
         overlayContainerEl.querySelector('.fd-list__item').dispatchEvent(unselectEvent);
         fixture.detectChanges();
 
-        expect(multiCombobox._selected.length).toEqual(0);
+        expect(multiCombobox._selectedSuggestions.length).toEqual(0);
     });
 });

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
@@ -289,9 +289,9 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
 
     /** @hidden Handle dialog approval, closes popover and propagates data changes. */
     dialogApprove(): void {
-        this._propagateChange(true);
         this.inputText = '';
         this.showList(false);
+        this._propagateChange(true);
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
@@ -150,7 +150,7 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
      * *select* attribute – if *true* select all, if *false* unselect all
      * */
     handleSelectAllItems(select: boolean): void {
-        this._flatSuggestions.forEach(item => (item.selected = select));
+        this._flatSuggestions.forEach((item) => (item.selected = select));
         this._selectedSuggestions = select ? [...this._flatSuggestions] : [];
 
         this._propagateChange();
@@ -296,7 +296,7 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
 
     /** @hidden */
     private _getTokenIndexByLabelOrValue(item: SelectableOptionItem): number {
-        return this._selectedSuggestions.findIndex(token => (token.label === item.label) || (token.value === item.value));
+        return this._selectedSuggestions.findIndex((token) => token.label === item.label || token.value === item.value);
     }
 
     /** @hidden */
@@ -306,7 +306,7 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
         // setting value, it will call setValue()
         this.value = selectedItems;
 
-        this.emitChangeEvent();
+        this._emitChangeEvent();
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
@@ -33,7 +33,7 @@ import {
     OptionItem,
     SelectableOptionItem
 } from '@fundamental-ngx/platform/shared';
-import { BaseMultiCombobox, MultiComboboxSelectionChangeEvent } from '../commons/base-multi-combobox';
+import { BaseMultiCombobox } from '../commons/base-multi-combobox';
 import { MultiComboboxMobileComponent } from '../multi-combobox-mobile/multi-combobox/multi-combobox-mobile.component';
 import { PlatformMultiComboboxMobileModule } from '../multi-combobox-mobile/multi-combobox-mobile.module';
 import { MULTICOMBOBOX_COMPONENT } from '../multi-combobox.interface';
@@ -68,7 +68,7 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
     /** @hidden
      * List of selected suggestions
      * */
-    _selected: SelectableOptionItem[] = [];
+    _selectedSuggestions: SelectableOptionItem[] = [];
 
     /** @hidden */
     private _timeout: any; // NodeJS.Timeout
@@ -109,17 +109,7 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
             this._setUpMobileMode();
         }
 
-        this._setSelectedItems();
-    }
-
-    /**
-     * @hidden
-     * Method to emit change event
-     */
-    emitChangeEvent<T>(value: T): void {
-        const event = new MultiComboboxSelectionChangeEvent(this, value);
-
-        this.selectionChange.emit(event);
+        this._setSelectedSuggestions();
     }
 
     /** @hidden */
@@ -127,9 +117,9 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
         const idx = this._getTokenIndexByLabelOrValue(item);
 
         if (idx === -1) {
-            this._selected.push(item);
+            this._selectedSuggestions.push(item);
         } else {
-            this._selected.splice(idx, 1);
+            this._selectedSuggestions.splice(idx, 1);
         }
 
         item.selected = !item.selected;
@@ -160,8 +150,8 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
      * *select* attribute – if *true* select all, if *false* unselect all
      * */
     handleSelectAllItems(select: boolean): void {
-        this._flatSuggestions.forEach((item) => (item.selected = select));
-        this._selected = select ? [...this._flatSuggestions] : [];
+        this._flatSuggestions.forEach(item => (item.selected = select));
+        this._selectedSuggestions = select ? [...this._flatSuggestions] : [];
 
         this._propagateChange();
     }
@@ -184,12 +174,12 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
             .pipe(takeUntil(this._destroyed), delay(1))
             .subscribe(() => {
                 const idx = this._getTokenIndexByLabelOrValue(token);
-                this._selected.splice(idx, 1);
+                this._selectedSuggestions.splice(idx, 1);
                 token.selected = false;
 
                 this._propagateChange(true);
 
-                if (!this._selected.length) {
+                if (!this._selectedSuggestions.length) {
                     this._focusToSearchField();
                 }
             });
@@ -198,8 +188,8 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
     /** @hidden */
     moreClicked(): void {
         this._suggestions = this.isGroup
-            ? this._convertObjectsToGroupOptionItems(this._selected.map(({ value }) => value))
-            : [...this._selected];
+            ? this._convertObjectsToGroupOptionItems(this._selectedSuggestions.map(({ value }) => value))
+            : [...this._selectedSuggestions];
 
         this.showList(true);
         this.selectedShown$.next(true);
@@ -291,7 +281,7 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
 
     /** @hidden Handle dialog dismissing, closes popover and sets backup data. */
     dialogDismiss(backup: SelectableOptionItem[]): void {
-        this._selected = [...backup];
+        this._selectedSuggestions = [...backup];
         this.inputText = '';
         this.showList(false);
         this.selectedShown$.next(false);
@@ -306,43 +296,23 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
 
     /** @hidden */
     private _getTokenIndexByLabelOrValue(item: SelectableOptionItem): number {
-        return this._selected.findIndex((token) => token.label === item.label || token.value === item.value);
-    }
-
-    /** @hidden */
-    private _setSelectedItems(): void {
-        if (!this.selectedItems?.length) {
-            return;
-        }
-
-        for (let i = 0; i <= this.selectedItems.length; i++) {
-            const selectedItem = this.selectedItems[i];
-            const idx = this._flatSuggestions.findIndex(
-                (item) => item.label === selectedItem || item.value === selectedItem
-            );
-            if (idx !== -1) {
-                this._selected.push(this._flatSuggestions[idx]);
-                this._flatSuggestions[idx].selected = true;
-            }
-        }
-
-        this.cd.detectChanges();
+        return this._selectedSuggestions.findIndex(token => (token.label === item.label) || (token.value === item.value));
     }
 
     /** @hidden */
     private _mapAndUpdateModel(): void {
-        const selectedItems = this._selected.map(({ value }) => value);
+        const selectedItems = this._selectedSuggestions.map(({ value }) => value);
 
         // setting value, it will call setValue()
         this.value = selectedItems;
 
-        this.emitChangeEvent(selectedItems || null);
+        this.emitChangeEvent();
     }
 
     /** @hidden */
     private _propagateChange(emitInMobile?: boolean): void {
         if (!this.mobile || emitInMobile) {
-            this.onChange(this._selected);
+            this.onChange(this._selectedSuggestions);
             this._mapAndUpdateModel();
         }
     }

--- a/libs/platform/src/lib/form/step-input/base.step-input.ts
+++ b/libs/platform/src/lib/form/step-input/base.step-input.ts
@@ -332,7 +332,7 @@ export abstract class StepInputComponent extends BaseInput implements OnInit {
     abstract createChangeEvent(value: number): StepInputChangeEvent;
 
     /** Format value for view presentation */
-    abstract formatValue(value: number): string;
+    abstract formatValue(value: number | null): string;
 
     /** Format value for "in focus" mode */
     abstract formatValueInFocusMode(value: number): string;
@@ -418,9 +418,6 @@ export abstract class StepInputComponent extends BaseInput implements OnInit {
 
     /** @hidden */
     private _updateViewValue(): void {
-        if (this._value === null) {
-            return;
-        }
         const formatted = this._formatValue();
         this._renderValue(formatted);
     }

--- a/libs/platform/src/lib/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/form/text-area/text-area.component.ts
@@ -237,21 +237,17 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
 
     /** write value for ControlValueAccessor */
     writeValue(value: any): void {
-        if (value) {
-            super.writeValue(value);
-            this.updateCounterInteractions();
-            this.stateChanges.next('textarea: writeValue');
-        }
+        super.writeValue(value);
+        this.updateCounterInteractions();
+        this.stateChanges.next('textarea: writeValue');
     }
 
     /** update the counter message and related interactions */
     updateCounterInteractions(): void {
-        if (this.value) {
-            this._textAreaCharCount = this.value.length;
-            if (this.maxLength) {
-                // newly added to avoid unnecessary iteration, remove if issue found
-                this.validateLengthOnCustomSet();
-            }
+        this._textAreaCharCount = this.value?.length ?? 0;
+        if (this.maxLength) {
+            // newly added to avoid unnecessary iteration, remove if issue found
+            this.validateLengthOnCustomSet();
         }
     }
 

--- a/libs/platform/src/lib/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/form/text-area/text-area.component.ts
@@ -333,11 +333,13 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         }
         if (this._shouldTrackTextLimit && KeyUtil.isKeyCode(event, [DELETE, BACKSPACE])) {
             // for the custom value set and showExceededText=false case, on any key press, remove excess characters
-            this._textAreaCharCount = this.value?.length ?? 0;
-            if (this._textAreaCharCount > this.maxLength) {
-                // remove excess characters
-                this.value = this.value?.substring(0, this.maxLength) ?? '';
-                this.isValueCustomSet = false; // since value is now changed, it is no longer custom set
+            if (this.value) {
+                this._textAreaCharCount = this.value.length;
+                if (this._textAreaCharCount > this.maxLength) {
+                    // remove excess characters
+                    this.value = this.value.substring(0, this.maxLength);
+                    this.isValueCustomSet = false; // since value is now changed, it is no longer custom set
+                }
             }
         }
     }
@@ -369,7 +371,9 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         if (this._targetElement) {
             contentLength = this._targetElement.value.length;
         }
-        contentLength = this.value?.length ?? 0;
+        if (this.value) {
+            contentLength = this.value.length;
+        }
         return contentLength;
     }
 

--- a/libs/platform/src/lib/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/form/text-area/text-area.component.ts
@@ -237,7 +237,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
 
     /** write value for ControlValueAccessor */
     writeValue(value: any): void {
-        super.writeValue(value);
+        super.writeValue(value ?? '');
         this.updateCounterInteractions();
         this.stateChanges.next('textarea: writeValue');
     }
@@ -333,13 +333,11 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         }
         if (this._shouldTrackTextLimit && KeyUtil.isKeyCode(event, [DELETE, BACKSPACE])) {
             // for the custom value set and showExceededText=false case, on any key press, remove excess characters
-            if (this.value) {
-                this._textAreaCharCount = this.value.length;
-                if (this._textAreaCharCount > this.maxLength) {
-                    // remove excess characters
-                    this.value = this.value.substring(0, this.maxLength);
-                    this.isValueCustomSet = false; // since value is now changed, it is no longer custom set
-                }
+            this._textAreaCharCount = this.value?.length ?? 0;
+            if (this._textAreaCharCount > this.maxLength) {
+                // remove excess characters
+                this.value = this.value?.substring(0, this.maxLength) ?? '';
+                this.isValueCustomSet = false; // since value is now changed, it is no longer custom set
             }
         }
     }
@@ -371,9 +369,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         if (this._targetElement) {
             contentLength = this._targetElement.value.length;
         }
-        if (this.value) {
-            contentLength = this.value.length;
-        }
+        contentLength = this.value?.length ?? 0;
         return contentLength;
     }
 

--- a/libs/platform/src/lib/shared/domain/data-model.ts
+++ b/libs/platform/src/lib/shared/domain/data-model.ts
@@ -1,3 +1,6 @@
+import { coerceArray } from '@angular/cdk/coercion';
+import { isBlank } from './../';
+
 /**
  * Interface SelectItem is used to deal with complex object in order to be able to format
  * custom label that is shown in the options.
@@ -75,3 +78,11 @@ export interface MultiInputOption {
 
 export const isOptionItem = isSelectItem;
 export const isSelectableOptionItem = isSelectableItem;
+
+/** 
+ * Wraps the provided value in an array, unless it is an array already.
+ * If `null` or `undefined` is received, will return an empty array.
+ */
+export function coerceArraySafe<T>(value: T | T[]): T[] {
+    return isBlank(value) ? [] : coerceArray(value);
+}

--- a/libs/platform/src/lib/shared/domain/data-model.ts
+++ b/libs/platform/src/lib/shared/domain/data-model.ts
@@ -1,5 +1,5 @@
 import { coerceArray } from '@angular/cdk/coercion';
-import { isBlank } from './../';
+import { isBlank } from './../utils/lang';
 
 /**
  * Interface SelectItem is used to deal with complex object in order to be able to format
@@ -79,7 +79,7 @@ export interface MultiInputOption {
 export const isOptionItem = isSelectItem;
 export const isSelectableOptionItem = isSelectableItem;
 
-/** 
+/**
  * Wraps the provided value in an array, unless it is an array already.
  * If `null` or `undefined` is received, will return an empty array.
  */


### PR DESCRIPTION
## Related Issue.
Closes https://github.com/sap/fundamental-ngx/issues/6781

## Description
Some of the components are not being visually reset when using `setValue(null)` or `reset()` on the reactive form.
Affected components:
- combobox
- multi-combobox
- number step input
- textarea
- slider

#### Please check whether the PR fulfills the following requirements


##### During Implementation
1. Visual Testing:
- [x] visual misalignments/updates
- [x] check Light/Dark/HCB/HCW themes
- [x] RTL/LTR - proper rendering and labeling
- [x] responsiveness(resize)
- [x] Content Density (Cozy/Compact/(Condensed))
- [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
- [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- [x] Mouse vs. Keyboard support
- [x] Text Truncation
2. API and functional correctness
- [x] check for console logs (warnings, errors)
- [x] API boundary values
- [n/a] different combinations of components - free style
- [x] change the API values during testing
3. Documentation and Example validations
- [n/a] missing API documentation or it is not understandable
- [n/a] poor examples
- [x] Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox


##### PR Quality
- [x] the commit message(s) follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [n/a] Run npm run build-pack-library and test in external application
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
