### PR TITLE
fix(core): product switch should loop back to the start after right arrow key

### DIFF
--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.spec.ts
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.spec.ts
@@ -95,6 +95,17 @@ describe('ProductSwitchBodyComponent', () => {
         expect(document.activeElement).toBe(nextEl);
     });
 
+    it('should handle keydown arrow right when the last item is focused', () => {
+        spyOn(componentInstance, '_isListMode').and.returnValue(false);
+        const els = fixture.debugElement.queryAll(By.css('li'));
+        const el = els[els.length - 1];
+        el.nativeElement.focus();
+        const keyboardEvent = createKeyboardEvent('keydown', RIGHT_ARROW, 'ArrowRight', el.nativeElement);
+        el.nativeElement.dispatchEvent(keyboardEvent);
+
+        expect(document.activeElement).toBe(els[0].nativeElement);
+    });
+
     it('should handle no list keydown arrow left', () => {
         spyOn(componentInstance, '_isListMode').and.returnValue(false);
         const el = fixture.debugElement.query(By.css('li'));

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.ts
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.ts
@@ -144,6 +144,16 @@ export class ProductSwitchBodyComponent implements OnInit, OnDestroy {
         const previousElementSibling = <HTMLElement>target.previousElementSibling;
         const nextElementSibling = <HTMLElement>target.nextElementSibling;
 
+        if (
+            i === this.products.length - 1 &&
+            (KeyUtil.isKeyCode(event, RIGHT_ARROW) || (KeyUtil.isKeyCode(event, LEFT_ARROW) && this._isRtl))
+        ) {
+            while (<HTMLElement>target.previousElementSibling) {
+                target = <HTMLElement>target.previousElementSibling;
+            }
+            target.focus();
+        }
+
         if (KeyUtil.isKeyCode(event, LEFT_ARROW)) {
             this._isRtl ? nextElementSibling?.focus() : previousElementSibling?.focus();
         } else if (KeyUtil.isKeyCode(event, RIGHT_ARROW)) {


### PR DESCRIPTION
fixes #8406 

When the user has navigated to the end of the products, right arrow key (or left in RTL) should bring focus back to the start