### PR TITLE
fix(core): breadcrumb keyboard arrow support

### DIFF
--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -61,8 +61,8 @@
                 fd-link
                 tabindex="0"
                 class="fd-breadcrumb__collapsed"
-                (keydown.enter)="_keyDownHandle($event)"
-                (keydown.space)="_keyDownHandle($event)"
+                (keydown.enter)="_overflowKeyDownHandle($event)"
+                (keydown.space)="_overflowKeyDownHandle($event)"
             >
                 …
                 <fd-icon glyph="slim-arrow-down"></fd-icon>

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,7 +1,7 @@
 <fd-overflow-layout
     [reverseHiddenItems]="!reverse"
     showMorePosition="left"
-    [enableKeyboardNavigation]="false"
+    [enableKeyboardNavigation]="true"
     (visibleItemsCount)="_onVisibleItemsCountChange($event)"
     (hiddenItemsCount)="_onHiddenItemsCountChange($event)"
 >
@@ -9,6 +9,9 @@
         <div
             *fdOverflowItemRef="breadcrumb; let hidden"
             fdOverflowLayoutItem
+            [navigable]="!!breadcrumb.breadcrumbLink"
+            [focusable]="true"
+            [skipSelfFocus]="true"
             (hiddenChange)="_onHiddenChange($event, breadcrumb)"
         >
             <ng-template [cdkPortalOutlet]="breadcrumb.portal"></ng-template>

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -90,4 +90,17 @@ describe('BreadcrumbComponent', () => {
 
         expect(hiddenItemsCountSpy).toHaveBeenCalledWith(2);
     }));
+
+    it('should test arrow key focus functionality', () => {
+        const breadcrumbLinks = component.elementRef.nativeElement.querySelectorAll('.fd-breadcrumb__item .fd-link');
+        if (breadcrumbLinks) {
+            const firstLink = breadcrumbLinks[0] as HTMLElement;
+            firstLink.focus();
+            component.elementRef.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+            const secondLink = breadcrumbLinks[1] as HTMLElement;
+            expect(document.activeElement).toBe(secondLink);
+            component.elementRef.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+            expect(document.activeElement).toBe(firstLink);
+        }
+    });
 });

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -7,7 +7,6 @@ import {
     ElementRef,
     EventEmitter,
     forwardRef,
-    HostListener,
     Input,
     isDevMode,
     OnInit,
@@ -18,12 +17,11 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { OverflowLayoutComponent } from '@fundamental-ngx/core/overflow-layout';
-import { DestroyedService, KeyUtil, RtlService } from '@fundamental-ngx/core/utils';
+import { DestroyedService, RtlService } from '@fundamental-ngx/core/utils';
 import { BehaviorSubject, takeUntil } from 'rxjs';
 import { MenuComponent } from '@fundamental-ngx/core/menu';
 import { Placement } from '@fundamental-ngx/core/shared';
 import { BreadcrumbItemComponent } from './breadcrumb-item.component';
-import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 
 /**
  * Breadcrumb parent wrapper directive. Must have breadcrumb item child directives.
@@ -110,9 +108,6 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     _placement$ = new BehaviorSubject<Placement>('bottom-start');
 
     /** @hidden */
-    private _isRtl = false;
-
-    /** @hidden */
     constructor(
         public elementRef: ElementRef<HTMLElement>,
         private _onDestroy$: DestroyedService,
@@ -123,7 +118,6 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     /** @hidden */
     ngOnInit(): void {
         this._rtlService?.rtl.pipe(takeUntil(this._onDestroy$)).subscribe((value) => {
-            this._isRtl = value;
             this._placement$.next(value ? 'bottom-end' : 'bottom-start');
         });
     }
@@ -155,37 +149,6 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     _overflowKeyDownHandle(event: Event): void {
         this._menuComponent.toggle();
         event.preventDefault();
-    }
-
-    /** @hidden */
-    @HostListener('keydown', ['$event'])
-    _arrowKeyDownHandle(event: KeyboardEvent): void {
-        if (KeyUtil.isKeyCode(event, [UP_ARROW, DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW])) {
-            event.preventDefault();
-            const breadcrumbItemElements = this.elementRef.nativeElement.querySelectorAll(
-                '.fd-breadcrumb__item .fd-link'
-            );
-            for (let i = 0; i < breadcrumbItemElements.length; i++) {
-                if (document.activeElement === breadcrumbItemElements[i]) {
-                    if (
-                        breadcrumbItemElements[i - 1] &&
-                        (KeyUtil.isKeyCode(event, UP_ARROW) ||
-                            (!this._isRtl && KeyUtil.isKeyCode(event, LEFT_ARROW)) ||
-                            (this._isRtl && KeyUtil.isKeyCode(event, RIGHT_ARROW)))
-                    ) {
-                        (breadcrumbItemElements[i - 1] as HTMLElement).focus();
-                    } else if (
-                        breadcrumbItemElements[i + 1] &&
-                        (KeyUtil.isKeyCode(event, DOWN_ARROW) ||
-                            (!this._isRtl && KeyUtil.isKeyCode(event, RIGHT_ARROW)) ||
-                            (this._isRtl && KeyUtil.isKeyCode(event, LEFT_ARROW)))
-                    ) {
-                        (breadcrumbItemElements[i + 1] as HTMLElement).focus();
-                    }
-                    break;
-                }
-            }
-        }
     }
 
     /** @hidden */

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -110,6 +110,9 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     _placement$ = new BehaviorSubject<Placement>('bottom-start');
 
     /** @hidden */
+    private _isRtl = false;
+
+    /** @hidden */
     constructor(
         public elementRef: ElementRef<HTMLElement>,
         private _onDestroy$: DestroyedService,
@@ -119,9 +122,10 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
 
     /** @hidden */
     ngOnInit(): void {
-        this._rtlService?.rtl
-            .pipe(takeUntil(this._onDestroy$))
-            .subscribe((value) => this._placement$.next(value ? 'bottom-end' : 'bottom-start'));
+        this._rtlService?.rtl.pipe(takeUntil(this._onDestroy$)).subscribe((value) => {
+            this._isRtl = value;
+            this._placement$.next(value ? 'bottom-end' : 'bottom-start');
+        });
     }
 
     /** @hidden */
@@ -165,12 +169,16 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
                 if (document.activeElement === breadcrumbItemElements[i]) {
                     if (
                         breadcrumbItemElements[i - 1] &&
-                        (KeyUtil.isKeyCode(event, UP_ARROW) || KeyUtil.isKeyCode(event, LEFT_ARROW))
+                        (KeyUtil.isKeyCode(event, UP_ARROW) ||
+                            (!this._isRtl && KeyUtil.isKeyCode(event, LEFT_ARROW)) ||
+                            (this._isRtl && KeyUtil.isKeyCode(event, RIGHT_ARROW)))
                     ) {
                         (breadcrumbItemElements[i - 1] as HTMLElement).focus();
                     } else if (
                         breadcrumbItemElements[i + 1] &&
-                        (KeyUtil.isKeyCode(event, DOWN_ARROW) || KeyUtil.isKeyCode(event, RIGHT_ARROW))
+                        (KeyUtil.isKeyCode(event, DOWN_ARROW) ||
+                            (!this._isRtl && KeyUtil.isKeyCode(event, RIGHT_ARROW)) ||
+                            (this._isRtl && KeyUtil.isKeyCode(event, LEFT_ARROW)))
                     ) {
                         (breadcrumbItemElements[i + 1] as HTMLElement).focus();
                     }

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -7,6 +7,7 @@ import {
     ElementRef,
     EventEmitter,
     forwardRef,
+    HostListener,
     Input,
     isDevMode,
     OnInit,
@@ -17,11 +18,12 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { OverflowLayoutComponent } from '@fundamental-ngx/core/overflow-layout';
-import { DestroyedService, RtlService } from '@fundamental-ngx/core/utils';
+import { DestroyedService, KeyUtil, RtlService } from '@fundamental-ngx/core/utils';
 import { BehaviorSubject, takeUntil } from 'rxjs';
 import { MenuComponent } from '@fundamental-ngx/core/menu';
 import { Placement } from '@fundamental-ngx/core/shared';
 import { BreadcrumbItemComponent } from './breadcrumb-item.component';
+import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 
 /**
  * Breadcrumb parent wrapper directive. Must have breadcrumb item child directives.
@@ -146,9 +148,36 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     }
 
     /** @hidden */
-    _keyDownHandle(event: Event): void {
+    _overflowKeyDownHandle(event: Event): void {
         this._menuComponent.toggle();
         event.preventDefault();
+    }
+
+    /** @hidden */
+    @HostListener('keydown', ['$event'])
+    _arrowKeyDownHandle(event: KeyboardEvent): void {
+        if (KeyUtil.isKeyCode(event, [UP_ARROW, DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW])) {
+            event.preventDefault();
+            const breadcrumbItemElements = this.elementRef.nativeElement.querySelectorAll(
+                '.fd-breadcrumb__item .fd-link'
+            );
+            for (let i = 0; i < breadcrumbItemElements.length; i++) {
+                if (document.activeElement === breadcrumbItemElements[i]) {
+                    if (
+                        breadcrumbItemElements[i - 1] &&
+                        (KeyUtil.isKeyCode(event, UP_ARROW) || KeyUtil.isKeyCode(event, LEFT_ARROW))
+                    ) {
+                        (breadcrumbItemElements[i - 1] as HTMLElement).focus();
+                    } else if (
+                        breadcrumbItemElements[i + 1] &&
+                        (KeyUtil.isKeyCode(event, DOWN_ARROW) || KeyUtil.isKeyCode(event, RIGHT_ARROW))
+                    ) {
+                        (breadcrumbItemElements[i + 1] as HTMLElement).focus();
+                    }
+                    break;
+                }
+            }
+        }
     }
 
     /** @hidden */

--- a/libs/core/src/lib/overflow-layout/directives/overflow-layout-focusable-item.directive.ts
+++ b/libs/core/src/lib/overflow-layout/directives/overflow-layout-focusable-item.directive.ts
@@ -58,17 +58,11 @@ export class OverflowLayoutFocusableItemDirective implements OverflowLayoutFocus
 
     /** @hidden */
     focus(): void {
-        if (!this.skipSelfFocus) {
+        if (this.skipSelfFocus) {
+            this._focusFirstChild();
+        } else {
             this.elementRef.nativeElement.focus();
-            return;
         }
-        const tabbableElement = this._tabbableElementService.getTabbableElement(
-            this.elementRef.nativeElement,
-            false,
-            true
-        );
-        // Try to find first focusable child.
-        tabbableElement?.focus();
     }
 
     /** @hidden */
@@ -76,16 +70,19 @@ export class OverflowLayoutFocusableItemDirective implements OverflowLayoutFocus
     private _onFocus(): void {
         this._overflowContainer.setFocusedElement(this);
 
-        if (!this.skipSelfFocus) {
-            return;
+        if (this.skipSelfFocus) {
+            this._focusFirstChild();
         }
+    }
 
+    /** @hidden */
+    private _focusFirstChild(): void {
         const tabbableElement = this._tabbableElementService.getTabbableElement(
             this.elementRef.nativeElement,
             false,
             true
         );
-        // Pass the focus to the first tabbable child element.
+        // Try to find first focusable child.
         tabbableElement?.focus();
     }
 }

--- a/libs/core/src/lib/overflow-layout/overflow-layout.component.scss
+++ b/libs/core/src/lib/overflow-layout/overflow-layout.component.scss
@@ -63,5 +63,12 @@ $fd-block: 'fd-overflow-layout';
             opacity: 0 !important;
             position: absolute !important;
         }
+
+        &--skip-focus {
+            &:focus,
+            &:focus-visible {
+                outline: none;
+            }
+        }
     }
 }

--- a/libs/core/src/lib/overflow-layout/overflow-layout.component.ts
+++ b/libs/core/src/lib/overflow-layout/overflow-layout.component.ts
@@ -305,6 +305,8 @@ export class OverflowLayoutComponent implements OnInit, AfterViewInit, OnDestroy
                     if (KeyUtil.isKeyCode(event, [DOWN_ARROW, UP_ARROW, LEFT_ARROW, RIGHT_ARROW])) {
                         event.preventDefault();
 
+                        console.log('something');
+
                         // passing the event to key manager so, we get a change fired
                         this._overflowLayoutService._keyboardEventsManager.onKeydown(event);
                     }

--- a/libs/core/src/lib/overflow-layout/overflow-layout.component.ts
+++ b/libs/core/src/lib/overflow-layout/overflow-layout.component.ts
@@ -305,8 +305,6 @@ export class OverflowLayoutComponent implements OnInit, AfterViewInit, OnDestroy
                     if (KeyUtil.isKeyCode(event, [DOWN_ARROW, UP_ARROW, LEFT_ARROW, RIGHT_ARROW])) {
                         event.preventDefault();
 
-                        console.log('something');
-
                         // passing the event to key manager so, we get a change fired
                         this._overflowLayoutService._keyboardEventsManager.onKeydown(event);
                     }

--- a/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.ts
+++ b/libs/core/src/lib/utils/directives/initial-focus/initial-focus.directive.ts
@@ -1,10 +1,10 @@
-import { DOCUMENT } from '@angular/common';
-import { AfterViewInit, Directive, ElementRef, Inject, Input, NgZone, Optional } from '@angular/core';
-import { InteractivityChecker } from '@angular/cdk/a11y';
+import { AfterViewInit, Directive, ElementRef, Input, NgZone } from '@angular/core';
 import { take } from 'rxjs/operators';
+import { TabbableElementService } from '../../services/tabbable-element.service';
 
 @Directive({
-    selector: '[fdInitialFocus], [fd-initial-focus]'
+    selector: '[fdInitialFocus], [fd-initial-focus]',
+    providers: [TabbableElementService]
 })
 export class InitialFocusDirective implements AfterViewInit {
     /**
@@ -28,9 +28,8 @@ export class InitialFocusDirective implements AfterViewInit {
     /** @hidden */
     constructor(
         private _elmRef: ElementRef<HTMLElement>,
-        private _checker: InteractivityChecker,
         private _ngZone: NgZone,
-        @Optional() @Inject(DOCUMENT) private readonly _document: Document | null
+        private readonly _tabbableService: TabbableElementService
     ) {}
 
     /** @hidden */
@@ -56,7 +55,7 @@ export class InitialFocusDirective implements AfterViewInit {
      */
     private _getFocusableElement(): HTMLElement | null {
         if (!this.focusableItem) {
-            return this._getTabbableElement(this._elmRef.nativeElement);
+            return this._tabbableService.getTabbableElement(this._elmRef.nativeElement, this.focusLastElement);
         }
 
         const autoFocusableItems = this._elmRef.nativeElement.querySelectorAll(
@@ -68,35 +67,7 @@ export class InitialFocusDirective implements AfterViewInit {
         }
 
         // If no elements found, fallback to first tabbable element.
-        return this._getTabbableElement(this._elmRef.nativeElement);
-    }
-
-    /** @hidden
-     * Get the first tabbable element from a DOM subtree (inclusive).
-     */
-    private _getTabbableElement(root: HTMLElement): HTMLElement | null {
-        if (this._checker.isFocusable(root) && this._checker.isTabbable(root)) {
-            return root;
-        }
-
-        // Iterate in DOM order. Note that IE doesn't have `children` for SVG, so we fall
-        // back to `childNodes` which includes text nodes, comments etc.
-        const rootChildren = root.children || root.childNodes;
-
-        const children = this.focusLastElement ? Array.from(rootChildren).reverse() : rootChildren;
-
-        for (let i = 0; i < children.length; i++) {
-            const tabbableChild =
-                children[i].nodeType === this._document?.ELEMENT_NODE
-                    ? this._getTabbableElement(children[i] as HTMLElement)
-                    : null;
-
-            if (tabbableChild) {
-                return tabbableChild;
-            }
-        }
-
-        return null;
+        return this._tabbableService.getTabbableElement(this._elmRef.nativeElement, this.focusLastElement);
     }
 
     /** @hidden */

--- a/libs/core/src/lib/utils/public_api.ts
+++ b/libs/core/src/lib/utils/public_api.ts
@@ -66,6 +66,7 @@ export * from './services/keyboard-support/keyboard-support.service';
 export * from './services/resize-observer.service';
 export * from './services/local-storage.service';
 export * from './services/destroyed.service';
+export * from './services/tabbable-element.service';
 
 export * from './functions';
 

--- a/libs/core/src/lib/utils/services/tabbable-element.service.ts
+++ b/libs/core/src/lib/utils/services/tabbable-element.service.ts
@@ -1,0 +1,37 @@
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable, Optional } from '@angular/core';
+
+@Injectable()
+export class TabbableElementService {
+    constructor(
+        private readonly _checker: InteractivityChecker,
+        @Optional() @Inject(DOCUMENT) private readonly _document: Document | null
+    ) {}
+
+    /** Get the first tabbable element from a DOM subtree (inclusive). */
+    getTabbableElement(root: HTMLElement, focusLastElement = false, skipSelf = false): HTMLElement | null {
+        if (!skipSelf && this._checker.isFocusable(root) && this._checker.isTabbable(root)) {
+            return root;
+        }
+
+        // Iterate in DOM order. Note that IE doesn't have `children` for SVG, so we fall
+        // back to `childNodes` which includes text nodes, comments etc.
+        const rootChildren = root.children || root.childNodes;
+
+        const children = focusLastElement ? Array.from(rootChildren).reverse() : rootChildren;
+
+        for (let i = 0; i < children.length; i++) {
+            const tabbableChild =
+                children[i].nodeType === this._document?.ELEMENT_NODE
+                    ? this.getTabbableElement(children[i] as HTMLElement, focusLastElement)
+                    : null;
+
+            if (tabbableChild) {
+                return tabbableChild;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
fixes #8565 

Adds arrow support for breadcrumbs. Using this instead of cdk's FocusKeyManager because FocusKeyManager does not cooperate with tab keypresses, nor the functionality with the collapsed breadcrumb menu.