### PR TITLE
fix(core): logic for splitting timeline nodes in half

### DIFF
--- a/libs/core/src/lib/timeline/services/position-strategies/base-strategy.ts
+++ b/libs/core/src/lib/timeline/services/position-strategies/base-strategy.ts
@@ -21,9 +21,9 @@ export abstract class BaseStrategy {
 
     /** @hidden */
     protected _getTwoListFromOne(nodes: TimelineNodeComponent[]): [TimelineNodeComponent[], TimelineNodeComponent[]] {
-        const lastIndexInFirstList = Math.floor(nodes.length / 2);
-        const firstList = nodes.slice(0, lastIndexInFirstList + 1);
-        const secondList = nodes.slice(lastIndexInFirstList + 1, nodes.length);
+        const lastIndexInFirstList = Math.ceil(nodes.length / 2);
+        const firstList = nodes.slice(0, lastIndexInFirstList);
+        const secondList = nodes.slice(lastIndexInFirstList, nodes.length);
         return [firstList, secondList];
     }
 


### PR DESCRIPTION
fixes #8576 

Fixes logic for splitting timeline nodes in half for double sided views when there is an even number of timeline nodes. Previous logic would put too many nodes on the first side, breaking positioning calculation.

Before:
<img width="825" alt="Screen Shot 2022-08-26 at 9 46 45 AM" src="https://user-images.githubusercontent.com/2471874/186943582-b4cfe96d-4354-4c1c-987e-0316415f2e19.png">

After:
<img width="819" alt="Screen Shot 2022-08-26 at 9 45 50 AM" src="https://user-images.githubusercontent.com/2471874/186943386-fc996e6a-933a-4f92-b11c-7f064d212d4e.png">

