### PR TITLE
feat(core): combobox dropdown values list can containt duplicate display names

### DIFF
--- a/apps/docs/src/app/core/component-docs/combobox/examples/combobox-forms-example.component.ts
+++ b/apps/docs/src/app/core/component-docs/combobox/examples/combobox-forms-example.component.ts
@@ -19,6 +19,7 @@ export class ComboboxFormsExampleComponent {
 
     dropdownValues: ComboboxItem[] = [
         { displayedValue: 'Apple', value: 'AppleValue' },
+        { displayedValue: 'Apple', value: 'AppleValue2' },
         { displayedValue: 'Banana', value: 'BananaValue' },
         { displayedValue: 'Kiwi', value: 'KiwiValue' },
         { displayedValue: 'Strawberry', value: 'StrawberryValue' },

--- a/libs/core/src/lib/combobox/combobox-mobile/combobox-mobile.component.ts
+++ b/libs/core/src/lib/combobox/combobox-mobile/combobox-mobile.component.ts
@@ -76,7 +76,7 @@ export class ComboboxMobileComponent extends MobileModeBase<ComboboxInterface> i
 
     private _toggleDialog(open: boolean): void {
         if (open) {
-            this._selectedBackup = this._component.inputText;
+            this._selectedBackup = this._component.getValue();
             if (!this._dialogService.hasOpenDialogs()) {
                 this._open();
             }

--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -140,7 +140,7 @@
                     [tabindex]="0"
                     class="fd-combobox-list-item"
                     *ngFor="let term of group.value"
-                    [selected]="inputText === (term | displayFnPipe: displayFn)"
+                    [selected]="isSelected(term)"
                     (keyDown)="onItemKeyDownHandler($event, term)"
                     (click)="onMenuClickHandler(term)"
                 >
@@ -158,7 +158,7 @@
                 [tabindex]="0"
                 class="fd-combobox-list-item"
                 *ngFor="let term of displayedValues"
-                [selected]="inputText === (term | displayFnPipe: displayFn)"
+                [selected]="isSelected(term)"
                 (keyDown)="onItemKeyDownHandler($event, term)"
                 (click)="onMenuClickHandler(term)"
             >

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -611,6 +611,11 @@ export class ComboboxComponent
         this.clearInputBtnFocused = false;
     }
 
+    /** Current select value */
+    getValue(): any {
+        return this._value;
+    }
+
     /** Method that picks other value moved from current one by offset, called only when combobox is closed */
     private _chooseOtherItem(offset: number): void {
         const activeValue: any = this._getOptionObjectByDisplayedValue(this.inputTextValue);
@@ -694,16 +699,13 @@ export class ComboboxComponent
         this.onChange(this.getValue());
     }
 
+    /** @hidden */
     private setValue(value: any): void {
         if (this.communicateByObject) {
             this._value = value;
         } else {
             this._value = this.displayFn(value);
         }
-    }
-
-    getValue(): any {
-        return this._value;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -348,6 +348,9 @@ export class ComboboxComponent
     private _subscriptions = new Subscription();
 
     /** @hidden */
+    private _value: any;
+
+    /** @hidden */
     onChange: (value: any) => void = () => {};
 
     /** @hidden */
@@ -450,8 +453,9 @@ export class ComboboxComponent
     }
 
     /** Handle dialog dismissing, closes popover and sets backup data. */
-    dialogDismiss(term: string): void {
-        this.inputText = term;
+    dialogDismiss(term: any): void {
+        this.inputText = this.displayFn(term);
+        this.setValue(term);
         this.isOpenChangeHandle(false);
     }
 
@@ -502,6 +506,7 @@ export class ComboboxComponent
     /** @hidden */
     writeValue(value: any): void {
         this.inputTextValue = this.displayFn(value);
+        this.setValue(value);
         this._cdRef.markForCheck();
     }
 
@@ -643,9 +648,7 @@ export class ComboboxComponent
             return contentArray.filter((item) => {
                 if (item) {
                     const term = this.displayFn(item).toLocaleLowerCase();
-                    let retVal;
-                    this.includes ? (retVal = term.includes(searchLower)) : (retVal = term.startsWith(searchLower));
-                    return retVal;
+                    return this.includes ? term.includes(searchLower) : term.startsWith(searchLower);
                 }
             });
         } else if (typeof searchTerm === 'object') {
@@ -660,6 +663,7 @@ export class ComboboxComponent
             this.isOpenChangeHandle(false);
         }
         if (this.fillOnSelect) {
+            this.setValue(term);
             this.inputText = this.displayFn(term);
             this.searchInputElement.nativeElement.value = this.inputText;
             this._cdRef.detectChanges();
@@ -687,11 +691,19 @@ export class ComboboxComponent
 
     /** @hidden */
     private _propagateChange(): void {
+        this.onChange(this.getValue());
+    }
+
+    private setValue(value: any): void {
         if (this.communicateByObject) {
-            this.onChange(this._getOptionObjectByDisplayedValue(this.inputTextValue));
+            this._value = value;
         } else {
-            this.onChange(this.inputTextValue);
+            this._value = this.displayFn(value);
         }
+    }
+
+    getValue(): any {
+        return this._value;
     }
 
     /** @hidden */
@@ -708,5 +720,10 @@ export class ComboboxComponent
             this._viewContainerRef,
             injector
         );
+    }
+
+    isSelected(term: any): boolean {
+        const termValue = this.communicateByObject ? term : this.displayFn(term);
+        return this.getValue() === termValue;
     }
 }

--- a/libs/core/src/lib/combobox/combobox.interface.ts
+++ b/libs/core/src/lib/combobox/combobox.interface.ts
@@ -11,6 +11,7 @@ export interface ComboboxInterface extends MobileMode {
     inputText: string;
     openChange: EventEmitter<boolean>;
 
+    getValue(): any;
     dialogApprove(): void;
     dialogDismiss(backup: string): void;
 }


### PR DESCRIPTION
## Related Issue(s)

closes #8466

## Description
Now, instead of only saving the display name and then trying to guess to which one it belonged originally, we save full value and then use it for the output.
