### PR TITLE
fix(core): prevent page scroll on up/down arrow key in table

### DIFF
--- a/libs/core/src/lib/table/table.component.ts
+++ b/libs/core/src/lib/table/table.component.ts
@@ -118,6 +118,7 @@ export class TableComponent implements AfterViewInit, OnDestroy, FdTable {
     _onCellKeydown(event: KeyboardEvent, cell: TableCellDirective): void {
         const cellElement = cell.elementRef.nativeElement;
         if (KeyUtil.isKeyCode(event, [DOWN_ARROW, UP_ARROW])) {
+            event.preventDefault();
             const data = cell.getCellPosition();
             if (!data) {
                 return;


### PR DESCRIPTION
part of #8557 

Disable page scroll when user is navigating through a focusable table with up/down arrow keys