### PR TITLE
fix(core, platform): dynamic page spacer fix, update for tabs

### DIFF
--- a/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.html
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.html
@@ -1,3 +1,3 @@
 <ng-content></ng-content>
 
-<div *ngIf="_dynamicPageComponent?._footerComponent" class="footer-spacer"></div>
+<div *ngIf="_showSpacer" class="footer-spacer"></div>

--- a/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
@@ -1,18 +1,16 @@
 import {
     ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     ElementRef,
-    Inject,
     Input,
     OnInit,
-    Optional,
     Renderer2,
     ViewEncapsulation
 } from '@angular/core';
 
 import { DYNAMIC_PAGE_CLASS_NAME } from '../constants';
 import { addClassNameToElement } from '../utils';
-import { FD_DYNAMIC_PAGE_COMPONENT, WithDynamicPageFooterComponent } from '../dynamic-page.component';
 
 @Component({
     selector: 'fd-dynamic-page-content',
@@ -35,10 +33,13 @@ export class DynamicPageContentComponent implements OnInit {
     id: string;
 
     /** @hidden */
+    _showSpacer = true;
+
+    /** @hidden */
     constructor(
         public _renderer: Renderer2,
-        @Inject(FD_DYNAMIC_PAGE_COMPONENT) @Optional() public _dynamicPageComponent: WithDynamicPageFooterComponent,
-        private _elementRef: ElementRef<HTMLElement>
+        private _elementRef: ElementRef<HTMLElement>,
+        private _cdr: ChangeDetectorRef
     ) {}
 
     /** @hidden */
@@ -49,6 +50,13 @@ export class DynamicPageContentComponent implements OnInit {
     /** Element reference to host of content dynamic page */
     get elementRef(): ElementRef {
         return this._elementRef;
+    }
+
+    /** @hidden */
+    _toggleSpacer(state: boolean): void {
+        this._showSpacer = state;
+
+        this._cdr.markForCheck();
     }
 
     /** @hidden */

--- a/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-content/dynamic-page-content.component.ts
@@ -33,7 +33,7 @@ export class DynamicPageContentComponent implements OnInit {
     id: string;
 
     /** @hidden */
-    _showSpacer = true;
+    _showSpacer = false;
 
     /** @hidden */
     constructor(

--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.spec.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.spec.ts
@@ -58,7 +58,7 @@ xdescribe('DynamicPageComponent default values', () => {
 
     it('should collapse on scroll content', fakeAsync(() => {
         fixture.detectChanges();
-        const element = dynamicPageComponent._contentComponent.elementRef.nativeElement;
+        const element = dynamicPageComponent._contentComponent.first.elementRef.nativeElement;
         element.scrollTop = 1000;
         fixture.detectChanges();
         element.dispatchEvent(new Event('scroll'));
@@ -69,7 +69,7 @@ xdescribe('DynamicPageComponent default values', () => {
     it('should not collapse on scroll content, when pinned', fakeAsync(() => {
         fixture.detectChanges();
         (<any>dynamicPageComponent)._dynamicPageService.pinned.next(true);
-        const element = dynamicPageComponent._contentComponent.elementRef.nativeElement;
+        const element = dynamicPageComponent._contentComponent.first.elementRef.nativeElement;
         element.scrollTop = 1000;
         fixture.detectChanges();
         element.dispatchEvent(new Event('scroll'));
@@ -98,7 +98,7 @@ xdescribe('DynamicPageComponent default values', () => {
         (<any>dynamicPageComponent)._setContainerPositions();
         fixture.detectChanges();
 
-        const element = dynamicPageComponent._contentComponent.elementRef.nativeElement;
+        const element = dynamicPageComponent._contentComponent.first.elementRef.nativeElement;
         const styles = window.getComputedStyle(element);
         expect(styles.height).toBe(size);
     });

--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
@@ -27,8 +27,8 @@ import { addClassNameToElement, dynamicPageWidthToSize } from './utils';
 import { TabListComponent } from '@fundamental-ngx/core/tabs';
 import { FlexibleColumnLayoutComponent } from '@fundamental-ngx/core/flexible-column-layout';
 
-import { fromEvent, Observable, startWith, Subject } from 'rxjs';
-import { debounceTime, delay, map, takeUntil } from 'rxjs/operators';
+import { asyncScheduler, fromEvent, Observable, startWith, Subject } from 'rxjs';
+import { debounceTime, delay, map, observeOn, takeUntil } from 'rxjs/operators';
 
 @Component({
     selector: 'fd-dynamic-page',
@@ -314,12 +314,7 @@ export class DynamicPageComponent implements AfterViewInit, OnDestroy {
     /** @hidden */
     private _setContentFooterSpacer(): void {
         this._contentComponent.changes
-            .pipe(
-                startWith(this._contentComponent.toArray()),
-                // to avoid NG0100: Expression has changed after it was checked
-                debounceTime(0),
-                takeUntil(this._onDestroy$)
-            )
+            .pipe(startWith(this._contentComponent.toArray()), observeOn(asyncScheduler), takeUntil(this._onDestroy$))
             .subscribe((components) => {
                 components.forEach((content, index) => {
                     /** show spacer when:

--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
@@ -245,7 +245,7 @@ export class DynamicPageComponent implements AfterViewInit, OnDestroy {
             return;
         }
 
-        const contentElement = this._contentComponent?.first.elementRef?.nativeElement;
+        const contentElement = this._contentComponent.first?.elementRef?.nativeElement;
         if (contentElement) {
             this._listenOnScroll(contentElement);
         }

--- a/libs/core/src/lib/dynamic-page/tsconfig.json
+++ b/libs/core/src/lib/dynamic-page/tsconfig.json
@@ -21,6 +21,7 @@
     },
     "angularCompilerOptions": {
         "strictInjectionParameters": false,
-        "strictTemplates": false
+        "strictTemplates": true,
+        "fullTemplateTypeCheck": true
     }
 }


### PR DESCRIPTION
## Related Issue(s)

Follow up https://github.com/SAP/fundamental-ngx/pull/7962

## Description

I missed that dynamic page may contain tabs and then there will be several dynamic page content components, so the approach of showing spacer should be different a bit. 

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

Spacer is not shown in stacked tabs example

<img width="1409" alt="image" src="https://user-images.githubusercontent.com/20265336/162420572-7fa87286-dab8-4bb1-ae51-423a634ae08d.png">

### After:

Spacer is shown for only the last content component when there is stacked tabs

<img width="1402" alt="image" src="https://user-images.githubusercontent.com/20265336/162421475-f189a1de-3f92-4b77-84e7-068077d8e802.png">