### PR TITLE
fix(docs): fixed incorrect rendering of subItems

### DIFF
--- a/apps/docs/src/app/documentation/core-helpers/sections-toolbar/sections-toolbar.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/sections-toolbar/sections-toolbar.component.html
@@ -30,7 +30,7 @@
                         </div>
                         <ul fd-nested-list>
                             <ng-container *ngFor="let item of section.content; trackBy: trackBySectionContent">
-                                <ng-container *ngIf="item.subItems; else listItemTpl">
+                                <ng-container *ngIf="item.subItems; else rootListItem">
                                     <li fd-nested-list-item [expanded]="true">
                                         <div fd-nested-list-content>
                                             <a fd-nested-list-link>
@@ -42,24 +42,16 @@
                                             <ng-container
                                                 *ngFor="let subItem of item.subItems; trackBy: trackBySectionContent"
                                                 [ngTemplateOutlet]="listItemTpl"
+                                                [ngTemplateOutletContext]="{$implicit: subItem}"
                                             >
                                             </ng-container>
                                         </ul>
                                     </li>
                                 </ng-container>
-                                <ng-template #listItemTpl>
-                                    <li fd-nested-list-item>
-                                        <a
-                                            fd-nested-list-link
-                                            [routerLink]="'/' + item.url"
-                                            routerLinkActive="is-selected"
-                                            (keypress)="onKeypressHandler($event)"
-                                            tabindex="0"
-                                            role="button"
-                                        >
-                                            <span fd-nested-list-title>{{ item.name }}</span>
-                                        </a>
-                                    </li>
+                                <ng-template #rootListItem>
+                                    <ng-template [ngTemplateOutlet]="listItemTpl"
+                                                 [ngTemplateOutletContext]="{$implicit: item}">
+                                    </ng-template>
                                 </ng-template>
                             </ng-container>
                         </ul>
@@ -69,3 +61,18 @@
         </fd-side-nav>
     </div>
 </div>
+
+<ng-template #listItemTpl let-item>
+    <li fd-nested-list-item>
+        <a
+            fd-nested-list-link
+            [routerLink]="'/' + item.url"
+            routerLinkActive="is-selected"
+            (keypress)="onKeypressHandler($event)"
+            tabindex="0"
+            role="button"
+        >
+            <span fd-nested-list-title>{{ item.name }}</span>
+        </a>
+    </li>
+</ng-template>

--- a/apps/docs/src/app/documentation/core-helpers/sections-toolbar/sections-toolbar.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/sections-toolbar/sections-toolbar.component.html
@@ -42,15 +42,17 @@
                                             <ng-container
                                                 *ngFor="let subItem of item.subItems; trackBy: trackBySectionContent"
                                                 [ngTemplateOutlet]="listItemTpl"
-                                                [ngTemplateOutletContext]="{$implicit: subItem}"
+                                                [ngTemplateOutletContext]="{ $implicit: subItem }"
                                             >
                                             </ng-container>
                                         </ul>
                                     </li>
                                 </ng-container>
                                 <ng-template #rootListItem>
-                                    <ng-template [ngTemplateOutlet]="listItemTpl"
-                                                 [ngTemplateOutletContext]="{$implicit: item}">
+                                    <ng-template
+                                        [ngTemplateOutlet]="listItemTpl"
+                                        [ngTemplateOutletContext]="{ $implicit: item }"
+                                    >
                                     </ng-template>
                                 </ng-template>
                             </ng-container>


### PR DESCRIPTION
## Related Issue(s)
 Not aware if any

## Description

Sub items of the toolbar sections were not rendered correctly. Now it is fixed

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/28543391/156427437-c751a73e-33cd-4943-a0ad-cc598aeca445.png)

### After:
![image](https://user-images.githubusercontent.com/28543391/156427517-fea190ce-63c5-431c-b61c-0e75866c458f.png)
