### PR TITLE
feat(fn,docs): added custom angular event and added docs for fnClicked

### DIFF
--- a/apps/docs/src/app/app.module.ts
+++ b/apps/docs/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { MarkdownModule } from 'ngx-markdown';
 
 import { ContentDensityService } from '@fundamental-ngx/core/utils';
 import { AppComponent } from './app.component';
+import { ClickedBehaviorModule } from '@fundamental-ngx/fn/cdk';
 
 const routes: Routes = [
     {
@@ -39,7 +40,8 @@ const routes: Routes = [
         BrowserAnimationsModule,
         HttpClientModule,
         RouterModule.forRoot(routes, { useHash: true, relativeLinkResolution: 'legacy' }),
-        MarkdownModule.forRoot({ loader: HttpClient })
+        MarkdownModule.forRoot({ loader: HttpClient }),
+        ClickedBehaviorModule.forRoot()
     ],
     bootstrap: [AppComponent],
     providers: [ContentDensityService]

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/basic-example/basic-example.component.html
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/basic-example/basic-example.component.html
@@ -1,0 +1,14 @@
+<div
+    (fnClicked)="fnClickEvent = $event"
+    fnFocusableItem
+    style="border: 1px solid #dedede; display: inline-block; padding: 5px 7px; cursor: pointer"
+>
+    Trigger
+</div>
+
+<div>
+    Emitted event type is <code>{{ fnClickEvent?.type | json }}</code>
+    <ng-container *ngIf="fnClickEvent?.code">
+        , Key is <code>{{ fnClickEvent?.code | json }}</code>
+    </ng-container>
+</div>

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/basic-example/basic-example.component.ts
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/basic-example/basic-example.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'fd-fn-click-basic-example',
+    templateUrl: './basic-example.component.html'
+})
+export class BasicExampleComponent {
+    fnClickEvent: any;
+}

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/basic-example/exampleFiles.ts
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/basic-example/exampleFiles.ts
@@ -1,0 +1,18 @@
+import { ExampleFile } from '../../../../../../documentation/core-helpers/code-example/example-file';
+import defaultExampleHtml from '!./basic-example.component.html?raw';
+import defaultExampleTs from '!./basic-example.component.ts?raw';
+
+export default [
+    {
+        code: defaultExampleHtml,
+        language: 'html',
+        fileName: 'fn-clicked-basic-example',
+        component: 'FnClickedBasicExample'
+    },
+    {
+        code: defaultExampleTs,
+        language: 'ts',
+        fileName: 'fn-clicked-basic-example',
+        component: 'FnClickedBasicExample'
+    }
+] as ExampleFile[];

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/provider-example/exampleFiles.ts
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/provider-example/exampleFiles.ts
@@ -1,0 +1,25 @@
+import { ExampleFile } from '../../../../../../documentation/core-helpers/code-example/example-file';
+import providerExampleHtml from '!./provider-example.component.html?raw';
+import providerExampleTs from '!./provider-example.component.ts?raw';
+import providerExampleDirectiveTs from '!./usage-with-provider.directive.ts?raw';
+
+export default [
+    {
+        code: providerExampleHtml,
+        language: 'html',
+        fileName: 'fn-clicked-provider-example',
+        component: 'FnClickedProviderExample'
+    },
+    {
+        code: providerExampleTs,
+        language: 'ts',
+        fileName: 'fn-clicked-provider-example',
+        component: 'FnClickedProviderExample'
+    },
+    {
+        code: providerExampleDirectiveTs,
+        language: 'ts',
+        fileName: 'fn-clicked-provider-directive-example',
+        component: 'FnClickedProviderDirectiveExample'
+    }
+] as ExampleFile[];

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/provider-example/provider-example.component.html
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/provider-example/provider-example.component.html
@@ -1,0 +1,15 @@
+<div
+    fnClickedUsageWithProvider
+    (anyOutputName)="fnClickEvent = $event"
+    fnFocusableItem
+    style="border: 1px solid #dedede; display: inline-block; padding: 5px 7px; cursor: pointer"
+>
+    Trigger
+</div>
+
+<div>
+    Emitted event type is <code>{{ fnClickEvent?.type | json }}</code>
+    <ng-container *ngIf="fnClickEvent?.code">
+        , Key is <code>{{ fnClickEvent?.code | json }}</code>
+    </ng-container>
+</div>

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/provider-example/provider-example.component.ts
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/provider-example/provider-example.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'fd-fn-clicked-provider-example',
+    templateUrl: './provider-example.component.html'
+})
+export class ProviderExampleComponent {
+    fnClickEvent: any;
+}

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/provider-example/usage-with-provider.directive.ts
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/examples/provider-example/usage-with-provider.directive.ts
@@ -1,0 +1,16 @@
+import { Directive, Output } from '@angular/core';
+import { FnClickedProvider } from '@fundamental-ngx/fn/cdk';
+import { Observable } from 'rxjs';
+
+@Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
+    selector: '[fnClickedUsageWithProvider]',
+    providers: [FnClickedProvider]
+})
+export class UsageWithProviderDirective {
+    @Output() anyOutputName: Observable<MouseEvent | KeyboardEvent>;
+
+    constructor(_clicked: FnClickedProvider) {
+        this.anyOutputName = _clicked;
+    }
+}

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-docs.component.html
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-docs.component.html
@@ -1,0 +1,27 @@
+<fd-docs-section-title id="simple" componentName="FnClicked">Basic example</fd-docs-section-title>
+<description>
+    <p>
+        Just add <code>(fnClicked)</code> to the element. In given example <code>div</code> also has
+        <code>[fnFocusableItem]</code> directive added to allow focus on <code>div</code>
+    </p>
+</description>
+<component-example [hasBackground]="false">
+    <fd-fn-click-basic-example></fd-fn-click-basic-example>
+</component-example>
+<code-example [exampleFiles]="basicExample"></code-example>
+
+<fd-docs-section-title id="provider" componentName="FnClickedProvider"
+    >Usage with provider example</fd-docs-section-title
+>
+<description>
+    <p>
+        In some cases you might not want to include <code>(fnClicked)</code> event in your application, but want to have
+        that unified event on disposal. For that reason you can include into you component's providers
+        <code>FnClickedProvider</code> and use it as output, or just notifier for your internal needs. This provider
+        will work in both cases, when <code>(fnClicked)</code> is available or not.
+    </p>
+</description>
+<component-example [hasBackground]="false">
+    <fd-fn-clicked-provider-example></fd-fn-clicked-provider-example>
+</component-example>
+<code-example [exampleFiles]="providerExample"></code-example>

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-docs.component.ts
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-docs.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import basicExampleFiles from './examples/basic-example/exampleFiles';
+import providerExampleFiles from './examples/provider-example/exampleFiles';
+
+@Component({
+    templateUrl: './fn-clicked-docs.component.html'
+})
+export class FnClickedDocsComponent {
+    basicExample = basicExampleFiles;
+    providerExample = providerExampleFiles;
+}

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-docs.module.ts
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-docs.module.ts
@@ -1,0 +1,42 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { FnClickedDocsComponent } from './fn-clicked-docs.component';
+import { FnClickedHeaderComponent } from './fn-clicked-header/fn-clicked-header.component';
+import { SharedDocumentationPageModule } from '../../../../documentation/shared-documentation-page.module';
+import { BasicExampleComponent } from './examples/basic-example/basic-example.component';
+import { ClickedBehaviorModule, FocusableItemModule } from '@fundamental-ngx/fn/cdk';
+import { ProviderExampleComponent } from './examples/provider-example/provider-example.component';
+import { UsageWithProviderDirective } from './examples/provider-example/usage-with-provider.directive';
+
+const routes: Routes = [
+    {
+        path: '',
+        component: FnClickedHeaderComponent,
+        children: [
+            {
+                path: '',
+                component: FnClickedDocsComponent
+            }
+        ]
+    }
+];
+
+@NgModule({
+    imports: [
+        CommonModule,
+        RouterModule.forChild(routes),
+        SharedDocumentationPageModule,
+        ClickedBehaviorModule,
+        FocusableItemModule
+    ],
+    exports: [RouterModule],
+    declarations: [
+        FnClickedDocsComponent,
+        FnClickedHeaderComponent,
+        BasicExampleComponent,
+        ProviderExampleComponent,
+        UsageWithProviderDirective
+    ]
+})
+export class FnClickedDocsModule {}

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-header/fn-clicked-header.component.html
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-header/fn-clicked-header.component.html
@@ -1,0 +1,24 @@
+<header>Clicked event manager</header>
+<description>
+    <p>
+        During development of the components, which should be accessible we encounter a lot of the repeated cases. One
+        of them is interaction detection. Besides "click" event, both "space" and "enter" can be indication of user's
+        will to select something. This is correct in most cases. Because of that need, we implement those three handlers
+        manually all the time. To eliminate that much repeated code we wrote custom Angular Event manager. Syntax is
+        very simple, just like you'd write <code>(click)="onClickHandler($event)"</code>, you will write
+        <code>(fnClicked)="onClickHandler($event)"</code>
+        and it will catch both "keydown.enter" and "keydown.space" events alongside with regular "click" event.
+    </p>
+    <p>
+        <code>(fnClicked)</code> also works with <code>@HostListener</code> decorator and with
+        <code>Renderer2.listen</code>
+    </p>
+    <p>
+        Include <code>ClickedBehaviorModule.forRoot()</code> in <code>imports</code> array of your <b>Root</b> module to
+        have access to the event handler.
+    </p>
+</description>
+<import module="ClickedBehaviorModule" subPackage="cdk"></import>
+
+<fd-header-tabs></fd-header-tabs>
+<router-outlet></router-outlet>

--- a/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-header/fn-clicked-header.component.ts
+++ b/apps/docs/src/app/fn/component-docs/utilities/fn-clicked/fn-clicked-header/fn-clicked-header.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+    templateUrl: './fn-clicked-header.component.html'
+})
+export class FnClickedHeaderComponent {
+    constructor() {}
+}

--- a/apps/docs/src/app/fn/documentation/fn-documentation-data.ts
+++ b/apps/docs/src/app/fn/documentation/fn-documentation-data.ts
@@ -56,6 +56,10 @@ export const utilities: SectionInterfaceContent[] = [
     {
         url: 'fn/disabled',
         name: 'Disabled'
+    },
+    {
+        url: 'fn/clicked',
+        name: 'Clicked'
     }
 ];
 

--- a/apps/docs/src/app/fn/fn-documentation.routes.ts
+++ b/apps/docs/src/app/fn/fn-documentation.routes.ts
@@ -118,6 +118,13 @@ export const ROUTES: Routes = [
                     import('./component-docs/utilities/fn-disabled/fn-disabled-docs.module').then(
                         (m) => m.FnDisabledDocsModule
                     )
+            },
+            {
+                path: 'clicked',
+                loadChildren: () =>
+                    import('./component-docs/utilities/fn-clicked/fn-clicked-docs.module').then(
+                        (m) => m.FnClickedDocsModule
+                    )
             }
         ]
     }

--- a/libs/fn/src/lib/cdk/clicked/clicked-behavior.module.ts
+++ b/libs/fn/src/lib/cdk/clicked/clicked-behavior.module.ts
@@ -1,8 +1,42 @@
-import { NgModule } from '@angular/core';
+import { Inject, InjectionToken, isDevMode, ModuleWithProviders, NgModule } from '@angular/core';
+import { EVENT_MANAGER_PLUGINS } from '@angular/platform-browser';
+import { ClickedEventPlugin } from './clicked-event.plugin';
 import { ClickedDirective } from './clicked.directive';
+
+const ClickedBehaviorModuleForRootLoadedOnce = new InjectionToken<boolean>(
+    'Checking Module providers had been loaded',
+    { factory: () => false }
+);
 
 @NgModule({
     declarations: [ClickedDirective],
     exports: [ClickedDirective]
 })
-export class ClickedBehaviorModule {}
+export class ClickedBehaviorModule {
+    constructor(
+        @Inject(ClickedBehaviorModuleForRootLoadedOnce) private clickedBehaviorModuleForRootLoadedOnce: boolean
+    ) {
+        if (!clickedBehaviorModuleForRootLoadedOnce && isDevMode()) {
+            console.warn(
+                'ClickedBehaviorModule.forRoot() was not called from RootModule, you will not be able to use (fnClicked) events'
+            );
+        }
+    }
+
+    static forRoot(): ModuleWithProviders<ClickedBehaviorModule> {
+        return {
+            ngModule: ClickedBehaviorModule,
+            providers: [
+                {
+                    provide: EVENT_MANAGER_PLUGINS,
+                    useClass: ClickedEventPlugin,
+                    multi: true
+                },
+                {
+                    provide: ClickedBehaviorModuleForRootLoadedOnce,
+                    useValue: true
+                }
+            ]
+        };
+    }
+}

--- a/libs/fn/src/lib/cdk/clicked/clicked-event.plugin.ts
+++ b/libs/fn/src/lib/cdk/clicked/clicked-event.plugin.ts
@@ -1,0 +1,74 @@
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { ENTER, SPACE } from '@angular/cdk/keycodes';
+import { DOCUMENT } from '@angular/common';
+
+type EventHandlerFunction = ($event: Event) => void;
+type HandlerRemoveFunction = () => void;
+
+@Injectable()
+export class ClickedEventPlugin {
+    constructor(@Inject(DOCUMENT) private document: Document, @Inject(PLATFORM_ID) private platformId: any) {}
+
+    private parseHigherOrderElement(selector: string): EventTarget {
+        if (this.platformId !== 'browser') {
+            return this.document;
+        }
+        switch (selector) {
+            case 'window':
+                return window;
+            case 'document':
+                return document;
+            case 'body':
+                return document.body;
+            default:
+                throw new Error(`Element selector [${selector}] not supported.`);
+        }
+    }
+
+    public addEventListener(
+        element: HTMLElement,
+        eventName: string,
+        handler: EventHandlerFunction
+    ): ($event: Event) => void {
+        return this.setupEventBinding(element, handler);
+    }
+
+    public addGlobalEventListener(
+        higherOrderElement: string,
+        eventName: string,
+        handler: EventHandlerFunction
+    ): HandlerRemoveFunction {
+        const target = this.parseHigherOrderElement(higherOrderElement);
+        return this.setupEventBinding(target, handler);
+    }
+
+    public supports(eventName: string): boolean {
+        return eventName === 'fnClicked';
+    }
+
+    private setupEventBinding(target: EventTarget, handler: EventHandlerFunction): HandlerRemoveFunction {
+        const addProxyFunction = (): void => {
+            target.addEventListener('click', proxyFunction, false);
+            target.addEventListener('keydown', proxyFunction, false);
+        };
+
+        const removeProxyFunction = (): void => {
+            target.removeEventListener('click', proxyFunction, false);
+            target.removeEventListener('keydown', proxyFunction, false);
+        };
+
+        const proxyFunction = (event: Event | MouseEvent | KeyboardEvent): void => {
+            if (event instanceof KeyboardEvent) {
+                if (event.keyCode !== ENTER && event.keyCode !== SPACE) {
+                    return;
+                }
+            }
+            console.log({ event });
+            handler(event);
+        };
+
+        addProxyFunction();
+
+        return removeProxyFunction;
+    }
+}

--- a/libs/fn/src/lib/cdk/clicked/clicked.directive.ts
+++ b/libs/fn/src/lib/cdk/clicked/clicked.directive.ts
@@ -1,15 +1,14 @@
-import { Directive, Output } from '@angular/core';
-import { FnClickedProvider } from './fn-clicked.provider';
+import { Directive, EventEmitter, Output } from '@angular/core';
 import { Observable } from 'rxjs';
 
 @Directive({
-    selector: '[fnClicked]',
-    providers: [FnClickedProvider]
+    selector: '[fnClicked]'
 })
 export class ClickedDirective {
-    @Output() fnClicked: Observable<MouseEvent | KeyboardEvent>;
-
-    constructor(_clicked: FnClickedProvider) {
-        this.fnClicked = _clicked.asObservable();
-    }
+    /**
+     * FnClicked output. Sole purpose of existence of this directive is to just silence Angular Language Service.
+     * This is only viable solution, since NO_ERRORS_SCHEMA silences everything and valuable exception might slip
+     * through your eyes.
+     */
+    @Output() fnClicked: Observable<MouseEvent | KeyboardEvent> = new EventEmitter();
 }


### PR DESCRIPTION
## Related Issue(s)
none

## Description

With this update from now on there is no need for existence of (fnClicked) directive on component to be able to gain those unified events. @HostListened, Renderer2.listen, fromEvent will work on fnClicked, just like it works on angular's native (click). Also there is left way for a user to use provider and have previous available methods. No deprecations