### PR TITLE
fix(core): split button selection

### DIFF
--- a/libs/core/src/lib/menu/directives/menu-interactive.directive.ts
+++ b/libs/core/src/lib/menu/directives/menu-interactive.directive.ts
@@ -34,11 +34,14 @@ export class MenuInteractiveDirective {
     readonly fdMenuLinkClass: boolean = true;
 
     /** @hidden */
+    _fromSplitButton = false;
+
+    /** @hidden */
     constructor(public elementRef: ElementRef) {}
 
     /** @hidden */
     setSelected(isSelected: boolean): void {
-        this.selected = isSelected && this.ariaHaspopup;
+        this.selected = isSelected && (this.ariaHaspopup || this._fromSplitButton);
     }
 
     /** @hidden */

--- a/libs/core/src/lib/menu/menu-item/menu-item.component.ts
+++ b/libs/core/src/lib/menu/menu-item/menu-item.component.ts
@@ -139,10 +139,12 @@ export class MenuItemComponent implements DefaultMenuItem, OnChanges, AfterConte
     }
 
     /** @hidden Sets menu item as selected/unselected based on isSelected flag */
-    setSelected(isSelected: boolean): void {
+    setSelected(isSelected: boolean, fromSplit?: boolean): void {
         this.menuInteractive.setSelected(isSelected);
         this.submenuVisible = isSelected && !!this.submenu;
-        this.onSelect.emit();
+        if (!fromSplit) {
+            this.onSelect.emit();
+        }
         this._changeDetectorRef.markForCheck();
     }
 

--- a/libs/core/src/lib/split-button/split-button.component.ts
+++ b/libs/core/src/lib/split-button/split-button.component.ts
@@ -174,8 +174,8 @@ export class SplitButtonComponent implements AfterContentInit, OnChanges, OnDest
 
     /** @hidden */
     ngAfterContentInit(): void {
-        this.menuInteractives.forEach((item) => {
-            item._fromSplitButton = true;
+        this.menu.menuItems.forEach((item) => {
+            item.menuInteractive._fromSplitButton = true;
         });
         this._setupMenuSubscription();
         this._setupMenuItemSubscriptions();
@@ -258,6 +258,10 @@ export class SplitButtonComponent implements AfterContentInit, OnChanges, OnDest
     private _handleMenuItemSelection(menuItem: MenuItemComponent): void {
         if (!this.mainAction || !this.mainAction.keepMainAction) {
             this.selected = menuItem;
+            this.menu.menuItems.forEach((item) => {
+                item.setSelected(false, true);
+            });
+            menuItem.setSelected(true, true);
             this.titleTemplate = null;
             this.mainActionTitle = menuItem.menuItemTitle.title;
             this._cdRef.detectChanges();

--- a/libs/core/src/lib/split-button/split-button.component.ts
+++ b/libs/core/src/lib/split-button/split-button.component.ts
@@ -5,6 +5,7 @@ import {
     ChangeDetectorRef,
     Component,
     ContentChild,
+    ContentChildren,
     ElementRef,
     EventEmitter,
     Input,
@@ -13,6 +14,7 @@ import {
     OnInit,
     Optional,
     Output,
+    QueryList,
     Renderer2,
     SimpleChanges,
     TemplateRef,
@@ -21,7 +23,7 @@ import {
 } from '@angular/core';
 import { SplitButtonActionTitle } from './split-button-utils/split-button.directives';
 import { ButtonType } from '@fundamental-ngx/core/button';
-import { MenuComponent } from '@fundamental-ngx/core/menu';
+import { MenuComponent, MenuInteractiveDirective } from '@fundamental-ngx/core/menu';
 import { MenuItemComponent } from '@fundamental-ngx/core/menu';
 import { Subscription } from 'rxjs';
 import { MainAction } from './main-action';
@@ -114,6 +116,10 @@ export class SplitButtonComponent implements AfterContentInit, OnChanges, OnDest
     menu: MenuComponent;
 
     /** @hidden */
+    @ContentChildren(MenuInteractiveDirective)
+    menuInteractives: QueryList<MenuInteractiveDirective>;
+
+    /** @hidden */
     @ViewChild('mainActionButton', { read: ElementRef })
     mainActionBtn: ElementRef;
 
@@ -168,6 +174,9 @@ export class SplitButtonComponent implements AfterContentInit, OnChanges, OnDest
 
     /** @hidden */
     ngAfterContentInit(): void {
+        this.menuInteractives.forEach((item) => {
+            item._fromSplitButton = true;
+        });
         this._setupMenuSubscription();
         this._setupMenuItemSubscriptions();
         this._handleMainActionObject();


### PR DESCRIPTION
fixes #6451 

Selected styling needs to appear on the selected option in the split button dropdown menu.

Before
![Screen Shot 2021-10-27 at 10 50 20 AM](https://user-images.githubusercontent.com/2471874/139110849-431d0c73-bcc1-4957-b00f-7241077aa140.png)

After
![Screen Shot 2021-10-27 at 10 49 54 AM](https://user-images.githubusercontent.com/2471874/139110769-9f24584f-f113-43bd-a313-b0267dfaafe6.png)

