### PR TITLE
fix(core,platform): missing class on split button

### DIFF
--- a/libs/core/src/lib/split-button/split-button.component.html
+++ b/libs/core/src/lib/split-button/split-button.component.html
@@ -1,5 +1,6 @@
 <div
     class="fd-button-split fd-has-margin-right-small"
+    [ngClass]="typeClass"
     role="group"
     tabindex="-1"
     [attr.aria-label]="arialLabel"

--- a/libs/core/src/lib/split-button/split-button.component.scss
+++ b/libs/core/src/lib/split-button/split-button.component.scss
@@ -1,9 +1,1 @@
 @import '~fundamental-styles/dist/button-split';
-
-// Remove after merging https://github.com/SAP/fundamental-styles/issues/2163
-.fd-button-split,
-.fd-button-split > :first-child:hover {
-    .fd-button-split__text {
-        color: inherit;
-    }
-}

--- a/libs/core/src/lib/split-button/split-button.component.ts
+++ b/libs/core/src/lib/split-button/split-button.component.ts
@@ -134,6 +134,11 @@ export class SplitButtonComponent implements AfterContentInit, OnChanges, OnDest
     mainButtonWidth: string;
 
     /** @hidden */
+    get typeClass(): string {
+        return this.fdType ? `fd-button-split--${this.fdType}` : '';
+    }
+
+    /** @hidden */
     private _menuItemSubscriptions = new Subscription();
 
     /** @hidden */

--- a/libs/platform/src/lib/split-menu-button/split-menu-button.component.html
+++ b/libs/platform/src/lib/split-menu-button/split-menu-button.component.html
@@ -1,5 +1,6 @@
 <div
     class="fd-button-split"
+    [class]="typeClass"
     role="group"
     aria-label="split-button"
     [attr.dir]="dir"

--- a/libs/platform/src/lib/split-menu-button/split-menu-button.component.ts
+++ b/libs/platform/src/lib/split-menu-button/split-menu-button.component.ts
@@ -91,6 +91,11 @@ export class SplitMenuButtonComponent extends BaseComponent implements OnInit, A
      * @hidden */
     private _rtlChangeSubscription = Subscription.EMPTY;
 
+    /** @hidden */
+    get typeClass(): string {
+        return this.type ? `fd-button-split--${this.type}` : '';
+    }
+
     constructor(protected _cd: ChangeDetectorRef, @Optional() private _rtlService: RtlService) {
         super(_cd);
     }


### PR DESCRIPTION
## Related Issue(s)

part of #7984

## Description

Type class should have been applied to the parent class too

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/28543391/165479664-603da038-3df1-4c2d-b5a9-60b1a5587678.png)

### After:
![image](https://user-images.githubusercontent.com/28543391/165479765-2fa6dd66-027c-4a9e-98c0-59241ad8f30e.png)