### PR TITLE
fix(core): popover - fix subsequent openings triggered by same event

### DIFF
--- a/libs/core/src/lib/popover/base/base-popover.class.ts
+++ b/libs/core/src/lib/popover/base/base-popover.class.ts
@@ -42,10 +42,24 @@ export class BasePopoverClass {
     @Input()
     placement: Placement | null = null;
 
-    /** The trigger events that will open/close the popover.
-     *  Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp). */
+    /**
+     * The trigger events that will open/close the popover.
+     * Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp) or a config object for the corresponding event.
+     * Using the config object allows to specify whether an event should apply both for open and close actions or only some of them.
+     *
+     * Consider the following value for `triggers`:
+     * ```
+     * [
+     *  'click', // basically it's an alias for "{ trigger: 'click', openAction: true, closeAction: true }"
+     *  { trigger: 'mouseenter', openAction: true, closeAction: false }, // "mouseenter" will only open the popover
+     *  { trigger: 'mouseleave', openAction: false, closeAction: true } // "mouseleave" will only close the popover
+     * ]
+     * ```
+     *
+     * @default ['click']
+     */
     @Input()
-    triggers: string[] = ['click'];
+    triggers: (string | TriggerConfig)[] = ['click'];
 
     /** Whether the popover is open. Can be used through two-way binding. */
     @Input()
@@ -117,4 +131,14 @@ export class BasePopoverClass {
     /** Event emitted when the state of the isOpen property changes. */
     @Output()
     isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+}
+
+/**
+ * Config for the trigger event, which allows to specify
+ * whether an event should apply both for open and close actions or only some of them
+ */
+export interface TriggerConfig {
+    trigger: string;
+    openAction: boolean;
+    closeAction: boolean;
 }

--- a/libs/core/src/lib/popover/popover-service/popover.service.spec.ts
+++ b/libs/core/src/lib/popover/popover-service/popover.service.spec.ts
@@ -288,11 +288,89 @@ describe('PopoverService', () => {
     });
 
     it('should toggle open state on trigger event', () => {
-        componentInstance.triggers = ['mouseenter'];
+        componentInstance.triggers = ['mouseenter', 'keydown'];
         service.initialise(componentInstance.triggerRef, componentInstance, componentInstance.getPopoverTemplateData());
-        const mouseoverEvent = new Event('mouseenter');
-        spyOn(service, 'toggle');
-        componentInstance.triggerRef.nativeElement.dispatchEvent(mouseoverEvent);
-        expect(service.toggle).toHaveBeenCalled();
+        spyOn(service, 'toggle').and.callThrough();
+        spyOn(service, 'open').and.callThrough();
+        spyOn(service, 'close').and.callThrough();
+        // should trigger the toggling
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('mouseenter'));
+        expect(service.toggle).toHaveBeenCalledTimes(1);
+        // should work fine with subsequent events
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('mouseenter'));
+        expect(service.toggle).toHaveBeenCalledTimes(2);
+        // should ignore irrelevant events
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('click'));
+        expect(service.toggle).toHaveBeenCalledTimes(2);
+        // should work fine with all specified triggers
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('keydown'));
+        expect(service.toggle).toHaveBeenCalledTimes(3);
+
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('keydown'));
+        expect(service.toggle).toHaveBeenCalledTimes(4);
+
+        expect(service.open).toHaveBeenCalledTimes(2);
+        // "close" is being invoked twice for each action
+        expect(service.close).toHaveBeenCalledTimes(4);
+    });
+
+    it('should support trigger config', () => {
+        componentInstance.triggers = [
+            'mouseenter',
+            { trigger: 'click', closeAction: false, openAction: true },
+            { trigger: 'mouseleave', closeAction: true, openAction: false }
+        ];
+        service.initialise(componentInstance.triggerRef, componentInstance, componentInstance.getPopoverTemplateData());
+        spyOn(service, 'toggle').and.callThrough();
+        spyOn(service, 'open').and.callThrough();
+        spyOn(service, 'close').and.callThrough();
+
+        expect(service.isOpen).toBe(false);
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('click'));
+        expect(service.toggle).toHaveBeenCalledTimes(1);
+        expect(service.open).toHaveBeenCalledTimes(1);
+        expect(service.close).toHaveBeenCalledTimes(0 * 2);
+
+        expect(service.isOpen).toBe(true);
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('click'));
+        expect(service.toggle).toHaveBeenCalledTimes(2);
+        expect(service.open).toHaveBeenCalledTimes(1);
+        expect(service.close).toHaveBeenCalledTimes(0 * 2);
+
+        expect(service.isOpen).toBe(true);
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('click'));
+        expect(service.toggle).toHaveBeenCalledTimes(3);
+        expect(service.open).toHaveBeenCalledTimes(1);
+        expect(service.close).toHaveBeenCalledTimes(0 * 2);
+
+        expect(service.isOpen).toBe(true);
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('mouseenter'));
+        expect(service.toggle).toHaveBeenCalledTimes(4);
+        expect(service.open).toHaveBeenCalledTimes(1);
+        expect(service.close).toHaveBeenCalledTimes(1 * 2);
+
+        expect(service.isOpen).toBe(false);
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('mouseenter'));
+        expect(service.toggle).toHaveBeenCalledTimes(5);
+        expect(service.open).toHaveBeenCalledTimes(2);
+        expect(service.close).toHaveBeenCalledTimes(1 * 2);
+
+        expect(service.isOpen).toBe(true);
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('mouseleave'));
+        expect(service.toggle).toHaveBeenCalledTimes(6);
+        expect(service.open).toHaveBeenCalledTimes(2);
+        expect(service.close).toHaveBeenCalledTimes(2 * 2);
+
+        expect(service.isOpen).toBe(false);
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('mouseleave'));
+        expect(service.toggle).toHaveBeenCalledTimes(7);
+        expect(service.open).toHaveBeenCalledTimes(2);
+        expect(service.close).toHaveBeenCalledTimes(2 * 2);
+
+        expect(service.isOpen).toBe(false);
+        componentInstance.triggerRef.nativeElement.dispatchEvent(new Event('mouseleave'));
+        expect(service.toggle).toHaveBeenCalledTimes(8);
+        expect(service.open).toHaveBeenCalledTimes(2);
+        expect(service.close).toHaveBeenCalledTimes(2 * 2);
     });
 });

--- a/libs/core/src/lib/popover/popover-service/popover.service.ts
+++ b/libs/core/src/lib/popover/popover-service/popover.service.ts
@@ -62,9 +62,6 @@ export class PopoverService extends BasePopoverClass {
     /** @hidden */
     private _templateData: Nullable<PopoverTemplate>;
 
-    /** @hidden */
-    private _prevTrigger: string;
-
     /** An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */
     private readonly _onDestroy$: Subject<void> = new Subject<void>();
 
@@ -170,11 +167,11 @@ export class PopoverService extends BasePopoverClass {
     }
 
     /** Toggles the popover open state */
-    toggle(): void {
+    toggle(openAction = true, closeAction = true): void {
         if (this.isOpen) {
-            this.close();
+            closeAction && this.close();
         } else {
-            this.open();
+            openAction && this.open();
         }
     }
 
@@ -249,23 +246,16 @@ export class PopoverService extends BasePopoverClass {
 
         if (this.triggers?.length) {
             this.triggers.forEach((trigger) => {
+                const triggerName = typeof trigger === 'string' ? trigger : trigger.trigger;
                 this._eventRef.push(
-                    this._renderer.listen(this._triggerElement.nativeElement, trigger, () => {
-                        this._isToggle(trigger);
+                    this._renderer.listen(this._triggerElement.nativeElement, triggerName, () => {
+                        const closeAction = typeof trigger !== 'object' || !!trigger.closeAction;
+                        const openAction = typeof trigger !== 'object' || !!trigger.openAction;
+                        this.toggle(openAction, closeAction);
                     })
                 );
             });
         }
-    }
-
-    /** @hidden */
-    private _isToggle(trigger: string): void {
-        // prevent unexpected toggling when it triggers the same event
-        if (this._prevTrigger !== trigger || this.triggers?.length <= 1) {
-            this.toggle();
-        }
-
-        this._prevTrigger = trigger;
     }
 
     /** @hidden */


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes none

## Description

When there're multiple triggers specified for the popover, the same trigger event will not change popover state if invoked subsequently. For example, `triggers = ['keydown', 'click']`, then if clicked twice, the second event won't do anything.

There was a fix for https://github.com/SAP/fundamental-ngx/issues/5203, in which there was some logic added to fulfil the behavior described in the ticket. However, the previous behavior was correct and we should not prevent subsequent events from being triggered. 

Reproduction https://stackblitz.com/edit/angular-dm5bfi

Instead, in this PR adding `TriggerConfig` support, that will allow do specify whether specific events should apply for both opening and close actions (as default behavior) or to work only for close/open behavior apart


<!-- Enter short description of the change -->

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

### After:

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [n/a] visual misalignments/updates
-   [n/a] check Light/Dark/HCB/HCW themes
-   [n/a] RTL/LTR - proper rendering and labeling
-   [n/a] responsiveness(resize)
-   [n/a] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [n/a] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [n/a] different combinations of components - free style
-   [n/a] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [n/a] poor examples
-   [n/a] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [n/a] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [n/a] Run npm run build-pack-library and test in external application
-   [n/a] update `README.md`
-   [n/a] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
