### PR TITLE
fix(core, platform): dynamic page spacer

### DIFF
--- a/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.html
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.html
@@ -1,2 +1,3 @@
 <ng-content></ng-content>
-<div class="footer-spacer"></div>
+
+<div *ngIf="_dynamicPageComponent?._footerComponent" class="footer-spacer"></div>

--- a/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
@@ -2,6 +2,7 @@ import {
     ChangeDetectionStrategy,
     Component,
     ElementRef,
+    Inject,
     Input,
     OnInit,
     Optional,
@@ -11,7 +12,7 @@ import {
 
 import { DYNAMIC_PAGE_CLASS_NAME } from '../constants';
 import { addClassNameToElement } from '../utils';
-import { DynamicPageComponent } from '../dynamic-page.component';
+import { FD_DYNAMIC_PAGE_COMPONENT, WithDynamicPageFooterComponent } from '../dynamic-page.component';
 
 @Component({
     selector: 'fd-dynamic-page-content',
@@ -36,7 +37,7 @@ export class DynamicPageContentComponent implements OnInit {
     /** @hidden */
     constructor(
         public _renderer: Renderer2,
-        @Optional() public _dynamicPageComponent: DynamicPageComponent,
+        @Inject(FD_DYNAMIC_PAGE_COMPONENT) @Optional() public _dynamicPageComponent: WithDynamicPageFooterComponent,
         private _elementRef: ElementRef<HTMLElement>
     ) {}
 

--- a/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
@@ -4,12 +4,14 @@ import {
     ElementRef,
     Input,
     OnInit,
+    Optional,
     Renderer2,
     ViewEncapsulation
 } from '@angular/core';
 
 import { DYNAMIC_PAGE_CLASS_NAME } from '../constants';
 import { addClassNameToElement } from '../utils';
+import { DynamicPageComponent } from '../dynamic-page.component';
 
 @Component({
     selector: 'fd-dynamic-page-content',
@@ -32,7 +34,11 @@ export class DynamicPageContentComponent implements OnInit {
     id: string;
 
     /** @hidden */
-    constructor(private _elementRef: ElementRef<HTMLElement>, public _renderer: Renderer2) {}
+    constructor(
+        public _renderer: Renderer2,
+        @Optional() public _dynamicPageComponent: DynamicPageComponent,
+        private _elementRef: ElementRef<HTMLElement>
+    ) {}
 
     /** @hidden */
     ngOnInit(): void {

--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.html
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.html
@@ -19,7 +19,9 @@
     </header>
 
     <ng-content select="fd-tab-list"></ng-content>
+
     <ng-content select="fd-dynamic-page-content"></ng-content>
+
     <footer>
         <ng-content select="fd-dynamic-page-footer"></ng-content>
     </footer>

--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
@@ -6,6 +6,7 @@ import {
     ContentChild,
     ElementRef,
     HostBinding,
+    InjectionToken,
     Input,
     OnDestroy,
     Optional,
@@ -28,15 +29,27 @@ import { FlexibleColumnLayoutComponent } from '@fundamental-ngx/core/flexible-co
 import { fromEvent, Observable, Subject } from 'rxjs';
 import { debounceTime, delay, map, takeUntil } from 'rxjs/operators';
 
+export const FD_DYNAMIC_PAGE_COMPONENT = new InjectionToken('FD_DYNAMIC_PAGE_COMPONENT');
+
+export interface WithDynamicPageFooterComponent {
+    _footerComponent: DynamicPageFooterComponent;
+}
+
 @Component({
     selector: 'fd-dynamic-page',
     templateUrl: './dynamic-page.component.html',
     styleUrls: ['./dynamic-page.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [DynamicPageService]
+    providers: [
+        DynamicPageService,
+        {
+            provide: FD_DYNAMIC_PAGE_COMPONENT,
+            useExisting: DynamicPageComponent
+        }
+    ]
 })
-export class DynamicPageComponent implements AfterViewInit, OnDestroy {
+export class DynamicPageComponent implements AfterViewInit, OnDestroy, WithDynamicPageFooterComponent {
     /** Page role  */
     @Input()
     @HostBinding('attr.role')

--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
@@ -18,6 +18,7 @@ import { DYNAMIC_PAGE_CLASS_NAME, DynamicPageBackgroundType, DynamicPageResponsi
 import { DynamicPageContentComponent } from './dynamic-page-content/dynamic-page-content.component';
 import { DynamicPageSubheaderComponent } from './dynamic-page-header/subheader/dynamic-page-subheader.component';
 import { DynamicPageHeaderComponent } from './dynamic-page-header/header/dynamic-page-header.component';
+import { DynamicPageFooterComponent } from './dynamic-page-footer/dynamic-page-footer.component';
 import { DynamicPageWrapperDirective } from './dynamic-page-wrapper.directive';
 import { DynamicPageService } from './dynamic-page.service';
 import { addClassNameToElement, dynamicPageWidthToSize } from './utils';
@@ -100,6 +101,10 @@ export class DynamicPageComponent implements AfterViewInit, OnDestroy {
     /** @hidden reference to content component  */
     @ContentChild(DynamicPageContentComponent)
     _contentComponent: DynamicPageContentComponent;
+
+    /** @hidden reference to footer component  */
+    @ContentChild(DynamicPageFooterComponent)
+    _footerComponent: DynamicPageContentComponent;
 
     /** @hidden reference to tab component */
     @ContentChild(TabListComponent)


### PR DESCRIPTION
## Related Issue(s)

Closes #7914.

## Description

Dynamic page spacer aka footer pad now is shown only if footer component is provided.

This pr also fixes platform dynamic page implicitly.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

<img width="1381" alt="image" src="https://user-images.githubusercontent.com/20265336/161918111-3d08e8cf-4c67-4b59-b257-6530fb89ca73.png">

### After:

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/20265336/161918159-2348bb47-a7c9-4465-b839-b7d97b27a1b1.png">