### PR TITLE
fix(core): select fillControlMode property forwarding to the popover

### DIFF
--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -10,7 +10,7 @@
             [disabled]="disabled || readonly"
             [appendTo]="appendTo"
             [closeOnEscapeKey]="true"
-            fillControlMode="at-least"
+            [fillControlMode]="fillControlMode"
             [maxWidth]="600"
             [closeOnOutsideClick]="closeOnOutsideClick"
             (isOpenChange)="_popoverOpenChangeHandle($event)"


### PR DESCRIPTION
## Related Issue(s)

Closes https://github.com/SAP/fundamental-ngx/issues/7929

## Description

Select `fillControlMode` property forwarding to the popover

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
<img width="200" alt="image" src="https://user-images.githubusercontent.com/20265336/172486761-6533942a-2583-49d1-92a3-62a77cf31aa0.png">

### After:
<img width="237" alt="image" src="https://user-images.githubusercontent.com/20265336/172486631-daa1be6b-c31e-4fb3-b5f2-3eb474ea75c4.png">
