### PR TITLE
fix(core,platform,fn): lodash-es & fast-deep-equal as deps & docs update about jest issue with lodash-es

### DIFF
--- a/PLATFORM_README.md
+++ b/PLATFORM_README.md
@@ -211,6 +211,25 @@ Run `ng test platform`. Append `--code-coverage` to generate code coverage docum
 
 For models prior to 0.11.1 use `fundamental-ngx`
 
+### Using Jest for running tests in the host application
+
+If you're using Jest for running tests in the host application some additional steps needed to be done due to the Jest issues with importing ES modules.
+
+1. Install `lodash` package as the development dependency.
+   `npm i -D lodash`
+   Using yarn?
+   `yarn add -D lodash`
+   Don't worry, as we're installing package as the development dependency it won't increase build size.
+
+2. Adjust Jest config (`jest.config.js`) by adding these lines:
+    ```
+    moduleNameMapper: {
+      "^lodash-es$": "lodash"
+    },
+    ```
+
+That's it, now your tests should be working fine. In case of any issues please raise the issue in the github repository.
+
 ## Versioning
 
 The `@fundamental-ngx/platform` library follows [Semantic Versioning](https://semver.org/). These components strictly adhere to the `[MAJOR].[MINOR].[PATCH]` numbering system (also known as `[BREAKING].[FEATURE].[FIX]`).

--- a/libs/core/src/lib/ng-package.json
+++ b/libs/core/src/lib/ng-package.json
@@ -9,6 +9,8 @@
         "@angular/cdk",
         "@sap-theming/theming-base-content",
         "focus-trap",
-        "fundamental-styles"
+        "fundamental-styles",
+        "lodash-es",
+        "fast-deep-equal"
     ]
 }

--- a/libs/core/src/lib/package.json
+++ b/libs/core/src/lib/package.json
@@ -18,8 +18,6 @@
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
     "@angular/animations": "ANGULAR_VER_PLACEHOLDER",
     "@angular/router": "ANGULAR_VER_PLACEHOLDER",
-    "fast-deep-equal": "FAST_DEEP_EQUAL_VER_PLACEHOLDER",
-    "lodash-es": "LODASH_ES_VER_PLACEHOLDER",
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {
@@ -27,6 +25,8 @@
     "@sap-theming/theming-base-content": "THEMING_VER_PLACEHOLDER",
     "focus-trap": "FOCUSTRAP_VER_PLACEHOLDER",
     "fundamental-styles": "FDSTYLES_VER_PLACEHOLDER",
+    "fast-deep-equal": "FAST_DEEP_EQUAL_VER_PLACEHOLDER",
+    "lodash-es": "LODASH_ES_VER_PLACEHOLDER",
     "tslib": "^2.0.0"
   }
 }

--- a/libs/fn/src/lib/ng-package.json
+++ b/libs/fn/src/lib/ng-package.json
@@ -10,6 +10,8 @@
         "@sap-theming/theming-base-content",
         "focus-trap",
         "focus-visible",
-        "fundamental-styles"
+        "fundamental-styles",
+        "lodash-es",
+        "fast-deep-equal"
     ]
 }

--- a/libs/fn/src/lib/package.json
+++ b/libs/fn/src/lib/package.json
@@ -18,8 +18,6 @@
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
     "@angular/animations": "ANGULAR_VER_PLACEHOLDER",
     "@angular/router": "ANGULAR_VER_PLACEHOLDER",
-    "fast-deep-equal": "FAST_DEEP_EQUAL_VER_PLACEHOLDER",
-    "lodash-es": "LODASH_ES_VER_PLACEHOLDER",
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {
@@ -29,6 +27,8 @@
     "focus-visible": "FOCUSVISIBLE_VER_PLACEHOLDER",
     "fundamental-styles": "FDSTYLES_VER_PLACEHOLDER",
     "@fundamental-styles/fn": "FDNSTYLES_VER_PLACEHOLDER",
+    "fast-deep-equal": "FAST_DEEP_EQUAL_VER_PLACEHOLDER",
+    "lodash-es": "LODASH_ES_VER_PLACEHOLDER",
     "tslib": "^2.0.0"
   }
 }

--- a/libs/platform/src/lib/ng-package.json
+++ b/libs/platform/src/lib/ng-package.json
@@ -11,6 +11,8 @@
         "focus-trap",
         "fundamental-styles",
         "@fundamental-ngx/core",
-        "xml2js"
+        "xml2js",
+        "lodash-es",
+        "fast-deep-equal"
     ]
 }

--- a/libs/platform/src/lib/package.json
+++ b/libs/platform/src/lib/package.json
@@ -18,8 +18,6 @@
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
     "@angular/animations": "ANGULAR_VER_PLACEHOLDER",
     "@angular/router": "ANGULAR_VER_PLACEHOLDER",
-    "fast-deep-equal": "FAST_DEEP_EQUAL_VER_PLACEHOLDER",
-    "lodash-es": "LODASH_ES_VER_PLACEHOLDER",
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {
@@ -27,6 +25,8 @@
     "@sap-theming/theming-base-content": "THEMING_VER_PLACEHOLDER",
     "focus-trap": "FOCUSTRAP_VER_PLACEHOLDER",
     "fundamental-styles": "FDSTYLES_VER_PLACEHOLDER",
+    "fast-deep-equal": "FAST_DEEP_EQUAL_VER_PLACEHOLDER",
+    "lodash-es": "LODASH_ES_VER_PLACEHOLDER",
     "tslib": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Related Issue(s)

Closes https://github.com/SAP/fundamental-ngx/issues/7542

## Description

* Platform readme update to notify about jest issue with lodash-es
* `lodash-es` & `fast-deep-equal` added as `deps`, not `peerDeps`

## Readme updates

https://deploy-preview-7544--fundamental-ngx.netlify.app/#/platform/home
https://github.com/SAP/fundamental-ngx/wiki/Full-Installation-Guide