### PR TITLE
fix(platform): compensate label offset when additional form-field content is added

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-columns/combobox-columns-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-columns/combobox-columns-example.component.html
@@ -9,6 +9,6 @@
             [showSecondaryText]="true"
             (selectionChange)="onSelect($event)"
         ></fdp-combobox>
-        <p>Selected Item: {{ selectedItem | json }}</p>
+        <fdp-form-field-extras> Selected Item: {{ selectedItem | json }} </fdp-form-field-extras>
     </fdp-form-field>
 </fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-datasource/combobox-datasource-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-datasource/combobox-datasource-example.component.html
@@ -6,7 +6,7 @@
             [dataSource]="dataSourceStrings"
             (selectionChange)="onSelect1($event)"
         ></fdp-combobox>
-        <p>Selected Item: {{ selectedItem1 }}</p>
+        <fdp-form-field-extras> Selected Item: {{ selectedItem1 }} </fdp-form-field-extras>
     </fdp-form-field>
 
     <fdp-form-field id="array-of-objects" label="Array of Objects" [column]="2">
@@ -18,7 +18,7 @@
             lookupKey="name"
             (selectionChange)="onSelect2($event)"
         ></fdp-combobox>
-        <p>Selected Item: {{ selectedItem2 | json }}</p>
+        <fdp-form-field-extras> Selected Item: {{ selectedItem2 | json }} </fdp-form-field-extras>
     </fdp-form-field>
 
     <fdp-form-field id="observable" label="Observable" [column]="1">
@@ -30,7 +30,7 @@
             lookupKey="name"
             (selectionChange)="onSelect3($event)"
         ></fdp-combobox>
-        <p>Selected Item: {{ selectedItem3 | json }}</p>
+        <fdp-form-field-extras> Selected Item: {{ selectedItem3 | json }} </fdp-form-field-extras>
     </fdp-form-field>
 
     <fdp-form-field id="ds" label="Data Source" [column]="2">
@@ -42,6 +42,6 @@
             lookupKey="name"
             (selectionChange)="onSelect4($event)"
         ></fdp-combobox>
-        <p>Selected Item: {{ selectedItem4 | json }}</p>
+        <fdp-form-field-extras> Selected Item: {{ selectedItem4 | json }} </fdp-form-field-extras>
     </fdp-form-field>
 </fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-forms/combobox-forms-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-forms/combobox-forms-example.component.html
@@ -8,8 +8,11 @@
             (selectionChange)="onSelect($event)"
             formControlName="field"
         ></fdp-combobox>
-        <p>Selected Item: {{ selectedItem | json }}</p>
-        <p>Form Selected Item: {{ customForm.getRawValue() | json }}</p>
+        <fdp-form-field-extras>
+            Selected Item: {{ selectedItem | json }}
+            <br />
+            Form Selected Item: {{ customForm.getRawValue() | json }}
+        </fdp-form-field-extras>
     </fdp-form-field>
     <ng-template #i18n let-errors>
         <span *ngIf="errors.required">Field is required</span>

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-group/combobox-group-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-group/combobox-group-example.component.html
@@ -9,7 +9,7 @@
             groupKey="type"
             (selectionChange)="onSelect($event)"
         ></fdp-combobox>
-        <p>Selected: {{ selectedItem | json }}</p>
+        <fdp-form-field-extras> Selected: {{ selectedItem | json }} </fdp-form-field-extras>
     </fdp-form-field>
 
     <fdp-form-field id="group-without-key" label="Group without Key" [column]="2">
@@ -21,6 +21,6 @@
             [group]="true"
             (selectionChange)="onSelect1($event)"
         ></fdp-combobox>
-        <p>Selected: {{ selectedItem1 | json }}</p>
+        <fdp-form-field-extras> Selected: {{ selectedItem1 | json }} </fdp-form-field-extras>
     </fdp-form-field>
 </fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-loading/combobox-loading-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-loading/combobox-loading-example.component.html
@@ -9,7 +9,7 @@
                 [dataSource]="dataSource"
                 [(ngModel)]="selectedItem"
             ></fdp-combobox>
-            <p>Selected: {{ selectedItem }}</p>
         </fd-busy-indicator>
+        <fdp-form-field-extras>Selected: {{ selectedItem }}</fdp-form-field-extras>
     </fdp-form-field>
 </fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-mobile/combobox-mobile-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-mobile/combobox-mobile-example.component.html
@@ -9,6 +9,6 @@
             [mobileConfig]="mobileConfig"
             (selectionChange)="onSelect($event)"
         ></fdp-combobox>
-        <p>Selected: {{ selectedItem | json }}</p>
+        <fdp-form-field-extras> Selected: {{ selectedItem | json }} </fdp-form-field-extras>
     </fdp-form-field>
 </fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-standard/combobox-standard.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-standard/combobox-standard.component.html
@@ -7,7 +7,7 @@
                 [dataSource]="dataSource"
                 (selectionChange)="onSelect1($event)"
             ></fdp-combobox>
-            <p>Selected: {{ selectedItem1 }}</p>
+            <fdp-form-field-extras> Selected: {{ selectedItem1 }} </fdp-form-field-extras>
         </fdp-form-field>
 
         <fdp-form-field id="compact" label="Compact" [column]="1">
@@ -18,7 +18,7 @@
                 [dataSource]="dataSource"
                 (selectionChange)="onSelect2($event)"
             ></fdp-combobox>
-            <p>Selected: {{ selectedItem2 }}</p>
+            <fdp-form-field-extras> Selected: {{ selectedItem2 }} </fdp-form-field-extras>
         </fdp-form-field>
 
         <fdp-form-field id="readonly" label="ReadOnly" [column]="3">
@@ -30,7 +30,7 @@
                 [readonly]="true"
                 (selectionChange)="onSelect3($event)"
             ></fdp-combobox>
-            <p>Selected: {{ selectedItem3 }}</p>
+            <fdp-form-field-extras> Selected: {{ selectedItem3 }} </fdp-form-field-extras>
         </fdp-form-field>
 
         <fdp-form-field id="disabled" label="Disabled" [column]="3">
@@ -42,7 +42,7 @@
                 [disabled]="true"
                 (selectionChange)="onSelect4($event)"
             ></fdp-combobox>
-            <p>Selected: {{ selectedItem4 }}</p>
+            <fdp-form-field-extras> Selected: {{ selectedItem4 }} </fdp-form-field-extras>
         </fdp-form-field>
 
         <fdp-form-field id="max-height" label="Max Height" [column]="2">
@@ -53,7 +53,7 @@
                 maxHeight="400px"
                 (selectionChange)="onSelect5($event)"
             ></fdp-combobox>
-            <p>Selected: {{ selectedItem5 }}</p>
+            <fdp-form-field-extras> Selected: {{ selectedItem5 }} </fdp-form-field-extras>
         </fdp-form-field>
 
         <fdp-form-field
@@ -69,7 +69,7 @@
                 [autoResize]="true"
                 (selectionChange)="onSelect6($event)"
             ></fdp-combobox>
-            <p>Selected: {{ selectedItem6 }}</p>
+            <fdp-form-field-extras> Selected: {{ selectedItem6 }} </fdp-form-field-extras>
         </fdp-form-field>
     </fdp-form-group>
 </div>

--- a/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-templates/combobox-templates-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-combobox/examples/combobox-templates/combobox-templates-example.component.html
@@ -1,6 +1,5 @@
 <fdp-form-group [noLabelLayout]="false" columnLayout="XL2-L2-M1-S1">
-    <fdp-form-field id="optionItemTemplate" label="Option Item Template" [column]="1">
-        <span>Allows to customize display item template</span>
+    <fdp-form-field id="optionItemTemplate" label="Custom Item Template" [column]="1">
         <fdp-combobox
             name="optionItemTemplate"
             placeholder="Type some text..."
@@ -15,11 +14,10 @@
                 </div>
             </ng-template>
         </fdp-combobox>
-        <p>Selected: {{ selectedItem | json }}</p>
+        <fdp-form-field-extras> Selected: {{ selectedItem | json }} </fdp-form-field-extras>
     </fdp-form-field>
 
-    <fdp-form-field id="groupItemTemplate" label="Group Item Template" [column]="2">
-        <span>Allows to customize group header item template</span>
+    <fdp-form-field id="groupItemTemplate" label="Custom Group Item Template" [column]="2">
         <fdp-combobox
             name="groupItemTemplate"
             placeholder="Type some text..."
@@ -33,11 +31,10 @@
                 <li class="fd-list__group-header" [innerText]="'Type: ' + item.label"></li>
             </ng-template>
         </fdp-combobox>
-        <p>Selected: {{ selectedItem1 | json }}</p>
+        <fdp-form-field-extras> Selected: {{ selectedItem1 | json }} </fdp-form-field-extras>
     </fdp-form-field>
 
-    <fdp-form-field id="secondaryItemTemplate" label="Secondary Item Template" [column]="1">
-        <span>Allows to customize secondary item template</span>
+    <fdp-form-field id="secondaryItemTemplate" label="Custom Secondary Item Template" [column]="1">
         <fdp-combobox
             name="secondaryItemTemplate"
             placeholder="Type some text..."
@@ -50,11 +47,10 @@
                 <span class="fd-list__secondary" [innerText]="item.type"></span>
             </ng-template>
         </fdp-combobox>
-        <p>Selected: {{ selectedItem2 | json }}</p>
+        <fdp-form-field-extras> Selected: {{ selectedItem2 | json }} </fdp-form-field-extras>
     </fdp-form-field>
 
-    <fdp-form-field id="selectedItemTemplate" label="Selected Item Template" [column]="2">
-        <span>Allows to customize selected item template</span>
+    <fdp-form-field id="selectedItemTemplate" label=" Custom Selected Item Template" [column]="2">
         <fdp-combobox
             name="secondaryItemTemplate"
             placeholder="Type some text..."
@@ -69,6 +65,6 @@
                 </div>
             </ng-template>
         </fdp-combobox>
-        <p>Selected: {{ selectedItem3 | json }}</p>
+        <fdp-form-field-extras> Selected: {{ selectedItem3 | json }} </fdp-form-field-extras>
     </fdp-form-field>
 </fdp-form-group>

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-custom-layout.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-container/platform-form-container-examples/platform-form-custom-layout.component.html
@@ -99,3 +99,46 @@
         <fdp-textarea name="basicTextarea7" [formControl]="f7.formControl"></fdp-textarea>
     </fdp-form-field>
 </fdp-form-group>
+
+<fdp-form-group mainTitle="Fields with field extras" columnLayout="XL2-L2-M1-S1">
+    <fdp-form-field
+        #f8
+        id="basicTextarea5"
+        label="Basic Textarea 8"
+        placeholder="Start entering detailed description"
+        [column]="1"
+        [rank]="1"
+        [fieldColumnLayout]="{ S: 10 }"
+        [gapColumnLayout]="{ S: 2 }"
+    >
+        <fdp-textarea name="basicTextarea5" [formControl]="f8.formControl"></fdp-textarea>
+        <fdp-form-field-extras> Some extra information that doesn't affect the layout </fdp-form-field-extras>
+    </fdp-form-field>
+
+    <fdp-form-field
+        #f9
+        id="basicTextarea6"
+        label="Basic Textarea 9"
+        placeholder="Start entering detailed description"
+        [column]="2"
+        [rank]="2"
+        [fieldColumnLayout]="{ S: 10 }"
+        [gapColumnLayout]="{ S: 2 }"
+    >
+        <fdp-textarea name="basicTextarea6" [formControl]="f9.formControl"></fdp-textarea>
+        <fdp-form-field-extras> Some extra information that doesn't affect the layout </fdp-form-field-extras>
+    </fdp-form-field>
+    <fdp-form-field
+        #f10
+        id="basicTextarea7"
+        label="Basic Textarea 10"
+        placeholder="Start entering detailed description"
+        [column]="2"
+        [rank]="2"
+        [fieldColumnLayout]="{ S: 10 }"
+        [gapColumnLayout]="{ S: 2 }"
+    >
+        <fdp-textarea name="basicTextarea7" [formControl]="f10.formControl"></fdp-textarea>
+        <fdp-form-field-extras> Some extra information that doesn't affect the layout </fdp-form-field-extras>
+    </fdp-form-field>
+</fdp-form-group>

--- a/e2e/wdio/platform/pages/input.po.ts
+++ b/e2e/wdio/platform/pages/input.po.ts
@@ -19,7 +19,7 @@ export class InputPo extends BaseComponentPo {
     errorTextAttr = 'fd-form-message span';
     requiredInputLabel = 'fdp-platform-input-reactive-validation-example .fd-form-label--required';
     questionMarkSpan = '.sap-icon--question-mark';
-    inputsLabels = '.fd-container label span.ng-star-inserted';
+    inputsLabels = '.fd-container label .fd-form-label';
     inputsArray = 'input.fd-input';
     autocompleteInput = 'input#form-input-10';
     autocompleteInputLabel = 'fdp-platform-input-auto-complete-validation-example label';

--- a/e2e/wdio/platform/tests/form-generator.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/form-generator.e2e-spec.ts
@@ -158,14 +158,14 @@ describe('Form generator test suite', () => {
         expect(doesItExist(formValue)).toBe(false, 'form value row exists');
         click(customExample + submitButton);
         if (!browserIsSafari()) {
-            expect(getText(formValue)).toEqual('Form value: { "some_slider": { "value": 20, "label": "Twenty" } }');
+            expect(getText(formValue)).toEqual('Form value: { "some_slider": { "value": 10, "label": "Ten" } }');
         }
         if (browserIsSafari()) {
             expect(getText(formValue)).toEqual(
                 'Form value: {\n' +
                     '  "some_slider": {\n' +
-                    '    "value": 20,\n' +
-                    '    "label": "Twenty"\n' +
+                    '    "value": 10,\n' +
+                    '    "label": "Ten"\n' +
                     '  }\n' +
                     '}'
             );

--- a/libs/core/src/lib/input-group/input-group.component.scss
+++ b/libs/core/src/lib/input-group/input-group.component.scss
@@ -2,6 +2,10 @@
 @import '~fundamental-styles/dist/input-group';
 
 fd-input-group {
+    .fd-input-group {
+        margin: 0.25rem 0;
+    }
+
     .fd-input-group__addon--button.fd-input-group__addon--textarea > * {
         max-height: 100%;
         height: 100%;

--- a/libs/platform/src/lib/form/form-group/fdp-form.module.ts
+++ b/libs/platform/src/lib/form/form-group/fdp-form.module.ts
@@ -10,9 +10,18 @@ import { FormGroupComponent } from './form-group.component';
 import { FormFieldComponent } from './form-field/form-field.component';
 import { InputMessageGroupWithTemplate } from '../input-message-group-with-template/input-message-group-with-template.component';
 import { FormFieldGroupComponent } from './form-field-group/form-field-group.component';
+import { FormFieldControlExtrasComponent } from './form-field-extras/form-field-extras.component';
+
+const EXPORTABLE_DECLARATIONS = [
+    FormGroupComponent,
+    FormFieldComponent,
+    InputMessageGroupWithTemplate,
+    FormFieldGroupComponent,
+    FormFieldControlExtrasComponent
+];
 
 @NgModule({
-    declarations: [FormGroupComponent, FormFieldComponent, InputMessageGroupWithTemplate, FormFieldGroupComponent],
+    declarations: [...EXPORTABLE_DECLARATIONS],
     imports: [
         CommonModule,
         FormsModule,
@@ -22,6 +31,6 @@ import { FormFieldGroupComponent } from './form-field-group/form-field-group.com
         PopoverModule,
         IconModule
     ],
-    exports: [FormGroupComponent, FormFieldComponent, InputMessageGroupWithTemplate, FormFieldGroupComponent]
+    exports: [...EXPORTABLE_DECLARATIONS]
 })
 export class FdpFormGroupModule {}

--- a/libs/platform/src/lib/form/form-group/form-field-extras/form-field-extras.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-field-extras/form-field-extras.component.ts
@@ -1,0 +1,10 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+    selector: 'fdp-form-field-extras',
+    template: '<ng-content></ng-content>',
+    // "display: flex" is used in order to have margin included in control's dimensions
+    styles: [':host { display: flex; white-space: normal; }'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FormFieldControlExtrasComponent {}

--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
@@ -1,5 +1,5 @@
 <ng-template #renderer>
-    <div [horizontal]="true" fd-form-item class="fd-row">
+    <div [horizontal]="true" fd-form-item class="fd-row" [style.margin-bottom.px]="_extraContentHeightPx">
         <div class="fd-col" [class]="_labelColumnLayoutClass" *ngIf="!noLabelLayout">
             <label
                 [id]="'fdp-form-label-' + id"
@@ -18,7 +18,11 @@
 </ng-template>
 
 <ng-template #withFormMessage>
-    <fdp-input-message-group class="fd-col" [class]="_fieldColumnLayoutClass">
+    <fdp-input-message-group
+        class="fd-col"
+        [class]="_fieldColumnLayoutClass"
+        [style.margin-bottom.px]="_extraContentHeightPx ? _extraContentHeightPx * -1 : null"
+    >
         <!--
          Todo: we should extend this on FormGroup Level and have error trigger strategy that will be applied to
          all the field e.g.: [triggers]="['mouseenter', 'mouseleave']"

--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
@@ -1,6 +1,12 @@
 <ng-template #renderer>
-    <div [horizontal]="true" fd-form-item class="fd-row" [style.margin-bottom.px]="_extraContentHeightPx">
-        <div class="fd-col" [class]="_labelColumnLayoutClass" *ngIf="!noLabelLayout">
+    <div [horizontal]="true" fd-form-item class="fd-row">
+        <div
+            class="fd-col"
+            #labelCol
+            [class]="_labelColumnLayoutClass"
+            *ngIf="!noLabelLayout"
+            [style.margin-bottom.px]="_controlExtrasHeightPx"
+        >
             <label
                 [id]="'fdp-form-label-' + id"
                 [required]="editable && required"
@@ -8,7 +14,7 @@
                 [inlineHelpTitle]="hint"
                 [inlineHelpBodyPlacement]="hintPlacement"
             >
-                <span *ngIf="!noLabelLayout" [id]="'fdp-form-label-content-' + id">{{ label }}</span>
+                <span [id]="'fdp-form-label-content-' + id">{{ label }}</span>
             </label>
         </div>
         <ng-container *ngTemplateOutlet="withFormMessage"></ng-container>
@@ -18,11 +24,7 @@
 </ng-template>
 
 <ng-template #withFormMessage>
-    <fdp-input-message-group
-        class="fd-col"
-        [class]="_fieldColumnLayoutClass"
-        [style.margin-bottom.px]="_extraContentHeightPx ? _extraContentHeightPx * -1 : null"
-    >
+    <fdp-input-message-group class="fd-col" [class]="_fieldColumnLayoutClass">
         <!--
          Todo: we should extend this on FormGroup Level and have error trigger strategy that will be applied to
          all the field e.g.: [triggers]="['mouseenter', 'mouseleave']"

--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.ts
@@ -349,6 +349,11 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
     private _gapColumnLayout: ColumnLayout;
 
     /** @hidden */
+    get _extraContentHeightPx(): number | null {
+        return this.control?.extraContentHeightPx ?? null;
+    }
+
+    /** @hidden */
     constructor(
         private _cd: ChangeDetectorRef,
         @Optional() formGroupContainer: FormGroupContainer,

--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.ts
@@ -4,6 +4,8 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    ContentChild,
+    ElementRef,
     EventEmitter,
     forwardRef,
     Inject,
@@ -43,6 +45,8 @@ import {
     FORM_GROUP_CHILD_FIELD_TOKEN
 } from '../constants';
 import { normalizeColumnLayout, generateColumnClass } from '../helpers';
+import { FormFieldControlExtrasComponent } from './../form-field-extras/form-field-extras.component';
+import { InputMessageGroupWithTemplate } from '../../input-message-group-with-template/input-message-group-with-template.component';
 
 const formFieldProvider: Provider = {
     provide: FormField,
@@ -280,6 +284,17 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
     @ViewChild('renderer', { static: true })
     renderer: TemplateRef<any>;
 
+    /** @hidden */
+    @ContentChild(FormFieldControlExtrasComponent, { read: ElementRef })
+    formFieldExtras?: ElementRef<HTMLElement>;
+
+    /** @hidden */
+    @ViewChild('labelCol') labelCol?: ElementRef<HTMLDivElement>;
+
+    /** @hidden */
+    @ViewChild(InputMessageGroupWithTemplate, { read: ElementRef })
+    inputMessageGroup: ElementRef<HTMLElement>;
+
     /**
      * Child FormFieldControl
      */
@@ -313,7 +328,7 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
     protected _required = false;
 
     /** @hidden */
-    protected _destroyed = new Subject<void>();
+    protected _destroyed$ = new Subject<void>();
 
     /** @hidden */
     private _isColumnLayoutEnabled = false;
@@ -348,9 +363,30 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
     /** @hidden */
     private _gapColumnLayout: ColumnLayout;
 
-    /** @hidden */
-    get _extraContentHeightPx(): number | null {
-        return this.control?.extraContentHeightPx ?? null;
+    /** @hidden whether label and control are vertically aligned */
+    private get _isHorizontalAlignment(): boolean {
+        if (!this.inputMessageGroup || !this.labelCol) {
+            return false;
+        }
+        const inputMessageGroupY = this.inputMessageGroup.nativeElement.getBoundingClientRect().y;
+        const labelColRect = this.labelCol.nativeElement.getBoundingClientRect();
+        const labelColBottomY = labelColRect.y + labelColRect.height;
+        return labelColBottomY > inputMessageGroupY;
+    }
+
+    /**
+     * @hidden
+     * Sum of extra heights inside form control and formFieldExtras.
+     * Label will be shifted by this number in order to be properly aligned with the control
+     */
+    get _controlExtrasHeightPx(): number | null {
+        if (this.noLabelLayout || !this._isHorizontalAlignment) {
+            // proceed only if 1. there's a label; 2. control has vertical alignment
+            return null;
+        }
+        return (
+            (this.formFieldExtras?.nativeElement.offsetHeight ?? 0 + this.control?.extraContentHeightPx ?? 0) || null
+        );
     }
 
     /** @hidden */
@@ -400,6 +436,7 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
         if (this._isColumnLayoutEnabled) {
             this._responsiveBreakpointsService
                 .observeBreakpointByConfig(this._responsiveBreakPointConfig)
+                .pipe(takeUntil(this._destroyed$))
                 .subscribe((breakPointName) => this._updateLayout(breakPointName));
         }
 
@@ -421,8 +458,8 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
     /** @hidden */
     ngOnDestroy(): void {
         this._removeFromFormGroup();
-        this._destroyed.next();
-        this._destroyed.complete();
+        this._destroyed$.next();
+        this._destroyed$.complete();
     }
 
     /** @hidden */
@@ -441,7 +478,7 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
 
         this.control = formFieldControl;
 
-        formFieldControl.stateChanges.pipe(startWith(null), takeUntil(this._destroyed)).subscribe(() => {
+        formFieldControl.stateChanges.pipe(startWith(null), takeUntil(this._destroyed$)).subscribe(() => {
             this._updateControlProperties();
             // need to call explicitly detectChanges() instead of markForCheck before the
             // modified validation state of the control passes over checked phase
@@ -451,7 +488,7 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
 
         // Refresh UI when value changes
         if (formFieldControl?.ngControl) {
-            formFieldControl.ngControl.valueChanges.pipe(takeUntil(this._destroyed)).subscribe(() => {
+            formFieldControl.ngControl.valueChanges.pipe(takeUntil(this._destroyed$)).subscribe(() => {
                 // this.onChange.emit('valueChanges');
                 this._cd.markForCheck();
             });

--- a/libs/platform/src/lib/form/form-group/form-group.component.scss
+++ b/libs/platform/src/lib/form/form-group/form-group.component.scss
@@ -3,6 +3,11 @@
 @import '~fundamental-styles/dist/form-group';
 @import '~fundamental-styles/dist/form-header';
 
+fdp-form-group {
+    // resize observer won't work with inline elements
+    display: inline-block;
+}
+
 .fd-form-layout-grid-container {
     padding: 1rem;
 }

--- a/libs/platform/src/lib/form/public_api.ts
+++ b/libs/platform/src/lib/form/public_api.ts
@@ -53,6 +53,7 @@ export * from './form-group/fdp-form.module';
 export * from './form-group/form-group.component';
 export * from './form-group/form-field/form-field.component';
 export * from './form-group/form-field-group/form-field-group.component';
+export * from './form-group/form-field-extras/form-field-extras.component';
 
 export * from './input/fdp-input.module';
 export * from './input/input.component';

--- a/libs/platform/src/lib/form/text-area/text-area.component.html
+++ b/libs/platform/src/lib/form/text-area/text-area.component.html
@@ -28,6 +28,7 @@
     aria-live="polite"
     aria-atomic="true"
     [attr.id]="id + '-counter'"
+    #counter
 >
     <span>
         <ng-container

--- a/libs/platform/src/lib/form/text-area/text-area.component.scss
+++ b/libs/platform/src/lib/form/text-area/text-area.component.scss
@@ -1,8 +1,4 @@
 .fd-textarea-counter {
-    display: inline;
-    float: right;
-
-    [dir='rtl'] & {
-        float: left;
-    }
+    display: inline-block;
+    width: 100%;
 }

--- a/libs/platform/src/lib/form/text-area/text-area.component.spec.ts
+++ b/libs/platform/src/lib/form/text-area/text-area.component.spec.ts
@@ -239,7 +239,7 @@ describe('Advanced Textarea', () => {
         textareaComponent.growing = false;
         const keyboardEvent = createKeyboardEvent('keydown', DELETE, 'Delete');
         textareaComponent.handleBackPress(keyboardEvent);
-        await wait(fixture);
+        await fixture.whenStable();
 
         expect(host.form.get('basicTextarea').value).toBe('abcde');
     });

--- a/libs/platform/src/lib/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/form/text-area/text-area.component.ts
@@ -4,6 +4,7 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    ElementRef,
     Host,
     HostListener,
     Input,
@@ -12,6 +13,7 @@ import {
     Optional,
     Self,
     SkipSelf,
+    ViewChild,
     ViewEncapsulation
 } from '@angular/core';
 import { NgControl, NgForm } from '@angular/forms';
@@ -138,6 +140,10 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
     }
 
     /** @hidden */
+    @ViewChild('counter')
+    _textareaCounter?: ElementRef<HTMLDivElement>;
+
+    /** @hidden */
     _contentDensity: ContentDensity = this._textAreaConfig.contentDensity;
 
     /** @hidden */
@@ -162,6 +168,14 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
     /** for i18n counter message translation */
     private readonly remainingText = 'remaining';
     private readonly excessText = 'excess';
+
+    /**
+     * @hidden
+     * @see FormFieldControl.extraContentHeightPx
+     */
+    get extraContentHeightPx(): number {
+        return this._textareaCounter?.nativeElement.offsetHeight;
+    }
 
     /** @hidden */
     private get _shouldTrackTextLimit(): boolean {

--- a/libs/platform/src/lib/shared/form/form-control.ts
+++ b/libs/platform/src/lib/shared/form/form-control.ts
@@ -34,6 +34,13 @@ export abstract class FormFieldControl<T> {
      *  Components works in two sizes compact or cozy
      */
     contentDensity: ContentDensity;
+
+    /**
+     * The height of the extra content at the bottom of the form control,
+     * which should not affect the alignment of form control and it's label
+     */
+    extraContentHeightPx?: number;
+
     /**
      *
      * Form Field listen for all the changes happening inside the input

--- a/libs/platform/src/lib/slider/slider.component.spec.ts
+++ b/libs/platform/src/lib/slider/slider.component.spec.ts
@@ -160,7 +160,7 @@ describe('PlatformSliderComponent', () => {
 
         fixture.detectChanges();
 
-        expect(component.value1).toEqual(-0.8);
+        expect(component.value1).toEqual(-0.2);
     });
 
     it('should emit value "-1" if cursor outside left side of slider', () => {


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes https://github.com/SAP/fundamental-ngx/issues/7607
closes https://github.com/SAP/fundamental-ngx/issues/7614

## Description
This PR combines changes from https://github.com/SAP/fundamental-ngx/pull/7697 (textarea label alignment) with additional enhancements for aligning labels, when there're additional content inside form-field.

Created a new component `fpd-form-field-extras`, that should be used to wrap such additional content.
<!-- Enter short description of the change -->

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
<img height="400px" src="https://user-images.githubusercontent.com/33101123/153595822-9524e231-4d9d-44b6-8e08-fafa3b9756a2.png">
<img height="400px" src="https://user-images.githubusercontent.com/33101123/153595871-5b75f87a-20ba-48af-9b4c-25c9aa697bdb.png">
<img height="400px" src="https://user-images.githubusercontent.com/33101123/152836362-6db719a2-578e-427f-a670-7c434fbe2faf.png">

### After:
<img height="400px" src="https://user-images.githubusercontent.com/33101123/153595743-d3f0f9c5-e921-4c58-979b-0f67c45fa8ef.png">
<img height="400px" src="https://user-images.githubusercontent.com/33101123/153595775-c4b5db90-7187-43d8-869d-ef5fa8f1de35.png">
<img height="400px" src="https://user-images.githubusercontent.com/33101123/152836263-d1887877-f017-4f4f-b6c7-e3ee6e3e1fa4.png">

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [n/a] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [n/a] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [n/a] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [n/a] different combinations of components - free style
-   [n/a] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [n/a] poor examples
-   [n/a] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [n/a] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [n/a] Run npm run build-pack-library and test in external application
-   [n/a] update `README.md`
-   [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
