### PR TITLE
fix(docs): busy indicator - remove common margin for buttons in examples

### DIFF
--- a/apps/docs/src/app/core/component-docs/busy-indicator/busy-indicator-docs.component.ts
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/busy-indicator-docs.component.ts
@@ -13,13 +13,6 @@ import { ExampleFile } from '../../../documentation/core-helpers/code-example/ex
 @Component({
     selector: 'app-busy-indicator-docs',
     templateUrl: './busy-indicator-docs.component.html',
-    styles: [
-        `
-            app-busy-indicator-docs .fd-button {
-                margin-right: 8px;
-            }
-        `
-    ],
     encapsulation: ViewEncapsulation.None
 })
 export class BusyIndicatorDocsComponent {

--- a/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
+++ b/apps/docs/src/app/core/component-docs/busy-indicator/examples/busy-indicator-extended-example.component.html
@@ -1,4 +1,4 @@
-<button fd-button label="Open from Template" (click)="openFromTemplate(template)"></button>
+<button style="margin-right: 8px" fd-button label="Open from Template" (click)="openFromTemplate(template)"></button>
 <button fd-button label="Hide All" fdType="emphasized" (click)="messageToastService.hideAll()"></button>
 
 <ng-template #template>


### PR DESCRIPTION
## Related Issue(s)
part of #8557 

## Description

Removed common margin applied to all buttons of examples.

## Screenshots

### Before:
<img width="266" alt="Screen Shot 2022-08-18 at 2 41 24 PM" src="https://user-images.githubusercontent.com/65063487/185470228-caf99057-65b2-4fd2-8d70-6986c2ab85a7.png">

### After:
<img width="279" alt="Screen Shot 2022-08-18 at 2 42 28 PM" src="https://user-images.githubusercontent.com/65063487/185470318-ec4ef532-7279-490b-ad5c-53f2c1b175ce.png">