### PR TITLE
fix(core): correctly display null validity for datepicker

### DIFF
--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -210,7 +210,7 @@ export class DatetimePickerComponent<D>
     }
 
     get state(): FormStates {
-        if (this._state == null && this.useValidation && this.isInvalidDateInput) {
+        if (this.useValidation && this.isInvalidDateInput) {
             return 'error';
         }
         return this._state;


### PR DESCRIPTION
part of https://github.com/SAP/fundamental-ngx/issues/8342

before:
<img width="738" alt="Screen Shot 2022-07-11 at 2 07 21 PM" src="https://user-images.githubusercontent.com/2471874/178349444-07ce4fb5-a5d6-4f22-9e2f-51b11f46a32f.png">

after:
<img width="234" alt="Screen Shot 2022-07-12 at 11 50 56 AM" src="https://user-images.githubusercontent.com/2471874/178559644-3bc7c9d5-336a-4050-a383-c090d761847a.png">

