### PR TITLE
chore(ci): add backup e2e flow to cron config

### DIFF
--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -111,7 +111,7 @@ jobs:
 
     # build docs
     build-docs:
-        needs: [build-core, build-platform]
+        needs: install
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
@@ -217,3 +217,13 @@ jobs:
                   CAP_SLUG: ${{ matrix.browser }}
               if: ${{ needs.firebase_preview.outputs.output_url }}
               run: TS_NODE_PROJECT=./e2e/tsconfig.json npx wdio wdio-cron.conf.js --${{ matrix.suite }} --baseUrl=${{ needs.firebase_preview.outputs.output_url }}/fundamental-ngx
+
+            - name: smoke e2e on saucelabs without firebase
+              env:
+                  CAP_SLUG: ${{ matrix.browser }}
+              if: ${{ !needs.firebase_preview.outputs.output_url }}
+              run: |
+                  sudo echo "127.0.0.1 sap.dev" | sudo tee -a /etc/hosts
+                  npx ng serve --disable-host-check --ssl --no-watch --aot --prod &
+                  npx wait-on https://localhost:4200
+                  TS_NODE_PROJECT=./e2e/tsconfig.json npx wdio wdio-cron.conf.js --${{ matrix.suite }} --baseUrl="https://sap.dev:4200/"


### PR DESCRIPTION
## Related Issue.
Closes none

## Description

adds an alt flow to run e2e if firebase deploy is unavailable


#### Please check whether the PR fulfills the following requirements

##### PR Quality
- [x] the commit message(s) follows the guideline:
https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
- [x] tests for the changes that have been done
- [x] all items on the PR Review Checklist are addressed :
https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
- [ n/a] Run npm run build-pack-library and test in external application
- [ n/a] update `README.md`
- [ n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)

