### PR TITLE
fix(core): fixed time picker drag end on last array element

### DIFF
--- a/libs/core/src/lib/time/time-column/time-column.component.ts
+++ b/libs/core/src/lib/time/time-column/time-column.component.ts
@@ -284,7 +284,7 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
         const array = this.items.toArray();
         let index: number = array.findIndex((__item) => __item === output.item) + this.offset;
 
-        if (index > array.length) {
+        if (index >= array.length) {
             index = index - array.length;
         }
 


### PR DESCRIPTION
## Related Issue(s)

closes #7959

## Description

Equal check was missing, it would try to access out of boundary element from array to get value, instead it should have started from delta index element when index was out of boundary
