### PR TITLE
fix(core): select options should be li elements (border radius, accessibility issue)

### DIFF
--- a/apps/docs/src/app/core/component-docs/card/examples/list-card/card-list-example.component.html
+++ b/apps/docs/src/app/core/component-docs/card/examples/list-card/card-list-example.component.html
@@ -64,7 +64,7 @@
                     [(value)]="selectedMovie"
                     (valueChange)="onValueChange()"
                 >
-                    <fd-option *ngFor="let movie of movies" [value]="movie">{{ movie }}</fd-option>
+                    <li fd-option *ngFor="let movie of movies" [value]="movie">{{ movie }}</li>
                 </fd-select>
             </li>
             <ng-container *ngFor="let cast of casts">

--- a/apps/docs/src/app/core/component-docs/content-density/examples/content-density-example.component.html
+++ b/apps/docs/src/app/core/component-docs/content-density/examples/content-density-example.component.html
@@ -4,9 +4,9 @@
         (ngModelChange)="onChange($event)"
         style="margin-right: 8px"
     >
-        <fd-option value="cozy">Cozy</fd-option>
-        <fd-option value="condensed">Condensed</fd-option>
-        <fd-option value="compact">Compact</fd-option>
+        <li fd-option value="cozy">Cozy</li>
+        <li fd-option value="condensed">Condensed</li>
+        <li fd-option value="compact">Compact</li>
     </fd-select>
 </div>
 

--- a/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
+++ b/apps/docs/src/app/core/component-docs/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
@@ -1,9 +1,9 @@
 <label fd-form-label>Languages</label>
 <div class="example">
     <fd-select (valueChange)="setLocale($event)" placeholder="Select an option" [(value)]="locale">
-        <fd-option *ngFor="let option of ['en-ca', 'fr', 'de', 'bg', 'ar-eg', 'zh']" [value]="option">{{
-            option
-        }}</fd-option>
+        <li fd-option *ngFor="let option of ['en-ca', 'fr', 'de', 'bg', 'ar-eg', 'zh']" [value]="option">
+            {{ option }}
+        </li>
     </fd-select>
 </div>
 

--- a/apps/docs/src/app/core/component-docs/initial-focus/examples/initial-focus-complex-example.component.html
+++ b/apps/docs/src/app/core/component-docs/initial-focus/examples/initial-focus-complex-example.component.html
@@ -8,7 +8,7 @@
 <div class="fd-initial-focus-examples">
     <div *ngIf="currentExample === 'select'">
         <fd-select fd-initial-focus=".fd-select__button" placeholder="Autofocusable select">
-            <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+            <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
         </fd-select>
     </div>
     <div *ngIf="currentExample === 'combobox'">

--- a/apps/docs/src/app/core/component-docs/old-content-density/examples/content-density-example.component.html
+++ b/apps/docs/src/app/core/component-docs/old-content-density/examples/content-density-example.component.html
@@ -1,8 +1,8 @@
 <div style="display: flex">
     <fd-select [(ngModel)]="selectedDensity" (ngModelChange)="onChange()" style="margin-right: 8px">
-        <fd-option value="cozy">Cozy</fd-option>
-        <fd-option value="condensed">Condensed</fd-option>
-        <fd-option value="compact">Compact</fd-option>
+        <li fd-option value="cozy">Cozy</li>
+        <li fd-option value="condensed">Condensed</li>
+        <li fd-option value="compact">Compact</li>
     </fd-select>
 
     <button fd-button>My size changes when "Compact" or "Condensed" is selected</button>

--- a/apps/docs/src/app/core/component-docs/select/examples/select-adding-example/select-adding-example.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-adding-example/select-adding-example.component.html
@@ -4,6 +4,6 @@
 </div>
 
 <fd-select placeholder="Select an option" [(value)]="selectedValue" [closeOnOutsideClick]="false">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <small style="display: block">Selected value: {{ selectedValue }}</small>

--- a/apps/docs/src/app/core/component-docs/select/examples/select-custom-trigger/select-custom-trigger.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-custom-trigger/select-custom-trigger.component.html
@@ -1,5 +1,5 @@
 <fd-select placeholder="Select an option" [(value)]="selectedValue" [controlTemplate]="customSelectTemplate">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 
 <ng-template #customSelectTemplate let-textValue let-selected="selected">

--- a/apps/docs/src/app/core/component-docs/select/examples/select-forms/select-forms.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-forms/select-forms.component.html
@@ -1,7 +1,7 @@
 <h4>Default select</h4>
 <form [formGroup]="customForm">
     <fd-select formControlName="selectControl" [required]="true">
-        <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+        <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
     </fd-select>
 </form>
 <small style="display: block">Value: {{ customForm.controls.selectControl.value }}</small>
@@ -12,7 +12,7 @@
 <h4>Disabled select</h4>
 <form [formGroup]="disabledForm">
     <fd-select formControlName="disabledControl">
-        <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+        <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
     </fd-select>
 </form>
 <small style="display: block">Value: {{ disabledForm.controls.disabledControl.value }}</small>

--- a/apps/docs/src/app/core/component-docs/select/examples/select-height/select-max-height-example.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-height/select-max-height-example.component.html
@@ -1,4 +1,4 @@
 <fd-select placeholder="Select an option" [(value)]="selectedValue" maxHeight="250px">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <small style="display: block">Selected value: {{ selectedValue }}</small>

--- a/apps/docs/src/app/core/component-docs/select/examples/select-mobile-example/select-mobile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-mobile-example/select-mobile-example.component.html
@@ -6,6 +6,6 @@
     [mobile]="true"
     [mobileConfig]="mobileConfig"
 >
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <small style="display: block">Selected value: {{ selectedValue }}</small>

--- a/apps/docs/src/app/core/component-docs/select/examples/select-mode-example/select-mode-example.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-mode-example/select-mode-example.component.html
@@ -1,23 +1,23 @@
 <h4>Default select</h4>
 <fd-select placeholder="Select an option" [(value)]="selectedValue1">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <small style="display: block">Selected value: {{ selectedValue1 }}</small>
 
 <h4>Compact select</h4>
 <fd-select placeholder="Select an option" fdCompact [(value)]="selectedValue2">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <small style="display: block">Selected value: {{ selectedValue2 }}</small>
 
 <h4>Select in disabled mode</h4>
 <fd-select placeholder="Select an option" [disabled]="true" [(value)]="selectedValue4">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <small style="display: block">Selected value: {{ selectedValue4 }}</small>
 
 <h4>Select in read-only mode</h4>
 <fd-select placeholder="Select an option" [readonly]="true" [(value)]="selectedValue5">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <small style="display: block">Selected value: {{ selectedValue5 }}</small>

--- a/apps/docs/src/app/core/component-docs/select/examples/select-nested-options/select-nested-options.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-nested-options/select-nested-options.component.html
@@ -2,20 +2,20 @@
     <li fd-list-group-header>
         <span fd-list-title>Fruits</span>
     </li>
-    <fd-option *ngFor="let option of fruits" [value]="option">
+    <li fd-option *ngFor="let option of fruits" [value]="option">
         <i fd-list-icon glyph="add"></i>
         <span fd-list-title>{{ option.name }}</span>
         <span fd-list-secondary>{{ option.kCal }} kcal</span>
-    </fd-option>
+    </li>
 
     <li fd-list-group-header>
         <span fd-list-title>Vegetables</span>
     </li>
-    <fd-option *ngFor="let option of vegetables" [value]="option">
+    <li fd-option *ngFor="let option of vegetables" [value]="option">
         <i fd-list-icon glyph="add"></i>
         <span fd-list-title>{{ option.name }}</span>
         <span fd-list-secondary>{{ option.kCal }} kcal</span>
-    </fd-option>
+    </li>
 
     <ng-template #customSelectTemplate let-selected="selected">
         {{ selected?.value.name || 'Select an option' }}

--- a/apps/docs/src/app/core/component-docs/select/examples/select-programmatic-example/select-programmatic-example.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-programmatic-example/select-programmatic-example.component.html
@@ -5,6 +5,6 @@
 </div>
 
 <fd-select placeholder="Select value" #select [(value)]="selectedValue" [closeOnOutsideClick]="false">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <small style="display: block">Selected value: {{ selectedValue }}</small>

--- a/apps/docs/src/app/core/component-docs/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
+++ b/apps/docs/src/app/core/component-docs/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
@@ -1,23 +1,23 @@
 <h4>Success state</h4>
 <fd-select placeholder="Select value" stateMessage="Success message" [(value)]="selectedValue1" state="success">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <fd-form-message [static]="true" type="success">Success message</fd-form-message>
 
 <h4>Warning state</h4>
 <fd-select placeholder="Select value" stateMessage="Warning message" [(value)]="selectedValue2" state="warning">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <fd-form-message [static]="true" type="warning">Warning message</fd-form-message>
 
 <h4>Error state</h4>
 <fd-select placeholder="Select value" stateMessage="Error message" [(value)]="selectedValue3" state="error">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <fd-form-message [static]="true" type="error">Error message</fd-form-message>
 
 <h4>Information state</h4>
 <fd-select placeholder="Select value" stateMessage="Information message" [(value)]="selectedValue4" state="information">
-    <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+    <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
 </fd-select>
 <fd-form-message [static]="true" type="information">Information message</fd-form-message>

--- a/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-locale-example/time-picker-locale-example.component.html
+++ b/apps/docs/src/app/core/component-docs/time-picker/examples/time-picker-locale-example/time-picker-locale-example.component.html
@@ -6,7 +6,7 @@
         placeholder="Select locale option"
         [(value)]="locale"
     >
-        <fd-option *ngFor="let locale of locales" [value]="locale">{{ locale }}</fd-option>
+        <li fd-option *ngFor="let locale of locales" [value]="locale">{{ locale }}</li>
     </fd-select>
 </div>
 <div fd-form-item>

--- a/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-example.component.html
+++ b/apps/docs/src/app/core/component-docs/toolbar/examples/toolbar-overflow-example.component.html
@@ -6,9 +6,9 @@
     <fd-datetime-picker fd-toolbar-item fdCompact></fd-datetime-picker>
 
     <fd-select fd-toolbar-item fdCompact placeholder="Select an option" [closeOnOutsideClick]="false">
-        <fd-option *ngFor="let option of ['Apple', 'Pineapple', 'Tomato', 'Strawberry']" [value]="option">{{
-            option
-        }}</fd-option>
+        <li fd-option *ngFor="let option of ['Apple', 'Pineapple', 'Tomato', 'Strawberry']" [value]="option">
+            {{ option }}
+        </li>
     </fd-select>
 
     <button fd-toolbar-item fd-button label="Button" fdCompact></button>

--- a/apps/docs/src/app/platform/component-docs/platform-table/platform-table-examples/editable-rows/platform-table-editable-rows-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-table/platform-table-examples/editable-rows/platform-table-editable-rows-example.component.html
@@ -40,7 +40,7 @@
         <fdp-table-cell *fdpEditableCellDef="let item">
             <form fdpEditableCellForm>
                 <fd-select placeholder="Select an option" [(value)]="item.status">
-                    <fd-option *ngFor="let option of statusOptions" [value]="option">{{ option }}</fd-option>
+                    <li fd-option *ngFor="let option of statusOptions" [value]="option">{{ option }}</li>
                 </fd-select>
             </form>
         </fdp-table-cell>

--- a/e2e/wdio/core/pages/time-picker.po.ts
+++ b/e2e/wdio/core/pages/time-picker.po.ts
@@ -35,12 +35,12 @@ export class TimePickerPo extends CoreBaseComponentPo {
     hoursPoint = this.hoursColumn + '> .fd-time__wrapper ul > li';
 
     formatList = '.fd-popover__popper';
-    usFormat = '.cdk-overlay-container ul[fd-list] fd-option:nth-child(1)';
-    frFormat = '.cdk-overlay-container ul[fd-list] fd-option:nth-child(2)';
-    bgFormat = '.cdk-overlay-container ul[fd-list] fd-option:nth-child(3)';
-    zhFormat = '.cdk-overlay-container ul[fd-list] fd-option:nth-child(4)';
-    bnFormat = '.cdk-overlay-container ul[fd-list] fd-option:nth-child(5)';
-    arFormat = '.cdk-overlay-container ul[fd-list] fd-option:nth-child(6)';
+    usFormat = '.cdk-overlay-container ul[fd-list] li[fd-option]:nth-child(1)';
+    frFormat = '.cdk-overlay-container ul[fd-list] li[fd-option]:nth-child(2)';
+    bgFormat = '.cdk-overlay-container ul[fd-list] li[fd-option]:nth-child(3)';
+    zhFormat = '.cdk-overlay-container ul[fd-list] li[fd-option]:nth-child(4)';
+    bnFormat = '.cdk-overlay-container ul[fd-list] li[fd-option]:nth-child(5)';
+    arFormat = '.cdk-overlay-container ul[fd-list] li[fd-option]:nth-child(6)';
 
     openClock(): void {
         click(this.localExample + this.clockIcon);

--- a/e2e/wdio/platform/pages/approval-flow.po.ts
+++ b/e2e/wdio/platform/pages/approval-flow.po.ts
@@ -22,7 +22,7 @@ export class ApprovalFlowPo extends BaseComponentPo {
 
     detailsDialogUserTeamButton = this.detailsDialog + ' fd-multi-input button';
     detailsDialogParallelSerialSelect = this.detailsDialog + ' fd-select';
-    detailsDialogParallelSerialSelectOption = 'fd-option';
+    detailsDialogParallelSerialSelectOption = 'li[fd-option]';
 
     selectExample = 'select';
     approvalFlowNode = 'fdp-approval-flow-node .fd-grid-list__item-body';

--- a/e2e/wdio/platform/pages/form-container.po.ts
+++ b/e2e/wdio/platform/pages/form-container.po.ts
@@ -10,7 +10,7 @@ export class FormContainerPo extends BaseComponentPo {
     popover = '.cdk-overlay-container .cdk-overlay-pane';
     helpIcon = '.sap-icon--hint';
     fdSwitch = 'fd-switch label';
-    dropdownOption = '.cdk-overlay-container fd-option';
+    dropdownOption = '.cdk-overlay-container li[fd-option]';
     dropdownOptionAlt = 'ul .fd-list__item span';
     comboboxListItem = '.cdk-overlay-container li';
 

--- a/e2e/wdio/platform/pages/table.po.ts
+++ b/e2e/wdio/platform/pages/table.po.ts
@@ -76,7 +76,7 @@ export class TablePo extends BaseComponentPo {
     playgroundSchemaInput = '.form-control.fd-input';
     toolbarText = '.fd-label.fd-toolbar__overflow-label';
     dropdownList = '.fd-select-options';
-    dropdownOption = 'fd-option.fd-list__item ';
+    dropdownOption = 'li[fd-option].fd-list__item ';
     dialogButton = 'fd-dialog-body .sort-row__actions .fd-button';
     dialogFilters = 'fd-dialog-body .fd-list__item:not(.fd-list__group-header)';
     filterInput = 'fdp-filter-custom input';

--- a/e2e/wdio/platform/pages/value-help-dialog.po.ts
+++ b/e2e/wdio/platform/pages/value-help-dialog.po.ts
@@ -45,7 +45,7 @@ export class ValueHelpDialogPo extends BaseComponentPo {
     addBtn = 'button[label="Add"]';
     conditionsInputField = '.fd-popover__control.ng-star-inserted input';
     conditionSelectors = 'fd-popover .fd-select__text-content';
-    dropdownOptions = 'ul fd-option';
+    dropdownOptions = 'ul li[fd-option]';
     xBtn = 'button[glyph="decline"]';
     conditionsButton = 'fd-popover .fd-select__control .fd-button';
     cancelButton = '.fd-dialog__decisive-button';

--- a/libs/core/src/lib/pagination/pagination.component.html
+++ b/libs/core/src/lib/pagination/pagination.component.html
@@ -184,6 +184,6 @@
     <label fd-form-label class="fd-pagination__per-page-label">{{ itemsPerPageLabel }}:</label>
 
     <fd-select class="fd-pagination__per-page-select" [value]="itemsPerPage" (valueChange)="_onChangePerPage($event)">
-        <fd-option *ngFor="let option of pageOptions" [value]="option">{{ option }}</fd-option>
+        <li fd-option *ngFor="let option of pageOptions" [value]="option">{{ option }}</li>
     </fd-select>
 </ng-template>

--- a/libs/core/src/lib/select/option/option.component.ts
+++ b/libs/core/src/lib/select/option/option.component.ts
@@ -37,7 +37,8 @@ export class FdOptionSelectionChange {
  * Used to represent an option of the select component.
  */
 @Component({
-    selector: 'fd-option',
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: '[fd-option], fd-option',
     templateUrl: './option.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/core/src/lib/select/select-key-manager.service.spec.ts
+++ b/libs/core/src/lib/select/select-key-manager.service.spec.ts
@@ -8,10 +8,10 @@ import { SelectModule } from './select.module';
 @Component({
     template: `
         <fd-select [(value)]="value" formControlName="selectControl" (isOpenChange)="onOpen($event)">
-            <fd-option id="option-1" [value]="'value-1'">Test1</fd-option>
-            <fd-option id="option-2" [value]="'value-2'">Test2</fd-option>
-            <fd-option id="option-3" [value]="'value-3'">Test3</fd-option>
-            <fd-option id="option-4" [disabled]="disabled" [value]="'value-4'">Test4</fd-option>
+            <li fd-option id="option-1" [value]="'value-1'">Test1</li>
+            <li fd-option id="option-2" [value]="'value-2'">Test2</li>
+            <li fd-option id="option-3" [value]="'value-3'">Test3</li>
+            <li fd-option id="option-4" [disabled]="disabled" [value]="'value-4'">Test4</li>
         </fd-select>
     `,
     providers: [SelectKeyManagerService]

--- a/libs/core/src/lib/select/select-mobile/select-mobile.component.spec.ts
+++ b/libs/core/src/lib/select/select-mobile/select-mobile.component.spec.ts
@@ -82,7 +82,7 @@ describe('SelectComponent in mobile mode', () => {
 
         expect(fixture.nativeElement.querySelector('.fd-dialog--active')).toBeTruthy();
 
-        expect(fixture.nativeElement.querySelectorAll('fd-option').length).toBe(testComponent.options.length);
+        expect(fixture.nativeElement.querySelectorAll('li').length).toBe(testComponent.options.length);
     });
 
     it('should close', async () => {
@@ -135,7 +135,7 @@ describe('SelectComponent in mobile mode', () => {
 
         await whenStable(fixture);
 
-        fixture.nativeElement.querySelector('fd-option').click();
+        fixture.nativeElement.querySelector('li').click();
 
         await whenStable(fixture);
 
@@ -168,7 +168,7 @@ describe('SelectComponent in mobile mode', () => {
 
         await whenStable(fixture);
 
-        fixture.nativeElement.querySelector('fd-option').click();
+        fixture.nativeElement.querySelector('li').click();
 
         await whenStable(fixture);
 
@@ -186,7 +186,7 @@ describe('SelectComponent in mobile mode', () => {
 
         await whenStable(fixture);
 
-        fixture.nativeElement.querySelector('fd-option').click();
+        fixture.nativeElement.querySelector('li').click();
 
         await whenStable(fixture);
         fixture.nativeElement.querySelector('.sap-icon--decline').click();

--- a/libs/core/src/lib/select/select-mobile/select-mobile.component.spec.ts
+++ b/libs/core/src/lib/select/select-mobile/select-mobile.component.spec.ts
@@ -17,7 +17,7 @@ const MOBILE_CONFIG: MobileModeConfig = { title: 'TITLE', hasCloseButton: true }
             [mobile]="true"
             [mobileConfig]="mobileConfig"
         >
-            <fd-option *ngFor="let option of options" [value]="option">{{ option }}</fd-option>
+            <li fd-option *ngFor="let option of options" [value]="option">{{ option }}</li>
         </fd-select>
     `
 })

--- a/libs/core/src/lib/select/select.component.spec.ts
+++ b/libs/core/src/lib/select/select.component.spec.ts
@@ -16,10 +16,10 @@ import { SelectKeyManagerService } from './select-key-manager.service';
             (isOpenChange)="onOpen($event)"
             [fdCompact]="compact"
         >
-            <fd-option id="option-1" [value]="'value-1'">Test1</fd-option>
-            <fd-option id="option-2" [value]="'value-2'">Test2</fd-option>
-            <fd-option id="option-3" [value]="'value-3'">Test3</fd-option>
-            <fd-option id="option-4" [disabled]="disabled" [value]="'value-4'">Test4</fd-option>
+            <li fd-option id="option-1" [value]="'value-1'">Test1</li>
+            <li fd-option id="option-2" [value]="'value-2'">Test2</li>
+            <li fd-option id="option-3" [value]="'value-3'">Test3</li>
+            <li fd-option id="option-4" [disabled]="disabled" [value]="'value-4'">Test4</li>
         </fd-select>
     `
 })
@@ -46,11 +46,11 @@ class TestWrapperComponent {
 @Component({
     template: `
         <fd-select [(value)]="value" formControlName="selectControl">
-            <fd-option id="option-1" [value]="'aaa'">aaaa</fd-option>
-            <fd-option id="option-2" [value]="'bbb'">bbbb</fd-option>
-            <fd-option id="option-2a" [value]="'bxbb'">bxbb</fd-option>
-            <fd-option id="option-3" [value]="'ccc'">cccc</fd-option>
-            <fd-option id="option-4" [value]="'ddd'">dddd</fd-option>
+            <li fd-option id="option-1" [value]="'aaa'">aaaa</li>
+            <li fd-option id="option-2" [value]="'bbb'">bbbb</li>
+            <li fd-option id="option-2a" [value]="'bxbb'">bxbb</li>
+            <li fd-option id="option-3" [value]="'ccc'">cccc</li>
+            <li fd-option id="option-4" [value]="'ddd'">dddd</li>
         </fd-select>
     `
 })

--- a/libs/platform/src/lib/approval-flow/approval-flow-add-node/approval-flow-add-node.component.html
+++ b/libs/platform/src/lib/approval-flow/approval-flow-add-node/approval-flow-add-node.component.html
@@ -53,21 +53,23 @@
                 <fd-select [compact]="true" [(value)]="_nodeType">
                     <ng-container *ngFor="let option of _nodeTypesArray">
                         <ng-container [ngSwitch]="option">
-                            <fd-option
+                            <li
+                                fd-option
                                 *ngSwitchCase="_nodeTypes.SERIAL"
                                 [value]="option"
                                 i18n="@@platformApprovalFlowAddNodeDialogNodeTypeSerial"
                             >
                                 Serial
-                            </fd-option>
+                            </li>
 
-                            <fd-option
+                            <li
+                                fd-option
                                 *ngSwitchCase="_nodeTypes.PARALLEL"
                                 [value]="option"
                                 i18n="@@platformApprovalFlowAddNodeDialogNodeTypeParallel"
                             >
                                 Parallel
-                            </fd-option>
+                            </li>
                         </ng-container>
                     </ng-container>
                 </fd-select>
@@ -79,29 +81,32 @@
                 <fd-select [compact]="true" [(value)]="_approverType">
                     <ng-container *ngFor="let option of _approverTypesArray">
                         <ng-container [ngSwitch]="option">
-                            <fd-option
+                            <li
+                                fd-option
                                 *ngSwitchCase="_approverTypes.SINGLE_USER"
                                 [value]="option"
                                 i18n="platformApprovalFlowAddNodeDialogApproverTypeUser"
                             >
                                 A user
-                            </fd-option>
+                            </li>
 
-                            <fd-option
+                            <li
+                                fd-option
                                 *ngSwitchCase="_approverTypes.ANYONE"
                                 [value]="option"
                                 i18n="platformApprovalFlowAddNodeDialogApproverTypeTeamAnyone"
                             >
                                 Anyone on the team
-                            </fd-option>
+                            </li>
 
-                            <fd-option
+                            <li
+                                fd-option
                                 *ngSwitchCase="_approverTypes.EVERYONE"
                                 [value]="option"
                                 i18n="platformApprovalFlowAddNodeDialogApproverTypeTeamEveryone"
                             >
                                 Everyone on the team
-                            </fd-option>
+                            </li>
                         </ng-container>
                     </ng-container>
                 </fd-select>

--- a/libs/platform/src/lib/form/select/option/option.component.ts
+++ b/libs/platform/src/lib/form/select/option/option.component.ts
@@ -8,7 +8,7 @@ let nextUniqueId = 0;
  */
 @Component({
     selector: 'fdp-option',
-    template: `<fd-option [id]="id" [value]="value" [disabled]="disabled"><ng-content></ng-content></fd-option>`,
+    template: `<li fd-option [id]="id" [value]="value" [disabled]="disabled"><ng-content></ng-content></li>`,
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/libs/platform/src/lib/form/select/select/select.component.html
+++ b/libs/platform/src/lib/form/select/select/select.component.html
@@ -24,10 +24,11 @@
     (valueChange)="_onSelection($event)"
 >
     <ng-content></ng-content>
-    <fd-option *ngIf="noValueLabel" [disabled]="false" [value]="null">
+    <li fd-option *ngIf="noValueLabel" [disabled]="false" [value]="null">
         {{ noValueLabel }}
-    </fd-option>
-    <fd-option
+    </li>
+    <li
+        fd-option
         *ngFor="let item of _optionItems; index as index"
         [disabled]="item.disabled ? true : false"
         [value]="item.value"
@@ -39,7 +40,7 @@
             [ngTemplateOutlet]="listItem"
             [ngTemplateOutletContext]="{ optionItem: item, index: index }"
         ></ng-container>
-    </fd-option>
+    </li>
 </fd-select>
 
 <ng-template let-optionItem="optionItem" let-index="index" #listItem>

--- a/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filter-rule.component.html
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filter-rule.component.html
@@ -11,7 +11,7 @@
                 (ngModelChange)="rule.setColumnKey($event)"
                 (ngModelChange)="_onModelChange()"
             >
-                <fd-option *ngFor="let column of rule.columns" [value]="column.key">{{ column.label }}</fd-option>
+                <li fd-option *ngFor="let column of rule.columns" [value]="column.key">{{ column.label }}</li>
             </fd-select>
             <!-- Strategy -->
             <fd-select
@@ -23,7 +23,7 @@
                 (ngModelChange)="rule.setStrategy($event)"
                 (ngModelChange)="_onModelChange()"
             >
-                <fd-option *ngFor="let strategy of rule.strategies" [value]="strategy">
+                <li fd-option *ngFor="let strategy of rule.strategies" [value]="strategy">
                     <ng-container [ngSwitch]="strategy">
                         <span *ngSwitchCase="'between'" i18n="@@platformTableP13FilterStrategyLabelBetween">
                             between
@@ -85,7 +85,7 @@
                             Not Defined
                         </span>
                     </ng-container>
-                </fd-option>
+                </li>
             </fd-select>
         </div>
     </div>
@@ -137,13 +137,11 @@
                             (ngModelChange)="_onModelChange()"
                             [required]="true"
                         >
-                            <fd-option [value]="undefined" i18n="@@platformTableP13FilterBooleanOptionNotDefined">
+                            <li fd-option [value]="undefined" i18n="@@platformTableP13FilterBooleanOptionNotDefined">
                                 &nbsp;
-                            </fd-option>
-                            <fd-option [value]="true" i18n="@@platformTableP13FilterBooleanOptionTrue"> Yes </fd-option>
-                            <fd-option [value]="false" i18n="@@platformTableP13FilterBooleanOptionFalse">
-                                No
-                            </fd-option>
+                            </li>
+                            <li fd-option [value]="true" i18n="@@platformTableP13FilterBooleanOptionTrue">Yes</li>
+                            <li fd-option [value]="false" i18n="@@platformTableP13FilterBooleanOptionFalse">No</li>
                         </fd-select>
                     </ng-container>
                     <ng-container *ngSwitchDefault>

--- a/libs/platform/src/lib/table/components/table-p13-dialog/grouping/grouping.component.html
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/grouping/grouping.component.html
@@ -26,9 +26,9 @@
                 placeholder="(none)"
                 i18n-placeholder="@@platformTableP13GroupDialogNoneSelectedColumn|Table column select placeholder"
             >
-                <fd-option *ngFor="let column of columns" [value]="column.key">
+                <li fd-option *ngFor="let column of columns" [value]="column.key">
                     {{ column.label }}
-                </fd-option>
+                </li>
             </fd-select>
 
             <fd-checkbox

--- a/libs/platform/src/lib/table/components/table-p13-dialog/sorting/sorting.component.html
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/sorting/sorting.component.html
@@ -24,12 +24,13 @@
                 placeholder="(none)"
                 i18n-placeholder="@@platformTableP13SortDialogNoneSelectedColumn|Table column select placeholder"
             >
-                <fd-option
+                <li
+                    fd-option
                     *ngFor="let column of columns | getAvailableSortColumns: rules:rule.columnKey"
                     [value]="column.key"
                 >
                     {{ column.label }}
-                </fd-option>
+                </li>
             </fd-select>
 
             <fd-select
@@ -40,12 +41,12 @@
                 placeholder="(none)"
                 i18n-placeholder="@@platformTableP13SortDialogNoneSelectedSorting|Sorting select placeholder"
             >
-                <fd-option [value]="SORT_DIRECTION.ASC" i18n="@@platformTableP13SortDialogSortOrderAsc">
+                <li fd-option [value]="SORT_DIRECTION.ASC" i18n="@@platformTableP13SortDialogSortOrderAsc">
                     Ascending
-                </fd-option>
-                <fd-option [value]="SORT_DIRECTION.DESC" i18n="@@platformTableP13SortDialogSortOrderDesc">
+                </li>
+                <li fd-option [value]="SORT_DIRECTION.DESC" i18n="@@platformTableP13SortDialogSortOrderDesc">
                     Descending
-                </fd-option>
+                </li>
             </fd-select>
 
             <div class="sort-row__actions">

--- a/libs/platform/src/lib/value-help-dialog/components/define-tab/define-tab.component.html
+++ b/libs/platform/src/lib/value-help-dialog/components/define-tab/define-tab.component.html
@@ -36,21 +36,21 @@
                 >
                     <ng-container *ngIf="_includeStrategy.length">
                         <li fd-list-group-header>Include</li>
-                        <fd-option *ngFor="let strategy of _includeStrategy" [value]="strategy.key">
+                        <li fd-option *ngFor="let strategy of _includeStrategy" [value]="strategy.key">
                             <ng-container
                                 [ngTemplateOutlet]="conditionStrategyOption"
                                 [ngTemplateOutletContext]="{ type: _defineTypes.include, strategy: strategy }"
                             ></ng-container>
-                        </fd-option>
+                        </li>
                     </ng-container>
                     <ng-container *ngIf="_excludeStrategy.length">
                         <li fd-list-group-header>Exclude</li>
-                        <fd-option *ngFor="let strategy of _excludeStrategy" [value]="strategy.key">
+                        <li fd-option *ngFor="let strategy of _excludeStrategy" [value]="strategy.key">
                             <ng-container
                                 [ngTemplateOutlet]="conditionStrategyOption"
                                 [ngTemplateOutletContext]="{ type: _defineTypes.exclude, strategy: strategy }"
                             ></ng-container>
-                        </fd-option>
+                        </li>
                     </ng-container>
                 </fd-select>
             </div>


### PR DESCRIPTION
part of #8342 

Similar to https://github.com/SAP/fundamental-ngx/pull/8353

Changes `fd-option` to an attribute selector. All immediate children of `ul` elements should be `li`s. This is a breaking change to fd-option, however I have left the old selector in place so no one's selects will fail entirely when this is merged.

before
<img width="184" alt="Screen Shot 2022-07-12 at 3 39 06 PM" src="https://user-images.githubusercontent.com/2471874/178601261-fa105c96-ec00-43b9-8185-50572b9cad09.png">

after
<img width="205" alt="Screen Shot 2022-07-12 at 3 48 13 PM" src="https://user-images.githubusercontent.com/2471874/178601308-d106a2af-d0f7-45f2-951f-45f4af0681e3.png">

