### PR TITLE
fix(core): fixed busy indicator overlay background color

### DIFF
--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
@@ -37,7 +37,8 @@
         left: 0;
         right: 0;
         z-index: 1;
-        background-color: rgba(247, 247, 247, 0.72);
+        background-color: var(--sapBaseColor);
+        opacity: 0.72;
 
         &--transparent {
             background-color: transparent;


### PR DESCRIPTION
## Related issue

Part of https://github.com/SAP/fundamental-ngx/issues/7984#issuecomment-1151480271

## Description

Changed overlay color from hardcoded value to theme-based color

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![image](https://user-images.githubusercontent.com/28543391/173368709-e9506522-d9c7-4ff4-a8b5-b7af8029f183.png)

### After:
![image](https://user-images.githubusercontent.com/28543391/173368639-f0d6a2e0-094d-47a0-bfee-5716f4ce4f07.png)
