### PR TITLE
fix(docs): card examples

### DIFF
--- a/apps/docs/src/app/core/component-docs/card/card-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/card/card-docs.component.ts
@@ -3,6 +3,8 @@ import { Component } from '@angular/core';
 import { ExampleFile } from '../../../documentation/core-helpers/code-example/example-file';
 
 import cardExampleHtml from '!./examples/card-example.component.html?raw';
+import cardExampleTs from '!./examples/card-example.component.ts?raw';
+import cardExampleScss from '!./examples/card-example.component.scss?raw';
 import cardCompactExampleHtml from '!./examples/card-compact-example.component.html?raw';
 import cardLoaderExampleHtml from '!./examples/card-loader-example.component.html?raw';
 import cardFooterExampleHtml from '!./examples/card-footer-example.component.html?raw';
@@ -36,6 +38,16 @@ export class CardDocsComponent {
         {
             language: 'html',
             code: cardExampleHtml,
+            fileName: 'card-example'
+        },
+        {
+            language: 'ts',
+            code: cardExampleTs,
+            fileName: 'card-example'
+        },
+        {
+            language: 'scss',
+            code: cardExampleScss,
             fileName: 'card-example'
         }
     ];

--- a/apps/docs/src/app/core/component-docs/card/examples/card-example.component.html
+++ b/apps/docs/src/app/core/component-docs/card/examples/card-example.component.html
@@ -21,6 +21,7 @@
 <fd-card class="fd-docs-example-card-fix-width">
     <fd-card-content>
         <img
+            width="100%"
             src="http://placeimg.com/298/300/nature/1"
             class="fd-docs-example-image-bottom-adjustment"
             alt="first image"


### PR DESCRIPTION
## Related Issue(s)

part of #7984 

## Description

Fixed card image example. Updating fundamental styles version so that after that cards do not have overflown content

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![analytical_before](https://user-images.githubusercontent.com/28543391/166670043-081c34b2-cf5b-40b0-9699-7daeed831c6a.jpg)
![calendar_before](https://user-images.githubusercontent.com/28543391/166669876-ac30508e-a187-4127-aeac-48b99815571b.jpg)
![image_before](https://user-images.githubusercontent.com/28543391/166669878-4f0f642d-0022-4660-8dfb-b37a91eeb37e.jpg)

### After:
![analytical_afterjpg](https://user-images.githubusercontent.com/28543391/166669931-438a1c20-2edd-4fc2-88c2-6bb3b95aef74.jpg)
![calendar_after](https://user-images.githubusercontent.com/28543391/166669934-9c30996c-ebb1-459b-ac00-724266cb6aa6.jpg)
![image_after](https://user-images.githubusercontent.com/28543391/166669935-c7e362a8-9fab-4261-a9ed-fb147fde5f30.jpg)


## Blocked
https://github.com/SAP/fundamental-styles/pull/3379