### PR TITLE
fix(core,platform): fix bug where extra popover would be shown when clicking more text on multi-input

### DIFF
--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -396,6 +396,7 @@ export class MultiInputComponent
         if (this.mobile) {
             this._setUpMobileMode();
         }
+        this.tokenizer._showOverflowPopover = false;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/token/tokenizer.component.html
+++ b/libs/core/src/lib/token/tokenizer.component.html
@@ -6,7 +6,7 @@
     <div class="fd-tokenizer__inner" #tokenizerInner>
         <ng-content select="fd-token"></ng-content>
 
-        <ng-container *ngIf="compact || compactCollapse; else moreElement">
+        <ng-container *ngIf="_showOverflowPopover && (compact || compactCollapse); else moreElement">
             <ng-container *ngTemplateOutlet="tokensOverflow"></ng-container>
         </ng-container>
 

--- a/libs/core/src/lib/token/tokenizer.component.ts
+++ b/libs/core/src/lib/token/tokenizer.component.ts
@@ -149,6 +149,9 @@ export class TokenizerComponent
     _tokenizerHasFocus = false;
 
     /** @hidden */
+    _showOverflowPopover = true;
+
+    /** @hidden */
     private _contentDensitySubscription = new Subscription();
 
     /** @hidden */

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
@@ -38,6 +38,7 @@ import { PlatformMultiComboboxMobileModule } from '../multi-combobox-mobile/mult
 import { MULTICOMBOBOX_COMPONENT } from '../multi-combobox.interface';
 import { MultiComboboxConfig } from '../multi-combobox.config';
 import { AutoCompleteEvent } from '../../auto-complete/auto-complete.directive';
+import { TokenizerComponent } from '@fundamental-ngx/core/token';
 
 @Component({
     selector: 'fdp-multi-combobox',
@@ -55,6 +56,10 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
     /** @hidden */
     @ViewChild('listTemplate')
     listTemplate: TemplateRef<any>;
+
+    /** @hidden */
+    @ViewChild(TokenizerComponent)
+    _tokenizer: TokenizerComponent;
 
     /**
      * @hidden
@@ -100,6 +105,8 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
         }
 
         this._setSelectedSuggestions();
+
+        this._tokenizer._showOverflowPopover = false;
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/form/multi-input/multi-input.component.ts
+++ b/libs/platform/src/lib/form/multi-input/multi-input.component.ts
@@ -210,6 +210,8 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
         if (this.autofocus) {
             this.searchInputElement.nativeElement.focus();
         }
+
+        this.tokenizer._showOverflowPopover = false;
     }
 
     /** @hidden Method to emit change event */


### PR DESCRIPTION
closes none

Fixes a bug that arose from #7619 where clicking the "more" text on a multi-input would display the multi-input's dropdown list as well as the tokenizer's popover of overflowing tokens.

before:
![Screen Shot 2022-06-14 at 1 51 02 PM](https://user-images.githubusercontent.com/2471874/173676943-c68be0dd-39c0-4f2c-8e5a-c471b515f37d.png)

after:
![Screen Shot 2022-06-14 at 1 51 27 PM](https://user-images.githubusercontent.com/2471874/173676984-eaa27705-c55f-4a06-ba3e-68a46850c7de.png)

