### PR TITLE
fix(core): fd-list-link handle by enter key

### DIFF
--- a/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
+++ b/apps/docs/src/app/core/component-docs/popover/examples/popover-simple/popover-example.component.html
@@ -122,4 +122,17 @@
             </ul>
         </fd-popover-body>
     </fd-popover>
+
+    <fd-popover placement="bottom" [noArrow]="false" [focusTrapped]="true" [focusAutoCapture]="true">
+        <fd-popover-control>
+            <button fd-button label="With Link"></button>
+        </fd-popover-control>
+        <fd-popover-body *ngIf="list1 && list1.length">
+            <ul fd-list>
+                <li fd-list-item *ngFor="let option of list1">
+                    <a [attr.href]="option.url" fd-list-link>{{ option.text }}</a>
+                </li>
+            </ul>
+        </fd-popover-body>
+    </fd-popover>
 </div>

--- a/libs/core/src/lib/list/directives/list-link.directive.ts
+++ b/libs/core/src/lib/list/directives/list-link.directive.ts
@@ -1,4 +1,4 @@
-import { Attribute, Directive, ElementRef, HostBinding, Input, OnInit } from '@angular/core';
+import { Directive, ElementRef, HostBinding, Input, OnInit } from '@angular/core';
 
 @Directive({
     selector: '[fd-list-link], [fdListLink]'

--- a/libs/core/src/lib/list/directives/list-link.directive.ts
+++ b/libs/core/src/lib/list/directives/list-link.directive.ts
@@ -1,9 +1,9 @@
-import { Directive, HostBinding, Input } from '@angular/core';
+import { Attribute, Directive, ElementRef, HostBinding, Input, OnInit } from '@angular/core';
 
 @Directive({
     selector: '[fd-list-link], [fdListLink]'
 })
-export class ListLinkDirective {
+export class ListLinkDirective implements OnInit {
     /** Defines if navigation indicator arrow should be included inside list item */
     @Input()
     @HostBinding('class.fd-list__link--navigation-indicator')
@@ -22,4 +22,14 @@ export class ListLinkDirective {
     /** @hidden */
     @HostBinding('class.fd-list__link')
     fdListLinkClass = true;
+
+    /** Keeps href string */
+    href: string;
+
+    constructor(private _elementRef: ElementRef) {}
+
+    /** @hidden */
+    ngOnInit(): void {
+        this.href = this._elementRef.nativeElement.getAttribute('href');
+    }
 }

--- a/libs/core/src/lib/list/list-item/list-item.component.ts
+++ b/libs/core/src/lib/list/list-item/list-item.component.ts
@@ -116,6 +116,9 @@ export class ListItemComponent extends ListFocusItem implements AfterContentInit
     @ContentChild(RadioButtonComponent)
     radio: RadioButtonComponent;
 
+    @ContentChild(ListLinkDirective)
+    linkComponent: ListLinkDirective;
+
     /** @hidden */
     @ContentChildren(ListLinkDirective)
     linkDirectives: QueryList<ListLinkDirective>;
@@ -133,6 +136,9 @@ export class ListItemComponent extends ListFocusItem implements AfterContentInit
     /** @hidden */
     private _tabIndex = 0;
 
+    /** @hidden */
+    private _url: string;
+
     constructor(public elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef) {
         super(elementRef);
     }
@@ -141,6 +147,8 @@ export class ListItemComponent extends ListFocusItem implements AfterContentInit
     ngAfterContentInit(): void {
         this._listenOnLinkQueryChange();
         this._listenOnButtonQueryChange();
+
+        this._url = this.linkComponent?.href;
     }
 
     /** @hidden */
@@ -160,6 +168,9 @@ export class ListItemComponent extends ListFocusItem implements AfterContentInit
             if (this.radio) {
                 this.radio.labelClicked(event);
                 this._muteEvent(event);
+            }
+            if (this.link && this._url) {
+                window.open(this._url, '_self');
             }
         }
         this.keyDown.emit(event);


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/6156

## Description

- For now, `fd-list-link` can handle links only by click. Added ability to handle it by Enter key as well 
- Added example `With Link` in Popover doc 

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [n/a] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [n/a] update `README.md`
-   [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
