### PR TITLE
fix(platform): table column's width

### DIFF
--- a/libs/platform/src/lib/table/table-column-resize.service.ts
+++ b/libs/platform/src/lib/table/table-column-resize.service.ts
@@ -151,6 +151,10 @@ export class TableColumnResizeService implements OnDestroy {
      *  corresponding value will be treated as higher priority
      */
     getColumnWidthStyle(column: TableColumn): string {
+        if (!this._tableRef._tableWidthPx) {
+            return 'auto';
+        }
+
         const calculatedWidth = this._columnsWidthMap.get(column.name);
         const changeSource = this._columnsWidthChangeSourceMap.get(column.name);
 
@@ -185,10 +189,8 @@ export class TableColumnResizeService implements OnDestroy {
         if (!width.trim().endsWith('%')) {
             return width;
         }
+
         const percent = parseFloat(width);
-        if (!this._tableRef._tableWidthPx) {
-            throw new Error('Cannot resolve column width until table width is set');
-        }
         return (this._tableRef._tableWidthPx * percent) / 100 + 'px';
     }
 


### PR DESCRIPTION
## Related Issue(s)

DXP.

## Description

Currently, if table column has width set in `%` and table has `0` width - we will see a lot of errors in the console. 

![image](https://user-images.githubusercontent.com/20265336/149344854-8799672a-0444-4fcd-a67c-34ef7906fab2.png)

Table can be initialized and not rendered due to many reasons (it's inside the not active tab, for example) and it shouldn't come up with endless errors in the console.

The fix is to return `auto` as a column width and skip all the calculations if table doesn't have width.

## Screenshots

### Before:

Errors in the console.

### After:

No errors.
