### PR TITLE
fix(platform): table reset button behaviour

### DIFF
--- a/apps/docs/src/app/platform/component-docs/platform-table/platform-table-docs.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-table/platform-table-docs.component.html
@@ -96,8 +96,14 @@
 
 <fd-docs-section-title id="sortable" componentName="table"> Column Sorting</fd-docs-section-title>
 <description>
-    Use <code>[sortable]="true"</code> to mark a column as an sortable one.<br />
-    In this example <code>Name</code>, <code>Description</code> and <code>Price</code> columns can be sorted.
+    <p>Use <code>[sortable]="true"</code> to mark a column as an sortable one.</p>
+    <p>
+        Developers can restrict selecting "Not Sorted" option by providing
+        <code>[allowDisablingSorting]="false"</code> input property for the
+        <code>fdp-table-view-settings-dialog</code> component and providing
+        <a routerLink="/platform/table" fragment="initial-state">[initialSortBy]</a> input property of the table.
+    </p>
+    <p>In this example <code>Name</code>, <code>Description</code> and <code>Price</code> columns can be sorted.</p>
 </description>
 <component-example>
     <fdp-platform-table-sortable-example></fdp-platform-table-sortable-example>

--- a/apps/docs/src/app/platform/component-docs/platform-table/platform-table-examples/platform-table-initial-state-example.component.html
+++ b/apps/docs/src/app/platform/component-docs/platform-table/platform-table-examples/platform-table-initial-state-example.component.html
@@ -3,18 +3,61 @@
     [dataSource]="source"
     [initialVisibleColumns]="['updatedOn', 'name', 'price', 'status']"
     [initialSortBy]="[{ field: 'price.value', direction: sortDirectionEnum.ASC }]"
-    [initialFilterBy]="[{ field: 'price.value', strategy: 'greaterThanOrEqualTo', value: 100 }]"
+    [initialFilterBy]="initialFilterBy"
     [initialGroupBy]="[{ field: 'verified', direction: sortDirectionEnum.NONE, showAsColumn: true }]"
 >
     <fdp-table-toolbar title="Order Items"></fdp-table-toolbar>
 
-    <fdp-column name="name" key="name" label="Name"> </fdp-column>
+    <fdp-column name="name" key="name" label="Name" [sortable]="true" [groupable]="true" [filterable]="true">
+    </fdp-column>
 
-    <fdp-column name="description" key="description" label="Description"> </fdp-column>
+    <fdp-column
+        name="description"
+        key="description"
+        label="Description"
+        [sortable]="true"
+        [groupable]="true"
+        [filterable]="true"
+    >
+    </fdp-column>
 
-    <fdp-column name="price" key="price.value" label="Price"> </fdp-column>
+    <fdp-column name="price" key="price.value" label="Price" [sortable]="true" [groupable]="true" [filterable]="true">
+    </fdp-column>
 
-    <fdp-column name="verified" key="verified" label="Verified"> </fdp-column>
+    <fdp-column name="verified" key="verified" label="Verified" [groupable]="true"> </fdp-column>
 
-    <fdp-column name="status" key="status" label="Status"> </fdp-column>
+    <fdp-column name="status" key="status" label="Status" [sortable]="true" [groupable]="true" [filterable]="true">
+    </fdp-column>
 </fdp-table>
+
+<!-- View Settings Dialog-->
+<fdp-table-view-settings-dialog [table]="table" [allowDisablingSorting]="false">
+    <fdp-table-view-settings-filter column="price" label="Price" [type]="filterTypeEnum.CUSTOM">
+        <ng-container *fdpViewSettingsFilterCustomDef="let model">
+            <fdp-form-group #fg1 columnLayout="XL1-L1-M1-S1" labelLayout="vertical">
+                <fdp-form-field label="Minimum Price">
+                    <fdp-input type="number" name="min" [(ngModel)]="model.min"></fdp-input>
+                </fdp-form-field>
+                <fdp-form-field label="Maximum Price">
+                    <fdp-input type="number" name="max" [(ngModel)]="model.max"></fdp-input>
+                </fdp-form-field>
+            </fdp-form-group>
+        </ng-container>
+    </fdp-table-view-settings-filter>
+
+    <fdp-table-view-settings-filter
+        column="status"
+        [type]="filterTypeEnum.MULTI"
+        label="Status"
+        [values]="statusFilteringValues"
+    >
+    </fdp-table-view-settings-filter>
+
+    <fdp-table-view-settings-filter
+        column="statusColor"
+        [type]="filterTypeEnum.SINGLE"
+        label="Status Color"
+        [values]="statusColorFilteringValues"
+    >
+    </fdp-table-view-settings-filter>
+</fdp-table-view-settings-dialog>

--- a/apps/docs/src/app/platform/component-docs/platform-table/platform-table-examples/platform-table-initial-state-example.component.ts
+++ b/apps/docs/src/app/platform/component-docs/platform-table/platform-table-examples/platform-table-initial-state-example.component.ts
@@ -12,7 +12,11 @@ import {
     CollectionStringFilter,
     SortDirection,
     TableDataProvider,
-    TableState
+    TableState,
+    TableFilterSelectOption,
+    FilterType,
+    CollectionCustomFilter,
+    FilterNumberStrategy
 } from '@fundamental-ngx/platform/table';
 
 @Component({
@@ -26,9 +30,25 @@ import {
     ]
 })
 export class PlatformTableInitialStateExampleComponent {
+    readonly filterTypeEnum = FilterType;
+    statusFilteringValues: TableFilterSelectOption[] = [
+        { value: 'Out of stock', label: 'Out of stock' },
+        { value: 'Stocked on demand', label: 'Stocked on demand' }
+    ];
+
+    statusColorFilteringValues: TableFilterSelectOption[] = [
+        { value: 'positive', label: 'Positive' },
+        { value: 'negative', label: 'Negative' },
+        { value: 'critical', label: 'Critical' }
+    ];
+
     source: TableDataSource<ExampleItem>;
 
     readonly sortDirectionEnum = SortDirection;
+
+    readonly initialFilterBy: CollectionCustomFilter<FilterNumberStrategy>[] = [
+        { field: 'price.value', strategy: 'greaterThanOrEqualTo', value: { min: 100 } }
+    ];
 
     constructor(datetimeAdapter: DatetimeAdapter<FdDate>) {
         this.source = new TableDataSource(new TableDataProviderExample(datetimeAdapter));

--- a/e2e/wdio/platform/tests/table.e2e-spec.ts
+++ b/e2e/wdio/platform/tests/table.e2e-spec.ts
@@ -253,15 +253,15 @@ describe('Table component test suite', () => {
 
         it('should check ascending sorting by name, description and price', () => {
             scrollIntoView(tableSortableExample);
-            chooseSortOptionBy(tableSortableExample, ellipsisButton, 1);
+            chooseSortOptionBy(tableSortableExample, ellipsisButton, 2);
             expect(getText(tableSortableExample + tableCellDescription).trim()).toBe(descriptionStartTestText);
             expect(getText(tableSortableExample + tableCellDescription, 15).trim()).toBe(descriptionEndTestText);
 
-            chooseSortOptionBy(tableSortableExample, ellipsisButton, 2);
+            chooseSortOptionBy(tableSortableExample, ellipsisButton, 3);
             expect(getText(tableSortableExample + tableCellPrice).trim()).toBe(priceStartTestText);
             expect(getText(tableSortableExample + tableCellPrice, 15).trim()).toBe(priceEndTestText);
 
-            chooseSortOptionBy(tableSortableExample, ellipsisButton, 0);
+            chooseSortOptionBy(tableSortableExample, ellipsisButton, 1);
             expect(getText(tableSortableExample + tableCellName).trim()).toBe(nameStartTestText);
             expect(getText(tableSortableExample + tableCellName, 15).trim()).toBe(nameEndTestText);
         });
@@ -270,16 +270,16 @@ describe('Table component test suite', () => {
             scrollIntoView(tableSortableExample);
             click(tableSortableExample + ellipsisButton);
             click(buttonSortedOrder, 1);
-            click(buttonSortedBy, 1);
+            click(buttonSortedBy, 2);
             click(barButton);
             expect(getText(tableSortableExample + tableCellDescription).trim()).toBe(descriptionEndTestText);
             expect(getText(tableSortableExample + tableCellDescription, 15).trim()).toBe(descriptionStartTestText);
 
-            chooseSortOptionBy(tableSortableExample, ellipsisButton, 2);
+            chooseSortOptionBy(tableSortableExample, ellipsisButton, 3);
             expect(getText(tableSortableExample + tableCellPrice).trim()).toBe(priceEndTestText);
             expect(getText(tableSortableExample + tableCellPrice, 15).trim()).toBe(priceStartTestText);
 
-            chooseSortOptionBy(tableSortableExample, ellipsisButton, 0);
+            chooseSortOptionBy(tableSortableExample, ellipsisButton, 1);
             expect(getText(tableSortableExample + tableCellName).trim()).toBe(nameEndTestText);
             expect(getText(tableSortableExample + tableCellName, 15).trim()).toBe(nameStartTestText);
         });

--- a/libs/i18n/src/lib/languages/arabic.ts
+++ b/libs/i18n/src/lib/languages/arabic.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_ARABIC: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/belarusian.ts
+++ b/libs/i18n/src/lib/languages/belarusian.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_BELARUSIAN: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/bulgarian.ts
+++ b/libs/i18n/src/lib/languages/bulgarian.ts
@@ -500,7 +500,7 @@ export const FD_LANGUAGE_BULGARIAN: FdLanguage = {
         sortDialogSortOrderHeader: 'Сортирано',
         sortDialogSortOrderAsc: 'Възходяща',
         sortDialogSortOrderDesc: 'Низходяща',
-        sortDialogSortByHeader: 'Сортирано по',
+        sortDialogSortByHeader: 'Сортирай по',
         sortDialogNotSortedLabel: '(Несортирано)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Отмени'

--- a/libs/i18n/src/lib/languages/chinese.ts
+++ b/libs/i18n/src/lib/languages/chinese.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_CHINESE: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/croatian.ts
+++ b/libs/i18n/src/lib/languages/croatian.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_CROATIAN: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/english.ts
+++ b/libs/i18n/src/lib/languages/english.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_ENGLISH: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/german.ts
+++ b/libs/i18n/src/lib/languages/german.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_GERMAN: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/hebrew.ts
+++ b/libs/i18n/src/lib/languages/hebrew.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_HEBREW: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/hindi.ts
+++ b/libs/i18n/src/lib/languages/hindi.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_HINDI: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/polish.ts
+++ b/libs/i18n/src/lib/languages/polish.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_POLISH: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/portuguese.ts
+++ b/libs/i18n/src/lib/languages/portuguese.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_PORTUGUESE: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/romanian.ts
+++ b/libs/i18n/src/lib/languages/romanian.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_ROMANIAN: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/russian.ts
+++ b/libs/i18n/src/lib/languages/russian.ts
@@ -585,7 +585,7 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         sortDialogSortOrderHeader: 'Порядок сортировки',
         sortDialogSortOrderAsc: 'По росту',
         sortDialogSortOrderDesc: 'по убыванию',
-        sortDialogSortByHeader: 'Порядок сортировки',
+        sortDialogSortByHeader: 'Сортировать по',
         sortDialogNotSortedLabel: '(Не отсортировано)',
         sortDialogConfirmBtnLabel: 'ОК',
         sortDialogCancelBtnLabel: 'Отменить'

--- a/libs/i18n/src/lib/languages/sinhala.ts
+++ b/libs/i18n/src/lib/languages/sinhala.ts
@@ -430,7 +430,7 @@ export const FD_LANGUAGE_SINHALA: FdLanguage = {
         sortDialogSortOrderHeader: 'Sort Order',
         sortDialogSortOrderAsc: 'Ascending',
         sortDialogSortOrderDesc: 'Descending',
-        sortDialogSortByHeader: 'Sorted By',
+        sortDialogSortByHeader: 'Sort By',
         sortDialogNotSortedLabel: '(Not Sorted)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Cancel'

--- a/libs/i18n/src/lib/languages/ukrainian.ts
+++ b/libs/i18n/src/lib/languages/ukrainian.ts
@@ -583,7 +583,7 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         sortDialogSortOrderHeader: 'Порядок сортування',
         sortDialogSortOrderAsc: 'За зростанням',
         sortDialogSortOrderDesc: 'за спаданням',
-        sortDialogSortByHeader: 'Порядок сортування',
+        sortDialogSortByHeader: 'Сортувати за',
         sortDialogNotSortedLabel: '(Не відсортовано)',
         sortDialogConfirmBtnLabel: 'OK',
         sortDialogCancelBtnLabel: 'Скасувати'

--- a/libs/platform/src/lib/table/components/table-view-settings-dialog/filtering/filters.component.spec.ts
+++ b/libs/platform/src/lib/table/components/table-view-settings-dialog/filtering/filters.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { DialogConfig, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
+import { Table } from '@fundamental-ngx/platform/table';
 import { FiltersComponent } from './filters.component';
 import { PlatformTableModule } from '../../../table.module';
 
@@ -18,7 +19,12 @@ describe('PlatformTableFiltersDialogComponent', () => {
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
             imports: [PlatformTableModule, NoopAnimationsModule],
-            providers: [{ provide: DialogRef, useValue: dialogRef }, DialogService, DialogConfig]
+            providers: [
+                { provide: DialogRef, useValue: dialogRef },
+                { provide: Table, useValue: {} },
+                DialogService,
+                DialogConfig
+            ]
         }).compileComponents();
     }));
 

--- a/libs/platform/src/lib/table/components/table-view-settings-dialog/grouping/grouping.component.spec.ts
+++ b/libs/platform/src/lib/table/components/table-view-settings-dialog/grouping/grouping.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { DialogConfig, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
+import { Table } from '@fundamental-ngx/platform/table';
 import { GroupingComponent } from './grouping.component';
 import { PlatformTableModule } from '../../../table.module';
 import { SortDirection } from '../../../enums';
@@ -19,7 +20,12 @@ describe('PlatformTableGroupDialogComponent', () => {
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
             imports: [PlatformTableModule, NoopAnimationsModule],
-            providers: [{ provide: DialogRef, useValue: dialogRef }, DialogService, DialogConfig]
+            providers: [
+                { provide: DialogRef, useValue: dialogRef },
+                { provide: Table, useValue: {} },
+                DialogService,
+                DialogConfig
+            ]
         }).compileComponents();
     }));
 

--- a/libs/platform/src/lib/table/components/table-view-settings-dialog/sorting/sorting.component.html
+++ b/libs/platform/src/lib/table/components/table-view-settings-dialog/sorting/sorting.component.html
@@ -47,7 +47,7 @@
                 <span fd-list-title>{{ 'platformTable.sortDialogSortByHeader' | fdTranslate }}</span>
             </li>
 
-            <li fd-list-item [selected]="field === NOT_SORTED_OPTION_VALUE">
+            <li fd-list-item *ngIf="allowDisablingSorting" [selected]="field === NOT_SORTED_OPTION_VALUE">
                 <fd-radio-button
                     name="sort-by"
                     [value]="NOT_SORTED_OPTION_VALUE"

--- a/libs/platform/src/lib/table/components/table-view-settings-dialog/sorting/sorting.component.spec.ts
+++ b/libs/platform/src/lib/table/components/table-view-settings-dialog/sorting/sorting.component.spec.ts
@@ -1,6 +1,7 @@
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { DialogConfig, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
+import { Table } from '@fundamental-ngx/platform/table';
 
 import { SettingsSortDialogData, SortingComponent } from './sorting.component';
 import { PlatformTableModule } from '../../../table.module';
@@ -13,13 +14,19 @@ describe('PlatformTableSortDialogComponent', () => {
     const dialogData: SettingsSortDialogData = {
         columns: [],
         direction: SortDirection.NONE,
-        field: null
+        field: null,
+        allowDisablingSorting: false
     };
     dialogRef.data = dialogData;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            providers: [{ provide: DialogRef, useValue: dialogRef }, DialogService, DialogConfig],
+            providers: [
+                { provide: DialogRef, useValue: dialogRef },
+                { provide: Table, useValue: {} },
+                DialogService,
+                DialogConfig
+            ],
             imports: [PlatformTableModule, NoopAnimationsModule]
         }).compileComponents();
     }));

--- a/libs/platform/src/lib/table/components/table-view-settings-dialog/table-view-settings-dialog.component.ts
+++ b/libs/platform/src/lib/table/components/table-view-settings-dialog/table-view-settings-dialog.component.ts
@@ -68,6 +68,10 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
         return this._table;
     }
 
+    /** Whether to allow selecting '(Not sorted)' option in sorting dialog. */
+    @Input()
+    allowDisablingSorting = true;
+
     /** @hidden */
     @ContentChildren(forwardRef(() => TableViewSettingsFilterComponent))
     filters: QueryList<TableViewSettingsFilterComponent>;
@@ -103,7 +107,8 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
         const dialogData: SettingsSortDialogData = {
             columns: columns.filter(({ sortable }) => sortable),
             direction: sortBy?.direction,
-            field: sortBy?.field
+            field: sortBy?.field,
+            allowDisablingSorting: this.allowDisablingSorting
         };
 
         const dialogRef = this._dialogService.open(

--- a/libs/platform/src/lib/table/directives/table-view-settings-filter-custom.directive.ts
+++ b/libs/platform/src/lib/table/directives/table-view-settings-filter-custom.directive.ts
@@ -1,14 +1,22 @@
 import { Directive, EventEmitter, TemplateRef } from '@angular/core';
 import { ContentDensityMode } from '@fundamental-ngx/core/content-density';
 
+export interface FdpViewSettingsFilterCustomDefContext {
+    $implicit: any;
+    valueChangeEmitter: EventEmitter<unknown>;
+    contentDensity: ContentDensityMode;
+}
+
 @Directive({ selector: '[fdpViewSettingsFilterCustomDef]' })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class FdpViewSettingsFilterCustomDef {
-    constructor(
-        public templateRef: TemplateRef<{
-            $implicit: any;
-            valueChangeEmitter: EventEmitter<unknown>;
-            contentDensity: ContentDensityMode;
-        }>
-    ) {}
+    /** @hidden */
+    static ngTemplateContextGuard(
+        dir: FdpViewSettingsFilterCustomDef,
+        ctx: FdpViewSettingsFilterCustomDefContext
+    ): ctx is FdpViewSettingsFilterCustomDefContext {
+        return true;
+    }
+
+    constructor(public templateRef: TemplateRef<FdpViewSettingsFilterCustomDefContext>) {}
 }

--- a/libs/platform/src/lib/table/interfaces/collection-filter.interface.ts
+++ b/libs/platform/src/lib/table/interfaces/collection-filter.interface.ts
@@ -8,7 +8,7 @@ import {
     FilterableColumnDataType
 } from '../enums';
 
-interface BaseCollectionFilter<T> {
+export interface BaseCollectionFilter<T> {
     field: string;
     type?: FilterableColumnDataType;
     value: T;
@@ -36,8 +36,9 @@ export interface CollectionSelectFilter extends BaseCollectionFilter<any[]> {
     strategy: FilterDefaultStrategy;
 }
 
-export interface CollectionCustomFilter extends BaseCollectionFilter<{ [key: string]: any }> {
-    strategy: FilterDefaultStrategy;
+export interface CollectionCustomFilter<P extends FilterStrategy = FilterDefaultStrategy>
+    extends BaseCollectionFilter<{ [key: string]: any }> {
+    strategy: P;
 }
 
 export type CollectionFilter =
@@ -46,7 +47,7 @@ export type CollectionFilter =
     | CollectionDateFilter
     | CollectionSelectFilter
     | CollectionBooleanFilter
-    | CollectionCustomFilter;
+    | CollectionCustomFilter<FilterStrategy>;
 
 export type CollectionFilterGroupStrategy = 'and' | 'or';
 

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -289,15 +289,15 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
 
     /** Initial sort options. */
     @Input()
-    initialSortBy: CollectionSort[];
+    initialSortBy: CollectionSort[] = [];
 
     /** Initial filter options. */
     @Input()
-    initialFilterBy: CollectionFilter[];
+    initialFilterBy: CollectionFilter[] = [];
 
     /** Initial group options. */
     @Input()
-    initialGroupBy: CollectionGroup[];
+    initialGroupBy: CollectionGroup[] = [];
 
     /** Whether tree mode is enabled. */
     @Input()

--- a/libs/platform/src/lib/table/table.ts
+++ b/libs/platform/src/lib/table/table.ts
@@ -11,6 +11,12 @@ import { TableColumn } from './components/table-column/table-column';
 import { TableDataSource } from './domain';
 
 export abstract class Table<T = any> {
+    abstract initialSortBy?: CollectionSort[];
+
+    abstract initialGroupBy: CollectionGroup[];
+
+    abstract initialFilterBy: CollectionFilter[];
+
     /** Sum of widths of fixed columns (semantic highlighting, selection) */
     abstract get _fixedColumnsPadding(): number;
 


### PR DESCRIPTION
## Related Issue(s)

relates #8524

## Description
- Fixed reset button behaviour for the View Settings Dialog
- Refactored custom filter type strategies
- Updated initial state documentation example
- Added ability to disable "Not sorted" option for sorting dialog

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [x] update `README.md`
-   [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
