### PR TITLE
fix(docs): add content height to mobile wizard

### DIFF
--- a/apps/docs/src/app/core/component-docs/wizard/examples/wizard-mobile-example.component.html
+++ b/apps/docs/src/app/core/component-docs/wizard/examples/wizard-mobile-example.component.html
@@ -1,5 +1,5 @@
 <div style="display: flex; justify-content: space-around; flex-wrap: wrap">
-    <fd-wizard [appendToWizard]="false">
+    <fd-wizard [appendToWizard]="false" [contentHeight]="contentHeight">
         <fd-wizard-navigation>
             <ul fd-wizard-progress-bar size="sm" role="list" aria-label="Wizard Steps">
                 <li
@@ -64,7 +64,7 @@
         </div>
     </fd-wizard>
 
-    <fd-wizard [appendToWizard]="false">
+    <fd-wizard [appendToWizard]="false" [contentHeight]="contentHeight">
         <fd-wizard-navigation>
             <ul fd-wizard-progress-bar size="sm">
                 <li

--- a/apps/docs/src/app/core/component-docs/wizard/examples/wizard-mobile-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/wizard/examples/wizard-mobile-example.component.ts
@@ -20,6 +20,7 @@ import { WizardService } from '@fundamental-ngx/core/wizard';
     providers: [WizardService]
 })
 export class WizardMobileExampleComponent {
+    contentHeight = '450px';
     example1step1status: WizardStepStatus = 'current';
     example1step2status: WizardStepStatus = 'upcoming';
     example1step3status: WizardStepStatus = 'upcoming';


### PR DESCRIPTION
## Related Issue(s)

closes #8408 

## Description

Added `contentHeight` to `fd-wizard`.