### PR TITLE
fix(core): bug where list items focus logic updates incorrectly

### DIFF
--- a/libs/core/src/lib/list/list.component.ts
+++ b/libs/core/src/lib/list/list.component.ts
@@ -168,7 +168,7 @@ export class ListComponent implements OnInit, AfterContentInit, OnDestroy {
 
     /** @hidden */
     private _listenOnQueryChange(): void {
-        this.items.changes.pipe(startWith(0), takeUntil(this._onDestroy$)).subscribe(() => {
+        this._focusItems.changes.pipe(startWith(0), takeUntil(this._onDestroy$)).subscribe(() => {
             this._recheckLinks();
             this._listenOnItemsClick();
         });


### PR DESCRIPTION
fixes #6607 

Before: Go to the "Filter and Sort List" List example and delete "Orange", then click "Pineapple". Strawberry gets focused. 

After: focusing works as expected

This issue is happening because `ListItemComponent` extends `ListFocusItem`, and when a `ListItemComponent` `ContentChild` is removed from a template, the `ListItemComponent` `changes` function is called before the `ListFocusItem` `ContentChild` has _also_ been removed. So when that `changes` function is called there is one more ListItemComponent than there is ListFocusItem.  We should be watching for changes on `ListFocusItem` instead as this `ContentChild` will be removed after the `ListItemComponent` has been removed.