### PR TITLE
chore(ci): override github actions virtual machine node version

### DIFF
--- a/.github/workflows/on-push-or-pull.yml
+++ b/.github/workflows/on-push-or-pull.yml
@@ -55,7 +55,6 @@ jobs:
                   path: ${{ env.CACHE_NODE_MODULES_PATH }}
                   key: node_modules-${{ hashFiles('**/package-lock.json') }}
             - run: npm ci
-              if: steps.cache.outputs.cache-hit != 'true'
 
     # lint commit name
     commit_lint:

--- a/.github/workflows/on-push-or-pull.yml
+++ b/.github/workflows/on-push-or-pull.yml
@@ -54,7 +54,11 @@ jobs:
               with:
                   path: ${{ env.CACHE_NODE_MODULES_PATH }}
                   key: node_modules-${{ hashFiles('**/package-lock.json') }}
-            - run: npm ci
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 15.11.0
+            - name: install dependencies
+              run: npm ci
 
     # lint commit name
     commit_lint:
@@ -259,12 +263,17 @@ jobs:
               with:
                   path: ${{ env.CACHE_NODE_MODULES_PATH }}
                   key: node_modules-${{ hashFiles('**/package-lock.json') }}
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 15.11.0
 
             - name: smoke e2e on firebase
               env:
                   CAP_SLUG: ${{ matrix.browser }}
               if: ${{ needs.firebase_preview.outputs.output_url }}
               run: |
+                  npm rebuild
+                  npm ci
                   export DISPLAY=:99
                   chrome --version
                   sudo Xvfb -ac :99 -screen 0 1920x1080x24 > /dev/null 2>&1 & # optional
@@ -275,6 +284,8 @@ jobs:
                   CAP_SLUG: ${{ matrix.browser }}
               if: ${{ !needs.firebase_preview.outputs.output_url }}
               run: |
+                  npm rebuild
+                  npm ci
                   npx ng serve --no-watch --aot --prod &
                   npx wait-on http://localhost:4200
                   export DISPLAY=:99

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -35,7 +35,6 @@ jobs:
                   path: ${{ env.CACHE_NODE_MODULES_PATH }}
                   key: node_modules-${{ hashFiles('**/package-lock.json') }}
             - run: npm ci
-              if: steps.cache.outputs.cache-hit != 'true'
 
     # build core
     build-core:

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -34,7 +34,12 @@ jobs:
               with:
                   path: ${{ env.CACHE_NODE_MODULES_PATH }}
                   key: node_modules-${{ hashFiles('**/package-lock.json') }}
-            - run: npm ci
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 15.11.0
+                  cache: npm
+            - name: install dependencies
+              run: npm ci
 
     # build core
     build-core:
@@ -210,8 +215,17 @@ jobs:
               with:
                   path: ${{ env.CACHE_NODE_MODULES_PATH }}
                   key: node_modules-${{ hashFiles('**/package-lock.json') }}
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 15.11.0
 
-            - name: smoke e2e on saucelabs with firebase deployment
+            - name: smoke e2e on saucelabs with localhost
               env:
                   CAP_SLUG: ${{ matrix.browser }}
-              run: TS_NODE_PROJECT=./e2e/tsconfig.json npx wdio wdio-cron.conf.js --${{ matrix.suite }} --baseUrl=https://fundamental-ngx-gh.web.app/fundamental-ngx
+              run: |
+                  npm rebuild
+                  npm ci
+                  sudo echo "127.0.0.1 sap.dev" | sudo tee -a /etc/hosts
+                  npx ng serve --disable-host-check --ssl --no-watch --aot --prod &
+                  npx wait-on https://localhost:4200
+                  TS_NODE_PROJECT=./e2e/tsconfig.json npx wdio wdio-cron.conf.js --${{ matrix.suite }} --baseUrl="https://sap.dev:4200/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4512,6 +4512,14 @@
         "comment-parser": "1.2.4",
         "esquery": "^1.4.0",
         "jsdoc-type-pratt-parser": "2.0.0"
+      },
+      "dependencies": {
+        "comment-parser": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
+          "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
+          "dev": true
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -13825,9 +13833,9 @@
       "dev": true
     },
     "comment-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
-      "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
+      "integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
       "dev": true
     },
     "commondir": {
@@ -17192,30 +17200,36 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "37.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.0.3.tgz",
-      "integrity": "sha512-Qg/gIZAfcrM4Qu/JzcnxPGD45Je6wPLFzMZQboeqit/CL4aY6wuzBTkgUMiWXfw/PaPl+sb0GF1XdBlV23ReDA==",
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.1.0.tgz",
+      "integrity": "sha512-DpkFzX5Sqkqzy4MCgowhDXmusWcF1Gn7wYnphdGfWmIkoQr6SwL0jEtltGAVyF5Rj6ACi6ydw0oCCI5hF3yz6w==",
       "dev": true,
       "requires": {
         "@es-joy/jsdoccomment": "0.12.0",
-        "comment-parser": "1.2.4",
-        "debug": "^4.3.2",
+        "comment-parser": "1.3.0",
+        "debug": "^4.3.3",
+        "escape-string-regexp": "^4.0.0",
         "esquery": "^1.4.0",
         "jsdoc-type-pratt-parser": "^2.0.0",
-        "lodash": "^4.17.21",
         "regextras": "^0.8.0",
         "semver": "^7.3.5",
         "spdx-expression-parse": "^3.0.1"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
         },
         "semver": {
           "version": "7.3.5",


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes none

## Description
github actions virtual machines switched to node 16 which doesn't support some of our dependencies. This PR makes the github actions machines use node 15.11.0 instead.

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [n/a] Run npm run build-pack-library and test in external application
-   [n/a] update `README.md`
-   [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
