### PR TITLE
docs(platform): rtl support for wizard generator in dialogs

### DIFF
--- a/apps/docs/src/app/documentation/core-helpers/component-example/component-example.component.ts
+++ b/apps/docs/src/app/documentation/core-helpers/component-example/component-example.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { DialogService } from '@fundamental-ngx/core/dialog';
 import { RtlService } from '@fundamental-ngx/core/utils';
+import { WizardDialogGeneratorService } from '@fundamental-ngx/platform/wizard-generator';
 
 let componentExampleUniqueId = 0;
 
@@ -23,7 +24,8 @@ let componentExampleUniqueId = 0;
     providers: [
         RtlService,
         // Needed in order for dialog service and components to inherit local rtl service.
-        DialogService
+        DialogService,
+        WizardDialogGeneratorService
     ],
     encapsulation: ViewEncapsulation.None
 })


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

RTL support for the Platform Wizard Generator examples in the docs app.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

<img width="1327" alt="image" src="https://user-images.githubusercontent.com/20265336/180389913-b13eb73a-87bf-414c-a323-b0a36c9dc53d.png">

### After:

<img width="1332" alt="image" src="https://user-images.githubusercontent.com/20265336/180389873-e8cbc144-9594-4a01-b760-0c2c5b916f1f.png">

