### PR TITLE
fix(platform): hide password at summary page

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-default-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-default-example.component.ts
@@ -54,6 +54,12 @@ export class WizardGeneratorDefaultExampleComponent {
                             name: 'address2',
                             message: 'Address Line 2',
                             type: 'input'
+                        },
+                        {
+                            name: 'password',
+                            message: 'Password',
+                            type: 'password',
+                            controlType: 'password'
                         }
                     ]
                 }

--- a/libs/platform/src/lib/wizard-generator/components/wizard-summary-step/wizard-summary-step.component.ts
+++ b/libs/platform/src/lib/wizard-generator/components/wizard-summary-step/wizard-summary-step.component.ts
@@ -151,7 +151,10 @@ export class WizardSummaryStepComponent {
                 items: Object.keys(this._submittedForms[step.id][formId]).map((key) => {
                     return {
                         label: form.form.controls[key].formItem.message as string,
-                        value: formattedFormValue[key]
+                        value:
+                            form.form.controls[key].formItem.controlType !== 'password'
+                                ? formattedFormValue[key]
+                                : this._formatPasswordValue(formattedFormValue[key])
                     };
                 })
             };
@@ -160,5 +163,10 @@ export class WizardSummaryStepComponent {
         }
 
         return formattedStepValue;
+    }
+
+    /** @hidden */
+    private _formatPasswordValue(password: string): string {
+        return '*'.repeat(password.length);
     }
 }


### PR DESCRIPTION
## Related Issue(s)
fixes #7136 

## Description

mask password at summary page

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

### After:

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

