### PR TITLE
fix(core): combobox scroll strategy

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -7,6 +7,7 @@
         [isOpen]="open && displayedValues && displayedValues.length > 0"
         (isOpenChange)="isOpenChangeHandle($event)"
         [fillControlMode]="fillControlMode"
+        [scrollStrategy]="_repositionScrollStrategy"
         [focusTrapped]="true"
         [triggers]="triggers"
         [disabled]="disabled || readOnly"

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -51,6 +51,7 @@ import { COMBOBOX_COMPONENT, ComboboxInterface } from './combobox.interface';
 import { ComboboxItem } from './combobox-item';
 import { GroupFunction } from './list-group.pipe';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
+import { Overlay, RepositionScrollStrategy } from '@angular/cdk/overlay';
 
 let comboboxUniqueId = 0;
 
@@ -326,6 +327,9 @@ export class ComboboxComponent
     /** Keys, that will close popover's body, when dispatched on search input */
     readonly closingKeys: number[] = [ESCAPE];
 
+    /** @hidden */
+    readonly _repositionScrollStrategy: RepositionScrollStrategy;
+
     /** Whether the combobox is opened. */
     open = false;
 
@@ -358,12 +362,15 @@ export class ComboboxComponent
 
     /** @hidden */
     constructor(
+        private readonly _overlay: Overlay,
         private readonly _cdRef: ChangeDetectorRef,
         private readonly _injector: Injector,
         private readonly _viewContainerRef: ViewContainerRef,
         private readonly _dynamicComponentService: DynamicComponentService,
         readonly _contentDensityObserver: ContentDensityObserver
-    ) {}
+    ) {
+        this._repositionScrollStrategy = this._overlay.scrollStrategies.reposition({ autoClose: true });
+    }
 
     /** @hidden */
     ngOnInit(): void {

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -575,7 +575,7 @@ export class ComboboxComponent
 
         if (!this.open && !this.mobile) {
             this.handleBlur();
-            this.searchInputElement.nativeElement.focus();
+            this.searchInputElement.nativeElement.focus({ preventScroll: true });
         }
 
         this._cdRef.detectChanges();


### PR DESCRIPTION
## Related Issue(s)

Closes #8228.

## Description

Combobox scroll strategy fix.

Ideally, the scroll strategy should be set to `BLOCK` the same as the default HTML select but it seems very buggy and doesn't respect when the scroll container if it's not a body. https://github.com/angular/components/issues/21195

So, the scroll strategy is set to `REPOSITION` but with the "close when scrolled out of viewport" flag enabled.

The issue about z-indexes probably should be fixed separately because it relates to our docs app and not any component. We have various z-indexes set for different components, and probably we have to review all those values.

## Screenshots

### After:

https://user-images.githubusercontent.com/20265336/187691632-73ea3dfc-74d0-4909-b687-6f96b95f15a6.mov
