### PR TITLE
docs(core): small css docs fix

### DIFF
--- a/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.scss
+++ b/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.scss
@@ -26,13 +26,6 @@
     }
 
     &__version {
-        color: #fff;
-        color: var(--sapShell_TextColor, #fff);
-        line-height: 2.3rem;
-        flex: 0 0 auto;
-        display: inline-block;
-        margin-right: 0.5rem;
-
         @media (max-width: 576px) {
             display: none;
         }


### PR DESCRIPTION
closes none

before:
![Screen Shot 2022-06-28 at 11 19 57 AM](https://user-images.githubusercontent.com/2471874/176245069-6d1b37f8-08ed-424b-87f4-36455ac13f0f.png)

after:
![Screen Shot 2022-06-28 at 11 24 35 AM](https://user-images.githubusercontent.com/2471874/176245086-aaa9b6b8-932b-465c-ba1b-626c1d08c5eb.png)

