### PR TITLE
feat(core): grid list horizon, styles breaking changes adoption

### DIFF
--- a/apps/docs/src/app/core/component-docs/grid-list/examples/default/grid-list-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/default/grid-list-example.component.html
@@ -34,20 +34,22 @@
         ></button>
     </fd-grid-list-title-bar>
 
-    <fd-grid-list-item *ngFor="let item of list" [type]="item.type" [counter]="item.counter" (navigate)="navigate()">
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+    <fd-grid-list-item
+        *ngFor="let item of list"
+        [type]="item.type"
+        [counter]="item.counter"
+        [title]="item.title"
+        [description]="item.description"
+        (navigate)="navigate()"
+    >
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 </fd-grid-list>
 

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/default/grid-list-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/default/grid-list-example.component.html
@@ -35,19 +35,18 @@
     </fd-grid-list-title-bar>
 
     <fd-grid-list-item *ngFor="let item of list" [type]="item.type" [counter]="item.counter" (navigate)="navigate()">
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title"></h6>
-                <p [innerText]="item.description"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/delete/grid-list-delete-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/delete/grid-list-delete-example.component.html
@@ -6,19 +6,18 @@
     <fd-grid-list-item *ngFor="let item of list" [value]="item.id" (delete)="delete($event)">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title"></h6>
-                <p [innerText]="item.description"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/delete/grid-list-delete-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/delete/grid-list-delete-example.component.html
@@ -3,22 +3,23 @@
         <span fd-grid-list-title-bar-additional-title-item [innerText]="'(' + list.length + ')'"></span>
     </fd-grid-list-title-bar>
 
-    <fd-grid-list-item *ngFor="let item of list" [value]="item.id" (delete)="delete($event)">
+    <fd-grid-list-item
+        *ngFor="let item of list"
+        [value]="item.id"
+        [title]="item.title"
+        [description]="item.description"
+        (delete)="delete($event)"
+    >
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
     <div class="fd-col fd-col--12" *ngIf="!list.length">No items available.</div>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/dnd/grid-list-dnd-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/dnd/grid-list-dnd-example.component.html
@@ -1,4 +1,4 @@
-<fd-grid-list>
+<fd-grid-list fd-dnd-list [items]="list" [gridMode]="true" (itemDropped)="itemsChangeHandle($event)">
     <fd-grid-list-title-bar [title]="'Products'">
         <span fd-grid-list-title-bar-additional-title-item [innerText]="'(' + list.length + ')'"></span>
 
@@ -34,41 +34,32 @@
         ></button>
     </fd-grid-list-title-bar>
 
-    <div
-        class="fd-row"
-        fd-dnd-list
-        [items]="list"
-        [gridMode]="true"
-        (itemDropped)="itemsChangeHandle($event)"
-        style="margin-top: 0"
+    <fd-grid-list-item
+        *ngFor="let item of list"
+        [value]="item.id"
+        fd-dnd-item
+        containerSelector=".fd-grid-list__item"
+        type="navigation"
+        (navigate)="navigate($event)"
     >
-        <fd-grid-list-item
-            *ngFor="let item of list"
-            [value]="item.id"
-            fd-dnd-item
-            containerSelector=".fd-grid-list__item"
-            type="navigation"
-            (navigate)="navigate($event)"
-        >
-            <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
+        <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-            <div class="fd-grid-list-item-body--container">
-                <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-                <div class="fd-grid-list-item-body--content">
-                    <h6 fd-title [innerText]="item.title"></h6>
-                    <p [innerText]="item.description"></p>
-                    <div class="fd-grid-list-item-body--content-address">
-                        <p>781 Main Street</p>
-                        <p>Anytown, SD 57401</p>
-                        <p>USA</p>
-                    </div>
-                    <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-                </div>
-            </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-            <fd-grid-list-item-footer-bar> Footer Item </fd-grid-list-item-footer-bar>
-        </fd-grid-list-item>
-    </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
+        </div>
+
+        <fd-grid-list-item-footer-bar> Footer Item </fd-grid-list-item-footer-bar>
+    </fd-grid-list-item>
 </fd-grid-list>
 
 <span aria-hidden="true" style="display: none" id="grid-list-button-dnd-1">Sort</span>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/dnd/grid-list-dnd-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/dnd/grid-list-dnd-example.component.html
@@ -37,6 +37,8 @@
     <fd-grid-list-item
         *ngFor="let item of list"
         [value]="item.id"
+        [title]="item.title"
+        [description]="item.description"
         fd-dnd-item
         containerSelector=".fd-grid-list__item"
         type="navigation"
@@ -44,19 +46,14 @@
     >
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
 
         <fd-grid-list-item-footer-bar> Footer Item </fd-grid-list-item-footer-bar>
     </fd-grid-list-item>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/focusing/grid-list-focusing-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/focusing/grid-list-focusing-example.component.html
@@ -30,19 +30,18 @@
         [counter]="item.counter"
         (navigate)="navigate($event)"
     >
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title"></h6>
-                <p [innerText]="item.description"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/focusing/grid-list-focusing-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/focusing/grid-list-focusing-example.component.html
@@ -28,20 +28,19 @@
         *ngFor="let item of list"
         [type]="item.type"
         [counter]="item.counter"
+        [title]="item.title"
+        [description]="item.description"
         (navigate)="navigate($event)"
     >
         <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/footer/grid-list-footer-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/footer/grid-list-footer-example.component.html
@@ -3,20 +3,15 @@
         <span fd-grid-list-title-bar-additional-title-item [innerText]="'(' + list.length + ')'"></span>
     </fd-grid-list-title-bar>
 
-    <fd-grid-list-item *ngFor="let item of list; let i = index">
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+    <fd-grid-list-item *ngFor="let item of list; let i = index" [title]="item.title" [description]="item.description">
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
     <fd-grid-list-footer>Footer</fd-grid-list-footer>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/footer/grid-list-footer-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/footer/grid-list-footer-example.component.html
@@ -4,19 +4,18 @@
     </fd-grid-list-title-bar>
 
     <fd-grid-list-item *ngFor="let item of list; let i = index">
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title + ' ' + (i + 1)"></h6>
-                <p [innerText]="item.description + ' ' + (i + 1)"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/grid-list.component.scss
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/grid-list.component.scss
@@ -1,31 +1,7 @@
-.fd-grid-list-item-body {
-    &--container {
-        display: flex;
-        word-break: break-all;
-
-        fd-avatar {
-            margin-right: 1rem;
-
-            @at-root {
-                [dir='rtl'] & {
-                    margin-right: 0;
-                    margin-left: 1rem;
-                }
-            }
-        }
-    }
-
-    &--content {
-        * {
-            margin: 0;
-        }
-
-        .fd-title {
-            font-weight: bold;
-        }
-
-        .fd-grid-list-item-body--content-address {
-            margin: 10px 0;
+.fd-grid-list__item-body {
+    .fd-grid-list__item-content {
+        p:first-child {
+            margin-top: 0;
         }
     }
 }

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/grid-list.component.scss
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/grid-list.component.scss
@@ -1,7 +1,11 @@
 .fd-grid-list__item-body {
     .fd-grid-list__item-content {
-        p:first-child {
+        p {
             margin-top: 0;
+
+            &:not(:last-of-type) {
+                margin-bottom: 0;
+            }
         }
     }
 }

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/group/grid-list-group-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/group/grid-list-group-example.component.html
@@ -6,47 +6,37 @@
         ></span>
     </fd-grid-list-title-bar>
 
-    <fd-grid-list-filter-bar *ngIf="showFilterBur" (close)="close()"
-        >Grouped by: Company (Company A, Company B)</fd-grid-list-filter-bar
-    >
+    <fd-grid-list-filter-bar *ngIf="showFilterBur" (close)="close()">
+        Grouped by: Company (Company A, Company B)
+    </fd-grid-list-filter-bar>
 
     <fd-grid-list-group-header> Company: Company A </fd-grid-list-group-header>
 
-    <fd-grid-list-item *ngFor="let item of group1">
+    <fd-grid-list-item *ngFor="let item of group1" [title]="item.title" [description]="item.description">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
     <fd-grid-list-group-header> Company: Company B </fd-grid-list-group-header>
 
-    <fd-grid-list-item *ngFor="let item of group2">
+    <fd-grid-list-item *ngFor="let item of group2" [title]="item.title" [description]="item.description">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/group/grid-list-group-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/group/grid-list-group-example.component.html
@@ -15,19 +15,18 @@
     <fd-grid-list-item *ngFor="let item of group1">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title"></h6>
-                <p [innerText]="item.description"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 
@@ -36,19 +35,18 @@
     <fd-grid-list-item *ngFor="let item of group2">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title"></h6>
-                <p [innerText]="item.description"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/layout/grid-list-layout-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/layout/grid-list-layout-example.component.html
@@ -6,19 +6,18 @@
     <fd-grid-list-item *ngFor="let item of list" [layoutItemPattern]="item.layoutItemPattern">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title"></h6>
-                <p [innerText]="item.description"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/layout/grid-list-layout-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/layout/grid-list-layout-example.component.html
@@ -3,21 +3,21 @@
         <span fd-grid-list-title-bar-additional-title-item [innerText]="'(' + list.length + ')'"></span>
     </fd-grid-list-title-bar>
 
-    <fd-grid-list-item *ngFor="let item of list" [layoutItemPattern]="item.layoutItemPattern">
+    <fd-grid-list-item
+        *ngFor="let item of list"
+        [layoutItemPattern]="item.layoutItemPattern"
+        [title]="item.title"
+        [description]="item.description"
+    >
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/more/grid-list-more-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/more/grid-list-more-example.component.html
@@ -1,20 +1,17 @@
 <fd-grid-list>
     <fd-grid-list-title-bar title="Products"></fd-grid-list-title-bar>
 
-    <fd-grid-list-item *ngFor="let item of list; let i = index">
+    <fd-grid-list-item *ngFor="let item of list; let i = index" [title]="item.title" [description]="item.description">
         <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
     <fd-grid-list-more-btn

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/more/grid-list-more-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/more/grid-list-more-example.component.html
@@ -2,19 +2,18 @@
     <fd-grid-list-title-bar title="Products"></fd-grid-list-title-bar>
 
     <fd-grid-list-item *ngFor="let item of list; let i = index">
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title + ' ' + (i + 1)"></h6>
-                <p [innerText]="item.description + ' ' + (i + 1)"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/multi-select/grid-list-multi-select-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/multi-select/grid-list-multi-select-example.component.html
@@ -9,25 +9,22 @@
         [counter]="item.counter"
         [value]="item.id"
         [selected]="item.selected"
+        [title]="item.title"
+        [description]="item.description"
         (press)="press($event)"
         (detail)="detail($event)"
         (navigate)="navigate($event)"
     >
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 </fd-grid-list>
 <br /><br />

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/multi-select/grid-list-multi-select-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/multi-select/grid-list-multi-select-example.component.html
@@ -15,19 +15,18 @@
     >
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title"></h6>
-                <p [innerText]="item.description"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/single-select-left/grid-list-single-select-left-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/single-select-left/grid-list-single-select-left-example.component.html
@@ -9,24 +9,21 @@
         [counter]="item.counter"
         [value]="item.id"
         [selected]="item.selected"
+        [title]="item.title"
+        [description]="item.description"
         (press)="press($event)"
         (detail)="detail($event)"
         (navigate)="navigate($event)"
     >
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/single-select-left/grid-list-single-select-left-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/single-select-left/grid-list-single-select-left-example.component.html
@@ -15,19 +15,18 @@
     >
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title"></h6>
-                <p [innerText]="item.description"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/single-select-right/grid-list-single-select-right-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/single-select-right/grid-list-single-select-right-example.component.html
@@ -9,24 +9,21 @@
         [counter]="item.counter"
         [value]="item.id"
         [selected]="item.selected"
+        [title]="item.title"
+        [description]="item.description"
         (press)="press($event)"
         (detail)="detail($event)"
         (navigate)="navigate($event)"
     >
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
-            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/single-select-right/grid-list-single-select-right-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/single-select-right/grid-list-single-select-right-example.component.html
@@ -15,19 +15,18 @@
     >
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title [innerText]="item.title"></h6>
-                <p [innerText]="item.description"></p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title [innerText]="item.title" class="fd-grid-list__item-title"></h4>
+            <span class="fd-grid-list__item-subtitle" [innerText]="item.description"></span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/single-select/grid-list-single-select-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/single-select/grid-list-single-select-example.component.html
@@ -16,6 +16,8 @@
     >
         <fd-grid-list-item-toolbar *ngIf="item.toolbarText">{{ item.toolbarText }}</fd-grid-list-item-toolbar>
 
-        <img [src]="item.url" alt="Image" />
+        <ng-template fd-grid-list-item-body>
+            <img [src]="item.url" alt="Image" />
+        </ng-template>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/single-select/grid-list-single-select-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/single-select/grid-list-single-select-example.component.scss
@@ -3,5 +3,6 @@
 .fd-grid-list__item-body {
     img {
         min-width: 100%;
+        min-height: 100%;
     }
 }

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/single-select/grid-list-single-select-example.component.scss
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/single-select/grid-list-single-select-example.component.scss
@@ -1,1 +1,7 @@
 @import '../grid-list.component';
+
+.fd-grid-list__item-body {
+    img {
+        min-width: 100%;
+    }
+}

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/single-select/grid-list-single-select-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/single-select/grid-list-single-select-example.component.ts
@@ -30,7 +30,7 @@ export class GridListSingleSelectExampleComponent {
             id: 2,
             selected: true,
             toolbarText: 'Custom Text',
-            type: 'navigation',
+            type: 'detailsAndActive',
             counter: 8,
             url: 'https://picsum.photos/id/1001/300/200'
         },

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/states/grid-list-states-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/states/grid-list-states-example.component.html
@@ -5,140 +5,105 @@
 
     <fd-grid-list-group-header> State: Unread </fd-grid-list-group-header>
 
-    <fd-grid-list-item state="unread">
+    <fd-grid-list-item state="unread" title="Title 1" description="Description 1">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 1</h4>
-            <span class="fd-grid-list__item-subtitle">Description 1</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
     <fd-grid-list-group-header> State: Error </fd-grid-list-group-header>
 
-    <fd-grid-list-item state="error">
+    <fd-grid-list-item state="error" title="Title 2" description="Description 2">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 2</h4>
-            <span class="fd-grid-list__item-subtitle">Description 2</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
-    <fd-grid-list-item state="error">
+    <fd-grid-list-item state="error" title="Title 2.1" description="Description 2.1">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 2.1</h4>
-            <span class="fd-grid-list__item-subtitle">Description 2.1</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
 
         <fd-grid-list-item-footer-bar> Custom error message </fd-grid-list-item-footer-bar>
     </fd-grid-list-item>
 
     <fd-grid-list-group-header> State: Locked </fd-grid-list-group-header>
 
-    <fd-grid-list-item state="locked" (locked)="locked($event)">
+    <fd-grid-list-item state="locked" title="Title 3" description="Description 3" (locked)="locked($event)">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 3</h4>
-            <span class="fd-grid-list__item-subtitle">Description 3</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
-    <fd-grid-list-item state="locked">
+    <fd-grid-list-item state="locked" title="Title 3.1" description="Description 3.1">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 3.1.</h4>
-            <span class="fd-grid-list__item-subtitle">Description 3.1</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
 
         <fd-grid-list-item-footer-bar> Locked button redefined to text </fd-grid-list-item-footer-bar>
     </fd-grid-list-item>
 
     <fd-grid-list-group-header> State: Draft </fd-grid-list-group-header>
 
-    <fd-grid-list-item state="draft" (draft)="draft($event)">
+    <fd-grid-list-item state="draft" title="Title 4" description="Description 4" (draft)="draft($event)">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 4</h4>
-            <span class="fd-grid-list__item-subtitle">Description 4</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
-    <fd-grid-list-item state="draft">
+    <fd-grid-list-item state="draft" title="Title 4.1" description="Description 4.1">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 4.1</h4>
-            <span class="fd-grid-list__item-subtitle">Description 4.1</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
 
         <fd-grid-list-item-footer-bar> Draft button redefined to text </fd-grid-list-item-footer-bar>
     </fd-grid-list-item>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/states/grid-list-states-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/states/grid-list-states-example.component.html
@@ -8,19 +8,18 @@
     <fd-grid-list-item state="unread">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 1</h6>
-                <p>Description 1</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 1</h4>
+            <span class="fd-grid-list__item-subtitle">Description 1</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 
@@ -29,38 +28,36 @@
     <fd-grid-list-item state="error">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 2</h6>
-                <p>Description 2</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 2</h4>
+            <span class="fd-grid-list__item-subtitle">Description 2</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 
     <fd-grid-list-item state="error">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 2.1</h6>
-                <p>Description 2.1</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 2.1</h4>
+            <span class="fd-grid-list__item-subtitle">Description 2.1</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
 
         <fd-grid-list-item-footer-bar> Custom error message </fd-grid-list-item-footer-bar>
@@ -71,38 +68,36 @@
     <fd-grid-list-item state="locked" (locked)="locked($event)">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 3</h6>
-                <p>Description 3</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 3</h4>
+            <span class="fd-grid-list__item-subtitle">Description 3</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 
     <fd-grid-list-item state="locked">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 3.1</h6>
-                <p>Description 3.1</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 3.1.</h4>
+            <span class="fd-grid-list__item-subtitle">Description 3.1</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
 
         <fd-grid-list-item-footer-bar> Locked button redefined to text </fd-grid-list-item-footer-bar>
@@ -113,38 +108,36 @@
     <fd-grid-list-item state="draft" (draft)="draft($event)">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 4</h6>
-                <p>Description 4</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 4</h4>
+            <span class="fd-grid-list__item-subtitle">Description 4</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 
     <fd-grid-list-item state="draft">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 4.1</h6>
-                <p>Description 4.1</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 4.1</h4>
+            <span class="fd-grid-list__item-subtitle">Description 4.1</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
 
         <fd-grid-list-item-footer-bar> Draft button redefined to text </fd-grid-list-item-footer-bar>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/statuses/grid-list-statuses-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/statuses/grid-list-statuses-example.component.html
@@ -6,76 +6,72 @@
     <fd-grid-list-item status="success">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 1</h6>
-                <p>Description 1</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 1</h4>
+            <span class="fd-grid-list__item-subtitle">Description 1</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 
     <fd-grid-list-item status="warning">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 2</h6>
-                <p>Description 2</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 2</h4>
+            <span class="fd-grid-list__item-subtitle">Description 2</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 
     <fd-grid-list-item status="error">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 3</h6>
-                <p>Description 3</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 3</h4>
+            <span class="fd-grid-list__item-subtitle">Description 3</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 
     <fd-grid-list-item status="neutral">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <div class="fd-grid-list-item-body--container">
-            <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
-            <div class="fd-grid-list-item-body--content">
-                <h6 fd-title>Title 4</h6>
-                <p>Description 4</p>
-                <div class="fd-grid-list-item-body--content-address">
-                    <p>781 Main Street</p>
-                    <p>Anytown, SD 57401</p>
-                    <p>USA</p>
-                </div>
+        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
 
-                <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-            </div>
+        <div class="fd-grid-list__item-header">
+            <h4 fd-title class="fd-grid-list__item-title">Title 4</h4>
+            <span class="fd-grid-list__item-subtitle">Description 4</span>
+        </div>
+
+        <div class="fd-grid-list__item-content">
+            <p>781 Main Street</p>
+            <p>Anytown, SD 57401</p>
+            <p>USA</p>
+            <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
         </div>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/examples/statuses/grid-list-statuses-example.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/examples/statuses/grid-list-statuses-example.component.html
@@ -3,75 +3,55 @@
         <span fd-grid-list-title-bar-additional-title-item>(4)</span>
     </fd-grid-list-title-bar>
 
-    <fd-grid-list-item status="success">
+    <fd-grid-list-item status="success" title="Title 1" description="Description 1">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 1</h4>
-            <span class="fd-grid-list__item-subtitle">Description 1</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
-    <fd-grid-list-item status="warning">
+    <fd-grid-list-item status="warning" title="Title 2" description="Description 2">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 2</h4>
-            <span class="fd-grid-list__item-subtitle">Description 2</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
-    <fd-grid-list-item status="error">
+    <fd-grid-list-item status="error" title="Title 3" description="Description 3">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 3</h4>
-            <span class="fd-grid-list__item-subtitle">Description 3</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 
-    <fd-grid-list-item status="neutral">
+    <fd-grid-list-item status="neutral" title="Title 3" description="Description 3">
         <fd-grid-list-item-toolbar> Custom Text </fd-grid-list-item-toolbar>
 
-        <fd-avatar image="https://picsum.photos/id/1062/300/200" size="s" class="fd-grid-list__item-image"></fd-avatar>
+        <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
 
-        <div class="fd-grid-list__item-header">
-            <h4 fd-title class="fd-grid-list__item-title">Title 4</h4>
-            <span class="fd-grid-list__item-subtitle">Description 4</span>
-        </div>
-
-        <div class="fd-grid-list__item-content">
+        <ng-template fd-grid-list-item-body>
             <p>781 Main Street</p>
             <p>Anytown, SD 57401</p>
             <p>USA</p>
             <a [routerLink]="['./']" fd-link tabindex="0">john_li@example.com</a>
-        </div>
+        </ng-template>
     </fd-grid-list-item>
 </fd-grid-list>

--- a/apps/docs/src/app/core/component-docs/grid-list/grid-list-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/grid-list/grid-list-docs.component.html
@@ -33,6 +33,11 @@
 <description>
     One item in the grid list can be selected. Need click on an item to select it. To use the Single select mode, set
     <code>[mode]</code> as <code>singleSelect</code>.
+
+    <p>
+        <b>Note</b>: Whole item with link is clickable. If used within single select mode - selection event will be
+        emitted first, then navigation event.
+    </p>
 </description>
 <component-example>
     <fd-grid-list-single-select-example></fd-grid-list-single-select-example>

--- a/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.html
@@ -108,6 +108,7 @@
 
             <button
                 fd-button
+                fdType="transparent"
                 [fdMenu]="true"
                 [fdMenuTrigger]="versionsMenu"
                 class="fd-shellbar__button fd-shellbar__button--menu fd-docs--toolbar__version fd-docs--theme-menu"

--- a/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.html
+++ b/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.html
@@ -108,7 +108,6 @@
 
             <button
                 fd-button
-                fdType="transparent"
                 [fdMenu]="true"
                 [fdMenuTrigger]="versionsMenu"
                 class="fd-shellbar__button fd-shellbar__button--menu fd-docs--toolbar__version fd-docs--theme-menu"

--- a/e2e/wdio/core/pages/grid-list.po.ts
+++ b/e2e/wdio/core/pages/grid-list.po.ts
@@ -20,7 +20,7 @@ export class GridListPo extends CoreBaseComponentPo {
     unreadStateItem = '[state="unread"] h6';
     errorStateItem = '.fd-object-status--negative';
     lockedStateItemButton = '[state="locked"] button';
-    lockedStateItemText = '[state="locked"] span';
+    lockedStateItemText = '[state="locked"] .fd-button__text';
     draftStateItemButton = '[state="draft"] button';
     draftStateItemText = '[state="draft"] span';
     successStatusIndicator = '[status="success"] span';

--- a/e2e/wdio/core/pages/grid-list.po.ts
+++ b/e2e/wdio/core/pages/grid-list.po.ts
@@ -41,7 +41,6 @@ export class GridListPo extends CoreBaseComponentPo {
     gridListToolbar = '.fd-toolbar.fd-toolbar--info ';
     gridListRadioButton = '.fd-grid-list__item-toolbar .fd-grid-list__radio-label';
     gridListCheckbox = '.fd-grid-list__checkbox-label';
-    button = '.fd-button';
 
     gridListItemsByMode = (name: string): string => ` [selectionmode="${name}"] fd-grid-list-item`;
 

--- a/e2e/wdio/core/tests/grid-list.e2e-spec.ts
+++ b/e2e/wdio/core/tests/grid-list.e2e-spec.ts
@@ -34,8 +34,7 @@ describe('Grid-list test suite', () => {
         multiSelectModeSelectedItems,
         singleSelectItemsSelected,
         dragAndDropItems,
-        gridListToolbar,
-        button
+        gridListToolbar
     } = gridListPage;
 
     beforeAll(() => {
@@ -130,7 +129,7 @@ describe('Grid-list test suite', () => {
 
     it('should check closing grid list toolbar', () => {
         scrollIntoView(gridListToolbar);
-        click(gridListToolbar + button);
+        click(gridListToolbar);
         expect(doesItExist(gridListToolbar)).toBe(false);
     });
 

--- a/e2e/wdio/platform/pages/approval-flow.po.ts
+++ b/e2e/wdio/platform/pages/approval-flow.po.ts
@@ -24,9 +24,8 @@ export class ApprovalFlowPo extends BaseComponentPo {
     detailsDialogParallelSerialSelect = this.detailsDialog + ' fd-select';
     detailsDialogParallelSerialSelectOption = 'fd-option';
 
-    approvalFlow = 'fdp-approval-flow .approval-flow__container';
     selectExample = 'select';
-    approvalFlowNode = '.fdp-approval-flow-node__inner';
+    approvalFlowNode = 'fdp-approval-flow-node .fd-grid-list__item-body';
     approvalFlowTeamNode = this.approvalFlowNode + '.fdp-approval-flow-node__name--members-count';
     approvalFlowNodeAvatar = this.approvalFlowNode + ' fd-avatar';
     approvalFlowNodeStatus = this.approvalFlowNode + ' fdp-object-status';

--- a/libs/core/src/lib/grid-list/components/grid-list-filter-bar/grid-list-filter-bar.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list-filter-bar/grid-list-filter-bar.component.html
@@ -1,18 +1,17 @@
-<div class="fd-toolbar fd-toolbar--info fd-toolbar--active fd-grid-list__filter">
+<fd-toolbar
+    fdType="info"
+    [active]="true"
+    [tabindex]="0"
+    class="fd-grid-list__filter"
+    aria-label="Cancel"
+    (click)="close.emit()"
+    (keydown.space)="$event.preventDefault()"
+    (keyup.space)="close.emit()"
+    (keydown.enter)="close.emit()"
+>
     <ng-content></ng-content>
 
-    <span class="fd-toolbar__spacer"></span>
+    <fd-toolbar-spacer></fd-toolbar-spacer>
 
-    <button
-        fd-button
-        fdType="transparent"
-        glyph="decline"
-        i18n-aria-label
-        aria-label="Cancel"
-        i18n-title
-        title="Cancel"
-        [compact]="true"
-        class="fd-grid-list__filter-button"
-        (click)="close.emit()"
-    ></button>
-</div>
+    <fd-icon glyph="decline"></fd-icon>
+</fd-toolbar>

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
@@ -100,11 +100,7 @@
             (click)="_onDelete($event)"
         ></button>
 
-        <span
-            *ngIf="type === 'navigation'"
-            class="fd-grid-list__item-navigation-indicator"
-            (click)="_onNavigate($event)"
-        >
+        <span *ngIf="type === 'navigation'" class="fd-grid-list__item-navigation-indicator">
             <fd-icon glyph="navigation-right-arrow"></fd-icon>
         </span>
 

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
@@ -63,6 +63,7 @@
         </ng-container>
 
         <fd-grid-list-title-bar-spacer></fd-grid-list-title-bar-spacer>
+
         <span
             *ngIf="counter"
             class="fd-grid-list__item-counter"
@@ -113,12 +114,16 @@
     </div>
 
     <div class="fd-grid-list__item-body" [class.fd-grid-list__item-body--no-padding]="noPadding">
-        <ng-template>
-            <ng-content select="fd-grid-list-item-toolbar"></ng-content>
-            <ng-content select="fd-grid-list-item-footer-bar"></ng-content>
-        </ng-template>
+        <ng-content select="[fd-grid-list-item-image]"></ng-content>
 
-        <ng-content></ng-content>
+        <div *ngIf="title || description" class="fd-grid-list__item-header">
+            <h4 *ngIf="title" fd-title>{{ title }}</h4>
+            <span *ngIf="description" class="fd-grid-list__item-subtitle">{{ description }}</span>
+        </div>
+
+        <div *ngIf="body?.templateRef" class="fd-grid-list__item-content">
+            <ng-container [ngTemplateOutlet]="body.templateRef"></ng-container>
+        </div>
 
         <ng-container *ngIf="footerBarComponent?.contentTemplateRef">
             <ng-container *ngTemplateOutlet="itemFooter"></ng-container>

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
@@ -36,7 +36,7 @@
     </ng-container>
 
     <div
-        class="fd-toolbar fd-toolbar--transparent fd-grid-list__item-toolbar"
+        class="fd-toolbar fd-grid-list__item-toolbar"
         *ngIf="
             counter ||
             itemToolbarComponent?.contentTemplateRef ||
@@ -45,15 +45,11 @@
         "
     >
         <ng-container *ngIf="selectionMode === 'singleSelectLeft'">
-            <div class="fd-grid-list__item-input">
-                <ng-container *ngTemplateOutlet="radio"></ng-container>
-            </div>
+            <ng-container *ngTemplateOutlet="radio"></ng-container>
         </ng-container>
 
         <ng-container *ngIf="selectionMode === 'multiSelect'">
-            <div class="fd-grid-list__item-input">
-                <ng-container *ngTemplateOutlet="checkbox"></ng-container>
-            </div>
+            <ng-container *ngTemplateOutlet="checkbox"></ng-container>
         </ng-container>
 
         <ng-container *ngIf="itemToolbarComponent?.contentTemplateRef">
@@ -121,7 +117,7 @@
             <ng-container [ngTemplateOutlet]="body.templateRef"></ng-container>
         </div>
 
-        <ng-container *ngIf="footerBarComponent?.contentTemplateRef">
+        <ng-container *ngIf="state || footerBarComponent?.contentTemplateRef">
             <ng-container *ngTemplateOutlet="itemFooter"></ng-container>
         </ng-container>
     </div>

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
@@ -6,7 +6,9 @@
     role="option"
     [class.is-navigated]="isNavigated"
     [class.is-selected]="!!_selectedItem"
-    [class.fd-grid-list__item--link]="_isActive && (type === 'active' || type === 'detailsAndActive')"
+    [class.fd-grid-list__item--link]="
+        _isActive && (type === 'active' || type === 'detailsAndActive' || type === 'navigation')
+    "
     [class.fd-grid-list__item--unread]="state === 'unread'"
     [class.fd-grid-list__item--locked]="state === 'locked'"
     [class.fd-grid-list__item--draft]="state === 'draft'"
@@ -97,19 +99,13 @@
             (click)="_onDelete($event)"
         ></button>
 
-        <button
+        <span
             *ngIf="type === 'navigation'"
-            fd-button
-            fdType="transparent"
-            glyph="navigation-right-arrow"
-            i18n-aria-label="coreGridList.Item.Btn.Navigation|Button aria-label attribute"
-            aria-label="Navigation"
-            i18n-title="coreGridList.Item.Btn.Navigation|Button aria-label attribute"
-            title="Navigation"
-            class="fd-grid-list__action-button fd-grid-list__btn-navigation"
-            [compact]="true"
+            class="fd-grid-list__item-navigation-indicator"
             (click)="_onNavigate($event)"
-        ></button>
+        >
+            <fd-icon glyph="navigation-right-arrow"></fd-icon>
+        </span>
 
         <ng-container *ngIf="selectionMode === 'singleSelectRight'">
             <ng-container *ngTemplateOutlet="radio"></ng-container>
@@ -117,10 +113,6 @@
     </div>
 
     <div class="fd-grid-list__item-body" [class.fd-grid-list__item-body--no-padding]="noPadding">
-        <ng-container *ngIf="state">
-            <ng-container *ngTemplateOutlet="itemFooter"></ng-container>
-        </ng-container>
-
         <ng-template>
             <ng-content select="fd-grid-list-item-toolbar"></ng-content>
             <ng-content select="fd-grid-list-item-footer-bar"></ng-content>
@@ -128,7 +120,7 @@
 
         <ng-content></ng-content>
 
-        <ng-container *ngIf="!state && footerBarComponent?.contentTemplateRef">
+        <ng-container *ngIf="footerBarComponent?.contentTemplateRef">
             <ng-container *ngTemplateOutlet="itemFooter"></ng-container>
         </ng-container>
     </div>

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.scss
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.scss
@@ -21,6 +21,14 @@
     }
 
     &__item {
+        &-header {
+            padding-bottom: 1rem;
+        }
+
+        &-content {
+            padding-top: 0;
+        }
+
         .drop-area__line--vertical {
             height: 100%;
 

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.scss
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.scss
@@ -1,4 +1,4 @@
-// these css are related to drag and drop
+/* All these css are related to drag and drop */
 @mixin grabbing-cursor {
     cursor: -webkit-grabbing;
     cursor: -moz-grabbing;
@@ -21,14 +21,6 @@
     }
 
     &__item {
-        &-header {
-            padding-bottom: 1rem;
-        }
-
-        &-content {
-            padding-top: 0;
-        }
-
         .drop-area__line--vertical {
             height: 100%;
 

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.ts
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.ts
@@ -20,6 +20,7 @@ import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { KeyUtil } from '@fundamental-ngx/core/utils';
 import { Nullable } from '@fundamental-ngx/core/shared';
 
+import { GridListItemBodyDirective } from '../../directives/grid-list-item-body.directive';
 import { parseLayoutPattern } from '../../helpers/parse-layout-pattern';
 import { GridListItemToolbarComponent } from '../grid-list-item-toolbar/grid-list-item-toolbar.component';
 import { GridListSelectionMode, GridListSelectionActions } from '../../models/grid-list-selection.models';
@@ -143,11 +144,13 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
     @Input()
     isNavigated = false;
 
-    /** @hidden
-     * The active state of the list item.
-     * If set to true, the whole card has active state. Becomes false only when the Edit button is clicked.
-     */
-    _isActive = true;
+    /** Title of the item */
+    @Input()
+    title: string;
+
+    /** Description of the item */
+    @Input()
+    description: string;
 
     /**
      * Event is thrown, when type is active
@@ -195,6 +198,12 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
     @ViewChild('gridListItem')
     _gridListItem: ElementRef;
 
+    /** @hidden
+     * The active state of the list item.
+     * If set to true, the whole card has active state. Becomes false only when the Edit button is clicked.
+     */
+    _isActive = true;
+
     /** @hidden */
     get gridLayoutClasses(): string[] {
         return this._gridLayoutClasses;
@@ -213,6 +222,9 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
     /** @hidden */
     @ContentChild(GridListItemToolbarComponent)
     itemToolbarComponent: GridListItemToolbarComponent;
+
+    @ContentChild(GridListItemBodyDirective)
+    body: GridListItemBodyDirective;
 
     /** @hidden */
     _selectedItem?: T;

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.ts
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.ts
@@ -295,6 +295,7 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
         if (typeof this._selectedItem !== 'undefined' || !this.value || this._index == null) {
             return;
         }
+
         this._gridList.setSelectedItem(this.value, this._index);
     }
 
@@ -360,7 +361,12 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
             return;
         }
 
-        if (this.type !== 'active' && this.type !== 'detailsAndActive') {
+        if (this.type !== 'active' && this.type !== 'detailsAndActive' && this.type !== 'navigation') {
+            return;
+        }
+
+        if (this.type === 'navigation') {
+            this._onNavigate(event);
             return;
         }
 

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.ts
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.ts
@@ -223,6 +223,7 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
     @ContentChild(GridListItemToolbarComponent)
     itemToolbarComponent: GridListItemToolbarComponent;
 
+    /** @hidden */
     @ContentChild(GridListItemBodyDirective)
     body: GridListItemBodyDirective;
 

--- a/libs/core/src/lib/grid-list/components/grid-list/grid-list.component.spec.ts
+++ b/libs/core/src/lib/grid-list/components/grid-list/grid-list.component.spec.ts
@@ -139,21 +139,22 @@ describe('GridListComponent', () => {
         expect(toolbarsLength).toEqual(1);
     });
 
-    it('toolbar should contain counter and button', () => {
+    it('toolbar should contain counter and nav indicator', () => {
         const counters = fixture.debugElement.queryAll(By.css('.fd-grid-list__item .fd-grid-list__item-counter'));
         expect(counters.length).toEqual(1);
         expect(counters[0].nativeElement.innerText).toEqual('15');
 
-        const buttons = fixture.debugElement.queryAll(By.css('.fd-grid-list__item .fd-button'));
-        expect(buttons.length).toEqual(1);
-        expect(buttons[0].nativeElement.getAttribute('title')).toEqual('Navigation');
+        const navIndicators = fixture.debugElement.queryAll(
+            By.css('.fd-grid-list__item .fd-grid-list__item-navigation-indicator')
+        );
+        expect(navIndicators.length).toEqual(1);
     });
 
     it('should throw Navigation event if click on Navigation button', () => {
         spyOn(component, 'navigate');
-        const button = fixture.debugElement.query(By.css('.fd-grid-list__item .fd-toolbar .fd-button'));
-        button.nativeElement.click();
+        const item = fixture.debugElement.query(By.css('.fd-grid-list__item.fd-grid-list__item--link'));
 
+        item.nativeElement.click();
         fixture.detectChanges();
 
         expect(component.navigate).toHaveBeenCalledWith({ value: 'Title 3', index: 2 });

--- a/libs/core/src/lib/grid-list/directives/grid-list-item-body.directive.ts
+++ b/libs/core/src/lib/grid-list/directives/grid-list-item-body.directive.ts
@@ -1,0 +1,9 @@
+import { Directive, TemplateRef } from '@angular/core';
+
+@Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
+    selector: '[fd-grid-list-item-body]'
+})
+export class GridListItemBodyDirective {
+    constructor(public readonly templateRef: TemplateRef<any>) {}
+}

--- a/libs/core/src/lib/grid-list/directives/grid-list-item-body.directive.ts
+++ b/libs/core/src/lib/grid-list/directives/grid-list-item-body.directive.ts
@@ -5,5 +5,6 @@ import { Directive, TemplateRef } from '@angular/core';
     selector: '[fd-grid-list-item-body]'
 })
 export class GridListItemBodyDirective {
+    /** @hidden */
     constructor(public readonly templateRef: TemplateRef<any>) {}
 }

--- a/libs/core/src/lib/grid-list/directives/grid-list-item-image.directive.ts
+++ b/libs/core/src/lib/grid-list/directives/grid-list-item-image.directive.ts
@@ -4,8 +4,7 @@ import { Directive } from '@angular/core';
     // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[fd-grid-list-item-image]',
     host: {
-        class: 'fd-grid-list__item-image',
-        '[class.fd-grid-list__item-image--with-text]': 'withText'
+        class: 'fd-grid-list__item-image'
     }
 })
 export class GridListItemImageDirective {}

--- a/libs/core/src/lib/grid-list/directives/grid-list-item-image.directive.ts
+++ b/libs/core/src/lib/grid-list/directives/grid-list-item-image.directive.ts
@@ -1,0 +1,11 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+    // eslint-disable-next-line @angular-eslint/directive-selector
+    selector: '[fd-grid-list-item-image]',
+    host: {
+        class: 'fd-grid-list__item-image',
+        '[class.fd-grid-list__item-image--with-text]': 'withText'
+    }
+})
+export class GridListItemImageDirective {}

--- a/libs/core/src/lib/grid-list/grid-list.module.ts
+++ b/libs/core/src/lib/grid-list/grid-list.module.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { ObjectStatusModule } from '@fundamental-ngx/core/object-status';
 import { ButtonModule } from '@fundamental-ngx/core/button';
 import { ToolbarModule } from '@fundamental-ngx/core/toolbar';
+import { IconModule } from '@fundamental-ngx/core/icon';
 
 import { GridListComponent } from './components/grid-list/grid-list.component';
 import { GridListFilterBarComponent } from './components/grid-list-filter-bar/grid-list-filter-bar.component';
@@ -32,7 +33,7 @@ import { GridListTitleBarSpacerComponent } from './components/grid-list-title-ba
         GridListTitleBarSpacerComponent,
         GridListTitleBarAdditionalTitleItemDirective
     ],
-    imports: [CommonModule, ButtonModule, ToolbarModule, ObjectStatusModule, FormsModule],
+    imports: [CommonModule, ButtonModule, IconModule, ToolbarModule, ObjectStatusModule, FormsModule],
     exports: [
         GridListComponent,
         GridListItemComponent,

--- a/libs/core/src/lib/grid-list/grid-list.module.ts
+++ b/libs/core/src/lib/grid-list/grid-list.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 
 import { ObjectStatusModule } from '@fundamental-ngx/core/object-status';
 import { ButtonModule } from '@fundamental-ngx/core/button';
+import { TitleModule } from '@fundamental-ngx/core/title';
 import { ToolbarModule } from '@fundamental-ngx/core/toolbar';
 import { IconModule } from '@fundamental-ngx/core/icon';
 
@@ -18,6 +19,8 @@ import { GridListMoreBtnComponent } from './components/grid-list-more-btn/grid-l
 import { GridListTitleBarComponent } from './components/grid-list-title-bar/grid-list-title-bar.component';
 import { GridListTitleBarAdditionalTitleItemDirective } from './components/grid-list-title-bar/grid-list-title-bar.directive';
 import { GridListTitleBarSpacerComponent } from './components/grid-list-title-bar-spacer/grid-list-title-bar-spacer.component';
+import { GridListItemBodyDirective } from './directives/grid-list-item-body.directive';
+import { GridListItemImageDirective } from './directives/grid-list-item-image.directive';
 
 @NgModule({
     declarations: [
@@ -31,9 +34,11 @@ import { GridListTitleBarSpacerComponent } from './components/grid-list-title-ba
         GridListItemToolbarComponent,
         GridListGroupHeaderComponent,
         GridListTitleBarSpacerComponent,
-        GridListTitleBarAdditionalTitleItemDirective
+        GridListTitleBarAdditionalTitleItemDirective,
+        GridListItemImageDirective,
+        GridListItemBodyDirective
     ],
-    imports: [CommonModule, ButtonModule, IconModule, ToolbarModule, ObjectStatusModule, FormsModule],
+    imports: [CommonModule, FormsModule, ButtonModule, IconModule, TitleModule, ToolbarModule, ObjectStatusModule],
     exports: [
         GridListComponent,
         GridListItemComponent,
@@ -45,7 +50,9 @@ import { GridListTitleBarSpacerComponent } from './components/grid-list-title-ba
         GridListItemToolbarComponent,
         GridListGroupHeaderComponent,
         GridListTitleBarSpacerComponent,
-        GridListTitleBarAdditionalTitleItemDirective
+        GridListTitleBarAdditionalTitleItemDirective,
+        GridListItemImageDirective,
+        GridListItemBodyDirective
     ]
 })
 export class GridListModule {}

--- a/libs/core/src/lib/grid-list/public_api.ts
+++ b/libs/core/src/lib/grid-list/public_api.ts
@@ -9,5 +9,10 @@ export * from './components/grid-list-more-btn/grid-list-more-btn.component';
 export * from './components/grid-list-title-bar/grid-list-title-bar.component';
 export * from './components/grid-list-title-bar/grid-list-title-bar.directive';
 export * from './components/grid-list-title-bar-spacer/grid-list-title-bar-spacer.component';
+
+export * from './directives/grid-list-item-body.directive';
+export * from './directives/grid-list-item-image.directive';
+
 export * from './models/grid-list-selection.models';
+
 export * from './grid-list.module';

--- a/libs/core/src/lib/toolbar/toolbar.component.html
+++ b/libs/core/src/lib/toolbar/toolbar.component.html
@@ -1,9 +1,13 @@
-<div #toolbar>
+<div #toolbar [tabindex]="tabindex">
     <h4 *ngIf="title" class="fd-title fd-title--h4 fd-toolbar__title">{{ title }}</h4>
+
     <ng-content></ng-content>
+
     <ng-container *ngIf="shouldOverflow">
         <span #overflowSpacer class="fd-toolbar__spacer"></span>
+
         <span class="fd-toolbar__separator" *ngIf="overflowVisibility | async"></span>
+
         <fd-popover placement="bottom-end" [noArrow]="true" class="fd-popover">
             <fd-popover-control>
                 <button
@@ -17,6 +21,7 @@
                     glyph="overflow"
                 ></button>
             </fd-popover-control>
+
             <fd-popover-body>
                 <div class="fd-toolbar__overflow" #overflowBody></div>
             </fd-popover-body>

--- a/libs/core/src/lib/toolbar/toolbar.component.ts
+++ b/libs/core/src/lib/toolbar/toolbar.component.ts
@@ -109,6 +109,10 @@ export class ToolbarComponent
     @Input()
     forceOverflow = false;
 
+    /** Tabindex of the toolbar element, to be used when fdType="info" */
+    @Input()
+    tabindex = -1;
+
     /** @hidden */
     @ViewChild('toolbar')
     toolbar: ElementRef;

--- a/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.html
+++ b/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.html
@@ -36,59 +36,47 @@
 </ng-template>
 
 <ng-template #nodeContent>
-    <div class="fdp-approval-flow-node__inner">
-        <div class="fdp-approval-flow-node__avatar">
-            <ng-container *ngIf="node.approvers.length === 1">
-                <fd-avatar [image]="node.approvers[0].imgUrl" size="xs" [circle]="true"></fd-avatar>
+    <div class="fdp-approval-flow-node__info">
+        <div
+            class="fdp-approval-flow-node__name"
+            [class.fdp-approval-flow-node__name--members-count]="node.approvers.length > 1"
+        >
+            <ng-container *ngIf="node.approvers.length === 1; else multipleApprovers">
+                {{ node.approvers[0].name }}
             </ng-container>
 
-            <ng-container *ngIf="node.approvers.length > 1">
-                <fd-avatar [label]="node.description" size="xs" [circle]="true"></fd-avatar>
+            <ng-template #multipleApprovers i18n="@@platformApprovalFlowNodeMembers">
+                {{ node.approvers.length }} members
+            </ng-template>
+        </div>
+
+        <div class="fdp-approval-flow-node__description">
+            <ng-container *ngIf="!node.variousTeams; else variousTeams">
+                {{ node.approvers.length > 1 ? node.description : node.approvers[0]?.description }}
             </ng-container>
+
+            <ng-template #variousTeams i18n="@@platformApprovalFlowNodeVariousTeams"> Various teams </ng-template>
         </div>
 
-        <div class="fdp-approval-flow-node__info">
-            <div
-                class="fdp-approval-flow-node__name"
-                [class.fdp-approval-flow-node__name--members-count]="node.approvers.length > 1"
-            >
-                <ng-container *ngIf="node.approvers.length === 1; else multipleApprovers">
-                    {{ node.approvers[0].name }}
+        <fdp-object-status [status]="_objectStatus" [inverted]="true">
+            <ng-container *ngIf="!checkDueDate || !_showDueDateWarning">
+                {{ node.status }}
+            </ng-container>
+
+            <ng-container *ngIf="checkDueDate && _showDueDateWarning">
+                <ng-container *ngIf="_dueIn === dueDateThreshold" i18n="@@platformApprovalFlowNodeStatusDueToday">
+                    Due today
                 </ng-container>
 
-                <ng-template #multipleApprovers i18n="@@platformApprovalFlowNodeMembers">
-                    {{ node.approvers.length }} members
-                </ng-template>
-            </div>
-
-            <div class="fdp-approval-flow-node__description">
-                <ng-container *ngIf="!node.variousTeams; else variousTeams">
-                    {{ node.approvers.length > 1 ? node.description : node.approvers[0]?.description }}
+                <ng-container *ngIf="_dueIn < dueDateThreshold" i18n="@@platformApprovalFlowNodeStatusDueInXDays">
+                    Due in {{ dueDateThreshold - _dueIn }} days
                 </ng-container>
 
-                <ng-template #variousTeams i18n="@@platformApprovalFlowNodeVariousTeams"> Various teams </ng-template>
-            </div>
-
-            <fdp-object-status [status]="_objectStatus" [inverted]="true">
-                <ng-container *ngIf="!checkDueDate || !_showDueDateWarning">
-                    {{ node.status }}
+                <ng-container *ngIf="_dueIn > dueDateThreshold" i18n="@@platformApprovalFlowNodeStatusXDaysOverdue">
+                    {{ _dueIn - dueDateThreshold }} days overdue
                 </ng-container>
-
-                <ng-container *ngIf="checkDueDate && _showDueDateWarning">
-                    <ng-container *ngIf="_dueIn === dueDateThreshold" i18n="@@platformApprovalFlowNodeStatusDueToday">
-                        Due today
-                    </ng-container>
-
-                    <ng-container *ngIf="_dueIn < dueDateThreshold" i18n="@@platformApprovalFlowNodeStatusDueInXDays">
-                        Due in {{ dueDateThreshold - _dueIn }} days
-                    </ng-container>
-
-                    <ng-container *ngIf="_dueIn > dueDateThreshold" i18n="@@platformApprovalFlowNodeStatusXDaysOverdue">
-                        {{ _dueIn - dueDateThreshold }} days overdue
-                    </ng-container>
-                </ng-container>
-            </fdp-object-status>
-        </div>
+            </ng-container>
+        </fdp-object-status>
     </div>
 </ng-template>
 

--- a/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.scss
+++ b/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.scss
@@ -347,14 +347,6 @@ $border-color-variable: var(--sapGroup_TitleBorderColor, #d9d9d9);
             }
         }
 
-        .#{$block}__inner {
-            display: flex;
-        }
-
-        .#{$block}__avatar {
-            margin-right: 1rem;
-        }
-
         .#{$block}__name {
             font-size: 1rem;
             line-height: 1.25rem;
@@ -406,11 +398,6 @@ $border-color-variable: var(--sapGroup_TitleBorderColor, #d9d9d9);
         }
 
         @include fd-rtl() {
-            .#{$block}__avatar {
-                margin-right: 0;
-                margin-left: 1rem;
-            }
-
             .#{$block}__arrow {
                 left: auto;
                 right: -0.5rem;

--- a/libs/platform/src/lib/approval-flow/approval-flow.component.html
+++ b/libs/platform/src/lib/approval-flow/approval-flow.component.html
@@ -160,7 +160,17 @@
                                         </ng-container>
                                     </fd-grid-list-item-toolbar>
 
-                                    <ng-container [ngTemplateOutlet]="approvalFlowNode._nodeContent"></ng-container>
+                                    <fd-avatar
+                                        fd-grid-list-item-image
+                                        [image]="node.approvers.length === 1 ? node.approvers[0].imgUrl : null"
+                                        [label]="node.approvers.length > 1 ? node.description : null"
+                                        size="xs"
+                                        [circle]="true"
+                                    ></fd-avatar>
+
+                                    <ng-template fd-grid-list-item-body>
+                                        <ng-container [ngTemplateOutlet]="approvalFlowNode._nodeContent"></ng-container>
+                                    </ng-template>
                                 </fd-grid-list-item>
                             </fdp-approval-flow-node>
                         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17090,9 +17090,9 @@
             "dev": true
         },
         "fundamental-styles": {
-            "version": "0.24.0-rc.102",
-            "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.24.0-rc.102.tgz",
-            "integrity": "sha512-cHKZnxX08ZghzgGjGxsGG/sve/dcwow3iLxt/3XMMwo34MNKBq6BaxO8fYw33Cht56vw06HOf5j+m/dQVihYdA=="
+            "version": "0.24.0-rc.114",
+            "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.24.0-rc.114.tgz",
+            "integrity": "sha512-+t8rCb2OMfNvnZJgQPdf9LQ8xvQ53pHknI829NmAp2LRWB7OBljICwxYXpKTTSiaJN2taAUTrqwRbQZKDe/5Cg=="
         },
         "gauge": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
         "fast-deep-equal": "3.1.3",
         "focus-trap": "6.7.3",
         "focus-visible": "5.2.0",
-        "fundamental-styles": "0.24.0-rc.102",
+        "fundamental-styles": "0.24.0-rc.114",
         "highlight.js": "10.7.2",
         "intl": "1.2.5",
         "jasminewd2": "2.2.0",


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

Grid List Horizon support, breaking changes adoption.

## Screenshots

### Before:

<img width="323" alt="image" src="https://user-images.githubusercontent.com/20265336/165931153-3d9ffe82-85cc-4921-9c0e-632c55e0c70d.png">

### After:

Blocked by https://github.com/SAP/fundamental-styles/pull/3374

<img width="324" alt="image" src="https://user-images.githubusercontent.com/20265336/165931075-18a8788a-e8c9-4bd2-81ad-ec84dcf33a3f.png">

## BREAKING CHANGE

* Grid List Item body markup changed, see [wiki](https://github.com/SAP/fundamental-ngx/wiki/0.35.0-Breaking-changes#grid-list-core-8039)
* The whole item with link is clickable now, it might cause issues in a single selection mode but selection event emitted first.

https://github.com/SAP/fundamental-ngx/wiki/0.35.0-Breaking-changes#grid-list-core-8039
