### PR TITLE
fix(core): getters and setters for list-item checkboxes/radios to fix tab issue

### DIFF
--- a/libs/core/src/lib/list/list-item/list-item.component.ts
+++ b/libs/core/src/lib/list/list-item/list-item.component.ts
@@ -125,12 +125,32 @@ export class ListItemComponent
     link = false;
 
     /** @hidden */
-    @ContentChild(CheckboxComponent)
-    checkbox: CheckboxComponent;
+    @ContentChild(RadioButtonComponent)
+    get radio(): RadioButtonComponent {
+        return this._radio;
+    }
 
     /** @hidden */
-    @ContentChild(RadioButtonComponent)
-    radio: RadioButtonComponent;
+    set radio(value: RadioButtonComponent) {
+        this._radio = value;
+        if (this._radio && this._radio.tabIndex == null) {
+            this._radio.tabIndex = -1;
+        }
+    }
+
+    /** @hidden */
+    @ContentChild(CheckboxComponent)
+    get checkbox(): CheckboxComponent {
+        return this._checkbox;
+    }
+
+    /** @hidden */
+    set checkbox(value: CheckboxComponent) {
+        this._checkbox = value;
+        if (this._checkbox && this._checkbox.tabIndexValue == null) {
+            this._checkbox.tabIndexValue = -1;
+        }
+    }
 
     /** @hidden */
     @ContentChildren(ListLinkDirective)
@@ -145,6 +165,12 @@ export class ListItemComponent
 
     /** @hidden */
     private readonly _onLinkListChanged$ = new Subject<void>();
+
+    /** @hidden */
+    private _radio: RadioButtonComponent;
+
+    /** @hidden */
+    private _checkbox: CheckboxComponent;
 
     /** @hidden */
     screenReaderContent = '';


### PR DESCRIPTION
Adopting @g-cheishvili's comments from a PR that has been stuck in the stale loop for a while https://github.com/SAP/fundamental-ngx/pull/8271

Fixes an issue where checkboxes in list items would receive focus in addition to the list item itself.