### PR TITLE
fix(core): tokenizer overflow

### DIFF
--- a/libs/core/src/lib/token/token.component.html
+++ b/libs/core/src/lib/token/token.component.html
@@ -12,7 +12,7 @@
     [attr.aria-readonly]="readOnly"
 >
     <span class="fd-token__text no-text-select">
-        <ng-content></ng-content>
+        <ng-container #viewContainer></ng-container>
     </span>
     <span
         (click)="closeClickHandler($event)"
@@ -23,3 +23,7 @@
         tabindex="-1"
     ></span>
 </span>
+
+<ng-template #content>
+    <ng-content></ng-content>
+</ng-template>

--- a/libs/core/src/lib/token/token.component.ts
+++ b/libs/core/src/lib/token/token.component.ts
@@ -1,4 +1,5 @@
 import {
+    AfterViewInit,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -9,7 +10,9 @@ import {
     OnInit,
     Optional,
     Output,
+    TemplateRef,
     ViewChild,
+    ViewContainerRef,
     ViewEncapsulation
 } from '@angular/core';
 import { Subscription } from 'rxjs';
@@ -26,7 +29,7 @@ import { ContentDensityService } from '@fundamental-ngx/core/utils';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class TokenComponent implements OnInit, OnDestroy {
+export class TokenComponent implements OnInit, AfterViewInit, OnDestroy {
     /** Whether the token is disabled. */
     @Input()
     disabled = false;
@@ -38,6 +41,14 @@ export class TokenComponent implements OnInit, OnDestroy {
     /** @hidden */
     @ViewChild('tokenWrapperElement')
     tokenWrapperElement: ElementRef;
+
+    /** @hidden */
+    @ViewChild('content')
+    readonly _content: TemplateRef<any>;
+
+    /** @hidden */
+    @ViewChild('viewContainer', { read: ViewContainerRef })
+    readonly _viewContainer: ViewContainerRef;
 
     private _selected = false;
 
@@ -100,6 +111,11 @@ export class TokenComponent implements OnInit, OnDestroy {
                 })
             );
         }
+    }
+
+    /** @hidden */
+    ngAfterViewInit(): void {
+        this._viewContainer.createEmbeddedView(this._content);
     }
 
     /** @hidden */

--- a/libs/core/src/lib/token/token.module.ts
+++ b/libs/core/src/lib/token/token.module.ts
@@ -5,10 +5,12 @@ import { TokenizerComponent } from './tokenizer.component';
 import { TokenizerInputDirective } from './token-input.directive';
 import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 import { ButtonModule } from '@fundamental-ngx/core/button';
+import { PopoverModule } from '@fundamental-ngx/core/popover';
+import { ListModule } from '@fundamental-ngx/core/list';
 
 @NgModule({
     declarations: [TokenComponent, TokenizerComponent, TokenizerInputDirective],
-    imports: [CommonModule, InputGroupModule, ButtonModule],
+    imports: [CommonModule, InputGroupModule, ButtonModule, PopoverModule, ListModule],
     exports: [TokenComponent, TokenizerComponent, TokenizerInputDirective]
 })
 export class TokenModule {}

--- a/libs/core/src/lib/token/tokenizer.component.html
+++ b/libs/core/src/lib/token/tokenizer.component.html
@@ -5,21 +5,11 @@
 >
     <div class="fd-tokenizer__inner" #tokenizerInner>
         <ng-content select="fd-token"></ng-content>
-        <span
-            (click)="moreClicked()"
-            *ngIf="
-                (moreTokensLeft.length > 0 || moreTokensRight.length > 0 || hiddenCozyTokenCount > 0) &&
-                !open &&
-                !_tokenizerHasFocus
-            "
-            class="fd-tokenizer-more"
-            #moreElement
-        >
-            <ng-container *ngIf="compact || compactCollapse"
-                >{{ moreTokensLeft.length + moreTokensRight.length }} {{ moreTerm }}</ng-container
-            >
-            <ng-container *ngIf="!compact && !compactCollapse">{{ hiddenCozyTokenCount }} {{ moreTerm }}</ng-container>
-        </span>
+
+        <ng-container *ngIf="compact || compactCollapse; else moreElement">
+            <ng-container *ngTemplateOutlet="tokensOverflow"></ng-container>
+        </ng-container>
+
         <ng-content select="[fd-form-control]"></ng-content>
     </div>
     <span fd-input-group-addon *ngIf="glyph" #inputGroupAddOn [compact]="compact" [button]="true" placement="after">
@@ -33,3 +23,46 @@
         ></button>
     </span>
 </div>
+
+<ng-template #tokensOverflow>
+    <fd-popover placement="bottom-start" title="" [noArrow]="false" [focusTrapped]="true" [focusAutoCapture]="true">
+        <fd-popover-control>
+            <ng-container *ngTemplateOutlet="moreElement"></ng-container>
+        </fd-popover-control>
+
+        <fd-popover-body>
+            <ul fd-list class="fd-tokenizer__overflow-list">
+                <li fd-list-item class="fd-tokenizer__overflow-list-item" *ngFor="let token of _hiddenTokens">
+                    <ng-container #viewContainer></ng-container>
+
+                    <span
+                        *ngIf="!token.readOnly"
+                        class="fd-token__close"
+                        role="button"
+                        tabindex="-1"
+                        [attr.aria-label]="token.deleteButtonLabel"
+                        (click)="token.closeClickHandler($event)"
+                    ></span>
+                </li>
+            </ul>
+        </fd-popover-body>
+    </fd-popover>
+</ng-template>
+
+<ng-template #moreElement>
+    <span
+        (click)="moreClicked()"
+        *ngIf="
+            (moreTokensLeft.length > 0 || moreTokensRight.length > 0 || hiddenCozyTokenCount > 0) &&
+            !open &&
+            !_tokenizerHasFocus
+        "
+        class="fd-tokenizer-more"
+        #moreElement
+    >
+        <ng-container *ngIf="compact || compactCollapse"
+            >{{ moreTokensLeft.length + moreTokensRight.length }} {{ moreTerm }}</ng-container
+        >
+        <ng-container *ngIf="!compact && !compactCollapse">{{ hiddenCozyTokenCount }} {{ moreTerm }}</ng-container>
+    </span>
+</ng-template>

--- a/libs/core/src/lib/token/tokenizer.component.scss
+++ b/libs/core/src/lib/token/tokenizer.component.scss
@@ -32,3 +32,8 @@ input {
         height: 1.625rem;
     }
 }
+
+.fd-tokenizer__overflow-list-item {
+    display: flex;
+    justify-content: space-between;
+}


### PR DESCRIPTION
## Related Issue(s)

Part of https://github.com/SAP/fundamental-ngx/issues/7550

## Description

Overflow list implemented for the tokenizer component in compact mode.

Because of https://github.com/angular/angular/issues/37995#issuecomment-1015880820 approach with `viewContainerRef` was used, i.e. we cannot have token projected via `ng-content` in tokenizer & overflow list at the same time, so token content hides from the tokenizer (or overflow list) `viewContainer` and shows in overflow list (or tokenizer) `viewContainer`, depending on the current state.

## Screenshots

### After:

![image](https://user-images.githubusercontent.com/20265336/151157853-c73b196c-7795-477e-9b87-763fae16cf32.png)