### PR TITLE
fix(core,platform): rxjs debounceTime instead of delay

### DIFF
--- a/libs/core/src/lib/splitter/splitter-resizer/splitter-resizer.component.ts
+++ b/libs/core/src/lib/splitter/splitter-resizer/splitter-resizer.component.ts
@@ -16,8 +16,8 @@ import {
     Output,
     ViewEncapsulation
 } from '@angular/core';
-import { fromEvent, Subject } from 'rxjs';
-import { delay, take, takeUntil } from 'rxjs/operators';
+import { debounceTime, fromEvent, Subject } from 'rxjs';
+import { take, takeUntil } from 'rxjs/operators';
 
 import { KeyUtil } from '@fundamental-ngx/core/utils';
 
@@ -181,7 +181,7 @@ export class SplitterResizerComponent implements OnDestroy {
 
         this._ngZone.runOutsideAngular(() => {
             fromEvent(this._document, 'mousemove')
-                .pipe(delay(10), takeUntil(this._pointerMoveListener))
+                .pipe(debounceTime(10), takeUntil(this._pointerMoveListener))
                 .subscribe((event: MouseEvent) => {
                     this._ngZone.run(() => {
                         const newPosition = this._isHorizontal ? event.clientY : event.clientX;

--- a/libs/platform/src/lib/table/table-column-resize.service.ts
+++ b/libs/platform/src/lib/table/table-column-resize.service.ts
@@ -1,6 +1,6 @@
 import { ElementRef, Injectable, OnDestroy, Optional } from '@angular/core';
 import { fromEvent, Observable, Subject, Subscription } from 'rxjs';
-import { delay, takeUntil } from 'rxjs/operators';
+import { debounceTime, takeUntil } from 'rxjs/operators';
 
 import { RtlService } from '@fundamental-ngx/core/utils';
 
@@ -314,7 +314,7 @@ export class TableColumnResizeService implements OnDestroy {
     /** Update column resizer position. */
     private _updateResizerPositionOnMouseMove(): void {
         this._resizerMoveSubscription = fromEvent(document, 'mousemove')
-            .pipe(delay(10))
+            .pipe(debounceTime(10))
             .subscribe((event: MouseEvent) => {
                 const diffX = this._rtl ? this._clientStartX - event.clientX : event.clientX - this._clientStartX;
 


### PR DESCRIPTION
## Related Issue(s)

Closes #7911.

## Description

rxjs `debounceTime` instead of `delay` where it were misapplied.
