### PR TITLE
fix(core): clicking on tabs in overflow menu produced errors

### DIFF
--- a/libs/core/src/lib/menu/services/menu.service.ts
+++ b/libs/core/src/lib/menu/services/menu.service.ts
@@ -153,12 +153,14 @@ export class MenuService {
     /** @hidden Removes given element and all its successors from the Active Node Path and setts as inactive*/
     private _removeFromActivePath(menuItem: MenuItemComponent): void {
         const menuNode = this.menuMap.get(menuItem);
-        const pathIndex = this.activeNodePath.findIndex((i) => i.item === menuNode?.item);
+        if (menuNode) {
+            const pathIndex = this.activeNodePath.findIndex((i) => i.item === menuNode.item);
 
-        if (pathIndex !== -1) {
-            this.activeNodePath
-                .splice(pathIndex)
-                .forEach((removedActiveNode) => removedActiveNode.item.setSelected(false));
+            if (pathIndex !== -1) {
+                this.activeNodePath
+                    .splice(pathIndex)
+                    .forEach((removedActiveNode) => removedActiveNode.item.setSelected(false));
+            }
         }
     }
 

--- a/libs/core/src/lib/menu/services/menu.service.ts
+++ b/libs/core/src/lib/menu/services/menu.service.ts
@@ -153,7 +153,7 @@ export class MenuService {
     /** @hidden Removes given element and all its successors from the Active Node Path and setts as inactive*/
     private _removeFromActivePath(menuItem: MenuItemComponent): void {
         const menuNode = this.menuMap.get(menuItem);
-        const pathIndex = this.activeNodePath.findIndex((i) => i.item === menuNode.item);
+        const pathIndex = this.activeNodePath.findIndex((i) => i.item === menuNode?.item);
 
         if (pathIndex !== -1) {
             this.activeNodePath


### PR DESCRIPTION
## Related Issue(s)

closes #7968

## Description

Problem was that after re-render, in menuMap old item would not exist, but code was still thinking that it existed and tried to access `item` on non-existent node, although next lines were ready for that circumstances, Find was still going on. This change fixes that.