### PR TITLE
fix(platform) WizardGenerator Dots in labels are not supported in wizard

### DIFF
--- a/libs/platform/src/lib/form/form-generator/form-generator.service.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.ts
@@ -251,11 +251,11 @@ export class FormGeneratorService implements OnDestroy {
      * @returns Found form control.
      */
     getFormControl(form: DynamicFormGroup, controlName: string): DynamicFormGroupControl {
-        let control = form?.get(controlName);
+        let control = form?.get([controlName]);
 
         // If no control found, try to find it in ungrouped group
         if (!control) {
-            control = form?.get(UNGROUPED_FORM_GROUP_NAME + '.' + controlName);
+            control = form?.get([UNGROUPED_FORM_GROUP_NAME,controlName]);
         }
 
         return control as DynamicFormGroupControl;


### PR DESCRIPTION
Currently, dots in labels are not supported as these are interpreted as delimiters of subpaths by angular/forms. Therefore, the dot notation should no longer be used to identify paths in wizard items.

https://github.com/angular/angular/issues/21950


There exists an issue '[WizardGenerator] Dots in labels are not supported in wizard', which describes this with more detailed information in the repository whose name, for confidentiality reasons, I will not post here.