### PR TITLE
fix(platform): value help dialog table cell

### DIFF
--- a/libs/platform/src/lib/value-help-dialog/components/select-tab/select-tab.component.html
+++ b/libs/platform/src/lib/value-help-dialog/components/select-tab/select-tab.component.html
@@ -94,7 +94,7 @@
                     [attr.aria-selected]="_selectedMap[row[uniqueKey]]"
                 >
                     <td fd-table-cell></td>
-                    <td colspan="100%" [fitContent]="true">
+                    <td colspan="100%" fd-table-cell [fitContent]="true">
                         <p fd-table-text *ngFor="let filter of _tableFilters.secondary">
                             <label>{{ filter.label }}:</label>
                             {{ row[filter.key] || '' }}


### PR DESCRIPTION
## Description

Fix for the `fd-table-cell` directive missed in value help dialog so build may fail because `fitContent` is not a known property of `td`.