### PR TITLE
fix(core): small bug with combobox border radius

### DIFF
--- a/libs/core/src/lib/popover/popover-body/popover-body.component.scss
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.scss
@@ -2,7 +2,7 @@
 @import '~@angular/cdk/overlay-prebuilt';
 
 $block: fd-popover;
-$fd-popover-border-radius: var(--sapElement_BorderCornerRadius, 0.25rem);
+$fd-popover-border-radius: var(--fdPopover_Border_Radius);
 
 @mixin set-list-border-radius($position, $radius: $fd-popover-border-radius) {
     border-#{$position}-right-radius: $radius;


### PR DESCRIPTION
part of #8342 

before:
![image](https://user-images.githubusercontent.com/2471874/178598157-a4aa3fe2-a378-4189-94d4-ebb6c7df4043.png)

after:
<img width="557" alt="Screen Shot 2022-07-12 at 3 24 21 PM" src="https://user-images.githubusercontent.com/2471874/178598175-bfa79de7-b948-47bc-beca-87175f4a4dbd.png">

