### PR TITLE
feat(platform): when function for global wizard generator scope

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-visibility-between-steps-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-visibility-between-steps-example.component.html
@@ -1,0 +1,3 @@
+<fdp-button (click)="openDialog()" label="Open branching wizard in dialog"></fdp-button>
+
+<p *ngIf="wizardValue">Wizard value: {{ wizardValue | json }}</p>

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-visibility-between-steps-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-visibility-between-steps-example.component.ts
@@ -1,0 +1,268 @@
+import { Component } from '@angular/core';
+import { Validators } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { DynamicFormGroup, DynamicFormValue, FormGeneratorService } from '@fundamental-ngx/platform/form';
+import {
+    WizardDialogGeneratorService,
+    WizardGeneratorFormsValue,
+    WizardGeneratorItem,
+    WizardTitle
+} from '@fundamental-ngx/platform/wizard-generator';
+
+@Component({
+    selector: 'fdp-wizard-generator-visibility-between-steps-example',
+    templateUrl: './wizard-generator-visibility-between-steps-example.component.html'
+})
+export class WizardGeneratorVisibilityBetweenStepsExampleComponent {
+    wizardTitle: WizardTitle = {
+        size: 2,
+        text: 'Checkout'
+    };
+
+    wizardValue: WizardGeneratorFormsValue;
+
+    stepItems: WizardGeneratorItem[] = [
+        {
+            name: 'Product type',
+            id: 'productTypeStep',
+            formGroups: [
+                {
+                    title: '1. Product Type',
+                    id: 'productType',
+                    formItems: [
+                        {
+                            name: 'product',
+                            message: 'Select appropriate product type',
+                            type: 'select',
+                            choices: ['Mobile', 'Tablet', 'Desktop'],
+                            validators: [Validators.required]
+                        },
+                        {
+                            name: 'cpuManufacturer',
+                            message: 'Select appropriate CPU Manufacturer',
+                            type: 'select',
+                            choices: ['Intel', 'AMD', 'Apple'],
+                            validators: [Validators.required],
+                            when: (formValue: DynamicFormValue): boolean => formValue.product === 'Desktop'
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            name: 'Warranty',
+            id: 'warrantyStep',
+            formGroups: [
+                {
+                    title: '2. Warranty',
+                    id: 'warranty',
+                    formItems: [
+                        {
+                            name: 'handheldWarranty',
+                            message: 'Include handheld devices warranty',
+                            type: 'switch',
+                            default: true,
+                            dependencyFields: {
+                                productTypeStep: {
+                                    productType: ['product']
+                                }
+                            },
+                            when: (formValue: DynamicFormValue, forms: Map<string, DynamicFormGroup>): boolean => {
+                                const productTypeForm = forms.get('productType');
+
+                                const productControl = this._formGeneratorService.getFormControl(
+                                    productTypeForm,
+                                    'product'
+                                );
+
+                                return productControl?.value !== 'Desktop';
+                            }
+                        },
+                        {
+                            name: 'desktopWarranty',
+                            message: 'Include Desktop devices warranty',
+                            type: 'switch',
+                            default: true,
+                            dependencyFields: {
+                                productTypeStep: {
+                                    productType: ['product']
+                                }
+                            },
+                            when: (formValue: DynamicFormValue, forms: Map<string, DynamicFormGroup>): boolean => {
+                                const productTypeForm = forms.get('productType');
+
+                                const productControl = this._formGeneratorService.getFormControl(
+                                    productTypeForm,
+                                    'product'
+                                );
+
+                                return productControl?.value === 'Desktop';
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            name: 'Customer information',
+            id: 'customerInformationStep',
+            formGroups: [
+                {
+                    title: '2. Customer Information',
+                    id: 'customerInformation',
+                    formItems: [
+                        {
+                            name: 'name',
+                            message: 'Name',
+                            type: 'input',
+                            validators: [Validators.required]
+                        },
+                        {
+                            name: 'address',
+                            message: 'Address Line 1',
+                            type: 'input',
+                            validators: [Validators.required]
+                        },
+                        {
+                            name: 'address2',
+                            message: 'Address Line 2',
+                            type: 'input'
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            name: 'Payment method',
+            id: 'paymentMethodStep',
+            formGroups: [
+                {
+                    title: '3. Payment method',
+                    id: 'paymentMethodForm',
+                    formItems: [
+                        {
+                            name: 'paymentMethod',
+                            message: 'Select appropriate payment method',
+                            type: 'select',
+                            choices: ['Credit Card', 'Bank Transfer'],
+                            validators: [Validators.required]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            name: 'Credit Card Details',
+            id: 'creditCardStep',
+            when: (_completedSteps, answers) =>
+                answers.paymentMethodStep?.paymentMethodForm?.paymentMethod === 'Credit Card',
+            dependencyFields: {
+                paymentMethodStep: {
+                    paymentMethodForm: ['paymentMethod']
+                }
+            },
+            formGroups: [
+                {
+                    title: '4. Credit Card Details',
+                    id: 'cardPayment',
+                    formItems: [
+                        {
+                            name: 'creditCardNumber',
+                            message: 'Enter your credit card details',
+                            type: 'input',
+                            validators: [Validators.required]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            name: 'Bank Details',
+            id: 'bankDetailsStep',
+            when: (_completedSteps, answers) =>
+                answers.paymentMethodStep?.paymentMethodForm?.paymentMethod === 'Bank Transfer',
+            dependencyFields: {
+                paymentMethodStep: {
+                    paymentMethodForm: ['paymentMethod']
+                }
+            },
+            formGroups: [
+                {
+                    title: '4. Bank Details',
+                    id: 'bankDetailsForm',
+                    formItems: [
+                        {
+                            name: 'bankDetails',
+                            message: 'Enter your bank details',
+                            type: 'input',
+                            validators: [Validators.required]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            name: 'Discount',
+            id: 'discountStep',
+            when: (_completedSteps, answers) =>
+                answers.paymentMethodStep?.paymentMethodForm?.paymentMethod === 'Bank Transfer' ||
+                answers.paymentMethodStep?.paymentMethodForm?.paymentMethod === 'Credit Card',
+            formGroups: [
+                {
+                    title: '5. Discount details',
+                    id: 'discountForm',
+                    formItems: [
+                        {
+                            name: 'discount',
+                            message: 'Enter your discount coupon code',
+                            type: 'input'
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            name: 'Summary',
+            id: 'summary',
+            summary: true
+        }
+    ];
+
+    /** An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */
+    private readonly _onDestroy$: Subject<void> = new Subject<void>();
+
+    constructor(
+        private _wizardDialogService: WizardDialogGeneratorService,
+        private _formGeneratorService: FormGeneratorService
+    ) {}
+
+    ngOnDestroy(): void {
+        this._onDestroy$.next();
+        this._onDestroy$.complete();
+    }
+
+    openDialog(): void {
+        this._wizardDialogService
+            .open({
+                width: '100%',
+                height: '100%',
+                verticalPadding: false,
+                data: {
+                    items: this.stepItems,
+                    appendToWizard: false,
+                    displaySummaryStep: true,
+                    responsivePaddings: true,
+                    title: this.wizardTitle
+                }
+            })
+            .afterClosed.pipe(takeUntil(this._onDestroy$))
+            .subscribe((wizardValue: WizardGeneratorFormsValue) => {
+                this.wizardValue = wizardValue;
+            });
+    }
+
+    wizardFinished(wizardValue: WizardGeneratorFormsValue): void {
+        this.wizardValue = wizardValue;
+    }
+}

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/platform-wizard-generator-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/platform-wizard-generator-docs.component.html
@@ -84,9 +84,13 @@
 
 <fd-docs-section-title id="branching" componentName="wizard-generator"> Branching Wizard </fd-docs-section-title>
 <description>
-    Developers can configure branching behaviour of the wizard by providing <code>when</code> property function to the
-    wizard generator step and by specifying <code>dependencyFields</code> property of the wizard generator step to
-    reflect which steps are creating branches.
+    <p>
+        Developers can configure branching behaviour of the wizard by providing <code>when</code> property function to
+        the wizard generator step and by specifying <code>dependencyFields</code> property of the wizard generator step
+        to reflect which steps are creating branches.
+    </p>
+    <p>Additionally, Developers can configure each field to be dependent on the other fields value across all steps.</p>
+    <p>More information could be found in <a [routerLink]="['/platform/form-generator']">Form Generator</a> docs.</p>
 </description>
 <component-example>
     <fdp-wizard-generator-condition-example></fdp-wizard-generator-condition-example>
@@ -234,3 +238,20 @@
     <fdp-wizard-generator-onchange-example></fdp-wizard-generator-onchange-example>
 </component-example>
 <code-example [exampleFiles]="fieldsInteractionExample"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="inter-steps-conditions" componentName="wizard-generator"
+    >Handling form items visibility across the steps</fd-docs-section-title
+>
+<description>
+    <p>
+        Additionally to branching functionality, developers can configure wizard form items visibility across all the
+        steps.
+    </p>
+    <p>More information could be found in <a [routerLink]="['/platform/form-generator']">Form Generator</a> docs.</p>
+</description>
+<component-example>
+    <fdp-wizard-generator-visibility-between-steps-example></fdp-wizard-generator-visibility-between-steps-example>
+</component-example>
+<code-example [exampleFiles]="fieldsVisibilityExample"></code-example>

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/platform-wizard-generator-docs.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/platform-wizard-generator-docs.component.ts
@@ -36,6 +36,10 @@ import summaryObjectsTsExample from '!./examples/wizard-generator-summary-object
 
 import interactionHtmlExample from '!./examples/wizard-generator-onchange-example.component.html?raw';
 import interactionTsExample from '!./examples/wizard-generator-onchange-example.component.ts?raw';
+
+import whenConditionHtmlExample from '!./examples/wizard-generator-visibility-between-steps-example.component.html?raw';
+import whenConditionTsExample from '!./examples/wizard-generator-visibility-between-steps-example.component.ts?raw';
+
 @Component({
     selector: 'fdp-platform-wizard-generator-docs',
     templateUrl: './platform-wizard-generator-docs.component.html'
@@ -206,6 +210,20 @@ export class PlatformWizardGeneratorDocsComponent {
             code: interactionTsExample,
             fileName: 'wizard-generator-onchange-example',
             component: 'WizardGeneratorOnchangeExampleComponent'
+        }
+    ];
+
+    fieldsVisibilityExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: whenConditionHtmlExample,
+            fileName: 'wizard-generator-onchange-example'
+        },
+        {
+            language: 'typescript',
+            code: whenConditionTsExample,
+            fileName: 'wizard-generator-visibility-between-steps-example',
+            component: 'WizardGeneratorVisibilityBetweenStepsExampleComponent'
         }
     ];
 

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/platform-wizard-generator-docs.module.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/platform-wizard-generator-docs.module.ts
@@ -26,6 +26,7 @@ import { WizardGeneratorSummaryObjectsExampleComponent } from './examples/wizard
 import { WizardGeneratorExternalNavigationExampleComponent } from './examples/wizard-generator-external-navigation-example.component';
 import { WizardGeneratorOnchangeExampleComponent } from './examples/wizard-generator-onchange-example.component';
 import { IconModule } from '@fundamental-ngx/core/icon';
+import { WizardGeneratorVisibilityBetweenStepsExampleComponent } from './examples/wizard-generator-visibility-between-steps-example.component';
 
 const routes: Routes = [
     {
@@ -53,7 +54,8 @@ const routes: Routes = [
         WizardGeneratorCustomizableEmbededExampleComponent,
         WizardGeneratorSummaryObjectsExampleComponent,
         WizardGeneratorExternalNavigationExampleComponent,
-        WizardGeneratorOnchangeExampleComponent
+        WizardGeneratorOnchangeExampleComponent,
+        WizardGeneratorVisibilityBetweenStepsExampleComponent
     ],
     imports: [
         RouterModule.forChild(routes),

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control-field.directive.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control-field.directive.ts
@@ -56,7 +56,7 @@ export class DynamicFormControlFieldDirective implements OnInit {
     /**
      * @hidden
      */
-    private _shouldShowFormItem = false;
+    private _shouldShowFormItem: boolean;
 
     constructor(private readonly _templateRef: TemplateRef<any>, private readonly _viewContainer: ViewContainerRef) {}
 

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control.ts
@@ -3,8 +3,10 @@ import { AbstractControlOptions, AsyncValidatorFn, FormControl, FormGroup, Valid
 import { DynamicAbstractControlOptions } from './interfaces/dynamic-abstract-control';
 import { DynamicFormFieldGroup, DynamicFormFieldItem } from './interfaces/dynamic-form-item';
 
+export type DynamicFormGroupControl = DynamicFormControl | DynamicFormControlGroup;
+
 export interface DynamicFormGroupControls {
-    [key: string]: DynamicFormControl | DynamicFormControlGroup;
+    [key: string]: DynamicFormGroupControl;
 }
 
 export class DynamicFormControlGroup extends FormGroup {

--- a/libs/platform/src/lib/form/form-generator/fdp-form-generator.module.ts
+++ b/libs/platform/src/lib/form/form-generator/fdp-form-generator.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FormMessageModule } from '@fundamental-ngx/core/form';
 import { BusyIndicatorModule } from '@fundamental-ngx/core/busy-indicator';
 import { PlatformButtonModule } from '@fundamental-ngx/platform/button';
+import { FormGeneratorComponentsAccessorService } from './form-generator-components-accessor.service';
 import { FormGeneratorComponent } from './form-generator/form-generator.component';
 import { DynamicFormControlFieldDirective } from './dynamic-form-control-field.directive';
 import { PlatformInputModule } from '../input/fdp-input.module';
@@ -63,7 +64,7 @@ import { PlatformMultiInputModule } from '../multi-input/multi-input.module';
         PlatformMultiComboboxModule,
         PlatformMultiInputModule
     ],
-    providers: [FormGeneratorService],
+    providers: [FormGeneratorService, FormGeneratorComponentsAccessorService],
     exports: [
         FormGeneratorComponent,
         DynamicFormControlFieldDirective,

--- a/libs/platform/src/lib/form/form-generator/form-generator-components-accessor.service.spec.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator-components-accessor.service.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FormGeneratorComponentsAccessorService } from './form-generator-components-accessor.service';
+import { TestCustomComponent } from './form-generator.service.spec';
+
+describe('FormGeneratorComponentsAccessorService', () => {
+    let service: FormGeneratorComponentsAccessorService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [FormGeneratorComponentsAccessorService]
+        });
+        service = TestBed.inject(FormGeneratorComponentsAccessorService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    it('should add custom component', async () => {
+        expect(service.addComponent(TestCustomComponent, ['slider'])).toBeTruthy();
+    });
+
+    it('should add custom component and return it by the type', async () => {
+        service.addComponent(TestCustomComponent, ['slider']);
+
+        expect(service.getComponentDefinitionByType('slider').component).toEqual(TestCustomComponent);
+    });
+});

--- a/libs/platform/src/lib/form/form-generator/form-generator-components-accessor.service.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator-components-accessor.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Type } from '@angular/core';
+import { FormComponentDefinition } from './interfaces/form-component-definition';
+import { DEFAULT_COMPONENTS_LIST } from './config/default-components-list';
+import { BaseDynamicFormGeneratorControl } from './base-dynamic-form-generator-control';
+
+/**
+ * Since form generator service most probably will be provided by parent component,
+ * so that forms map does not interfere with other form generators,
+ * Components Accessor is a separate service with a global scope, which can be also provided per component.
+ */
+@Injectable()
+export class FormGeneratorComponentsAccessorService {
+    /**
+     * @hidden
+     */
+    private _formComponentDefinitions: FormComponentDefinition[] = DEFAULT_COMPONENTS_LIST;
+
+    /**
+     * @description Adds custom component to the list of available components for the form generator items.
+     * @param component Angular component.
+     * @param types types of the form item.
+     */
+    addComponent(component: Type<BaseDynamicFormGeneratorControl>, types: string[]): boolean {
+        const bestMatchComponentIndex = this._formComponentDefinitions.findIndex((c) =>
+            c.types.every((t) => types.includes(t))
+        );
+
+        if (bestMatchComponentIndex > -1) {
+            this._formComponentDefinitions[bestMatchComponentIndex].component = component;
+            return true;
+        }
+
+        // Try to find component in types key. There might be some unique cases when new component might replace multiple.
+        const existingComponents = this._formComponentDefinitions.filter((c) =>
+            c.types.filter((t) => types.includes(t))
+        );
+
+        existingComponents.forEach((existingComponent, index) => {
+            existingComponent.types = existingComponent.types.filter((t) => !types.includes(t));
+            this._formComponentDefinitions[index] = existingComponent;
+        });
+
+        this._formComponentDefinitions.push({
+            types,
+            component
+        });
+
+        return true;
+    }
+
+    /**
+     * @description Returns best-matched component based on provided `type` argument
+     * @param type form item type
+     * @returns @see FormComponentDefinition Component definition for the form item
+     */
+    getComponentDefinitionByType(type: string): FormComponentDefinition | null {
+        return this._formComponentDefinitions.find((c) => c.types.includes(type));
+    }
+}

--- a/libs/platform/src/lib/form/form-generator/form-generator.service.spec.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { PlatformSliderModule } from '../../slider/slider.module';
+import { FormGeneratorComponentsAccessorService } from './form-generator-components-accessor.service';
 import { FormGeneratorService } from './form-generator.service';
 import { DynamicFormFieldItem } from './interfaces/dynamic-form-item';
 import { BaseDynamicFormGeneratorControl, dynamicFormFieldProvider, dynamicFormGroupChildProvider } from './public_api';
@@ -75,7 +76,7 @@ describe('FormGeneratorService', () => {
         TestBed.configureTestingModule({
             declarations: [TestCustomComponent],
             imports: [FormsModule, ReactiveFormsModule, PlatformSliderModule],
-            providers: [FormGeneratorService]
+            providers: [FormGeneratorService, FormGeneratorComponentsAccessorService]
         });
         service = TestBed.inject(FormGeneratorService);
     });

--- a/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.ts
@@ -11,14 +11,19 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import { FormGroup, NgForm } from '@angular/forms';
+import { NgForm } from '@angular/forms';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Subject, Subscription } from 'rxjs';
 import { ColumnLayout, LabelLayout } from '@fundamental-ngx/platform/shared';
 
 import { FormGeneratorService } from '../form-generator.service';
 import { DynamicFormItem, DynamicFormValue } from '../interfaces/dynamic-form-item';
-import { DynamicFormControl, DynamicFormControlGroup, DynamicFormGroupControls } from '../dynamic-form-control';
+import {
+    DynamicFormControl,
+    DynamicFormControlGroup,
+    DynamicFormGroupControl,
+    DynamicFormGroupControls
+} from '../dynamic-form-control';
 import { DynamicFormGroup } from '../interfaces/dynamic-form-group';
 import {
     DefaultGapLayout,
@@ -156,14 +161,14 @@ export class FormGeneratorComponent implements OnDestroy {
     noAdditionalContent = false;
 
     /**
-     * @description Event which notifies parent component that the form has been successfuly created
+     * @description Event which notifies parent component that the form has been successfully created
      * and all controls are in place.
      */
     @Output()
-    formCreated = new EventEmitter<FormGroup>();
+    formCreated = new EventEmitter<DynamicFormGroup>();
 
     /**
-     * @description Event which notifies parent component that the form has been successfuly validated
+     * @description Event which notifies parent component that the form has been successfully validated
      * and submitted. Contains form
      */
     @Output()
@@ -188,7 +193,7 @@ export class FormGeneratorComponent implements OnDestroy {
     /**
      * @description List of the form controls.
      */
-    formControlItems: (DynamicFormControl | DynamicFormControlGroup)[];
+    formControlItems: DynamicFormGroupControl[];
 
     /**
      * Set of flags representing if particular form item should be visible to the user.

--- a/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-group.ts
+++ b/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-group.ts
@@ -1,9 +1,9 @@
 import { FormGroup } from '@angular/forms';
 
-import { DynamicFormControl, DynamicFormControlGroup } from '../dynamic-form-control';
+import { DynamicFormGroupControl } from '../dynamic-form-control';
 
 export interface DynamicFormGroup extends FormGroup {
     controls: {
-        [key: string]: DynamicFormControl | DynamicFormControlGroup;
+        [key: string]: DynamicFormGroupControl;
     };
 }

--- a/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
+++ b/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
@@ -5,7 +5,7 @@ import { ContentDensity } from '@fundamental-ngx/core/utils';
 import { InlineLayout, ColumnLayout, HintPlacement, LabelLayout, SelectItem } from '@fundamental-ngx/platform/shared';
 import { InputType } from '../../input/input.component';
 import { DynamicFormGroup } from './dynamic-form-group';
-import { DynamicFormControl } from '../dynamic-form-control';
+import { DynamicFormControl, DynamicFormGroupControl } from '../dynamic-form-control';
 
 export type DynamicFormItemChoices = number | string | SelectItem;
 export type DynamicFormItemValidationResult = null | boolean | string;
@@ -166,16 +166,23 @@ export interface DynamicFormFieldItem {
     ) => any | Promise<any>;
 
     /**
-     * @description Should return true or false depending on whether or not this form item should be asked.
+     * @description Should return true or false depending on whether this form item should be asked.
      * @param formValue the form value hash.
+     * @param forms All available forms stored in form generator service.
+     * @param control Dynamic form control.
      * @returns Boolean
      */
-    when?: (formValue: DynamicFormValue) => boolean | Promise<boolean> | Observable<boolean>;
+    when?: (
+        formValue: DynamicFormValue,
+        forms: Map<string, DynamicFormGroup>,
+        control: DynamicFormGroupControl
+    ) => boolean | Promise<boolean> | Observable<boolean>;
 
     /**
      * @description Callback function that is triggered after field value has been changed.
      * @param fieldValue Field value.
-     * @param formGeneratorService Form generator service instance.
+     * @param forms All available forms stored in form generator service.
+     * @param control Dynamic form control.
      */
     onchange?: (
         fieldValue: any,

--- a/libs/platform/src/lib/wizard-generator/base-wizard-generator.ts
+++ b/libs/platform/src/lib/wizard-generator/base-wizard-generator.ts
@@ -83,7 +83,7 @@ export class BaseWizardGenerator implements OnDestroy {
     }
 
     /**
-     * Whether or not to append the step to the wizard. If false, each step will be displayed on a different page.
+     * Whether to append the step to the wizard. If false, each step will be displayed on a different page.
      * Default is true.
      */
     @Input()
@@ -107,12 +107,12 @@ export class BaseWizardGenerator implements OnDestroy {
     contentHeight: string;
 
     /**
-     * @description Boolean flag indicating whether or not to display Summary step in Wizard progress bar.
+     * @description Boolean flag indicating whether to display Summary step in Wizard progress bar.
      */
     @Input()
     displaySummaryStep = false;
 
-    /** Whether or not all form items should have identical layout provided for form group. */
+    /** Whether all form items should have identical layout provided for form group. */
     @Input()
     unifiedLayout = true;
 
@@ -163,7 +163,7 @@ export class BaseWizardGenerator implements OnDestroy {
     }
 
     /**
-     * Whether or not current step is a branching step.
+     * Whether current step is a branching step.
      */
     get isBranchingStep(): boolean {
         const currentIndex = this._wizardGeneratorService.getCurrentStepIndex();
@@ -172,7 +172,7 @@ export class BaseWizardGenerator implements OnDestroy {
     }
 
     /**
-     * Whether or not the next step is a Summary step.
+     * Whether the next step is a Summary step.
      */
     get isNextStepSummary(): boolean {
         const nextStep = this.visibleItems[this._nextStepIndex];
@@ -254,7 +254,7 @@ export class BaseWizardGenerator implements OnDestroy {
             });
 
         this._wizardGeneratorService
-            .trackNextStepindex()
+            .trackNextStepIndex()
             .pipe(takeUntil(this._onDestroy$))
             .subscribe((index) => {
                 this._nextStepIndex = index;

--- a/libs/platform/src/lib/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.ts
+++ b/libs/platform/src/lib/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.ts
@@ -6,6 +6,7 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
+import { FormGeneratorService } from '@fundamental-ngx/platform/form';
 import { filter, takeUntil } from 'rxjs/operators';
 
 import { DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
@@ -19,7 +20,7 @@ import { WizardGeneratorService } from '../../wizard-generator.service';
     templateUrl: './dialog-wizard-generator.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [WizardGeneratorService]
+    providers: [WizardGeneratorService, FormGeneratorService]
 })
 export class DialogWizardGeneratorComponent extends BaseWizardGenerator {
     @ViewChild('defaultConfirmationDialogTemplate') defaultConfirmationDialogTemplate: TemplateRef<HTMLElement>;

--- a/libs/platform/src/lib/wizard-generator/components/wizard-body/wizard-body.component.html
+++ b/libs/platform/src/lib/wizard-generator/components/wizard-body/wizard-body.component.html
@@ -13,7 +13,7 @@
                     [label]="step.name"
                     [status]="step.status"
                     [branching]="step.branching"
-                    [stepClickValidator]="stepClickValidatorFn(i, step)"
+                    [stepClickValidator]="stepClickValidatorFn(i)"
                     [isSummary]="step.summary"
                     (statusChange)="stepStatusChanged(step.id, $event)"
                     (stepClicked)="stepClicked(step.id)"
@@ -26,6 +26,7 @@
                             *ngIf="!step.summary"
                             [unifiedLayout]="unifiedLayout"
                             [item]="step"
+                            [stepStatus]="step.status"
                         ></fdp-wizard-generator-step>
                         <fdp-wizard-summary-step
                             *ngIf="step.summary"

--- a/libs/platform/src/lib/wizard-generator/components/wizard-body/wizard-body.component.ts
+++ b/libs/platform/src/lib/wizard-generator/components/wizard-body/wizard-body.component.ts
@@ -51,7 +51,7 @@ export class WizardBodyComponent implements OnInit, OnDestroy {
 
     /**
      * @description Custom height to use for the wizard's content pane. By default, this value is calc(100vh - 144px), where 144px
-     * is the combined height of the shellbar, wizard header and wizard footer.
+     * is the combined height of the Shellbar, wizard header and wizard footer.
      */
     @Input()
     contentHeight: string;
@@ -63,19 +63,19 @@ export class WizardBodyComponent implements OnInit, OnDestroy {
     isFirstStep = false;
 
     /**
-     * @description Whether or not Wizard is currently on the last step.
+     * @description Whether Wizard is currently on the last step.
      */
     @Input()
     isLastStep = false;
 
     /**
-     * Whether or not next step is a Summary step.
+     * Whether next step is a Summary step.
      */
     @Input()
     isNextStepSummary = false;
 
     /**
-     * @description Boolean flag indicating whether or not to display Summary step in Wizard progress bar.
+     * @description Boolean flag indicating whether to display Summary step in Wizard progress bar.
      */
     @Input()
     displaySummaryStep = false;

--- a/libs/platform/src/lib/wizard-generator/components/wizard-generator/wizard-generator.component.ts
+++ b/libs/platform/src/lib/wizard-generator/components/wizard-generator/wizard-generator.component.ts
@@ -6,6 +6,7 @@ import {
     TemplateRef,
     ViewEncapsulation
 } from '@angular/core';
+import { FormGeneratorService } from '@fundamental-ngx/platform/form';
 
 import { WizardGeneratorService } from '../../wizard-generator.service';
 import { BaseWizardGenerator } from '../../base-wizard-generator';
@@ -19,7 +20,7 @@ import { WizardGeneratorReviewButtonDirective } from '../../directives/wizard-ge
     templateUrl: './wizard-generator.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [WizardGeneratorService]
+    providers: [WizardGeneratorService, FormGeneratorService]
 })
 export class WizardGeneratorComponent extends BaseWizardGenerator {
     /**

--- a/libs/platform/src/lib/wizard-generator/interfaces/wizard-generator-form-group.interface.ts
+++ b/libs/platform/src/lib/wizard-generator/interfaces/wizard-generator-form-group.interface.ts
@@ -1,4 +1,5 @@
-import { DynamicFormItem } from '@fundamental-ngx/platform/form';
+import { DynamicFormFieldGroup, DynamicFormFieldItem } from '@fundamental-ngx/platform/form';
+import { WizardGeneratorDependencyFields } from './wizard-generator-item.interface';
 
 export interface WizardGeneratorFormGroup {
     /**
@@ -16,10 +17,26 @@ export interface WizardGeneratorFormGroup {
      * @description List of @see DynamicFormItem representing the list of items
      * to be rendered in the form.
      */
-    formItems: DynamicFormItem[];
+    formItems: WizardGeneratorFormItem[];
 
     /**
      * @description Unique form ID.
      */
     id: string;
+}
+
+export type WizardGeneratorFormItem = WizardGeneratorFormGroupItem | WizardGeneratorFormFieldItem;
+
+export interface WizardGeneratorFormGroupItem extends DynamicFormFieldGroup {
+    /**
+     * @description Object of dependency fields that are used with `when` function
+     */
+    dependencyFields?: WizardGeneratorDependencyFields;
+}
+
+export interface WizardGeneratorFormFieldItem extends DynamicFormFieldItem {
+    /**
+     * @description Object of dependency fields that are used with `when` function
+     */
+    dependencyFields?: WizardGeneratorDependencyFields;
 }

--- a/libs/platform/src/lib/wizard-generator/interfaces/wizard-generator-item.interface.ts
+++ b/libs/platform/src/lib/wizard-generator/interfaces/wizard-generator-item.interface.ts
@@ -17,6 +17,12 @@ export interface WizardVisibleSteps {
     [key: string]: boolean;
 }
 
+export interface WizardGeneratorDependencyFields {
+    [key: string]: {
+        [key: string]: string[];
+    };
+}
+
 export interface WizardGeneratorItem {
     /**
      * @description Name of the wizard step. Will be used in navigation bar.
@@ -45,7 +51,7 @@ export interface WizardGeneratorItem {
      */
     icon?: string;
     /**
-     * @description Should return true or false depending on whether or not this step should be visible.
+     * @description Should return true or false depending on whether this step should be visible.
      * @returns Boolean
      */
     when?: (
@@ -56,11 +62,7 @@ export interface WizardGeneratorItem {
     /**
      * @description Object of dependency fields that are used with `when` function
      */
-    dependencyFields?: {
-        [key: string]: {
-            [key: string]: string[];
-        };
-    };
+    dependencyFields?: WizardGeneratorDependencyFields;
 
     /**
      * @description Whether or not this step is going to create a branch.


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #7332 

## Description
* Updated `when` function scope for wizard generator. Previously it was only form group scope, now it can be uses as whole wizard scope.
* Refactored Form Generator Service so that storing custom components is now independent from the form generator service itself, because form generator service can be provided on component level, thus, previously registered components are not available for this instance of the service.

For testing, please check last example of Platform Wizard Generator.


#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

