### PR TITLE
fix(core): time picker tabindexes

### DIFF
--- a/libs/core/src/lib/time/time-column/time-column.component.html
+++ b/libs/core/src/lib/time/time-column/time-column.component.html
@@ -31,7 +31,6 @@
             fdCarouselItem
             *ngFor="let row of rows; let index = index"
             #item="fdCarouselItem"
-            [attr.tabindex]="row.label === activeValue?.label ? 0 : -1"
             [id]="_createColumnItemIdByIndex(index)"
             [value]="row"
         >


### PR DESCRIPTION
## Related Issue(s)

Part of #7815.

## Description

Unneeded tab stop removed when tabbing between elements (hours, minutes, am\pm) of the time picker.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

2 tab stops.

### After:

1 tab stop.
