### PR TITLE
fix(core): grid list filter-bar & group-header tabindexes

### DIFF
--- a/libs/core/src/lib/grid-list/components/grid-list-filter-bar/grid-list-filter-bar.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list-filter-bar/grid-list-filter-bar.component.html
@@ -1,4 +1,4 @@
-<div class="fd-toolbar fd-toolbar--info fd-toolbar--active fd-grid-list__filter" tabindex="0">
+<div class="fd-toolbar fd-toolbar--info fd-toolbar--active fd-grid-list__filter">
     <ng-content></ng-content>
 
     <span class="fd-toolbar__spacer"></span>

--- a/libs/core/src/lib/grid-list/components/grid-list-group-header/grid-list-group-header.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list-group-header/grid-list-group-header.component.html
@@ -1,7 +1,3 @@
-<div
-    class="fd-grid-list__group-header fd-grid-list__group-header--no-margin"
-    tabindex="0"
-    [attr.aria-label]="ariaLabel"
->
+<div class="fd-grid-list__group-header fd-grid-list__group-header--no-margin" [attr.aria-label]="ariaLabel">
     <ng-content></ng-content>
 </div>


### PR DESCRIPTION
## Related Issue(s)

Part of #7815.

## Description

Tabindexes set to `-1` for filter-bar & group-header elements.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

<img width="220" alt="image" src="https://user-images.githubusercontent.com/20265336/156763921-55239a56-e393-4428-b4f9-4011c5842849.png">

<img width="111" alt="image" src="https://user-images.githubusercontent.com/20265336/156764054-3335539d-779d-4a1f-9d1a-b0c1bfe33fc6.png">

### After:

<img width="139" alt="image" src="https://user-images.githubusercontent.com/20265336/156763986-abef9b75-1a64-4d36-8b63-d9bbeaabaa28.png">

<img width="121" alt="image" src="https://user-images.githubusercontent.com/20265336/156764089-2424a86a-d76f-4da1-8f69-4520cb3995e7.png">


