### PR TITLE
feat(core,platform): local content density, smart filter bar density support

### DIFF
--- a/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
+++ b/libs/core/src/lib/dialog/dialog-service/dialog.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Injector, Optional, TemplateRef, Type } from '@angular/core';
+import { Inject, Injectable, Injector, Optional, StaticProvider, TemplateRef, Type } from '@angular/core';
 import { DialogContainerComponent } from '../dialog-container/dialog-container.component';
 import { DIALOG_DEFAULT_CONFIG, DialogConfig } from '../utils/dialog-config.class';
 import { DynamicComponentService, RtlService } from '@fundamental-ngx/core/utils';
@@ -23,9 +23,14 @@ export class DialogService extends DialogBaseService<DialogContainerComponent> {
     /**
      * Opens a dialog component with provided content.
      * @param content Content of the dialog component.
-     * @param dialogConfig Configuration of the dialog component.
+     * @param dialogConfig Configuration of the dialog component (optional).
+     * @param providers Additional providers (optional).
      */
-    public open<T = any>(content: DialogContentType, dialogConfig?: DialogConfig<T>): DialogRef<T> {
+    public open<T = any>(
+        content: DialogContentType,
+        dialogConfig?: DialogConfig<T>,
+        providers?: StaticProvider[]
+    ): DialogRef<T> {
         const dialogRef = new DialogRef();
 
         dialogConfig = this._applyDefaultConfig(dialogConfig || {}, this._defaultConfig || new DialogConfig());
@@ -36,7 +41,8 @@ export class DialogService extends DialogBaseService<DialogContainerComponent> {
                 { provide: DialogConfig, useValue: dialogConfig },
                 { provide: DialogRef, useValue: dialogRef },
                 { provide: RtlService, useValue: this._rtlService },
-                { provide: DialogService, useValue: this }
+                { provide: DialogService, useValue: this },
+                ...(providers ?? [])
             ]
         });
 

--- a/libs/core/src/lib/utils/pipes/listen-to-density.pipe.ts
+++ b/libs/core/src/lib/utils/pipes/listen-to-density.pipe.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectorRef, OnDestroy, Optional, Pipe, PipeTransform } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { LocalContentDensityService } from '../services/local-content-density.service';
+
+import { ContentDensity, DEFAULT_CONTENT_DENSITY } from './../services/content-density.service';
+
+@Pipe({
+    name: 'listenDensity',
+    pure: false
+})
+export class ListenToDensityPipe implements PipeTransform, OnDestroy {
+    /** @hidden */
+    private _subscription = new Subscription();
+
+    /** @hidden */
+    constructor(private _cdr: ChangeDetectorRef, @Optional() private _localDensityService: LocalContentDensityService) {
+        this._setupLocalDenistyListener();
+    }
+
+    /** @hidden */
+    ngOnDestroy(): void {
+        this._subscription.unsubscribe();
+    }
+
+    /** @hidden */
+    transform(value: ContentDensity | null): ContentDensity {
+        return value || this._localDensityService?.contentDensity.getValue() || DEFAULT_CONTENT_DENSITY;
+    }
+
+    /** @hidden */
+    private _setupLocalDenistyListener(): void {
+        this._subscription.add(
+            this._localDensityService?._contentDensityListener.subscribe(() => this._cdr.markForCheck())
+        );
+    }
+}

--- a/libs/core/src/lib/utils/pipes/pipe.module.ts
+++ b/libs/core/src/lib/utils/pipes/pipe.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 
 import { DisplayFnPipe } from './displayFn.pipe';
+import { ListenToDensityPipe } from './listen-to-density.pipe';
 import { SearchHighlightPipe } from './search-highlight.pipe';
 import { TwoDigitsPipe } from './two-digits.pipe';
 import { SafePipe } from './safe.pipe';
@@ -8,7 +9,23 @@ import { ValueByPathPipe } from './value-by-path.pipe';
 import { IsCompactDensityPipe } from './is-compact.pipe';
 
 @NgModule({
-    declarations: [DisplayFnPipe, SearchHighlightPipe, TwoDigitsPipe, SafePipe, ValueByPathPipe, IsCompactDensityPipe],
-    exports: [DisplayFnPipe, SearchHighlightPipe, TwoDigitsPipe, SafePipe, ValueByPathPipe, IsCompactDensityPipe]
+    declarations: [
+        DisplayFnPipe,
+        SearchHighlightPipe,
+        TwoDigitsPipe,
+        SafePipe,
+        ValueByPathPipe,
+        IsCompactDensityPipe,
+        ListenToDensityPipe
+    ],
+    exports: [
+        DisplayFnPipe,
+        SearchHighlightPipe,
+        TwoDigitsPipe,
+        SafePipe,
+        ValueByPathPipe,
+        IsCompactDensityPipe,
+        ListenToDensityPipe
+    ]
 })
 export class PipeModule {}

--- a/libs/core/src/lib/utils/public_api.ts
+++ b/libs/core/src/lib/utils/public_api.ts
@@ -29,6 +29,7 @@ export * from './pipes/search-highlight.pipe';
 export * from './pipes/safe.pipe';
 export * from './pipes/is-compact.pipe';
 export * from './pipes/value-by-path.pipe';
+export * from './pipes/listen-to-density.pipe';
 
 export * from './drag-and-drop/drag-and-drop.module';
 export * from './drag-and-drop/dnd-list/dnd-list.directive';
@@ -56,7 +57,9 @@ export * from './utils.module';
 export * from './datatypes/hash.datatype';
 export * from './datatypes/size.datatype';
 export * from './datatypes/color-accent.datatype';
+
 export * from './services/content-density.service';
+export * from './services/local-content-density.service';
 export * from './services/rtl.service';
 export * from './services/themes.service';
 export * from './services/keyboard-support/keyboard-support.service';

--- a/libs/core/src/lib/utils/services/content-density.service.ts
+++ b/libs/core/src/lib/utils/services/content-density.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { distinctUntilChanged, map, startWith } from 'rxjs/operators';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 import { isCompactDensity } from '../functions/is-compact-density';
 
 export type ContentDensity = 'cozy' | 'condensed' | 'compact';
@@ -21,7 +21,7 @@ export class ContentDensityService {
 
     /** @hidden */
     get _contentDensityListener(): Observable<ContentDensity> {
-        return this.contentDensity.pipe(distinctUntilChanged(), startWith(this.contentDensity.getValue()));
+        return this.contentDensity.pipe(distinctUntilChanged());
     }
 
     /** @hidden */

--- a/libs/core/src/lib/utils/services/local-content-density.service.ts
+++ b/libs/core/src/lib/utils/services/local-content-density.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, Optional } from '@angular/core';
+import { ContentDensity, ContentDensityService } from './content-density.service';
+import { distinctUntilChanged, filter, merge, Observable, tap } from 'rxjs';
+
+/**
+ * Service to share ContentDensity with children components
+ * and to stop reacting to global ContentDensity changes once the value is set in the @Input.
+ * Child components can get the ContentDensity value in template using | listenDensity pipe.
+ * This service should be provided in the root component & setDensity method should be called in ContentDensity @Input setter.
+ */
+@Injectable()
+export class LocalContentDensityService extends ContentDensityService {
+    private updatedLocally = false;
+
+    constructor(@Optional() private contentDensityService: ContentDensityService) {
+        super();
+    }
+
+    /** @hidden */
+    get _contentDensityListener(): Observable<ContentDensity> {
+        if (!this.contentDensityService) {
+            return this.contentDensity.pipe(distinctUntilChanged());
+        }
+
+        return merge(
+            this.contentDensityService._contentDensityListener.pipe(
+                filter(() => !this.updatedLocally),
+                tap((value) => this.contentDensity.next(value)),
+                filter(() => false)
+            ),
+            this.contentDensity
+        ).pipe(distinctUntilChanged());
+    }
+
+    /** Notify to stop listening for global ContentDensity changes. */
+    setDensity(value: ContentDensity): void {
+        if (!value) {
+            return;
+        }
+
+        this.updatedLocally = true;
+
+        this.contentDensity.next(value);
+    }
+}

--- a/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-settings-dialog/smart-filter-bar-settings-dialog.component.html
+++ b/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-settings-dialog/smart-filter-bar-settings-dialog.component.html
@@ -19,7 +19,7 @@
             #table
             (rowSelectionChange)="_onRowSelectionChange($event)"
             [dataSource]="source"
-            contentDensity="compact"
+            [contentDensity]="null | listenDensity"
             selectionMode="multiple"
         >
             <fdp-table-toolbar
@@ -32,7 +32,7 @@
                         (selectionChange)="_onFilterVisibilityChange($event)"
                         [list]="_filterVisibilityOptions"
                         [value]="_filterVisibilityOptions[0].value"
-                        contentDensity="compact"
+                        [contentDensity]="null | listenDensity"
                     >
                     </fdp-select>
                 </fdp-table-toolbar-actions>
@@ -64,7 +64,7 @@
             <fdp-button
                 (click)="_confirm()"
                 buttonType="emphasized"
-                contentDensity="compact"
+                [contentDensity]="null | listenDensity"
                 i18n-label="@@PlatformSmartFilterBarSelectFiltersSubmitButton"
                 label="Go"
             ></fdp-button>
@@ -74,7 +74,7 @@
             <fdp-button
                 (click)="_cancel()"
                 buttonType="transparent"
-                contentDensity="compact"
+                [contentDensity]="null | listenDensity"
                 i18n-label="@@PlatformSmartFilterBarSelectFiltersCancelButton"
                 label="Cancel"
             ></fdp-button>

--- a/libs/platform/src/lib/smart-filter-bar/smart-filter-bar.component.html
+++ b/libs/platform/src/lib/smart-filter-bar/smart-filter-bar.component.html
@@ -4,7 +4,7 @@
             (inputChange)="_onSearchInputChange($event)"
             (searchSubmit)="submitForm()"
             [disableRefresh]="true"
-            contentDensity="compact"
+            [contentDensity]="contentDensity | listenDensity"
             i18n-placeholder="@@PlatformSmartFilterBarSearchPlaceholder"
             placeholder="Search"
         ></fdp-search-field>
@@ -12,23 +12,28 @@
         <fdp-button
             (click)="submitForm()"
             buttonType="emphasized"
-            contentDensity="compact"
+            [contentDensity]="contentDensity | listenDensity"
             fd-toolbar-item
             i18n-placeholder="@@PlatformSmartFilterBarSubmitButton"
             label="Go"
         ></fdp-button>
-        <fdp-button (click)="submitForm()" contentDensity="compact" fd-toolbar-item glyph="synchronize"></fdp-button>
+        <fdp-button
+            (click)="submitForm()"
+            [contentDensity]="contentDensity | listenDensity"
+            fd-toolbar-item
+            glyph="synchronize"
+        ></fdp-button>
         <fdp-button
             (click)="showFilteringSettings()"
             [label]="filtersLabel + ' (' + _selectedFilters.length + ')'"
-            contentDensity="compact"
+            [contentDensity]="contentDensity | listenDensity"
             fd-toolbar-item
         ></fdp-button>
         <fdp-button
             (click)="_toggleFilterBar()"
             [label]="_showFilterBar ? hideFiltersLabel : showFiltersLabel"
             buttonType="transparent"
-            contentDensity="compact"
+            [contentDensity]="contentDensity | listenDensity"
             fd-toolbar-item
         ></fdp-button>
     </fd-toolbar>

--- a/libs/platform/src/lib/smart-filter-bar/smart-filter-bar.module.ts
+++ b/libs/platform/src/lib/smart-filter-bar/smart-filter-bar.module.ts
@@ -21,6 +21,7 @@ import { ListModule } from '@fundamental-ngx/core/list';
 import { CheckboxModule } from '@fundamental-ngx/core/checkbox';
 import { PlatformTableModule } from '@fundamental-ngx/platform/table';
 import { LayoutGridModule } from '@fundamental-ngx/core/layout-grid';
+import { PipeModule } from '@fundamental-ngx/core/utils';
 
 import { SmartFilterBarComponent } from './smart-filter-bar.component';
 
@@ -59,7 +60,8 @@ import { SmartFilterBarService } from './smart-filter-bar.service';
         PlatformSelectModule,
         PlatformMultiInputModule,
         FdpFormGroupModule,
-        LayoutGridModule
+        LayoutGridModule,
+        PipeModule
     ],
     exports: [
         SmartFilterBarComponent,


### PR DESCRIPTION
## Related Issue(s)

Part of https://github.com/SAP/fundamental-ngx/issues/7765

## Description

This pr introduces local (provided on the sub-package level) content density service that handles global content density changes and shares content density value with child components. Explicit subscription to the global content density service is not needed anymore. Local content density service to be provided on the root component of the sub-package and content density value should be consumed using `listenDensity` pipe in the template. 

Local content density service set up for the Smart Filter Bar Component.

## Screenshots

### Before:

<img width="944" alt="image" src="https://user-images.githubusercontent.com/20265336/170649875-75d60733-0595-468f-81eb-14a0329308a8.png">

### After:

<img width="947" alt="image" src="https://user-images.githubusercontent.com/20265336/170649813-b6f5b58c-cafe-4c7f-8284-bd24817ac46b.png">