### PR TITLE
fix(platform): table columns' width error

### DIFF
--- a/libs/platform/src/lib/table/table-column-resize.service.ts
+++ b/libs/platform/src/lib/table/table-column-resize.service.ts
@@ -160,11 +160,13 @@ export class TableColumnResizeService implements OnDestroy {
                     if (calculatedWidth) {
                         return calculatedWidth + 'px';
                     }
+
                     break;
                 case ColumnWidthChangeSource.WidthInput:
                     if (column.width) {
                         return this.getColumnWidth(column.width);
                     }
+
                     break;
             }
         }
@@ -185,10 +187,9 @@ export class TableColumnResizeService implements OnDestroy {
         if (!width.trim().endsWith('%')) {
             return width;
         }
+
         const percent = parseFloat(width);
-        if (!this._tableRef._tableWidthPx) {
-            throw new Error('Cannot resolve column width until table width is set');
-        }
+
         return (this._tableRef._tableWidthPx * percent) / 100 + 'px';
     }
 

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1214,6 +1214,10 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
 
     /** @hidden */
     _getCellStyles(column: TableColumn): { [styleProp: string]: number | string } {
+        if (!this._tableWidthPx) {
+            return {};
+        }
+
         const styles: { [property: string]: number | string } = {};
 
         if (this._freezableColumns.has(column.name)) {


### PR DESCRIPTION
## Related Issue(s)

Closes #7648.

## Description

Platform table columns' width error not emitted anymore if the table container has 0 width, instead method that returns styles for the cells returns `{}` (empty object) instead of constructing styles object.

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/20265336/152572619-d33b978b-39bf-4d49-b4c5-63d803f7a810.png)

### After:

No errors.

## Testing

In case you need to reproduce the issue you need to adjust any of the table examples by wrapping table in tab/tabbed-dynamic-page & set width in `%` for any column. Or just apply this path - [table-patch.txt](https://github.com/SAP/fundamental-ngx/files/8004979/table-patch.txt)
