### PR TITLE
feat(core,platform): date & datetime picker - ability to process input value on blur

### DIFF
--- a/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.component.html
@@ -10,7 +10,6 @@
     The default format for the input is provided via DateTimeFormats. See the 'Formatting' section for details on how to
     change this.
 </description>
-<description> The value for the input only changes the model on blur or an enter/return keystroke. </description>
 <component-example>
     <fd-date-picker-single-example></fd-date-picker-single-example>
 </component-example>
@@ -103,6 +102,20 @@
     <fd-date-picker-disable-func-example></fd-date-picker-disable-func-example>
 </component-example>
 <code-example [exampleFiles]="datePickerSingleDisable"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="update-on-blur" componentName="date-picker">
+    Date picker that updates it's value on blur.
+</fd-docs-section-title>
+<description>
+    Set <code>[processInputOnBlur]="true"</code> in order to move the processing of input value to whenever component
+    loses focus. You may also hit "enter" to apply the value
+</description>
+<component-example>
+    <fd-date-picker-update-on-blur-example></fd-date-picker-update-on-blur-example>
+</component-example>
+<code-example [exampleFiles]="datePickerUpdateOnBlur"></code-example>
 
 <separator></separator>
 

--- a/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.component.ts
@@ -14,6 +14,7 @@ import datePickerRangeDisableTs from '!./examples/date-picker-range-disabled-exa
 import datePickerRangeDisableH from '!./examples/date-picker-range-disabled-example/date-picker-range-disabled-example.component.html?raw';
 import datePickerSingleDisableTs from '!./examples/date-picker-disable-func-example/date-picker-disable-func-example.component.ts?raw';
 import datePickerSingleDisableH from '!./examples/date-picker-disable-func-example/date-picker-disable-func-example.component.html?raw';
+import datePickerUpdateOnBlurSrcTs from '!./examples/date-picker-update-on-blur-example.component.ts?raw';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
 
 @Component({
@@ -135,6 +136,15 @@ export class DatePickerDocsComponent {
             component: 'DatePickerComplexI18nExampleComponent',
             code: datePickerComplexI18nSrcH,
             fileName: 'date-picker-complex-i18n-example'
+        }
+    ];
+
+    datePickerUpdateOnBlur: ExampleFile[] = [
+        {
+            language: 'typescript',
+            component: 'DatePickerUpdateOnBlurExampleComponent',
+            code: datePickerUpdateOnBlurSrcTs,
+            fileName: 'date-picker-update-on-blur-example'
         }
     ];
 }

--- a/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.module.ts
@@ -24,6 +24,7 @@ import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 import { FdDatetimeModule } from '@fundamental-ngx/core/datetime';
 import { DatePickerModule } from '@fundamental-ngx/core/date-picker';
 import { PipeModule } from '@fundamental-ngx/core/utils';
+import { DatePickerUpdateOnBlurExampleComponent } from './examples/date-picker-update-on-blur-example.component';
 
 const routes: Routes = [
     {
@@ -62,7 +63,8 @@ const routes: Routes = [
         DatePickerFormRangeExampleComponent,
         DatePickerComplexI18nExampleComponent,
         DatePickerDisableFuncExampleComponent,
-        DatePickerRangeDisabledExampleComponent
+        DatePickerRangeDisabledExampleComponent,
+        DatePickerUpdateOnBlurExampleComponent
     ]
 })
 export class DatePickerDocsModule {}

--- a/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-update-on-blur-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-update-on-blur-example.component.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+    DatetimeAdapter,
+    DATE_TIME_FORMATS,
+    FdDate,
+    FdDatetimeAdapter,
+    FD_DATETIME_FORMATS
+} from '@fundamental-ngx/core/datetime';
+
+@Component({
+    selector: 'fd-date-picker-update-on-blur-example',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: ` <label fd-form-label for="datePickerOnBlur">Date Picker</label>
+        <fd-date-picker id="datePickerOnBlur" [processInputOnBlur]="true" [(ngModel)]="date"></fd-date-picker>
+        <br />
+        <div>Selected Date: {{ date?.toDateString() || 'null' }}</div>`,
+    providers: [
+        {
+            provide: DatetimeAdapter,
+            useClass: FdDatetimeAdapter
+        },
+        {
+            provide: DATE_TIME_FORMATS,
+            useValue: FD_DATETIME_FORMATS
+        }
+    ]
+})
+export class DatePickerUpdateOnBlurExampleComponent {
+    date = FdDate.getNow();
+}

--- a/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.component.html
@@ -94,3 +94,17 @@
     <fd-datetime-picker-complex-i18n-example></fd-datetime-picker-complex-i18n-example>
 </component-example>
 <code-example [exampleFiles]="datetimeI18nComplex"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="updates-on-blur" componentName="datetime-picker">
+    Date Time picker that updates it's value on blur.
+</fd-docs-section-title>
+<description>
+    Set <code>[processInputOnBlur]="true"</code> in order to move the processing of input value to whenever component
+    loses focus. You may also hit "enter" to apply the value
+</description>
+<component-example>
+    <fd-datetime-picker-update-on-blur-example></fd-datetime-picker-update-on-blur-example>
+</component-example>
+<code-example [exampleFiles]="dateTimePickerUpdateOnBlur"></code-example>

--- a/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.component.ts
@@ -14,6 +14,8 @@ import dateTimeFormatTs from '!./examples/datetime-format-example/datetime-forma
 import datetimeI18nComplexTs from '!./examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts?raw';
 import datetimeI18nComplexH from '!./examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html?raw';
 
+import datetimeUpdateOnBlurSrcTs from '!./examples/datetime-picker-update-on-blur-example/datetime-picker-update-on-blur-example.component?raw';
+
 import dateTimeDisabledHtml from '!./examples/datetime-disabled-example/datetime-disabled-example.component.html?raw';
 import dateTimeDisabledTs from '!./examples/datetime-disabled-example/datetime-disabled-example.component.ts?raw';
 import dateTimeFormHtml from '!./examples/datetime-form-example/datetime-form-example.component.html?raw';
@@ -117,6 +119,15 @@ export class DatetimePickerDocsComponent {
             code: datetimeI18nComplexH,
             fileName: 'datetime-picker-complex-i18n-example',
             component: 'DatetimePickerComplexI18nExampleComponent'
+        }
+    ];
+
+    dateTimePickerUpdateOnBlur: ExampleFile[] = [
+        {
+            language: 'typescript',
+            code: datetimeUpdateOnBlurSrcTs,
+            fileName: 'datetime-picker-update-on-blur-example',
+            component: 'DateTimePickerUpdateOnBlurExampleComponent'
         }
     ];
 }

--- a/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/datetime-picker-docs.module.ts
@@ -10,6 +10,7 @@ import { DatetimeExampleComponent } from './examples/datetime-example/datetime-e
 import { DatetimeProgramExampleComponent } from './examples/datetime-program-example/datetime-program-example.component';
 import { DatetimeFormatExampleComponent } from './examples/datetime-format-example/datetime-format-example.component';
 import { DatetimeFormExampleComponent } from './examples/datetime-form-example/datetime-form-example.component';
+import { DateTimePickerUpdateOnBlurExampleComponent } from './examples/datetime-picker-update-on-blur-example/datetime-picker-update-on-blur-example.component';
 import { DatetimePickerAllowNullExampleComponent } from './examples/datetime-allow-null-example/datetime-allow-null-example.component';
 import { DatetimeDisabledExampleComponent } from './examples/datetime-disabled-example/datetime-disabled-example.component';
 import { SharedDocumentationPageModule } from '../../../documentation/shared-documentation-page.module';
@@ -49,6 +50,7 @@ const routes: Routes = [
         DatetimeExampleComponent,
         DatetimePickerDocsComponent,
         DatetimeFormExampleComponent,
+        DateTimePickerUpdateOnBlurExampleComponent,
         DatetimePickerHeaderComponent,
         DatetimeFormatExampleComponent,
         DatetimeProgramExampleComponent,

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-update-on-blur-example/datetime-picker-update-on-blur-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-update-on-blur-example/datetime-picker-update-on-blur-example.component.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+    DatetimeAdapter,
+    DATE_TIME_FORMATS,
+    FdDate,
+    FdDatetimeAdapter,
+    FD_DATETIME_FORMATS
+} from '@fundamental-ngx/core/datetime';
+
+@Component({
+    selector: 'fd-datetime-picker-update-on-blur-example',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: `
+        <label fd-form-label for="dateTimePickerOnBlur">DateTime Picker</label>
+        <fd-datetime-picker
+            inputId="dateTimePickerOnBlur"
+            [processInputOnBlur]="true"
+            [(ngModel)]="date"
+        ></fd-datetime-picker>
+        <br />
+        <span> Selected: {{ date || 'null' }} </span>
+    `,
+    providers: [
+        {
+            provide: DatetimeAdapter,
+            useClass: FdDatetimeAdapter
+        },
+        {
+            provide: DATE_TIME_FORMATS,
+            useValue: FD_DATETIME_FORMATS
+        }
+    ]
+})
+export class DateTimePickerUpdateOnBlurExampleComponent {
+    date = FdDate.getNow();
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-date-picker/platform-date-picker-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-date-picker/platform-date-picker-docs.component.html
@@ -45,3 +45,17 @@
     <fdp-platform-date-picker-i18n-example></fdp-platform-date-picker-i18n-example>
 </component-example>
 <code-example [exampleFiles]="datePickeri18nExample"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="update-on-blur" componentName="date-picker">
+    Date picker that updates it's value on blur.
+</fd-docs-section-title>
+<description>
+    Set <code>[processInputOnBlur]="true"</code> in order to move the processing of input value to whenever component
+    loses focus. You may also hit "enter" to apply the value
+</description>
+<component-example>
+    <fdp-date-picker-update-on-blur-example></fdp-date-picker-update-on-blur-example>
+</component-example>
+<code-example [exampleFiles]="datePickerUpdateOnBlur"></code-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-date-picker/platform-date-picker-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-date-picker/platform-date-picker-docs.component.ts
@@ -8,6 +8,7 @@ import datepickerDisabledFnCodeTs from '!./platform-date-picker-examples/platfor
 import datepickerDisabledFnHtml from '!./platform-date-picker-examples/platform-date-picker-disable-func-example.component.html?raw';
 import datepickerFormatTs from '!./platform-date-picker-examples/platform-date-picker-format-example.component?raw';
 import datepickerFormatHtml from '!./platform-date-picker-examples/platform-date-picker-format-example.component.html?raw';
+import datePickerUpdateOnBlurSrcTs from '!./platform-date-picker-examples/platform-date-picker-update-on-blur-example.component.ts?raw';
 
 import { ExampleFile } from '../../../../documentation/core-helpers/code-example/example-file';
 
@@ -70,6 +71,15 @@ export class PlatformDatePickerDocsComponent {
             code: datepickerFormatHtml,
             fileName: 'platform-date-picker-format-example',
             component: 'PlatformDatePickerFormatExampleComponent'
+        }
+    ];
+
+    datePickerUpdateOnBlur: ExampleFile[] = [
+        {
+            language: 'typescript',
+            component: 'DatePickerUpdateOnBlurExampleComponent',
+            code: datePickerUpdateOnBlurSrcTs,
+            fileName: 'date-picker-update-on-blur-example'
         }
     ];
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-date-picker/platform-date-picker-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-date-picker/platform-date-picker-docs.module.ts
@@ -15,6 +15,7 @@ import { PlatformDatePickerExampleComponent } from './platform-date-picker-examp
 import { PlatformDatePickeri18nExampleComponent } from './platform-date-picker-examples/platform-date-picker-i18n-example.component';
 import { PlatformDatePickerDisableFuncExampleComponent } from './platform-date-picker-examples/platform-date-picker-disable-func-example.component';
 import { PlatformDatePickerFormatExampleComponent } from './platform-date-picker-examples/platform-date-picker-format-example.component';
+import { PlatformDatePickerUpdateOnBlurExampleComponent } from './platform-date-picker-examples/platform-date-picker-update-on-blur-example.component';
 
 const routes: Routes = [
     {
@@ -34,7 +35,8 @@ const routes: Routes = [
         PlatformDatePickerDisableFuncExampleComponent,
         PlatformDatePickerHeaderComponent,
         PlatformDatePickeri18nExampleComponent,
-        PlatformDatePickerFormatExampleComponent
+        PlatformDatePickerFormatExampleComponent,
+        PlatformDatePickerUpdateOnBlurExampleComponent
     ],
     imports: [
         RouterModule.forChild(routes),

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-date-picker/platform-date-picker-examples/platform-date-picker-update-on-blur-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-date-picker/platform-date-picker-examples/platform-date-picker-update-on-blur-example.component.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+    DatetimeAdapter,
+    DATE_TIME_FORMATS,
+    FdDate,
+    FdDatetimeAdapter,
+    FD_DATETIME_FORMATS
+} from '@fundamental-ngx/core/datetime';
+
+@Component({
+    selector: 'fdp-date-picker-update-on-blur-example',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: ` <label fd-form-label for="datePickerOnBlur">Date Picker</label>
+        <fdp-date-picker
+            id="datePickerOnBlur"
+            name="datePickerOnBlur"
+            [processInputOnBlur]="true"
+            [(ngModel)]="date"
+        ></fdp-date-picker>
+        <br />
+        <div>Selected Date: {{ date?.toDateString() || 'null' }}</div>`,
+    providers: [
+        // Note that this is usually provided in the root of your application.
+        // Due to the limit of this example we must provide it on this level.
+        {
+            provide: DatetimeAdapter,
+            useClass: FdDatetimeAdapter
+        },
+        {
+            provide: DATE_TIME_FORMATS,
+            useValue: FD_DATETIME_FORMATS
+        }
+    ]
+})
+export class PlatformDatePickerUpdateOnBlurExampleComponent {
+    date = FdDate.getNow();
+}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-docs.component.html
@@ -44,3 +44,15 @@
 <code-example [exampleFiles]="datetimePickerDisableFunction"></code-example>
 
 <separator></separator>
+
+<fd-docs-section-title id="update-on-blur" componentName="datetime-picker">
+    Date Time picker that updates it's value on blur.
+</fd-docs-section-title>
+<description>
+    Set <code>[processInputOnBlur]="true"</code> in order to move the processing of input value to whenever component
+    loses focus. You may also hit "enter" to apply the value
+</description>
+<component-example>
+    <fdp-platform-datetime-picker-update-on-blur-example></fdp-platform-datetime-picker-update-on-blur-example>
+</component-example>
+<code-example [exampleFiles]="dateTimePickerUpdateOnBlur"></code-example>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-docs.component.ts
@@ -7,6 +7,7 @@ import datetimePickerReactiveHtml from '!./platform-datetime-picker-examples/pla
 import datetimePickerReactiveTs from '!./platform-datetime-picker-examples/platform-datetime-picker-reactive-example.component.ts?raw';
 import datetimePickerTemplateHtml from '!./platform-datetime-picker-examples/platform-datetime-picker-template-example.component.html?raw';
 import datetimePickerTemplateTs from '!./platform-datetime-picker-examples/platform-datetime-picker-template-example.component.ts?raw';
+import datetimePickerUpdateOnBlurTs from '!./platform-datetime-picker-examples/platform-datetime-picker-update-on-blur-example.component.ts?raw';
 
 import { ExampleFile } from '../../../../documentation/core-helpers/code-example/example-file';
 
@@ -68,6 +69,15 @@ export class PlatformDatetimePickerDocsComponent {
             code: datetimePickerDisableFunctionTs,
             fileName: 'platform-datetime-picker-disable-function-example',
             component: 'PlatformDatetimePickerDisableFunctionExampleComponent'
+        }
+    ];
+
+    dateTimePickerUpdateOnBlur: ExampleFile[] = [
+        {
+            language: 'typescript',
+            code: datetimePickerUpdateOnBlurTs,
+            fileName: 'platform-datetime-picker-update-on-blur-example',
+            component: 'PlatformDatetimePickerUpdateOnBlurExampleComponent'
         }
     ];
 }

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-docs.module.ts
@@ -12,6 +12,7 @@ import { PlatformDatetimePickerBasicExampleComponent } from './platform-datetime
 import { PlatformDatetimePickerDisableFunctionExampleComponent } from './platform-datetime-picker-examples/platform-datetime-picker-disable-function-example.component';
 import { PlatformDatetimePickerReactiveExampleComponent } from './platform-datetime-picker-examples/platform-datetime-picker-reactive-example.component';
 import { PlatformDatetimePickerTemplateExampleComponent } from './platform-datetime-picker-examples/platform-datetime-picker-template-example.component';
+import { PlatformDatetimePickerUpdateOnBlurExampleComponent } from './platform-datetime-picker-examples/platform-datetime-picker-update-on-blur-example.component';
 import { PlatformDatetimePickerHeaderComponent } from './platform-datetime-picker-header/platform-datetime-picker-header.component';
 
 const routes: Routes = [
@@ -40,7 +41,8 @@ const routes: Routes = [
         PlatformDatetimePickerBasicExampleComponent,
         PlatformDatetimePickerReactiveExampleComponent,
         PlatformDatetimePickerTemplateExampleComponent,
-        PlatformDatetimePickerDisableFunctionExampleComponent
+        PlatformDatetimePickerDisableFunctionExampleComponent,
+        PlatformDatetimePickerUpdateOnBlurExampleComponent
     ]
 })
 export class PlatformDatetimePickerDocsModule {}

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-update-on-blur-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-datetime-picker/platform-datetime-picker-examples/platform-datetime-picker-update-on-blur-example.component.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import {
+    DatetimeAdapter,
+    DATE_TIME_FORMATS,
+    FdDate,
+    FdDatetimeAdapter,
+    FD_DATETIME_FORMATS
+} from '@fundamental-ngx/core/datetime';
+
+@Component({
+    selector: 'fdp-platform-datetime-picker-update-on-blur-example',
+    template: `<label for="update-on-blur">Datetime picker:</label>
+        <fdp-datetime-picker
+            name="update-on-blur"
+            placeholder="MM/dd/YYYY, hh:mm aa"
+            [(ngModel)]="date"
+            [processInputOnBlur]="true"
+        ></fdp-datetime-picker>
+        <br />
+        <div>Selected Date: {{ date | date: 'MM/dd/YYYY, hh:mm aa' }}</div> `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [
+        // Note that this is usually provided in the root of your application.
+        // Due to the limit of this example we must provide it on this level.
+        {
+            provide: DatetimeAdapter,
+            useClass: FdDatetimeAdapter
+        },
+        {
+            provide: DATE_TIME_FORMATS,
+            useValue: FD_DATETIME_FORMATS
+        }
+    ]
+})
+export class PlatformDatetimePickerUpdateOnBlurExampleComponent {
+    date = new FdDate(2020, 11, 27, 14, 30);
+}

--- a/e2e/wdio/platform/tests/date-time-picker.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/date-time-picker.e2e-spec.ts
@@ -111,7 +111,7 @@ describe('Datetime picker suite', () => {
     it('Verify by default today date is focused', () => {
         const activeButtons = elementArray(activeDateTimePickerButton);
         for (let i = 0; i < activeButtons.length; i++) {
-            if (i !== 2 && i !== 7) {
+            if (i !== 2 && i !== 7 && i !== 11) {
                 // other default days in these calendars
                 if (!getElementClass(activeDateTimePickerButton, i).includes('is-disabled')) {
                     sendKeys(['Escape']);

--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -37,9 +37,10 @@
                 [attr.aria-label]="_dateInputArialLabel"
                 [attr.aria-required]="required"
                 [attr.aria-describedby]="_formValueStateMessageId"
-                [(ngModel)]="_inputFieldDate"
-                (ngModelChange)="handleInputChange($event)"
-                (focus)="onTouched()"
+                [ngModel]="_inputFieldDate"
+                (keyup.enter)="handleInputChange($event.target.value, false)"
+                (ngModelChange)="handleInputChange($event, true)"
+                (blur)="handleInputChange($event.target.value, false)"
             />
         </fd-input-group>
     </fd-popover-control>

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -28,15 +28,16 @@
                     type="text"
                     class="fd-input"
                     fd-input-group-input
-                    [(ngModel)]="_inputFieldDate"
                     [attr.aria-label]="datetimeInputLabel"
                     [attr.id]="inputId"
                     [attr.aria-required]="required"
                     [placeholder]="placeholder"
                     [compact]="compact"
                     [disabled]="disabled"
-                    (ngModelChange)="handleInputChange($event)"
-                    (blur)="handleOnTouched()"
+                    [ngModel]="_inputFieldDate"
+                    (keyup.enter)="handleInputChange($event.target.value, false)"
+                    (ngModelChange)="handleInputChange($event, true)"
+                    (blur)="handleOnTouched($event)"
                 />
             </fd-input-group>
         </fd-popover-control>

--- a/libs/platform/src/lib/form/date-picker/date-picker.component.html
+++ b/libs/platform/src/lib/form/date-picker/date-picker.component.html
@@ -32,6 +32,7 @@
     [disableRangeStartFunction]="disableRangeStartFunction"
     [disableRangeEndFunction]="disableRangeEndFunction"
     [inline]="inline"
+    [processInputOnBlur]="processInputOnBlur"
     [(ngModel)]="value"
     (ngModelChange)="handleDateChange($event)"
     (isOpenChange)="handleOpenChange($event)"

--- a/libs/platform/src/lib/form/date-picker/date-picker.component.ts
+++ b/libs/platform/src/lib/form/date-picker/date-picker.component.ts
@@ -212,6 +212,14 @@ export class PlatformDatePickerComponent<D> extends BaseInput {
     @Input()
     inline = true;
 
+    /**
+     * Whether to recalculate value from the input as user types or on blur.
+     * By default, updates the value as user types.
+     * @default false
+     */
+    @Input()
+    processInputOnBlur = false;
+
     /** Event emitted when the state of the isOpen property changes. */
     @Output()
     readonly isOpenChange = new EventEmitter<boolean>();

--- a/libs/platform/src/lib/form/datetime-picker/datetime-picker.component.html
+++ b/libs/platform/src/lib/form/datetime-picker/datetime-picker.component.html
@@ -31,6 +31,7 @@
     [showWeekNumbers]="showWeekNumbers"
     [showFooter]="showFooter"
     [disableFunction]="disableFunction"
+    [processInputOnBlur]="processInputOnBlur"
     [(ngModel)]="value"
     (ngModelChange)="handleDatetimeInputChange($event)"
     (activeViewChange)="handleActiveViewChange($event)"

--- a/libs/platform/src/lib/form/datetime-picker/datetime-picker.component.ts
+++ b/libs/platform/src/lib/form/datetime-picker/datetime-picker.component.ts
@@ -190,6 +190,14 @@ export class PlatformDatetimePickerComponent<D> extends BaseInput implements Aft
     @Input()
     showFooter = true;
 
+    /**
+     * Whether to recalculate value from the input as user types or on blur.
+     * By default, updates the value as user types.
+     * @default false
+     */
+    @Input()
+    processInputOnBlur = false;
+
     /** Event emitted when the state of the isOpen property changes. */
     @Output()
     readonly isOpenChange = new EventEmitter<boolean>();


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #7525 

## Description
Currently input updates it's value and validity as user types. Adding an ability to apply changes on leaving the input or by hitting enter.

Functionality has been added to:
- core-date-picker
- core-datetime-picker
- platform-date-picker
- core-datetime-picker
<!-- Enter short description of the change -->

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

### After:

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [n/a] visual misalignments/updates
-   [n/a] check Light/Dark/HCB/HCW themes
-   [n/a] RTL/LTR - proper rendering and labeling
-   [n/a] responsiveness(resize)
-   [n/a] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [n/a] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [n/a] different combinations of components - free style
-   [n/a] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [n/a] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [n/a] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [n/a] Run npm run build-pack-library and test in external application
-   [n/a] update `README.md`
-   [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
