### PR TITLE
fix(core): intersection observable for unsupported browsers

### DIFF
--- a/libs/core/src/lib/utils/functions/intersection-observable.ts
+++ b/libs/core/src/lib/utils/functions/intersection-observable.ts
@@ -1,4 +1,4 @@
-import { Observable } from 'rxjs';
+import { NEVER, Observable } from 'rxjs';
 
 /**
  * RxJS wrapper for IntersectionObserver class.
@@ -22,5 +22,9 @@ export function intersectionObservable(
                 io.disconnect();
             };
         });
+    } else {
+        // If browser doesn't support IntersectionObserver API never emit a value
+        // since we're not supporting IE11 and any other browser should have it.
+        return NEVER;
     }
 }


### PR DESCRIPTION
## Description

Fix for intersection observable for unsupported browsers.

### Before:

`.subscribe()` fails on `intersectionObservable()` if no `IntersectionObserver` present in `window` object.

### After:

No error.
