### PR TITLE
fix(docs): theming service init

### DIFF
--- a/apps/docs/src/app/app.component.ts
+++ b/apps/docs/src/app/app.component.ts
@@ -1,7 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ThemingService } from '@fundamental-ngx/core/theming';
 
 @Component({
     selector: 'app-root',
     template: `<router-outlet></router-outlet>`
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+    /** @hidden */
+    constructor(private readonly _themingService: ThemingService) {}
+
+    /** @hidden */
+    ngOnInit(): void {
+        this._themingService.init();
+    }
+}

--- a/apps/docs/src/app/app.module.ts
+++ b/apps/docs/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { NgModule } from '@angular/core';
 import { MarkdownModule } from 'ngx-markdown';
 
 import { ContentDensityService } from '@fundamental-ngx/core/utils';
+import { ThemingModule } from '@fundamental-ngx/core/theming';
 import { AppComponent } from './app.component';
 
 const routes: Routes = [
@@ -39,7 +40,8 @@ const routes: Routes = [
         BrowserAnimationsModule,
         HttpClientModule,
         RouterModule.forRoot(routes, { useHash: true, relativeLinkResolution: 'legacy' }),
-        MarkdownModule.forRoot({ loader: HttpClient })
+        MarkdownModule.forRoot({ loader: HttpClient }),
+        ThemingModule
     ],
     bootstrap: [AppComponent],
     providers: [ContentDensityService]

--- a/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.ts
+++ b/apps/docs/src/app/documentation/core-helpers/toolbar/toolbar.component.ts
@@ -77,7 +77,6 @@ export class ToolbarDocsComponent implements OnInit, OnDestroy {
         private _route: ActivatedRoute,
         private _domSanitizer: DomSanitizer
     ) {
-        this._themingService.init();
         this.library = this._route.snapshot.data.library || 'core';
 
         this._themingService.currentTheme

--- a/apps/docs/src/app/documentation/shared-documentation.module.ts
+++ b/apps/docs/src/app/documentation/shared-documentation.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MarkdownModule } from 'ngx-markdown';
-import { ThemingModule } from '@fundamental-ngx/core/theming';
 // services
 import { SchemaModule } from '../schema/schema.module';
 import { COMPONENT_SCHEMAS } from '../core/component-docs/schemas';
@@ -32,8 +31,7 @@ import { SideNavigationModule } from '@fundamental-ngx/core/side-navigation';
         InputGroupModule,
         SideNavigationModule,
         MarkdownModule.forChild(),
-        SchemaModule.forRoot(COMPONENT_SCHEMAS),
-        ThemingModule
+        SchemaModule.forRoot(COMPONENT_SCHEMAS)
     ],
     exports: [CommonModule, SchemaModule, ToolbarDocsComponent, SectionsToolbarComponent, SortByPipe, FilterPipe]
 })

--- a/libs/core/src/lib/theming/theming.service.ts
+++ b/libs/core/src/lib/theming/theming.service.ts
@@ -109,6 +109,7 @@ export class ThemingService implements OnDestroy {
         if (!this.config.excludeThemingFonts) {
             this._setThemeResource('fonts', theme.theming.themeFontPath);
         }
+
         this._currentTheme = theme;
         this._currentThemeSubject.next(theme);
 


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

Fit for the theming service was initialising a bit too late.

## Screenshots

_To see the difference come directly to the page (or reload) because if we come from another page -  styles are already loaded so we don't see the issue._

_http://localhost:4200/fundamental-ngx#/core/fixed-card-layout_

### Before:
<img width="991" alt="image" src="https://user-images.githubusercontent.com/20265336/177150440-f152d1d1-328f-4ef9-9b90-b632e6663aab.png">

### After:

<img width="974" alt="image" src="https://user-images.githubusercontent.com/20265336/177150493-cb5774f5-3623-40f7-a8e9-2a651534c8d0.png">
