### PR TITLE
feat(platform): when property of form groups

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-visibility-between-steps-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/examples/wizard-generator-visibility-between-steps-example.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { Validators } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -14,7 +14,7 @@ import {
     selector: 'fdp-wizard-generator-visibility-between-steps-example',
     templateUrl: './wizard-generator-visibility-between-steps-example.component.html'
 })
-export class WizardGeneratorVisibilityBetweenStepsExampleComponent {
+export class WizardGeneratorVisibilityBetweenStepsExampleComponent implements OnDestroy {
     wizardTitle: WizardTitle = {
         size: 2,
         text: 'Checkout'
@@ -45,6 +45,35 @@ export class WizardGeneratorVisibilityBetweenStepsExampleComponent {
                             choices: ['Intel', 'AMD', 'Apple'],
                             validators: [Validators.required],
                             when: (formValue: DynamicFormValue): boolean => formValue.product === 'Desktop'
+                        }
+                    ]
+                },
+                {
+                    title: '1.1. Protective case',
+                    id: 'protectiveCase',
+                    dependencyFields: {
+                        productTypeStep: {
+                            productType: ['product']
+                        }
+                    },
+                    when: (completedSteps: string[], answers: WizardGeneratorFormsValue) => {
+                        const value = answers.productTypeStep?.productType?.product;
+                        return value !== undefined && value !== 'Desktop';
+                    },
+                    formItems: [
+                        {
+                            name: 'protectiveCaseNeeded',
+                            message: 'Would you like to include a protective case?',
+                            type: 'switch',
+                            default: false
+                        },
+                        {
+                            name: 'protectiveCaseMaterial',
+                            message: 'Select protective case material',
+                            type: 'select',
+                            choices: ['Leather', 'Silicone'],
+                            validators: [Validators.required],
+                            when: (formValue: DynamicFormValue): boolean => formValue.protectiveCaseNeeded
                         }
                     ]
                 }

--- a/apps/docs/src/app/platform/component-docs/platform-wizard-generator/platform-wizard-generator-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-wizard-generator/platform-wizard-generator-docs.component.html
@@ -246,9 +246,14 @@
 >
 <description>
     <p>
-        Additionally to branching functionality, developers can configure wizard form items visibility across all the
-        steps.
+        Additionally to branching functionality, developers can configure wizard items visibility across all the steps.
     </p>
+    <p>Conditional visibility can be applied to the following items:</p>
+    <ul>
+        <li>Wizard steps</li>
+        <li>Wizard step forms</li>
+        <li>Form group items</li>
+    </ul>
     <p>More information could be found in <a [routerLink]="['/platform/form-generator']">Form Generator</a> docs.</p>
 </description>
 <component-example>

--- a/libs/platform/src/lib/form/form-generator/form-generator.service.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnDestroy, Type } from '@angular/core';
 import { AsyncValidatorFn, FormBuilder, Validators } from '@angular/forms';
+import { cloneDeep } from 'lodash-es';
 
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
@@ -196,7 +197,7 @@ export class FormGeneratorService implements OnDestroy {
         form: DynamicFormGroup | DynamicFormControlGroup,
         renderValue = false
     ): Promise<DynamicFormValue> {
-        const formValue = Object.assign({}, form.value);
+        const formValue = cloneDeep(form.value);
 
         for (const [i, control] of Object.entries(form.controls)) {
             const formItem = control.formItem;
@@ -272,7 +273,7 @@ export class FormGeneratorService implements OnDestroy {
      * @returns `Set` where key is item name, and boolean value if field needs to be shown.
      */
     async checkVisibleFormItems(form: DynamicFormGroup): Promise<{ [key: string]: boolean }> {
-        const formValue = this._getFormValueWithoutUngrouped(form.value);
+        const formValue = this._getFormValueWithoutUngrouped(cloneDeep(form.value));
         return await this._checkFormControlsVisibility(form, formValue);
     }
 

--- a/libs/platform/src/lib/wizard-generator/components/wizard-generator-step/wizard-generator-step.component.html
+++ b/libs/platform/src/lib/wizard-generator/components/wizard-generator-step/wizard-generator-step.component.html
@@ -1,12 +1,14 @@
 <h3 *ngIf="item.title" fd-title>{{ item.title }}</h3>
 
-<fdp-form-generator
-    *ngFor="let form of item.formGroups; let i = index"
-    [mainTitle]="form.title"
-    [columnLayout]="form.columnLayout"
-    [formName]="form.id"
-    [formItems]="form.formItems"
-    [unifiedLayout]="unifiedLayout"
-    (formCreated)="onFormCreated($event, form.id)"
-    (formSubmittedStatus)="onFormSubmitted($event, form.id)"
-></fdp-form-generator>
+<ng-container *ngFor="let form of item.formGroups; let i = index">
+    <fdp-form-generator
+        *ngIf="_visibleFormGroupIds[form.id] !== false"
+        [mainTitle]="form.title"
+        [columnLayout]="form.columnLayout"
+        [formName]="form.id"
+        [formItems]="form.formItems"
+        [unifiedLayout]="unifiedLayout"
+        (formCreated)="onFormCreated($event, form.id)"
+        (formSubmittedStatus)="onFormSubmitted($event, form.id)"
+    ></fdp-form-generator>
+</ng-container>

--- a/libs/platform/src/lib/wizard-generator/interfaces/wizard-generator-form-group.interface.ts
+++ b/libs/platform/src/lib/wizard-generator/interfaces/wizard-generator-form-group.interface.ts
@@ -1,5 +1,6 @@
-import { DynamicFormFieldGroup, DynamicFormFieldItem } from '@fundamental-ngx/platform/form';
-import { WizardGeneratorDependencyFields } from './wizard-generator-item.interface';
+import { DynamicFormFieldGroup, DynamicFormFieldItem, DynamicFormGroup } from '@fundamental-ngx/platform/form';
+import { Observable } from 'rxjs';
+import { WizardGeneratorDependencyFields, WizardGeneratorFormsValue } from './wizard-generator-item.interface';
 
 export interface WizardGeneratorFormGroup {
     /**
@@ -18,11 +19,23 @@ export interface WizardGeneratorFormGroup {
      * to be rendered in the form.
      */
     formItems: WizardGeneratorFormItem[];
-
     /**
      * @description Unique form ID.
      */
     id: string;
+    /**
+     * @description Should return true or false depending on whether this form group should be visible.
+     * @returns Boolean
+     */
+    when?: (
+        completedSteps: string[],
+        answers: WizardGeneratorFormsValue,
+        forms: Map<string, DynamicFormGroup>
+    ) => boolean | Promise<boolean> | Observable<boolean>;
+    /**
+     * @description Object of dependency fields that are used with `when` function
+     */
+    dependencyFields?: WizardGeneratorDependencyFields;
 }
 
 export type WizardGeneratorFormItem = WizardGeneratorFormGroupItem | WizardGeneratorFormFieldItem;

--- a/libs/platform/src/lib/wizard-generator/interfaces/wizard-generator-item.interface.ts
+++ b/libs/platform/src/lib/wizard-generator/interfaces/wizard-generator-item.interface.ts
@@ -1,5 +1,6 @@
 import { Observable } from 'rxjs';
 
+import { DynamicFormGroup } from '@fundamental-ngx/platform/form';
 import { WizardStepStatus } from '@fundamental-ngx/core/wizard';
 import { WizardGeneratorFormGroup } from './wizard-generator-form-group.interface';
 
@@ -56,7 +57,8 @@ export interface WizardGeneratorItem {
      */
     when?: (
         completedSteps: string[],
-        answers: WizardGeneratorFormsValue
+        answers: WizardGeneratorFormsValue,
+        forms: Map<string, DynamicFormGroup>
     ) => boolean | Promise<boolean> | Observable<boolean>;
 
     /**


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #7500 

## Description
Added `when` method for form groups of wizard generator step.
To check the functionality, please check last wizard generator example.

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

