### PR TITLE
fix(docs): lowercase typedoc files

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "test:platform": "nx test platform --watch false --code-coverage true --browsers=ChromeHeadless",
         "active-test": "nx test core --watch true --browsers=ChromeHeadless",
         "test:coveralls": "cat ./coverage/libs/core/lcov.info  | ./node_modules/coveralls/bin/coveralls.js || echo -e \"Coveralls failed.\"",
-        "compile-typedoc-all": "npm run compile-typedoc-core && npm run compile-typedoc-platform && npm run compile-typedoc-moment-adapter",
+        "compile-typedoc-all": "npm run compile-typedoc-core && npm run compile-typedoc-platform && npm run compile-typedoc-moment-adapter && npm run transform-typedocs",
         "compile-typedoc-core": "rm -rf apps/docs/src/assets/typedoc/core && typedoc --out apps/docs/src/assets/typedoc/core libs/core/src/lib --tsconfig libs/core/src/lib/tsconfig.lib.json --hideGenerator --theme apps/docs/src/fd-typedoc",
         "compile-typedoc-moment-adapter": "rm -rf apps/docs/src/assets/typedoc/moment-adapter && typedoc --out apps/docs/src/assets/typedoc/moment-adapter libs/moment-adapter/src/lib --tsconfig libs/moment-adapter/tsconfig.lib.json --hideGenerator --theme apps/docs/src/fd-typedoc",
         "compile-typedoc-platform": "rm -rf apps/docs/src/assets/typedoc/platform && typedoc --out apps/docs/src/assets/typedoc/platform libs/platform/src/lib --tsconfig libs/platform/src/lib/tsconfig.lib.json --hideGenerator --theme apps/docs/src/fd-typedoc",
@@ -100,7 +100,8 @@
         "e2e-generate-report": "allure generate allure-results --clean -o allure-report",
         "prepare": "husky install",
         "pre-commit": "lint-staged",
-        "std-version": "standard-version --infile ./CHANGELOG.md --releaseCommitMessageFormat \"chore(release): version {{currentTag}} build ${GITHUB_RUN_NUMBER} [ci skip]\" --header \"\""
+        "std-version": "standard-version --infile ./CHANGELOG.md --releaseCommitMessageFormat \"chore(release): version {{currentTag}} build ${GITHUB_RUN_NUMBER} [ci skip]\" --header \"\"",
+        "transform-typedocs": "node ./transform-typedoc-files.js"
     },
     "publishConfig": {
         "registry": "https://repository.hybris.com/api/npm/npm-repository/"

--- a/transform-typedoc-files.js
+++ b/transform-typedoc-files.js
@@ -1,0 +1,28 @@
+const { resolve } = require('path');
+const exists = require('fs').existsSync;
+const fs = require('fs').promises;
+
+const typedocDir = './apps/docs/src/assets/typedoc';
+
+if (!exists(typedocDir)) {
+    console.log("Typedocs folder doesn't exist.\r\n");
+    return;
+}
+
+async function* getFiles(dir) {
+    const items = await fs.readdir(dir, { withFileTypes: true });
+    for (const item of items) {
+        const res = resolve(dir, item.name);
+        if (item.isDirectory()) {
+            yield* getFiles(res);
+        } else {
+            yield res;
+        }
+    }
+}
+
+(async () => {
+    for await (const f of getFiles(typedocDir)) {
+        await fs.rename(f, f.toLocaleLowerCase());
+    }
+})();


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #7677 

## Description
Since some servers are case-sensitive for filenames in url, now we transform typedoc files to be in lowercase registry.

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
