### PR TITLE
fix(platform): table columns' width recalc on resize

### DIFF
--- a/libs/platform/src/lib/table/table-column-resize.service.ts
+++ b/libs/platform/src/lib/table/table-column-resize.service.ts
@@ -111,13 +111,17 @@ export class TableColumnResizeService implements OnDestroy {
         this._resizerMoveSubscription.unsubscribe();
     }
 
+    /** Reset columns width */
+    resetColumnsWidth(): void {
+        this._columnsWidthMap.clear();
+    }
+
     /** Initialize service with data, trigger columns width calculation. */
     setColumnsWidth(visibleColumnNames: string[], freezeColumnsTo: string, offsetWidth: number): void {
         this._visibleColumnNames = visibleColumnNames;
         this._preventResize = this._visibleColumnNames.includes(freezeColumnsTo);
         this._offsetWidth = offsetWidth;
 
-        this._resetColumnsWidth();
         this._calculateColumnsWidth();
     }
 
@@ -257,11 +261,6 @@ export class TableColumnResizeService implements OnDestroy {
         this._columnsCellMap.forEach((cell, columnName) => {
             this._columnsWidthMap.set(columnName, cell.nativeElement.offsetWidth);
         });
-    }
-
-    /** @hidden */
-    private _resetColumnsWidth(): void {
-        this._columnsWidthMap.clear();
     }
 
     /** Update column resizer position. */

--- a/libs/platform/src/lib/table/table.component.spec.ts
+++ b/libs/platform/src/lib/table/table.component.spec.ts
@@ -931,7 +931,7 @@ describe('TableComponent internal', () => {
         const tableBodyScrollTop = async (scrollTop) => {
             const container = tableBodyContainer.nativeElement as HTMLElement;
             container.scrollTop = scrollTop;
-            await new Promise((resolve) => setTimeout(() => resolve(null), 100));
+            await new Promise((resolve) => setTimeout(() => resolve(null), 200));
             fixture.detectChanges();
             calculateTableElementsMetaData();
         };

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -846,9 +846,10 @@ export class TableComponent<T = any> extends Table implements AfterViewInit, OnD
             this._tableColumnResizeService.setColumnsWidth(columnNames, this.freezeColumnsTo, offsetWidth);
             this._setFreezableInfo();
 
-            this._cdr.markForCheck();
+            this._cdr.detectChanges();
         };
 
+        this._tableColumnResizeService.resetColumnsWidth();
         this._cdr.detectChanges();
 
         let elRect = this._elRef.nativeElement.getBoundingClientRect();
@@ -1978,7 +1979,7 @@ export class TableComponent<T = any> extends Table implements AfterViewInit, OnD
         this._subscriptions.add(
             resizeObservable(this.tableContainer.nativeElement)
                 .pipe(debounceTime(100))
-                .subscribe(() => this._cdr.detectChanges())
+                .subscribe(() => this.recalculateTableColumnWidth())
         );
     }
 


### PR DESCRIPTION
## Related Issue(s)

Related to https://github.tools.sap/dxp/organization/issues/76

## Description

Platform table columns' width recalculation on resizing.

## Screenshots

### Before:

https://user-images.githubusercontent.com/20265336/141960333-189fc89a-223e-4ff1-8223-ef1b374cac3a.mov

### After:

Resizing goes not instantly to decrease the number of recalculations.

https://user-images.githubusercontent.com/20265336/141960202-98d379d6-812f-43f0-a781-28f1cfdd7c58.mov
