### PR TITLE
fix(docs): keep on same table-page upon change in items per page

### DIFF
--- a/apps/docs/src/app/core/component-docs/table/examples/table-pagination-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/table/examples/table-pagination-example.component.ts
@@ -30,7 +30,7 @@ export class TablePaginationExampleComponent implements OnInit {
 
     itemsPerPageChange(value: number): void {
         this.itemsPerPage = value;
-        this.newPageClicked(1);
+        this.newPageClicked(this.currentPage);
     }
 
     constructor(private _rtlService: RtlService) {}


### PR DESCRIPTION
## Related Issue(s)

closes #7148 

## Description

In "Table with pagination example", keep on same table-page when user changes the "Items per Page" (now: Results per Page)

## Screenshots

### Before:

![issue7148](https://user-images.githubusercontent.com/65063487/174404939-bcbbd04d-af2f-4436-ba4f-7dd6f4499c4a.gif)

### After:

![solve](https://user-images.githubusercontent.com/65063487/174405193-b59af588-6d78-433c-b2fe-f7256fa2e620.gif)

