### PR TITLE
docs(core): update dialog with textarea example

### DIFF
--- a/apps/docs/src/app/core/component-docs/dialog/examples/dialog-form/form-dialog-example.component.html
+++ b/apps/docs/src/app/core/component-docs/dialog/examples/dialog-form/form-dialog-example.component.html
@@ -85,7 +85,7 @@
                         <label class="fd-form-label" for="text-2434-name">Bio:</label>
                     </div>
                     <div class="fd-col">
-                        <textarea class="fd-textarea" id="text-2434-name">Disabled textarea</textarea>
+                        <textarea class="fd-textarea" id="text-2434-name">textarea</textarea>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
part of #7744 - remove word `disabled` from not-disabled textarea example in dialog