### PR TITLE
fix(core): popover vertical overflow

### DIFF
--- a/libs/core/src/lib/popover/popover.component.scss
+++ b/libs/core/src/lib/popover/popover.component.scss
@@ -1,0 +1,4 @@
+.fd-popover__popper {
+    max-height: 80vh;
+    overflow-y: auto;
+}


### PR DESCRIPTION
## Related Issue(s)

Part of https://github.com/SAP/fundamental-ngx/issues/7445

## Description

Temporary fix for the popover's vertical overflow.

It's not the final solution because to reach the popover's footer you need to scroll down. Ideally, only the popover's body should be scrollable but due to the complexity of the task it will be done later.

## Screenshots

### Before:

<img width="627" alt="image" src="https://user-images.githubusercontent.com/20265336/148805829-d3d0825f-e01a-4cb4-b928-d4cfcc8f0f84.png">

### After:

<img width="643" alt="image" src="https://user-images.githubusercontent.com/20265336/148805724-83b5387d-0afd-4deb-bdb4-4cd5dea08854.png">
