### PR TITLE
feat: i18n pluralization

### DIFF
--- a/libs/i18n/src/lib/languages/english.ts
+++ b/libs/i18n/src/lib/languages/english.ts
@@ -338,7 +338,7 @@ export const FD_LANGUAGE_ENGLISH: FdLanguage = {
         messageFileRenameSuccess: '"{{ from }}" has been renamed to "{{ to }}".',
         messageRemoveFoldersAndFilesFailed: 'Failed to remove {{ foldersCount }} folders and {{ filesCount }} files.',
         messageRemoveFoldersAndFilesSuccess: '{{ foldersCount }} folders and {{ filesCount }} files have been removed.',
-        messageRemoveFoldersFailed: 'Failed to remove {{ folderCount }} folders.',
+        messageRemoveFoldersFailed: 'Failed to remove {{ foldersCount }} folders.',
         messageRemoveFoldersSuccess: '{{ foldersCount }} folders have been removed.',
         messageRemoveFilesFailed: 'Failed to remove {{ filesCount }} files.',
         messageRemoveFilesSuccess: '{{ filesCount }} files have been removed.',

--- a/libs/i18n/src/lib/languages/pluralization/set1.ts
+++ b/libs/i18n/src/lib/languages/pluralization/set1.ts
@@ -1,0 +1,37 @@
+export type PluralizationSet1Options = 'zero' | 'one' | 'few' | 'many' | 'other';
+
+/**
+ * Applies to 'be', 'bs', 'cnr', 'dz', 'hr', 'ru', 'sr','uk' locales.
+ * See details here http://translate.sourceforge.net/wiki/l10n/pluralforms
+ */
+export class PluralizationSet1 {
+    private readonly fewInlusive: ReadonlySet<number> = new Set([2, 3, 4]);
+    private readonly fewExclusive: ReadonlySet<number> = new Set([12, 13, 14]);
+    private readonly manyInclusiveTenths: ReadonlySet<number> = new Set([5, 6, 7, 8, 9]);
+    private readonly manyInclusiveHundredths: ReadonlySet<number> = new Set([11, 12, 13, 14]);
+
+    process(num: any): PluralizationSet1Options {
+        num = parseInt(num, 10);
+        if (!isNaN(num)) {
+            const tenth = num % 10;
+            const hundredth = num % 100;
+            if (num === 0) {
+                return 'zero';
+            } else if (tenth === 1 && num % 100 !== 11) {
+                // 1, 21, 31, 41, 51, 61..
+                return 'one';
+            } else if (this.fewInlusive.has(tenth) && !this.fewExclusive.has(hundredth)) {
+                // 2-4, 22-24, 32-34..
+                return 'few';
+            } else if (
+                tenth === 0 ||
+                this.manyInclusiveTenths.has(tenth) ||
+                this.manyInclusiveHundredths.has(hundredth)
+            ) {
+                // 5-20, 25-30, 35-40...
+                return 'many';
+            }
+        }
+        return 'other';
+    }
+}

--- a/libs/i18n/src/lib/languages/russian.ts
+++ b/libs/i18n/src/lib/languages/russian.ts
@@ -1,4 +1,7 @@
-import { FdLanguage } from '../models/lang';
+import { FdLanguage, FdLanguageKeyArgs } from '../models/lang';
+import { PluralizationSet1 } from './pluralization/set1';
+
+const pluralization = new PluralizationSet1();
 
 /**
  * Default set of translations of Fundamental UI libarary for Russian language
@@ -7,7 +10,18 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
     coreGridList: {
         filterBarCancelButtonTitle: 'Отмена',
         listItemStatusAriaLabel: 'Элемент имеет статус. Статус: {{ status }}.',
-        listItemCounterAriaLabel: 'Элемент имеет {{ count }} дочерних элементов.',
+        listItemCounterAriaLabel: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Элемент имеет 1 дочерний элемент.`;
+                case 'few':
+                    return `Элемент имеет ${count} дочерних элемента.`;
+                default:
+                    return `Элемент имеет ${count} дочeрних элементов.`;
+            }
+        },
         listItemButtonDetailsTitle: 'Подробности',
         listItemButtonDeleteTitle: 'Удалить',
         listItemStatusContainsErrors: 'Содержит ошибки',
@@ -61,19 +75,52 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         userDetailsHeader: 'Детали',
         userDetailsSendReminderBtnLabel: 'Отправить напоминание',
         userDetailsCancelBtnLabel: 'Отменить',
-        messagesApproverAddedSuccess: '1 утверждающий был добавлен',
-        messagesTeamAddedSuccess: '1 команда была добавлена',
-        messagesNodeEdited: '1 утверждающий был отредактирован',
-        messagesNodeRemovedSingular: '1 утверждающий был удален',
-        messagesNodeRemovedPlural: 'Утверждающие были удалены',
+        messagesApproverAddedSuccess: '1 утверждающий добавлен',
+        messagesTeamAddedSuccess: '1 команда добавлена',
+        messagesNodeEdited: '1 утверждающий отредактирован',
+        messagesNodeRemovedSingular: '1 утверждающий удален',
+        messagesNodeRemovedPlural: 'Утверждающие удалены',
         messagesTeamRemoved: '1 команда удалена',
         messagesErrorBuildGraph: 'При попытке построить график произошла ошибка. Проверьте входящие данные.',
         messagesUndoAction: 'Отменить',
-        nodeMembersCount: '{{ count }} членов команды',
+        nodeMembersCount: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `1 член команды`;
+                case 'few':
+                    return `${count} члена команды`;
+                default:
+                    return `${count || 0} членов команды`;
+            }
+        },
         nodeVariousTeams: 'Различные команды',
         nodeStatusDueToday: 'Срок выполнения сегодня',
-        nodeStatusDueInXDays: ' Срок выполнения через {{ count }} дней',
-        nodeStatusXDaysOverdue: 'Просрочено на {{ count }} дней',
+        nodeStatusDueInXDays: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Срок выполнения через 1 день`;
+                case 'few':
+                    return `Срок выполнения через ${count} дня`;
+                default:
+                    return `Срок выполнения через ${count || 0} дней`;
+            }
+        },
+        nodeStatusXDaysOverdue: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Просрочено на 1 день`;
+                case 'few':
+                    return `Просрочено на ${count} дня`;
+                default:
+                    return `Просрочено на ${count || 0} дней`;
+            }
+        },
         nodeActionAddApproversBefore: 'Добавить утверждающих до',
         nodeActionAddApproversAfter: 'Добавить утверждающих после',
         nodeActionAddApproversParallel: 'Добавить параллельных утверждающих',
@@ -94,9 +141,19 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         toolbarEditApprover: 'Редактировать утверждающего',
         watchersInputPlaceholder: 'Поиск',
         userListSelectedItemsCountSingular: 'Выбран 1 элемент',
-        userListSelectedItemsCountPlural: 'Выбрано {{ count }} элементов'
+        userListSelectedItemsCountPlural: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Выбрано 1 элемент`;
+                case 'few':
+                    return `Выбрано ${count} элемента`;
+                default:
+                    return `Выбрано ${count || 0} элементов`;
+            }
+        }
     },
-    //
     platformVHD: {
         selectionBarLabel: 'Выбранные элементы и условия',
         selectedAndConditionLabel: 'Выбранные элементы и условия',
@@ -114,7 +171,37 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         searchHideAllAdvancedSearchLabel: 'Скрыть все фильтры',
         selectTabDisplayCountLabel: 'Элементы ({{ count }})',
         selectTabMoreBtnLabel: 'Больше',
-        selectTabCountHiddenA11yLabel: 'содержащие {{ rowCount }} строк и {{ colCount }} столбцов',
+        selectTabCountHiddenA11yLabel: (params) => {
+            const rowCount = params['rowCount'];
+            const rowOption = pluralization.process(rowCount);
+            let rowPart: string;
+            switch (rowOption) {
+                case 'one':
+                    rowPart = 'содержит 1 строку';
+                    break;
+                case 'few':
+                    rowPart = `содержит ${rowCount} строки`;
+                    break;
+                default:
+                    rowPart = `содержит ${rowCount} строк`;
+                    break;
+            }
+            const colCount = params['colCount'];
+            const colOption = pluralization.process(colCount);
+            let colPart: string;
+            switch (colOption) {
+                case 'one':
+                    colPart = '1 столбец';
+                    break;
+                case 'few':
+                    colPart = `${colCount} столбца`;
+                    break;
+                default:
+                    colPart = `${colCount} столбцов`;
+                    break;
+            }
+            return `${rowPart} и ${colPart}`;
+        },
         selectMobileTabBackBtnTitle: 'Назад',
         selectMobileTabBtnOpenDialogLabel: 'Открыть диалоговое окно',
         selectMobileTabTitle: '{{ title }} вкладка',
@@ -141,11 +228,31 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         defineConditionConditionStrategyLabelEmpty: 'пусто',
         defineConditionConditionStrategyLabelNotEqualTo: 'не равно',
         defineConditionConditionStrategyLabelNotEmpty: 'не пусто',
-        defineConditionMaxCountError: 'Введите значение не более {{ count }} символов'
+        defineConditionMaxCountError: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Введите значение не более 1 символа`;
+                default:
+                    return `Введите значение не более ${count || 0} символов`;
+            }
+        }
     },
     platformCombobox: {
         countListResultsSingular: '1 элемент',
-        countListResultsPlural: '{{ count }} элементов'
+        countListResultsPlural: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `1 элемент`;
+                case 'few':
+                    return `${count} элемента`;
+                default:
+                    return `${count || 0} элементов`;
+            }
+        }
     },
     platformMultiCombobox: {
         inputGlyphAriaLabel: 'Выбрать опции',
@@ -155,9 +262,31 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'Превышен лимит на 1 символ',
-        counterMessageCharactersOverTheLimitPlural: 'Превышен лимит на {{ count }} символов',
+        counterMessageCharactersOverTheLimitPlural: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Превышен лимит на 1 символ`;
+                case 'few':
+                    return `Превышен лимит на ${count} символа`;
+                default:
+                    return `Превышен лимит на ${count || 0} символов`;
+            }
+        },
         counterMessageCharactersRemainingSingular: 'Остался 1 символ',
-        counterMessageCharactersRemainingPlural: 'Осталось {{ count }} символов'
+        counterMessageCharactersRemainingPlural: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Остался 1 символ`;
+                case 'few':
+                    return `Осталось ${count} символа`;
+                default:
+                    return `Осталось ${count || 0} символов`;
+            }
+        }
     },
 
     platformLink: {
@@ -308,7 +437,18 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         newFolderAtRootInputLabel: 'Название новой папки',
         newFolderAtFolderInputLabel: 'Название новой папки внутри {{ folderName }',
         newFolderInputPlaceholder: 'Введите имя..',
-        newFolderInputErrorLabel: 'Максимально разрешено {{ count }} символов',
+        newFolderInputErrorLabel: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Максимально разрешено 1 символ`;
+                case 'few':
+                    return `Максимально разрешено ${count} символа`;
+                default:
+                    return `Максимально разрешено ${count} символов`;
+            }
+        },
         newFolderDialogCreateBtnLabel: 'Создать',
         newFolderDialogCancelBtnLabel: 'Отменить',
         breadcrumbLabelAllFiles: 'Все файлы',
@@ -336,46 +476,86 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         messageCreateFailed: 'Не удалось создать {{ folderName }}.',
         messageCreateSuccess: '{{ folderName }} успешно создано.',
         messageUpdateVersionFailed: 'Не удалось обновить версию {{ folderName }}.',
-        messageUpdateVersionSuccess: 'Версия {{ folderName }} была обновлена.',
+        messageUpdateVersionSuccess: 'Версия {{ folderName }} обновлена.',
         messageFileRenameFailed: 'Не удалось переименовать "{{ from }}" в "{{ to }}."',
-        messageFileRenameSuccess: '{{ from }}" было переименовано в "{{ to }}".',
-        messageRemoveFoldersAndFilesFailed: 'Не удалось удалить {{ foldersCount }} папок и {{ filesCount }} файлов.',
-        messageRemoveFoldersAndFilesSuccess: '{{ foldersCount }} папок и {{ filesCount }} файлов было удалено.',
-        messageRemoveFoldersFailed: 'Не удалось удалить {{ folderCount }} папок.',
-        messageRemoveFoldersSuccess: 'Удалено {{ foldersCount }} папок.',
+        messageFileRenameSuccess: '{{ from }}" переименовано в "{{ to }}".',
+        messageRemoveFoldersAndFilesFailed: (params) =>
+            `Не удалось удалить ${folderNamePluralization(params)} и ${fileNamePluralization(params)}.`,
+        messageRemoveFoldersAndFilesSuccess: (params) =>
+            `${folderNamePluralization(params)} и ${fileNamePluralization(params)} удалено.`,
+        messageRemoveFoldersFailed: (params) => `Не удалось удалить ${folderNamePluralization(params)}.`,
+        messageRemoveFoldersSuccess: (params) => `Удалено ${folderNamePluralization(params)}.`,
         messageRemoveFilesFailed: 'Не удалось удалить файлы {{ filesCount }}.',
-        messageRemoveFilesSuccess: 'Удалено {{ filesCount }} файлов.',
+        messageRemoveFilesSuccess: (params) => `Удалено ${fileNamePluralization(params)}.`,
         messageRemoveFileOrFolderFailed: 'Не удалось удалить {{ name }}.',
         messageRemoveFileOrFolderSuccess: '{{ name }} удалено.',
-        messageMoveFoldersAndFilesFailed:
-            'Не удалось переместить {{ foldersCount }} папок и {{ filesCount }} файлов в {{ to }}.',
-        messageMoveFoldersAndFilesSuccess: '{{ foldersCount }} папок и {{ filesCount }} файлов перемещены в {{ to }}.',
-        messageMoveFoldersFailed: 'Не удалось переместить {{ foldersCount }} папок в {{ to }}.',
-        messageMoveFoldersSuccess: '{{ foldersCount }} папок перемещен в {{ to }}.',
-        messageMoveFilesFailed: 'Не удалось переместить {{ filesCount }} файлов в {{ to }}.',
-        messageMoveFilesSuccess: '{{ filesCount }} файлов перемещен в {{ to }}.',
+        messageMoveFoldersAndFilesFailed: (params) =>
+            `Не удалось переместить ${folderNamePluralization(params)} и ${fileNamePluralization(params)} в {{ to }}.`,
+        messageMoveFoldersAndFilesSuccess: (params) =>
+            `${folderNamePluralization(params)} и ${fileNamePluralization(params)} перемещены в {{ to }}.`,
+        messageMoveFoldersFailed: (params) => `Не удалось переместить ${folderNamePluralization(params)} в {{ to }}.`,
+        messageMoveFoldersSuccess: (params) => `${folderNamePluralization(params)} перемещен в {{ to }}.`,
+        messageMoveFilesFailed: (params) => `Не удалось переместить ${fileNamePluralization(params)} в {{ to }}.`,
+        messageMoveFilesSuccess: (params) => `${fileNamePluralization(params)} перемещен в {{ to }}.`,
         messageMoveFileOrFolderFailed: 'Не удалось переместить {{ name }} в {{ to }}.',
         messageMoveFileOrFolderSuccess: '{{ name }} перемещен в {{ to }}.',
-        messageMoveRootFoldersAndFilesFailed:
-            'Не удалось переместить {{ foldersCount }} папок и {{ filesCount }} файлов во все файлы.',
-        messageMoveRootFoldersAndFilesSuccess:
-            '{{ foldersCount }} папок и {{ filesCount }} файлов перемещены ко всем файлам.',
-        messageMoveRootFoldersFailed: 'Не удалось переместить папки {{ foldersCount }} во все файлы.',
-        messageMoveRootFoldersSuccess: '{{ foldersCount }} папок перемещен ко всем файлам.',
-        messageMoveRootFilesFailed: 'Не удалось переместить файлы {{ filesCount }} во все файлы.',
-        messageMoveRootFilesSuccess: '{{ filesCount }} файлов перемещены ко всем файлам.',
+        messageMoveRootFoldersAndFilesFailed: (params) =>
+            `Не удалось переместить ${folderNamePluralization(params)} и ${fileNamePluralization(
+                params
+            )} во все файлы.`,
+        messageMoveRootFoldersAndFilesSuccess: (params) =>
+            `${folderNamePluralization(params)} и ${fileNamePluralization(params)} перемещены ко всем файлам.`,
+        messageMoveRootFoldersFailed: (params) =>
+            `Не удалось переместить ${folderNamePluralization(params)} во все файлы.`,
+        messageMoveRootFoldersSuccess: (params) => `${folderNamePluralization(params)} перемещен ко всем файлам.`,
+        messageMoveRootFilesFailed: (params) => `Не удалось переместить ${fileNamePluralization(params)} во все файлы.`,
+        messageMoveRootFilesSuccess: (params) => `${fileNamePluralization(params)} перемещены ко всем файлам.`,
         messageMoveRootFileOrFolderFailed: 'Не удалось переместить {{ name }} во все файлы.',
         messageMoveRootFileOrFolderSuccess: '{{ name }} перемещен ко всем файлам.',
-        messageFileTypeMismatchPlural:
-            '{{filesCount}} файлов имеют неправильный тип. Разрешенные типы: {{ allowedTypes }}.',
+        messageFileTypeMismatchPlural: (params) => {
+            const filesCount = params['filesCount'];
+            const foldersCountOption = pluralization.process(filesCount);
+            switch (foldersCountOption) {
+                case 'one':
+                    return '1 файл имеет неправильный тип. Разрешенные типы: {{ allowedTypes }}.';
+                case 'few':
+                    return `${filesCount} файла имеют неправильный тип. Разрешенные типы: {{ allowedTypes }}.`;
+                default:
+                    return `${filesCount || 0} файлов имеют неправильный тип. Разрешенные типы: {{ allowedTypes }}.`;
+            }
+        },
         messageFileTypeMismatchSingular:
             'Файл "{{ fileName }}" имеет неправильный тип. Разрешенные типы: {{ allowedTypes }}.',
-        messageFileSizeExceededPlural:
-            '{{ filesCount }} файлов превышают максимальный размер файла. Разрешен максимальный размер файла: {{ maxFileSize }}.',
+        messageFileSizeExceededPlural: (params) => {
+            const filesCount = params['filesCount'];
+            const foldersCountOption = pluralization.process(filesCount);
+            switch (foldersCountOption) {
+                case 'one':
+                    return '1 файл превышают максимальный размер файла. Разрешен максимальный размер файла: {{ maxFileSize }}.';
+                case 'few':
+                    return `${filesCount} файла превышают максимальный размер файла. Разрешен максимальный размер файла: {{ maxFileSize }}.`;
+                default:
+                    return `${
+                        filesCount || 0
+                    } файлов превышают максимальный размер файла. Разрешен максимальный размер файла: {{ maxFileSize }}.`;
+            }
+        },
         messageFileSizeExceededSingular:
             'Файл "{{ fileName }}" превышает максимальный размер файла. Разрешен максимальный размер файла: {{ maxFileSize }}.',
-        messageFileNameLengthExceededPlural:
-            '{{ filesCount }} файлов превысили максимальную длину имени файла. Разрешена длина имени файла: {{ maxFilenameLength }} символов.',
+        messageFileNameLengthExceededPlural: (params) => {
+            const filesCount = params['filesCount'];
+            const foldersCountOption = pluralization.process(filesCount);
+            switch (foldersCountOption) {
+                case 'one':
+                    return '1 файл превысили максимальную длину имени файла. Разрешена длина имени файла: {{ maxFilenameLength }} символов.';
+                case 'few':
+                    return `${filesCount} файла превысили максимальную длину имени файла. Разрешена длина имени файла: {{ maxFilenameLength }} символов.`;
+                default:
+                    return `${
+                        filesCount || 0
+                    } файлов превысили максимальную длину имени файла. Разрешена длина имени файла: {{ maxFilenameLength }} символов.`;
+            }
+        },
         messageFileNameLengthExceededSingular:
             'Имя "{{ fileName }}" превышает максимальную длину имени файла. Разрешена длина имени файла: {{ maxFilenameLength }} символов.'
     },
@@ -389,3 +569,45 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         valueNowDetails: 'Текущее значение: {{ value }}'
     }
 };
+
+/**
+ * Pluralization for "file" word in russian language
+ *
+ * Output samples:
+ * * 1 файл
+ * * 2 файла
+ * * 10 файлов
+ */
+function fileNamePluralization(params: FdLanguageKeyArgs): string {
+    const filesCount = params['filesCount'];
+    const filesCountOption = pluralization.process(filesCount);
+    switch (filesCountOption) {
+        case 'one':
+            return '1 файл';
+        case 'few':
+            return `${filesCount} файла`;
+        default:
+            return `${filesCount || 0} файлов`;
+    }
+}
+
+/**
+ * Pluralization for "folder" word in russian language
+ *
+ * Outputs samples:
+ * * 1 папку
+ * * 2 папки
+ * * 10 папок
+ */
+function folderNamePluralization(params: FdLanguageKeyArgs): string {
+    const foldersCount = params['foldersCount'];
+    const foldersCountOption = pluralization.process(foldersCount);
+    switch (foldersCountOption) {
+        case 'one':
+            return '1 папку';
+        case 'few':
+            return `${foldersCount} папки`;
+        default:
+            return `${foldersCount || 0} папок`;
+    }
+}

--- a/libs/i18n/src/lib/languages/ukrainian.ts
+++ b/libs/i18n/src/lib/languages/ukrainian.ts
@@ -1,5 +1,7 @@
-import { FdLanguage } from '../models/lang';
+import { FdLanguage, FdLanguageKeyArgs } from '../models/lang';
+import { PluralizationSet1 } from './pluralization/set1';
 
+const pluralization = new PluralizationSet1();
 /**
  * Default set of translations of Fundamental UI libarary for Ukrainian language
  */
@@ -7,7 +9,18 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
     coreGridList: {
         filterBarCancelButtonTitle: 'Скасувати',
         listItemStatusAriaLabel: 'Елемент має статус. Статус: {{ status }}.',
-        listItemCounterAriaLabel: 'Елемент має {{ count }} дочірніх елементів.',
+        listItemCounterAriaLabel: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Елемент має 1 дочірній елемент.`;
+                case 'few':
+                    return `Елемент має ${count} дочірніх елемента.`;
+                default:
+                    return `Елемент має ${count} дочірніх елементів.`;
+            }
+        },
         listItemButtonDetailsTitle: 'Подробиці',
         listItemButtonDeleteTitle: 'Видалити',
         listItemStatusContainsErrors: 'Містить помилки',
@@ -61,19 +74,52 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         userDetailsHeader: 'Деталі',
         userDetailsSendReminderBtnLabel: 'Надіслати нагадування',
         userDetailsCancelBtnLabel: 'Скасувати',
-        messagesApproverAddedSuccess: '1 стверджувача було додано',
-        messagesTeamAddedSuccess: '1 команда була додана',
-        messagesNodeEdited: '1 стверджувача було відредаговано',
-        messagesNodeRemovedSingular: '1 стверджувача було видалено',
-        messagesNodeRemovedPlural: 'Стверджувачі були видалені',
+        messagesApproverAddedSuccess: '1 стверджувач доданий',
+        messagesTeamAddedSuccess: '1 команда додана',
+        messagesNodeEdited: '1 стверджувач відредагований',
+        messagesNodeRemovedSingular: '1 стверджувач видалений',
+        messagesNodeRemovedPlural: 'Стверджувачі видалені',
         messagesTeamRemoved: '1 команду видалено',
         messagesErrorBuildGraph: 'Під час спроби побудувати графік сталася помилка. Перевірте вхідні дані.',
         messagesUndoAction: 'Скасувати',
-        nodeMembersCount: '{{ count }} членів команди',
+        nodeMembersCount: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `1 член команди`;
+                case 'few':
+                    return `${count} члена команди`;
+                default:
+                    return `${count || 0} членів команди`;
+            }
+        },
         nodeVariousTeams: 'Різні команди',
         nodeStatusDueToday: 'Термін виконання сьогодні',
-        nodeStatusDueInXDays: ' Термін виконання через {{ count }} днів',
-        nodeStatusXDaysOverdue: 'Прострочено на {{ count }} днів',
+        nodeStatusDueInXDays: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Термін виконання через 1 день`;
+                case 'few':
+                    return `Термін виконання через ${count} дні`;
+                default:
+                    return `Термін виконання через ${count || 0} днів`;
+            }
+        },
+        nodeStatusXDaysOverdue: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Прострочено на 1 день`;
+                case 'few':
+                    return `Прострочено на ${count} дні`;
+                default:
+                    return `Прострочено на ${count || 0} днів`;
+            }
+        },
         nodeActionAddApproversBefore: 'Додати стверджувача до',
         nodeActionAddApproversAfter: 'Додати стверджувача після',
         nodeActionAddApproversParallel: 'Додати паралельних стверджувачів',
@@ -94,7 +140,18 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         toolbarEditApprover: 'Редагувати стверджувача',
         watchersInputPlaceholder: 'Пошук',
         userListSelectedItemsCountSingular: 'Вибрано 1 елемент',
-        userListSelectedItemsCountPlural: 'Вибрано {{ count }} елементів'
+        userListSelectedItemsCountPlural: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Вибрано 1 елемент`;
+                case 'few':
+                    return `Вибрано ${count} елементи`;
+                default:
+                    return `Вибрано ${count || 0} елементів`;
+            }
+        }
     },
     platformVHD: {
         selectionBarLabel: 'Вибрані елементи та умови',
@@ -113,7 +170,37 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         searchHideAllAdvancedSearchLabel: 'Сховати всі фільтри',
         selectTabDisplayCountLabel: 'Елементи ({{ count }})',
         selectTabMoreBtnLabel: 'Більше',
-        selectTabCountHiddenA11yLabel: 'містить {{ rowCount }} рядків і {{ colCount }} стовпців',
+        selectTabCountHiddenA11yLabel: (params) => {
+            const rowCount = params['rowCount'];
+            const rowOption = pluralization.process(rowCount);
+            let rowPart: string;
+            switch (rowOption) {
+                case 'one':
+                    rowPart = 'містить 1 ряд';
+                    break;
+                case 'few':
+                    rowPart = `містить ${rowCount} ряди`;
+                    break;
+                default:
+                    rowPart = `містить ${rowCount} рядів`;
+                    break;
+            }
+            const colCount = params['colCount'];
+            const colOption = pluralization.process(colCount);
+            let colPart: string;
+            switch (colOption) {
+                case 'one':
+                    colPart = '1 колонку';
+                    break;
+                case 'few':
+                    colPart = `${colCount} колонки`;
+                    break;
+                default:
+                    colPart = `${colCount} колонок`;
+                    break;
+            }
+            return `${rowPart} і ${colPart}`;
+        },
         selectMobileTabBackBtnTitle: 'Назад',
         selectMobileTabBtnOpenDialogLabel: 'Відкрити діалогове вікно',
         selectMobileTabTitle: '{{ title }} вкладка',
@@ -140,11 +227,31 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         defineConditionConditionStrategyLabelEmpty: 'порожнє',
         defineConditionConditionStrategyLabelNotEqualTo: 'не дорівнює',
         defineConditionConditionStrategyLabelNotEmpty: 'не порожнє',
-        defineConditionMaxCountError: 'Введіть значення не більше ніж {{ count }} символів'
+        defineConditionMaxCountError: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Введіть значення не більше ніж 1 символу`;
+                default:
+                    return `Введіть значення не більше ніж ${count || 0} символів`;
+            }
+        }
     },
     platformCombobox: {
         countListResultsSingular: '1 елемент',
-        countListResultsPlural: '{{ count }} елементів'
+        countListResultsPlural: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `1 елемент`;
+                case 'few':
+                    return `${count} елементи`;
+                default:
+                    return `${count || 0} елементів`;
+            }
+        }
     },
     platformMultiCombobox: {
         inputGlyphAriaLabel: 'Вибрати опції',
@@ -154,11 +261,32 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'Перевищено ліміт на 1 символ',
-        counterMessageCharactersOverTheLimitPlural: 'Перевищено ліміт на {{ count }} символів',
+        counterMessageCharactersOverTheLimitPlural: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Перевищено ліміт на 1 символ`;
+                case 'few':
+                    return `Перевищено ліміт на ${count} символи`;
+                default:
+                    return `Перевищено ліміт на ${count || 0} символів`;
+            }
+        },
         counterMessageCharactersRemainingSingular: 'Залишився 1 символ',
-        counterMessageCharactersRemainingPlural: 'Залишилось {{ count }} символів'
+        counterMessageCharactersRemainingPlural: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Залишилось 1 символ`;
+                case 'few':
+                    return `Залишилось ${count} символи`;
+                default:
+                    return `Залишилось ${count || 0} символів`;
+            }
+        }
     },
-    //
     platformLink: {
         roleDescriptionWithMedia: 'Медіа: {{ media }}'
     },
@@ -307,7 +435,18 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         newFolderAtRootInputLabel: 'Назва нової папки',
         newFolderAtFolderInputLabel: 'Назва нової папки усередині {{ folderName }',
         newFolderInputPlaceholder: 'Введіть назву..',
-        newFolderInputErrorLabel: 'Максимально дозволено {{ count }} символів',
+        newFolderInputErrorLabel: (params) => {
+            const count = params['count'];
+            const option = pluralization.process(count);
+            switch (option) {
+                case 'one':
+                    return `Максимально дозволено 1 символ`;
+                case 'few':
+                    return `Максимально дозволено ${count} символи`;
+                default:
+                    return `Максимально дозволено ${count} символів`;
+            }
+        },
         newFolderDialogCreateBtnLabel: 'Створити',
         newFolderDialogCancelBtnLabel: 'Скасувати',
         breadcrumbLabelAllFiles: 'Усі файли',
@@ -333,48 +472,89 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         paginationTotal: 'Показано {{ from }}-{{ to }} із {{ total }}',
         resultsPerPage: 'Результатів на сторінці',
         messageCreateFailed: 'Не вдалося створити {{ folderName }}.',
-        messageCreateSuccess: '{{ folderName }} було успішно створено.',
+        messageCreateSuccess: '{{ folderName }} успішно створено.',
         messageUpdateVersionFailed: 'Не вдалося оновити версію {{ folderName }}.',
-        messageUpdateVersionSuccess: 'Версія {{ folderName }} була оновлена.',
+        messageUpdateVersionSuccess: 'Версія {{ folderName }} оновлена.',
         messageFileRenameFailed: 'Не вдалося перейменувати "{{ from }}" на "{{ to }}."',
-        messageFileRenameSuccess: '{{ from }}" було перейменовано на "{{ to }}".',
-        messageRemoveFoldersAndFilesFailed: 'Не вдалося видалити {{ foldersCount }} папок та {{ filesCount }} файлів.',
-        messageRemoveFoldersAndFilesSuccess: '{{ foldersCount }} папок і {{ filesCount }} файлів було видалено.',
-        messageRemoveFoldersFailed: 'Не вдалося видалити {{ folderCount }} папок.',
-        messageRemoveFoldersSuccess: 'Видалено {{ foldersCount }} папок.',
-        messageRemoveFilesFailed: 'Не вдалося видалити {{ filesCount }} файлів.',
-        messageRemoveFilesSuccess: 'Видалено {{ filesCount }} файлів.',
+        messageFileRenameSuccess: '{{ from }}" перейменовано на "{{ to }}".',
+        messageRemoveFoldersAndFilesFailed: (params) =>
+            `Не вдалося видалити ${folderNamePluralization(params)} і ${fileNamePluralization(params)}.`,
+        messageRemoveFoldersAndFilesSuccess: (params) =>
+            `${folderNamePluralization(params)} і ${fileNamePluralization(params)} видалено.`,
+        messageRemoveFoldersFailed: (params) => `Не вдалося видалити ${folderNamePluralization(params)}.`,
+        messageRemoveFoldersSuccess: (params) => `Видалено ${folderNamePluralization(params)}.`,
+        messageRemoveFilesFailed: (params) => `Не вдалося видалити ${fileNamePluralization(params)}.`,
+        messageRemoveFilesSuccess: (params) => `Видалено ${fileNamePluralization(params)}.`,
         messageRemoveFileOrFolderFailed: 'Не вдалося видалити {{ name }}.',
         messageRemoveFileOrFolderSuccess: '{{ name }} видалено.',
-        messageMoveFoldersAndFilesFailed:
-            'Не вдалося перемістити {{ foldersCount }} папок і {{ filesCount }} файлів до {{ to }}.',
-        messageMoveFoldersAndFilesSuccess: '{{ foldersCount }} папок і {{ filesCount }} файлів переміщено в {{ to }}.',
-        messageMoveFoldersFailed: 'Не вдалося перемістити {{ foldersCount }} папок до {{ to }}.',
-        messageMoveFoldersSuccess: '{{ foldersCount }} папок переміщено в {{ to }}.',
-        messageMoveFilesFailed: 'Не вдалося перемістити {{ filesCount }} файлів до {{ to }}.',
-        messageMoveFilesSuccess: '{{ filesCount }} файлів переміщено до {{ to }}.',
+        messageMoveFoldersAndFilesFailed: (params) =>
+            `Не вдалося перемістити ${folderNamePluralization(params)} і ${fileNamePluralization(params)} до {{ to }}.`,
+        messageMoveFoldersAndFilesSuccess: (params) =>
+            `${folderNamePluralization(params)} і ${fileNamePluralization(params)} переміщено в {{ to }}.`,
+        messageMoveFoldersFailed: (params) => `Не вдалося перемістити ${folderNamePluralization(params)} до {{ to }}.`,
+        messageMoveFoldersSuccess: (params) => `${folderNamePluralization(params)} переміщено до {{ to }}.`,
+        messageMoveFilesFailed: (params) => `Не вдалося перемістити ${fileNamePluralization(params)} до {{ to }}.`,
+        messageMoveFilesSuccess: (params) => `${fileNamePluralization(params)} переміщено до {{ to }}.`,
         messageMoveFileOrFolderFailed: 'Не вдалося перемістити {{ name }} до {{ to }}.',
         messageMoveFileOrFolderSuccess: '{{ name }} переміщено в {{ to }}.',
-        messageMoveRootFoldersAndFilesFailed:
-            'Не вдалося перемістити {{ foldersCount }} папок і {{ filesCount }} файлів до всіх файлів.',
-        messageMoveRootFoldersAndFilesSuccess:
-            '{{ foldersCount }} папок і {{ filesCount }} файлів переміщено до всіх файлів.',
-        messageMoveRootFoldersFailed: 'Не вдалося перемістити {{ foldersCount }} папок до всіх файлів.',
-        messageMoveRootFoldersSuccess: '{{ foldersCount }} папок переміщено до всіх файлів.',
-        messageMoveRootFilesFailed: 'Не вдалося перемістити {{ filesCount }} файлів до всіх файлів.',
-        messageMoveRootFilesSuccess: '{{ filesCount }} файлів переміщено до всіх файлів.',
+        messageMoveRootFoldersAndFilesFailed: (params) =>
+            `Не вдалося перемістити ${folderNamePluralization(params)} і ${fileNamePluralization(
+                params
+            )} до всіх файлів.`,
+        messageMoveRootFoldersAndFilesSuccess: (params) =>
+            `${folderNamePluralization(params)} і ${fileNamePluralization(params)} переміщено до всіх файлів.`,
+        messageMoveRootFoldersFailed: (params) =>
+            `Не вдалося перемістити ${folderNamePluralization(params)} до всіх файлів.`,
+        messageMoveRootFoldersSuccess: (params) => `${folderNamePluralization(params)} переміщено до всіх файлів.`,
+        messageMoveRootFilesFailed: (params) =>
+            `Не вдалося перемістити ${fileNamePluralization(params)} до всіх файлів.`,
+        messageMoveRootFilesSuccess: (params) => `${fileNamePluralization(params)} переміщено до всіх файлів.`,
         messageMoveRootFileOrFolderFailed: 'Не вдалося перемістити {{ name }} до всіх файлів.',
         messageMoveRootFileOrFolderSuccess: '{{ name }} переміщено до всіх файлів.',
-        messageFileTypeMismatchPlural:
-            '{{ filesCount }} файлів мають неправильний тип. Дозволені типи: {{ allowedTypes }}.',
+        messageFileTypeMismatchPlural: (params) => {
+            const filesCount = params['filesCount'];
+            const foldersCountOption = pluralization.process(filesCount);
+            switch (foldersCountOption) {
+                case 'one':
+                    return '1 файл має неправильний тип. Дозволені типи: {{ allowedTypes }}.';
+                case 'few':
+                    return `${filesCount} файли мають неправильний тип. Дозволені типи: {{ allowedTypes }}.`;
+                default:
+                    return `${filesCount || 0} файлів мають неправильний тип. Дозволені типи: {{ allowedTypes }}.`;
+            }
+        },
         messageFileTypeMismatchSingular:
             'Файл "{{ fileName }}" має неправильний тип. Дозволені типи: {{ allowedTypes }}.',
-        messageFileSizeExceededPlural:
-            '{{ filesCount }} файлів перевищують максимальний розмір файлу. Дозволений максимальний розмір файлу: {{ maxFileSize }}.',
+        messageFileSizeExceededPlural: (params) => {
+            const filesCount = params['filesCount'];
+            const foldersCountOption = pluralization.process(filesCount);
+            switch (foldersCountOption) {
+                case 'one':
+                    return '1 файл перевищує максимальний розмір файлу. Дозволений максимальний розмір файлу: {{ maxFileSize }}.';
+                case 'few':
+                    return `${filesCount} файли перевищують максимальний розмір файлу. Дозволений максимальний розмір файлу: {{ maxFileSize }}.`;
+                default:
+                    return `${
+                        filesCount || 0
+                    } файлів перевищують максимальний розмір файлу. Дозволений максимальний розмір файлу: {{ maxFileSize }}.`;
+            }
+        },
         messageFileSizeExceededSingular:
             'Файл "{{ fileName }}" перевищує максимальний розмір файлу. Дозволений максимальний розмір файлу: {{ maxFileSize }}.',
-        messageFileNameLengthExceededPlural:
-            '{{ filesCount }} файлів перевищили максимальну довжину імені файлу. Дозволена довжина імені файлу: {{ maxFilenameLength }} символів.',
+        messageFileNameLengthExceededPlural: (params) => {
+            const filesCount = params['filesCount'];
+            const foldersCountOption = pluralization.process(filesCount);
+            switch (foldersCountOption) {
+                case 'one':
+                    return '1 файл перевищив максимальну довжину імені файлу. Дозволена довжина імені файлу: {{ maxFilenameLength }} символів.';
+                case 'few':
+                    return `${filesCount} файли перевищили максимальну довжину імені файлу. Дозволена довжина імені файлу: {{ maxFilenameLength }} символів.`;
+                default:
+                    return `${
+                        filesCount || 0
+                    } файлів перевищили максимальну довжину імені файлу. Дозволена довжина імені файлу: {{ maxFilenameLength }} символів.`;
+            }
+        },
         messageFileNameLengthExceededSingular:
             'Назва "{{ fileName }}" перевищує максимальну довжину імені файлу. Дозволена довжина імені файлу: {{ maxFilenameLength }} символів.'
     },
@@ -388,3 +568,45 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         valueNowDetails: 'Поточне значення: {{ value }}'
     }
 };
+
+/**
+ * Pluralization for "file" word in ukrainian language
+ *
+ * Output samples:
+ * * 1 файл
+ * * 2 файли
+ * * 10 файлів
+ */
+function fileNamePluralization(params: FdLanguageKeyArgs): string {
+    const filesCount = params['filesCount'];
+    const filesCountOption = pluralization.process(filesCount);
+    switch (filesCountOption) {
+        case 'one':
+            return '1 файл';
+        case 'few':
+            return `${filesCount} файли`;
+        default:
+            return `${filesCount || 0} файлів`;
+    }
+}
+
+/**
+ * Pluralization for "folder" word in ukrainian language
+ *
+ * Outputs samples:
+ * * 1 папку
+ * * 2 папки
+ * * 10 папок
+ */
+function folderNamePluralization(params: FdLanguageKeyArgs): string {
+    const foldersCount = params['foldersCount'];
+    const foldersCountOption = pluralization.process(foldersCount);
+    switch (foldersCountOption) {
+        case 'one':
+            return '1 папку';
+        case 'few':
+            return `${foldersCount} папки`;
+        default:
+            return `${foldersCount || 0} папок`;
+    }
+}

--- a/libs/i18n/src/lib/pipes/fd-translate.pipe.ts
+++ b/libs/i18n/src/lib/pipes/fd-translate.pipe.ts
@@ -100,7 +100,7 @@ export class FdTranslatePipe implements PipeTransform, OnDestroy {
             // attempt to resolve function
             const resolvedFunctionValue = this._tryExecuteLanguageFunction(resolvedKey, args);
             if (resolvedFunctionValue) {
-                return resolvedFunctionValue;
+                return this._interpolate(resolvedFunctionValue, args);
             }
         }
         return null;


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes none

## Description
Enhancing existing translations for ukrainian and russian languages by adding proper plural forms to nouns.

This PR also includes few fixes to the translation params and wording updates according to SAP translation guidelines (see below)
[Translation_Style_Guide_UK.pdf](https://github.com/SAP/fundamental-ngx/files/8919761/Translation_Style_Guide_UK.pdf)

