### PR TITLE
chore(core,platform): prohibit fit

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -162,7 +162,7 @@
                     }
                 ],
                 "no-new-wrappers": "error",
-                "no-restricted-globals": ["error", "fdescribe"],
+                "no-restricted-globals": ["error", "fdescribe", "fit"],
                 "no-restricted-imports": ["error", "rxjs/Rx"],
                 "no-shadow": "off",
                 "no-throw-literal": "error",


### PR DESCRIPTION
## Description

Prohibit `fit` on the linting level same as `fdescribe`. 