### PR TITLE
fix(platform): value help dialog search

### DIFF
--- a/e2e/wdio/platform/fixtures/appData/value-help-dialog-contents.ts
+++ b/e2e/wdio/platform/fixtures/appData/value-help-dialog-contents.ts
@@ -29,4 +29,3 @@ export const customLabels = [
     'not equal to',
     'not empty'
 ];
-export const basicSearchId = 'value-help-dialog-search';

--- a/e2e/wdio/platform/pages/value-help-dialog.po.ts
+++ b/e2e/wdio/platform/pages/value-help-dialog.po.ts
@@ -12,8 +12,8 @@ export class ValueHelpDialogPo extends BaseComponentPo {
     menuDialogBtn = 'fd-popover button';
     menuItemNames = 'fd-popover-body .fd-list__title';
     miniOpenDialogBtn = 'button[class*="fd-button--compact"]';
-    mobileExampleDialog = 'fdp-value-help-dialog[dialogtitle="Mobile value help dialog"]';
     openDialogBtn = 'button[class="fd-button fd-button--standard"]';
+    basicSearchInput = '.fdp-search-field__input';
 
     // Dialog form selectors
     advSearchLabels = 'fd-layout-grid .fd-form-label';

--- a/e2e/wdio/platform/tests/value-help-dialog.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/value-help-dialog.e2e-spec.ts
@@ -18,12 +18,7 @@ import {
     waitForElDisplayed,
     waitForPresent
 } from '../../driver/wdio';
-import {
-    basicSearchId,
-    conditionsValues,
-    customLabels,
-    inputIDs
-} from '../fixtures/appData/value-help-dialog-contents';
+import { conditionsValues, customLabels, inputIDs } from '../fixtures/appData/value-help-dialog-contents';
 import { searchValues, valueOne, valueZero } from '../fixtures/testData/value-help-dialog';
 
 describe('Value help dialog test suite', () => {
@@ -31,6 +26,7 @@ describe('Value help dialog test suite', () => {
     const {
         dialogHeader,
         openDialogBtn,
+        basicSearchInput,
         formInputField,
         goBtn,
         tableRows,
@@ -102,8 +98,8 @@ describe('Value help dialog test suite', () => {
 
         it('should check the basic search results', () => {
             click(openDialogBtn);
-            click(formInputField(basicSearchId));
-            setValue(formInputField(basicSearchId), searchValues[0]);
+            click(basicSearchInput);
+            setValue(basicSearchInput, searchValues[0]);
             click(goBtn);
             pause(300);
             checkResults(tableRows, searchValues[0]);
@@ -331,7 +327,7 @@ describe('Value help dialog test suite', () => {
             click(openMobileExampleBtn);
             click(dialogButton);
             const text = getText(productNameColumn);
-            click(dialogButton, 2);
+            click(dialogButton, 3);
             setValue(dialogInput, text);
             click(dialogButton, 2);
             const itemsQuantity = getElementArrayLength(productNameColumn);

--- a/libs/platform/src/lib/search-field/search-field.component.html
+++ b/libs/platform/src/lib/search-field/search-field.component.html
@@ -41,7 +41,7 @@
                 aria-haspopup="true"
                 [class.fd-input--compact]="contentDensity | isCompactDensity"
                 (keydown)="onKeydown($event)"
-                (keydown.enter)="onSearchSubmit()"
+                (keydown.enter)="onSearchSubmit($event)"
                 [(ngModel)]="inputText"
                 (ngModelChange)="onValueChange($event)"
                 (click)="mobile && openMobileMode()"

--- a/libs/platform/src/lib/search-field/search-field.component.ts
+++ b/libs/platform/src/lib/search-field/search-field.component.ts
@@ -441,10 +441,11 @@ export class SearchFieldComponent
      * Callback function which gets executed on keyboard enter of input text field.
      * @hidden
      */
-    onSearchSubmit(): void {
+    onSearchSubmit(event?: Event): void {
+        event?.preventDefault();
+
         if (this.isLoading) {
             this.cancelSearch.emit();
-
             return;
         }
 

--- a/libs/platform/src/lib/value-help-dialog/value-help-dialog.module.ts
+++ b/libs/platform/src/lib/value-help-dialog/value-help-dialog.module.ts
@@ -22,6 +22,7 @@ import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 import { PopoverModule } from '@fundamental-ngx/core/popover';
 import { InfiniteScrollModule } from '@fundamental-ngx/core/infinite-scroll';
 import { BusyIndicatorModule } from '@fundamental-ngx/core/busy-indicator';
+import { PlatformSearchFieldModule } from '@fundamental-ngx/platform/search-field';
 
 import { PlatformValueHelpDialogComponent } from './value-help-dialog/value-help-dialog.component';
 import { VhdFilterComponent } from './components/value-help-dialog-filter/value-help-dialog-filter.component';
@@ -64,7 +65,8 @@ import { ConditionCountMessageDirective } from './directives/condition-count-mes
         PanelModule,
         InputGroupModule,
         PopoverModule,
-        InfiniteScrollModule
+        InfiniteScrollModule,
+        PlatformSearchFieldModule
     ],
     exports: [PlatformValueHelpDialogComponent, VhdFilterComponent, VhdSearchComponent]
 })

--- a/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.html
+++ b/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.html
@@ -146,37 +146,16 @@
             class="fdp-value-help-dialog__row fdp-value-help-dialog__advanced-search"
             aria-label="Selectid filters"
             [id]="'advanced-search-' + id"
-            (ngSubmit)="search()"
         >
             <fd-layout-grid *ngIf="!mobile || (mobile && !isOpenAdvanced)">
                 <div [fdLayoutGridCol]="12" [colMd]="12" [colLg]="mobile ? 12 : 6" [colXl]="mobile ? 12 : 6">
-                    <div fd-form-item>
-                        <fd-input-group>
-                            <input
-                                #inputGroupField
-                                fd-input-group-input
-                                fd-form-control
-                                [compact]="contentDensity | isCompactDensity"
-                                type="search"
-                                [(ngModel)]="_mainSearch"
-                                name="value-help-dialog-search"
-                                id="value-help-dialog-search"
-                                [placeholder]="searchField.placeholder"
-                                [attr.aria-label]="searchField.placeholder"
-                            />
-
-                            <span fd-input-group-addon [compact]="contentDensity | isCompactDensity" [button]="true">
-                                <button
-                                    fd-button
-                                    [compact]="contentDensity | isCompactDensity"
-                                    title="Search"
-                                    glyph="search"
-                                    fdType="transparent"
-                                    (click)="_searchAction(inputGroupField)"
-                                ></button>
-                            </span>
-                        </fd-input-group>
-                    </div>
+                    <fdp-search-field
+                        [contentDensity]="contentDensity"
+                        [placeholder]="searchField.placeholder"
+                        [ariaLabel]="searchField.placeholder"
+                        (searchSubmit)="search()"
+                        (inputChange)="_mainSearch = $event.text"
+                    ></fdp-search-field>
                 </div>
 
                 <div
@@ -222,6 +201,7 @@
                             [compact]="contentDensity | isCompactDensity"
                             aria-label="Go"
                             i18n-aria-label="@@platformI18nValueHelpDialog.Search.Button"
+                            (click)="filter()"
                         ></button>
                     </fd-toolbar>
                 </div>

--- a/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.ts
+++ b/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.ts
@@ -591,7 +591,6 @@ export class PlatformValueHelpDialogComponent<T = any> implements OnChanges, OnD
             const dsSub = this.openDataStream()
                 .pipe(takeUntil(this._destroyed))
                 .subscribe((data) => {
-                    console.log(data);
                     this._displayedData = data.slice();
                     this._changeDetectorRef.markForCheck();
                 });

--- a/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.ts
+++ b/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.ts
@@ -23,7 +23,6 @@ import { filter, takeUntil } from 'rxjs/operators';
 
 import { DialogConfig, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
 import { ContentDensity, ContentDensityEnum, RtlService, ContentDensityService } from '@fundamental-ngx/core/utils';
-import { FormControlComponent } from '@fundamental-ngx/core/form';
 import { isDataSource } from '@fundamental-ngx/platform/shared';
 import {
     ArrayValueHelpDialogDataSource,
@@ -437,20 +436,27 @@ export class PlatformValueHelpDialogComponent<T = any> implements OnChanges, OnD
         this._changeDetectorRef.markForCheck();
     }
 
-    /**
-     * Bacis search by all filled filters
-     */
+    /** Search by only the search term. */
     search(): void {
+        this.filter(true);
+    }
+
+    /**
+     * Search by all filled filters, including the search term.
+     */
+    filter(onlySearch = false): void {
         const nonEmptyFilters = new Map();
-        this._displayedFilters
-            .filter(({ value }) => !!value && value.trim().length)
-            .forEach((e) => {
-                nonEmptyFilters.set(e.key, e.value);
-            });
+
+        if (!onlySearch) {
+            this._displayedFilters
+                .filter(({ value }) => !!value && value.trim().length)
+                .forEach((e) => nonEmptyFilters.set(e.key, e.value));
+        }
 
         if (this._mainSearch.length) {
             nonEmptyFilters.set('*', this._mainSearch);
         }
+
         this.dataSource.match(nonEmptyFilters);
     }
 
@@ -458,7 +464,7 @@ export class PlatformValueHelpDialogComponent<T = any> implements OnChanges, OnD
      * Apply search from advanced filters view, using when mobile view is active
      */
     searchAdvanced(): void {
-        this.search();
+        this.filter();
         this.selectedTab = VhdTab.selectFromList;
         this.isOpenAdvanced = false;
     }
@@ -552,12 +558,6 @@ export class PlatformValueHelpDialogComponent<T = any> implements OnChanges, OnD
     }
 
     /** @hidden */
-    _searchAction(input: FormControlComponent): void {
-        const inputElement = input.elementRef().nativeElement as HTMLInputElement;
-        inputElement.focus();
-    }
-
-    /** @hidden */
     private _initShownFilters(): void {
         this.shownFilterCount = this.maxShownInitialFilters || Infinity;
     }
@@ -584,23 +584,27 @@ export class PlatformValueHelpDialogComponent<T = any> implements OnChanges, OnD
     /** @hidden */
     private _initializeDS(ds: FdpValueHelpDialogDataSource<any> = this.dataSource): void {
         this._resetSourceStream();
+
         if (this.showSelectionTab) {
             this._dsSubscription = new Subscription();
 
             const dsSub = this.openDataStream()
                 .pipe(takeUntil(this._destroyed))
                 .subscribe((data) => {
+                    console.log(data);
                     this._displayedData = data.slice();
                     this._changeDetectorRef.markForCheck();
                 });
 
             this._dsSubscription.add(dsSub);
+
             this._dsSubscription.add(
                 ds.onDataRequested().subscribe(() => {
                     this._internalLoadingState = true;
                     this.onDataRequested.emit();
                 })
             );
+
             this._dsSubscription.add(
                 ds.onDataReceived().subscribe(() => {
                     this._internalLoadingState = false;


### PR DESCRIPTION
## Related Issue(s)

Closes #7908.

## Description

Previously search button was used only to focus search field input, now by clicking on it search is performed by the value in the search field input without any other filter values. Button "Go" still performs search by all of the filters, including search, nothing changed here.
