### PR TITLE
feat(core): tile clickable flag & event emit on click

### DIFF
--- a/apps/docs/src/app/core/component-docs/tile/examples/clickable-tile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/tile/examples/clickable-tile-example.component.html
@@ -1,0 +1,13 @@
+<fd-tile [clickable]="false">
+    <div fd-tile-header></div>
+    <div fd-tile-content>I'm not clickable!</div>
+    <div fd-tile-footer></div>
+</fd-tile>
+
+<br />
+
+<fd-tile [clickable]="true" (tileClick)="onTileClick()">
+    <div fd-tile-header></div>
+    <div fd-tile-content>I'm clickable, look for the event in the console</div>
+    <div fd-tile-footer></div>
+</fd-tile>

--- a/apps/docs/src/app/core/component-docs/tile/examples/tile-examples.component.ts
+++ b/apps/docs/src/app/core/component-docs/tile/examples/tile-examples.component.ts
@@ -83,3 +83,13 @@ export class BadgeTileExampleComponent {}
     templateUrl: './feed-tile-example.component.html'
 })
 export class FeedTileExampleComponent {}
+
+@Component({
+    selector: 'fd-clickable-tile-example',
+    templateUrl: './clickable-tile-example.component.html'
+})
+export class ClickableTileExampleComponent {
+    onTileClick(): void {
+        console.log('tile clicked!');
+    }
+}

--- a/apps/docs/src/app/core/component-docs/tile/tile-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/tile/tile-docs.component.html
@@ -78,6 +78,31 @@
 </component-example>
 <code-example [exampleFiles]="feed"></code-example>
 
+<fd-docs-section-title id="feed" componentName="tile"> Feed Tile </fd-docs-section-title>
+<description>
+    The Feed tile can be used to show new notification content in a news feed. If there are no new notifications, the
+    tile displays the most recent notification. To create a Feed tile, use the <code>type="feed"</code> input.
+</description>
+<component-example>
+    <div class="grid">
+        <fd-feed-tile-example></fd-feed-tile-example>
+    </div>
+</component-example>
+<code-example [exampleFiles]="feed"></code-example>
+
+<fd-docs-section-title id="clickable" componentName="tile"> Clickable Tile </fd-docs-section-title>
+<description>
+    Tile clickable by the default, but you can change it behavior by providing <code>[clickable]</code> input property.
+    When tile is clickable it can get focus & event will be emitted on click, enter and space press, listen for
+    <code>(tileClick)</code>.
+</description>
+<component-example>
+    <div class="grid">
+        <fd-clickable-tile-example></fd-clickable-tile-example>
+    </div>
+</component-example>
+<code-example [exampleFiles]="clickable"></code-example>
+
 <!--TODO: wip fd-docs-section-title id="slide" componentName="tile">
     Slide Tile
 </fd-docs-section-title>

--- a/apps/docs/src/app/core/component-docs/tile/tile-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/tile/tile-docs.component.ts
@@ -8,6 +8,7 @@ import actionSrc from '!./examples/action-tile-example.component.html?raw';
 import badgeSrc from '!./examples/badge-tile-example.component.html?raw';
 import feedSrc from '!./examples/feed-tile-example.component.html?raw';
 import lineSrc from '!./examples/line-tile-example.component.html?raw';
+import clickableSrc from '!./examples/clickable-tile-example.component.html?raw';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
 
 @Component({
@@ -84,6 +85,14 @@ export class TileDocsComponent {
             language: 'html',
             code: lineSrc,
             fileName: 'line-example'
+        }
+    ];
+
+    clickable: ExampleFile[] = [
+        {
+            language: 'html',
+            code: clickableSrc,
+            fileName: 'clickable-example'
         }
     ];
 }

--- a/apps/docs/src/app/core/component-docs/tile/tile-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/tile/tile-docs.module.ts
@@ -8,6 +8,7 @@ import { TileDocsComponent } from './tile-docs.component';
 import {
     ActionTileExampleComponent,
     BadgeTileExampleComponent,
+    ClickableTileExampleComponent,
     FeedTileExampleComponent,
     KpiTileExampleComponent,
     LaunchTileExampleComponent,
@@ -44,7 +45,8 @@ const routes: Routes = [
         BadgeTileExampleComponent,
         FeedTileExampleComponent,
         LineTileExampleComponent,
-        TileDocsHeaderComponent
+        TileDocsHeaderComponent,
+        ClickableTileExampleComponent
     ]
 })
 export class TileDocsModule {}

--- a/libs/core/src/lib/tile/tile.component.html
+++ b/libs/core/src/lib/tile/tile.component.html
@@ -1,12 +1,29 @@
-<div class="fd-tile" #container tabindex="0">
+<div
+    class="fd-tile"
+    #container
+    [attr.tabindex]="clickable ? 0 : -1"
+    (click)="clickable && tileClick.emit()"
+    (keyup.enter)="clickable && tileClick.emit()"
+    (keydown.space)="clickable && $event.preventDefault()"
+    (keyup.space)="clickable && tileClick.emit()"
+>
     <div *ngIf="action && type !== 'line'" class="fd-tile__overlay"></div>
+
     <ng-content select="[fd-tile-action-close]"></ng-content>
+
     <ng-content select="[fd-tile-action-indicator]"></ng-content>
+
     <ng-content select="[fd-badge]"></ng-content>
+
     <ng-content select="[fd-tile-header]"></ng-content>
+
     <ng-content select="[fd-tile-header-content]"></ng-content>
+
     <ng-content select="[fd-tile-content]"></ng-content>
+
     <ng-content select="[fd-tile-footer]"></ng-content>
+
     <ng-content select="[fd-tile-action-container]"></ng-content>
+
     <ng-content></ng-content>
 </div>

--- a/libs/core/src/lib/tile/tile.component.ts
+++ b/libs/core/src/lib/tile/tile.component.ts
@@ -1,10 +1,13 @@
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
     Component,
     ElementRef,
+    EventEmitter,
     Input,
     OnChanges,
+    Output,
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
@@ -42,9 +45,26 @@ export class TileComponent implements CssClassBuilder, AfterViewInit, OnChanges 
     @Input()
     action = false;
 
+    /** Whether tile is focusable & clickable, (tileClick) event will be emitted on click. */
+    @Input()
+    set clickable(value: BooleanInput) {
+        this._clickable = coerceBooleanProperty(value);
+    }
+
+    get clickable(): boolean {
+        return this._clickable;
+    }
+
+    /** Whether tile gets clicked or space/enter pressed. */
+    @Output()
+    readonly tileClick = new EventEmitter<void>();
+
     /** @hidden */
     @ViewChild('container')
     ref: ElementRef;
+
+    /** @hidden */
+    private _clickable = true;
 
     /** @hidden */
     ngOnChanges(): void {

--- a/libs/core/src/lib/tile/tile.component.ts
+++ b/libs/core/src/lib/tile/tile.component.ts
@@ -64,7 +64,7 @@ export class TileComponent implements CssClassBuilder, AfterViewInit, OnChanges 
     ref: ElementRef;
 
     /** @hidden */
-    private _clickable = true;
+    private _clickable = false;
 
     /** @hidden */
     ngOnChanges(): void {


### PR DESCRIPTION
## Related Issue(s)

Part of https://github.com/SAP/fundamental-ngx/issues/7587
>  (Core) Tile, has unneeded tab stop (or event on click needed)

## Description

As tile is focusable in [SAPUI5](https://sapui5.hana.ondemand.com/#/entity/sap.m.GenericTile/sample/sap.m.sample.GenericTileAsLaunchTile) i decided to left such behavior but also add:
* event emitting on click (as in the SAPUI5)
* ability to make tile not focusable (of course clicking is not possible also).
