### PR TITLE
fix(platform): table empty message box-sizing

### DIFF
--- a/libs/platform/src/lib/table/table.component.scss
+++ b/libs/platform/src/lib/table/table.component.scss
@@ -235,6 +235,7 @@ $fd-table-scrollbar-width-with-border: calc(#{$fd-table-scrollbar-width} + var(-
 
     &__empty {
         &-table-message {
+            box-sizing: border-box;
             padding: 1rem;
             text-align: center;
             display: flex;


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

platform table empty message box-sizing. 

*previously we didn't see the bug because of the styles in the docs app*

## Screenshots

### Before:
<img width="949" alt="image" src="https://user-images.githubusercontent.com/20265336/176870718-07a8b182-093d-4658-9c3c-81c1d511d62b.png">

### After:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/20265336/176870759-e14de584-b9e5-4926-a2c1-2cd692cf824b.png">
