### PR TITLE
(fix platform)  wizardGenerator dots in labels are not supported

### DIFF
--- a/libs/platform/src/lib/form/form-generator/form-generator.service.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.ts
@@ -251,18 +251,19 @@ export class FormGeneratorService implements OnDestroy {
      * @returns Found form control.
      */
     getFormControl(form: DynamicFormGroup, controlName: string): DynamicFormGroupControl {
-        let control = form?.get(controlName);
+        let control = form?.get([controlName]);
 
         // If no control found, try to find it in ungrouped group
         if (!control) {
-            control = form?.get(UNGROUPED_FORM_GROUP_NAME + '.' + controlName);
+            control = form?.get([UNGROUPED_FORM_GROUP_NAME, controlName]);
         }
 
         return control as DynamicFormGroupControl;
     }
 
     /** @hidden */
-    _getFormValueWithoutUngrouped(value: any): any {
+    _getFormValueWithout
+    (value: any): any {
         if (value[UNGROUPED_FORM_GROUP_NAME]) {
             const ungroupedGroupValue: { [key: string]: any } = value[UNGROUPED_FORM_GROUP_NAME];
             for (const [fieldName, fieldValue] of Object.entries(ungroupedGroupValue)) {

--- a/libs/platform/src/lib/form/form-generator/form-generator.service.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.ts
@@ -262,8 +262,7 @@ export class FormGeneratorService implements OnDestroy {
     }
 
     /** @hidden */
-    _getFormValueWithout
-    (value: any): any {
+    _getFormValueWithout(value: any): any {
         if (value[UNGROUPED_FORM_GROUP_NAME]) {
             const ungroupedGroupValue: { [key: string]: any } = value[UNGROUPED_FORM_GROUP_NAME];
             for (const [fieldName, fieldValue] of Object.entries(ungroupedGroupValue)) {

--- a/libs/platform/src/lib/form/form-generator/form-generator.service.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.ts
@@ -262,7 +262,7 @@ export class FormGeneratorService implements OnDestroy {
     }
 
     /** @hidden */
-    _getFormValueWithout(value: any): any {
+    _getFormValueWithoutUngrouped(value: any): any {
         if (value[UNGROUPED_FORM_GROUP_NAME]) {
             const ungroupedGroupValue: { [key: string]: any } = value[UNGROUPED_FORM_GROUP_NAME];
             for (const [fieldName, fieldValue] of Object.entries(ungroupedGroupValue)) {


### PR DESCRIPTION
Currently, dots in labels are not supported as these are interpreted as delimiters of subpaths by angular/forms. Therefore, the dot notation should no longer be used to identify paths in wizard items.

angular/angular#21950

There exists an issue '[WizardGenerator] Dots in labels are not supported in wizard', which describes this with more detailed information in the repository whose name, for confidentiality reasons, I will not post here.