### PR TITLE
fix(core): multi input - show input when mobile dialog opened

### DIFF
--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -1,7 +1,8 @@
-<ng-container *ngIf="viewModel$ | async as vm">
+<ng-container *ngIf="_viewModel$ | async as viewModel">
     <div class="fd-multi-input fd-multi-input-custom">
         <div class="fd-multi-input-field">
-            <ng-container [ngTemplateOutlet]="control" *ngIf="mobile && !open"></ng-container>
+            <ng-container [ngTemplateOutlet]="control" *ngIf="mobile"></ng-container>
+
             <fd-popover
                 additionalBodyClass="fd-popover-custom-list"
                 *ngIf="!mobile"
@@ -20,11 +21,13 @@
                         <ng-container *ngTemplateOutlet="control"></ng-container>
                     </form>
                 </fd-popover-control>
+
                 <fd-popover-body
                     [attr.aria-hidden]="!open"
-                    [class.fd-popover__body--hidden]="!vm.displayedOptions.length"
+                    [class.fd-popover__body--hidden]="!viewModel.displayedOptions.length"
                 >
                     <ng-container *ngTemplateOutlet="list"></ng-container>
+
                     <ng-content></ng-content>
                 </fd-popover-body>
             </fd-popover>
@@ -39,7 +42,7 @@
             [button]="displayAddonButton"
             [compact]="compact"
             [disabled]="disabled"
-            [isExpanded]="open && !mobile && vm.displayedOptions.length > 0"
+            [isExpanded]="open && !mobile && viewModel.displayedOptions.length > 0"
             [isControl]="true"
             [glyph]="displayAddonButton ? glyph : ''"
             [iconTitle]="title"
@@ -56,7 +59,7 @@
                 tabindex="-1"
             >
                 <fd-token
-                    *ngFor="let option of vm.selectedOptions; trackBy: valueFn"
+                    *ngFor="let option of viewModel.selectedOptions; trackBy: valueFn"
                     [compact]="compact"
                     [disabled]="disabled"
                     (onCloseClick)="_onTokenClick(option.value, false, $event)"
@@ -64,6 +67,7 @@
                 >
                     <span [innerHtml]="option.label"></span>
                 </fd-token>
+
                 <input
                     type="text"
                     class="fd-input fd-tokenizer__input fd-multi-input-tokenizer-input"
@@ -91,7 +95,7 @@
 
     <ng-template #list>
         <ul
-            *ngIf="vm.displayedOptions.length"
+            *ngIf="viewModel.displayedOptions.length"
             fd-list
             class="fd-multi-input-menu-overflow"
             [selection]="true"
@@ -102,7 +106,7 @@
             [style.minWidth]="'100%'"
         >
             <li
-                *ngFor="let option of vm.displayedOptions; index as idx; trackBy: valueFn"
+                *ngFor="let option of viewModel.displayedOptions; index as idx; trackBy: valueFn"
                 fd-list-item
                 (click)="_onCheckboxClick(option.value, $event, idx, true)"
                 (keyup)="_onCheckboxKeyup(option.value, $event, idx)"
@@ -115,13 +119,15 @@
                 >
                     <!-- TODO -->
                 </fd-checkbox>
+
                 <ng-container
                     [ngTemplateOutlet]="itemSource"
                     [ngTemplateOutletContext]="{ option: option }"
                 ></ng-container>
             </li>
+
             <li
-                *ngIf="showAllButton && vm.displayedOptions.length < dropdownValues.length"
+                *ngIf="showAllButton && viewModel.displayedOptions.length < dropdownValues.length"
                 fd-list-item
                 class="fd-multi-input-show-all"
                 (keyDown)="_showAllKeyDown($event)"
@@ -137,8 +143,7 @@
             *ngIf="!itemTemplate"
             fd-list-title
             [innerHtml]="option.label | highlight: _searchTermCtrl.value:highlight"
-        >
-        </span>
+        ></span>
 
         <ng-container *ngIf="itemTemplate">
             <ng-container

--- a/libs/core/src/lib/multi-input/multi-input.component.spec.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.spec.ts
@@ -95,7 +95,7 @@ describe('MultiInputComponent', () => {
 
         expect(component.filterFn).toHaveBeenCalled();
         expect(component.dropdownValues.length).toBe(3);
-        const vm = await firstValueFrom(component.viewModel$);
+        const vm = await firstValueFrom(component._viewModel$);
         expect(vm.displayedOptions.length).toBe(1);
     });
 
@@ -212,7 +212,7 @@ describe('MultiInputComponent', () => {
         expect(event.stopPropagation).toHaveBeenCalled();
         expect(component.searchTerm).toBe('');
 
-        const vm = await firstValueFrom(component.viewModel$);
+        const vm = await firstValueFrom(component._viewModel$);
 
         expect(vm.displayedOptions.length).toBe(component.dropdownValues.length);
     });
@@ -227,7 +227,7 @@ describe('MultiInputComponent', () => {
         updateComponentInput('displayFn', (el) => el.name);
         updateComponentInput('selected', ['foo']);
 
-        const vm = await firstValueFrom(component.viewModel$);
+        const vm = await firstValueFrom(component._viewModel$);
         expect(vm.displayedOptions.length).toEqual(1);
         expect(component.selected).toEqual(['foo']);
     });
@@ -236,14 +236,14 @@ describe('MultiInputComponent', () => {
         updateComponentInput('dropdownValues', ['foo', 'baz', 'bar']);
         updateComponentInput('selected', ['foo1']);
 
-        const vm1 = await firstValueFrom(component.viewModel$);
+        const vm1 = await firstValueFrom(component._viewModel$);
         expect(vm1.displayedOptions.length).toEqual(3);
         expect(vm1.selectedOptions.length).toEqual(1);
         expect(component.selected).toEqual(['foo1']);
 
         component._handleSelect(true, component.dropdownValues[1]);
 
-        const vm2 = await firstValueFrom(component.viewModel$);
+        const vm2 = await firstValueFrom(component._viewModel$);
         expect(vm2.displayedOptions.length).toEqual(3);
         // displaying only those options that were "seen" as values
         expect(vm2.selectedOptions.map((o) => o.value)).toEqual(['foo1', 'baz']);
@@ -252,7 +252,7 @@ describe('MultiInputComponent', () => {
 
         updateComponentInput('dropdownValues', ['foo1']);
 
-        const vm3 = await firstValueFrom(component.viewModel$);
+        const vm3 = await firstValueFrom(component._viewModel$);
         expect(vm3.displayedOptions.length).toEqual(1);
         expect(vm3.selectedOptions.map((o) => o.value)).toEqual(['foo1', 'baz']);
         // displaying only those options that were "seen" as values

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -308,7 +308,7 @@ export class MultiInputComponent
     readonly _selectionModel = new SelectionModel<any>(true);
 
     /** @hidden */
-    readonly viewModel$: Observable<ViewModel> = this._getViewModel();
+    readonly _viewModel$: Observable<ViewModel> = this._getViewModel();
 
     /** @hidden */
     _dir: string;
@@ -520,7 +520,7 @@ export class MultiInputComponent
     ): Promise<void> {
         const toggledSelection = !this._selectionModel.isSelected(value);
         this._rangeSelector.onRangeElementToggled(index, event);
-        const sub = this.viewModel$.pipe(first()).subscribe((vm) => {
+        const sub = this._viewModel$.pipe(first()).subscribe((vm) => {
             this._rangeSelector.applyValueToEachInRange((idx) =>
                 this._handleSelect(toggledSelection, vm.displayedOptions[idx].value, false)
             );


### PR DESCRIPTION
## Related Issue(s)

Part of https://github.com/SAP/fundamental-ngx/issues/7984#issuecomment-1146820476

## Description

Do not hide multi input when mobile dialog is open.

## Screenshots

### Before:
![image](https://user-images.githubusercontent.com/20265336/172351670-9f6aab02-e865-40ef-b0e3-2330afb60872.png)

### After:
<img width="533" alt="image" src="https://user-images.githubusercontent.com/20265336/172351729-dc837bcb-26b2-45dd-be73-b9165507e7c6.png">
