### PR TITLE
fix(core): update layout when component initialized completely

### DIFF
--- a/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.ts
+++ b/libs/core/src/lib/fixed-card-layout/fixed-card-layout.component.ts
@@ -96,7 +96,11 @@ export class FixedCardLayoutComponent implements OnInit, AfterContentInit, After
     @Input()
     set cardMinimumWidth(value: number) {
         this._cardMinimumWidth = coerceNumberProperty(value);
-        this.updateLayout();
+
+        // // If component is ready, do the recalculation.
+        if (this.layout) {
+            this.updateLayout();
+        }
     }
 
     get cardMinimumWidth(): number {


### PR DESCRIPTION
## Description

Previously, setting cardMinimumWidth property may cause an error due to the component's incomplete initialization. This fix adds a check whether or not the layout is initialized.