### PR TITLE
fix(platform): add more cols for labels in form items

### DIFF
--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
@@ -2,7 +2,7 @@
     <div [horizontal]="labelLayout === 'horizontal'" fd-form-item class="fd-row">
         <div
             class="fd-col {{
-                labelLayout === 'horizontal' ? 'fd-col-md--2 fd-col-lg--4' : 'fd-col-md--12 fd-col-lg--12'
+                labelLayout === 'horizontal' ? 'fd-col-md--4 fd-col-lg--4' : 'fd-col-md--12 fd-col-lg--12'
             }} fd-col-xl--12"
         >
             <label
@@ -23,7 +23,7 @@
 <ng-template #withFormMessage>
     <fdp-input-message-group
         class="fd-col {{
-            labelLayout === 'horizontal' ? 'fd-col-md--10 fd-col-lg--8' : 'fd-col-md--12 fd-col-lg--12'
+            labelLayout === 'horizontal' ? 'fd-col-md--8 fd-col-lg--8' : 'fd-col-md--12 fd-col-lg--12'
         }} fd-col-xl--12"
     >
         <!--


### PR DESCRIPTION
add more cols for labels in form items for medim(temp workaround)
before:
label:input(2:10)
after:
label:input(4:8)