### PR TITLE
fix(core): datetime vertical overflow

### DIFF
--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -46,64 +46,66 @@
             [attr.aria-hidden]="!isOpen"
             [style.display]="'block'"
         >
-            <fd-form-message id="fd-form-message" [embedded]="true" *ngIf="_message" [type]="state">
-                {{ _message }}
-            </fd-form-message>
-            <ng-content></ng-content>
-            <div class="fd-datetime__container">
-                <fd-calendar
-                    calType="single"
-                    [activeView]="activeView"
-                    [disableFunction]="disableFunction ? disableFunction : null"
-                    [selectedDate]="_tempDate"
-                    [escapeFocusFunction]="null"
-                    [compact]="compact"
-                    [markWeekends]="markWeekends"
-                    [specialDaysRules]="specialDaysRules"
-                    [showWeekNumbers]="showWeekNumbers"
-                    [aggregatedYearGrid]="aggregatedYearGrid"
-                    [yearGrid]="yearGrid"
-                    [startingDayOfWeek]="startingDayOfWeek"
-                    (activeViewChange)="handleCalendarActiveViewChange($event)"
-                    (selectedDateChange)="handleDateChange($event)"
-                    (isValidDateChange)="setInvalidDateInputHandler($event)"
-                ></fd-calendar>
-                <div class="fd-datetime__separator"></div>
-                <fd-time
-                    *ngIf="isOpen"
-                    [disabled]="disabled"
-                    [keepTwoDigits]="keepTwoDigitsTime"
-                    [ngModel]="_tempTime"
-                    [compact]="compact"
-                    [spinnerButtons]="spinnerButtons"
-                    [meridian]="_meridian"
-                    [displaySeconds]="_displaySeconds"
-                    [displayMinutes]="_displayMinutes"
-                    [displayHours]="_displayHours"
-                    (ngModelChange)="handleTimeChange($event)"
-                ></fd-time>
-            </div>
-            <div fd-popover-body-footer *ngIf="showFooter">
-                <div fd-bar barDesign="footer" [cozy]="!compact">
-                    <div fd-bar-right>
-                        <fd-bar-element>
-                            <button
-                                fd-button
-                                fdType="emphasized"
-                                label="OK"
-                                [compact]="compact"
-                                (click)="submit()"
-                            ></button>
-                        </fd-bar-element>
-                        <fd-bar-element>
-                            <button
-                                fd-button
-                                fdType="transparent"
-                                [compact]="compact"
-                                label="Cancel"
-                                (click)="cancel()"
-                            ></button>
-                        </fd-bar-element>
+            <div class="fd-popover__wrapper fd-datetime__wrapper">
+                <fd-form-message id="fd-form-message" [embedded]="true" *ngIf="_message" [type]="state">
+                    {{ _message }}
+                </fd-form-message>
+                <ng-content></ng-content>
+                <div class="fd-datetime__container">
+                    <fd-calendar
+                        calType="single"
+                        [activeView]="activeView"
+                        [disableFunction]="disableFunction ? disableFunction : null"
+                        [selectedDate]="_tempDate"
+                        [escapeFocusFunction]="null"
+                        [compact]="compact"
+                        [markWeekends]="markWeekends"
+                        [specialDaysRules]="specialDaysRules"
+                        [showWeekNumbers]="showWeekNumbers"
+                        [aggregatedYearGrid]="aggregatedYearGrid"
+                        [yearGrid]="yearGrid"
+                        [startingDayOfWeek]="startingDayOfWeek"
+                        (activeViewChange)="handleCalendarActiveViewChange($event)"
+                        (selectedDateChange)="handleDateChange($event)"
+                        (isValidDateChange)="setInvalidDateInputHandler($event)"
+                    ></fd-calendar>
+                    <div class="fd-datetime__separator"></div>
+                    <fd-time
+                        *ngIf="isOpen"
+                        [disabled]="disabled"
+                        [keepTwoDigits]="keepTwoDigitsTime"
+                        [ngModel]="_tempTime"
+                        [compact]="compact"
+                        [spinnerButtons]="spinnerButtons"
+                        [meridian]="_meridian"
+                        [displaySeconds]="_displaySeconds"
+                        [displayMinutes]="_displayMinutes"
+                        [displayHours]="_displayHours"
+                        (ngModelChange)="handleTimeChange($event)"
+                    ></fd-time>
+                </div>
+                <div fd-popover-body-footer *ngIf="showFooter">
+                    <div fd-bar barDesign="footer" [cozy]="!compact">
+                        <div fd-bar-right>
+                            <fd-bar-element>
+                                <button
+                                    fd-button
+                                    fdType="emphasized"
+                                    label="OK"
+                                    [compact]="compact"
+                                    (click)="submit()"
+                                ></button>
+                            </fd-bar-element>
+                            <fd-bar-element>
+                                <button
+                                    fd-button
+                                    fdType="transparent"
+                                    [compact]="compact"
+                                    label="Cancel"
+                                    (click)="cancel()"
+                                ></button>
+                            </fd-bar-element>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.scss
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.scss
@@ -1,6 +1,10 @@
 .fd-datetime {
     display: block;
 
+    &__wrapper {
+        max-height: 80vh;
+    }
+
     &__container {
         display: flex;
         align-items: center;

--- a/libs/core/src/lib/popover/popover.component.scss
+++ b/libs/core/src/lib/popover/popover.component.scss
@@ -1,4 +1,0 @@
-.fd-popover__popper {
-    max-height: 80vh;
-    overflow-y: auto;
-}


### PR DESCRIPTION
## Related Issue(s)

Refers to https://github.com/SAP/fundamental-ngx/issues/7445

## Description

Previously we merged https://github.com/SAP/fundamental-ngx/pull/7528. There was a fix to add a scrollbar if popover goes `> 80vh` but it brokes some other components that use popover.

Here i limit the fix by applying it only for the datetime and the rest will be fixed separately.

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/20265336/149174770-0d0c9239-8019-4da7-b7b1-396a3c721103.png)

### After:

![image](https://user-images.githubusercontent.com/20265336/149174893-03e93256-b036-44b9-8f7b-11ef1fed6259.png)
