### PR TITLE
fix(core): force button outline when clicked on safari

### DIFF
--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -59,7 +59,10 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
     /** Forces the focus outline around the button, which is not default behavior in Safari. */
     @HostListener('click', ['$event'])
     clicked(event: MouseEvent): void {
-        (event.target as HTMLElement).focus();
+        const target = event.target as HTMLElement;
+        if (document.activeElement !== target) {
+            target.focus();
+        }
     }
 
     /** @hidden */


### PR DESCRIPTION
fixes #6550 

By default, Safari does not apply `:focus` styles when a button is clicked, only when it is focused via the keyboard.  Here's a fix for that but I'm wondering if we want to diverge from the browser's default behavior.  But maybe this is what we need to meet Fiori specs. Thoughts @droshev ?