### PR TITLE
fix(platform): dynamic tab page event on tab change

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-flexible-column-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-flexible-column-example.component.html
@@ -8,7 +8,11 @@
             </div>
 
             <!-- Flexible Column Layout -->
-            <fd-flexible-column-layout [(layout)]="localLayout" (layoutChange)="onLayoutChanged($event)">
+            <fd-flexible-column-layout
+                [(layout)]="localLayout"
+                (layoutChange)="onLayoutChanged($event)"
+                (tabChange)="onTabChanged($event)"
+            >
                 <ng-template #startColumn>
                     <div class="docs-fcl-example-section">
                         <h2>Start Column</h2>
@@ -108,7 +112,7 @@
                                 numquam asperiores tenetur iure. Cum consequuntur impedit repellendus esse, facere autem
                                 optio consequatur nobis?
                             </fdp-dynamic-page-header>
-                            <fdp-dynamic-page-content tabLabel="Tab 1" id="tab_1" (tabChange)="onTabChanged($event)">
+                            <fdp-dynamic-page-content tabLabel="Tab 1" id="tab_1">
                                 tab1 dsfsdf dfg Lorem ipsum dolor sit amet consectetur adipisicing elit. Reprehenderit
                                 sunt laboriosam totam maiores. Unde quas quis soluta adipisci mollitia distinctio. Natus
                                 nam repellat, aut ad et tempore cum. Corporis, nobis. Lorem ipsum dolor sit amet
@@ -240,7 +244,7 @@
                                 explicabo sed odit? Recusandae praesentium voluptatum cum omnis, placeat beatae quasi
                                 eum odio doloribus inventore, eos iusto sed. kav
                             </fdp-dynamic-page-content>
-                            <fdp-dynamic-page-content tabLabel="Tab 2" id="tab_2" (tabChange)="onTabChanged($event)">
+                            <fdp-dynamic-page-content tabLabel="Tab 2" id="tab_2">
                                 <!-- page content goes here -->
                                 tabs 2 Lorem ipsum dolor sasdasit amet consectetur adipisicing elit. Reprehenderit sunt
                                 laboriosam totam maiores. Unde quas quis soluta adipisci mollitia distinctio. Natus nam

--- a/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-dynamic-page/platform-dynamic-page-examples/platform-dynamic-page-tabbed-example.component.html
@@ -4,7 +4,7 @@
 <button fd-button (click)="openPage(true)">Click to open full screen</button>
 <div class="overlay" #overlay>
     <ng-container *ngIf="fullscreen">
-        <fdp-dynamic-page [stackContent]="stackedTabs" [background]="background">
+        <fdp-dynamic-page [stackContent]="stackedTabs" [background]="background" (tabChange)="onTabChanged($event)">
             <fdp-dynamic-page-title [title]="pageTitle" subtitle="Oversized multimaterial sneakers with quilted effect">
                 <!-- breadcrumb content -->
                 <fd-breadcrumb>
@@ -94,7 +94,7 @@
                 corrupti architecto perspiciatis, delectus necessitatibus incidunt numquam asperiores tenetur iure. Cum
                 consequuntur impedit repellendus esse, facere autem optio consequatur nobis?
             </fdp-dynamic-page-header>
-            <fdp-dynamic-page-content tabLabel="Tab 1" id="tab_1" (tabChange)="onTabChanged($event)">
+            <fdp-dynamic-page-content tabLabel="Tab 1" id="tab_1">
                 <!-- page content goes here -->
                 tab1 Lorem ipsum dolor sit amet consectetur adipisicing elit. Reprehenderit sunt laboriosam totam
                 maiores. Unde quas quis soluta adipisci mollitia distinctio. Natus nam repellat, aut ad et tempore cum.
@@ -211,7 +211,7 @@
                 odit? Recusandae praesentium voluptatum cum omnis, placeat beatae quasi eum odio doloribus inventore,
                 eos iusto sed.
             </fdp-dynamic-page-content>
-            <fdp-dynamic-page-content tabLabel="Tab 2" id="tab_2" (tabChange)="onTabChanged($event)">
+            <fdp-dynamic-page-content tabLabel="Tab 2" id="tab_2">
                 <!-- page content goes here -->
                 tabs 2 Lorem ipsum dolor sasdasit amet consectetur adipisicing elit. Reprehenderit sunt laboriosam totam
                 maiores. Unde quas quis soluta adipisci mollitia distinctio. Natus nam repellat, aut ad et tempore cum.

--- a/libs/platform/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
@@ -1,21 +1,6 @@
-import {
-    ChangeDetectionStrategy,
-    Component,
-    ElementRef,
-    EventEmitter,
-    Input,
-    Output,
-    TemplateRef,
-    ViewChild
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, TemplateRef, ViewChild } from '@angular/core';
 
-import { TabPanelComponent } from '@fundamental-ngx/core/tabs';
 import { DynamicPageBackgroundType, DynamicPageResponsiveSize } from '../constants';
-
-/** Dynamic Page tab change event */
-export class DynamicPageTabChangeEvent {
-    constructor(public source: DynamicPageContentComponent, public payload: TabPanelComponent) {}
-}
 
 /**
  * Dynamic Page Content Component.
@@ -56,12 +41,6 @@ export class DynamicPageContentComponent {
      */
     @Input()
     size: DynamicPageResponsiveSize;
-
-    /**
-     * Tab Change event
-     */
-    @Output()
-    tabChange: EventEmitter<DynamicPageTabChangeEvent> = new EventEmitter<DynamicPageTabChangeEvent>();
 
     /**
      * @hidden

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.component.html
@@ -40,7 +40,7 @@
         *ngIf="_isTabbed"
         [stackContent]="stackContent"
         maxContentHeight="auto"
-        (selectedTabChange)="_handleTabChange($event)"
+        (selectedTabChange)="_onSelectedTabChange($event)"
     >
         <ng-container *ngFor="let tab of _tabs">
             <fd-tab [title]="tab.tabLabel" [id]="tab.id">

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.component.html
@@ -36,7 +36,12 @@
         <ng-container [ngTemplateOutlet]="headerComponent.contentTemplateRef"></ng-container>
     </fd-dynamic-page-subheader>
 
-    <fd-tab-list *ngIf="_isTabbed" [stackContent]="stackContent" maxContentHeight="auto">
+    <fd-tab-list
+        *ngIf="_isTabbed"
+        [stackContent]="stackContent"
+        maxContentHeight="auto"
+        (selectedTabChange)="_handleTabChange($event)"
+    >
         <ng-container *ngFor="let tab of _tabs">
             <fd-tab [title]="tab.tabLabel" [id]="tab.id">
                 <fd-dynamic-page-content>

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
@@ -21,7 +21,10 @@ import { TabPanelComponent } from '@fundamental-ngx/core/tabs';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
 import { DynamicPageBackgroundType, DynamicPageResponsiveSize } from './constants';
 import { DynamicPageContentHostComponent } from './dynamic-page-content/dynamic-page-content-host.component';
-import { DynamicPageContentComponent } from './dynamic-page-content/dynamic-page-content.component';
+import {
+    DynamicPageContentComponent,
+    DynamicPageTabChangeEvent
+} from './dynamic-page-content/dynamic-page-content.component';
 import { DynamicPageFooterComponent } from './dynamic-page-footer/dynamic-page-footer.component';
 import { DynamicPageHeaderComponent } from './dynamic-page-header/header/dynamic-page-header.component';
 import { DynamicPageTitleComponent } from './dynamic-page-header/title/dynamic-page-title.component';
@@ -168,6 +171,15 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
      */
     elementRef(): ElementRef<HTMLElement> {
         return this._elementRef;
+    }
+
+    /**
+     * @hidden
+     * handle tab changes and emit event
+     */
+    _handleTabChange(tabPanel: TabPanelComponent): void {
+        const event = new DynamicPageTabChangeEvent(this.contentComponent, tabPanel);
+        this.contentComponent.tabChange.emit(event);
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
@@ -8,9 +8,11 @@ import {
     ContentChildren,
     DoCheck,
     ElementRef,
+    EventEmitter,
     HostBinding,
     Input,
     OnDestroy,
+    Output,
     QueryList,
     ViewChildren,
     ViewEncapsulation
@@ -21,14 +23,16 @@ import { TabPanelComponent } from '@fundamental-ngx/core/tabs';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
 import { DynamicPageBackgroundType, DynamicPageResponsiveSize } from './constants';
 import { DynamicPageContentHostComponent } from './dynamic-page-content/dynamic-page-content-host.component';
-import {
-    DynamicPageContentComponent,
-    DynamicPageTabChangeEvent
-} from './dynamic-page-content/dynamic-page-content.component';
+import { DynamicPageContentComponent } from './dynamic-page-content/dynamic-page-content.component';
 import { DynamicPageFooterComponent } from './dynamic-page-footer/dynamic-page-footer.component';
 import { DynamicPageHeaderComponent } from './dynamic-page-header/header/dynamic-page-header.component';
 import { DynamicPageTitleComponent } from './dynamic-page-header/title/dynamic-page-title.component';
 import { DynamicPageService } from './dynamic-page.service';
+
+/** Dynamic Page tab change event */
+export class DynamicPageTabChangeEvent {
+    constructor(public source: DynamicPageContentComponent, public payload: TabPanelComponent) {}
+}
 
 @Component({
     selector: 'fdp-dynamic-page',
@@ -87,6 +91,12 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
      */
     @Input()
     expandContent = true;
+
+    /**
+     * Tab Change event
+     */
+    @Output()
+    tabChange = new EventEmitter<DynamicPageTabChangeEvent>();
 
     /** reference to title component  */
     @ContentChild(DynamicPageTitleComponent)
@@ -173,13 +183,10 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
         return this._elementRef;
     }
 
-    /**
-     * @hidden
-     * handle tab changes and emit event
-     */
-    _handleTabChange(tabPanel: TabPanelComponent): void {
-        const event = new DynamicPageTabChangeEvent(this.contentComponent, tabPanel);
-        this.contentComponent.tabChange.emit(event);
+    _onSelectedTabChange(event: TabPanelComponent): void {
+        const content = this.contentComponents.find((contentComponent) => contentComponent.id === event.id);
+
+        this.tabChange.emit(new DynamicPageTabChangeEvent(content, event));
     }
 
     /** @hidden */
@@ -191,20 +198,23 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
 
     /** @hidden */
     private _createContentTabs(): void {
-        const content = this.contentComponents.toArray();
+        const contentComponents = this.contentComponents.toArray();
+
         // reset array
         this._tabs = [];
-        if (!this._isTabContentPresent(content)) {
-            if (content.length > 1) {
+
+        if (!this._isTabContentPresent(contentComponents)) {
+            if (contentComponents.length > 1) {
                 throw new Error(
                     'Cannot have more than one content section. Use `tabLabel` to have a tabbed navigation.'
                 );
             }
+
             return;
         }
 
-        if (content) {
-            content.forEach((contentItem) => {
+        if (contentComponents) {
+            contentComponents.forEach((contentItem) => {
                 if (!contentItem.tabLabel && this._isTabbed) {
                     throw new Error('At least one element is already tabbed, please provide a `tabLabel`.');
                 } else {
@@ -215,13 +225,14 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
     }
 
     /** @hidden */
-    private _isTabContentPresent(content: DynamicPageContentComponent[]): boolean {
-        content.forEach((contentItem) => {
-            if (contentItem.tabLabel) {
+    private _isTabContentPresent(contentComponents: DynamicPageContentComponent[]): boolean {
+        contentComponents.forEach((contentComponent) => {
+            if (contentComponent.tabLabel) {
                 this._isTabbed = true;
                 return;
             }
         });
+
         return this._isTabbed;
     }
 }


### PR DESCRIPTION
## Related Issue(s)

None.

## Description

Event emitting of tab change for the platform dynamic page component.

Event is now emitted from dynamic page component instead of dynamic page content (tab) component to fix the behavior when events were emitted only from the first content (tab) component and to avoid emitting multiple identical events from every content (tab) component.

BREAKING CHANGES:
`(tabChange)` event now emitted on `DynamicPageComponent` instead of `DynamicPageContentComponent`.
Interface not changed.

https://github.com/SAP/fundamental-ngx/wiki/0.33.0-Breaking-Changes#dynamic-page-component-platform-7669