### PR TITLE
feat(core, platform): datepicker today button

### DIFF
--- a/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.component.html
+++ b/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.component.html
@@ -49,6 +49,22 @@
 
 <separator></separator>
 
+<fd-docs-section-title id="todayButton" componentName="date-picker">Today Selection Button</fd-docs-section-title>
+<description>
+    The Today selection button in the footer of the calendar selects today's date in the system or user-preferred
+    timezone. <code>[showTodayButton]</code> input should be <code>true</code> to enable the button.
+</description>
+
+<description>
+    For <b>Range Date Picker</b>, it sets both <code>start</code> and <code>end</code> date to today's date.
+</description>
+<component-example>
+    <fd-date-picker-today-button-example></fd-date-picker-today-button-example>
+</component-example>
+<code-example [exampleFiles]="datePickerTodayButton"></code-example>
+
+<separator></separator>
+
 <fd-docs-section-title id="formatting" componentName="date-picker"> Formatting </fd-docs-section-title>
 <description>
     Providing a custom format for the dates is possible through providing <code>DATE_TIME_FORMATS</code> config. Note

--- a/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import datePickerRangeSrc from '!./examples/date-picker-range-example.component.ts?raw';
 import datePickerSingleSrc from '!./examples/date-picker-single-example.component.ts?raw';
 import datePickeri18nSrc from '!./examples/date-picker-i18n-example.component.ts?raw';
+import datePickerTodayButton from '!./examples/date-picker-today-button-example.component.ts?raw';
 import datePickerFormatSrc from '!./examples/date-picker-format-example.component.ts?raw';
 import datePickerAllowNullSrc from '!./examples/date-picker-allow-null-example.component.ts?raw';
 import datePickerFormTsSrc from '!./examples/date-picker-form-example.component.ts?raw';
@@ -47,6 +48,15 @@ export class DatePickerDocsComponent {
             component: 'DatePickerI18nExampleComponent',
             code: datePickeri18nSrc,
             fileName: 'datepicker-i18n-example'
+        }
+    ];
+
+    datePickerTodayButton: ExampleFile[] = [
+        {
+            language: 'typescript',
+            component: 'DatePickerTodayButtonExampleComponent',
+            code: datePickerTodayButton,
+            fileName: 'date-picker-today-button-example'
         }
     ];
 

--- a/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.module.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/date-picker-docs.module.ts
@@ -7,6 +7,7 @@ import { DatePickerHeaderComponent } from './date-picker-header/date-picker-head
 import { DatePickerDocsComponent } from './date-picker-docs.component';
 import { DatePickerRangeExampleComponent } from './examples/date-picker-range-example.component';
 import { DatePickerSingleExampleComponent } from './examples/date-picker-single-example.component';
+import { DatePickerTodayButtonExampleComponent } from './examples/date-picker-today-button-example.component';
 import { DatePickerAllowNullExampleComponent } from './examples/date-picker-allow-null-example.component';
 import { DatePickerDisabledExampleComponent } from './examples/date-picker-disabled-example.component';
 import { DatePickerFormExampleComponent } from './examples/date-picker-form-example.component';
@@ -54,6 +55,7 @@ const routes: Routes = [
         DatePickerDocsComponent,
         DatePickerHeaderComponent,
         DatePickerI18nExampleComponent,
+        DatePickerTodayButtonExampleComponent,
         DatePickerFormExampleComponent,
         DatePickerRangeExampleComponent,
         DatePickerFormatExampleComponent,

--- a/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-today-button-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/date-picker/examples/date-picker-today-button-example.component.ts
@@ -1,0 +1,54 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+    DatetimeAdapter,
+    DATE_TIME_FORMATS,
+    FdDate,
+    FdDatetimeAdapter,
+    FD_DATETIME_FORMATS
+} from '@fundamental-ngx/core/datetime';
+import { DateRange } from '@fundamental-ngx/core/calendar';
+
+@Component({
+    selector: 'fd-date-picker-today-button-example',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: ` <label fd-form-label for="datePicker">Date Picker</label>
+        <fd-date-picker type="single" inputId="datePicker" [showTodayButton]="true" [(ngModel)]="date"></fd-date-picker>
+        <br />
+        <div>Selected Date: {{ date?.toDateString() || 'null' }}</div>
+        <br />
+        <label fd-form-label for="compactDatePicker">Compact Date Picker</label>
+        <fd-date-picker
+            type="single"
+            inputId="compactDatePicker"
+            [showTodayButton]="true"
+            [(ngModel)]="date"
+            fdCompact
+        ></fd-date-picker>
+        <div>Selected Date: {{ date?.toDateString() || 'null' }}</div>
+        <br />
+        <fd-date-picker type="range" [showTodayButton]="true" [(ngModel)]="selectedRange"> </fd-date-picker>
+        <br />
+        <div>Selected First Date: {{ this.selectedRange?.start?.toDateString() || 'null' }}</div>
+        <br />
+        <div>Selected Last Date: {{ this.selectedRange?.end?.toDateString() || 'null' }}</div>`,
+    providers: [
+        {
+            provide: DatetimeAdapter,
+            useClass: FdDatetimeAdapter
+        },
+        {
+            provide: DATE_TIME_FORMATS,
+            useValue: FD_DATETIME_FORMATS
+        }
+    ]
+})
+export class DatePickerTodayButtonExampleComponent {
+    date = FdDate.getNow();
+
+    selectedRange: DateRange<FdDate>;
+
+    constructor(private datetimeAdapter: DatetimeAdapter<FdDate>) {
+        const today = this.datetimeAdapter.today();
+        this.selectedRange = new DateRange(today, this.datetimeAdapter.addCalendarDays(today, 1));
+    }
+}

--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -75,7 +75,7 @@
         <div *ngIf="showTodayButton" fd-bar barDesign="footer">
             <div fd-bar-right>
                 <fd-bar-element>
-                    <button fd-button label="Today" (click)="onTodayButtonClick()"></button>
+                    <button fd-button [label]="todayButtonLabel" (click)="onTodayButtonClick()"></button>
                 </fd-bar-element>
             </div>
         </div>

--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -72,7 +72,7 @@
             [nextButtonDisableFunction]="nextButtonDisableFunction"
         ></fd-calendar>
 
-        <div fd-bar barDesign="footer">
+        <div *ngIf="showTodayButton" fd-bar barDesign="footer">
             <div fd-bar-right>
                 <fd-bar-element>
                     <button fd-button label="Today" (click)="onTodayButtonClick()"></button>

--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -71,6 +71,14 @@
             [previousButtonDisableFunction]="previousButtonDisableFunction"
             [nextButtonDisableFunction]="nextButtonDisableFunction"
         ></fd-calendar>
+
+        <div fd-bar barDesign="footer">
+            <div fd-bar-right>
+                <fd-bar-element>
+                    <button fd-button label="Today" (click)="onTodayButtonClick()"></button>
+                </fd-bar-element>
+            </div>
+        </div>
     </fd-popover-body>
 </fd-popover>
 

--- a/libs/core/src/lib/date-picker/date-picker.component.spec.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.spec.ts
@@ -97,6 +97,26 @@ describe('DatePickerComponent', () => {
         expect(component.selectedRangeDateChange.emit).toHaveBeenCalledWith({ start: dateStart, end: dateLast });
     });
 
+    it('should handle today button click and, change and update input', () => {
+        spyOn(component, 'onChange');
+        spyOn(component.selectedRangeDateChange, 'emit');
+        const date = adapter.today();
+        const dateStr = (<any>component)._formatDate(date);
+
+        component.type = 'single';
+        component._inputFieldDate = '';
+        component.onTodayButtonClick();
+        expect(component._inputFieldDate).toEqual(dateStr);
+        expect(component.onChange).toHaveBeenCalledWith(date);
+
+        component.type = 'range';
+        component._inputFieldDate = '';
+        component.onTodayButtonClick();
+        expect(component._inputFieldDate).toBe(dateStr + component._rangeDelimiter + dateStr);
+        expect(component.onChange).toHaveBeenCalledWith({ start: date, end: date });
+        expect(component.selectedRangeDateChange.emit).toHaveBeenCalledWith({ start: date, end: date });
+    });
+
     it('should handle correct write value for single mode', () => {
         const date = adapter.today();
         const dateStr = (<any>component)._formatDate(date);

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -202,10 +202,11 @@ export class DatePickerComponent<D>
     @Input()
     closeOnDateChoose = true;
 
-    /** Enables Today date selection button if true */
+    /** Enables Today-Selection-Button if true */
     @Input()
     showTodayButton = false;
 
+    /** Label for Today-Selection-Button */
     @Input()
     todayButtonLabel = 'Today';
 
@@ -536,6 +537,10 @@ export class DatePickerComponent<D>
         }
     }
 
+    /**
+     * @hidden
+     * Method that is triggered when Today-Selection-Button clicked, it changes selected date or date range to today's date
+     */
     onTodayButtonClick(): void {
         const todayDate = this._dateTimeAdapter.today();
         if (this.type === 'single') {

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -529,6 +529,18 @@ export class DatePickerComponent<D>
         }
     }
 
+    onTodayButtonClick(): void {
+        const todayDate = this._dateTimeAdapter.today();
+        const todayDateRange: DateRange<D> = { start: todayDate, end: todayDate };
+
+        if (this.type === 'single') {
+            this.handleSingleDateChange(todayDate);
+        } else if (this.type === 'range') {
+            this.handleRangeDateChange(todayDateRange);
+        }
+        this.closeFromCalendar(); // closes only single type calendar
+    }
+
     /**
      * @hidden
      * Method that is triggered when the text input is confirmed to ba changed, by clicking enter, or blur

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -206,6 +206,9 @@ export class DatePickerComponent<D>
     @Input()
     showTodayButton = false;
 
+    @Input()
+    todayButtonLabel = 'Today';
+
     /**
      * Function used to disable previous button in the calendar header.
      */

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -202,6 +202,10 @@ export class DatePickerComponent<D>
     @Input()
     closeOnDateChoose = true;
 
+    /** Enables Today date selection button if true */
+    @Input()
+    showTodayButton = false;
+
     /**
      * Function used to disable previous button in the calendar header.
      */
@@ -531,11 +535,11 @@ export class DatePickerComponent<D>
 
     onTodayButtonClick(): void {
         const todayDate = this._dateTimeAdapter.today();
-        const todayDateRange: DateRange<D> = { start: todayDate, end: todayDate };
 
         if (this.type === 'single') {
             this.handleSingleDateChange(todayDate);
         } else if (this.type === 'range') {
+            const todayDateRange: DateRange<D> = { start: todayDate, end: todayDate };
             this.handleRangeDateChange(todayDateRange);
         }
         this.closeFromCalendar(); // closes only single type calendar

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -538,14 +538,12 @@ export class DatePickerComponent<D>
 
     onTodayButtonClick(): void {
         const todayDate = this._dateTimeAdapter.today();
-
         if (this.type === 'single') {
             this.handleSingleDateChange(todayDate);
+            this.closeFromCalendar();
         } else if (this.type === 'range') {
-            const todayDateRange: DateRange<D> = { start: todayDate, end: todayDate };
-            this.handleRangeDateChange(todayDateRange);
+            this.handleRangeDateChange({ start: todayDate, end: todayDate });
         }
-        this.closeFromCalendar(); // closes only single type calendar
     }
 
     /**

--- a/libs/core/src/lib/date-picker/date-picker.module.ts
+++ b/libs/core/src/lib/date-picker/date-picker.module.ts
@@ -11,6 +11,7 @@ import { ButtonModule } from '@fundamental-ngx/core/button';
 import { FormMessageModule } from '@fundamental-ngx/core/form';
 import { DeprecatedDatePickerCompactDirective } from './deprecated-date-picker-compact.directive';
 import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
+import { BarModule } from '@fundamental-ngx/core/bar';
 
 @NgModule({
     declarations: [DatePickerComponent, DeprecatedDatePickerCompactDirective],
@@ -23,6 +24,7 @@ import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
         InputGroupModule,
         ButtonModule,
         FormMessageModule,
+        BarModule,
         ContentDensityModule
     ],
     exports: [DatePickerComponent, DeprecatedDatePickerCompactDirective, ContentDensityModule]

--- a/libs/platform/src/lib/form/date-picker/date-picker.component.html
+++ b/libs/platform/src/lib/form/date-picker/date-picker.component.html
@@ -9,6 +9,8 @@
     [compact]="contentDensity | isCompactDensity"
     [required]="required"
     [selectedDate]="selectedDate"
+    [showTodayButton]="showTodayButton"
+    [todayButtonLabel]="todayButtonLabel"
     [selectedRangeDate]="selectedRangeDate"
     [startingDayOfWeek]="startingDayOfWeek"
     [rangeHoverEffect]="rangeHoverEffect"

--- a/libs/platform/src/lib/form/date-picker/date-picker.component.ts
+++ b/libs/platform/src/lib/form/date-picker/date-picker.component.ts
@@ -98,6 +98,14 @@ export class PlatformDatePickerComponent<D> extends BaseInput {
     @Input()
     displayCalendarToggleLabel = 'Display calendar toggle';
 
+    /** Enables Today-Selection-Button if true */
+    @Input()
+    showTodayButton = false;
+
+    /** Label for Today-Selection-Button */
+    @Input()
+    todayButtonLabel = 'Today';
+
     /** Whether a null input is considered valid. */
     @Input()
     allowNull = true;


### PR DESCRIPTION
## Related Issue(s)

closes #8362 

## Description

Added Today Selection Button in the footer selects today's date in the system or user-preferred timezone and closes the DatePicker popover.

`Important:`
For date range it sets start and end both to today's date.