### PR TITLE
feat(core): add inline svg option for illustrated message

### DIFF
--- a/apps/docs/src/app/core/component-docs/illustrated-message/examples/illustrated-message-inline-example.component.html
+++ b/apps/docs/src/app/core/component-docs/illustrated-message/examples/illustrated-message-inline-example.component.html
@@ -1,0 +1,12 @@
+<div style="width: 100%; display: flex; justify-content: center">
+    <figure fd-illustrated-message [svgConfig]="sceneConfig">
+        <figcaption fd-illustrated-message-figcaption>
+            <h3 fd-illustrated-message-title>Headline text goes here</h3>
+            <p fd-illustrated-message-text>Description provides user with clarity and possible next steps.</p>
+        </figcaption>
+        <fd-illustrated-message-actions>
+            <button fd-button label="Action One"></button>
+            <button fd-button label="Action Two"></button>
+        </fd-illustrated-message-actions>
+    </figure>
+</div>

--- a/apps/docs/src/app/core/component-docs/illustrated-message/examples/illustrated-message-inline-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/illustrated-message/examples/illustrated-message-inline-example.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { SvgConfig } from '@fundamental-ngx/core/illustrated-message';
+import sceneSvg from '!../../../../../assets/images/sapIllus-Scene-NoMail.svg?raw';
+import dialogSvg from '!../../../../../assets/images/sapIllus-Dialog-NoMail.svg?raw';
+
+@Component({
+    selector: 'fd-illustrated-message-inline-example',
+    templateUrl: './illustrated-message-inline-example.component.html'
+})
+export class IllustratedMessageInlineExampleComponent {
+    sceneConfig: SvgConfig = {
+        scene: { file: sceneSvg, id: 'sapIllus-Scene-NoMail-1' },
+        dialog: { file: dialogSvg, id: 'sapIllus-Dialog-NoMail' }
+    };
+}

--- a/apps/docs/src/app/core/component-docs/illustrated-message/illustrated-message-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/illustrated-message/illustrated-message-docs.component.html
@@ -8,6 +8,8 @@
 </component-example>
 <code-example [exampleFiles]="illustratedMessageExample"></code-example>
 
+<separator></separator>
+
 <fd-docs-section-title id="dialog" componentName="illustrated-message"> Dialog </fd-docs-section-title>
 <description
     >Set the <code>type</code> property to <code>dialog</code> for Illustration Message used in a Dialog or a Message
@@ -18,6 +20,8 @@
 </component-example>
 <code-example [exampleFiles]="illustratedMessageDialogExample"></code-example>
 
+<separator></separator>
+
 <fd-docs-section-title id="spot" componentName="illustrated-message"> Spot </fd-docs-section-title>
 <description
     >Set the <code>type</code> property to <code>spot</code> for Illustration Message used in medium-sized cards or UI
@@ -27,3 +31,15 @@
     <fd-illustrated-message-spot-example></fd-illustrated-message-spot-example>
 </component-example>
 <code-example [exampleFiles]="illustratedMessageSpotExample"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="inline" componentName="illustrated-message"> Inline SVG </fd-docs-section-title>
+<description>
+    <p>In some cases it's not applicable to use URLs for the SVG locations.</p>
+    <p>In this case developers can load SVG directly into their js code and pass it as a string to the component.</p>
+</description>
+<component-example>
+    <fd-illustrated-message-inline-example></fd-illustrated-message-inline-example>
+</component-example>
+<code-example [exampleFiles]="illustratedMessageInlineExample"></code-example>

--- a/apps/docs/src/app/core/component-docs/illustrated-message/illustrated-message-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/illustrated-message/illustrated-message-docs.component.ts
@@ -17,6 +17,9 @@ import illustrationDialogNoMail from '!../../../../assets/images/sapIllus-Dialog
 
 import illustrationSpotNoMail from '!../../../../assets/images/sapIllus-Spot-NoMail.svg?raw';
 
+import illusratedMessageInlineSrc from '!./examples/illustrated-message-inline-example.component.ts?raw';
+import illusratedMessageInlineHtmlSrc from '!./examples/illustrated-message-inline-example.component.html?raw';
+
 @Component({
     selector: 'app-illustrated-message',
     templateUrl: './illustrated-message-docs.component.html'
@@ -84,6 +87,32 @@ export class IllustratedMessageDocsComponent {
             language: 'svg',
             code: illustrationSpotNoMail,
             fileName: 'sapIllus-Spot-NoMail',
+            path: 'src/assets/images'
+        }
+    ];
+
+    illustratedMessageInlineExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: illusratedMessageInlineHtmlSrc,
+            fileName: 'illustrated-message-inline-example'
+        },
+        {
+            language: 'typescript',
+            code: illusratedMessageInlineSrc,
+            fileName: 'illustrated-message-inline-example',
+            component: 'IllustratedMessageInlineExampleComponent'
+        },
+        {
+            language: 'svg',
+            code: illustration,
+            fileName: 'sapIllus-Dialog-NoMail',
+            path: 'src/assets/images'
+        },
+        {
+            language: 'svg',
+            code: illustrationSceneNoMail,
+            fileName: 'sapIllus-Scene-NoMail',
             path: 'src/assets/images'
         }
     ];

--- a/apps/docs/src/app/core/component-docs/illustrated-message/illustrated-message-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/illustrated-message/illustrated-message-docs.module.ts
@@ -13,6 +13,7 @@ import { IllustratedMessageModule } from '@fundamental-ngx/core/illustrated-mess
 import { ButtonModule } from '@fundamental-ngx/core/button';
 import { DialogModule } from '@fundamental-ngx/core/dialog';
 import { CardModule } from '@fundamental-ngx/core/card';
+import { IllustratedMessageInlineExampleComponent } from './examples/illustrated-message-inline-example.component';
 
 const routes: Routes = [
     {
@@ -40,7 +41,8 @@ const routes: Routes = [
         IllustratedMessageHeaderComponent,
         IllustratedMessageExampleComponent,
         IllustratedMessageDialogExampleComponent,
-        IllustratedMessageSpotExampleComponent
+        IllustratedMessageSpotExampleComponent,
+        IllustratedMessageInlineExampleComponent
     ]
 })
 export class IllustratedMessageDocsModule {}

--- a/libs/core/src/lib/illustrated-message/illustrated-message.component.spec.ts
+++ b/libs/core/src/lib/illustrated-message/illustrated-message.component.spec.ts
@@ -1,6 +1,6 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { IllustratedMessageComponent } from './illustrated-message.component';
+import { IllustratedMessageComponent, IllustratedMessageType } from './illustrated-message.component';
 import { Component, ElementRef, ViewChild } from '@angular/core';
 
 @Component({
@@ -9,8 +9,8 @@ import { Component, ElementRef, ViewChild } from '@angular/core';
             <figcaption fd-illustrated-message-figcaption>
                 <h3 fd-illustrated-message-title>Unable to load data</h3>
                 <p fd-illustrated-message-text>
-                    Check your internet connection. If that's not it, try refereshing the page. If that still doesn't
-                    help, check with your administratior.
+                    Check your internet connection. If that's not it, try refreshing the page. If that still doesn't
+                    help, check with your administrator.
                 </p>
             </figcaption>
         </figure>
@@ -20,7 +20,7 @@ class TestIllustratedMessageComponent {
     @ViewChild(IllustratedMessageComponent, { static: true, read: ElementRef })
     illustratedMessageElementRef: ElementRef;
 
-    type = 'scene';
+    type: IllustratedMessageType = 'scene';
 }
 
 describe('IllustratedMessageComponent', () => {
@@ -28,11 +28,13 @@ describe('IllustratedMessageComponent', () => {
     let testComponent: TestIllustratedMessageComponent;
     let fixture: ComponentFixture<TestIllustratedMessageComponent>;
 
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
-            declarations: [IllustratedMessageComponent, TestIllustratedMessageComponent]
-        }).compileComponents();
-    }));
+    beforeEach(
+        waitForAsync(() => {
+            TestBed.configureTestingModule({
+                declarations: [IllustratedMessageComponent, TestIllustratedMessageComponent]
+            }).compileComponents();
+        })
+    );
 
     beforeEach(() => {
         fixture = TestBed.createComponent(TestIllustratedMessageComponent);

--- a/libs/core/src/lib/illustrated-message/illustrated-message.component.ts
+++ b/libs/core/src/lib/illustrated-message/illustrated-message.component.ts
@@ -11,15 +11,24 @@ import {
     OnInit,
     ViewEncapsulation
 } from '@angular/core';
-import { applyCssClass } from '@fundamental-ngx/core/utils';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { applyCssClass, RequireOnlyOne } from '@fundamental-ngx/core/utils';
 import { CssClassBuilder } from '@fundamental-ngx/core/utils';
 import { fromEvent, Subscription } from 'rxjs';
 
 export interface SvgConfig {
-    scene?: { url: string; id: string };
-    dialog?: { url: string; id: string };
-    spot?: { url: string; id: string };
+    scene?: RequireOnlyOne<SvgItemConfig, 'url' | 'file'>;
+    dialog?: RequireOnlyOne<SvgItemConfig, 'url' | 'file'>;
+    spot?: RequireOnlyOne<SvgItemConfig, 'url' | 'file'>;
 }
+
+export interface SvgItemConfig {
+    url: string;
+    id: string;
+    file: string;
+}
+
+export type IllustratedMessageType = 'scene' | 'dialog' | 'spot';
 
 let illustratedMessageUniqueId = 0;
 
@@ -27,9 +36,10 @@ let illustratedMessageUniqueId = 0;
     // eslint-disable-next-line @angular-eslint/component-selector
     selector: '[fd-illustrated-message]',
     template: `
-        <svg class="fd-illustrated-message__illustration" *ngIf="!noSvg">
+        <svg class="fd-illustrated-message__illustration" *ngIf="!noSvg || _inlineSvg">
             <use [attr.href]="_href"></use>
         </svg>
+        <div *ngIf="_inlineSvg" style="display: none;" [innerHTML]="_inlineSvg"></div>
         <ng-content select="[fd-illustrated-message-figcaption]"></ng-content>
         <ng-content select="fd-illustrated-message-actions"></ng-content>
     `,
@@ -44,20 +54,23 @@ export class IllustratedMessageComponent implements AfterViewInit, OnChanges, On
      * Options include: 'scene' | 'spot' | 'dialog'
      * The default type is set to 'scene'
      */
-    @Input() type: 'scene' | 'dialog' | 'spot' = 'scene';
+    @Input()
+    type: IllustratedMessageType = 'scene';
 
     /**
      * An object containing url and id for each type used to construct the svg href
      * For 'scene' type 'scene' and 'dialog' values are required
      * In small screens (less than 600px) 'dialog' svg will be applied for 'scene' type
      */
-    @Input() svgConfig: SvgConfig;
+    @Input()
+    svgConfig: SvgConfig;
 
     /**
      * When set to true will remove the illustration from the Illustrated Message
      * The default is set to false
      */
-    @Input() noSvg = false;
+    @Input()
+    noSvg = false;
 
     /**
      * Id of the Illustrated Message
@@ -78,10 +91,13 @@ export class IllustratedMessageComponent implements AfterViewInit, OnChanges, On
     _isSmallScreen: boolean;
 
     /** @hidden */
+    _inlineSvg: SafeHtml | undefined;
+
+    /** @hidden */
     private _subscriptions = new Subscription();
 
     /** @hidden */
-    constructor(private _elementRef: ElementRef, private _cdRef: ChangeDetectorRef) {}
+    constructor(private _elementRef: ElementRef, private _cdRef: ChangeDetectorRef, private _sanitizer: DomSanitizer) {}
 
     /** @hidden */
     ngOnChanges(): void {
@@ -107,7 +123,7 @@ export class IllustratedMessageComponent implements AfterViewInit, OnChanges, On
     }
 
     /** @hidden */
-    elementRef(): ElementRef<any> {
+    elementRef(): ElementRef {
         return this._elementRef;
     }
 
@@ -122,31 +138,35 @@ export class IllustratedMessageComponent implements AfterViewInit, OnChanges, On
 
     /** @hidden */
     private _constructHref(): void {
+        let inlineSvg;
+        this._inlineSvg = undefined;
         if (this.svgConfig) {
             switch (this.type) {
                 case 'scene':
-                    {
-                        this._isSmallScreen = window.innerWidth < 600;
+                    this._isSmallScreen = window.innerWidth < 600;
 
-                        this._href = this._isSmallScreen
-                            ? `${this.svgConfig.dialog?.url}#${this.svgConfig.dialog?.id}`
-                            : `${this.svgConfig.scene?.url}#${this.svgConfig.scene?.id}`;
-                        this._cdRef.detectChanges();
-                    }
+                    inlineSvg = this._isSmallScreen ? this.svgConfig.dialog?.file : this.svgConfig.scene?.file;
+
+                    this._href = this._isSmallScreen
+                        ? `${this.svgConfig.dialog?.url || ''}#${this.svgConfig.dialog?.id}`
+                        : `${this.svgConfig.scene?.url || ''}#${this.svgConfig.scene?.id}`;
                     break;
 
                 case 'dialog':
-                    {
-                        this._href = `${this.svgConfig.dialog?.url}#${this.svgConfig.dialog?.id}`;
-                    }
+                    inlineSvg = this.svgConfig.dialog?.file;
+                    this._href = `${this.svgConfig.dialog?.url || ''}#${this.svgConfig.dialog?.id}`;
                     break;
 
                 case 'spot':
-                    {
-                        this._href = `${this.svgConfig.spot?.url}#${this.svgConfig.spot?.id}`;
-                    }
+                    inlineSvg = this.svgConfig.spot?.file;
+                    this._href = `${this.svgConfig.spot?.url || ''}#${this.svgConfig.spot?.id}`;
                     break;
             }
         }
+        if (inlineSvg) {
+            this._inlineSvg = this._sanitizer.bypassSecurityTrustHtml(inlineSvg);
+        }
+
+        this._cdRef.detectChanges();
     }
 }

--- a/libs/core/src/lib/utils/interfaces/require.interface.ts
+++ b/libs/core/src/lib/utils/interfaces/require.interface.ts
@@ -1,0 +1,9 @@
+export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+    {
+        [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+    }[Keys];
+
+export type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+    {
+        [K in Keys]-?: Required<Pick<T, K>> & Partial<Record<Exclude<Keys, K>, undefined>>;
+    }[Keys];

--- a/libs/core/src/lib/utils/public_api.ts
+++ b/libs/core/src/lib/utils/public_api.ts
@@ -41,6 +41,7 @@ export * from './interfaces/css-style-builder.interface';
 export * from './interfaces/has-element-ref.interface';
 export * from './interfaces/keyboard-support-item.interface';
 export * from './interfaces/module-deprecation.interface';
+export * from './interfaces/require.interface';
 
 export * from './decorators/apply-css-class.decorator';
 export * from './decorators/apply-css-style.decorator';


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #8361 

## Description
Added option to pass inline svg code into illustrated message.

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [ ] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [ ] tests for the changes that have been done
-   [ ] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [ ] Run npm run build-pack-library and test in external application
-   [ ] update `README.md`
-   [ ] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
