### PR TITLE
fix(docs): ignore fd-link styling

### DIFF
--- a/apps/docs/src/styles.scss
+++ b/apps/docs/src/styles.scss
@@ -214,8 +214,8 @@ pre {
     padding: 10px 10px 0 10px;
 }
 
-a,
-a:focus {
+a:not(.fd-link),
+a:not(.fd-link):focus {
     text-decoration: none;
 }
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

relates #8342

## Description
Added `:not` selector for anchor styling in order to skip `.fd-link` elements.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![image](https://user-images.githubusercontent.com/6586561/178998159-75b5c7b9-cf99-4bf5-802b-cf09e029a180.png)

### After:
<img width="224" alt="image" src="https://user-images.githubusercontent.com/6586561/178998234-786d3f74-d7ee-4e6d-906f-cf0b96945196.png">