### PR TITLE
fix(platform): allow platform menu items to be disabled

### DIFF
--- a/libs/platform/src/lib/menu/menu-item.component.html
+++ b/libs/platform/src/lib/menu/menu-item.component.html
@@ -1,5 +1,12 @@
 <ng-container *ngIf="!_fdMenuInteractiveChild; else projectedContent">
-    <div class="fd-menu__link" [class.is-selected]="isSelected" tabindex="0" role="menuitem">
+    <div
+        class="fd-menu__link"
+        [class.is-disabled]="disabled"
+        [attr.disabled]="disabled"
+        [class.is-selected]="isSelected"
+        tabindex="0"
+        role="menuitem"
+    >
         <span class="fd-menu__title">
             <ng-container [ngTemplateOutlet]="projectedContent"></ng-container>
         </span>

--- a/libs/platform/src/lib/menu/menu-item.component.ts
+++ b/libs/platform/src/lib/menu/menu-item.component.ts
@@ -90,7 +90,7 @@ export class MenuItemComponent implements OnDestroy, FocusableOption {
      * Handle selection of item via keyboard 'Enter'
      */
     @HostListener('keydown', ['$event'])
-    _onItemKeydown(event: KeyboardEvent): void {
+    private _onItemKeydown(event: KeyboardEvent): void {
         if (event && KeyUtil.isKeyCode(event, [SPACE, ENTER]) && !this.disabled) {
             this.itemSelect.emit();
         } else if (this.disabled) {
@@ -103,7 +103,7 @@ export class MenuItemComponent implements OnDestroy, FocusableOption {
      * Handle click of item via mouse click.
      */
     @HostListener('click', ['$event'])
-    _onItemClick(event: MouseEvent): void {
+    private _onItemClick(event: MouseEvent): void {
         if (!this.disabled) {
             this.itemSelect.emit();
         } else {
@@ -113,10 +113,10 @@ export class MenuItemComponent implements OnDestroy, FocusableOption {
 
     /**
      * @hidden
-     * Handle click of item via keyboard 'Enter'.
+     * Handle mouse enter event.
      */
     @HostListener('mouseenter')
-    _onMouseEnter(): void {
+    private _onMouseEnter(): void {
         this.hovered.next(this);
     }
 }

--- a/libs/platform/src/lib/menu/menu-item.component.ts
+++ b/libs/platform/src/lib/menu/menu-item.component.ts
@@ -31,6 +31,10 @@ import { MenuInteractiveDirective } from '@fundamental-ngx/core/menu';
     }
 })
 export class MenuItemComponent implements OnDestroy, FocusableOption {
+    /** Set the Menu Item as disabled/enabled */
+    @Input()
+    disabled = false;
+
     /** Menu direction */
     @Input()
     cascadeDirection: 'right' | 'left' = 'right';
@@ -83,22 +87,28 @@ export class MenuItemComponent implements OnDestroy, FocusableOption {
 
     /**
      * @hidden
-     * Handle selection of item via keyboard 'Enter' or mouseclick.
+     * Handle selection of item via keyboard 'Enter'
      */
     @HostListener('keydown', ['$event'])
     _onItemKeydown(event: KeyboardEvent): void {
-        if (event && KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
+        if (event && KeyUtil.isKeyCode(event, [SPACE, ENTER]) && !this.disabled) {
             this.itemSelect.emit();
+        } else if (this.disabled) {
+            event.stopPropagation();
         }
     }
 
     /**
      * @hidden
-     * Handle click of item via keyboard 'Enter'.
+     * Handle click of item via mouse click.
      */
-    @HostListener('click')
-    _onItemClick(): void {
-        this.itemSelect.emit();
+    @HostListener('click', ['$event'])
+    _onItemClick(event: MouseEvent): void {
+        if (!this.disabled) {
+            this.itemSelect.emit();
+        } else {
+            event.stopPropagation();
+        }
     }
 
     /**


### PR DESCRIPTION
fixes none, requested via slack

Allows the developer to disable platform menu items via input