### PR TITLE
docs(core): improve table sort/filter docs

### DIFF
--- a/apps/docs/src/app/core/component-docs/table/examples/table-column-sorting-example.component.html
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-column-sorting-example.component.html
@@ -1,14 +1,37 @@
+<fd-toolbar>
+    <label fd-toolbar-label> Filter and sort for table elements </label>
+    <fd-toolbar-spacer></fd-toolbar-spacer>
+    <fd-input-group
+        glyph="decline"
+        glyphAriaLabel="Clear"
+        placeholder="Search"
+        [button]="true"
+        [compact]="true"
+        [disabled]="false"
+        [(ngModel)]="filterVal"
+    >
+    </fd-input-group>
+    <button
+        ariaLabel="Sort ascending"
+        title="Sort ascending"
+        fd-button
+        [compact]="true"
+        glyph="sort-ascending"
+        (click)="changeSort(true)"
+    ></button>
+    <button
+        ariaLabel="Sort descending"
+        title="Sort descending"
+        fd-button
+        [compact]="true"
+        glyph="sort-descending"
+        (click)="changeSort(false)"
+    ></button>
+</fd-toolbar>
 <table fd-table>
     <thead fd-table-header>
         <tr fd-table-row>
-            <th
-                fd-table-cell
-                tabindex="0"
-                [fdMenuTrigger]="menu"
-                [activable]="true"
-                [hoverable]="true"
-                (keydown.space)="$event.preventDefault()"
-            >
+            <th fd-table-cell>
                 <span class="fd-table__inner">
                     Column 1
                     <div class="fd-table__column-header-icons">
@@ -36,34 +59,3 @@
         </tr>
     </tbody>
 </table>
-
-<fd-menu #menu [compact]="true">
-    <li fd-menu-item (click)="sortColumn1(true)">
-        <a fd-menu-interactive>
-            <fd-menu-addon position="before" glyph="sort-ascending"></fd-menu-addon>
-            <span fd-menu-title>Sort Ascending</span>
-        </a>
-    </li>
-    <li fd-menu-item (click)="sortColumn1(false)">
-        <a fd-menu-interactive>
-            <fd-menu-addon position="before" glyph="sort-descending"></fd-menu-addon>
-            <span fd-menu-title>Sort Descending</span>
-        </a>
-    </li>
-    <li fd-menu-item>
-        <a fd-menu-interactive>
-            <fd-menu-addon position="before" glyph="filter"></fd-menu-addon>
-            <div fd-form-item [horizontal]="true" (click)="$event.stopPropagation()">
-                <label fd-form-label for="input-1">Filter</label>
-                <input
-                    fd-form-control
-                    [compact]="true"
-                    id="input-1"
-                    (keyup)="inputKeyup($event)"
-                    [(ngModel)]="filterVal"
-                    style="min-width: 164px"
-                />
-            </div>
-        </a>
-    </li>
-</fd-menu>

--- a/apps/docs/src/app/core/component-docs/table/examples/table-column-sorting-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-column-sorting-example.component.ts
@@ -1,5 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
-import { MenuComponent } from '@fundamental-ngx/core/menu';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 
 interface ExampleRow {
     column1: any;
@@ -20,18 +19,8 @@ export class TableColumnSortingExampleComponent implements OnInit {
     ascending = true;
     filterVal = '';
 
-    @ViewChild('menu')
-    menu: MenuComponent;
-
-    sortColumn1(asc: boolean): void {
+    changeSort(asc: boolean): void {
         this.ascending = asc;
-        this.menu.close();
-    }
-
-    inputKeyup(event: KeyboardEvent): void {
-        if (event.key === 'Enter' || event.key === 'Esc') {
-            this.menu.close();
-        }
     }
 
     ngOnInit(): void {

--- a/apps/docs/src/app/core/component-docs/table/table-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/table/table-docs.component.html
@@ -48,8 +48,7 @@
 
 <fd-docs-section-title id="column-sorting" componentName="table"> Column Sorting and Filtering </fd-docs-section-title>
 <description>
-    In this example, the first column can be sorted alphabetically or filtered based on text in an input. Click the
-    first column header to try.
+    In this example, the first column can be sorted alphabetically or filtered based on text in an input.
 </description>
 <component-example>
     <fd-table-column-sorting-example></fd-table-column-sorting-example>

--- a/apps/docs/src/app/core/component-docs/table/table-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/table/table-docs.module.ts
@@ -35,7 +35,6 @@ import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 import { PaginationModule } from '@fundamental-ngx/core/pagination';
 import { ObjectStatusModule } from '@fundamental-ngx/core/object-status';
 import { BusyIndicatorModule } from '@fundamental-ngx/core/busy-indicator';
-import { MenuModule } from '@fundamental-ngx/core/menu';
 
 const routes: Routes = [
     {
@@ -64,8 +63,7 @@ const routes: Routes = [
         SharedDocumentationPageModule,
         RouterModule.forChild(routes),
         SharedDocumentationModule,
-        BusyIndicatorModule,
-        MenuModule
+        BusyIndicatorModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/e2e/wdio/core/pages/table.po.ts
+++ b/e2e/wdio/core/pages/table.po.ts
@@ -38,8 +38,9 @@ export class TablePo extends CoreBaseComponentPo {
     inputGroup = ' .fd-input-group__input';
     dialogValue = '.fd-list__item.ng-star-inserted .fd-list__title';
     tableInner = '.fd-table__inner';
-    columnSortingInput = '.fd-popover__popper input';
-    listItem = '.fd-menu__item';
+    columnSortingInput = '#fd-input-group-input-id-2';
+    sortAscending = 'button[title="Sort ascending"]';
+    sortDescending = 'button[title="Sort descending"]';
     selectedPage = this.paginationLink + '.is-selected';
     tableCellWOHeader = ' .fd-table__cell:not(.cdk-header-cell)';
 

--- a/e2e/wdio/core/tests/table.e2e-spec.ts
+++ b/e2e/wdio/core/tests/table.e2e-spec.ts
@@ -64,7 +64,8 @@ describe('Table test suite', () => {
         tableInner,
         columnSortingInput,
         tableColumnSortingExample,
-        listItem,
+        sortAscending,
+        sortDescending,
         markAllCheckboxesFF,
         clickableTableRowFF,
         selectedPage,
@@ -214,7 +215,7 @@ describe('Table test suite', () => {
         it('should check sort ascending and descending work correctly', () => {
             scrollIntoView(tableInner);
             click(tableInner);
-            click(listItem, 1);
+            click(sortDescending);
             saveElementScreenshot(
                 tableColumnSortingExample + table,
                 'table-descending-example-' + getImageTagBrowserPlatform(),
@@ -229,7 +230,7 @@ describe('Table test suite', () => {
             ).toBeLessThan(5, `element item state mismatch`);
 
             click(tableInner);
-            click(listItem);
+            click(sortAscending);
             saveElementScreenshot(
                 tableColumnSortingExample + table,
                 'table-ascending-example-' + getImageTagBrowserPlatform(),


### PR DESCRIPTION
part of #7984 

Improves the table sort/filter example documentation.

before:
![image](https://user-images.githubusercontent.com/2471874/172929601-07045188-b0f9-46bc-9215-65b98cbaeaf4.png)

after:
![Screen Shot 2022-06-09 at 1 32 20 PM](https://user-images.githubusercontent.com/2471874/172929625-167996c8-80f0-4e56-959f-c71af46cae2b.png)

