### PR TITLE
fix(platform): wizardgenerator dots in labels are not supported

### DIFF
--- a/libs/platform/src/lib/form/form-generator/form-generator.service.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.ts
@@ -254,14 +254,23 @@ export class FormGeneratorService implements OnDestroy {
      * @param controlName Name of the form control.
      * @returns Found form control.
      */
-    getFormControl(form: DynamicFormGroup, controlName: string): DynamicFormGroupControl {
-        let control = form?.get(controlName);
+    getFormControl(form: DynamicFormGroup, ...controlNames: string[]): DynamicFormGroupControl {
+        let control = form?.get(controlNames);
 
         // If no control found, try to find it in ungrouped group
         if (!control) {
-            control = form?.get(UNGROUPED_FORM_GROUP_NAME + '.' + controlName);
+            control = form?.get([UNGROUPED_FORM_GROUP_NAME, ...controlNames]);
         }
 
+        return control as DynamicFormGroupControl;
+    }
+        let control = form?.get([controlName]);
+
+        // If no control found, try to find it in ungrouped group
+        if (!control) {
+            control = form?.get([UNGROUPED_FORM_GROUP_NAME, controlName]);
+        }
+        
         return control as DynamicFormGroupControl;
     }
 

--- a/libs/platform/src/lib/form/form-generator/form-generator.service.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.ts
@@ -254,16 +254,7 @@ export class FormGeneratorService implements OnDestroy {
      * @param controlName Name of the form control.
      * @returns Found form control.
      */
-    getFormControl(form: DynamicFormGroup, ...controlNames: string[]): DynamicFormGroupControl {
-        let control = form?.get(controlNames);
-
-        // If no control found, try to find it in ungrouped group
-        if (!control) {
-            control = form?.get([UNGROUPED_FORM_GROUP_NAME, ...controlNames]);
-        }
-
-        return control as DynamicFormGroupControl;
-    }
+    getFormControl(form: DynamicFormGroup, controlName: string): DynamicFormGroupControl {
         let control = form?.get([controlName]);
 
         // If no control found, try to find it in ungrouped group
@@ -271,7 +262,7 @@ export class FormGeneratorService implements OnDestroy {
             control = form?.get([UNGROUPED_FORM_GROUP_NAME, controlName]);
         }
         
-        return control as DynamicFormGroupControl;
+            return control as DynamicFormGroupControl;
     }
 
     /** @hidden */


### PR DESCRIPTION
Currently, dots in labels are not supported as these are interpreted as delimiters of subpaths by angular/forms. Therefore, the dot notation should no longer be used to identify paths in wizard items.

https://github.com/angular/angular/issues/21950

There exists an issue '[WizardGenerator] Dots in labels are not supported in wizard', which describes this with more detailed information in the repository whose name, for confidentiality reasons, I will not post here.

Old PR: https://github.com/SAP/fundamental-ngx/pull/8106, https://github.com/SAP/fundamental-ngx/pull/8010