### PR TITLE
fix(core): @angular/cdk schematics issue

### DIFF
--- a/libs/core/schematics/add-animations/index.ts
+++ b/libs/core/schematics/add-animations/index.ts
@@ -1,0 +1,50 @@
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
+import { addModuleImportToModule, findModuleFromOptions } from '@angular/cdk/schematics';
+import { hasModuleImport } from '../utils/ng-module-utils';
+
+const browserAnimationsModuleName = 'BrowserAnimationsModule';
+const noopAnimationsModuleName = 'NoopAnimationsModule';
+
+// Configures animations modules
+export function addAnimations(options: any): any {
+    return async (tree: Tree, context: SchematicContext) => {
+        const modulePath = await findModuleFromOptions(tree, options);
+
+        if (options.animations) {
+            if (hasModuleImport(tree, modulePath, noopAnimationsModuleName)) {
+                context.logger.warn(
+                    `Could not set up "${browserAnimationsModuleName} because "${noopAnimationsModuleName}" is already imported. Please manually set up browser animations.`
+                );
+
+                return tree;
+            }
+
+            if (hasModuleImport(tree, modulePath, browserAnimationsModuleName)) {
+                context.logger.info(
+                    `✅️ Import of ${browserAnimationsModuleName} already present in root module. Skipping.`
+                );
+
+                return tree;
+            }
+
+            addModuleImportToModule(
+                tree,
+                modulePath,
+                browserAnimationsModuleName,
+                '@angular/platform-browser/animations'
+            );
+
+            context.logger.info(`✅️ Added ${browserAnimationsModuleName} to root module.`);
+
+            return tree;
+        }
+
+        if (!hasModuleImport(tree, modulePath, browserAnimationsModuleName)) {
+            addModuleImportToModule(tree, modulePath, noopAnimationsModuleName, '@angular/platform-browser/animations');
+
+            context.logger.info(`✅️ Added ${noopAnimationsModuleName} to root module.`);
+        }
+
+        return tree;
+    };
+}

--- a/libs/core/schematics/collection.json
+++ b/libs/core/schematics/collection.json
@@ -5,6 +5,10 @@
             "description": "Adds @fundamental-ngx/core to the project.",
             "factory": "./ng-add/index#ngAdd",
             "schema": "./ng-add/schema.json"
+        },
+        "add-animations": {
+            "description": "Adds animations module imports using @angular/cdk tools.",
+            "factory": "./add-animations/index#addAnimations"
         }
     }
 }


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

Methods that are using `@angular/cdk` moved into separate schematics to avoid importing package before its installation.

Probably, issue is reproducible using node v14 or below, doing `npm cache clear --force` also may help to reproduce the initial issue.

## Screenshots

No visual changes.
