### PR TITLE
fix(platform): schematics' translations tasks

### DIFF
--- a/libs/platform/schematics/collection.json
+++ b/libs/platform/schematics/collection.json
@@ -6,6 +6,11 @@
             "factory": "./ng-add/index#ngAdd",
             "schema": "./ng-add/schema.json"
         },
+        "ng-update": {
+            "description": "Updates existing @fundamental-ngx/platform.",
+            "factory": "./ng-update/index#ngUpdate",
+            "schema": "./ng-update/schema.json"
+        },
         "read-translation-files": {
             "description": "Read translation files. Runned as schematics to ensure the tasks order.",
             "factory": "./utils/translation-utils#readTranslationFiles",

--- a/libs/platform/schematics/collection.json
+++ b/libs/platform/schematics/collection.json
@@ -5,6 +5,16 @@
             "description": "Adds @fundamental-ngx/platform to the project.",
             "factory": "./ng-add/index#ngAdd",
             "schema": "./ng-add/schema.json"
+        },
+        "read-translation-files": {
+            "description": "Read translation files. Runned as schematics to ensure the tasks order.",
+            "factory": "./utils/translation-utils#readTranslationFiles",
+            "schema": "./ng-add/schema.json"
+        },
+        "remove-xml-to-js": {
+            "description": "Remove xml2js package. Runned as schematics to ensure the tasks order.",
+            "factory": "./utils/translation-utils#removeXML2JSPackage",
+            "schema": "./ng-add/schema.json"
         }
     }
 }

--- a/libs/platform/schematics/ng-add/index.ts
+++ b/libs/platform/schematics/ng-add/index.ts
@@ -3,7 +3,7 @@ import { addPackageJsonDependency, NodeDependencyType } from '@schematics/angula
 import { NodePackageInstallTask, RunSchematicTask } from '@angular-devkit/schematics/tasks';
 import { getPackageVersionFromPackageJson, hasDevPackage, hasPackage } from '../utils/package-utils';
 
-import { readTranslationFiles } from '../utils/translation-utils';
+import { processTranslations } from '../utils/translation-utils';
 import { Schema } from './schema';
 
 /**
@@ -19,12 +19,13 @@ import { Schema } from './schema';
 export function ngAdd(options: Schema): Rule {
     return (tree: Tree) => {
         const coreInstalled = hasPackage(tree, '@fundamental-ngx/core');
-        const localizeInstalled = hasDevPackage(tree, '@angular/localize');
+        const localizeInstalled = hasDevPackage(tree, '@angular/localize') || hasPackage(tree, "@angular/localize");
+        const XML2JSinstalled = hasDevPackage(tree, "xml2js") || hasPackage(tree, "xml2js");
 
         return chain([
             coreInstalled ? noop() : callCoreSchematic(options),
             localizeInstalled ? noop() : callLocalizeSchematic(options),
-            options.translations ? readTranslationFiles(options) : noop(),
+            options.translations ? processTranslations(options, XML2JSinstalled) : noop(),
             endInstallTask()
         ]);
     };

--- a/libs/platform/schematics/ng-add/index.ts
+++ b/libs/platform/schematics/ng-add/index.ts
@@ -19,8 +19,8 @@ import { Schema } from './schema';
 export function ngAdd(options: Schema): Rule {
     return (tree: Tree) => {
         const coreInstalled = hasPackage(tree, '@fundamental-ngx/core');
-        const localizeInstalled = hasDevPackage(tree, '@angular/localize') || hasPackage(tree, "@angular/localize");
-        const XML2JSinstalled = hasDevPackage(tree, "xml2js") || hasPackage(tree, "xml2js");
+        const localizeInstalled = hasDevPackage(tree, '@angular/localize') || hasPackage(tree, '@angular/localize');
+        const XML2JSinstalled = hasDevPackage(tree, 'xml2js') || hasPackage(tree, 'xml2js');
 
         return chain([
             coreInstalled ? noop() : callCoreSchematic(options),

--- a/libs/platform/schematics/ng-update/index.ts
+++ b/libs/platform/schematics/ng-update/index.ts
@@ -13,14 +13,10 @@ import { processTranslations } from '../utils/translation-utils';
  */
 export function ngUpdate(options: Schema): Rule {
     return (tree: Tree) => {
-        const XML2JSinstalled = hasDevPackage(tree, "xml2js") || hasPackage(tree, "xml2js");
+        const XML2JSinstalled = hasDevPackage(tree, 'xml2js') || hasPackage(tree, 'xml2js');
 
-        return chain([
-            options.translations ? processTranslations(options, XML2JSinstalled) : noop(),
-            endInstallTask()
-        ]);
-    }
-
+        return chain([options.translations ? processTranslations(options, XML2JSinstalled) : noop(), endInstallTask()]);
+    };
 }
 
 /**

--- a/libs/platform/schematics/ng-update/index.ts
+++ b/libs/platform/schematics/ng-update/index.ts
@@ -2,7 +2,8 @@ import { Rule, SchematicContext, Tree, chain, noop } from '@angular-devkit/schem
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
 import { Schema } from '../ng-add/schema';
-import { readTranslationFiles } from '../utils/translation-utils';
+import { hasDevPackage, hasPackage } from '../utils/package-utils';
+import { processTranslations } from '../utils/translation-utils';
 
 /**
  * ng update schematic that will overwrite existing lib translations or add new ones to the host app's translation files
@@ -11,7 +12,15 @@ import { readTranslationFiles } from '../utils/translation-utils';
  * @param options options passed for this schematic
  */
 export function ngUpdate(options: Schema): Rule {
-    return chain([options.translations ? readTranslationFiles(options) : noop(), endInstallTask()]);
+    return (tree: Tree) => {
+        const XML2JSinstalled = hasDevPackage(tree, "xml2js") || hasPackage(tree, "xml2js");
+
+        return chain([
+            options.translations ? processTranslations(options, XML2JSinstalled) : noop(),
+            endInstallTask()
+        ]);
+    }
+
 }
 
 /**

--- a/libs/platform/schematics/utils/translation-utils.ts
+++ b/libs/platform/schematics/utils/translation-utils.ts
@@ -1,8 +1,57 @@
-import { SchematicContext } from '@angular-devkit/schematics';
+import { Rule, SchematicContext, TaskId } from '@angular-devkit/schematics';
+import { addPackageJsonDependency, removePackageJsonDependency, NodeDependencyType } from '@schematics/angular/utility/dependencies';
+import { NodePackageInstallTask, RunSchematicTask } from '@angular-devkit/schematics/tasks';
 import { Tree } from '@angular-devkit/schematics/src/tree/interface';
 
 import { getSourceTreePath, getDistPath } from './package-utils';
 import { supportedLanguages } from './supported-languages';
+import { Schema } from '../ng-add/schema';
+
+/**
+ * Install XML2JS if needed
+ * Read/update translation files
+ * Remove XML2JS after run if it wasn't present before
+ */
+export function processTranslations(options: Schema, XML2JSInstalled: boolean | null) {
+    return (tree: Tree, context: SchematicContext) => {
+        let installTaskId: TaskId | undefined;
+
+        if (!XML2JSInstalled) {
+            addPackageJsonDependency(tree, {
+                type: NodeDependencyType.Dev,
+                version: 'latest',
+                name: 'xml2js'
+            });
+
+            installTaskId = context.addTask(
+                new NodePackageInstallTask({
+                    packageName: 'xml2js'
+                })
+            );
+
+            context.logger.info('✅️ Added XML2JS package to dependencies');
+        }
+
+        const dependentTasksArray = installTaskId ? [installTaskId] : [];
+        const readTranslationFilesTaskId = context.addTask(new RunSchematicTask('read-translation-files', options), dependentTasksArray);
+
+        if (!XML2JSInstalled) {
+            context.addTask(new RunSchematicTask('remove-xml-to-js', options), [readTranslationFilesTaskId]);
+        }
+
+        return tree;
+    }
+}
+
+export function removeXML2JSPackage(): Rule {
+    return (tree: Tree, context: SchematicContext) => {
+        removePackageJsonDependency(tree, "xml2js");
+
+        context.logger.info('✅️ Removed XML2JS package from dependencies');
+
+        return tree;
+    };
+}
 
 /**
  * adds/updates translations to host app if host app opts to have translations added to their app

--- a/libs/platform/schematics/utils/translation-utils.ts
+++ b/libs/platform/schematics/utils/translation-utils.ts
@@ -1,5 +1,9 @@
 import { Rule, SchematicContext, TaskId } from '@angular-devkit/schematics';
-import { addPackageJsonDependency, removePackageJsonDependency, NodeDependencyType } from '@schematics/angular/utility/dependencies';
+import {
+    addPackageJsonDependency,
+    removePackageJsonDependency,
+    NodeDependencyType
+} from '@schematics/angular/utility/dependencies';
 import { NodePackageInstallTask, RunSchematicTask } from '@angular-devkit/schematics/tasks';
 import { Tree } from '@angular-devkit/schematics/src/tree/interface';
 
@@ -33,19 +37,22 @@ export function processTranslations(options: Schema, XML2JSInstalled: boolean | 
         }
 
         const dependentTasksArray = installTaskId ? [installTaskId] : [];
-        const readTranslationFilesTaskId = context.addTask(new RunSchematicTask('read-translation-files', options), dependentTasksArray);
+        const readTranslationFilesTaskId = context.addTask(
+            new RunSchematicTask('read-translation-files', options),
+            dependentTasksArray
+        );
 
         if (!XML2JSInstalled) {
             context.addTask(new RunSchematicTask('remove-xml-to-js', options), [readTranslationFilesTaskId]);
         }
 
         return tree;
-    }
+    };
 }
 
 export function removeXML2JSPackage(): Rule {
     return (tree: Tree, context: SchematicContext) => {
-        removePackageJsonDependency(tree, "xml2js");
+        removePackageJsonDependency(tree, 'xml2js');
 
         context.logger.info('✅️ Removed XML2JS package from dependencies');
 


### PR DESCRIPTION
## Related Issue(s)

Closes #7420.

## Description

Platform schematics uses `xml2js` package while processing translation files. But the package may not be present in the host application so it leads schematic run to fail. Added steps of installing & removing `xml2js` package.

Previously bug wasn't catched because when running `ng add ../fundamental-ngx/dist/libs/platform` `xml2js` was found in `../fundamental-ngx/node_modules`.

## Testing

```
npm run build-pack-library
cd (new angular application folder)
cp ../fundamental-ngx/dist/libs/platform/fundamental-ngx-platform-0.33.0-rc.*.tgz ./
ng add fundamental-ngx-platform-0.33.0-rc.*.tgz
```