### PR TITLE
fix(core): correct breadcrumb order

### DIFF
--- a/apps/docs/src/app/core/component-docs/breadcrumb/breadcrumb-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/breadcrumb/breadcrumb-docs.component.html
@@ -1,6 +1,14 @@
 <fd-docs-section-title id="routerLink" componentName="breadcrumb">
     An example using <b>routerLink</b>
 </fd-docs-section-title>
+<description>
+    The breadcrumb component is a type of navigation that indicates the position of a page within the application’s page
+    hierarchy. Users can navigate backward by selecting the previous pages in the navigation path.<br />
+    The breadcrumb is responsive. When the last breadcrumbs item's edge overflows the available area, the earliest
+    breadcrumb will be added to an overflow menu at the start of the breadcrumb trail. By default, these items are
+    displayed in the menu with the most recently added at the top. This can be changed by setting the
+    <code>[reverse]</code> input to <code>[true]</code>.
+</description>
 <component-example>
     <fd-breadcrumb-routerLink-example></fd-breadcrumb-routerLink-example>
 </component-example>

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -76,6 +76,10 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit, OnDestroy 
     @Input()
     containerElement: HTMLElement;
 
+    /** Whether or not to append items to the overflow dropdown in reverse order. Default is true. */
+    @Input()
+    reverse = false;
+
     /** @hidden */
     containerBoundary: number;
 
@@ -177,7 +181,9 @@ export class BreadcrumbComponent implements AfterContentInit, OnInit, OnDestroy 
         ) {
             const breadcrumbItem = this.breadcrumbItems.filter((item, index) => index === i)[0];
             if (this.collapsedBreadcrumbItems.indexOf(breadcrumbItem) === -1) {
-                this.collapsedBreadcrumbItems.push(breadcrumbItem);
+                this.reverse
+                    ? this.collapsedBreadcrumbItems.push(breadcrumbItem)
+                    : this.collapsedBreadcrumbItems.unshift(breadcrumbItem);
             }
             // hide the original breadcrumb items that have been moved in to the collapsed menu
             breadcrumbItem.elementRef.nativeElement.style.display = 'none';


### PR DESCRIPTION
Fixes the default breadcrumb overflow order and allows the developer via input to specify if they'd like to stack the items in reverse

part of #7631 