### PR TITLE
feat(platform): enhancement of form generator and form container

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-component-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-component-example.component.ts
@@ -45,7 +45,7 @@ export class PlatformFormGeneratorCustomComponentExampleComponent {
         {
             type: 'slider',
             name: 'some_slider',
-            message: 'Slider component',
+            message: 'Slider Component',
             default: { value: 30, label: 'Thirty' },
             choices: [
                 { value: 10, label: 'Ten' },

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-error-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-error-example.component.ts
@@ -15,7 +15,7 @@ export class PlatformFormGeneratorCustomErrorExampleComponent {
     formItems: DynamicFormItem[] = [
         {
             type: 'input',
-            message: 'Custom validation error example',
+            message: 'Custom Validation Error Example',
             name: 'custom_validation_error_example',
             required: true,
             validate: (value: string) => (value !== 'abc' ? null : "This field value should not be equal to 'abc'"),
@@ -25,7 +25,7 @@ export class PlatformFormGeneratorCustomErrorExampleComponent {
         },
         {
             type: 'input',
-            message: 'Default validation error example',
+            message: 'Default Validation Error Example',
             name: 'default_validation_error_example',
             validators: [Validators.required],
             guiOptions: {
@@ -35,7 +35,7 @@ export class PlatformFormGeneratorCustomErrorExampleComponent {
         {
             type: 'input',
             name: 'custom_validation_example',
-            message: 'Custom generic validation error example',
+            message: 'Custom Generic Validation Error Example',
             validators: [Validators.pattern('^\\d+$')],
             guiOptions: {
                 hint: 'This field will fail validation if non-numeric symbols are present in the input'

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-field-layout-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-field-layout-example.component.ts
@@ -28,7 +28,7 @@ export class PlatformFormGeneratorCustomFieldLayoutExampleComponent {
         {
             type: 'input',
             name: 'formGroupColumnDefinition',
-            message: 'Form container column layout definition',
+            message: 'Form Container Column Layout Definition',
             default: 'John',
             placeholder: 'Please provide your first name',
             guiOptions: {
@@ -39,7 +39,7 @@ export class PlatformFormGeneratorCustomFieldLayoutExampleComponent {
         },
         {
             name: 'personalInformation',
-            message: 'Form field group column layout definition',
+            message: 'Form Field Group Column Layout Definition',
             guiOptions: {
                 labelColumnLayout: { S: 12, M: 4 },
                 fieldColumnLayout: { S: 12, M: 8 }
@@ -48,7 +48,7 @@ export class PlatformFormGeneratorCustomFieldLayoutExampleComponent {
                 {
                     type: 'input',
                     name: 'firstName',
-                    message: 'Your name',
+                    message: 'Your Name',
                     default: 'John',
                     placeholder: 'Please provide your first name',
                     guiOptions: {
@@ -60,7 +60,7 @@ export class PlatformFormGeneratorCustomFieldLayoutExampleComponent {
                 {
                     type: 'input',
                     name: 'secondName',
-                    message: 'Your name',
+                    message: 'Your Name',
                     default: 'Doe',
                     placeholder: 'Please provide your second name',
                     guiOptions: {
@@ -73,13 +73,13 @@ export class PlatformFormGeneratorCustomFieldLayoutExampleComponent {
         },
         {
             name: 'contactInformation',
-            message: 'Individual column layout per field',
+            message: 'Individual Column Layout Per Field',
             items: [
                 {
                     type: 'input',
                     name: 'state',
                     message: 'State/Province',
-                    placeholder: 'Please provide your state or province name',
+                    placeholder: 'Please Provide Your State Or Province Name',
                     guiOptions: {
                         hint: 'Some contextual hint',
                         column: 1,
@@ -92,7 +92,7 @@ export class PlatformFormGeneratorCustomFieldLayoutExampleComponent {
                     type: 'input',
                     name: 'street',
                     message: 'Street',
-                    placeholder: 'Please provide your street name',
+                    placeholder: 'Please Provide Your Street Name',
                     guiOptions: {
                         hint: 'Some contextual hint',
                         column: 2,

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-field-layout-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-custom-field-layout-example.component.ts
@@ -41,6 +41,7 @@ export class PlatformFormGeneratorCustomFieldLayoutExampleComponent {
             name: 'personalInformation',
             message: 'Form Field Group Column Layout Definition',
             guiOptions: {
+                hint: 'Some hint?',
                 labelColumnLayout: { S: 12, M: 4 },
                 fieldColumnLayout: { S: 12, M: 8 }
             },

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-example.component.ts
@@ -44,7 +44,7 @@ export class PlatformFormGeneratorExampleComponent {
     questions: DynamicFormItem[] = [
         {
             name: 'some',
-            message: 'Some group name',
+            message: 'Some Group Name',
             guiOptions: {
                 hint: 'Some contextual hint on group header'
             },
@@ -52,7 +52,7 @@ export class PlatformFormGeneratorExampleComponent {
                 {
                     type: 'input',
                     name: 'nameInGroup',
-                    message: 'Your name (group)',
+                    message: 'Your Name (Group)',
                     default: 'John',
                     placeholder: 'Please provide your name',
                     guiOptions: {
@@ -78,7 +78,7 @@ export class PlatformFormGeneratorExampleComponent {
         {
             type: 'input',
             name: 'name',
-            message: 'Your name',
+            message: 'Your Name',
             default: 'John',
             placeholder: 'Please provide your name',
             guiOptions: {
@@ -116,7 +116,7 @@ export class PlatformFormGeneratorExampleComponent {
             type: 'number',
             name: 'age',
             controlType: 'number',
-            message: () => 'Your age',
+            message: () => 'Your Age',
             default: '18',
             validators: [Validators.required],
             guiOptions: {
@@ -126,7 +126,7 @@ export class PlatformFormGeneratorExampleComponent {
         {
             type: 'editor',
             name: 'bio',
-            message: 'Your biography',
+            message: 'Your Biography',
             guiOptions: {
                 column: 1
             }
@@ -134,7 +134,7 @@ export class PlatformFormGeneratorExampleComponent {
         {
             type: 'checkbox',
             name: 'citizenship',
-            message: 'Your citizenship',
+            message: 'Your Citizenship',
             guiOptions: {
                 inline: true,
                 column: 2
@@ -153,7 +153,7 @@ export class PlatformFormGeneratorExampleComponent {
         {
             type: 'list',
             name: 'department',
-            message: 'Department you work in',
+            message: 'Department You Work In',
             validators: [Validators.required],
             default: 'IT',
             choices: ['IT', 'Accounting', 'Management'],
@@ -164,7 +164,7 @@ export class PlatformFormGeneratorExampleComponent {
         {
             type: 'list',
             name: 'main_speciality',
-            message: 'Main speciality',
+            message: 'Main Speciality',
             validators: [Validators.required],
             choices: async () => {
                 await dummyAwaitablePromise();
@@ -181,7 +181,7 @@ export class PlatformFormGeneratorExampleComponent {
         {
             type: 'confirm',
             name: 'agree',
-            message: 'Do you agree with terms and conditions?',
+            message: 'Do You Agree With Terms And Conditions?',
             choices: ['Yes', 'No'],
             validators: [Validators.required],
             validate: async (value) => {
@@ -195,7 +195,7 @@ export class PlatformFormGeneratorExampleComponent {
         {
             type: 'radio',
             name: 'choose_best_option',
-            message: 'Primary front-end framework you use',
+            message: 'Primary Front-end Framework You Use',
             choices: ['Angular', 'React', 'VueJS'],
             guiOptions: {
                 column: 2
@@ -206,7 +206,7 @@ export class PlatformFormGeneratorExampleComponent {
         {
             type: 'datepicker',
             name: 'birthday',
-            message: 'Your birthday',
+            message: 'Your Birthday',
             guiOptions: {
                 column: 1
             },
@@ -218,7 +218,7 @@ export class PlatformFormGeneratorExampleComponent {
         {
             type: 'switch',
             name: 'enable_feature',
-            message: 'Enable some analytics',
+            message: 'Enable Some Analytics',
             default: false,
             guiOptions: {
                 additionalData: {

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-field-layout-example.component.ts
@@ -44,7 +44,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'input',
             name: 'name1',
-            message: 'Your name: XL: 1, L: 2, M: 1, S: 2',
+            message: 'Your Name: XL: 1, L: 2, M: 1, S: 2',
             default: 'John',
             placeholder: 'Please provide your name',
             guiOptions: {
@@ -83,7 +83,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
             type: 'number',
             name: 'age1',
             controlType: 'number',
-            message: () => 'Your age: XL: 1, L: 2, M: 1, S: 1',
+            message: () => 'Your Age: XL: 1, L: 2, M: 1, S: 1',
             default: '18',
             validators: [Validators.required],
             guiOptions: {
@@ -94,7 +94,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'editor',
             name: 'bio1',
-            message: 'Your biography: XL: 2, L: 1, M: 2, S: 1',
+            message: 'Your Biography: XL: 2, L: 1, M: 2, S: 1',
             guiOptions: {
                 columnLayout: { XL: 2, L: 1, M: 2, S: 1 },
                 hint: 'XL: 2, L: 1, M: 2, S: 1'
@@ -103,7 +103,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'checkbox',
             name: 'citizenship1',
-            message: 'Your citizenship: XL: 2 true, L: 1 false, M: 2 true, S: 1 false',
+            message: 'Your Citizenship: XL: 2 true, L: 1 false, M: 2 true, S: 1 false',
             guiOptions: {
                 inline: true,
                 columnLayout: { XL: 2, L: 1, M: 2, S: 1 },
@@ -124,7 +124,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'list',
             name: 'department1',
-            message: 'Department you work in: column: 2',
+            message: 'Department You Work In: column: 2',
             validators: [Validators.required],
             default: 'IT',
             choices: ['IT', 'Accounting', 'Management'],
@@ -136,7 +136,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'list',
             name: 'main_speciality1',
-            message: 'Main speciality: XL: 2, L: 1, M: 1, S: 1',
+            message: 'Main Speciality: XL: 2, L: 1, M: 1, S: 1',
             validators: [Validators.required],
             choices: async () => {
                 await dummyAwaitablePromise();
@@ -154,7 +154,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'confirm',
             name: 'agree1',
-            message: 'Do you agree with terms and conditions?: XL: 2, L: 1, M: 2, S: 1',
+            message: 'Do You Agree With Terms And Conditions?: XL: 2, L: 1, M: 2, S: 1',
             choices: ['Yes', 'No'],
             validators: [Validators.required],
             validate: async (value) => {
@@ -169,7 +169,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'radio',
             name: 'choose_best_option1',
-            message: 'Primary front-end framework: XL: 2 false, L: 1 true, M: 1 false, S: 1 true',
+            message: 'Primary Front-end Framework: XL: 2 false, L: 1 true, M: 1 false, S: 1 true',
             choices: ['Angular', 'React', 'VueJS'],
             guiOptions: {
                 columnLayout: { XL: 2, L: 1, M: 1 },
@@ -182,7 +182,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'datepicker',
             name: 'birthday1',
-            message: 'Your birthday: XL: 1, L: 2, M: 1, S: 1',
+            message: 'Your Birthday: XL: 1, L: 2, M: 1, S: 1',
             guiOptions: {
                 columnLayout: { XL: 1, L: 2, M: 1, S: 1 },
                 hint: 'XL: 1, L: 2, M: 1, S: 1'
@@ -195,7 +195,7 @@ export class PlatformFormGeneratorFieldLayoutExampleComponent {
         {
             type: 'switch',
             name: 'enable_feature1',
-            message: 'Enable some analytics',
+            message: 'Enable Some Analytics',
             default: false,
             guiOptions: {
                 additionalData: {

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-grouping-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-grouping-example.component.ts
@@ -27,14 +27,14 @@ export class PlatformFormGeneratorGroupingExampleComponent {
     questions: DynamicFormItem[] = [
         {
             name: 'personalInformation',
-            message: 'Personal information',
+            message: 'Personal Information',
             items: [
                 {
                     type: 'input',
                     name: 'firstName',
                     message: 'Your name',
                     default: 'John',
-                    placeholder: 'Please provide your first name',
+                    placeholder: 'Please Provide Your First Name',
                     guiOptions: {
                         hint: 'Some contextual hint',
                         column: 1
@@ -46,7 +46,7 @@ export class PlatformFormGeneratorGroupingExampleComponent {
                     name: 'secondName',
                     message: 'Your name',
                     default: 'Doe',
-                    placeholder: 'Please provide your second name',
+                    placeholder: 'Please Provide Your Second Name',
                     guiOptions: {
                         hint: 'Some contextual hint',
                         column: 2
@@ -57,7 +57,7 @@ export class PlatformFormGeneratorGroupingExampleComponent {
         },
         {
             name: 'contactInformation',
-            message: 'Contact information',
+            message: 'Contact Information',
             items: [
                 {
                     type: 'input',

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-inline-help-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-inline-help-example.component.ts
@@ -52,7 +52,7 @@ export class PlatformFormGeneratorInlineHelpExampleComponent {
     formItemsHintOnGroupHeader: DynamicFormItem[] = [
         {
             name: 'firstAndLastName',
-            message: 'First and last name',
+            message: 'First And Last Name',
             guiOptions: {
                 hint: 'Some contextual hint on group header'
             },

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-no-colons-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-no-colons-example.component.ts
@@ -25,7 +25,7 @@ export class PlatformFormGeneratorNoColonsExampleComponent {
         {
             type: 'input',
             name: 'labelWithoutColon',
-            message: 'Label without colon',
+            message: 'Label Without Colon',
             guiOptions: {
                 hint: 'Some contextual hint',
                 column: 1,
@@ -35,7 +35,7 @@ export class PlatformFormGeneratorNoColonsExampleComponent {
         {
             type: 'input',
             name: 'labelWithColon',
-            message: 'Label with colon',
+            message: 'Label With Colon',
             guiOptions: {
                 hint: 'Some contextual hint',
                 column: 1,

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-observable-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-observable-example.component.ts
@@ -47,7 +47,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
         {
             type: 'input',
             name: 'name2',
-            message: 'Your name',
+            message: 'Your Name',
             default: 'John',
             placeholder: () => of('Please provide your name').pipe(delay(400)),
             guiOptions: {
@@ -82,7 +82,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
             type: 'number',
             name: 'age2',
             controlType: 'number',
-            message: () => of('Your age').pipe(delay(400)),
+            message: () => of('Your Age').pipe(delay(400)),
             default: '18',
             validators: [Validators.required],
             guiOptions: {
@@ -92,7 +92,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
         {
             type: 'editor',
             name: 'bio2',
-            message: 'Your biography',
+            message: 'Your Biography',
             guiOptions: {
                 column: 1
             }
@@ -100,7 +100,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
         {
             type: 'checkbox',
             name: 'citizenship2',
-            message: 'Your citizenship',
+            message: 'Your Citizenship',
             validators: [Validators.required],
             guiOptions: {
                 inline: true,
@@ -120,7 +120,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
         {
             type: 'list',
             name: 'department2',
-            message: 'Department you work in',
+            message: 'Department You Work In',
             validators: [Validators.required],
             default: 'IT',
             choices: () => of(['IT', 'Accounting', 'Management']),
@@ -131,7 +131,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
         {
             type: 'list',
             name: 'main_speciality2',
-            message: 'Main speciality',
+            message: 'Main Speciality',
             validators: [Validators.required],
             choices: () => of(['Front-end', 'Back-end']),
             when: (formValue: any) => of(formValue.department === 'IT'),
@@ -142,7 +142,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
         {
             type: 'confirm',
             name: 'agree2',
-            message: 'Do you agree with terms and conditions?',
+            message: 'Do You Agree With Terms And Conditions?',
             choices: ['Yes', 'No'],
             validators: [Validators.required],
             validate: (value) => of(value === 'Yes' ? null : 'You must agree'),
@@ -153,7 +153,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
         {
             type: 'radio',
             name: 'choose_best_option2',
-            message: 'Primary front-end framework you use',
+            message: 'Primary Front-end Framework You Use',
             choices: ['Angular', 'React', 'VueJS'],
             guiOptions: {
                 column: 2
@@ -164,7 +164,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
         {
             type: 'datepicker',
             name: 'birthday2',
-            message: 'Your birthday',
+            message: 'Your Birthday',
             guiOptions: {
                 column: 1
             },
@@ -176,7 +176,7 @@ export class PlatformFormGeneratorObservableExampleComponent {
         {
             type: 'switch',
             name: 'enable_feature2',
-            message: 'Enable some analytics',
+            message: 'Enable Some Analytics',
             default: false,
             guiOptions: {
                 additionalData: {

--- a/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-programatic-submit.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-forms/platform-form-generator/platform-form-generator-examples/platform-form-generator-programatic-submit.component.ts
@@ -47,7 +47,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
         {
             type: 'input',
             name: 'name3',
-            message: 'Your name',
+            message: 'Your Name',
             default: 'John',
             guiOptions: {
                 hint: 'Some contextual hint',
@@ -81,7 +81,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
             type: 'number',
             name: 'age3',
             controlType: 'number',
-            message: () => of('Your age').pipe(delay(400)),
+            message: () => of('Your Age').pipe(delay(400)),
             default: '18',
             validators: [Validators.required],
             guiOptions: {
@@ -91,7 +91,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
         {
             type: 'editor',
             name: 'bio3',
-            message: 'Your biography',
+            message: 'Your Biography',
             guiOptions: {
                 column: 1
             }
@@ -99,7 +99,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
         {
             type: 'checkbox',
             name: 'citizenship3',
-            message: 'Your citizenship',
+            message: 'Your Citizenship',
             guiOptions: {
                 inline: true,
                 column: 2
@@ -119,7 +119,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
         {
             type: 'list',
             name: 'department3',
-            message: 'Department you work in',
+            message: 'Department You Work In',
             validators: [Validators.required],
             default: 'IT',
             choices: () => of(['IT', 'Accounting', 'Management']),
@@ -130,7 +130,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
         {
             type: 'list',
             name: 'main_speciality3',
-            message: 'Main speciality',
+            message: 'Main Speciality',
             validators: [Validators.required],
             choices: () => of(['Front-end', 'Back-end']),
             when: (formValue: any) => of(formValue.department === 'IT'),
@@ -141,7 +141,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
         {
             type: 'confirm',
             name: 'agree3',
-            message: 'Do you agree with terms and conditions?',
+            message: 'Do You Agree With Terms And Conditions?',
             choices: ['Yes', 'No'],
             validators: [Validators.required],
             validate: (value) => of(value === 'Yes' ? null : 'You must agree'),
@@ -152,7 +152,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
         {
             type: 'radio',
             name: 'choose_best_option3',
-            message: 'Primary front-end framework you use',
+            message: 'Primary Front-end Framework You Use',
             choices: ['Angular', 'React', 'VueJS'],
             guiOptions: {
                 column: 2
@@ -163,7 +163,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
         {
             type: 'datepicker',
             name: 'birthday3',
-            message: 'Your birthday',
+            message: 'Your Birthday',
             guiOptions: {
                 column: 1
             },
@@ -175,7 +175,7 @@ export class PlatformFormGeneratorProgramaticSubmitComponent {
         {
             type: 'switch',
             name: 'enable_feature3',
-            message: 'Enable some analytics',
+            message: 'Enable Some Analytics',
             default: false,
             guiOptions: {
                 additionalData: {

--- a/e2e/wdio/platform/fixtures/appData/input-page-contents.ts
+++ b/e2e/wdio/platform/fixtures/appData/input-page-contents.ts
@@ -3,7 +3,7 @@ export const labelsArray = [
     'Text Input Field',
     'Number Input Field',
     'Compact Input Field',
-    'Readonly Input Field',
+    'ReadOnly Input Field',
     'Disabled Input Field',
     'Inline Help Input Field',
     'Password Input Field'

--- a/e2e/wdio/platform/fixtures/appData/textarea-page-content.ts
+++ b/e2e/wdio/platform/fixtures/appData/textarea-page-content.ts
@@ -1,4 +1,4 @@
-export const basic_text_area_label = 'Basic Textarea With Platform Forms';
+export const basic_text_area_label = 'Basic Textarea with Platform Forms';
 export const basic_text_area_placeholder = 'Start Entering Detailed Description';
 export const basic_text_area_popover = 'This Is Tooltip Help';
 export const readonly_text_area_label = 'Readonly Textarea';

--- a/e2e/wdio/platform/pages/form-container.po.ts
+++ b/e2e/wdio/platform/pages/form-container.po.ts
@@ -8,7 +8,7 @@ export class FormContainerPo extends BaseComponentPo {
     checkboxLabel = 'fd-checkbox label';
     formGroup = 'fdp-form-group';
     popover = '.cdk-overlay-container .cdk-overlay-pane';
-    helpIcon = '.sap-icon--message-information';
+    helpIcon = '.sap-icon--hint';
     fdSwitch = 'fd-switch label';
     dropdownOption = '.cdk-overlay-container fd-option';
     dropdownOptionAlt = 'ul .fd-list__item span';

--- a/e2e/wdio/platform/pages/form-generator.po.ts
+++ b/e2e/wdio/platform/pages/form-generator.po.ts
@@ -20,7 +20,7 @@ export class FormGeneratorPo extends BaseComponentPo {
     checkbox = '.fd-checkbox[aria-labelledby*="citizen"]';
     submitButton = '.fd-button[type="submit"]';
     calendarInputGroup = '.fd-input-group';
-    mainSpecialitySelect = ' .fd-select__control[aria-labelledby="Main speciality"]';
+    mainSpecialitySelect = ' .fd-select__control[aria-labelledby="Main Speciality"]';
     errorMessage = '.fd-form-message--error span';
     formValue = 'p.ng-star-inserted';
     sliderPoint = '.fd-slider__handle';

--- a/e2e/wdio/platform/pages/input-group.po.ts
+++ b/e2e/wdio/platform/pages/input-group.po.ts
@@ -38,7 +38,7 @@ export class InputGroupPo extends BaseComponentPo {
     withFormInputTextAddon = 'fdp-input-group-form-example fdp-input-group-addon-body';
     withFormInputButtonAddon = 'fdp-input-group-form-example fdp-input-group-addon-body button';
     withFormInputLabel = 'fdp-input-group-form-example label > span';
-    withFormInputQuestionMark = 'fdp-input-group-form-example .sap-icon--message-information';
+    withFormInputQuestionMark = 'fdp-input-group-form-example .sap-icon--hint';
     withFormInputAsterixMark = 'fdp-input-group-form-example label span';
     withFormInputErrorTooltip = '[type="error"] span';
     withFormInputInfoTooltip = '.fd-inline-help__content';

--- a/e2e/wdio/platform/pages/input.po.ts
+++ b/e2e/wdio/platform/pages/input.po.ts
@@ -18,7 +18,7 @@ export class InputPo extends BaseComponentPo {
     submitBtn = 'button[type="submit"]';
     errorTextAttr = 'fd-form-message span';
     requiredInputLabel = 'fdp-platform-input-reactive-validation-example .fd-form-label--required';
-    questionMarkSpan = '.sap-icon--message-information';
+    questionMarkSpan = '.sap-icon--hint';
     inputsLabels = '.fd-container label .fd-form-label';
     inputsArray = 'input.fd-input';
     autocompleteInput = 'input#form-input-10';

--- a/e2e/wdio/platform/tests/form-container.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/form-container.e2e-spec.ts
@@ -10,7 +10,6 @@ import {
     getValue,
     isElementClickable,
     isElementDisplayed,
-    mouseHoverElement,
     refreshPage,
     scrollIntoView,
     sendKeys,
@@ -84,7 +83,7 @@ describe('Form Container test suite', () => {
             checkAddingText(recommendedExampleTextArea);
         });
 
-        it('should show popover when hovering ? icon', () => {
+        it('should show popover when clicking ? icon', () => {
             refreshPage();
             waitForPresent(formContainerPage.title);
             checkHelpPopover(recommendedExampleHelpIcon);
@@ -104,7 +103,7 @@ describe('Form Container test suite', () => {
             checkAddingText(possibleExampleTextArea);
         });
 
-        it('should show popover when hovering ? icon', () => {
+        it('should show popover when clicking ? icon', () => {
             refreshPage();
             waitForPresent(formContainerPage.title);
             checkHelpPopover(possibleExampleHelpIcon);
@@ -124,7 +123,7 @@ describe('Form Container test suite', () => {
             checkAddingText(notRecommendedExampleTextArea);
         });
 
-        it('should show popover when hovering ? icon', () => {
+        it('should show popover when clicking ? icon', () => {
             refreshPage();
             waitForPresent(formContainerPage.title);
             checkHelpPopover(notRecommendedExampleHelpIcon);
@@ -144,7 +143,7 @@ describe('Form Container test suite', () => {
             checkAddingText(complexExampleTextArea);
         });
 
-        it('should show popover when hovering ? icon', () => {
+        it('should show popover when clicking ? icon', () => {
             if (browserIsSafari()) {
                 // mouse hover method not working correctly on Safari
                 return;
@@ -228,7 +227,7 @@ describe('Form Container test suite', () => {
             expect(isElementClickable(formExampleSwitch)).toBe(true, 'switch is not clickable');
         });
 
-        it('should show popover when hovering ? icon', () => {
+        it('should show popover when clicking ? icon', () => {
             refreshPage();
             waitForPresent(formContainerPage.title);
             checkHelpPopover(formExampleHelpIcon);
@@ -252,7 +251,7 @@ describe('Form Container test suite', () => {
             for (let i = 0; i < labelCount; i++) {
                 const labelText = getText(changeExampleTextAreaLabel, i);
                 scrollIntoView(changeExampleHelpIcon, i);
-                mouseHoverElement(changeExampleHelpIcon, i);
+                click(changeExampleHelpIcon, i);
                 waitForElDisplayed(popover);
 
                 expect(getText(popover).toLowerCase()).toEqual(labelText.toLowerCase());
@@ -317,11 +316,7 @@ describe('Form Container test suite', () => {
             expect(getValue(isInlineExampleCombobox)).toEqual(firstOption);
         });
 
-        it('should show popover when hovering ? icon', () => {
-            if (browserIsSafari()) {
-                // mouse hover method not working correctly on Safari
-                return;
-            }
+        it('should show popover when clicking ? icon', () => {
             refreshPage();
             waitForPresent(formContainerPage.title);
 
@@ -329,7 +324,7 @@ describe('Form Container test suite', () => {
 
             for (let i = 0; i < iconLength; i++) {
                 scrollIntoView(isInlineExampleHelpIcon, i);
-                mouseHoverElement(isInlineExampleHelpIcon, i);
+                click(isInlineExampleHelpIcon, i);
 
                 expect(waitForPresent(popover)).toBe(true, `tooltip for icon ${i} not displayed`);
                 expect(['', null, undefined]).not.toContain(getText(popover));
@@ -373,15 +368,11 @@ describe('Form Container test suite', () => {
     }
 
     function checkHelpPopover(selector: string): void {
-        if (browserIsSafari()) {
-            // mouse hover not working correctly on Safari
-            return;
-        }
         const iconLength = getElementArrayLength(selector);
 
         for (let i = 0; i < iconLength; i++) {
             scrollIntoView(selector, i);
-            mouseHoverElement(selector, i);
+            click(selector, i);
 
             expect(waitForPresent(popover)).toBe(true, `tooltip for icon ${i} not displayed`);
             expect(['This is tooltip help', 'This is tooltip to help']).toContain(getText(popover));

--- a/e2e/wdio/platform/tests/form-generator.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/form-generator.e2e-spec.ts
@@ -244,7 +244,7 @@ describe('Form generator test suite', () => {
         if (section === defaultExample) {
             expect(getElementClass(section + mainSpecialitySelect)).toContain(
                 'is-error',
-                'element is not highlited by error'
+                'element is not highlighted by error'
             );
         }
 

--- a/e2e/wdio/platform/tests/input-group.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/input-group.e2e-spec.ts
@@ -181,7 +181,7 @@ describe('Input Group should', () => {
         }
         waitForElDisplayed(withFormInput);
         scrollIntoView(withFormInput);
-        mouseHoverElement(withFormInputQuestionMark);
+        click(withFormInputQuestionMark);
         expect(getText(withFormInputInfoTooltip)).toBe('This is tooltip to help');
     });
 

--- a/libs/core/src/lib/form/form-label/form-label.component.html
+++ b/libs/core/src/lib/form/form-label/form-label.component.html
@@ -1,15 +1,17 @@
 <ng-template #inlineHelpRef>
-    <fd-icon
-        *ngIf="inlineHelpTitle"
-        [class.fd-form-label__help]="true"
-        [class.fd-form-label__help--after]="inlineHelpPlacement === 'after'"
-        [glyph]="inlineHelpGlyph"
-        [triggers]="inlineHelpTriggers"
-        [fd-inline-help]="inlineHelpTitle"
-        [ariaLabel]="inlineHelpTitle"
-        [placement]="inlineHelpBodyPlacement"
-        tabindex="0"
-    ></fd-icon>
+    <span fd-link [undecorated]="true">
+        <fd-icon
+            *ngIf="inlineHelpTitle"
+            class="fd-form-label__help"
+            [class.fd-form-label__help--after]="inlineHelpPlacement === 'after'"
+            [glyph]="inlineHelpGlyph"
+            [triggers]="inlineHelpTriggers"
+            [fd-inline-help]="inlineHelpTitle"
+            [ariaLabel]="inlineHelpTitle"
+            [placement]="inlineHelpBodyPlacement"
+            tabindex="0"
+        ></fd-icon>
+    </span>
 </ng-template>
 
 <ng-container *ngIf="inlineHelpPlacement === 'before' && inlineHelpTitle">

--- a/libs/core/src/lib/form/form-label/form-label.component.scss
+++ b/libs/core/src/lib/form/form-label/form-label.component.scss
@@ -62,10 +62,7 @@ $form-label-bottom-spacing: 0.125rem;
 
 .fd-form-label__help {
     position: relative;
-    top: 50%;
-    transform: translateY(3%);
-    align-items: center;
-    display: flex;
+    vertical-align: middle;
 
     @include left-placed();
 

--- a/libs/core/src/lib/form/form-label/form-label.module.ts
+++ b/libs/core/src/lib/form/form-label/form-label.module.ts
@@ -3,9 +3,10 @@ import { NgModule } from '@angular/core';
 import { FormLabelComponent } from './form-label.component';
 import { IconModule } from '@fundamental-ngx/core/icon';
 import { InlineHelpModule } from '@fundamental-ngx/core/inline-help';
+import { LinkModule } from '@fundamental-ngx/core/link';
 
 @NgModule({
-    imports: [CommonModule, IconModule, InlineHelpModule],
+    imports: [CommonModule, IconModule, InlineHelpModule, LinkModule],
     exports: [FormLabelComponent],
     declarations: [FormLabelComponent]
 })

--- a/libs/core/src/lib/link/link.component.scss
+++ b/libs/core/src/lib/link/link.component.scss
@@ -1,1 +1,14 @@
 @import '~fundamental-styles/dist/link';
+
+.fd-link {
+    &--undecorated {
+        &:hover {
+            text-decoration: none;
+
+            [class*='sap-icon'],
+            &[class*='sap-icon'] {
+                text-decoration: none;
+            }
+        }
+    }
+}

--- a/libs/core/src/lib/link/link.component.ts
+++ b/libs/core/src/lib/link/link.component.ts
@@ -39,6 +39,9 @@ export class LinkComponent implements OnChanges, OnInit, CssClassBuilder {
     @Input()
     subtle: boolean;
 
+    @Input()
+    undecorated: boolean;
+
     /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
@@ -58,6 +61,7 @@ export class LinkComponent implements OnChanges, OnInit, CssClassBuilder {
             this.disabled ? 'is-disabled' : '',
             this.inverted ? `fd-link--inverted` : '',
             this.subtle ? 'fd-link--subtle' : '',
+            this.undecorated ? 'fd-link--undecorated' : '',
             this.class
         ];
     }

--- a/libs/core/src/lib/link/link.component.ts
+++ b/libs/core/src/lib/link/link.component.ts
@@ -39,6 +39,7 @@ export class LinkComponent implements OnChanges, OnInit, CssClassBuilder {
     @Input()
     subtle: boolean;
 
+    /** Whether user wants to have a link without underline decoration */
     @Input()
     undecorated: boolean;
 

--- a/libs/platform/src/lib/form/form-generator/config/default-form-generator-hint-options.ts
+++ b/libs/platform/src/lib/form/form-generator/config/default-form-generator-hint-options.ts
@@ -3,7 +3,7 @@ import { FieldHintOptions } from '@fundamental-ngx/platform/shared';
 export const defaultFormGeneratorHintOptions: Omit<FieldHintOptions, 'text'> = {
     placement: 'left',
     position: 'after',
-    trigger: ['mouseenter', 'mouseleave', 'focusin', 'focusout'],
-    glyph: 'message-information',
+    trigger: ['click', 'focusout'],
+    glyph: 'hint',
     target: 'auto'
 };

--- a/libs/platform/src/lib/form/form-generator/config/default-form-generator-hint-options.ts
+++ b/libs/platform/src/lib/form/form-generator/config/default-form-generator-hint-options.ts
@@ -1,7 +1,7 @@
 import { FieldHintOptions } from '@fundamental-ngx/platform/shared';
 
 export const defaultFormGeneratorHintOptions: Omit<FieldHintOptions, 'text'> = {
-    placement: 'left',
+    placement: 'right',
     position: 'after',
     trigger: ['click', 'focusout'],
     glyph: 'hint',

--- a/libs/platform/src/lib/form/form-group/config/default-form-field-hint-options.ts
+++ b/libs/platform/src/lib/form/form-group/config/default-form-field-hint-options.ts
@@ -3,7 +3,7 @@ import { FieldHintOptions } from '@fundamental-ngx/platform/shared';
 export const defaultFormFieldHintOptions: Omit<FieldHintOptions, 'text'> = {
     placement: 'right',
     position: 'after',
-    trigger: ['mouseenter', 'mouseleave', 'focusin', 'focusout'],
-    glyph: 'message-information',
+    trigger: ['click', 'focusout'],
+    glyph: 'hint',
     target: 'auto'
 };

--- a/libs/platform/src/lib/form/form-group/fdp-form.module.ts
+++ b/libs/platform/src/lib/form/form-group/fdp-form.module.ts
@@ -12,6 +12,7 @@ import { InputMessageGroupWithTemplate } from '../input-message-group-with-templ
 import { FormFieldGroupComponent } from './form-field-group/form-field-group.component';
 import { FormFieldControlExtrasComponent } from './form-field-extras/form-field-extras.component';
 import { FormGroupHeaderComponent } from './form-group-header/form-group-header.component';
+import { LinkModule } from '@fundamental-ngx/core/link';
 
 const EXPORTABLE_DECLARATIONS = [
     FormGroupComponent,
@@ -31,7 +32,8 @@ const EXPORTABLE_DECLARATIONS = [
         FdFormModule,
         InlineHelpModule,
         PopoverModule,
-        IconModule
+        IconModule,
+        LinkModule
     ],
     exports: [...EXPORTABLE_DECLARATIONS]
 })

--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
@@ -46,7 +46,7 @@
             [inlineHelpTriggers]="hintOptions.trigger"
             [alignLabelEnd]="isHorizontal$ | async"
         >
-            <span [id]="'fdp-form-label-content-' + id">{{ label | titlecase }}</span>
+            <span [id]="'fdp-form-label-content-' + id">{{ label }}</span>
         </label>
     </ng-container>
     <ng-template #withoutHint>
@@ -56,7 +56,7 @@
             fd-form-label
             [alignLabelEnd]="isHorizontal$ | async"
         >
-            <span [id]="'fdp-form-label-content-' + id">{{ label | titlecase }}</span>
+            <span [id]="'fdp-form-label-content-' + id">{{ label }}</span>
         </label>
     </ng-template>
 </ng-template>

--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.html
@@ -10,17 +10,7 @@
             <ng-template [ngTemplateOutlet]="labelTemplate"></ng-template>
         </div>
         <ng-container *ngTemplateOutlet="withFormMessage"></ng-container>
-        <div class="fd-col" [class]="_gapColumnLayoutClass" [style.text-overflow]="'clip'">
-            <ng-container *ngIf="hintTarget === 'input' && hintOptions.text">
-                <fd-icon
-                    [fd-inline-help]="hintOptions.text"
-                    [glyph]="hintOptions.glyph"
-                    [placement]="hintOptions.placement"
-                    [triggers]="hintOptions.trigger"
-                >
-                </fd-icon>
-            </ng-container>
-        </div>
+        <ng-container *ngTemplateOutlet="gapTemplate"></ng-container>
     </div>
     <span aria-hidden="true" style="display: none" [id]="'fdp-form-hint-' + id">{{ hintOptions.text }}</span>
 </ng-template>
@@ -68,5 +58,25 @@
         >
             <span [id]="'fdp-form-label-content-' + id">{{ label | titlecase }}</span>
         </label>
+    </ng-template>
+</ng-template>
+
+<ng-template #gapTemplate>
+    <ng-container *ngIf="hintTarget === 'input' && hintOptions.text; else withoutHint">
+        <div class="fd-col fd-form-field-inline-help-container" [class]="_gapColumnLayoutClass">
+            <span fd-link [undecorated]="true">
+                <fd-icon
+                    [fd-inline-help]="hintOptions.text"
+                    [glyph]="hintOptions.glyph"
+                    [placement]="hintOptions.placement"
+                    [triggers]="hintOptions.trigger"
+                    tabindex="0"
+                >
+                </fd-icon>
+            </span>
+        </div>
+    </ng-container>
+    <ng-template #withoutHint>
+        <div class="fd-col" [class]="_gapColumnLayoutClass"></div>
     </ng-template>
 </ng-template>

--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.scss
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.scss
@@ -3,3 +3,9 @@
     width: 100%;
     white-space: nowrap;
 }
+.fd-form-field-inline-help-container {
+    text-overflow: clip;
+    .fd-link {
+        text-decoration: none;
+    }
+}

--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.scss
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.scss
@@ -5,7 +5,4 @@
 }
 .fd-form-field-inline-help-container {
     text-overflow: clip;
-    .fd-link {
-        text-decoration: none;
-    }
 }

--- a/libs/platform/src/lib/form/form-group/form-group-header/form-group-header.component.html
+++ b/libs/platform/src/lib/form/form-group/form-group-header/form-group-header.component.html
@@ -1,13 +1,16 @@
 <ng-container *ngIf="hintOptions(fieldGroup) as HintOptions; else noHint">
     <ng-template #inlineHelpRef>
-        <fd-icon
-            [ariaLabel]="HintOptions.text"
-            [fd-inline-help]="HintOptions.text"
-            [glyph]="HintOptions.glyph"
-            [placement]="HintOptions.placement"
-            [triggers]="HintOptions.trigger"
-            tabindex="0"
-        ></fd-icon>
+        <span fd-link [undecorated]="true">
+            <fd-icon
+                [style.vertical-align]="'middle'"
+                [ariaLabel]="HintOptions.text"
+                [fd-inline-help]="HintOptions.text"
+                [glyph]="HintOptions.glyph"
+                [placement]="HintOptions.placement"
+                [triggers]="HintOptions.trigger"
+                tabindex="0"
+            ></fd-icon>
+        </span>
     </ng-template>
     <h1 class="fd-form-group__header-text">
         <ng-container *ngIf="HintOptions.position === 'before'">

--- a/libs/platform/src/lib/form/form-group/form-group.component.html
+++ b/libs/platform/src/lib/form/form-group/form-group.component.html
@@ -54,14 +54,16 @@
             </ng-container>
         </span>
         <ng-template #hintTemplate>
-            <fd-icon
-                [ariaLabel]="_hintOptions.text"
-                [fd-inline-help]="_hintOptions.text"
-                [glyph]="_hintOptions.glyph"
-                [placement]="_hintOptions.placement"
-                [triggers]="_hintOptions.trigger"
-                tabindex="0"
-            ></fd-icon>
+            <span fd-link [undecorated]="true">
+                <fd-icon
+                    [ariaLabel]="_hintOptions.text"
+                    [fd-inline-help]="_hintOptions.text"
+                    [glyph]="_hintOptions.glyph"
+                    [placement]="_hintOptions.placement"
+                    [triggers]="_hintOptions.trigger"
+                    tabindex="0"
+                ></fd-icon>
+            </span>
         </ng-template>
     </ng-template>
 </ng-template>


### PR DESCRIPTION
## Related Issue(s)

closes #7955 

## Description

- [x] Icon should be hint instead of message-information as a default in inline help
- [x] Icon should have "interactive" color
- [x] Default triggers for inline help should be "click" instead of "hover"
- [x] Inline help popover's default placement should not hide object, to which it is attached to
- [x] Form label should not enforce TitleCase programmatically, but examples, which are shown in the Docs should have TitleCase
- [x] Labels with inline help needs fix to better align vertically with each other


## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![popover-position-before](https://user-images.githubusercontent.com/28543391/161999054-172d420b-623e-437f-8463-870ae0d6701b.jpg)
![icon-before](https://user-images.githubusercontent.com/28543391/161999088-48a59cb6-f8bd-49a2-9556-37f3c2200f69.png)
![form-label-before](https://user-images.githubusercontent.com/28543391/161999106-c6021147-fc6c-4e8f-85ed-bb697ec0fd9f.png)

### After:
![popover-position-after](https://user-images.githubusercontent.com/28543391/161999143-f555dc04-bc5b-41c7-b81e-3d1d935fe847.jpg)
![icon-after](https://user-images.githubusercontent.com/28543391/161999159-1d42fcd7-98f3-4910-9b1f-6e9541d5eee7.png)
![form-label-after](https://user-images.githubusercontent.com/28543391/161999185-4e457fdf-fe23-444f-8930-958eff17d97b.png)