### PR TITLE
feat(core): added ignore click on selection directive

### DIFF
--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
@@ -15,7 +15,7 @@
 
             <div class="fd-dynamic-page__title-subtitle-container">
                 <div class="fd-dynamic-page__title-container">
-                    <span class="fd-dynamic-page__title">
+                    <span class="fd-dynamic-page__title" fdIgnoreClickOnSelection>
                         {{ title }}
                     </span>
                     <ng-content select="fd-dynamic-page-title-content"></ng-content>
@@ -26,12 +26,14 @@
                         </ng-container>
                     </div>
                 </div>
-                <div class="fd-dynamic-page__subtitle" *ngIf="_collapsed && subtitle">{{ subtitle }}</div>
+                <div class="fd-dynamic-page__subtitle" *ngIf="_collapsed && subtitle" fdIgnoreClickOnSelection>
+                    {{ subtitle }}
+                </div>
             </div>
         </div>
     </div>
 </div>
-<div class="fd-dynamic-page__subtitle" *ngIf="!_collapsed && subtitle">{{ subtitle }}</div>
+<div class="fd-dynamic-page__subtitle" *ngIf="!_collapsed && subtitle" fdIgnoreClickOnSelection>{{ subtitle }}</div>
 
 <ng-template #dynamicPageGlobalActionsRef>
     <ng-content select="fd-dynamic-page-global-actions"></ng-content>

--- a/libs/core/src/lib/dynamic-page/dynamic-page.module.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.module.ts
@@ -13,6 +13,7 @@ import { DynamicPageTitleContentComponent } from './dynamic-page-header/actions/
 import { ToolbarModule } from '@fundamental-ngx/core/toolbar';
 import { PopoverModule } from '@fundamental-ngx/core/popover';
 import { DynamicPageWrapperDirective } from './dynamic-page-wrapper.directive';
+import { IgnoreClickOnSelectionModule } from '@fundamental-ngx/core/utils';
 
 @NgModule({
     declarations: [
@@ -26,7 +27,7 @@ import { DynamicPageWrapperDirective } from './dynamic-page-wrapper.directive';
         DynamicPageTitleContentComponent,
         DynamicPageWrapperDirective
     ],
-    imports: [CommonModule, ButtonModule, ToolbarModule, PopoverModule],
+    imports: [CommonModule, ButtonModule, ToolbarModule, PopoverModule, IgnoreClickOnSelectionModule],
     exports: [
         DynamicPageComponent,
         DynamicPageHeaderComponent,

--- a/libs/core/src/lib/utils/directives/ignore-click-on-selection/ignore-click-on-selection.directive.ts
+++ b/libs/core/src/lib/utils/directives/ignore-click-on-selection/ignore-click-on-selection.directive.ts
@@ -2,6 +2,11 @@ import { Directive, ElementRef, HostListener, Inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { IgnoreClickOnSelectionDirectiveToken } from './tokens';
 
+/**
+ * Directive will stop propagation and prevent default of click, if selected area is coming from
+ * directive's host element. This gives ability to not cancel all clicks on element, just the ones
+ * which include selection
+ */
 @Directive({
     selector: '[fdIgnoreClickOnSelection]',
     providers: [
@@ -12,8 +17,10 @@ import { IgnoreClickOnSelectionDirectiveToken } from './tokens';
     ]
 })
 export class IgnoreClickOnSelectionDirective {
+    /** @hidden */
     constructor(@Inject(DOCUMENT) private document: Document, private _elementRef: ElementRef<HTMLElement>) {}
 
+    /** Host click listener. Checks for selection existence and if finds one, checks anchor */
     @HostListener('click', ['$event'])
     clicked($event: MouseEvent): void {
         const selection = this.document.getSelection();
@@ -26,9 +33,5 @@ export class IgnoreClickOnSelectionDirective {
                 $event.preventDefault();
             }
         }
-    }
-
-    nativeElement(): Element {
-        return this._elementRef.nativeElement;
     }
 }

--- a/libs/core/src/lib/utils/directives/ignore-click-on-selection/ignore-click-on-selection.directive.ts
+++ b/libs/core/src/lib/utils/directives/ignore-click-on-selection/ignore-click-on-selection.directive.ts
@@ -1,0 +1,34 @@
+import { Directive, ElementRef, HostListener, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { IgnoreClickOnSelectionDirectiveToken } from './tokens';
+
+@Directive({
+    selector: '[fdIgnoreClickOnSelection]',
+    providers: [
+        {
+            provide: IgnoreClickOnSelectionDirectiveToken,
+            useExisting: IgnoreClickOnSelectionDirective
+        }
+    ]
+})
+export class IgnoreClickOnSelectionDirective {
+    constructor(@Inject(DOCUMENT) private document: Document, private _elementRef: ElementRef<HTMLElement>) {}
+
+    @HostListener('click', ['$event'])
+    clicked($event: MouseEvent): void {
+        const selection = this.document.getSelection();
+        if (selection.toString()) {
+            if (
+                this._elementRef.nativeElement.isSameNode(selection.anchorNode) ||
+                this._elementRef.nativeElement.isSameNode(selection.anchorNode.parentElement)
+            ) {
+                $event.stopPropagation();
+                $event.preventDefault();
+            }
+        }
+    }
+
+    nativeElement(): Element {
+        return this._elementRef.nativeElement;
+    }
+}

--- a/libs/core/src/lib/utils/directives/ignore-click-on-selection/ignore-click-on-selection.module.ts
+++ b/libs/core/src/lib/utils/directives/ignore-click-on-selection/ignore-click-on-selection.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IgnoreClickOnSelectionDirective } from './ignore-click-on-selection.directive';
+
+@NgModule({
+    declarations: [IgnoreClickOnSelectionDirective],
+    imports: [CommonModule],
+    exports: [IgnoreClickOnSelectionDirective]
+})
+export class IgnoreClickOnSelectionModule {}

--- a/libs/core/src/lib/utils/directives/ignore-click-on-selection/tokens.ts
+++ b/libs/core/src/lib/utils/directives/ignore-click-on-selection/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const IgnoreClickOnSelectionDirectiveToken = new InjectionToken('Ignore click on selection directive');

--- a/libs/core/src/lib/utils/public_api.ts
+++ b/libs/core/src/lib/utils/public_api.ts
@@ -1,3 +1,5 @@
+export * from './directives/ignore-click-on-selection/ignore-click-on-selection.directive';
+export * from './directives/ignore-click-on-selection/ignore-click-on-selection.module';
 export * from './directives/template/template.directive';
 export * from './directives/template/template.module';
 export * from './directives/only-digits/only-digits.directive';


### PR DESCRIPTION
## Related Issue(s)

closes #7910 

## Description

Added directive, which will listen on element click and if document has active selection from that element it will not propagate click events. This way we do not have to cancel every event, but only the ones which result selection