### PR TITLE
fix(core): datetime picker form-message trigger

### DIFF
--- a/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.component.html
@@ -85,8 +85,10 @@
 <fd-docs-section-title id="complex-i18n" componentName="datetime-picker"> i18n example. </fd-docs-section-title>
 <description>
     <fd-datetime-important componentName="DatetimePicker"></fd-datetime-important>
-    To change a locale option in <code>DatePicker</code> component, it is needed to set a locale via
-    <code>DatetimeAdapter.setLocale</code> method.
+    <p>
+        To change a locale option in <code>DatePicker</code> component, it is needed to set a locale via
+        <code>DatetimeAdapter.setLocale</code> method.
+    </p>
 </description>
 <component-example>
     <fd-datetime-picker-complex-i18n-example></fd-datetime-picker-complex-i18n-example>

--- a/apps/docs/src/app/documentation/common-components/datetime-important/datetime-important.component.html
+++ b/apps/docs/src/app/documentation/common-components/datetime-important/datetime-important.component.html
@@ -17,8 +17,8 @@
     </a>
     ).
     <br />
-    Since this adapter has some disadvantages, formatting may vary among browsers and parsing is limited to en locale
-    only.
+    Since this adapter has some disadvantages, formatting may vary among browsers and parsing is limited to
+    <b><i>en</i></b> locale only.
     <br />
     You can use a custom fundamental adapter based on a third party library:
     <a href="https://momentjs.com/" target="_blank">https://momentjs.com/</a>.

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -127,7 +127,7 @@ export class DatetimePickerComponent<D>
         this._popoverFormMessage.triggers = triggers;
     }
     /** @hidden */
-    _messageTriggers: string[] = ['mouseenter', 'mouseleave'];
+    _messageTriggers: string[] = ['focusin', 'focusout'];
 
     /**
      * Whether the time component shows minutes.


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

Part of https://github.com/SAP/fundamental-ngx/issues/7362
[Comment with the issue description](https://github.com/SAP/fundamental-ngx/issues/7362#issuecomment-992755343) 

## Description
1. 

> Disabled DateTime Picker has pointer events and triggers the validation message

 - changed to `focusin focusout` instead.
2. 

> DateTime Picker i18n example. Click inside the input field and delete the `m.`, it shows the input field is invalid and colors in red. Add back `m.` and the field is still invalid. Expected behaviour: field should become valid again

This is by design. There is a warning message right before this example that by default parsing is limitted only to en locale
![image](https://user-images.githubusercontent.com/3263744/147683580-f18f6336-cbca-4181-9ffc-70af82144997.png)
 


## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

### After:

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [na] visual misalignments/updates
-   [na] check Light/Dark/HCB/HCW themes
-   [na] RTL/LTR - proper rendering and labeling
-   [na] responsiveness(resize)
-   [na] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [na] Mouse vs. Keyboard support
-   [na] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [na] API boundary values
-   [na] different combinations of components - free style
-   [na] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [na] poor examples
-   [na] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [na] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [na] update `README.md`
-   [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
