### PR TITLE
fix(core,platform): schematics

### DIFF
--- a/libs/core/schematics/ng-add/index.ts
+++ b/libs/core/schematics/ng-add/index.ts
@@ -1,12 +1,13 @@
 import { Rule, SchematicContext, Tree, chain, SchematicsException } from '@angular-devkit/schematics';
+import { addModuleImportToModule, findModuleFromOptions } from '@angular/cdk/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import { getPackageVersionFromPackageJson, hasPackage } from '../utils/package-utils';
 import { addPackageJsonDependency, NodeDependency, NodeDependencyType } from '@schematics/angular/utility/dependencies';
-import { hasModuleImport } from '../utils/ng-module-utils';
 import { WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 
 import { defaultFontStyle } from './styles';
-import { addModuleImportToModule, findModuleFromOptions } from '@angular/cdk/schematics';
+import { hasModuleImport } from '../utils/ng-module-utils';
+import { getPackageVersionFromPackageJson, hasPackage } from '../utils/package-utils';
+import { Schema } from './schema';
 
 const browserAnimationsModuleName = 'BrowserAnimationsModule';
 const noopAnimationsModuleName = 'NoopAnimationsModule';
@@ -14,7 +15,7 @@ const fdStylesIconPath = 'node_modules/fundamental-styles/dist/icon.css';
 
 export function ngAdd(options: any): Rule {
     return chain([
-        addDependencies(),
+        addDependencies(options),
         endInstallTask(),
         addAnimations(options),
         addStylePathToConfig(options),
@@ -22,17 +23,9 @@ export function ngAdd(options: any): Rule {
     ]);
 }
 
-// Runs npm install. Called as the last rule.
-function endInstallTask(): Rule {
-    return (tree: Tree, context: SchematicContext) => {
-        context.addTask(new NodePackageInstallTask());
-        return tree;
-    };
-}
-
 // Adds missing dependencies to the project.
-function addDependencies(): Rule {
-    return (tree: Tree) => {
+function addDependencies(options: Schema): Rule {
+    return (tree: Tree, context: SchematicContext) => {
         const ngCoreVersionTag = getPackageVersionFromPackageJson(tree, '@angular/core');
         const dependencies: NodeDependency[] = [];
 
@@ -52,10 +45,40 @@ function addDependencies(): Rule {
             });
         }
 
+        if (options.styleFonts) {
+            if (!hasPackage(tree, 'fundamental-styles')) {
+                dependencies.push({
+                    type: NodeDependencyType.Default,
+                    // Will be replaced with the real version during sync-version scipt run
+                    version: `FDSTYLES_VER_PLACEHOLDER`,
+                    name: 'fundamental-styles'
+                });
+            }
+
+            if (!hasPackage(tree, '@sap-theming/theming-base-content')) {
+                dependencies.push({
+                    type: NodeDependencyType.Default,
+                    // Will be replaced with the real version during sync-version scipt run
+                    version: `THEMING_VER_PLACEHOLDER`,
+                    name: '@sap-theming/theming-base-content'
+                });
+            }
+        }
+
         dependencies.forEach((dependency) => {
             addPackageJsonDependency(tree, dependency);
-            console.log(`✅️ Added ${dependency.name} to ${dependency.type}.`);
+
+            context.logger.info(`✅️ Added ${dependency.name} to ${dependency.type}.`);
         });
+
+        return tree;
+    };
+}
+
+// Runs npm install. Called as the last rule.
+function endInstallTask(): Rule {
+    return (tree: Tree, context: SchematicContext) => {
+        context.addTask(new NodePackageInstallTask());
 
         return tree;
     };
@@ -63,17 +86,26 @@ function addDependencies(): Rule {
 
 // Configures browser animations.
 function addAnimations(options: any): any {
-    return async (tree: Tree) => {
+    return async (tree: Tree, context: SchematicContext) => {
         const modulePath = await findModuleFromOptions(tree, options);
 
         if (options.animations) {
             if (hasModuleImport(tree, modulePath, noopAnimationsModuleName)) {
-                return console.warn(
-                    `Could not set up "${browserAnimationsModuleName}" ` +
-                        `because "${noopAnimationsModuleName}" is already imported. Please manually ` +
-                        `set up browser animations.`
+                context.logger.warn(
+                    `Could not set up "${browserAnimationsModuleName} because "${noopAnimationsModuleName}" is already imported. Please manually set up browser animations.`
                 );
+
+                return tree;
             }
+
+            if (hasModuleImport(tree, modulePath, browserAnimationsModuleName)) {
+                context.logger.info(
+                    `✅️ Import of ${browserAnimationsModuleName} already present in root module. Skipping.`
+                );
+
+                return tree;
+            }
+
             addModuleImportToModule(
                 tree,
                 modulePath,
@@ -81,11 +113,15 @@ function addAnimations(options: any): any {
                 '@angular/platform-browser/animations'
             );
 
-            console.log(`✅️ Added ${browserAnimationsModuleName} to root module.`);
-        } else if (!hasModuleImport(tree, modulePath, browserAnimationsModuleName)) {
+            context.logger.info(`✅️ Added ${browserAnimationsModuleName} to root module.`);
+
+            return tree;
+        }
+
+        if (!hasModuleImport(tree, modulePath, browserAnimationsModuleName)) {
             addModuleImportToModule(tree, modulePath, noopAnimationsModuleName, '@angular/platform-browser/animations');
 
-            console.log(`✅️ Added ${noopAnimationsModuleName} to root module.`);
+            context.logger.info(`✅️ Added ${noopAnimationsModuleName} to root module.`);
         }
 
         return tree;
@@ -94,12 +130,14 @@ function addAnimations(options: any): any {
 
 // Adds the icon style path to the angular.json.
 function addStylePathToConfig(options: any): Rule {
-    return (tree: Tree) => {
+    return (tree: Tree, context: SchematicContext) => {
         const angularConfigPath = '/angular.json';
-        const workspaceConfig = tree.read('/angular.json');
+        const workspaceConfig = tree.read(angularConfigPath);
+
         if (!workspaceConfig) {
             throw new SchematicsException(`Unable to find angular.json. Please manually configure your styles array.`);
         }
+
         const workspaceJson: WorkspaceSchema = JSON.parse(workspaceConfig.toString());
 
         try {
@@ -109,7 +147,8 @@ function addStylePathToConfig(options: any): Rule {
                 stylesArray = pushStylesToArray(stylesArray, fdStylesIconPath);
                 (workspaceJson!.projects[options.project]!.architect!.build!.options as any)['styles'] = stylesArray;
             } else {
-                console.log(`✅️ Found duplicate style path in angular.json. Skipping.`);
+                context.logger.info(`✅️ Found duplicate style path in angular.json. Skipping.`);
+
                 return tree;
             }
         } catch (e) {
@@ -117,45 +156,10 @@ function addStylePathToConfig(options: any): Rule {
                 `Unable to find angular.json project styles. Please manually configure your styles array.`
             );
         }
+
         tree.overwrite(angularConfigPath, JSON.stringify(workspaceJson, null, 2));
-        console.log(`✅️ Added fundamental-styles path to angular.json.`);
-        return tree;
-    };
-}
 
-// Adds the default fonts import into styles.scss
-function addFontsToStyles(options: any): Rule {
-    return (tree: Tree) => {
-        const stylesFilePath = '/src/styles.scss';
-        const stylesFileContent = tree.read('/src/styles.scss');
-        const defaultFontStyleString = defaultFontStyle;
-        const sapThemingImport = 'node_modules/@sap-theming/theming-base-content/content/Base/baseLib';
-
-        if (options.styleFonts) {
-            if (!stylesFileContent) {
-                console.warn(
-                    `Unable to find styles.scss. Please manually configure your styles. For more info, visit https://fundamental-styles.netlify.com/getting-started.html`
-                );
-                return tree;
-            }
-
-            try {
-                let stylesFileString: string = stylesFileContent.toString();
-
-                if (!stylesFileString.includes(sapThemingImport)) {
-                    stylesFileString = defaultFontStyleString + stylesFileString;
-                    tree.overwrite(stylesFilePath, stylesFileString);
-                } else {
-                    console.log(`✅️ There are imports from @sap-theming in styles.scss already. Skipping`);
-                    return tree;
-                }
-            } catch (e) {
-                console.warn(
-                    `Unable to find styles.scss. Please manually configure your styles. For more info, visit https://fundamental-styles.netlify.com/getting-started.html`
-                );
-                return tree;
-            }
-        }
+        context.logger.info(`✅️ Added fundamental-styles path to angular.json.`);
 
         return tree;
     };
@@ -165,5 +169,68 @@ function pushStylesToArray(stylesArray: any, path: string): any {
     if (!stylesArray.includes(path)) {
         stylesArray.push(path);
     }
+
     return stylesArray;
+}
+
+// Adds the default fonts import into styles.scss
+function addFontsToStyles(options: any): Rule {
+    return (tree: Tree, context: SchematicContext) => {
+        let [stylesFilePath, stylesFileContent] = resolveStyles(tree);
+
+        if (options.styleFonts) {
+            if (!stylesFileContent) {
+                context.logger.warn(
+                    `Unable to find styles file. Please manually configure your styles. For more info, visit https://fundamental-styles.netlify.app/?path=/docs/introduction-overview--page#project-configuration`
+                );
+
+                return tree;
+            }
+
+            try {
+                let stylesFileString = stylesFileContent.toString();
+
+                if (!stylesFileString.includes(defaultFontStyle)) {
+                    stylesFileString = defaultFontStyle + stylesFileString;
+
+                    tree.overwrite(stylesFilePath, stylesFileString);
+
+                    context.logger.info(`✅️ Added imports from @sap-theming to styles file.`);
+
+                    return tree;
+                }
+
+                context.logger.info(`✅️ There are imports from @sap-theming in styles file already. Skipping.`);
+
+                return tree;
+            } catch (e) {
+                context.logger.warn(
+                    `Unable to find styles file. Please manually configure your styles. For more info, visit https://fundamental-styles.netlify.com/getting-started.html`
+                );
+
+                return tree;
+            }
+        }
+
+        return tree;
+    };
+}
+
+function resolveStyles(tree: Tree): [string, Buffer] {
+    const basePath = '/src/styles';
+    const extensions = ['.css', '.scss', '.less'];
+
+    let path: string;
+    let content: Buffer;
+
+    for (let extension of extensions) {
+        path = basePath + extension;
+        content = tree.read(path);
+
+        if (content) {
+            return [path, content];
+        }
+    }
+
+    return [path, content];
 }

--- a/libs/core/schematics/ng-add/schema.json
+++ b/libs/core/schematics/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "fundamental-ngx-ng-add",
+    "$id": "fundamental-ngx-ng-add",
     "title": "Fundamental Library for Angular ng-add schematic",
     "type": "object",
     "properties": {
@@ -13,8 +13,8 @@
         "styleFonts": {
             "type": "boolean",
             "default": true,
-            "description": "Whether default fonts from theming should be added to styles.scss.",
-            "x-prompt": "Add default font imports into styles.scss?"
+            "description": "Whether default fonts from theming should be added to styles file.",
+            "x-prompt": "Add default font imports into styles file?"
         },
         "project": {
             "type": "string",

--- a/libs/core/schematics/ng-add/schema.ts
+++ b/libs/core/schematics/ng-add/schema.ts
@@ -1,4 +1,5 @@
 export interface Schema {
     project: string;
     animations: boolean;
+    styleFonts: boolean;
 }

--- a/libs/fn/schematics/ng-add/schema.json
+++ b/libs/fn/schematics/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "fundamental-ngx-ng-add",
+    "$id": "fundamental-ngx-ng-add",
     "title": "Fundamental Library for Angular ng-add schematic",
     "type": "object",
     "properties": {

--- a/libs/moment-adapter/schematics/ng-add/index.ts
+++ b/libs/moment-adapter/schematics/ng-add/index.ts
@@ -4,10 +4,10 @@ import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 /**
  * ng add schematic that
  * - install moment-adapter package
- * @param _options options passed for this schematic
+ * @param options options passed for this schematic
  */
-export function ngAdd(_options: any): Rule {
-    return (_tree: Tree, _context: SchematicContext) => chain([endInstallTask()]);
+export function ngAdd(): Rule {
+    return () => chain([endInstallTask()]);
 }
 
 /**
@@ -16,6 +16,7 @@ export function ngAdd(_options: any): Rule {
 function endInstallTask(): Rule {
     return (tree: Tree, context: SchematicContext) => {
         context.addTask(new NodePackageInstallTask());
+
         return tree;
     };
 }

--- a/libs/moment-adapter/schematics/ng-add/schema.json
+++ b/libs/moment-adapter/schematics/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "fundamental-ngx-ng-add",
+    "$id": "fundamental-ngx-ng-add",
     "title": "Fundamental Library moment-adapter ng-add schema",
     "type": "object",
     "properties": {}

--- a/libs/moment-adapter/schematics/utils/ng-module-utils.ts
+++ b/libs/moment-adapter/schematics/utils/ng-module-utils.ts
@@ -1,7 +1,6 @@
-import { Tree, SchematicsException } from '@angular-devkit/schematics';
-
-import * as ts from 'typescript';
 import { WorkspaceProject, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
+import { Tree, SchematicsException } from '@angular-devkit/schematics';
+import * as ts from 'typescript';
 
 // Checks if an import is included in the module.
 export function hasModuleImport(tree: Tree, modulePath: string, className: string): boolean {

--- a/libs/moment-adapter/schematics/utils/package-utils.ts
+++ b/libs/moment-adapter/schematics/utils/package-utils.ts
@@ -1,5 +1,4 @@
 import { Tree, SchematicsException } from '@angular-devkit/schematics';
-
 import * as ts from 'typescript';
 
 // Gets the ts source file from a path

--- a/libs/platform/schematics/collection.json
+++ b/libs/platform/schematics/collection.json
@@ -5,16 +5,6 @@
             "description": "Adds @fundamental-ngx/platform to the project.",
             "factory": "./ng-add/index#ngAdd",
             "schema": "./ng-add/schema.json"
-        },
-        "addCoreSchematic": {
-            "description": "Calls dependency add schemas",
-            "private": true,
-            "factory": "./ng-add/index#addCoreSchematic"
-        },
-        "addLocalizeSchematic": {
-            "description": "Calls ng add localize schematic",
-            "private": true,
-            "factory": "./utils/translation-utils#addLocalizeSchematic"
         }
     }
 }

--- a/libs/platform/schematics/migration-collection.json
+++ b/libs/platform/schematics/migration-collection.json
@@ -5,12 +5,7 @@
             "version": "0.20.1-rc.2",
             "factory": "./ng-update/index#ngUpdate",
             "schema": "./ng-update/schema.json",
-            "description": "*****Updating Fundamental NGX Platform library translations*****"
-        },
-        "addLocalizeSchematic": {
-            "description": "Calls ng update localize schematic",
-            "private": true,
-            "factory": "./utils/translation-utils#addLocalizeSchematic"
+            "description": "Update Fundamental NGX Platform library & translations"
         }
     }
 }

--- a/libs/platform/schematics/ng-add/index.ts
+++ b/libs/platform/schematics/ng-add/index.ts
@@ -1,37 +1,32 @@
-import { Rule, SchematicContext, Tree, chain, externalSchematic, noop } from '@angular-devkit/schematics';
-import { NodePackageInstallTask, RunSchematicTask } from '@angular-devkit/schematics/tasks';
-import { hasPackage, getSourceTreePath } from '../utils/package-utils';
+import { chain, externalSchematic, noop, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { addPackageJsonDependency, NodeDependency, NodeDependencyType } from '@schematics/angular/utility/dependencies';
-import {
-    writeToAngularConfig,
-    createExtractionFiles,
-    replaceLibPaths,
-    addLocalizeLib,
-    callLocalizeSchematic
-} from '../utils/translation-utils';
-import { supportedLanguages } from '../utils/supported-languages';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { getPackageVersionFromPackageJson, hasPackage } from '../utils/package-utils';
+
+import { readTranslationFiles } from '../utils/translation-utils';
+import { Schema } from './schema';
 
 /**
  * ng add schematic that
- * - adds Core and Platform lib and their dependencies to package.json
- * - adds `ng add @fundamental-ngx/core` external schematic to task list
- * - adds `@angular/localize` to package.json
- * - adds `ng add @angular/localize` external schematic to task list
+ * - adds platform lib to package.json
+ * - adds @fundamental-ngx/core & @angular/localize to package.json if not present there already
+ * - installs dependent libraries and runs their external schematics
  * - adds lib translations and angular.json locale configurations to host app if no translations available
  * - updates lib translations to host app's translations if available by appending at the end of host app's files
  * - replaces lib source paths with node_modules source paths for lib-related trans units
- * - installs dependent libraries and runs their external schematics
- * @param _options options passed for this schematic
+ * @param options options passed for this schematic
  */
-export function ngAdd(_options: any): Rule {
-    return (_tree: Tree, _context: SchematicContext) => {
+export function ngAdd(options: Schema): Rule {
+    return (tree: Tree) => {
+        const coreInstalled = hasPackage(tree, '@fundamental-ngx/core');
+        const localizeInstalled = hasPackage(tree, '@angular/localize');
+
         return chain([
-            addCoreLib(_options),
-            addLocalizeLib(_options),
-            readTranslationFiles(_options),
-            _options.installations ? callCoreSchematic(_options) : noop(),
-            _options.installations ? callLocalizeSchematic(_options) : noop(),
-            endInstallTask()
+            addDependencies(),
+            endInstallTask(),
+            coreInstalled ? noop() : callCoreSchematic(options),
+            localizeInstalled ? noop() : callLocalizeSchematic(options),
+            options.translations ? readTranslationFiles(options) : noop()
         ]);
     };
 }
@@ -40,195 +35,67 @@ export function ngAdd(_options: any): Rule {
  * installs `@fundamental-ngx/core` lib and makes call to core's schematic
  * @param options options passed for this schematic
  */
-export function callCoreSchematic(options: any): Rule {
-    return (_tree: Tree, context: SchematicContext) => {
-        context.logger.info('Adding Fundamental NGX Core schematic to tasks');
-        const installTaskId = context.addTask(
-            new NodePackageInstallTask({
-                packageName: '@fundamental-ngx/core'
-            })
-        );
+function callCoreSchematic(options: Schema): Rule {
+    return (_: unknown, context: SchematicContext) => {
+        context.logger.info('Running @fundamental-ngx/core schematics...');
 
-        // Chain won't work here since we need the externals to be actually installed before we call their schemas
-        // This ensures the externals are a dependency of the node install, so they exist when their schemas run.
-        context.addTask(new RunSchematicTask('addCoreSchematic', options), [installTaskId]);
-        return _tree;
+        return externalSchematic('@fundamental-ngx/core', 'ng-add', options);
     };
 }
 
 /**
- * runs the core library's ng-add schematic
+ * installs `@angular/localize` lib and makes call to the localize schematic
  * @param options options passed for this schematic
  */
-export function addCoreSchematic(options: any): Rule {
-    return (_tree: Tree, _context: SchematicContext) => {
-        _context.logger.info('Running core schematics...\n');
-        return chain([externalSchematic('@fundamental-ngx/core', 'ng-add', options)]);
+export function callLocalizeSchematic(options: Schema): any {
+    return (_: unknown, context: SchematicContext) => {
+        context.logger.info('Running @angular/localize schematics...');
+
+        return externalSchematic('@angular/localize', 'ng-add', options);
     };
 }
 
-/**
- * adds the latest versions of core and platform libraries to package.json
- * @param _options options passed for this schematic
- */
-function addCoreLib(_options: any): Rule {
+function addDependencies(): Rule {
     return (tree: Tree, context: SchematicContext) => {
-        context.logger.info('***** Adding Platform dependencies to your application *****');
+        context.logger.info('Adding dependent libraries...');
+
+        const ngCoreVersionTag = getPackageVersionFromPackageJson(tree, '@angular/core');
         const dependencies: NodeDependency[] = [];
 
         if (!hasPackage(tree, '@fundamental-ngx/core')) {
             dependencies.push({
                 type: NodeDependencyType.Default,
-                version: `latest`,
+                // Will be replaced with the real version during sync-version scipt run
+                version: `VERSION_PLACEHOLDER`,
                 name: '@fundamental-ngx/core'
+            });
+        }
+
+        if (!hasPackage(tree, '@angular/localize')) {
+            dependencies.push({
+                type: NodeDependencyType.Default,
+                version: `${ngCoreVersionTag}`,
+                name: '@angular/localize'
             });
         }
 
         dependencies.forEach((dependency) => {
             addPackageJsonDependency(tree, dependency);
-            console.log(`✅️ Added ${dependency.name} to ${dependency.type} to your application`);
+
+            console.log(`✅️ Added ${dependency.name} to ${dependency.type}.`);
         });
 
         return tree;
     };
 }
-/**
- * adds/updates translations to host app if host app opts to have translations added to their app
- * @param options options passed for this schematic
- */
-export function readTranslationFiles(options: any): any {
-    return async (_tree: Tree, _context: SchematicContext) => {
-        const translationPromise = new Promise<Tree>((resolve, reject) => {
-            if (options.translations) {
-                try {
-                    const angularJsonFile = _tree.read('angular.json');
-
-                    if (angularJsonFile) {
-                        const angularJsonFileObject = JSON.parse(angularJsonFile.toString('utf-8'));
-                        const project = options.project
-                            ? options.project
-                            : Object.keys(angularJsonFileObject['projects'])[0];
-                        // set default project path
-                        if (!options.project) {
-                            options.name = project;
-                        }
-                        const projectObject = angularJsonFileObject.projects[project];
-                        // todo get the languages supported from platform, and fetch from a separate file probably
-                        const languages = supportedLanguages;
-
-                        let availableLanguages = 0;
-                        languages.forEach((language) => {
-                            if (projectObject.architect.build.configurations[language]) {
-                                availableLanguages++;
-                            }
-                        });
-                        languages.forEach(async (language) => {
-                            if (availableLanguages === 0 || languages.length > availableLanguages) {
-                                if (!projectObject.architect.build.configurations[language]) {
-                                    _context.logger.info(
-                                        'Adding translations for language "' +
-                                            language +
-                                            '" from ngx/platform to ' +
-                                            project
-                                    );
-                                    // not present, add the language settings to serve and build configurations in angular.json
-                                    await writeToAngularConfig(_tree, options, angularJsonFileObject, language);
-                                    // create the extraction .xlf files from the platform lib and place in host app's locale folder
-                                    await createExtractionFiles(_tree, options, language);
-                                }
-                            } else {
-                                const languageObject = projectObject.architect.build.configurations[language].i18nFile;
-
-                                const hostAppXlfContent = _tree.read(languageObject.toString());
-                                if (hostAppXlfContent) {
-                                    // merge the extraction .xlf files from the platform lib into the host app's files
-                                    await updateExtractionFiles(_tree, options, hostAppXlfContent, language);
-                                }
-                            }
-                            resolve(_tree);
-                        });
-                    } else {
-                        reject('error in promise');
-                    }
-                } catch (e) {
-                    _context.logger.log('info', e + '\n🚫 Failed to add translations correctly.');
-                }
-            }
-        });
-        _tree = await translationPromise;
-        return _tree;
-    };
-}
 
 /**
- * Merges the extraction .xlf files from the platform lib into the host app's files
- * @param tree the file tree
- * @param options options passed for this schematic
- * @param fileContent the host applications language .xlf file
- * @param language the language for which translations from lib will be applied to
- */
-async function updateExtractionFiles(tree: Tree, options: any, fileContent: any, language: string): Promise<Tree> {
-    const srcPath = await getSourceTreePath(tree, options);
-    const libXlfFileContent = tree.read(
-        'node_modules/@fundamental-ngx/platform/schematics/locale/' + language + '/messages.' + language + '.xlf'
-    );
-
-    if (libXlfFileContent) {
-        const builder = new (require('xml2js').Builder)();
-        let finalXlfContent: any;
-        require('xml2js').parseString(libXlfFileContent.toString(), function (err: any, libFile: any): void {
-            if (err) {
-                console.log(err);
-            }
-            // replace lib paths with node_modules paths
-            const modifiedLibFile = replaceLibPaths(libFile);
-
-            if (fileContent) {
-                // don't simply overwrite, merge here with existing file
-                // add the transUnits from lib to this file
-                require('xml2js').parseString(fileContent.toString(), function (error: any, hostFile: any): void {
-                    if (error) {
-                        console.log(error);
-                    }
-                    // compare the host file with the lib file to check if host file already has some lib trans-units
-                    // and append these trans units only if it is not already existing
-                    modifiedLibFile.xliff.file[0].body[0]['trans-unit'].forEach((libTransUnit: any) => {
-                        // append trans-unit only if not found
-                        let matchFound = false;
-                        hostFile.xliff.file[0].body[0]['trans-unit'].forEach((transUnit: any) => {
-                            if (transUnit['$'].id === libTransUnit['$'].id) {
-                                // lib trans unit already present in host file, don't add it
-                                matchFound = true;
-                            }
-                        });
-                        // if not found, add this trans unit to host file
-                        if (!matchFound) {
-                            hostFile.xliff.file[0].body[0]['trans-unit'][
-                                hostFile.xliff.file[0].body[0]['trans-unit'].length
-                            ] = libTransUnit;
-                        }
-                    });
-                    // write modified file as xml object
-                    finalXlfContent = builder.buildObject(hostFile);
-                });
-
-                try {
-                    tree.overwrite(srcPath + '/locale/' + language + '/messages.' + language + '.xlf', finalXlfContent);
-                } catch (e) {
-                    console.log(e + '\n🚫 There was a problem writing to file. ');
-                }
-            }
-        });
-    }
-    return tree;
-}
-
-/**
- *  Runs npm install. Called as the last rule.
+ *  Run npm install.
  */
 function endInstallTask(): Rule {
     return (tree: Tree, context: SchematicContext) => {
         context.addTask(new NodePackageInstallTask());
+
         return tree;
     };
 }

--- a/libs/platform/schematics/ng-add/index.ts
+++ b/libs/platform/schematics/ng-add/index.ts
@@ -1,7 +1,7 @@
 import { chain, externalSchematic, noop, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { addPackageJsonDependency, NodeDependency, NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import { getPackageVersionFromPackageJson, hasPackage } from '../utils/package-utils';
+import { getPackageVersionFromPackageJson, hasDevPackage, hasPackage } from '../utils/package-utils';
 
 import { readTranslationFiles } from '../utils/translation-utils';
 import { Schema } from './schema';
@@ -19,7 +19,7 @@ import { Schema } from './schema';
 export function ngAdd(options: Schema): Rule {
     return (tree: Tree) => {
         const coreInstalled = hasPackage(tree, '@fundamental-ngx/core');
-        const localizeInstalled = hasPackage(tree, '@angular/localize');
+        const localizeInstalled = hasDevPackage(tree, '@angular/localize');
 
         return chain([
             addDependencies(),
@@ -71,9 +71,9 @@ function addDependencies(): Rule {
             });
         }
 
-        if (!hasPackage(tree, '@angular/localize')) {
+        if (!hasDevPackage(tree, '@angular/localize')) {
             dependencies.push({
-                type: NodeDependencyType.Default,
+                type: NodeDependencyType.Dev,
                 version: `${ngCoreVersionTag}`,
                 name: '@angular/localize'
             });

--- a/libs/platform/schematics/ng-add/schema.json
+++ b/libs/platform/schematics/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "fundamental-ngx-ng-add",
+    "$id": "fundamental-ngx-ng-add",
     "title": "Fundamental Platform Library for Angular ng-add schematic",
     "type": "object",
     "properties": {
@@ -16,12 +16,6 @@
             "$default": {
                 "$source": "projectName"
             }
-        },
-        "installations": {
-            "type": "boolean",
-            "default": true,
-            "description": "Whether all dependent libraries for Fundamental Platform Library should be installed.",
-            "x-prompt": "Install all dependent libraries for Fundamental Platform Library to your project?"
         }
     }
 }

--- a/libs/platform/schematics/ng-add/schema.ts
+++ b/libs/platform/schematics/ng-add/schema.ts
@@ -1,0 +1,4 @@
+export interface Schema {
+    project: string;
+    translations: boolean;
+}

--- a/libs/platform/schematics/ng-update/index.ts
+++ b/libs/platform/schematics/ng-update/index.ts
@@ -1,151 +1,17 @@
-import { Rule, SchematicContext, Tree, chain } from '@angular-devkit/schematics';
+import { Rule, SchematicContext, Tree, chain, noop } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import { getSourceTreePath } from '../utils/package-utils';
-import {
-    writeToAngularConfig,
-    createExtractionFiles,
-    replaceLibPaths,
-    addLocalizeLib
-} from '../utils/translation-utils';
+
+import { Schema } from '../ng-add/schema';
+import { readTranslationFiles } from '../utils/translation-utils';
 
 /**
- * ng update schematic that will overwrite existing lib translations
- * or add new ones to the host app's translation files
- * Most apps that have an older version of platform lib will not do `ng add` to get the translations, this should
- * ideally be coming from `ng update`. Therefore we mostly do the same things as `ng add` except that we overwrite any
- * existing trans units coming from the lib
- * @param _options options passed for this schematic
- */
-export function ngUpdate(_options: any): Rule {
-    return (_tree: Tree, _context: SchematicContext) => {
-        return chain([addLocalizeLib(_options), readTranslationFiles(_options), endInstallTask()]);
-    };
-}
-
-/**
- * adds/updates translations, including existing ones, to host application's translation files
+ * ng update schematic that will overwrite existing lib translations or add new ones to the host app's translation files
+ * Most apps that have an older version of platform lib will not do `ng add` to get the translations, this should ideally be coming from `ng update`.
+ * Therefore we mostly do the same things as `ng add` except that we overwrite any existing trans units coming from the lib
  * @param options options passed for this schematic
  */
-function readTranslationFiles(options: any): any {
-    return async (tree: Tree, context: SchematicContext) => {
-        const readFilePromise = new Promise<Tree>((resolve, reject) => {
-            if (options.translations) {
-                try {
-                    const angularJsonFile = tree.read('angular.json');
-                    if (angularJsonFile) {
-                        const angularJsonFileObject = JSON.parse(angularJsonFile.toString('utf-8'));
-                        const project = options.project
-                            ? options.project
-                            : Object.keys(angularJsonFileObject['projects'])[0];
-                        // set default project path
-                        if (!options.project) {
-                            options.name = project;
-                        }
-                        const projectObject = angularJsonFileObject.projects[project];
-                        // todo get the languages supported from platform, and fetch from a separate file probably
-                        const languages = ['ar', 'fr'];
-
-                        let availableLanguages = 0;
-                        languages.forEach((language) => {
-                            if (projectObject.architect.build.configurations[language]) {
-                                availableLanguages++;
-                            }
-                        });
-                        languages.forEach(async (language) => {
-                            if (availableLanguages === 0 || languages.length > availableLanguages) {
-                                if (!projectObject.architect.build.configurations[language]) {
-                                    context.logger.info(
-                                        'Adding translations for language "' +
-                                            language +
-                                            '" from ngx/platform to ' +
-                                            project
-                                    );
-                                    // not present, add the language settings to serve and build configurations in angular.json
-                                    await writeToAngularConfig(tree, options, angularJsonFileObject, language);
-                                    // create the extraction .xlf files from the platform lib and place in host app's locale folder
-                                    await createExtractionFiles(tree, options, language);
-                                }
-                            } else {
-                                const languageObject = projectObject.architect.build.configurations[language].i18nFile;
-                                const hostAppXlfContent = tree.read(languageObject.toString());
-                                if (hostAppXlfContent) {
-                                    // merge the extraction .xlf files from the platform lib into the host app's files
-                                    await updateExtractionFiles(tree, options, hostAppXlfContent, language);
-                                }
-                            }
-                            resolve(tree);
-                        });
-                    }
-                } catch (e) {
-                    context.logger.log('info', e + '\n🚫 Failed to add translations correctly.');
-                    reject('failed');
-                }
-            }
-        });
-        tree = await readFilePromise;
-        return tree;
-    };
-}
-
-/**
- * overwrites existing lib translations
- * or adds new ones to the host app's translation files
- * @param tree the file tree
- * @param options options passed for this schematic
- * @param fileContent the host applications language .xlf file
- * @param language the language for which translations from lib will be applied to
- */
-async function updateExtractionFiles(tree: Tree, options: any, fileContent: any, language: string): Promise<void> {
-    const srcPath = await getSourceTreePath(tree, options);
-    const libXlfFileContent = tree.read(
-        'node_modules/@fundamental-ngx/platform/schematics/locale/' + language + '/messages.' + language + '.xlf'
-    );
-
-    if (libXlfFileContent) {
-        const builder = new (require('xml2js').Builder)();
-        let finalXlfContent: any;
-        require('xml2js').parseString(libXlfFileContent.toString(), function (err: any, libFile: any): void {
-            if (err) {
-                console.log(err);
-            }
-            // replace lib paths with node_modules paths
-            const modifiedLibFile = replaceLibPaths(libFile);
-
-            if (fileContent) {
-                // don't simply overwrite, merge here with existing file
-                // add the transUnits from lib to this file
-                require('xml2js').parseString(fileContent.toString(), function (error: any, hostFile: any): void {
-                    if (error) {
-                        console.log(error);
-                    }
-                    modifiedLibFile.xliff.file[0].body[0]['trans-unit'].forEach((libTransUnit: any) => {
-                        // append trans-unit only if not found
-                        let matchFound = false;
-                        hostFile.xliff.file[0].body[0]['trans-unit'].forEach((transUnit: any, hostIndex: number) => {
-                            if (transUnit['$'].id === libTransUnit['$'].id) {
-                                // match found, overwrite existing trans-unit in host app with updated lib trans unit
-                                matchFound = true;
-                                hostFile.xliff.file[0].body[0]['trans-unit'][hostIndex] = libTransUnit;
-                            }
-                        });
-                        // if not found, add this trans unit to host file
-                        if (!matchFound) {
-                            hostFile.xliff.file[0].body[0]['trans-unit'][
-                                hostFile.xliff.file[0].body[0]['trans-unit'].length
-                            ] = libTransUnit;
-                        }
-                    });
-                    // write modified file as xml object
-                    finalXlfContent = builder.buildObject(hostFile);
-                });
-                try {
-                    tree.overwrite(srcPath + '/locale/' + language + '/messages.' + language + '.xlf', finalXlfContent);
-                } catch (e) {
-                    console.log(e + '\n🚫 There was a problem writing to file. ');
-                }
-            }
-        });
-    }
+export function ngUpdate(options: Schema): Rule {
+    return chain([options.translations ? readTranslationFiles(options) : noop(), endInstallTask()]);
 }
 
 /**
@@ -155,6 +21,7 @@ async function updateExtractionFiles(tree: Tree, options: any, fileContent: any,
 function endInstallTask(): Rule {
     return (tree: Tree, context: SchematicContext) => {
         context.addTask(new NodePackageInstallTask());
+
         return tree;
     };
 }

--- a/libs/platform/schematics/ng-update/schema.json
+++ b/libs/platform/schematics/ng-update/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "fundamental-ngx-ng-update",
+    "$id": "fundamental-ngx-ng-update",
     "title": "Fundamental Platform Library for Angular ng-update schematic",
     "type": "object",
     "properties": {

--- a/libs/platform/schematics/utils/package-utils.ts
+++ b/libs/platform/schematics/utils/package-utils.ts
@@ -91,15 +91,3 @@ export async function getWorkspaceProject(host: Tree, options: any): Promise<wor
     }
     return project;
 }
-
-// Returns the default project for the application
-export async function getDefaultProject(host: Tree, options: any): Promise<any> {
-    const workspaceHost = createHost(host);
-    const { workspace } = await workspaces.readWorkspace('/', workspaceHost);
-
-    if (!options.project) {
-        options.project = workspace.extensions.defaultProject;
-    }
-
-    return options.project;
-}

--- a/libs/platform/schematics/utils/package-utils.ts
+++ b/libs/platform/schematics/utils/package-utils.ts
@@ -37,6 +37,17 @@ export function hasPackage(tree: Tree, name: string): boolean | null {
     return packageJson.dependencies && packageJson.dependencies[name];
 }
 
+// Check if a package exists in the package.json
+export function hasDevPackage(tree: Tree, name: string): boolean | null {
+    if (!tree.exists('package.json')) {
+        return null;
+    }
+
+    const packageJson = JSON.parse(tree.read('package.json')!.toString('utf-8'));
+
+    return packageJson.devDependencies && packageJson.devDependencies[name];
+}
+
 // Returns the source path for the application
 export async function getSourceTreePath(host: Tree, options: any): Promise<string> {
     const project = await getWorkspaceProject(host, options);


### PR DESCRIPTION
## Related Issue(s)

Closes #7349 
Closes #7347

## Description

Schematics fixes & refactoring.

#### Core schematics

* Fixed
* Added ability to add font imports to `*.css` and `*.less` files, not only to `*.scss` as before.
* Implemented installing of dependent libraries. 

#### Platform schematics

* Fixed
* Refactored
* `installations` prompt removed due to not making any sense.
  * If `fundamental-ngx/core` or (and) `@angular/localize` dependent libraries haven't installed then will be installed and their schematics will be run.

#### Moment Adapter schematics

* Fixed

## How to test

* `npm run build-pack-library` locally
* Run `ng add ../fundamental-ngx/dist/libs/core` from the new application's folder
* Run `ng add ../fundamental-ngx/dist/libs/platform` from the new application's folder
* Run `ng add ../fundamental-ngx/dist/libs/moment-adapter` from the new application's folder