### PR TITLE
feat(core): add input for responsive side nav

### DIFF
--- a/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component.html
+++ b/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component.html
@@ -1,0 +1,75 @@
+<fd-shellbar [sideNav]="true">
+    <button
+        fd-shellbar-side-nav
+        fd-button
+        glyph="menu2"
+        fdType="transparent"
+        style="width: 2.75rem"
+        (click)="condensed = !condensed"
+    ></button>
+
+    <fd-shellbar-logo>
+        <a href="#" class="fd-shellbar__logo fd-shellbar__logo--image-replaced" aria-label="SAP"></a>
+    </fd-shellbar-logo>
+</fd-shellbar>
+<div class="shellbar-sidenav-content-example">
+    <fd-side-nav [condensed]="condensed" [collapseWidth]="768">
+        <div fd-side-nav-main>
+            <ul fd-nested-list [textOnly]="false">
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <i fd-nested-list-icon glyph="menu"></i>
+                        <span fd-nested-list-title>Link 1</span>
+                    </a>
+                </li>
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <i fd-nested-list-icon glyph="home"></i>
+                        <span fd-nested-list-title>Link 2</span>
+                    </a>
+                </li>
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <i fd-nested-list-icon glyph="settings"></i>
+                        <span fd-nested-list-title>Link 3</span>
+                    </a>
+                </li>
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <i fd-nested-list-icon glyph="settings"></i>
+                        <span fd-nested-list-title>Link 4</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+
+        <div fd-side-nav-utility>
+            <ul fd-nested-list [textOnly]="false">
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <i fd-nested-list-icon glyph="menu"></i>
+                        <span fd-nested-list-title>Link 1</span>
+                    </a>
+                </li>
+                <li fd-nested-list-item>
+                    <a fd-nested-list-link>
+                        <i fd-nested-list-icon glyph="home"></i>
+                        <span fd-nested-list-title>Link 2</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </fd-side-nav>
+
+    <fd-layout-panel style="width: 100%">
+        <fd-layout-panel-header>
+            <fd-layout-panel-head>
+                <h2 fd-layout-panel-title>Sample Page Title</h2>
+                <fd-layout-panel-description>Sample Description</fd-layout-panel-description>
+            </fd-layout-panel-head>
+            <fd-layout-panel-actions> Sample Text </fd-layout-panel-actions>
+        </fd-layout-panel-header>
+        <fd-layout-panel-body> Sample Body </fd-layout-panel-body>
+        <fd-layout-panel-footer> Sample Footer </fd-layout-panel-footer>
+    </fd-layout-panel>
+</div>

--- a/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component.scss
@@ -1,0 +1,12 @@
+.display-none {
+    display: none;
+}
+
+.shellbar-sidenav-content-example {
+    display: flex;
+    align-items: flex-start;
+}
+
+.fd-nested-list__icon {
+    display: flex;
+}

--- a/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/shellbar/examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component.ts
@@ -1,0 +1,11 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+    selector: 'fd-shellbar-side-nav-responsive-example',
+    templateUrl: './shellbar-side-nav-responsive-example.component.html',
+    styleUrls: ['./shellbar-side-nav-responsive-example.component.scss'],
+    encapsulation: ViewEncapsulation.None
+})
+export class ShellbarSideNavResponsiveExampleComponent {
+    condensed = false;
+}

--- a/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.component.html
@@ -46,6 +46,20 @@
 
 <separator></separator>
 
+<fd-docs-section-title id="side-nav-responsive" componentName="shellbar">
+    Shellbar with Responsive SideNavigation
+</fd-docs-section-title>
+<description>
+    The Side Navigation can be set to collapse automatically at a width breakpoint specified by the developer via the
+    <code>[collapseWidth]</code> input. In this example the breakpoint has been set at 768 pixels.
+</description>
+<component-example>
+    <fd-shellbar-side-nav-responsive-example></fd-shellbar-side-nav-responsive-example>
+</component-example>
+<code-example [exampleFiles]="shellbarSideNavResponsive"></code-example>
+
+<separator></separator>
+
 <fd-docs-section-title id="how-it-works" componentName="shellbar"> How it works </fd-docs-section-title>
 <description>
     <ul>

--- a/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.component.ts
@@ -7,6 +7,9 @@ import shellbarCollapsibleTSSrc from '!./examples/shellbar-collapsible-example.c
 import sideNavShellbarHtml from '!./examples/shellbar-side-nav/shellbar-side-nav-example.component.html?raw';
 import sideNavShellbarTs from '!./examples/shellbar-side-nav/shellbar-side-nav-example.component.ts?raw';
 import sideNavShellbarScss from '!./examples/shellbar-side-nav/shellbar-side-nav-example.component.scss?raw';
+import sideNavResponsiveShellbarTs from '!./examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component.ts?raw';
+import sideNavResponsiveShellbarScss from '!./examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component.scss?raw';
+import sideNavResponsiveShellbarHtml from '!./examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component.html?raw';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
 
 @Component({
@@ -61,6 +64,28 @@ export class ShellbarDocsComponent {
             fileName: 'shellbar-side-nav-example',
             component: 'ShellbarSideNavExampleComponent',
             scssFileCode: sideNavShellbarScss
+        }
+    ];
+
+    shellbarSideNavResponsive: ExampleFile[] = [
+        {
+            language: 'html',
+            code: sideNavResponsiveShellbarHtml,
+            fileName: 'shellbar-side-nav-responsive-example'
+        },
+        {
+            language: 'typescript',
+            component: 'ShellbarSideNavResponsiveExampleComponent',
+            code: sideNavResponsiveShellbarTs,
+            fileName: 'shellbar-side-nav-responsive-example',
+            scssFileCode: sideNavResponsiveShellbarScss
+        },
+        {
+            language: 'scss',
+            code: sideNavResponsiveShellbarScss,
+            fileName: 'shellbar-side-nav-responsive-example',
+            component: 'ShellbarSideNavResponsiveExampleComponent',
+            scssFileCode: sideNavResponsiveShellbarScss
         }
     ];
 }

--- a/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/shellbar/shellbar-docs.module.ts
@@ -15,6 +15,7 @@ import { ProductSwitchModule } from '@fundamental-ngx/core/product-switch';
 import { TileModule } from '@fundamental-ngx/core/tile';
 import { LayoutPanelModule } from '@fundamental-ngx/core/layout-panel';
 import { SegmentedButtonModule } from '@fundamental-ngx/core/segmented-button';
+import { ShellbarSideNavResponsiveExampleComponent } from './examples/shellbar-side-nav-responsive/shellbar-side-nav-responsive-example.component';
 
 const routes: Routes = [
     {
@@ -45,7 +46,8 @@ const routes: Routes = [
         ShellbarDocsHeaderComponent,
         ShellbarBasicExampleComponent,
         ShellbarSideNavExampleComponent,
-        ShellbarCollapsibleExampleComponent
+        ShellbarCollapsibleExampleComponent,
+        ShellbarSideNavResponsiveExampleComponent
     ]
 })
 export class ShellbarDocsModule {}

--- a/libs/core/src/lib/shellbar/shellbar.component.ts
+++ b/libs/core/src/lib/shellbar/shellbar.component.ts
@@ -59,6 +59,8 @@ export class ShellbarComponent implements AfterContentInit {
             this.comboboxComponent.inShellbar = true;
         }
     }
+
+    /** @hidden */
     applyShellbarModeToButtons(): void {
         if (this.buttons && this.buttons.length) {
             this.buttons.forEach((button) => {

--- a/libs/core/src/lib/side-navigation/side-navigation.component.ts
+++ b/libs/core/src/lib/side-navigation/side-navigation.component.ts
@@ -4,6 +4,7 @@ import {
     Component,
     ContentChild,
     HostBinding,
+    HostListener,
     Input,
     OnInit,
     QueryList,
@@ -40,6 +41,12 @@ export class SideNavigationComponent implements AfterContentInit, AfterViewInit,
     @Input()
     @HostBinding('class.fd-side-nav--condensed')
     condensed = false;
+
+    /**
+     * The screen width, in pixels, at which to automatically collapse the side navigation on window resize.
+     */
+    @Input()
+    collapseWidth: number;
 
     /** Whether clicking on elements should change selected state of items */
     @Input()
@@ -84,6 +91,14 @@ export class SideNavigationComponent implements AfterContentInit, AfterViewInit,
     ngAfterViewInit(): void {
         if (this.sideNavigationConfiguration) {
             this.keyboardService.refreshItems(this.getLists());
+        }
+    }
+
+    /** @hidden */
+    @HostListener('window:resize')
+    onResize(): void {
+        if (this.collapseWidth) {
+            this.condensed = window.innerWidth <= this.collapseWidth;
         }
     }
 

--- a/libs/core/src/lib/side-navigation/side-navigation.component.ts
+++ b/libs/core/src/lib/side-navigation/side-navigation.component.ts
@@ -78,6 +78,10 @@ export class SideNavigationComponent implements AfterContentInit, AfterViewInit,
         /** Set up condensed state */
         this.nestedListState.condensed =
             this.condensed || (this.sideNavigationConfiguration && this.sideNavigationConfiguration.condensed);
+
+        if (this.collapseWidth) {
+            this.onResize();
+        }
     }
 
     /** @hidden */


### PR DESCRIPTION
closes #4522 

Adds the optional input `collapseWidth` to the side navigation component, allowing the developer to set a breakpoint at which the sidebar will automatically collapse on window resize.