### PR TITLE
fix(core): grid-list, not show indicator of new position on drag

### DIFF
--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.scss
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.scss
@@ -14,6 +14,12 @@
         background-color: transparent;
     }
 
+    .fd-dnd-item {
+        .fd-grid-list__item {
+            overflow: visible;
+        }
+    }
+
     &__item {
         .drop-area__line--vertical {
             height: 100%;


### PR DESCRIPTION
## Related Issue(s)

part of defect hunting spring 77 https://github.com/SAP/fundamental-ngx/issues/7362
issue has been raised in comment https://github.com/SAP/fundamental-ngx/issues/7362#issuecomment-992775647

## Description

Grid List Item does not indicate the new position on drag.

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [n/a] visual misalignments/updates
-   [n/a] check Light/Dark/HCB/HCW themes
-   [n/a] RTL/LTR - proper rendering and labeling
-   [n/a] responsiveness(resize)
-   [n/a] Content Density (Cozy/Compact/(Condensed))
-   [n/a] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [n/a] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [n/a] Mouse vs. Keyboard support
-   [n/a] Text Truncation

2. API and functional correctness

-   [n/a] check for console logs (warnings, errors)
-   [n/a] API boundary values
-   [n/a] different combinations of components - free style
-   [n/a] change the API values during testing

3. Documentation and Example validations

-   [n/a] missing API documentation or it is not understandable
-   [n/a] poor examples
-   [n/a] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [n/a] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [n/a] Run npm run build-pack-library and test in external application
-   [n/a] update `README.md`
-   [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
