### PR TITLE
fix(core): do not open combobox popover on alt keypress

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -425,7 +425,12 @@ export class ComboboxComponent
         } else if (KeyUtil.isKeyCode(event, this.closingKeys)) {
             this.isOpenChangeHandle(false);
             event.stopPropagation();
-        } else if (this.openOnKeyboardEvent && !event.ctrlKey && !KeyUtil.isKeyCode(event, this.nonOpeningKeys)) {
+        } else if (
+            this.openOnKeyboardEvent &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !KeyUtil.isKeyCode(event, this.nonOpeningKeys)
+        ) {
             this.isOpenChangeHandle(true);
             if (this.isEmptyValue && KeyUtil.isKeyType(event, 'control') && !KeyUtil.isKeyCode(event, BACKSPACE)) {
                 this.listComponent.setItemActive(0);


### PR DESCRIPTION
fixes #6501 

Combobox popover should not open when user presses the alt key