### PR TITLE
chore(core): moved deprecated warnings to setter instead of constructor

### DIFF
--- a/libs/core/src/lib/content-density/classes/deprecated-compact.directive.ts
+++ b/libs/core/src/lib/content-density/classes/deprecated-compact.directive.ts
@@ -15,6 +15,9 @@ export class DeprecatedCompactDirective
     /** @deprecated use fdCompact directive instead */
     @Input()
     set compact(value: BooleanInput) {
+        if (isDevMode()) {
+            console.warn(`${this.message}. Use [fdCompact] directive instead.`);
+        }
         this.next(coerceBooleanProperty(value) ? ContentDensityMode.COMPACT : ContentDensityMode.COZY);
     }
 
@@ -27,9 +30,6 @@ export class DeprecatedCompactDirective
     constructor(selectorBase: string) {
         super(ContentDensityMode.COZY);
         this.message = `Usage of ${selectorBase}[compact] is deprecated`;
-        if (isDevMode()) {
-            console.warn(`${this.message}. Use [fdCompact] directive instead.`);
-        }
     }
 
     ngOnDestroy(): void {

--- a/libs/core/src/lib/content-density/classes/deprecated-condensed.directive.ts
+++ b/libs/core/src/lib/content-density/classes/deprecated-condensed.directive.ts
@@ -14,6 +14,9 @@ export class DeprecatedCondensedDirective
 {
     @Input()
     set condensed(value: BooleanInput) {
+        if (isDevMode()) {
+            console.warn(`${this.message}. Use [fdCondensed] directive instead.`);
+        }
         this.next(coerceBooleanProperty(value) ? ContentDensityMode.CONDENSED : ContentDensityMode.COZY);
     }
 
@@ -26,9 +29,6 @@ export class DeprecatedCondensedDirective
     constructor(selectorBase: string) {
         super(ContentDensityMode.COZY);
         this.message = `Usage of ${selectorBase}[condensed] is deprecated`;
-        if (isDevMode()) {
-            console.warn(`${this.message}. Use [fdCondensed] directive instead.`);
-        }
     }
 
     ngOnDestroy(): void {

--- a/libs/core/src/lib/content-density/classes/deprecated-cozy.directive.ts
+++ b/libs/core/src/lib/content-density/classes/deprecated-cozy.directive.ts
@@ -14,6 +14,9 @@ export class DeprecatedCozyDirective
 {
     @Input()
     set cozy(value: BooleanInput) {
+        if (isDevMode()) {
+            console.warn(`${this.message}. Use [fdCozy] directive instead.`);
+        }
         this.next(coerceBooleanProperty(value) ? ContentDensityMode.COZY : ContentDensityMode.COMPACT);
     }
 
@@ -26,9 +29,6 @@ export class DeprecatedCozyDirective
     constructor(selectorBase: string) {
         super(ContentDensityMode.COMPACT);
         this.message = `Usage of ${selectorBase}[cozy] is deprecated`;
-        if (isDevMode()) {
-            console.warn(`${this.message}. Use [fdCozy] directive instead.`);
-        }
     }
 
     ngOnDestroy(): void {


### PR DESCRIPTION
## Related Issue(s)
N/a

## Description
Moved content density directive warnings to the setter, instead of the constructor. This way it will only log warns if the directive was actually used and not just created. Directives are also provided and injected into documentation pages