### PR TITLE
chore: reduced background noise in unit tests and made test results cleaner

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,6 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
-const { join } = require('path');
 const { constants } = require('karma');
 
 module.exports = () => {
@@ -15,6 +14,7 @@ module.exports = () => {
             require('karma-chrome-launcher'),
             require('karma-jasmine-html-reporter'),
             require('karma-coverage'),
+            require('karma-spec-reporter'),
             require('@angular-devkit/build-angular/plugins/karma')
         ],
         client: {
@@ -24,7 +24,7 @@ module.exports = () => {
             dir: 'coverage',
             type: 'html'
         },
-        reporters: ['progress', 'coverage'],
+        reporters: ['spec', 'coverage'],
         port: 9876,
         colors: true,
         logLevel: constants.LOG_INFO,

--- a/libs/core/src/lib/bar/directives/bar-element.directive.spec.ts
+++ b/libs/core/src/lib/bar/directives/bar-element.directive.spec.ts
@@ -4,9 +4,9 @@ import { BarModule } from '../bar.module';
 
 @Component({
     template: `
-        <fd-bar-element #directiveElement fd-bar-element [fullWidth]="fullWidth" [isTitle]="isTitle"
-            >Bar Element Test</fd-bar-element
-        >
+        <fd-bar-element #directiveElement [fullWidth]="fullWidth" [isTitle]="isTitle">
+            Bar Element Test
+        </fd-bar-element>
     `
 })
 class TestComponent {

--- a/libs/core/src/lib/card/card.component.spec.ts
+++ b/libs/core/src/lib/card/card.component.spec.ts
@@ -15,7 +15,7 @@ import { getCardModifierClassNameByCardType } from './utils';
 
 @Component({
     template: `
-        <fd-card [badge]="badgeText" [isLoading]="isLoading" [compact]="isCompact" [cardType]="cardType">
+        <fd-card [badge]="badgeText" [isLoading]="isLoading" [fdCompact]="isCompact" [cardType]="cardType">
             <fd-card-header>
                 <h2 fd-card-title>{{ titleText }}</h2>
             </fd-card-header>

--- a/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
+++ b/libs/core/src/lib/dialog/dialog-header/dialog-header.component.html
@@ -20,6 +20,6 @@
     </ng-template>
 </div>
 
-<div fd-bar *ngIf="subHeaderTemplate" class="fd-dialog__subheader" barDesign="subheader" [cozy]="dialogConfig.mobile">
+<div fd-bar *ngIf="subHeaderTemplate" class="fd-dialog__subheader" barDesign="subheader" [fdCozy]="dialogConfig.mobile">
     <ng-container *ngTemplateOutlet="subHeaderTemplate"></ng-container>
 </div>

--- a/libs/core/src/lib/flexible-column-layout/flexible-column-layout.component.html
+++ b/libs/core/src/lib/flexible-column-layout/flexible-column-layout.component.html
@@ -17,7 +17,7 @@
     <div *ngIf="_leftColumnSeparator" class="fd-flexible-column-layout__separator">
         <button
             fd-button
-            [compact]="true"
+            fdCompact
             fdType="transparent"
             class="fd-flexible-column-layout__button"
             ariaLabel="Expand"
@@ -43,7 +43,7 @@
     <div *ngIf="_rightColumnSeparator" class="fd-flexible-column-layout__separator">
         <button
             fd-button
-            [compact]="true"
+            fdCompact
             fdType="transparent"
             class="fd-flexible-column-layout__button"
             ariaLabel="Expand"

--- a/libs/core/src/lib/menu/menu.module.ts
+++ b/libs/core/src/lib/menu/menu.module.ts
@@ -11,7 +11,7 @@ import { MenuShortcutDirective } from './directives/menu-shortcut.directive';
 import { PopoverModule } from '@fundamental-ngx/core/popover';
 import { MenuTriggerDirective } from './directives/menu-trigger.directive';
 import { IconModule } from '@fundamental-ngx/core/icon';
-import { InitialFocusModule } from '@fundamental-ngx/core/utils';
+import { DynamicComponentService, InitialFocusModule } from '@fundamental-ngx/core/utils';
 import { DeprecatedMenuCompactDirective } from './directives/deprecated-menu-compact.directive';
 import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
 
@@ -41,6 +41,7 @@ import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
         MenuTriggerDirective,
         DeprecatedMenuCompactDirective,
         ContentDensityModule
-    ]
+    ],
+    providers: [DynamicComponentService]
 })
 export class MenuModule {}

--- a/libs/core/src/lib/message-box/message-box-footer/message-box-footer.component.html
+++ b/libs/core/src/lib/message-box/message-box-footer/message-box-footer.component.html
@@ -1,4 +1,4 @@
-<footer fd-bar class="fd-message-box__footer" barDesign="footer" [cozy]="messageBoxConfig.mobile">
+<footer fd-bar class="fd-message-box__footer" barDesign="footer" [fdCozy]="messageBoxConfig.mobile">
     <ng-container *ngTemplateOutlet="footerTemplate ? footerTemplate : defaultTemplate"></ng-container>
     <ng-template #defaultTemplate>
         <div fd-bar-right>

--- a/libs/core/src/lib/message-box/message-box-header/message-box-header.component.html
+++ b/libs/core/src/lib/message-box/message-box-header/message-box-header.component.html
@@ -1,7 +1,7 @@
 <div
     fd-bar
     class="fd-message-box__header"
-    [cozy]="messageBoxConfig.mobile"
+    [fdCozy]="messageBoxConfig.mobile"
     [barDesign]="subHeaderTemplate ? 'header-with-subheader' : 'header'"
 >
     <ng-container *ngTemplateOutlet="headerTemplate ? headerTemplate : defaultTemplate"></ng-container>
@@ -25,7 +25,7 @@
     *ngIf="subHeaderTemplate"
     class="fd-message-box__subheader"
     barDesign="subheader"
-    [cozy]="messageBoxConfig.mobile"
+    [fdCozy]="messageBoxConfig.mobile"
 >
     <ng-container *ngTemplateOutlet="subHeaderTemplate"></ng-container>
 </div>

--- a/libs/core/src/lib/shellbar/shellbar-action/shellbar-action.component.html
+++ b/libs/core/src/lib/shellbar/shellbar-action/shellbar-action.component.html
@@ -3,7 +3,7 @@
         fd-button
         fdType="transparent"
         class="fd-shellbar__button"
-        [compact]="false"
+        fdCozy
         [glyph]="glyph"
         (click)="callback ? callback($event) : ''"
     >

--- a/libs/core/src/lib/tile/directives/tile.directives.spec.ts
+++ b/libs/core/src/lib/tile/directives/tile.directives.spec.ts
@@ -12,8 +12,8 @@ import {
 @Component({
     selector: 'fd-test-component',
     template: `
-        <button fd-button fd-tile-action-close [compact]="true" fdType="transparent"></button>
-        <button fd-button fd-tile-action-indicator [compact]="true" fdType="transparent"></button>
+        <button fd-button fd-tile-action-close fdCompact fdType="transparent"></button>
+        <button fd-button fd-tile-action-indicator fdCompact fdType="transparent"></button>
         <div #header fd-tile-header [twoColumn]="true">
             <div fd-tile-header-content></div>
         </div>

--- a/libs/core/src/lib/toolbar/toolbar.component.spec.ts
+++ b/libs/core/src/lib/toolbar/toolbar.component.spec.ts
@@ -139,35 +139,35 @@ describe('ToolbarComponent - Prioritization and Grouping', () => {
     template: `
         <div [style.width]="width">
             <fd-toolbar #toolbar [shouldOverflow]="true">
-                <button fd-toolbar-item fd-button [compact]="true">Button1</button>
+                <button fd-toolbar-item fd-button fdCompact>Button1</button>
                 <fd-toolbar-separator fd-toolbar-item></fd-toolbar-separator>
-                <button fd-toolbar-item fd-button [compact]="true">Button2</button>
+                <button fd-toolbar-item fd-button fdCompact>Button2</button>
                 <fd-toolbar-separator fd-toolbar-item></fd-toolbar-separator>
-                <button fd-toolbar-item fd-button [compact]="true">Button3</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button4</button>
+                <button fd-toolbar-item fd-button fdCompact>Button3</button>
+                <button fd-toolbar-item fd-button fdCompact>Button4</button>
 
                 <fd-toolbar-spacer fd-toolbar-item></fd-toolbar-spacer>
 
                 <fd-toolbar-separator fd-toolbar-item></fd-toolbar-separator>
 
-                <button fd-toolbar-item fd-button [compact]="true">Button5</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button6</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button7</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button8</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button9</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button10</button>
+                <button fd-toolbar-item fd-button fdCompact>Button5</button>
+                <button fd-toolbar-item fd-button fdCompact>Button6</button>
+                <button fd-toolbar-item fd-button fdCompact>Button7</button>
+                <button fd-toolbar-item fd-button fdCompact>Button8</button>
+                <button fd-toolbar-item fd-button fdCompact>Button9</button>
+                <button fd-toolbar-item fd-button fdCompact>Button10</button>
                 <fd-toolbar-spacer fd-toolbar-item></fd-toolbar-spacer>
-                <button fd-toolbar-item fd-button [compact]="true">Button11</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button12</button>
+                <button fd-toolbar-item fd-button fdCompact>Button11</button>
+                <button fd-toolbar-item fd-button fdCompact>Button12</button>
                 <fd-toolbar-separator fd-toolbar-item></fd-toolbar-separator>
-                <button fd-toolbar-item fd-button [compact]="true">Button13</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button14</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button15</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button16</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button17</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button18</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button19</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button20</button>
+                <button fd-toolbar-item fd-button fdCompact>Button13</button>
+                <button fd-toolbar-item fd-button fdCompact>Button14</button>
+                <button fd-toolbar-item fd-button fdCompact>Button15</button>
+                <button fd-toolbar-item fd-button fdCompact>Button16</button>
+                <button fd-toolbar-item fd-button fdCompact>Button17</button>
+                <button fd-toolbar-item fd-button fdCompact>Button18</button>
+                <button fd-toolbar-item fd-button fdCompact>Button19</button>
+                <button fd-toolbar-item fd-button fdCompact>Button20</button>
                 <fd-toolbar-separator fd-toolbar-item></fd-toolbar-separator>
             </fd-toolbar>
         </div>
@@ -185,13 +185,13 @@ class ToolbarTestComponent {
     template: `
         <div [style.width]="width">
             <fd-toolbar #toolbar [shouldOverflow]="true">
-                <button fd-toolbar-item fd-button [compact]="true">Button First</button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="always">Always</button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="never">Never</button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low">Low</button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="high">High</button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="disappear">Disappear</button>
-                <button fd-toolbar-item fd-button [compact]="true">Button Last</button>
+                <button fd-toolbar-item fd-button fdCompact>Button First</button>
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="always">Always</button>
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="never">Never</button>
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="low">Low</button>
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="high">High</button>
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="disappear">Disappear</button>
+                <button fd-toolbar-item fd-button fdCompact>Button Last</button>
             </fd-toolbar>
         </div>
     `
@@ -208,22 +208,22 @@ class ToolbarOverflowPriorityTestComponent {
     template: `
         <div [style.width]="width">
             <fd-toolbar #toolbar [shouldOverflow]="true">
-                <button fd-toolbar-item fd-button [compact]="true">Button</button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="always">Always</button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="never">Never</button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="1">
+                <button fd-toolbar-item fd-button fdCompact>Button</button>
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="always">Always</button>
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="never">Never</button>
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="low" fdOverflowGroup="1">
                     Gr 1 / Low
                 </button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="2">
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="low" fdOverflowGroup="2">
                     Gr 2 / Low
                 </button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="disappear" fdOverflowGroup="2">
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="disappear" fdOverflowGroup="2">
                     Gr 2 / Disappear
                 </button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="low" fdOverflowGroup="2">
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="low" fdOverflowGroup="2">
                     Gr 2 / Low
                 </button>
-                <button fd-toolbar-item fd-button [compact]="true" fdOverflowPriority="high" fdOverflowGroup="1">
+                <button fd-toolbar-item fd-button fdCompact fdOverflowPriority="high" fdOverflowGroup="1">
                     Gr 1 / High
                 </button>
             </fd-toolbar>

--- a/libs/core/src/lib/upload-collection/upload-collection-item.directive.spec.ts
+++ b/libs/core/src/lib/upload-collection/upload-collection-item.directive.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angul
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { UploadCollectionModule } from './upload-collection.module';
 import { UploadCollectionItemDirective } from './upload-collection-item.directive';
+import { IconModule } from '@fundamental-ngx/core/icon';
 
 @Component({
     template: `
@@ -53,7 +54,7 @@ describe('UploadCollectionItemDirective', () => {
         waitForAsync(() => {
             TestBed.configureTestingModule({
                 declarations: [TestComponent],
-                imports: [UploadCollectionModule]
+                imports: [UploadCollectionModule, IconModule]
             }).compileComponents();
         })
     );


### PR DESCRIPTION
## Description

Reduced amount of logs in unit tests. Logs were caused by calling deprecated properties. Also since I was there, I removed deprecated properties from docs too. It was not mentioned anywhere and already stated in the docs that those inputs are removed, so not a big deal. I also added `spec` reporter to unit tests, so now we see a nice and clean list of tests that work and which do not
