### PR TITLE
fix(core,platform,fn): stackblitz inject issue

### DIFF
--- a/libs/core/schematics/ng-add/index.ts
+++ b/libs/core/schematics/ng-add/index.ts
@@ -27,6 +27,7 @@ export function ngAdd(options: any): Rule {
 function addDependencies(options: Schema): Rule {
     return (tree: Tree, context: SchematicContext) => {
         const ngCoreVersionTag = getPackageVersionFromPackageJson(tree, '@angular/core');
+        const ngCdkVersionTag = getPackageVersionFromPackageJson(tree, '@angular/cdk');
         const dependencies: NodeDependency[] = [];
 
         if (!hasPackage(tree, '@angular/forms')) {
@@ -42,6 +43,14 @@ function addDependencies(options: Schema): Rule {
                 type: NodeDependencyType.Default,
                 version: `${ngCoreVersionTag}`,
                 name: '@angular/animations'
+            });
+        }
+
+        if (!hasPackage(tree, '@angular/cdk')) {
+            dependencies.push({
+                type: NodeDependencyType.Default,
+                version: `${ngCdkVersionTag}`,
+                name: '@angular/cdk'
             });
         }
 

--- a/libs/core/src/lib/ng-package.json
+++ b/libs/core/src/lib/ng-package.json
@@ -6,7 +6,6 @@
         "entryFile": "./public_api.ts"
     },
     "allowedNonPeerDependencies": [
-        "@angular/cdk",
         "@sap-theming/theming-base-content",
         "focus-trap",
         "fundamental-styles",

--- a/libs/core/src/lib/package.json
+++ b/libs/core/src/lib/package.json
@@ -18,10 +18,10 @@
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
     "@angular/animations": "ANGULAR_VER_PLACEHOLDER",
     "@angular/router": "ANGULAR_VER_PLACEHOLDER",
+    "@angular/cdk": "CDK_VER_PLACEHOLDER",
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {
-    "@angular/cdk": "CDK_VER_PLACEHOLDER",
     "@sap-theming/theming-base-content": "THEMING_VER_PLACEHOLDER",
     "focus-trap": "FOCUSTRAP_VER_PLACEHOLDER",
     "fundamental-styles": "FDSTYLES_VER_PLACEHOLDER",

--- a/libs/fn/src/lib/ng-package.json
+++ b/libs/fn/src/lib/ng-package.json
@@ -6,7 +6,6 @@
         "entryFile": "./public_api.ts"
     },
     "allowedNonPeerDependencies": [
-        "@angular/cdk",
         "@sap-theming/theming-base-content",
         "focus-trap",
         "focus-visible",

--- a/libs/fn/src/lib/package.json
+++ b/libs/fn/src/lib/package.json
@@ -18,10 +18,10 @@
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
     "@angular/animations": "ANGULAR_VER_PLACEHOLDER",
     "@angular/router": "ANGULAR_VER_PLACEHOLDER",
+    "@angular/cdk": "CDK_VER_PLACEHOLDER",
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {
-    "@angular/cdk": "CDK_VER_PLACEHOLDER",
     "@sap-theming/theming-base-content": "THEMING_VER_PLACEHOLDER",
     "focus-trap": "FOCUSTRAP_VER_PLACEHOLDER",
     "focus-visible": "FOCUSVISIBLE_VER_PLACEHOLDER",

--- a/libs/platform/src/lib/ng-package.json
+++ b/libs/platform/src/lib/ng-package.json
@@ -6,7 +6,6 @@
         "entryFile": "./public_api.ts"
     },
     "allowedNonPeerDependencies": [
-        "@angular/cdk",
         "@sap-theming/theming-base-content",
         "focus-trap",
         "fundamental-styles",

--- a/libs/platform/src/lib/package.json
+++ b/libs/platform/src/lib/package.json
@@ -18,10 +18,10 @@
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
     "@angular/animations": "ANGULAR_VER_PLACEHOLDER",
     "@angular/router": "ANGULAR_VER_PLACEHOLDER",
+    "@angular/cdk": "CDK_VER_PLACEHOLDER",
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {
-    "@angular/cdk": "CDK_VER_PLACEHOLDER",
     "@sap-theming/theming-base-content": "THEMING_VER_PLACEHOLDER",
     "focus-trap": "FOCUSTRAP_VER_PLACEHOLDER",
     "fundamental-styles": "FDSTYLES_VER_PLACEHOLDER",


### PR DESCRIPTION
## Related Issue(s)

Closes #7710.

## Description

`@angular/cdk` listed as the dependency for the core, platform and fn. It's working okay for any local applications. But stackblitz resolves dependency slightly different so it's doesn't work there. `@angular/*` packages should be listed as `peerDependency`. Here is the recommendation from official angular docs https://angular.io/guide/creating-libraries#peer-dependencies. 

Example https://fundamental-ngx.netlify.app/#/core/popover#trigger in StackBlitz.

* `@angular/cdk` as `dependency` (current behavior): https://stackblitz.com/edit/angular-ecunnt **not working**
* `@angular/cdk` as `peerDependency` (i've published fork of the package to be able to test it): https://stackblitz.com/edit/angular-pdyeqe **working**

**Note**: this fix doesn't solve any `strictTemplates` \ `fullTemplateTypeCheck` related issues, they're still actual and should be fixed! See https://github.com/SAP/fundamental-ngx/issues/7563 for more information.