### PR TITLE
chore(core): remove unnecessary list detection from card

### DIFF
--- a/libs/core/src/lib/card/card-content.component.ts
+++ b/libs/core/src/lib/card/card-content.component.ts
@@ -1,33 +1,17 @@
-import { Component, OnInit, ChangeDetectionStrategy, ElementRef, ContentChild } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, ElementRef } from '@angular/core';
 import { applyCssClass } from '@fundamental-ngx/core/utils';
 import { CssClassBuilder } from '@fundamental-ngx/core/utils';
 
 import { CLASS_NAME } from './constants';
-import { FD_CARD_CONTAINER } from './card.tokens';
-import { FD_LIST } from '@fundamental-ngx/core/list';
 
 @Component({
     selector: 'fd-card-content',
     template: '<ng-content></ng-content>',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [{ provide: FD_CARD_CONTAINER, useExisting: CardContentComponent }]
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CardContentComponent implements OnInit, CssClassBuilder {
     /** @hidden */
     class: string;
-
-    /** @hidden */
-    @ContentChild(FD_LIST)
-    set containsList(list: any) {
-        this._containsList = !!list;
-    }
-
-    get containsList(): any {
-        return this._containsList;
-    }
-
-    /** @hidden */
-    private _containsList: boolean;
 
     /** @hidden */
     constructor(private _elementRef: ElementRef<HTMLElement>) {}

--- a/libs/core/src/lib/card/card.component.ts
+++ b/libs/core/src/lib/card/card.component.ts
@@ -9,7 +9,6 @@ import {
     HostBinding,
     OnDestroy,
     Optional,
-    ContentChild,
     AfterViewChecked
 } from '@angular/core';
 
@@ -21,7 +20,6 @@ import { Subscription } from 'rxjs';
 import { applyCssClass } from '@fundamental-ngx/core/utils';
 import { CssClassBuilder } from '@fundamental-ngx/core/utils';
 import { getCardModifierClassNameByCardType } from './utils';
-import { FD_CARD_CONTAINER } from './card.tokens';
 
 let cardId = 0;
 
@@ -63,10 +61,6 @@ export class CardComponent implements OnChanges, AfterViewChecked, OnInit, CssCl
     @HostBinding('attr.role')
     role = 'region';
 
-    /** Reference to the card container element */
-    @ContentChild(FD_CARD_CONTAINER)
-    cardContainer: { containsList: boolean };
-
     /** @hidden */
     class: string;
 
@@ -75,8 +69,7 @@ export class CardComponent implements OnChanges, AfterViewChecked, OnInit, CssCl
         return [
             CLASS_NAME.card,
             this.cardType ? getCardModifierClassNameByCardType(this.cardType) : null,
-            this.compact ? CLASS_NAME.cardCompact : null,
-            this.cardContainer?.containsList ? CLASS_NAME.cardList : null
+            this.compact ? CLASS_NAME.cardCompact : null
         ];
     }
 

--- a/libs/core/src/lib/card/card.tokens.ts
+++ b/libs/core/src/lib/card/card.tokens.ts
@@ -1,3 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export const FD_CARD_CONTAINER = new InjectionToken('Card container component');

--- a/libs/core/src/lib/card/constants.ts
+++ b/libs/core/src/lib/card/constants.ts
@@ -1,7 +1,6 @@
 export const CLASS_NAME = {
     card: 'fd-card',
     cardCompact: 'fd-card--compact',
-    cardList: 'fd-card--list',
 
     cardHeader: 'fd-card__header',
     cardHeaderNonInteractive: 'fd-card__header--non-interactive',


### PR DESCRIPTION
## Related Issue(s)

part of #7931 

## Description

Previously `&--list` modifier was required for card, it will not be after https://github.com/SAP/fundamental-styles/pull/3379
This PR will update that