### PR TITLE
fix(core): action list tabindex

### DIFF
--- a/apps/docs/src/app/core/component-docs/list/examples/list-action-example/list-action-example.component.html
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-action-example/list-action-example.component.html
@@ -5,11 +5,19 @@
     <li fd-list-item *ngFor="let i of items">
         <span fd-list-title> List Item {{ i }} </span>
     </li>
-    <li fd-list-item [action]="true" [growing]="true">
-        <button fd-list-title (click)="loadMore()">
+    <li
+        fd-list-item
+        [action]="true"
+        [growing]="true"
+        (click)="loadMore()"
+        (keyup.enter)="loadMore()"
+        (keydown.space)="$event.preventDefault()"
+        (keyup.space)="loadMore()"
+    >
+        <span fd-list-title>
             <fd-busy-indicator [block]="false" [loading]="loading"></fd-busy-indicator>
             <span fd-list-title-text> Show More </span>
-        </button>
+        </span>
     </li>
     <li fd-list-footer>List Footer</li>
 </ul>

--- a/apps/docs/src/app/core/component-docs/list/examples/list-action-example/list-action-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/list/examples/list-action-example/list-action-example.component.ts
@@ -15,6 +15,7 @@ export class ListActionExampleComponent {
 
     loadMore(): void {
         this.loading = true;
+
         of(this._getNewItems())
             .pipe(delay(2000))
             .subscribe((result) => {

--- a/e2e/wdio/core/tests/standard-list.e2e-spec.ts
+++ b/e2e/wdio/core/tests/standard-list.e2e-spec.ts
@@ -14,7 +14,8 @@ import {
     waitForElDisplayed,
     waitForNotDisplayed,
     getElementClass,
-    setValue
+    setValue,
+    elementArray
 } from '../../driver/wdio';
 
 describe('Standard List test suite', () => {
@@ -45,8 +46,9 @@ describe('Standard List test suite', () => {
     describe('action list examples', () => {
         it('should check show more button functionality', () => {
             const startItemsCount = getElementArrayLength(actionList + listItems);
+            const lastItem = elementArray(actionList + listItems)[startItemsCount - 1];
 
-            click(actionList + button);
+            click(lastItem);
             waitForNotDisplayed(actionList + busyIndicator);
 
             expect(getElementArrayLength(actionList + listItems)).not.toEqual(startItemsCount);

--- a/e2e/wdio/core/tests/standard-list.e2e-spec.ts
+++ b/e2e/wdio/core/tests/standard-list.e2e-spec.ts
@@ -14,8 +14,7 @@ import {
     waitForElDisplayed,
     waitForNotDisplayed,
     getElementClass,
-    setValue,
-    elementArray
+    setValue
 } from '../../driver/wdio';
 
 describe('Standard List test suite', () => {
@@ -46,9 +45,8 @@ describe('Standard List test suite', () => {
     describe('action list examples', () => {
         it('should check show more button functionality', () => {
             const startItemsCount = getElementArrayLength(actionList + listItems);
-            const lastItem = elementArray(actionList + listItems)[startItemsCount - 1];
 
-            click(lastItem);
+            click(actionList + listItems, startItemsCount - 1);
             waitForNotDisplayed(actionList + busyIndicator);
 
             expect(getElementArrayLength(actionList + listItems)).not.toEqual(startItemsCount);


### PR DESCRIPTION
## Related Issue(s)

Part of #7815.

## Description

Action list unneeded tab stop removed from the "load more" button.

## Screenshots

### Before:

2 tab stops.

### After:

1 tab stop.
