### PR TITLE
fix(core): dialog - keep only 1 non-transparent overlay

### DIFF
--- a/libs/core/src/lib/dialog/dialog-container/dialog-container.component.scss
+++ b/libs/core/src/lib/dialog/dialog-container/dialog-container.component.scss
@@ -1,0 +1,4 @@
+:host:not(:first-of-type) ::ng-deep .fd-dialog::before {
+    // keeping only 1 dialog with non-transparent overlay
+    opacity: 0;
+}

--- a/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
+++ b/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
@@ -22,7 +22,8 @@ import { DialogContentType } from '../dialog-service/dialog.service';
 /** Dialog container where the dialog content is embedded. */
 @Component({
     selector: 'fd-dialog-container',
-    template: '<ng-container #contentContainer></ng-container>'
+    template: '<ng-container #contentContainer></ng-container>',
+    styleUrls: ['./dialog-container.component.scss']
 })
 export class DialogContainerComponent extends DynamicComponentContainer<DialogContentType> implements AfterViewInit, CssClassBuilder {
     /** Custom classes */


### PR DESCRIPTION
## Related Issue.
Closes #6105

## Description
When there're multiple dialogs, overlays should not have "stacked" opacity. In other words, only one overlay should be non-transparent 
{{ _Enter short description of the change_ }}

## Screenshots
> **NOTE:** If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers.

### Before:
![image](https://user-images.githubusercontent.com/33101123/136248566-3a71601a-b1ec-4998-8fdd-9bf5321cff81.png)


### After:
![image](https://user-images.githubusercontent.com/33101123/136248553-5bed2127-e3c1-496a-8c6c-81b944f8d309.png)

#### Please check whether the PR fulfills the following requirements


##### During Implementation
1. Visual Testing:
- [x] visual misalignments/updates
- [x] check Light/Dark/HCB/HCW themes
- [x] RTL/LTR - proper rendering and labeling
- [x] responsiveness(resize)
- [x] Content Density (Cozy/Compact/(Condensed))
- [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
- [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- [x] Mouse vs. Keyboard support
- [x] Text Truncation
2. API and functional correctness
- [x] check for console logs (warnings, errors)
- [x] API boundary values
- [n/a] different combinations of components - free style
- [n/a] change the API values during testing
3. Documentation and Example validations
- [n/a] missing API documentation or it is not understandable
- [n/a] poor examples
- [n/a] Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox


##### PR Quality
- [x] the commit message(s) follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [n/a] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [n/a] Run npm run build-pack-library and test in external application
- [n/a] update `README.md`
- [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)

##### PR Review
- [ n/a] visual misalignments/updates
- [ n/a] check Light/Dark/HCB/HCW themes
- [ n/a] RTL/LTR - proper rendering and labeling
- [ n/a] responsiveness(resize)
- [ n/a] Content Density (Cozy/Compact/(Condensed))
- [ n/a] States - hover/disabled/focused/active/on click/selected/selected hover/press state
- [ n/a] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
- [ n/a] Mouse vs. Keyboard support
- [ n/a] Text Truncation
2. API and functional correctness
- [ n/a] check for console logs (warnings, errors)
- [ n/a] API boundary values
- [ n/a] different combinations of components - free style
- [n/a ] change the API values during testing
3. Documentation and Example validations
- [ n/a] missing API documentation or it is not understandable
- [ n/a] poor examples
- [ n/a] Stackblitz works for all examples
4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox
