### PR TITLE
feat(core,platform): require-jsdoc rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -144,10 +144,24 @@
                 "eol-last": "error",
                 "eqeqeq": ["error", "smart"],
                 "guard-for-in": "error",
+                "grouped-accessor-pairs": ["error", "setBeforeGet"],
                 "import/order": "off",
                 "jsdoc/check-alignment": "off",
                 "jsdoc/check-indentation": "off",
                 "jsdoc/newline-after-description": "off",
+                "jsdoc/require-jsdoc": [
+                    "error",
+                    {
+                        "publicOnly": true,
+                        "require": {
+                            "MethodDefinition": true
+                        },
+                        "contexts": ["PropertyDefinition"],
+                        "enableFixer": false,
+                        "checkGetters": "no-setter",
+                        "checkSetters": true
+                    }
+                ],
                 "key-spacing": [
                     "error",
                     {
@@ -227,6 +241,13 @@
                     }
                 ],
                 "valid-typeof": "off"
+            }
+        },
+        {
+            "files": ["*.spec.ts"],
+            "rules": {
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             }
         },
         {

--- a/apps/docs/.eslintrc.json
+++ b/apps/docs/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fd",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/e2e/.eslintrc.json
+++ b/e2e/.eslintrc.json
@@ -22,7 +22,9 @@
                         "prefix": "fd",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/core/src/lib/action-bar/action-bar-description/action-bar-description.directive.ts
+++ b/libs/core/src/lib/action-bar/action-bar-description/action-bar-description.directive.ts
@@ -19,9 +19,7 @@ import { Directive, HostBinding, Input } from '@angular/core';
     }
 })
 export class ActionBarDescriptionDirective {
-    /*
-     Whether the action bar also has a back button.
-     */
+    /** Whether the action bar also has a back button. */
     @Input()
     @HostBinding('class.fd-action-bar__description--back')
     withBackBtn = false;

--- a/libs/core/src/lib/action-sheet/action-sheet-body/action-sheet-body.component.ts
+++ b/libs/core/src/lib/action-sheet/action-sheet-body/action-sheet-body.component.ts
@@ -53,7 +53,9 @@ export class ActionSheetBodyComponent {
     @Input()
     ariaLabelledby: Nullable<string>;
 
-    @ViewChild('actionSheetElement') actionSheetElementRef: ElementRef<HTMLUListElement>;
+    /** @hidden */
+    @ViewChild('actionSheetElement')
+    actionSheetElementRef: ElementRef<HTMLUListElement>;
 
     /** @hidden */
     constructor(

--- a/libs/core/src/lib/action-sheet/action-sheet.component.ts
+++ b/libs/core/src/lib/action-sheet/action-sheet.component.ts
@@ -107,6 +107,7 @@ export class ActionSheetComponent implements AfterContentInit, AfterViewInit, On
     /** @hidden */
     private _subscriptions = new Subscription();
 
+    /** @hidden */
     constructor(
         private readonly _keyboardSupportService: KeyboardSupportService<ActionSheetItemComponent>,
         private readonly _changeDetectionRef: ChangeDetectorRef,

--- a/libs/core/src/lib/action-sheet/deprecated-action-sheet-compact.directive.ts
+++ b/libs/core/src/lib/action-sheet/deprecated-action-sheet-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedActionSheetCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super(`[fd-action-sheet-item][compact], fd-action-sheet-body[compact] and fd-action-sheet`);
     }

--- a/libs/core/src/lib/alert/alert-service/alert.service.ts
+++ b/libs/core/src/lib/alert/alert-service/alert.service.ts
@@ -14,7 +14,10 @@ import { AlertRef } from '../alert-utils/alert-ref';
  */
 @Injectable()
 export class AlertService {
+    /** @hidden */
     private alerts: ComponentRef<AlertComponent>[] = [];
+
+    /** @hidden */
     private alertContainerRef?: ComponentRef<AlertContainerComponent>;
 
     /** @hidden */
@@ -84,6 +87,7 @@ export class AlertService {
         });
     }
 
+    /** @hidden */
     private destroyAlertComponent(alert: ComponentRef<AlertComponent>): void {
         this.alerts = this.alerts.filter((item) => item && item !== alert);
         this.dynamicComponentService.destroyComponent(alert);
@@ -93,6 +97,7 @@ export class AlertService {
         }
     }
 
+    /** @hidden */
     private destroyAlertContainer(): void {
         this.alertContainerRef && this.dynamicComponentService.destroyComponent(this.alertContainerRef);
         this.alertContainerRef = undefined;

--- a/libs/core/src/lib/alert/alert-utils/alert-ref.ts
+++ b/libs/core/src/lib/alert/alert-utils/alert-ref.ts
@@ -10,6 +10,7 @@ import { Observable, Subject } from 'rxjs';
  * For a template, add let-alert to your ng-template tag. Now using *alert* in the template refers to this class.
  */
 export class AlertRef {
+    /** @hidden */
     private readonly _afterDismissed: Subject<any> = new Subject<any>();
 
     /** Observable that is triggered when the alert is dismissed. */

--- a/libs/core/src/lib/alert/alert.component.ts
+++ b/libs/core/src/lib/alert/alert.component.ts
@@ -228,6 +228,7 @@ export class AlertComponent extends AbstractFdNgxClass implements OnInit, AfterV
         }
     }
 
+    /** @hidden */
     private loadFromTemplate(template: TemplateRef<any>): void {
         const context = {
             $implicit: this.alertRef
@@ -235,17 +236,20 @@ export class AlertComponent extends AbstractFdNgxClass implements OnInit, AfterV
         this.componentRef = this.containerRef.createEmbeddedView(template, context);
     }
 
+    /** @hidden */
     private loadFromComponent(componentType: Type<any>): void {
         const componentFactory = this.componentFactoryResolver.resolveComponentFactory(componentType);
         this.containerRef.clear();
         this.componentRef = this.containerRef.createComponent(componentFactory);
     }
 
+    /** @hidden */
     private loadFromString(contentString: string): void {
         this.containerRef.clear();
         this.message = contentString;
     }
 
+    /** @hidden */
     private _setAlertConfig(alertConfig: AlertConfig): void {
         Object.keys(alertConfig || {})
             .filter((key) => key !== 'data' && key !== 'container')

--- a/libs/core/src/lib/avatar-group/directives/avatar-group-focusable-avatar.directive.ts
+++ b/libs/core/src/lib/avatar-group/directives/avatar-group-focusable-avatar.directive.ts
@@ -32,6 +32,7 @@ export class AvatarGroupFocusableAvatarDirective implements FocusableOption, Has
         private readonly _component: AvatarGroupInterface
     ) {}
 
+    /** @hidden */
     elementRef(): ElementRef {
         return this._elementRef;
     }

--- a/libs/core/src/lib/avatar/avatar.component.ts
+++ b/libs/core/src/lib/avatar/avatar.component.ts
@@ -224,11 +224,12 @@ export class AvatarComponent implements OnChanges, OnInit, CssClassBuilder, OnCh
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-avatar',

--- a/libs/core/src/lib/bar/bar.component.ts
+++ b/libs/core/src/lib/bar/bar.component.ts
@@ -88,11 +88,12 @@ export class BarComponent implements OnChanges, OnInit, CssClassBuilder, OnDestr
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-bar',
@@ -105,6 +106,7 @@ export class BarComponent implements OnChanges, OnInit, CssClassBuilder, OnDestr
         ];
     }
 
+    /** @hidden */
     elementRef(): ElementRef<any> {
         return this._elementRef;
     }

--- a/libs/core/src/lib/bar/button-bar/button-bar.component.ts
+++ b/libs/core/src/lib/bar/button-bar/button-bar.component.ts
@@ -55,20 +55,21 @@ export class ButtonBarComponent extends BaseButton implements OnDestroy {
 
     /** id for this element */
     @Input()
+    set id(value: string | null | undefined) {
+        this._id = value;
+    }
     get id(): string {
         return this._id || this._defaultId;
     }
 
-    set id(value: string | null | undefined) {
-        this._id = value;
-    }
-
+    /** @hidden */
     _id: string | null | undefined;
 
     /** @hidden */
     @HostBinding('class.fd-bar__element')
     _barElement = true;
 
+    /** @hidden */
     @HostBinding('style.pointer-events')
     get pointerEvents(): string {
         return this._disabled ? 'none' : 'auto';
@@ -81,6 +82,7 @@ export class ButtonBarComponent extends BaseButton implements OnDestroy {
     /** @hidden */
     private _subscriptions = new Subscription();
 
+    /** @hidden */
     constructor(private _cdRef: ChangeDetectorRef) {
         super();
     }

--- a/libs/core/src/lib/bar/deprecated-bar-button-content-density.directive.ts
+++ b/libs/core/src/lib/bar/deprecated-bar-button-content-density.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedBarButtonContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-button-bar');
     }

--- a/libs/core/src/lib/bar/deprecated-bar-content-density.directive.ts
+++ b/libs/core/src/lib/bar/deprecated-bar-content-density.directive.ts
@@ -11,6 +11,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCozyDirective } from '@fundamental
     ]
 })
 export class DeprecatedBarContentDensityDirective extends DeprecatedCozyDirective {
+    /** @hidden */
     constructor() {
         super('[fd-bar]');
     }

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -91,6 +91,7 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     @ContentChildren(forwardRef(() => BreadcrumbItemComponent))
     breadcrumbItems: QueryList<BreadcrumbItemComponent>;
 
+    /** @hidden */
     @ViewChild(MenuComponent)
     private readonly _menuComponent: MenuComponent;
 

--- a/libs/core/src/lib/breadcrumb/deprecated-breadcrumbs-compact.directive.ts
+++ b/libs/core/src/lib/breadcrumb/deprecated-breadcrumbs-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedBreadcrumbsCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-breadcrumb');
     }

--- a/libs/core/src/lib/button/base-button.ts
+++ b/libs/core/src/lib/button/base-button.ts
@@ -62,36 +62,33 @@ export class BaseButton {
 
     /** Whether button is in toggled state. */
     @Input()
-    get toggled(): boolean {
-        return this._toggled;
-    }
-
     set toggled(value: BooleanInput) {
         this._toggled = coerceBooleanProperty(value);
+    }
+    get toggled(): boolean {
+        return this._toggled;
     }
 
     /**
      * Native disabled attribute of button element
      */
     @Input()
-    get disabled(): boolean {
-        return this._disabled;
-    }
-
     set disabled(value: BooleanInput) {
         this._disabled = coerceBooleanProperty(value);
+    }
+    get disabled(): boolean {
+        return this._disabled;
     }
 
     /**
      * Native aria-disabled attribute of button element
      */
     @Input('aria-disabled')
-    get ariaDisabled(): boolean {
-        return this._ariaDisabled;
-    }
-
     set ariaDisabled(value: BooleanInput) {
         this._ariaDisabled = coerceBooleanProperty(value);
+    }
+    get ariaDisabled(): boolean {
+        return this._ariaDisabled;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/button/button.component.ts
+++ b/libs/core/src/lib/button/button.component.ts
@@ -111,6 +111,7 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
         this.buildComponentCssClass();
     }
 
+    /** @hidden */
     public ngOnInit(): void {
         this.buildComponentCssClass();
     }
@@ -120,11 +121,12 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
         this._subscriptions.unsubscribe();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-button',
@@ -143,6 +145,7 @@ export class ButtonComponent extends BaseButton implements OnChanges, CssClassBu
         return this._elementRef;
     }
 
+    /** @hidden */
     detectChanges(): void {
         this._changeDetectorRef.detectChanges();
     }

--- a/libs/core/src/lib/button/deprecated-button-content-density.directive.ts
+++ b/libs/core/src/lib/button/deprecated-button-content-density.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedButtonContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('[fd-button]');
     }

--- a/libs/core/src/lib/calendar/calendar-errors.ts
+++ b/libs/core/src/lib/calendar/calendar-errors.ts
@@ -1,3 +1,4 @@
+/** Create an Error to be thrown when attempting to use an invalid date implementation. */
 export function createMissingDateImplementationError(provider: string): Error {
     return Error(
         `Calendar: No provider found for ${provider}. You must import one of the following ` +

--- a/libs/core/src/lib/calendar/calendar-header/calendar-header.component.ts
+++ b/libs/core/src/lib/calendar/calendar-header/calendar-header.component.ts
@@ -216,6 +216,7 @@ export class CalendarHeaderComponent<D> implements OnDestroy, OnInit, OnChanges 
     /** Get information about amount of years displayed at once on year view  */
     private _amountOfYearsPerPeriod = 1;
 
+    /** @hidden */
     constructor(
         private _calendarI18nLabels: CalendarI18nLabels,
         private _changeDetRef: ChangeDetectorRef,
@@ -363,6 +364,7 @@ export class CalendarHeaderComponent<D> implements OnDestroy, OnInit, OnChanges 
         )}`;
     }
 
+    /** @hidden */
     private _calculateMonthNames(): void {
         this._monthNames = this._dateTimeAdapter.getMonthNames('long');
     }

--- a/libs/core/src/lib/calendar/calendar-views/calendar-month-view/calendar-month-view.component.ts
+++ b/libs/core/src/lib/calendar/calendar-views/calendar-month-view/calendar-month-view.component.ts
@@ -80,6 +80,7 @@ export class CalendarMonthViewComponent<D> implements OnInit, OnDestroy, OnChang
     /** @hidden */
     private _initiated = false;
 
+    /** @hidden */
     constructor(
         private _eRef: ElementRef,
         private _changeDetectorRef: ChangeDetectorRef,

--- a/libs/core/src/lib/calendar/calendar.component.ts
+++ b/libs/core/src/lib/calendar/calendar.component.ts
@@ -322,6 +322,7 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
         }
     }
 
+    /** @hidden */
     getWeekStartDay(): DaysOfWeek {
         return this.startingDayOfWeek === undefined ? this._adapterStartingDayOfWeek : this.startingDayOfWeek;
     }
@@ -575,12 +576,14 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
         this.activeViewChange.emit(this.activeView);
     }
 
+    /** Select year */
     selectedYear(yearSelected: number): void {
         this.activeView = 'day';
         this._currentlyDisplayed.year = yearSelected;
         this.onDaysViewSelected();
     }
 
+    /** Select year range */
     selectedYears(yearsSelected: AggregatedYear): void {
         this.activeView = 'year';
         this._currentlyDisplayed = {

--- a/libs/core/src/lib/calendar/calendar.service.ts
+++ b/libs/core/src/lib/calendar/calendar.service.ts
@@ -6,7 +6,10 @@ import { EscapeFocusFunction } from './models/common';
 
 @Injectable()
 export class CalendarService {
+    /** Row amount */
     rowAmount = 3;
+
+    /** Column amount */
     colAmount = 4;
 
     /** Event thrown, when the element is selected by space or enter keys */
@@ -27,6 +30,7 @@ export class CalendarService {
     /** Function that is called when the focus would escape the element. */
     focusEscapeFunction: EscapeFocusFunction;
 
+    /** @hidden */
     constructor(@Optional() private _rtlService: RtlService) {}
 
     /**

--- a/libs/core/src/lib/calendar/deprecated-calendar-content-density.directive.ts
+++ b/libs/core/src/lib/calendar/deprecated-calendar-content-density.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedCalendarContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-calendar');
     }

--- a/libs/core/src/lib/calendar/models/date-range.ts
+++ b/libs/core/src/lib/calendar/models/date-range.ts
@@ -1,5 +1,10 @@
 /** A class representing a range of dates. */
 export class DateRange<D> {
+    /**
+     * Date range.
+     * @param start
+     * @param end
+     */
     constructor(
         /** The start date of the range. */
         readonly start: D | null,

--- a/libs/core/src/lib/card/card-content.component.ts
+++ b/libs/core/src/lib/card/card-content.component.ts
@@ -21,8 +21,8 @@ export class CardContentComponent implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardContent];
     }

--- a/libs/core/src/lib/card/card-counter.directive.ts
+++ b/libs/core/src/lib/card/card-counter.directive.ts
@@ -34,8 +34,8 @@ export class CardCounterDirective implements OnInit, OnChanges, CssClassBuilder 
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         const objectStatusClasses = buildObjectStatusCssClasses(this);
         return [CLASS_NAME.cardCounter, ...objectStatusClasses];

--- a/libs/core/src/lib/card/card-footer-action-item.directive.ts
+++ b/libs/core/src/lib/card/card-footer-action-item.directive.ts
@@ -4,5 +4,6 @@ import { Directive, TemplateRef } from '@angular/core';
     selector: '[fdCardFooterActionItem]'
 })
 export class CardFooterActionItemDirective {
+    /** @hidden */
     constructor(readonly templateRef: TemplateRef<void>) {}
 }

--- a/libs/core/src/lib/card/card-footer.component.ts
+++ b/libs/core/src/lib/card/card-footer.component.ts
@@ -30,6 +30,7 @@ export class CardFooterComponent implements AfterViewInit, OnDestroy {
     /** @hidden */
     private _destroyed$ = new Subject<void>();
 
+    /** @hidden */
     constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/card/card-header.component.ts
+++ b/libs/core/src/lib/card/card-header.component.ts
@@ -37,6 +37,8 @@ export class CardHeaderComponent implements OnInit, OnChanges, CssClassBuilder, 
     get tabindex(): string {
         return !this.interactive ? '-1' : this._tabindex;
     }
+
+    /** @hidden */
     private _tabindex = '0';
 
     /** @hidden */
@@ -72,8 +74,8 @@ export class CardHeaderComponent implements OnInit, OnChanges, CssClassBuilder, 
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardHeader, !this.interactive ? CLASS_NAME.cardHeaderNonInteractive : ''];
     }

--- a/libs/core/src/lib/card/card-loader.component.ts
+++ b/libs/core/src/lib/card/card-loader.component.ts
@@ -21,8 +21,8 @@ export class CardLoaderComponent implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardLoader];
     }

--- a/libs/core/src/lib/card/card-second-subtitle.directive.ts
+++ b/libs/core/src/lib/card/card-second-subtitle.directive.ts
@@ -19,8 +19,8 @@ export class CardSecondSubtitleDirective implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardSecondSubtitle];
     }

--- a/libs/core/src/lib/card/card-subtitle.directive.ts
+++ b/libs/core/src/lib/card/card-subtitle.directive.ts
@@ -20,8 +20,8 @@ export class CardSubtitleDirective implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardSubtitle];
     }

--- a/libs/core/src/lib/card/card-title.directive.ts
+++ b/libs/core/src/lib/card/card-title.directive.ts
@@ -20,8 +20,8 @@ export class CardTitleDirective implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardTitle];
     }

--- a/libs/core/src/lib/card/card.component.ts
+++ b/libs/core/src/lib/card/card.component.ts
@@ -88,8 +88,8 @@ export class CardComponent implements OnChanges, OnInit, CssClassBuilder, OnDest
         this._subscriptions.unsubscribe();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.card, this.cardType ? getCardModifierClassNameByCardType(this.cardType) : ''];
     }

--- a/libs/core/src/lib/card/deprecated-card-content-density.directive.ts
+++ b/libs/core/src/lib/card/deprecated-card-content-density.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedCardContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-card');
     }

--- a/libs/core/src/lib/card/kpi/card-kpi-analytics-content.directive.ts
+++ b/libs/core/src/lib/card/kpi/card-kpi-analytics-content.directive.ts
@@ -20,8 +20,8 @@ export class CardKpiAnalyticsContentDirective implements OnInit, CssClassBuilder
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardAnalyticsContent];
     }

--- a/libs/core/src/lib/card/kpi/card-kpi-analytics-label.directive.ts
+++ b/libs/core/src/lib/card/kpi/card-kpi-analytics-label.directive.ts
@@ -20,8 +20,8 @@ export class CardKpiAnalyticsLabelDirective implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardAnalyticsText];
     }

--- a/libs/core/src/lib/card/kpi/card-kpi-analytics.directive.ts
+++ b/libs/core/src/lib/card/kpi/card-kpi-analytics.directive.ts
@@ -20,8 +20,8 @@ export class CardKpiAnalyticsDirective implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardAnalytics];
     }

--- a/libs/core/src/lib/card/kpi/card-kpi-header.component.ts
+++ b/libs/core/src/lib/card/kpi/card-kpi-header.component.ts
@@ -21,8 +21,8 @@ export class CardKpiHeaderComponent implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardAnalyticalArea];
     }

--- a/libs/core/src/lib/card/kpi/card-kpi-scale-icon.directive.ts
+++ b/libs/core/src/lib/card/kpi/card-kpi-scale-icon.directive.ts
@@ -20,8 +20,8 @@ export class CardKpiScaleIconDirective implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardAnalyticsScaleIcon];
     }

--- a/libs/core/src/lib/card/kpi/card-kpi-scale-text.directive.ts
+++ b/libs/core/src/lib/card/kpi/card-kpi-scale-text.directive.ts
@@ -20,8 +20,8 @@ export class CardKpiScaleTextDirective implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CLASS_NAME.cardAnalyticsScaleText];
     }

--- a/libs/core/src/lib/card/kpi/card-kpi-value.directive.ts
+++ b/libs/core/src/lib/card/kpi/card-kpi-value.directive.ts
@@ -26,8 +26,8 @@ export class CardKpiValueDirective implements OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             CLASS_NAME.cardAnalyticsKpiValue,

--- a/libs/core/src/lib/carousel/carousel.directive.ts
+++ b/libs/core/src/lib/carousel/carousel.directive.ts
@@ -28,6 +28,7 @@ export class CarouselDirective implements AfterContentInit {
     @Input()
     active: CarouselItemDirective;
 
+    /** @hidden */
     get carouselService(): CarouselService {
         return this._carouselService;
     }
@@ -60,10 +61,12 @@ export class CarouselDirective implements AfterContentInit {
         this._carouselService.goToItem(item, smooth);
     }
 
+    /** Pick previous carousel item */
     pickPrevious(): void {
         this._carouselService.pickPrevious();
     }
 
+    /** Pick next carousel item */
     pickNext(): void {
         this._carouselService.pickNext();
     }

--- a/libs/core/src/lib/carousel/carousel.service.ts
+++ b/libs/core/src/lib/carousel/carousel.service.ts
@@ -53,14 +53,12 @@ export class CarouselService implements OnDestroy {
     /** carousel items query list */
     items: QueryList<CarouselItemInterface>;
 
-    /** return current transition value in px */
-    get currentTransitionPx(): number {
-        return this._currentTransitionPx;
-    }
-
-    /** set current transition value in px */
+    /** Current transition value in px */
     set currentTransitionPx(currentTransitionPx: number) {
         this._currentTransitionPx = currentTransitionPx;
+    }
+    get currentTransitionPx(): number {
+        return this._currentTransitionPx;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -127,12 +127,11 @@ export class CheckboxComponent implements ControlValueAccessor, AfterViewInit, O
 
     /** Sets values returned by control. */
     @Input()
-    get values(): FdCheckboxValues {
-        return this._values;
-    }
-
     set values(checkboxValues: FdCheckboxValues) {
         this._values = { ...FD_CHECKBOX_VALUES_DEFAULT, ...(checkboxValues ?? {}) };
+    }
+    get values(): FdCheckboxValues {
+        return this._values;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/checkbox/deprecated-checkbox-content-density.directive.ts
+++ b/libs/core/src/lib/checkbox/deprecated-checkbox-content-density.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedCheckboxContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-checkbox');
     }

--- a/libs/core/src/lib/combobox/combobox-mobile/combobox-mobile.component.ts
+++ b/libs/core/src/lib/combobox/combobox-mobile/combobox-mobile.component.ts
@@ -44,6 +44,7 @@ export class ComboboxMobileComponent extends MobileModeBase<ComboboxInterface> i
     /** @hidden */
     private _selectedBackup: string;
 
+    /** @hidden */
     constructor(
         elementRef: ElementRef,
         dialogService: DialogService,
@@ -53,6 +54,7 @@ export class ComboboxMobileComponent extends MobileModeBase<ComboboxInterface> i
         super(elementRef, dialogService, comboboxComponent, MobileModeControl.COMBOBOX, mobileModes);
     }
 
+    /** @hidden */
     ngOnInit(): void {
         this._listenOnMultiInputOpenChange();
     }
@@ -74,6 +76,7 @@ export class ComboboxMobileComponent extends MobileModeBase<ComboboxInterface> i
         this._component.dialogApprove();
     }
 
+    /** @hidden */
     private _toggleDialog(open: boolean): void {
         if (open) {
             this._selectedBackup = this._component.getValue();

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -477,18 +477,16 @@ export class ComboboxComponent
         return !this.inputText || this.inputText?.trim().length === 0;
     }
 
-    /** Get the input text of the input. */
-    get inputText(): string {
-        return this.inputTextValue;
-    }
-
-    /** Set the input text of the input. */
+    /** Input text of the input. */
     set inputText(value: string) {
         this.inputTextValue = value;
         this.inputTextChange.emit(value);
         if (!this.mobile) {
             this._propagateChange();
         }
+    }
+    get inputText(): string {
+        return this.inputTextValue;
     }
 
     /** Get the glyph value based on whether the combobox is used as a search field or not. */
@@ -733,6 +731,7 @@ export class ComboboxComponent
         );
     }
 
+    /** @hidden */
     isSelected(term: any): boolean {
         const termValue = this.communicateByObject ? term : this.displayFn(term);
         return this.getValue() === termValue;

--- a/libs/core/src/lib/combobox/deprecated-combobox-content-density.directive.ts
+++ b/libs/core/src/lib/combobox/deprecated-combobox-content-density.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedComboboxContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor(private elRef: ElementRef) {
         super('fd-combobox');
     }

--- a/libs/core/src/lib/combobox/list-group.pipe.ts
+++ b/libs/core/src/lib/combobox/list-group.pipe.ts
@@ -7,6 +7,7 @@ export type GroupFunction<T = any> = (items: T[]) => { [key: string]: T[] };
     name: 'listGroupPipe'
 })
 export class ListGroupPipe<T = any> implements PipeTransform {
+    /** Group items */
     transform(items: any[], group: GroupFunction<T>): KeyValue<string, T[]>[] {
         return Object.entries(group(items)).map(([key, value]) => ({ key, value }));
     }

--- a/libs/core/src/lib/content-density/classes/content-density-observer.settings.ts
+++ b/libs/core/src/lib/content-density/classes/content-density-observer.settings.ts
@@ -2,8 +2,12 @@ import { FactorySansProvider, ProviderToken } from '@angular/core';
 import { ContentDensityMode } from '../types/content-density.mode';
 
 export class ContentDensityObserverSettings {
+    /** Classes to be added to the element. */
     modifiers?: Partial<Record<ContentDensityMode, string>>;
+    /** Supported content densities. */
     supportedContentDensity?: ContentDensityMode[];
+    /** Default content density. */
     defaultContentDensity?: ContentDensityMode | ProviderToken<ContentDensityMode> | FactorySansProvider;
+    /** Whether in debug mode. */
     debug?: boolean;
 }

--- a/libs/core/src/lib/content-density/classes/deprecated-compact.directive.ts
+++ b/libs/core/src/lib/content-density/classes/deprecated-compact.directive.ts
@@ -21,17 +21,22 @@ export class DeprecatedCompactDirective
         this.next(coerceBooleanProperty(value) ? ContentDensityMode.COMPACT : ContentDensityMode.COZY);
     }
 
+    /** @hidden */
     readonly message: string;
+
+    /** @hidden */
     readonly alternative = {
         name: 'Use [fdCompact] directive instead',
         link: ['/core', 'content-density']
     };
 
+    /** @hidden */
     constructor(selectorBase: string) {
         super(ContentDensityMode.COZY);
         this.message = `Usage of ${selectorBase}[compact] is deprecated`;
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this.complete();
     }

--- a/libs/core/src/lib/content-density/classes/deprecated-condensed.directive.ts
+++ b/libs/core/src/lib/content-density/classes/deprecated-condensed.directive.ts
@@ -12,6 +12,7 @@ export class DeprecatedCondensedDirective
     extends BehaviorSubject<ContentDensityMode>
     implements OnDestroy, ModuleDeprecation
 {
+    /** @deprecated use fdCondensed directive instead */
     @Input()
     set condensed(value: BooleanInput) {
         if (isDevMode()) {
@@ -20,17 +21,22 @@ export class DeprecatedCondensedDirective
         this.next(coerceBooleanProperty(value) ? ContentDensityMode.CONDENSED : ContentDensityMode.COZY);
     }
 
+    /** @hidden */
     readonly message: string;
+
+    /** @hidden */
     readonly alternative = {
         name: 'Use [fdCondensed] directive instead',
         link: ['/core', 'content-density']
     };
 
+    /** @hidden */
     constructor(selectorBase: string) {
         super(ContentDensityMode.COZY);
         this.message = `Usage of ${selectorBase}[condensed] is deprecated`;
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this.complete();
     }

--- a/libs/core/src/lib/content-density/classes/deprecated-content-density.directive.ts
+++ b/libs/core/src/lib/content-density/classes/deprecated-content-density.directive.ts
@@ -24,10 +24,12 @@ export class DeprecatedContentDensityDirective
         this.next(value);
     }
 
+    /** Deprecation message */
     get message(): string {
         return `Usage of ${this.selectorBase}[contentDensity] is deprecated`;
     }
 
+    /** Alternative usage description with a link to the docs */
     get alternative(): any {
         return {
             name: `Use [${this._manuallySet ? `fd${capitalize(this.value)}` : 'fdContentDensity'}] directive instead`,
@@ -35,14 +37,18 @@ export class DeprecatedContentDensityDirective
         };
     }
 
+    /** @hidden */
     selectorBase: string;
 
+    /** @hidden */
     private _manuallySet = false;
 
+    /** @hidden */
     constructor() {
         super(ContentDensityMode.COZY);
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this.complete();
     }

--- a/libs/core/src/lib/content-density/classes/deprecated-cozy.directive.ts
+++ b/libs/core/src/lib/content-density/classes/deprecated-cozy.directive.ts
@@ -12,6 +12,7 @@ export class DeprecatedCozyDirective
     extends BehaviorSubject<ContentDensityMode>
     implements OnDestroy, ModuleDeprecation
 {
+    /** @deprecated use fdCozy directive instead */
     @Input()
     set cozy(value: BooleanInput) {
         if (isDevMode()) {
@@ -20,17 +21,22 @@ export class DeprecatedCozyDirective
         this.next(coerceBooleanProperty(value) ? ContentDensityMode.COZY : ContentDensityMode.COMPACT);
     }
 
+    /** @hidden */
     readonly message: string;
+
+    /** @hidden */
     readonly alternative = {
         name: 'Use [fdCozy] directive instead',
         link: ['/core', 'content-density']
     };
 
+    /** @hidden */
     constructor(selectorBase: string) {
         super(ContentDensityMode.COMPACT);
         this.message = `Usage of ${selectorBase}[cozy] is deprecated`;
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this.complete();
     }

--- a/libs/core/src/lib/content-density/content-density.module.ts
+++ b/libs/core/src/lib/content-density/content-density.module.ts
@@ -43,6 +43,7 @@ function generateContentDensityStorage(config: ContentDensityModuleConfig): Prov
     declarations: [ContentDensityDirective]
 })
 export class ContentDensityModule {
+    /** Module with providers */
     static forRoot(config?: ContentDensityModuleConfig): ModuleWithProviders<ContentDensityModule> {
         let storage: Provider;
         const conf: ContentDensityModuleConfig = config || { storage: 'memory' };

--- a/libs/core/src/lib/content-density/helpers/content-density-change-callback-factory.ts
+++ b/libs/core/src/lib/content-density/helpers/content-density-change-callback-factory.ts
@@ -4,6 +4,7 @@ import { defaultContentDensityObserverConfigs } from '../variables/default-conte
 import { ContentDensityObserverSettings } from '../classes/content-density-observer.settings';
 import { ContentDensityMode } from '../types/content-density.mode';
 
+/** Content density callback factory */
 export function contentDensityCallbackFactory(
     consumerConfig: ContentDensityObserverTarget | ContentDensityCallbackFn
 ): ContentDensityCallbackFn {

--- a/libs/core/src/lib/content-density/providers/local-content-density-storage.ts
+++ b/libs/core/src/lib/content-density/providers/local-content-density-storage.ts
@@ -8,8 +8,10 @@ import { ContentDensityMode } from '../types/content-density.mode';
 
 @Injectable()
 export class LocalContentDensityStorage implements ContentDensityStorage {
+    /** @hidden */
     private _update$ = new Subject<void>();
 
+    /** @hidden */
     constructor(
         @Inject(DEFAULT_CONTENT_DENSITY) private _defaultContentDensity: ContentDensityMode,
         @Inject(CONTENT_DENSITY_STORAGE_KEY) private _storageKey: string,
@@ -18,6 +20,7 @@ export class LocalContentDensityStorage implements ContentDensityStorage {
         this._initialize();
     }
 
+    /** Content density observable */
     getContentDensity(): Observable<ContentDensityMode> {
         return new Observable<ContentDensityMode>((subscriber) => {
             subscriber.next(this._storage.get(this._storageKey));
@@ -30,12 +33,14 @@ export class LocalContentDensityStorage implements ContentDensityStorage {
         });
     }
 
+    /** Change content density */
     setContentDensity(density: ContentDensityMode): Observable<void> {
         this._storage.set(this._storageKey, density);
         this._update$.next();
         return of(undefined);
     }
 
+    /** @hidden */
     private _initialize(): void {
         if (!this._storage.get(this._storageKey)) {
             this._storage.set(this._storageKey, this._defaultContentDensity);

--- a/libs/core/src/lib/content-density/providers/memory-content-density-storage.ts
+++ b/libs/core/src/lib/content-density/providers/memory-content-density-storage.ts
@@ -6,16 +6,20 @@ import { DEFAULT_CONTENT_DENSITY } from '../tokens/default-content-density.token
 
 @Injectable()
 export class MemoryContentDensityStorage implements ContentDensityStorage {
+    /** @hidden */
     private _currentContentDensity$: BehaviorSubject<ContentDensityMode>;
 
+    /** @hidden */
     constructor(@Inject(DEFAULT_CONTENT_DENSITY) defaultContentDensity: ContentDensityMode) {
         this._currentContentDensity$ = new BehaviorSubject(defaultContentDensity);
     }
 
+    /** Content density observable */
     getContentDensity(): Observable<ContentDensityMode> {
         return this._currentContentDensity$.asObservable();
     }
 
+    /** Change content density */
     setContentDensity(density: ContentDensityMode): Observable<void> {
         this._currentContentDensity$.next(density);
         return of(undefined);

--- a/libs/core/src/lib/content-density/providers/url-content-density-storage.ts
+++ b/libs/core/src/lib/content-density/providers/url-content-density-storage.ts
@@ -8,8 +8,10 @@ import { BehaviorSubject, distinctUntilChanged, filter, Observable, of } from 'r
 
 @Injectable()
 export class UrlContentDensityStorage implements ContentDensityStorage {
+    /** @hidden */
     private _current$: BehaviorSubject<ContentDensityMode>;
 
+    /** @hidden */
     constructor(
         private _router: Router,
         private _activatedRoute: ActivatedRoute,
@@ -19,6 +21,7 @@ export class UrlContentDensityStorage implements ContentDensityStorage {
         this._initialize();
     }
 
+    /** @hidden */
     private _initialize(): void {
         this._current$ = new BehaviorSubject<ContentDensityMode>(this._defaultContentDensity);
 
@@ -29,6 +32,7 @@ export class UrlContentDensityStorage implements ContentDensityStorage {
             });
     }
 
+    /** @hidden */
     private _setUrlQueryParam(density: ContentDensityMode): void {
         const url = new URL(`https://google.com${this._router.url}`);
         url.searchParams.delete(this._storageKey);
@@ -39,10 +43,12 @@ export class UrlContentDensityStorage implements ContentDensityStorage {
         this._router.navigateByUrl(url.pathname + '?' + url.searchParams.toString());
     }
 
+    /** Content density observable */
     getContentDensity(): Observable<ContentDensityMode> {
         return this._current$.asObservable().pipe(distinctUntilChanged());
     }
 
+    /** Change content density */
     setContentDensity(density: ContentDensityMode): Observable<void> {
         this._current$.next(density);
         this._setUrlQueryParam(density);

--- a/libs/core/src/lib/content-density/services/content-density-observer.service.ts
+++ b/libs/core/src/lib/content-density/services/content-density-observer.service.ts
@@ -102,11 +102,16 @@ export class ContentDensityObserver extends BehaviorSubject<ContentDensityMode> 
         [ContentDensityMode.COZY]: (): ContentDensityMode => ContentDensityMode.COZY // No alternative here, everyone should support it
     };
 
+    /** @hidden */
     private readonly destroy$: Observable<void>;
+    /** @hidden */
     private changeDetectorRef: ChangeDetectorRef;
+    /** @hidden */
     private contentDensityDirective?: Observable<LocalContentDensityMode>;
+    /** @hidden */
     private contentDensityService?: GlobalContentDensityService;
 
+    /** @hidden */
     constructor(private _injector: Injector, private _providedConfig?: ContentDensityObserverSettings) {
         super(initialContentDensity(_injector, _providedConfig));
         if (_providedConfig?.debug) {
@@ -165,6 +170,7 @@ export class ContentDensityObserver extends BehaviorSubject<ContentDensityMode> 
         }
     }
 
+    /** Check if the given density is supported */
     isSupported(density: ContentDensityMode): boolean {
         return this.configuration.supportedContentDensity.includes(density);
     }

--- a/libs/core/src/lib/content-density/services/deprecated-content-density.service.ts
+++ b/libs/core/src/lib/content-density/services/deprecated-content-density.service.ts
@@ -14,6 +14,7 @@ export class DeprecatedContentDensityService implements OnDestroy {
     /** Content Density BehaviourSubject */
     readonly contentDensity = new BehaviorSubject<ContentDensityMode>(this._defaultContentDensity);
 
+    /** @hidden */
     constructor(
         private _contentDensityController: GlobalContentDensityService,
         @Inject(DEFAULT_CONTENT_DENSITY) private _defaultContentDensity: ContentDensityMode

--- a/libs/core/src/lib/content-density/testing/mocked-local-content-density-directive.ts
+++ b/libs/core/src/lib/content-density/testing/mocked-local-content-density-directive.ts
@@ -3,6 +3,7 @@ import { ContentDensityGlobalKeyword, LocalContentDensityMode } from '../content
 import { BehaviorSubject } from 'rxjs';
 import { CONTENT_DENSITY_DIRECTIVE } from '../tokens/content-density-directive';
 
+/** @hidden */
 export function mockedLocalContentDensityDirective(
     defaultValue: LocalContentDensityMode = ContentDensityGlobalKeyword
 ): { contentDensityDirectiveProvider: Provider; setContentDensity: (cd: LocalContentDensityMode) => void } {

--- a/libs/core/src/lib/date-picker/deprecated-date-picker-compact.directive.ts
+++ b/libs/core/src/lib/date-picker/deprecated-date-picker-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedDatePickerCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-date-picker');
     }

--- a/libs/core/src/lib/date-picker/errors.ts
+++ b/libs/core/src/lib/date-picker/errors.ts
@@ -1,3 +1,4 @@
+/** Creates an error to be thrown when attempting to use an invalid date implementation. */
 export function createMissingDateImplementationError(provider: string): Error {
     return Error(
         `FdDatePicker: No provider found for ${provider}. You must import one of the following ` +

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -714,6 +714,7 @@ export class DatetimePickerComponent<D>
         return this._dateTimeAdapter.isValid(date);
     }
 
+    /** @hidden */
     private _setInput(dateTime: Nullable<D>): void {
         this._inputFieldDate = dateTime ? this._formatDateTime(dateTime) : '';
         this._changeDetRef.detectChanges();

--- a/libs/core/src/lib/datetime-picker/deprecated-date-time-picker-content-density.directive.ts
+++ b/libs/core/src/lib/datetime-picker/deprecated-date-time-picker-content-density.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedDateTimePickerContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-datetime-picker');
     }

--- a/libs/core/src/lib/datetime-picker/errors.ts
+++ b/libs/core/src/lib/datetime-picker/errors.ts
@@ -1,3 +1,4 @@
+/** Creates an error to be thrown when attempting to use an invalid date implementation. */
 export function createMissingDateImplementationError(provider: string): Error {
     return Error(
         `FdDatetimePicker: No provider found for ${provider}. You must import one of the following ` +

--- a/libs/core/src/lib/datetime/datetime-format.pipes.ts
+++ b/libs/core/src/lib/datetime/datetime-format.pipes.ts
@@ -6,11 +6,13 @@ import { DatetimeAdapter } from './datetime-adapter';
     name: 'dateFormat'
 })
 export class DateFormatPipe<D> implements PipeTransform {
+    /** @hidden */
     constructor(
         private _dateTimeAdapter: DatetimeAdapter<D>,
         @Optional() @Inject(DATE_TIME_FORMATS) private _dateTimeFormats: DateTimeFormats
     ) {}
 
+    /** Format date object */
     transform(date: D, noDateMessage = ''): string {
         if (date) {
             return this._dateTimeAdapter.format(date, this._dateTimeFormats.display.dateInput);
@@ -24,11 +26,13 @@ export class DateFormatPipe<D> implements PipeTransform {
     name: 'dateTimeFormat'
 })
 export class DateTimeFormatPipe<D> implements PipeTransform {
+    /** @hidden */
     constructor(
         private _dateTimeAdapter: DatetimeAdapter<D>,
         @Optional() @Inject(DATE_TIME_FORMATS) private _dateTimeFormats: DateTimeFormats
     ) {}
 
+    /** Format date object */
     transform(date: D, noDateMessage = ''): string {
         if (date) {
             return this._dateTimeAdapter.format(date, this._dateTimeFormats.display.dateTimeInput);
@@ -42,8 +46,10 @@ export class DateTimeFormatPipe<D> implements PipeTransform {
     name: 'dateFromNow'
 })
 export class DateFromNowPipe<D> implements PipeTransform {
+    /** @hidden */
     constructor(private _dateTimeAdapter: DatetimeAdapter<D>) {}
 
+    /** Format date object */
     transform(date: D, noDateMessage = ''): string {
         if (this._dateTimeAdapter.fromNow && typeof this._dateTimeAdapter.fromNow === 'function') {
             if (date) {

--- a/libs/core/src/lib/datetime/fd-date.ts
+++ b/libs/core/src/lib/datetime/fd-date.ts
@@ -89,6 +89,7 @@ export class FdDate {
     // eslint-disable-next-line @typescript-eslint/unified-signatures
     constructor(year: number, month?: number, day?: number, hour?: number, minute?: number, second?: number);
 
+    /** Create a date object */
     constructor(...args: any[]) {
         if (args.length === 0) {
             return FdDate.getNow();

--- a/libs/core/src/lib/datetime/fd-date.utils.ts
+++ b/libs/core/src/lib/datetime/fd-date.utils.ts
@@ -1,3 +1,4 @@
+/** Generate range of given lengths using given function. */
 export function range<T>(length: number, mapFn: (index: number) => T): T[] {
     return Array.from(new Array(length)).map((_, index) => mapFn(index));
 }
@@ -7,6 +8,7 @@ export function _leftPad(n: number): string {
     return n === n % 10 ? `0${n}` : `${n}`;
 }
 
+/** Converts date to ISO8601 */
 export function toIso8601(fdDate: {
     year: number;
     month: number;

--- a/libs/core/src/lib/datetime/fd-datetime-adapter.ts
+++ b/libs/core/src/lib/datetime/fd-datetime-adapter.ts
@@ -23,8 +23,10 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
     /** Whether to clamp the date between 1 and 9999 to avoid IE and Edge errors. */
     private readonly _fixYearsRangeIssue: boolean;
 
+    /** @hidden */
     fromNow: undefined;
 
+    /** @hidden */
     constructor(@Optional() @Inject(LOCALE_ID) localeId: string, platform: Platform) {
         super();
 
@@ -33,34 +35,42 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         this._fixYearsRangeIssue = platform.TRIDENT || platform.EDGE;
     }
 
+    /** Get year */
     getYear(date: FdDate): number {
         return date.year;
     }
 
+    /** Get month */
     getMonth(date: FdDate): number {
         return date.month;
     }
 
+    /** Get date */
     getDate(date: FdDate): number {
         return date.day;
     }
 
+    /** Get day of week */
     getDayOfWeek(date: FdDate): number {
         return this._createDateInstanceByFdDate(date).getDay() + 1;
     }
 
+    /** Get hours */
     getHours(date: FdDate): number {
         return date.hour;
     }
 
+    /** Get minutes */
     getMinutes(date: FdDate): number {
         return date.minute;
     }
 
+    /** Get seconds */
     getSeconds(date: FdDate): number {
         return date.second;
     }
 
+    /** Get week number */
     getWeekNumber(fdDate: FdDate): number {
         const date = this._createDateInstanceByFdDate(fdDate);
 
@@ -75,6 +85,7 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         );
     }
 
+    /** Get month names */
     getMonthNames(style: 'long' | 'short' | 'narrow'): string[] {
         const dateTimeFormat = new Intl.DateTimeFormat(this.locale, { month: style, timeZone: 'utc' });
         return range(12, (i) =>
@@ -82,6 +93,7 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         );
     }
 
+    /** Get date names */
     getDateNames(): string[] {
         const dateTimeFormat = new Intl.DateTimeFormat(this.locale, { day: 'numeric', timeZone: 'utc' });
         return range(31, (i) =>
@@ -89,6 +101,7 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         );
     }
 
+    /** Get day of week names */
     getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[] {
         const dateTimeFormat = new Intl.DateTimeFormat(this.locale, { weekday: style, timeZone: 'utc' });
         return range(7, (i) =>
@@ -96,17 +109,20 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         );
     }
 
+    /** Get year name */
     getYearName(date: FdDate): string {
         const dateTimeFormat = new Intl.DateTimeFormat(this.locale, { year: 'numeric', timeZone: 'utc' });
         const dateInstance = this._createDateInstanceByFdDate(date);
         return this._stripDirectionalityCharacters(this._format(dateTimeFormat, dateInstance));
     }
 
+    /** Get week name */
     getWeekName(date: FdDate): string {
         const weekNumber = this.getWeekNumber(date);
         return weekNumber.toLocaleString(this.locale);
     }
 
+    /** Get hour names */
     getHourNames({ meridian, twoDigit }: { twoDigit: boolean; meridian: boolean }): string[] {
         return range(24, (hour) => {
             if (meridian) {
@@ -116,14 +132,17 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         });
     }
 
+    /** Get minute names */
     getMinuteNames({ twoDigit }: { twoDigit: boolean }): string[] {
         return range(60, (minute) => minute.toLocaleString(this.locale, { minimumIntegerDigits: twoDigit ? 2 : 1 }));
     }
 
+    /** Get second names */
     getSecondNames({ twoDigit }: { twoDigit: boolean }): string[] {
         return range(60, (second) => second.toLocaleString(this.locale, { minimumIntegerDigits: twoDigit ? 2 : 1 }));
     }
 
+    /** Get day period names */
     getDayPeriodNames(): [string, string] {
         const DEFAULT_PERIODS: [string, string] = [AM_DAY_PERIOD_DEFAULT, PM_DAY_PERIOD_DEFAULT];
 
@@ -151,29 +170,34 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         }
     }
 
+    /** Set hours */
     setHours(date: FdDate, hours: number): FdDate {
         const dateInstance = this._createDateInstanceByFdDate(date);
         dateInstance.setHours(hours);
         return this._createFdDateFromDateInstance(dateInstance);
     }
 
+    /** Set minutes */
     setMinutes(date: FdDate, hours: number): FdDate {
         const dateInstance = this._createDateInstanceByFdDate(date);
         dateInstance.setMinutes(hours);
         return this._createFdDateFromDateInstance(dateInstance);
     }
 
+    /** Set seconds */
     setSeconds(date: FdDate, hours: number): FdDate {
         const dateInstance = this._createDateInstanceByFdDate(date);
         dateInstance.setSeconds(hours);
         return this._createFdDateFromDateInstance(dateInstance);
     }
 
+    /** Get first day of week */
     getFirstDayOfWeek(): number {
         // can't retrieve this info from Intl object or Date object, default to Sunday.
         return 0;
     }
 
+    /** Get number of days in a month */
     getNumDaysInMonth(fdDate: FdDate): number {
         const date = this._createDateInstanceByFdDate(fdDate);
         date.setMonth(date.getMonth() + 1);
@@ -181,18 +205,22 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         return date.getDate();
     }
 
+    /** Create a date object */
     createDate(year: number, month = 1, date = 1): FdDate {
         return new FdDate(year, month, date);
     }
 
+    /** Get a today date object */
     today(): FdDate {
         return FdDate.getToday();
     }
 
+    /** Get a now date object */
     now(): FdDate {
         return FdDate.getNow();
     }
 
+    /** Parse any value to date object */
     parse(value: any, parseFormat: Intl.DateTimeFormatOptions = {}): FdDate | null {
         if (!value && value !== 0) {
             return null;
@@ -225,6 +253,7 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         return this._createFdDateFromDateInstance(date);
     }
 
+    /** Format date object to string */
     format(date: FdDate, displayFormat: Intl.DateTimeFormatOptions): string {
         if (!this.isValid(date)) {
             return INVALID_DATE_ERROR;
@@ -244,10 +273,12 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         return this._stripDirectionalityCharacters(this._format(dateTimeFormatter, dateInstance));
     }
 
+    /** Add years to a date */
     addCalendarYears(date: FdDate, years: number): FdDate {
         return this.addCalendarMonths(date, years * 12);
     }
 
+    /** Add months to a date */
     addCalendarMonths(fdDate: FdDate, months: number): FdDate {
         const date = this._createDateInstanceByFdDate(fdDate);
 
@@ -262,16 +293,19 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         return this._createFdDateFromDateInstance(date);
     }
 
+    /** Add days to a date */
     addCalendarDays(fdDate: FdDate, days: number): FdDate {
         const date = this._createDateInstanceByFdDate(fdDate);
         date.setDate(date.getDate() + days);
         return this._createFdDateFromDateInstance(date);
     }
 
+    /** Clone a date object */
     clone(date: FdDate): FdDate {
         return new FdDate(date.year, date.month, date.day, date.hour, date.minute, date.second);
     }
 
+    /** Check if date object is valid */
     isValid(date: FdDate): date is FdDate {
         if (!(date instanceof FdDate)) {
             return false;
@@ -279,6 +313,7 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         return date.isDateValid();
     }
 
+    /** Check if date between given dates */
     isBetween(dateToCheck: FdDate, startDate: FdDate, endDate: FdDate): boolean {
         const date = this._createDateInstanceByFdDate(dateToCheck);
         const start = this._createDateInstanceByFdDate(startDate);
@@ -286,6 +321,7 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         return date.getTime() > start.getTime() && date.getTime() < end.getTime();
     }
 
+    /** Check if dates are equal */
     datesEqual(date1: FdDate, date2: FdDate): boolean {
         if (!date1 || !date2) {
             return false;
@@ -296,6 +332,7 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         return date1Str === date2Str;
     }
 
+    /** Check if dates and time are equal */
     dateTimesEqual(date1: FdDate, date2: FdDate): boolean {
         if (!date1 || !date2) {
             return false;
@@ -303,10 +340,12 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         return this.toIso8601(date1) === this.toIso8601(date2);
     }
 
+    /** Format date object to ISO8601 string */
     toIso8601(fdDate: FdDate): string {
         return toIso8601(fdDate);
     }
 
+    /** Check if a time format includes a day period */
     isTimeFormatIncludesDayPeriod(displayFormat: Intl.DateTimeFormatOptions): boolean {
         if (typeof displayFormat?.hour12 === 'boolean') {
             return displayFormat.hour12;
@@ -316,14 +355,17 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
         return formattedDateWithPeriodOption === formattedDateNoPeriodOption;
     }
 
+    /** Check if a time format includes hours */
     isTimeFormatIncludesHours(displayFormat: Intl.DateTimeFormatOptions): boolean {
         return typeof displayFormat?.hour === 'string';
     }
 
+    /** Check if a time format includes minutes */
     isTimeFormatIncludesMinutes(displayFormat: Intl.DateTimeFormatOptions): boolean {
         return typeof displayFormat?.minute === 'string';
     }
 
+    /** Check if a time format includes seconds */
     isTimeFormatIncludesSeconds(displayFormat: Intl.DateTimeFormatOptions): boolean {
         return typeof displayFormat?.second === 'string';
     }

--- a/libs/core/src/lib/dialog/utils/dialog-ref.class.ts
+++ b/libs/core/src/lib/dialog/utils/dialog-ref.class.ts
@@ -10,7 +10,10 @@ import { DialogRefBase } from '../base/dialog-ref-base.class';
 
 @Injectable()
 export class DialogRef<T = any, P = any> extends DialogRefBase<T, P> {
+    /** @hidden */
     private readonly _onHide = new BehaviorSubject<boolean>(false);
+
+    /** @hidden */
     private readonly _onLoading = new BehaviorSubject<boolean>(false);
 
     /** Observable that is triggered whenever the dialog should be visually hidden or visible.*/

--- a/libs/core/src/lib/dynamic-page/deprecated-dynamic-page-compact.directive.ts
+++ b/libs/core/src/lib/dynamic-page/deprecated-dynamic-page-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedDynamicPageCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-dynamic-page-title-content');
     }

--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/actions/dynamic-page-base-actions.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/actions/dynamic-page-base-actions.ts
@@ -2,6 +2,7 @@ import { Directive, ElementRef } from '@angular/core';
 
 @Directive()
 export class DynamicPageBaseActions {
+    /** @hidden */
     addClassToToolbar(_class: string, elementRef: ElementRef): void {
         // adds global actions classes to its toolbar
         const toolbarEl = elementRef.nativeElement.querySelector('.fd-toolbar');

--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/actions/dynamic-page-layout-actions.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/actions/dynamic-page-layout-actions.component.ts
@@ -23,12 +23,14 @@ import { Subject } from 'rxjs';
     }
 })
 export class DynamicPageLayoutActionsComponent extends DynamicPageBaseActions implements AfterContentInit {
+    /** @hidden */
     @ContentChild(ToolbarComponent)
     toolbarComponent: ToolbarComponent;
 
     /** @hidden */
     private readonly _onDestroy$: Subject<void> = new Subject<void>();
 
+    /** @hidden */
     constructor(
         private _elementRef: ElementRef,
         private _renderer: Renderer2,

--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
@@ -72,6 +72,7 @@ export class DynamicPageHeaderComponent implements OnInit, AfterViewInit, OnDest
     @ContentChild(DynamicPageGlobalActionsComponent)
     _globalActions: DynamicPageGlobalActionsComponent;
 
+    /** @hidden */
     @ContentChild(DynamicPageLayoutActionsComponent)
     _layoutActions: DynamicPageLayoutActionsComponent;
 

--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.ts
@@ -140,6 +140,7 @@ export class DynamicPageSubheaderComponent {
         this._dynamicPageService.pinned.next(this._pinned);
     }
 
+    /** @hidden */
     private _handleCollapsedChange(collapsed: boolean): void {
         if (collapsed === this._collapsed) {
             return;

--- a/libs/core/src/lib/dynamic-page/dynamic-page-wrapper.directive.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-wrapper.directive.ts
@@ -4,5 +4,6 @@ import { Directive, ElementRef } from '@angular/core';
     selector: '[fdDynamicPageWrapper], [fd-dynamic-page-wrapper]'
 })
 export class DynamicPageWrapperDirective {
+    /** @hidden */
     constructor(public elementRef: ElementRef<HTMLElement>) {}
 }

--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
@@ -79,6 +79,7 @@ export class DynamicPageComponent implements AfterViewInit, OnDestroy {
         return this._size;
     }
 
+    /** @hidden */
     _size: DynamicPageResponsiveSize = 'extra-large';
 
     /** Offset in PX

--- a/libs/core/src/lib/facets/content/facet-content.component.ts
+++ b/libs/core/src/lib/facets/content/facet-content.component.ts
@@ -17,6 +17,7 @@ export class FacetContentComponent implements OnInit {
         this._addClassNameToHostElement(FACET_CLASS_NAME.facetContainer);
     }
 
+    /** @hidden */
     elementRef(): ElementRef<HTMLElement> {
         return this._elementRef;
     }

--- a/libs/core/src/lib/feed-input/directives/feed-input-avatar.directive.ts
+++ b/libs/core/src/lib/feed-input/directives/feed-input-avatar.directive.ts
@@ -17,6 +17,7 @@ export class FeedInputAvatarDirective implements OnInit, OnChanges, CssClassBuil
     @Input()
     placeholder: boolean;
 
+    /** @hidden */
     constructor(private readonly _elementRef: ElementRef<HTMLElement>) {}
 
     /** @hidden */

--- a/libs/core/src/lib/feed-input/directives/feed-input-button.directive.ts
+++ b/libs/core/src/lib/feed-input/directives/feed-input-button.directive.ts
@@ -16,6 +16,7 @@ export class FeedInputButtonDirective implements OnInit {
     @HostBinding('class.is-disabled')
     disabled = true;
 
+    /** @hidden */
     constructor(private readonly _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2) {}
 
     /** @hidden */

--- a/libs/core/src/lib/feed-list-item/components/item/feed-list-item.component.ts
+++ b/libs/core/src/lib/feed-list-item/components/item/feed-list-item.component.ts
@@ -89,7 +89,9 @@ export class FeedListItemComponent implements OnInit, OnChanges, CssClassBuilder
     @Input()
     mobile = false;
 
+    /** @hidden */
     maxCharsAtDefault = false;
+
     /**
      * Apply body class by default
      */
@@ -109,15 +111,18 @@ export class FeedListItemComponent implements OnInit, OnChanges, CssClassBuilder
     /** @hidden */
     constructor(private readonly _elementRef: ElementRef) {}
 
+    /** @hidden */
     setHasMore(): void {
         if (this.text) {
             this.hasMore = this.text.length > this.maxChars;
         }
     }
 
+    /** @hidden */
     setDefaultMaxChars(): void {
         this.maxChars = this.mobile ? 300 : 500;
     }
+
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
@@ -137,11 +142,12 @@ export class FeedListItemComponent implements OnInit, OnChanges, CssClassBuilder
         this.setHasMore();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [CSS_CLASS_NAME.item, this.class, this.isRichText ? '' : `${CSS_CLASS_NAME.item}--collapsible`];
     }

--- a/libs/core/src/lib/feed-list-item/components/list/feed-list.component.ts
+++ b/libs/core/src/lib/feed-list-item/components/list/feed-list.component.ts
@@ -91,11 +91,12 @@ export class FeedListComponent implements OnInit, AfterContentChecked, OnDestroy
         }
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             CSS_CLASS_NAME.list,

--- a/libs/core/src/lib/feed-list-item/directives/byline.directive.ts
+++ b/libs/core/src/lib/feed-list-item/directives/byline.directive.ts
@@ -5,6 +5,7 @@ import { Directive, HostBinding } from '@angular/core';
     selector: '[fd-item-footer-byline]'
 })
 export class FeedListFooterBylineDirective {
+    /** @hidden */
     @HostBinding('class.fd-feed-list__footer--byline')
     fdBylineClass = true;
 }

--- a/libs/core/src/lib/file-uploader/deprecated-file-uploader-content-density.directive.ts
+++ b/libs/core/src/lib/file-uploader/deprecated-file-uploader-content-density.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedFileUploaderContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-file-uploader');
     }

--- a/libs/core/src/lib/file-uploader/directives/file-uploader-dragndrop.directive.ts
+++ b/libs/core/src/lib/file-uploader/directives/file-uploader-dragndrop.directive.ts
@@ -44,8 +44,10 @@ export class FileUploaderDragndropDirective {
     @Output()
     readonly dragLeave = new EventEmitter<void>();
 
+    /** @hidden */
     private elementStateCounter = 0;
 
+    /** @hidden */
     constructor(private _fileUploadService: FileUploaderService) {}
 
     /** @hidden */

--- a/libs/core/src/lib/file-uploader/file-uploader.component.ts
+++ b/libs/core/src/lib/file-uploader/file-uploader.component.ts
@@ -57,6 +57,7 @@ export class FileUploaderComponent implements ControlValueAccessor, OnDestroy, F
     @ViewChild('fileInput')
     inputRef: ElementRef;
 
+    /** @hidden */
     @ViewChild('textInput')
     inputRefText: ElementRef;
 
@@ -158,6 +159,7 @@ export class FileUploaderComponent implements ControlValueAccessor, OnDestroy, F
     /** @hidden */
     private _subscriptions = new Subscription();
 
+    /** @hidden */
     constructor(
         private _fileUploadService: FileUploaderService,
         private _changeDetRef: ChangeDetectorRef,
@@ -215,6 +217,7 @@ export class FileUploaderComponent implements ControlValueAccessor, OnDestroy, F
         this._propagateFiles();
     }
 
+    /** @hidden */
     validateFiles(event: File[]): void {
         if (this.fileLimit && event.length > this.fileLimit) {
             throw new Error('FileLimitError - Selected files count is more than specified limit ');
@@ -231,6 +234,7 @@ export class FileUploaderComponent implements ControlValueAccessor, OnDestroy, F
         this.invalidFiles = fileOutput.invalidFiles ?? [];
     }
 
+    /** @hidden */
     setInputValue(selectedFiles: File[]): void {
         let fileName = '';
         selectedFiles.forEach((file) => (fileName = fileName.concat(' ' + file.name)));
@@ -279,6 +283,7 @@ export class FileUploaderComponent implements ControlValueAccessor, OnDestroy, F
         this.invalidFiles = [];
     }
 
+    /** @hidden */
     private _isEmpty(): boolean {
         return this.validFiles.length === 0 && this.invalidFiles.length === 0;
     }

--- a/libs/core/src/lib/file-uploader/file-uploader.service.ts
+++ b/libs/core/src/lib/file-uploader/file-uploader.service.ts
@@ -52,6 +52,7 @@ export class FileUploaderService {
         return allowedExtensions.lastIndexOf(extension) !== -1;
     }
 
+    /** @hidden */
     private _checkSize(fileSize: number, maxSize: number, minSize: number): boolean {
         if (maxSize && fileSize > maxSize) {
             return false;

--- a/libs/core/src/lib/fixed-card-layout/fixed-card-layout-item/fixed-card-layout-item.component.ts
+++ b/libs/core/src/lib/fixed-card-layout/fixed-card-layout-item/fixed-card-layout-item.component.ts
@@ -10,6 +10,7 @@ import { FocusableOption } from '@angular/cdk/a11y';
     }
 })
 export class FixedCardLayoutItemComponent implements FocusableOption {
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** Set focus on the element. */

--- a/libs/core/src/lib/flexible-column-layout/flexible-column-layout.component.ts
+++ b/libs/core/src/lib/flexible-column-layout/flexible-column-layout.component.ts
@@ -172,6 +172,7 @@ export class FlexibleColumnLayoutComponent implements AfterViewInit, OnChanges, 
      */
     private _responsiveFullscreenLayout = false;
 
+    /** @hidden */
     constructor(@Inject(FD_FLEXIBLE_LAYOUT_CONFIG) private readonly _config: FlexibleLayoutConfig) {}
 
     /**

--- a/libs/core/src/lib/form/form-control/deprecated-form-control-content-density.directive.ts
+++ b/libs/core/src/lib/form/form-control/deprecated-form-control-content-density.directive.ts
@@ -11,6 +11,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedFormControlContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('input[fd-form-control][compact], textarea[fd-form-control]');
     }

--- a/libs/core/src/lib/form/form-control/form-control.component.ts
+++ b/libs/core/src/lib/form/form-control/form-control.component.ts
@@ -39,6 +39,7 @@ export class FormControlComponent implements CssClassBuilder, OnInit, OnChanges,
     @Input()
     state: FormStates | null = null;
 
+    /** Type of the form control. */
     @Input()
     type: string;
 
@@ -67,11 +68,12 @@ export class FormControlComponent implements CssClassBuilder, OnInit, OnChanges,
     /** @hidden */
     private _subscriptions = new Subscription();
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [this.state ? 'is-' + this.state : '', this.class];
     }

--- a/libs/core/src/lib/form/form-control/input-form-control.directive.ts
+++ b/libs/core/src/lib/form/form-control/input-form-control.directive.ts
@@ -20,6 +20,7 @@ import {
     }
 })
 export class InputFormControlDirective {
+    /** @hidden */
     constructor(private _contentDensityObserver: ContentDensityObserver) {
         _contentDensityObserver.subscribe();
     }

--- a/libs/core/src/lib/form/form-control/textarea-form-control.directive.ts
+++ b/libs/core/src/lib/form/form-control/textarea-form-control.directive.ts
@@ -20,6 +20,7 @@ import {
     }
 })
 export class TextareaFormControlDirective {
+    /** @hidden */
     constructor(private _contentDensityObserver: ContentDensityObserver) {
         _contentDensityObserver.subscribe();
     }

--- a/libs/core/src/lib/form/form-group/form-group.component.ts
+++ b/libs/core/src/lib/form/form-group/form-group.component.ts
@@ -31,6 +31,7 @@ import { CssClassBuilder } from '@fundamental-ngx/core/utils';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FormGroupComponent implements CssClassBuilder, OnChanges, OnInit {
+    /** @hidden */
     @HostBinding('class.fd-form-group')
     fdFormGroupClass = true;
 

--- a/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.ts
+++ b/libs/core/src/lib/form/form-input-message-group/form-input-message-group.component.ts
@@ -9,16 +9,16 @@ import { Placement, PopoverFillMode } from '@fundamental-ngx/core/shared';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FormInputMessageGroupComponent {
-    /*
+    /**
      * To allow user to determine what event he wants to trigger the messages to show
      * Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp).
      */
     @Input()
     triggers: string[] = ['focusin', 'focusout'];
 
-    /*
+    /**
      * Allows the user to decide if he wants to keep the error message after they click outside
-     *  Whether the popover should close when a click is made outside its boundaries.
+     * Whether the popover should close when a click is made outside its boundaries.
      */
     @Input()
     closeOnOutsideClick = false;

--- a/libs/core/src/lib/form/form-item/form-item.component.ts
+++ b/libs/core/src/lib/form/form-item/form-item.component.ts
@@ -53,6 +53,7 @@ export class FormItemComponent implements AfterViewInit {
     @ContentChild(FORM_ITEM_CONTROL)
     formItemControl?: FormItemControl;
 
+    /** @hidden */
     constructor(private ngZone: NgZone) {}
 
     /** @hidden */

--- a/libs/core/src/lib/form/form-message/constants.ts
+++ b/libs/core/src/lib/form/form-message/constants.ts
@@ -10,6 +10,7 @@ export const CSS_CLASS_NAME = {
     messageInformation: 'fd-form-message--information'
 };
 
+/** Get form message CSS class accordingly to its type */
 export function getTypeClassName(size: FormStates): string | null {
     switch (size) {
         case 'error':

--- a/libs/core/src/lib/form/form-message/form-message.component.ts
+++ b/libs/core/src/lib/form/form-message/form-message.component.ts
@@ -49,6 +49,7 @@ export class FormMessageComponent implements CssClassBuilder, OnInit, OnChanges 
     @Input()
     class: string;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/form/form-message/popover-form-message.service.ts
+++ b/libs/core/src/lib/form/form-message/popover-form-message.service.ts
@@ -14,6 +14,7 @@ export class PopoverFormMessageService {
     /** @hidden */
     private _hidden = false;
 
+    /** @hidden */
     constructor(private _popoverService: PopoverService) {}
 
     /** @hidden */

--- a/libs/core/src/lib/formatted-text/utils/html-sanitizer.ts
+++ b/libs/core/src/lib/formatted-text/utils/html-sanitizer.ts
@@ -8,24 +8,31 @@ interface SanitizeWrapper {
 }
 
 export class HtmlSanitizer {
+    /** @hidden */
     tagWhitelist: StringKey<boolean> = {};
+    /** @hidden */
     attributeWhitelist: StringKey<string | boolean> = {};
 
+    /** @hidden */
     private _schemaWhiteList: string[] = ['http', 'https', 'ftp', 'mailto'];
 
+    /** @hidden */
     private _uriAttributes: StringKey<boolean> = {
         href: true
     };
 
+    /** @hidden */
     private _safeWrapper: SanitizeWrapper | null = {
         iframe: null,
         iframeDoc: null
     };
 
+    /** @hidden */
     constructor() {
         this.extendTags();
     }
 
+    /** @hidden */
     get defTagWhitelist(): StringKey<boolean> {
         return {
             A: true,
@@ -55,6 +62,7 @@ export class HtmlSanitizer {
         };
     }
 
+    /** @hidden */
     get defAttributeWhitelist(): StringKey<string | boolean> {
         return {
             class: true,
@@ -69,14 +77,17 @@ export class HtmlSanitizer {
         };
     }
 
+    /** @hidden */
     extendTags(customTags?: StringKey<boolean | string>): void {
         this.tagWhitelist = { ...this.defTagWhitelist, ...customTags, BODY: true };
     }
 
+    /** @hidden */
     extendAttrs(customAttrs?: StringKey<boolean | string>): void {
         this.attributeWhitelist = { ...this.defAttributeWhitelist, ...customAttrs };
     }
 
+    /** @hidden */
     sanitizeHtml(input: string): string {
         input = input.trim();
         if (input.length === 0) {
@@ -96,6 +107,7 @@ export class HtmlSanitizer {
         return resultElement.innerHTML;
     }
 
+    /** @hidden */
     private _makeSanitizedCopy(node: Node): HTMLElement {
         let newNode = node;
         if (node.nodeType === Node.TEXT_NODE) {
@@ -109,6 +121,7 @@ export class HtmlSanitizer {
         return newNode as HTMLElement;
     }
 
+    /** @hidden */
     private _implementTag(node: HTMLElement): HTMLElement {
         const newNode = this._safeWrapper?.iframeDoc?.createElement(node.tagName);
 
@@ -148,6 +161,7 @@ export class HtmlSanitizer {
         return newNode;
     }
 
+    /** @hidden */
     private _extendLinkTarget(node: HTMLElement): HTMLElement {
         if (node.tagName === 'A') {
             const hrefAttr = node.getAttribute('href');
@@ -162,6 +176,7 @@ export class HtmlSanitizer {
         return node;
     }
 
+    /** @hidden */
     private _getSafeWrapper(): SanitizeWrapper | null {
         const iframe = document.createElement('iframe');
         if (iframe.sandbox === undefined) {
@@ -184,16 +199,19 @@ export class HtmlSanitizer {
         return { iframe, iframeDoc };
     }
 
+    /** @hidden */
     private _removeSafeWrapper(): void {
         if (this._safeWrapper?.iframe) {
             document.body.removeChild(this._safeWrapper.iframe);
         }
     }
 
+    /** @hidden */
     private _validateBySchema(value: string | null): boolean {
         return !!value && value.indexOf(':') > -1 && !this._startsWithAny(value, this._schemaWhiteList);
     }
 
+    /** @hidden */
     private _startsWithAny(str: string, substrings: string[]): boolean {
         return !!str && substrings.some((value) => str.indexOf(value) === 0);
     }

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.ts
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.ts
@@ -209,14 +209,13 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
     _isActive = true;
 
     /** @hidden */
-    get gridLayoutClasses(): string[] {
-        return this._gridLayoutClasses;
-    }
-
     set gridLayoutClasses(value: string[]) {
         this._removeClassesNames(this._gridLayoutClasses);
         this._gridLayoutClasses = value;
         this._addClassesNames(this._gridLayoutClasses);
+    }
+    get gridLayoutClasses(): string[] {
+        return this._gridLayoutClasses;
     }
 
     /** @hidden */
@@ -235,11 +234,6 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
     _selectedItem?: T;
 
     /** @hidden */
-    get selectionMode(): GridListSelectionMode | undefined {
-        return this._selectionMode;
-    }
-
-    /** @hidden */
     set selectionMode(mode: GridListSelectionMode | undefined) {
         this._selectionMode = mode;
 
@@ -255,6 +249,9 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
 
         this._cd.detectChanges();
     }
+    get selectionMode(): GridListSelectionMode | undefined {
+        return this._selectionMode;
+    }
 
     /** @hidden */
     _index?: number;
@@ -268,6 +265,7 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
     /** @hidden */
     private readonly subscription = new Subscription();
 
+    /** @hidden */
     constructor(
         private readonly _cd: ChangeDetectorRef,
         private readonly _elementRef: ElementRef,

--- a/libs/core/src/lib/grid-list/components/grid-list/grid-list.component.ts
+++ b/libs/core/src/lib/grid-list/components/grid-list/grid-list.component.ts
@@ -100,6 +100,7 @@ export class GridListComponent<T> extends GridList<T> implements OnChanges, Afte
     /** @hidden */
     private readonly _selectedItemsSubject$ = new BehaviorSubject<GridListSelectionEvent<T>>(this._selectedItems);
 
+    /** @hidden */
     readonly _selectedItems$ = this._selectedItemsSubject$.asObservable();
 
     /** @hidden */

--- a/libs/core/src/lib/grid-list/helpers/parse-layout-pattern.ts
+++ b/libs/core/src/lib/grid-list/helpers/parse-layout-pattern.ts
@@ -6,6 +6,7 @@ interface ParseLayout {
     };
 }
 
+/** Parse layout pattern */
 export function parseLayoutPattern(pattern: string | undefined, isBaseLayout = true): string[] {
     const parseLayout = pattern && validateAndParseLayoutPattern(pattern, isBaseLayout);
 

--- a/libs/core/src/lib/icon/icon.component.ts
+++ b/libs/core/src/lib/icon/icon.component.ts
@@ -72,11 +72,12 @@ export class IconComponent implements OnChanges, OnInit, CssClassBuilder {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             this.class,
@@ -88,6 +89,7 @@ export class IconComponent implements OnChanges, OnInit, CssClassBuilder {
         ];
     }
 
+    /** @hidden */
     elementRef(): ElementRef<any> {
         return this._elementRef;
     }

--- a/libs/core/src/lib/illustrated-message/illustrated-message.component.ts
+++ b/libs/core/src/lib/illustrated-message/illustrated-message.component.ts
@@ -127,11 +127,13 @@ export class IllustratedMessageComponent implements AfterViewInit, OnChanges, On
         return this._elementRef;
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /**
+     * @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-illustrated-message', this.type ? `fd-illustrated-message--${this.type}` : '', this.class];
     }

--- a/libs/core/src/lib/infinite-scroll/infinite-scroll.directive.ts
+++ b/libs/core/src/lib/infinite-scroll/infinite-scroll.directive.ts
@@ -39,6 +39,7 @@ export class InfiniteScrollDirective implements OnInit, OnDestroy {
         this._subscription.unsubscribe();
     }
 
+    /** @hidden */
     shouldTriggerAction(): boolean {
         const element = this._element.nativeElement;
         const offset: number = element.scrollTop + element.offsetHeight;

--- a/libs/core/src/lib/inline-help/inline-help.directive.ts
+++ b/libs/core/src/lib/inline-help/inline-help.directive.ts
@@ -56,6 +56,7 @@ export class InlineHelpDirective extends BasePopoverClass implements OnInit, OnC
     @Input('fd-inline-help-template')
     inlineHelpTemplate: Nullable<TemplateRef<any>> = null;
 
+    /** @hidden */
     constructor(
         private _popoverService: PopoverService,
         private _elementRef: ElementRef,

--- a/libs/core/src/lib/input-group/deprecated-input-group-compact.directive.ts
+++ b/libs/core/src/lib/input-group/deprecated-input-group-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedInputGroupCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-input-group[compact], [fd-input-group-addon][compact], [fd-input-group-input]');
     }

--- a/libs/core/src/lib/input-group/input-group-directives.ts
+++ b/libs/core/src/lib/input-group/input-group-directives.ts
@@ -56,15 +56,17 @@ export class InputGroupInputDirective implements CssClassBuilder, OnInit, OnChan
         this._subscriptions.unsubscribe();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-input', 'fd-input-group__input'];
     }
 
+    /** @hidden */
     elementRef(): ElementRef<any> {
         return this._elementRef;
     }
@@ -155,11 +157,12 @@ export class InputGroupAddOnDirective implements OnInit, OnChanges, CssClassBuil
         this._subscriptions.unsubscribe();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-input-group__addon',
@@ -169,6 +172,7 @@ export class InputGroupAddOnDirective implements OnInit, OnChanges, CssClassBuil
         ];
     }
 
+    /** @hidden */
     elementRef(): ElementRef<any> {
         return this._elementRef;
     }

--- a/libs/core/src/lib/input-group/input-group.component.ts
+++ b/libs/core/src/lib/input-group/input-group.component.ts
@@ -217,16 +217,14 @@ export class InputGroupComponent implements ControlValueAccessor, AfterViewInit,
     /** @hidden */
     onTouched: any = () => {};
 
-    /** Get the value of the text input. */
-    get inputText(): string {
-        return this._inputTextValue;
-    }
-
-    /** Set the value of the text input. */
+    /** Value of the text input. */
     set inputText(value) {
         this._inputTextValue = value;
 
         this.onChange(value);
+    }
+    get inputText(): string {
+        return this._inputTextValue;
     }
 
     /** @hidden

--- a/libs/core/src/lib/layout-panel/layout-panel.component.ts
+++ b/libs/core/src/lib/layout-panel/layout-panel.component.ts
@@ -31,6 +31,7 @@ export class LayoutPanelComponent implements OnChanges, OnInit {
     @HostBinding('class.fd-layout-panel')
     fdLayoutPanelClass = true;
 
+    /** @hidden */
     constructor(private elRef: ElementRef) {}
 
     /** @hidden */
@@ -43,6 +44,7 @@ export class LayoutPanelComponent implements OnChanges, OnInit {
         this._applyBackgroundImage();
     }
 
+    /** @hidden */
     private _applyBackgroundImage(): void {
         if (this.backgroundImage) {
             (this.elRef.nativeElement as HTMLElement).style['background-image'] = 'url("' + this.backgroundImage + '")';

--- a/libs/core/src/lib/link/link.component.ts
+++ b/libs/core/src/lib/link/link.component.ts
@@ -46,9 +46,11 @@ import { IconComponent } from '@fundamental-ngx/core/icon';
     ]
 })
 export class LinkComponent implements OnChanges, OnInit, CssClassBuilder, AfterViewInit, OnDestroy {
+    /** @hidden */
     @ContentChildren(IconComponent)
     iconComponents: QueryList<IconComponent>;
 
+    /** @hidden */
     @ViewChild('content')
     contentSpan: ElementRef<HTMLSpanElement>;
 
@@ -107,10 +109,11 @@ export class LinkComponent implements OnChanges, OnInit, CssClassBuilder, AfterV
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-link',

--- a/libs/core/src/lib/list/deprecated-list-content-density,directive.ts
+++ b/libs/core/src/lib/list/deprecated-list-content-density,directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedListContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('[fd-list][compact], [fdList]');
     }

--- a/libs/core/src/lib/list/directives/list-icon.directive.ts
+++ b/libs/core/src/lib/list/directives/list-icon.directive.ts
@@ -20,6 +20,7 @@ export class ListIconDirective implements OnChanges, OnInit {
     @HostBinding('attr.role')
     role = 'presentation';
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -32,11 +33,12 @@ export class ListIconDirective implements OnChanges, OnInit {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-list__icon', this.glyph ? 'sap-icon--' + this.glyph : '', this.class];
     }

--- a/libs/core/src/lib/list/directives/list-link.directive.ts
+++ b/libs/core/src/lib/list/directives/list-link.directive.ts
@@ -25,6 +25,7 @@ export class ListLinkDirective implements OnChanges {
     /** Emits when some of the properties, that should be read by screenreader, are changed */
     readonly _onReadablePropertyChanged$ = new Subject<void>();
 
+    /** @hidden */
     constructor(public elementRef: ElementRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/list/directives/list-navigation-item-text.directive.ts
+++ b/libs/core/src/lib/list/directives/list-navigation-item-text.directive.ts
@@ -8,6 +8,7 @@ export class ListNavigationItemTextDirective {
     @HostBinding('class.fd-list__navigation-item-text')
     navigationItemTextClass = true;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/list/list-focus-item.model.ts
+++ b/libs/core/src/lib/list/list-focus-item.model.ts
@@ -8,14 +8,14 @@ export abstract class ListFocusItem implements KeyboardSupportItemInterface {
     /** tab index attribute */
     @Input()
     @HostBinding('attr.tabindex')
+    set tabindex(value: number) {
+        this._tabIndex = coerceNumberProperty(value, -1);
+    }
     get tabindex(): number {
         if (this._isFirstItem && isNaN(this._tabIndex as number)) {
             return 0;
         }
         return this._tabIndex ?? -1;
-    }
-    set tabindex(value: number) {
-        this._tabIndex = coerceNumberProperty(value, -1);
     }
 
     /** @hidden */
@@ -41,6 +41,7 @@ export abstract class ListFocusItem implements KeyboardSupportItemInterface {
         });
     }
 
+    /** @hidden */
     constructor(readonly elementRef: ElementRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/list/list-item/list-item.component.ts
+++ b/libs/core/src/lib/list/list-item/list-item.component.ts
@@ -127,30 +127,26 @@ export class ListItemComponent
 
     /** @hidden */
     @ContentChild(RadioButtonComponent)
-    get radio(): RadioButtonComponent {
-        return this._radio;
-    }
-
-    /** @hidden */
     set radio(value: RadioButtonComponent) {
         this._radio = value;
         if (this._radio && this._radio.tabIndex == null) {
             this._radio.tabIndex = -1;
         }
     }
-
-    /** @hidden */
-    @ContentChild(CheckboxComponent)
-    get checkbox(): CheckboxComponent {
-        return this._checkbox;
+    get radio(): RadioButtonComponent {
+        return this._radio;
     }
 
     /** @hidden */
+    @ContentChild(CheckboxComponent)
     set checkbox(value: CheckboxComponent) {
         this._checkbox = value;
         if (this._checkbox && this._checkbox.tabIndexValue == null) {
             this._checkbox.tabIndexValue = -1;
         }
+    }
+    get checkbox(): CheckboxComponent {
+        return this._checkbox;
     }
 
     /** @hidden */
@@ -198,6 +194,7 @@ export class ListItemComponent
     /** @hidden */
     readonly _uniqueId = 'fd-list-item-' + ++listItemUniqueId;
 
+    /** @hidden */
     constructor(public elementRef: ElementRef, private _changeDetectorRef: ChangeDetectorRef) {
         super(elementRef);
     }

--- a/libs/core/src/lib/list/list-message.directive.ts
+++ b/libs/core/src/lib/list/list-message.directive.ts
@@ -28,11 +28,12 @@ export class ListMessageDirective implements OnChanges, OnInit, CssClassBuilder 
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-list__message', this.type ? 'fd-list__message--' + this.type : '', this.class];
     }

--- a/libs/core/src/lib/menu/directives/deprecated-menu-compact.directive.ts
+++ b/libs/core/src/lib/menu/directives/deprecated-menu-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedMenuCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-menu');
     }

--- a/libs/core/src/lib/menu/directives/menu-trigger.directive.ts
+++ b/libs/core/src/lib/menu/directives/menu-trigger.directive.ts
@@ -21,12 +21,15 @@ export class MenuTriggerDirective implements OnDestroy {
         this._setAriaAttributes(menu);
     }
 
+    /** @hidden */
     @HostBinding('attr.aria-haspopup')
     ariaHasPopup: Nullable<boolean>;
 
+    /** @hidden */
     @HostBinding('attr.aria-controls')
     ariaControls: Nullable<string>;
 
+    /** @hidden */
     @HostBinding('attr.aria-expanded')
     ariaExpanded: Nullable<boolean>;
 

--- a/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.ts
+++ b/libs/core/src/lib/menu/menu-mobile/menu-mobile.component.ts
@@ -50,6 +50,7 @@ export class MenuMobileComponent extends MobileModeBase<MenuInterface> implement
     /** @hidden Navigation icon name based on RTL */
     navigationIcon$: Observable<string>;
 
+    /** @hidden */
     constructor(
         elementRef: ElementRef,
         dialogService: DialogService,

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -184,15 +184,15 @@ export class MenuComponent
         this._popoverService.onDestroy();
     }
 
-    get trigger(): ElementRef {
-        return this._externalTrigger;
-    }
-
+    /** @hidden */
     set trigger(trigger: ElementRef) {
         this._externalTrigger = trigger;
         this._popoverService.initialise(this._externalTrigger);
         this._destroyEventListeners();
         this._listenOnTriggerRefClicks();
+    }
+    get trigger(): ElementRef {
+        return this._externalTrigger;
     }
 
     /** Opens the menu */

--- a/libs/core/src/lib/menu/services/menu.service.ts
+++ b/libs/core/src/lib/menu/services/menu.service.ts
@@ -40,6 +40,7 @@ export class MenuService {
         return this._rtlService?.rtl.value;
     }
 
+    /** @hidden */
     constructor(private _renderer: Renderer2, @Optional() private readonly _rtlService: RtlService) {}
 
     /** Reference to menu component */
@@ -134,6 +135,7 @@ export class MenuService {
         }
     }
 
+    /** @hidden */
     onDestroy(): void {
         this.removeKeyboardSupport();
     }
@@ -232,6 +234,7 @@ export class MenuService {
         );
     }
 
+    /** @hidden */
     private _handleKey(event: KeyboardEvent): void {
         const focusRight = (node): void => {
             setTimeout(() => this.setFocused(node.children[0].item));

--- a/libs/core/src/lib/message-box/message-box-default/message-box-default.component.ts
+++ b/libs/core/src/lib/message-box/message-box-default/message-box-default.component.ts
@@ -33,6 +33,7 @@ export class MessageBoxDefaultComponent implements OnInit, AfterViewInit {
     /** @hidden */
     constructor(public _messageBoxConfig: MessageBoxConfig, private _changeDetectorRef: ChangeDetectorRef) {}
 
+    /** @hidden */
     ngOnInit(): void {
         this._footerVisible = !!(this._messageBoxContent.cancelButton || this._messageBoxContent.approveButton);
     }

--- a/libs/core/src/lib/message-box/utils/message-box-config.class.ts
+++ b/libs/core/src/lib/message-box/utils/message-box-config.class.ts
@@ -9,13 +9,18 @@ export type MessageBoxType = 'error' | 'success' | 'warning' | 'information' | '
 
 /** @hidden */
 export abstract class MessageBoxHost {
+    /** @hidden */
     _messageBoxConfig: MessageBoxConfig | undefined;
 }
 
 @Injectable()
 export class MessageBoxConfig<T = any> extends DialogConfigBase<T> {
+    /** Message box type */
     type?: MessageBoxType;
+    /** Whether to show the semantic icon */
     showSemanticIcon?: boolean = false;
+    /** Custom semantic icon name */
     customSemanticIcon?: string;
+    /** Injector */
     injector?: Injector;
 }

--- a/libs/core/src/lib/message-box/utils/message-box-content.class.ts
+++ b/libs/core/src/lib/message-box/utils/message-box-content.class.ts
@@ -2,5 +2,6 @@ import { DialogContentBase } from '@fundamental-ngx/core/dialog';
 import { TemplateRef } from '@angular/core';
 
 export class MessageBoxContent extends DialogContentBase {
+    /** @hidden */
     content?: TemplateRef<any> | string;
 }

--- a/libs/core/src/lib/message-page/message-page.component.ts
+++ b/libs/core/src/lib/message-page/message-page.component.ts
@@ -72,10 +72,11 @@ export class MessagePageComponent implements OnChanges, OnInit, CssClassBuilder 
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-message-page', this.class];
     }

--- a/libs/core/src/lib/message-strip/message-strip.component.ts
+++ b/libs/core/src/lib/message-strip/message-strip.component.ts
@@ -118,11 +118,12 @@ export class MessageStripComponent implements OnInit, OnChanges, CssClassBuilder
         this.onDismiss.emit();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-message-strip',

--- a/libs/core/src/lib/message-toast/message-toast-service/message-toast.service.ts
+++ b/libs/core/src/lib/message-toast/message-toast-service/message-toast.service.ts
@@ -12,7 +12,10 @@ import { DynamicComponentService } from '@fundamental-ngx/core/utils';
  */
 @Injectable()
 export class MessageToastService {
+    /** @hidden */
     private _messageToasts: ComponentRef<MessageToastComponent>[] = [];
+
+    /** @hidden */
     private _messageToastContainerRef: ComponentRef<MessageToastContainerComponent> | undefined;
 
     /** @hidden */

--- a/libs/core/src/lib/message-toast/message-toast-utils/message-toast-ref.ts
+++ b/libs/core/src/lib/message-toast/message-toast-utils/message-toast-ref.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
  * For a template, add let-messageToast to your ng-template tag. Now using *messageToast* in the template refers to this class.
  */
 export class MessageToastRef {
+    /** @hidden */
     private readonly _afterTimeout = new Subject<void>();
 
     /** Observable that is triggered when the message toast has timed out. */

--- a/libs/core/src/lib/micro-process-flow/components/micro-process-flow/deprecated-micro-process-flow-content-density.directive.ts
+++ b/libs/core/src/lib/micro-process-flow/components/micro-process-flow/deprecated-micro-process-flow-content-density.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedMicroProcessFlowContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-micro-process-flow');
     }

--- a/libs/core/src/lib/micro-process-flow/components/micro-process-flow/micro-process-flow.component.ts
+++ b/libs/core/src/lib/micro-process-flow/components/micro-process-flow/micro-process-flow.component.ts
@@ -117,6 +117,7 @@ export class MicroProcessFlowComponent implements OnInit, OnDestroy, AfterViewIn
     /** @hidden */
     private _navigationKeys = [LEFT_ARROW, RIGHT_ARROW];
 
+    /** @hidden */
     private _actionKeys = [SPACE, ENTER];
 
     /** @hidden */
@@ -342,6 +343,7 @@ export class MicroProcessFlowComponent implements OnInit, OnDestroy, AfterViewIn
             .reduce((width, item) => item.elRef.nativeElement.offsetWidth + width, 0);
     }
 
+    /** @hidden */
     private _disableFocusableItems(): void {
         this.items.forEach((item) => item.focusableElement?.setFocusable(false));
     }

--- a/libs/core/src/lib/micro-process-flow/micro-process-flow-focusable-item.directive.ts
+++ b/libs/core/src/lib/micro-process-flow/micro-process-flow-focusable-item.directive.ts
@@ -39,6 +39,7 @@ export class MicroProcessFlowFocusableItemDirective implements OnInit {
         this._microProcessFlow?.canItemsReceiveFocus.next(false);
     }
 
+    /** @hidden */
     @HostListener('blur')
     onBlur(): void {
         this._microProcessFlow?.canItemsReceiveFocus.next(true);

--- a/libs/core/src/lib/mobile-mode/mobile-mode.class.ts
+++ b/libs/core/src/lib/mobile-mode/mobile-mode.class.ts
@@ -39,6 +39,7 @@ export abstract class MobileModeBase<T extends MobileMode> {
     /** @hidden */
     protected readonly _onDestroy$: Subject<void> = new Subject<void>();
 
+    /** @hidden */
     constructor(
         protected _elementRef: ElementRef,
         protected _dialogService: DialogService,

--- a/libs/core/src/lib/multi-input/deprecated-multi-input-compact.directive.ts
+++ b/libs/core/src/lib/multi-input/deprecated-multi-input-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedMultiInputCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-multi-input');
     }

--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
@@ -51,6 +51,7 @@ export class MultiInputMobileComponent
     /** @hidden */
     private _selectedBackup: any[];
 
+    /** @hidden */
     constructor(
         elementRef: ElementRef,
         dialogService: DialogService,
@@ -71,6 +72,7 @@ export class MultiInputMobileComponent
         this.dialogRef.hide(true);
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this.dialogRef.close();
         super.onDestroy();

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -116,11 +116,11 @@ export class MultiInputComponent
 
     /** Search term, or more specifically the value of the inner input field. */
     @Input()
-    get searchTerm(): string {
-        return this._searchTermCtrl.value ?? '';
-    }
     set searchTerm(value: string) {
         this._searchTermCtrl.setValue(value);
+    }
+    get searchTerm(): string {
+        return this._searchTermCtrl.value ?? '';
     }
 
     /** Id attribute for input element inside MultiInput component */
@@ -133,12 +133,12 @@ export class MultiInputComponent
 
     /** Selected dropdown items. */
     @Input()
-    get selected(): any[] {
-        return this._selectionModel.selected;
-    }
     set selected(values: any[]) {
         this._selectionModel.clear();
         values?.forEach((item) => this._selectionModel.select(item));
+    }
+    get selected(): any[] {
+        return this._selectionModel.selected;
     }
 
     /** user's custom classes */
@@ -405,11 +405,11 @@ export class MultiInputComponent
         this._subscriptions.unsubscribe();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         // TODO: this icon flip may be addressed in styles in the future
         if (this.glyph === 'value-help' && this._dir === 'rtl') {
@@ -576,6 +576,7 @@ export class MultiInputComponent
         this._propagateChange();
     }
 
+    /** @hidden */
     _handleInputKeydown(event: KeyboardEvent): void {
         if (KeyUtil.isKeyCode(event, DOWN_ARROW) && !this.mobile) {
             if (event.altKey) {

--- a/libs/core/src/lib/nested-list/deprecated-nested-list-compact.directive.ts
+++ b/libs/core/src/lib/nested-list/deprecated-nested-list-compact.directive.ts
@@ -11,6 +11,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedNestedListCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('[fdNestedList][compact], [fd-nested-list]');
     }

--- a/libs/core/src/lib/nested-list/nested-content/nested-list-content.directive.ts
+++ b/libs/core/src/lib/nested-list/nested-content/nested-list-content.directive.ts
@@ -61,9 +61,11 @@ export class NestedListContentDirective implements AfterContentInit, OnDestroy {
     @HostBinding('class.has-child')
     hasChildren = false;
 
+    /** @hidden */
     @ContentChild(NestedLinkDirective)
     nestedLink: NestedLinkDirective;
 
+    /** @hidden */
     @ContentChild(NestedListExpandIconComponent)
     nestedExpandIcon: NestedListExpandIconComponent;
 

--- a/libs/core/src/lib/nested-list/nested-item/nested-item.service.ts
+++ b/libs/core/src/lib/nested-list/nested-item/nested-item.service.ts
@@ -4,7 +4,9 @@ import { Subject } from 'rxjs';
 
 /** Contains references to popover or list nested components, that are placed as direct children of item component */
 export class NestedItemService {
+    /** @hidden */
     list: NestedListInterface;
+    /** @hidden */
     popover?: NestedListPopoverInterface;
 
     /** Subject fired when expand icon is clicked */

--- a/libs/core/src/lib/nested-list/nested-list-directives.ts
+++ b/libs/core/src/lib/nested-list/nested-list-directives.ts
@@ -25,6 +25,7 @@ let uniqueId = 0;
     selector: '[fdNestedDirectivesHeader], [fd-nested-list-header]'
 })
 export class NestedListHeaderDirective {
+    /** Id of the element. */
     @Input()
     @HostBinding('attr.id')
     id: string | null = `fd-nested-list-group-header-${++uniqueId}`;
@@ -33,6 +34,7 @@ export class NestedListHeaderDirective {
     @HostBinding('class.fd-nested-list__group-header')
     fdNestedListHeaderClass = true;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** Get the header title */
@@ -77,8 +79,8 @@ export class NestedListIconDirective implements CssClassBuilder, OnChanges, OnIn
         this.buildComponentCssClass();
     }
 
+    /** @hidden CssClassBuilder interface implementation */
     @applyCssClass
-    /** CssClassBuilder interface implementation */
     buildComponentCssClass(): string[] {
         return ['fd-nested-list__icon', this.glyph ? `sap-icon--${this.glyph}` : '', this.class];
     }
@@ -144,6 +146,7 @@ export class NestedListExpandIconComponent {
     /** @hidden */
     sideArrowIcon$: Observable<string>;
 
+    /** @hidden */
     constructor(
         private _itemService: NestedItemService,
         private _changeDetRef: ChangeDetectorRef,

--- a/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
+++ b/libs/core/src/lib/nested-list/nested-list-keyboard.service.ts
@@ -19,6 +19,7 @@ export class NestedListKeyboardService {
      */
     readonly refresh$: Subject<void> = new Subject<void>();
 
+    /** @hidden */
     constructor(@Inject(MenuKeyboardService) private keyboardService: MenuKeyboardService) {}
 
     /**

--- a/libs/core/src/lib/notification/directives/notification-indicator.directive.ts
+++ b/libs/core/src/lib/notification/directives/notification-indicator.directive.ts
@@ -29,11 +29,12 @@ export class NotificationIndicatorDirective implements OnChanges, OnInit, CssCla
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-notification__indicator', this.type ? 'fd-notification__indicator--' + this.type : '', this.class];
     }

--- a/libs/core/src/lib/notification/notification-group-header/notification-group-header.component.ts
+++ b/libs/core/src/lib/notification/notification-group-header/notification-group-header.component.ts
@@ -79,10 +79,12 @@ export class NotificationGroupHeaderComponent extends NotificationGroupBaseDirec
     @Output()
     expandedChange = new EventEmitter<boolean>();
 
+    /** @hidden */
     get _expandButtonContentDensity(): LocalContentDensityMode {
         return typeof this.expandCompact === 'undefined' ? 'global' : ContentDensityMode.COMPACT;
     }
 
+    /** @hidden */
     constructor(private _cdRef: ChangeDetectorRef, @Optional() private _rtlService: RtlService, renderer: Renderer2) {
         super(renderer);
     }

--- a/libs/core/src/lib/notification/notification-group-list/notification-group-list.component.ts
+++ b/libs/core/src/lib/notification/notification-group-list/notification-group-list.component.ts
@@ -33,6 +33,7 @@ export class NotificationGroupListComponent implements AfterContentInit, OnDestr
     /** @hidden */
     private readonly _subscriptions = new Subscription();
 
+    /** @hidden */
     constructor(private readonly _changeDetectorRef: ChangeDetectorRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/notification/notification-group/notification-group.component.ts
+++ b/libs/core/src/lib/notification/notification-group/notification-group.component.ts
@@ -38,10 +38,10 @@ export class NotificationGroupComponent implements OnChanges, OnInit, CssClassBu
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden CssClassBuilder interface implementation
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-notification fd-notification--group fd-notification-custom-block',

--- a/libs/core/src/lib/notification/notification-service/notification.service.ts
+++ b/libs/core/src/lib/notification/notification-service/notification.service.ts
@@ -8,11 +8,13 @@ import { DOCUMENT } from '@angular/common';
 
 @Injectable()
 export class NotificationService {
+    /** @hidden */
     public notifications: {
         notificationComponent: ComponentRef<NotificationComponent>;
         notificationConfig: Readonly<NotificationConfig>;
     }[] = [];
 
+    /** @hidden */
     public containerRef: ComponentRef<NotificationContainer> | null;
 
     /**

--- a/libs/core/src/lib/notification/notification-utils/notification-group-base.ts
+++ b/libs/core/src/lib/notification/notification-utils/notification-group-base.ts
@@ -17,6 +17,7 @@ export abstract class NotificationGroupBaseDirective implements AfterViewInit, O
     /** @hidden */
     private readonly onDestroy$ = new Subject<void>();
 
+    /** @hidden */
     constructor(private renderer: Renderer2) {}
 
     /** @hidden */

--- a/libs/core/src/lib/notification/notification/notification.component.ts
+++ b/libs/core/src/lib/notification/notification/notification.component.ts
@@ -97,6 +97,7 @@ export class NotificationComponent extends AbstractFdNgxClass implements OnInit,
     /** @hidden The class that traps and manages focus within the notification. */
     private _focusTrap: FocusTrap;
 
+    /** @hidden */
     constructor(
         private _elRef: ElementRef,
         private _componentFactoryResolver: ComponentFactoryResolver,

--- a/libs/core/src/lib/object-identifier/object-identifier.component.ts
+++ b/libs/core/src/lib/object-identifier/object-identifier.component.ts
@@ -47,12 +47,14 @@ export class ObjectIdentifierComponent implements AfterContentInit, OnDestroy {
     @HostBinding('class.fd-object-identifier')
     objectIdentifierClass = true;
 
+    /** @hidden */
     @ContentChildren(LinkComponent)
     linkComponents: QueryList<LinkComponent>;
 
     /** An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */
     private readonly _onDestroy$: Subject<void> = new Subject<void>();
 
+    /** @hidden */
     constructor(private _changeDetectorRef: ChangeDetectorRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/object-marker/object-marker.component.ts
+++ b/libs/core/src/lib/object-marker/object-marker.component.ts
@@ -44,11 +44,12 @@ export class ObjectMarkerComponent implements OnChanges, OnInit, CssClassBuilder
     /** @hidden */
     constructor(private readonly _elementRef: ElementRef) {}
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-object-marker', this.clickable ? 'fd-object-marker--link' : '', this.class];
     }

--- a/libs/core/src/lib/object-number/object-number.component.ts
+++ b/libs/core/src/lib/object-number/object-number.component.ts
@@ -80,11 +80,12 @@ export class ObjectNumberComponent implements OnInit, OnChanges, CssClassBuilder
         this._onChanges();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-object-number',

--- a/libs/core/src/lib/object-status/object-status.component.ts
+++ b/libs/core/src/lib/object-status/object-status.component.ts
@@ -101,11 +101,12 @@ export class ObjectStatusComponent implements OnChanges, OnInit, CssClassBuilder
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return buildObjectStatusCssClasses(this);
     }

--- a/libs/core/src/lib/overflow-layout/directives/overflow-expand.directive.ts
+++ b/libs/core/src/lib/overflow-layout/directives/overflow-expand.directive.ts
@@ -15,6 +15,7 @@ import { FD_OVERFLOW_EXPAND } from '../tokens/overflow-expand.token';
     ]
 })
 export class OverflowExpandDirective<T extends any[] = any[]> implements OverflowExpand<T> {
+    /** Items to expand */
     @Input()
     fdOverflowExpandItems: T;
 

--- a/libs/core/src/lib/overflow-layout/directives/overflow-item-ref.directive.ts
+++ b/libs/core/src/lib/overflow-layout/directives/overflow-item-ref.directive.ts
@@ -24,16 +24,16 @@ export class OverflowItemRefDirective<T = any> implements OverflowItemRef<T> {
      * `fdOverflowLayoutItem` directive.
      */
     overflowItem: OverflowItem;
+
     /**
      * Whether the item is hidden.
      */
-    get hidden(): boolean {
-        return this._hidden;
-    }
-
     set hidden(value: boolean) {
         this._hidden = value;
         this.overflowItem.hiddenChange.emit(value);
+    }
+    get hidden(): boolean {
+        return this._hidden;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/overflow-layout/directives/overflow-layout-item.directive.ts
+++ b/libs/core/src/lib/overflow-layout/directives/overflow-layout-item.directive.ts
@@ -43,12 +43,11 @@ export class OverflowLayoutItemDirective implements OverflowItem, OnInit {
     /**
      * Whether the item is hidden.
      */
-    get hidden(): boolean {
-        return this._overflowItemRef?.hidden === true;
-    }
-
     set hidden(value: boolean) {
         this.hiddenChange.emit(value);
+    }
+    get hidden(): boolean {
+        return this._overflowItemRef?.hidden === true;
     }
 
     /**

--- a/libs/core/src/lib/overflow-layout/directives/overflow-layout-popover-content.directive.ts
+++ b/libs/core/src/lib/overflow-layout/directives/overflow-layout-popover-content.directive.ts
@@ -46,6 +46,7 @@ export class OverflowLayoutPopoverContentDirective implements OverflowPopoverCon
     @HostBinding('class')
     private readonly _initialClass = 'fd-overflow-layout__popover-container';
 
+    /** @hidden */
     private _dir: 'ltr' | 'rtl' = 'ltr';
 
     /** @hidden */

--- a/libs/core/src/lib/overflow-layout/overflow-layout.service.ts
+++ b/libs/core/src/lib/overflow-layout/overflow-layout.service.ts
@@ -20,9 +20,16 @@ export interface OverflowLayoutConfig {
 }
 
 export class OverflowLayoutListeningResult {
+    /** Whether to show more button */
     showMore = false;
+
+    /** Overflow item s */
     items: OverflowItemRef[] = [];
+
+    /** Hidden overflow items */
     hiddenItems: OverflowItemRef[] = [];
+
+    /** Visible overflow items */
     visibleItems: OverflowItemRef[] = [];
 }
 
@@ -84,6 +91,7 @@ export class OverflowLayoutService implements OnDestroy {
         this._subscription.unsubscribe();
     }
 
+    /** @hidden */
     startListening(config: OverflowLayoutConfig): void {
         this.setConfig(config);
         this.fitVisibleItems();
@@ -92,10 +100,12 @@ export class OverflowLayoutService implements OnDestroy {
         this._subscribeToRtl();
     }
 
+    /** @hidden */
     setConfig(config: OverflowLayoutConfig): void {
         this.config = config;
     }
 
+    /** @hidden */
     private _emitResult(): void {
         this._result$.next(this.result);
     }

--- a/libs/core/src/lib/pagination/deprecated-pagination-compact.directive.ts
+++ b/libs/core/src/lib/pagination/deprecated-pagination-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedPaginationCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-pagination');
     }

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -87,24 +87,24 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
 
     /** Represents the current page number. */
     @Input()
-    get currentPage(): number {
-        return this._currentPage;
-    }
     set currentPage(value: number) {
         this._currentPage = Math.floor(coerceNumberProperty(value, 1));
+    }
+    get currentPage(): number {
+        return this._currentPage;
     }
 
     /** Represents the number of items per page. */
     @Input()
-    get itemsPerPage(): number {
-        return this._itemsPerPage;
-    }
     set itemsPerPage(value: number) {
         value = Math.floor(coerceNumberProperty(value, DEFAULT_ITEMS_PER_PAGE));
 
         this._itemsPerPage = Math.max(value, 1);
 
         this._updateDisplayedPageSizeOptions();
+    }
+    get itemsPerPage(): number {
+        return this._itemsPerPage;
     }
 
     /**
@@ -124,9 +124,6 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
 
     /** Represents the options for items per page. */
     @Input()
-    get itemsPerPageOptions(): number[] {
-        return this._itemsPerPageOptions;
-    }
     set itemsPerPageOptions(value: number[]) {
         this._itemsPerPageOptions = coerceArray<number>(value)
             .map((v) => coerceNumberProperty(v, 0))
@@ -135,6 +132,9 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
             .sort((a, b) => a - b);
 
         this._updateDisplayedPageSizeOptions();
+    }
+    get itemsPerPageOptions(): number[] {
+        return this._itemsPerPageOptions;
     }
 
     /** Whether to display the total number of items. */

--- a/libs/core/src/lib/panel/deprecated-panel-compact.directive.ts
+++ b/libs/core/src/lib/panel/deprecated-panel-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedPanelCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-panel');
     }

--- a/libs/core/src/lib/panel/panel.component.ts
+++ b/libs/core/src/lib/panel/panel.component.ts
@@ -94,6 +94,7 @@ export class PanelComponent implements OnInit, OnDestroy {
         this._listenRtl();
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this._subscription.unsubscribe();
     }

--- a/libs/core/src/lib/popover/base/base-popover.class.ts
+++ b/libs/core/src/lib/popover/base/base-popover.class.ts
@@ -4,8 +4,8 @@ import { Placement, PopoverFillMode, Nullable } from '@fundamental-ngx/core/shar
 
 @Directive()
 export class BasePopoverClass {
-    @Input()
     /** Whether to close the popover on router navigation start. */
+    @Input()
     closeOnNavigation = true;
 
     /** Whether the popover is disabled. */

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.ts
@@ -106,6 +106,7 @@ export class PopoverBodyComponent {
         }
     }
 
+    /** @hidden */
     constructor(
         readonly _elementRef: ElementRef,
         private _changeDetectorRef: ChangeDetectorRef,

--- a/libs/core/src/lib/popover/popover-container/popover-container.directive.ts
+++ b/libs/core/src/lib/popover/popover-container/popover-container.directive.ts
@@ -13,6 +13,7 @@ export class PopoverContainerDirective implements OnInit, OnDestroy {
     /** @hidden */
     private _destroy$ = new Subject<void>();
 
+    /** @hidden */
     constructor(private _elmRef: ElementRef<HTMLElement>) {}
 
     /** @hidden */

--- a/libs/core/src/lib/popover/popover-service/popover.service.ts
+++ b/libs/core/src/lib/popover/popover-service/popover.service.ts
@@ -65,6 +65,7 @@ export class PopoverService extends BasePopoverClass {
     /** An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */
     private readonly _onDestroy$: Subject<void> = new Subject<void>();
 
+    /** @hidden */
     constructor(
         private _overlay: Overlay,
         private _renderer: Renderer2,

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -81,6 +81,7 @@ export class PopoverComponent
     @Input()
     mobile = false;
 
+    /** Mobile config */
     @Input()
     mobileConfig: MobileModeConfig = { hasCloseButton: true };
 

--- a/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.ts
+++ b/libs/core/src/lib/product-switch/product-switch-body/product-switch-body.component.ts
@@ -59,6 +59,7 @@ export class ProductSwitchBodyComponent implements OnInit, OnDestroy {
     /** @hidden */
     private _subscriptions = new Subscription();
 
+    /** @hidden */
     constructor(
         private _viewportRuler: ViewportRuler,
         @Optional() private readonly _rtlService: RtlService,

--- a/libs/core/src/lib/product-switch/product-switch/product-switch.component.ts
+++ b/libs/core/src/lib/product-switch/product-switch/product-switch.component.ts
@@ -9,6 +9,7 @@ import { BasePopoverClass } from '@fundamental-ngx/core/popover';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ProductSwitchComponent extends BasePopoverClass {
+    /** Placement of a popover. */
     @Input()
     placement: Placement = 'bottom-end';
 

--- a/libs/core/src/lib/progress-indicator/progress-indicator.component.ts
+++ b/libs/core/src/lib/progress-indicator/progress-indicator.component.ts
@@ -60,6 +60,7 @@ export class ProgressIndicatorComponent implements OnInit, OnDestroy, OnChanges,
     /** @hidden An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */
     private readonly _onDestroy$: Subject<void> = new Subject<void>();
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef, private _cdRef: ChangeDetectorRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/radio/deprecated-radio-button-compact.directive.ts
+++ b/libs/core/src/lib/radio/deprecated-radio-button-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedRadioButtonCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-radio-button');
     }

--- a/libs/core/src/lib/radio/radio-button/radio-button.component.ts
+++ b/libs/core/src/lib/radio/radio-button/radio-button.component.ts
@@ -112,6 +112,7 @@ export class RadioButtonComponent
     @Input()
     required = false;
 
+    /** Whether the radio button is checked. */
     get checked(): boolean {
         if (this.value === undefined) {
             return false;

--- a/libs/core/src/lib/rating-indicator/components/rating-indicator.component.ts
+++ b/libs/core/src/lib/rating-indicator/components/rating-indicator.component.ts
@@ -171,6 +171,7 @@ export class RatingIndicatorComponent
     @Output()
     ratingChanged = new EventEmitter<number>();
 
+    /** @hidden */
     sizeClass = this._getSizeClass(this.size);
     /** @hidden */
     _rates: { id: string; value: number }[] = [];
@@ -280,11 +281,12 @@ export class RatingIndicatorComponent
         return this._elementRef;
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         this.sizeClass = this._getSizeClass(this.size);
 

--- a/libs/core/src/lib/rating-indicator/pipes/rating-star-label.pipe.ts
+++ b/libs/core/src/lib/rating-indicator/pipes/rating-star-label.pipe.ts
@@ -2,6 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({ name: 'ratingStarLabel' })
 export class RatingStarLabelPipe implements PipeTransform {
+    /** Transforms the value to a rating value string. */
     transform(index: number, controlsCount: number, useHalves: boolean): string {
         if (useHalves) {
             return `${index / 2 + 0.5} of ${controlsCount / 2}`;

--- a/libs/core/src/lib/resizable-card-layout/resizable-card-layout/resizable-card-item/resizable-card-item.component.ts
+++ b/libs/core/src/lib/resizable-card-layout/resizable-card-layout/resizable-card-item/resizable-card-item.component.ts
@@ -49,17 +49,15 @@ let cardUniqueId = 0;
     encapsulation: ViewEncapsulation.None
 })
 export class ResizableCardItemComponent implements FocusableOption, OnDestroy {
-    /** get card properties from the config */
+    /** Card properties from the config */
     @Input()
-    get config(): ResizableCardItemConfig {
-        return this._config;
-    }
-
-    /** Set card properties from the config received */
     set config(config: ResizableCardItemConfig) {
         this._config = config;
         this._initialSetup();
         this._cd.detectChanges();
+    }
+    get config(): ResizableCardItemConfig {
+        return this._config;
     }
 
     /** set uinque id for the card */
@@ -71,18 +69,11 @@ export class ResizableCardItemComponent implements FocusableOption, OnDestroy {
     title: string;
 
     /**
-     * return serial order of card.
+     * Serial order of card.
      * cards are sorted based on ranks before displaying layout.
      * card with lower rank will be displayed first in layout than the card with higher rank.
      */
     @Input()
-    get rank(): number {
-        return this._rank;
-    }
-
-    /**
-     * set serial order of card.
-     * */
     set rank(rankValue: number) {
         // determine max value between user given value and default value
         this._rank = rankValue ? rankValue : cardRank++;
@@ -90,76 +81,62 @@ export class ResizableCardItemComponent implements FocusableOption, OnDestroy {
             cardRank = rankValue;
         }
     }
+    get rank(): number {
+        return this._rank;
+    }
 
     /**
      * Number of column span card width takes.
      * It will be in step of 20rem.
      */
     @Input()
+    set cardWidthColSpan(colSpan: number) {
+        this._cardWidthColSpan = colSpan;
+        this._setCardWidth();
+    }
     get cardWidthColSpan(): number {
         return this._cardWidthColSpan;
     }
 
     /**
-     * set the number of column span, card will take.
-     * It sets the width of the card accordingly
-     */
-    set cardWidthColSpan(colSpan: number) {
-        this._cardWidthColSpan = colSpan;
-        this._setCardWidth();
-    }
-
-    /**
-     * return number of row span, card height takes.
+     * Number of row span, card height takes.
      * It will be in the step of 1rem.
      */
     @Input()
+    set cardHeightRowSpan(rowSpan: number) {
+        this._cardHeightRowSpan = rowSpan;
+        this._setCardHeight();
+    }
     get cardHeightRowSpan(): number {
         return this._cardHeightRowSpan;
     }
 
     /**
-     * set number of row span, card will take.
-     * It sets the height of the card accordingly
-     */
-    set cardHeightRowSpan(rowSpan: number) {
-        this._cardHeightRowSpan = rowSpan;
-        this._setCardHeight();
-    }
-    /**
-     * return number of row span card mini header height takes.
+     * Number of row span card mini header height takes.
      * Mini Header: The smallest representation of the card is the header.
      * The card can be collapsed to only its header height.
      */
     @Input()
+    set cardMiniHeaderRowSpan(rowSpan: number) {
+        this._cardMiniHeaderRowSpan = rowSpan;
+        this._setCardMiniHeaderHeight();
+    }
     get cardMiniHeaderRowSpan(): number {
         return this._cardMiniHeaderRowSpan;
     }
 
     /**
-     * set number of row span card mini header height takes.
-     */
-    set cardMiniHeaderRowSpan(rowSpan: number) {
-        this._cardMiniHeaderRowSpan = rowSpan;
-        this._setCardMiniHeaderHeight();
-    }
-
-    /**
-     * return number of row span card mini content height takes.
+     * Number of row span card mini content height takes.
      * Mini Content: The minimum height for the card content depends on the card type,
      * and must be as high as the smallest representation of the content.
      */
     @Input()
-    get cardMiniContentRowSpan(): number {
-        return this._cardMiniContentRowSpan ?? 0;
-    }
-
-    /**
-     * set number of row span card mini content height takes.
-     */
     set cardMiniContentRowSpan(rowSpan: number) {
         this._cardMiniContentRowSpan = rowSpan;
         this._setCardMiniContentHeight();
+    }
+    get cardMiniContentRowSpan(): number {
+        return this._cardMiniContentRowSpan ?? 0;
     }
 
     /** Card can be set to resizable=false, to restrict card resize */
@@ -296,6 +273,7 @@ export class ResizableCardItemComponent implements FocusableOption, OnDestroy {
     /** @hidden */
     private _subscriptions = new Subscription();
 
+    /** @hidden */
     constructor(
         private readonly _cd: ChangeDetectorRef,
         private readonly _elementRef: ElementRef,
@@ -306,6 +284,7 @@ export class ResizableCardItemComponent implements FocusableOption, OnDestroy {
         }
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this._subscriptions.unsubscribe();
     }
@@ -522,7 +501,7 @@ export class ResizableCardItemComponent implements FocusableOption, OnDestroy {
         );
     }
 
-    // @hidden Return previous height row span of the card
+    /** @hidden Return previous height row span of the card */
     get previousCardHeightRowSpan(): number {
         return this._prevCardHeightRowSpan;
     }
@@ -755,6 +734,18 @@ export interface ResizableCardItemConfig {
 
 /** Object to emit on resize complete */
 export class ResizedEvent {
+    /**
+     * Object to emit on resize complete
+     * @param card
+     * @param prevCardWidth Previous card width
+     * @param prevCardHeight Previous card height
+     * @param cardWidth Current card width
+     * @param cardHeight Current card height
+     * @param cardWidthColSpan Current card width column span
+     * @param cardHeightRowSpan Current card height row span
+     * @param newCardWidthColSpan New card width column span
+     * @param newCardHeightRowSpan New card height row span
+     */
     constructor(
         public card: ResizableCardItemComponent,
         public prevCardWidth: number,

--- a/libs/core/src/lib/resizable-card-layout/resizable-card-layout/resizable-card-layout.component.ts
+++ b/libs/core/src/lib/resizable-card-layout/resizable-card-layout/resizable-card-layout.component.ts
@@ -107,6 +107,7 @@ export class ResizableCardLayoutComponent implements OnInit, AfterViewInit, Afte
     /** @hidden */
     private _directionPosition: 'left' | 'right' = 'left';
 
+    /** @hidden */
     constructor(
         private readonly _cd: ChangeDetectorRef,
         private readonly _elementRef: ElementRef,
@@ -164,19 +165,18 @@ export class ResizableCardLayoutComponent implements OnInit, AfterViewInit, Afte
         }
     }
 
+    /** @hidden */
     @HostListener('window:resize')
     onResize(): void {
         this._createLayout();
     }
 
-    /** return layout size */
-    get layoutSize(): LayoutSize {
-        return this._layout;
-    }
-
-    /** set layout size. available options are 'sm', 'md', 'lg' and 'xl' */
+    /** Layout size. Available options are 'sm', 'md', 'lg' and 'xl' */
     set layoutSize(layoutSize: LayoutSize) {
         this._layout = layoutSize;
+    }
+    get layoutSize(): LayoutSize {
+        return this._layout;
     }
 
     /**
@@ -224,6 +224,7 @@ export class ResizableCardLayoutComponent implements OnInit, AfterViewInit, Afte
         return this._elementRef;
     }
 
+    /** @hidden */
     updateLayout(): void {
         this.resizeCardItems?.forEach((card) => {
             card?.verifyUpdateCardWidth(this.layoutSize);
@@ -437,7 +438,6 @@ export class ResizableCardLayoutComponent implements OnInit, AfterViewInit, Afte
      * Method to loop till this._columns -1 positions and exchange the rank
      * @param currentCardIndex: Index of current card
      */
-
     private _moveCardDown(currentCardIndex: number): void {
         // taking width of adjacent card col-span into account
 

--- a/libs/core/src/lib/segmented-button/segmented-button.component.ts
+++ b/libs/core/src/lib/segmented-button/segmented-button.component.ts
@@ -87,6 +87,7 @@ export class SegmentedButtonComponent implements AfterContentInit, ControlValueA
     /** @hidden */
     onTouched = (): void => {};
 
+    /** @hidden */
     constructor(private readonly _changeDetRef: ChangeDetectorRef, private readonly _elementRef: ElementRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/select/deprecated-select-compact.directive.ts
+++ b/libs/core/src/lib/select/deprecated-select-compact.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedSelectCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-select');
     }

--- a/libs/core/src/lib/select/option/option.component.ts
+++ b/libs/core/src/lib/select/option/option.component.ts
@@ -22,9 +22,14 @@ let optionUniqueId = 0;
 
 /**
  * Event object emitted by OptionComponent when
- * selected or deselected. *
+ * selected or deselected.
  */
 export class FdOptionSelectionChange {
+    /**
+     * Reference to the OptionComponent that emitted the event.
+     * @param source The option that emitted the event.
+     * @param isUserInput Whether the change in the option's value was a result of a user interaction.
+     */
     constructor(
         /** Reference to the option that emitted the event. */
         readonly source: OptionComponent,
@@ -87,6 +92,7 @@ export class OptionComponent implements AfterViewChecked, OnDestroy, FocusableOp
     @Output()
     readonly selectionChange = new EventEmitter<FdOptionSelectionChange>();
 
+    /** @hidden */
     @HostBinding('class.is-selected')
     selected = false;
 
@@ -102,6 +108,7 @@ export class OptionComponent implements AfterViewChecked, OnDestroy, FocusableOp
         return this._active;
     }
 
+    /** @hidden */
     readonly _stateChanges = new Subject<void>();
 
     /** @hidden */

--- a/libs/core/src/lib/select/select-key-manager.service.ts
+++ b/libs/core/src/lib/select/select-key-manager.service.ts
@@ -9,7 +9,10 @@ import { OptionsInterface } from './options.interface';
 
 @Injectable()
 export class SelectKeyManagerService {
+    /** @hidden */
     _component: SelectInterface;
+
+    /** @hidden */
     _keyManager: ActiveDescendantKeyManager<OptionsInterface>;
 
     /**

--- a/libs/core/src/lib/select/select-mobile/select-mobile.component.ts
+++ b/libs/core/src/lib/select/select-mobile/select-mobile.component.ts
@@ -47,11 +47,15 @@ export class SelectMobileComponent extends MobileModeBase<SelectInterface> imple
     /** @hidden */
     private _subscriptions = new Subscription();
 
-    @HostListener('keydown', ['$event']) onItemKeydown(event: KeyboardEvent): void {
+    /** @hidden */
+    @HostListener('keydown', ['$event'])
+    onItemKeydown(event: KeyboardEvent): void {
         if (event && KeyUtil.isKeyCode(event, [ESCAPE])) {
             this._component.close(true);
         }
     }
+
+    /** @hidden */
     constructor(
         _elementRef: ElementRef,
         _dialogService: DialogService,

--- a/libs/core/src/lib/select/select.component.ts
+++ b/libs/core/src/lib/select/select.component.ts
@@ -124,16 +124,16 @@ export class SelectComponent
     @Input()
     placeholder: string;
 
+    /** Value of the select control. */
     @Input()
-    get value(): any {
-        return this._internalValue;
-    }
-
     set value(newValue: any) {
         if (newValue !== this._internalValue) {
             this.writeValue(newValue);
             this._internalValue = newValue;
         }
+    }
+    get value(): any {
+        return this._internalValue;
     }
 
     /** @deprecated
@@ -307,6 +307,7 @@ export class SelectComponent
         this._tabIndex = this.disabled ? -1 : 0;
     }
 
+    /** Selected option. */
     get selected(): OptionComponent {
         return this._selectionModel.selected[0];
     }
@@ -358,10 +359,6 @@ export class SelectComponent
 
     /** Function to compare the option values with the selected values. */
     @Input()
-    get compareWith(): (o1: any, o2: any) => boolean {
-        return this._compareWith;
-    }
-
     set compareWith(fn: (o1: any, o2: any) => boolean) {
         if (typeof fn !== 'function') {
             throw Error('compareWith` must be a function.');
@@ -371,6 +368,9 @@ export class SelectComponent
             // A different comparator means the selection could change.
             this._initializeSelection();
         }
+    }
+    get compareWith(): (o1: any, o2: any) => boolean {
+        return this._compareWith;
     }
 
     /** @hidden */
@@ -383,6 +383,7 @@ export class SelectComponent
         return this._maxHeight || this._calculatedMaxHeight;
     }
 
+    /** @hidden */
     constructor(
         @Attribute('tabindex') _tabIndex: string,
         @Optional() private readonly _rtlService: RtlService,

--- a/libs/core/src/lib/shared/interfaces/popover-position.ts
+++ b/libs/core/src/lib/shared/interfaces/popover-position.ts
@@ -94,6 +94,7 @@ export const PopoverFlippedRtlPlacement: { [key in RtlPlacement]: RtlPlacement }
 };
 
 export class PopoverPosition {
+    /** Get the cdk placement of the popover */
     static getCdkPlacement(placement: Placement, direction?: 'rtl' | 'ltr'): ConnectedPosition {
         const resultCdkPlacement = popoverPlacementMap[placement];
 
@@ -112,6 +113,7 @@ export class PopoverPosition {
         return resultCdkPlacement;
     }
 
+    /** Set arrow position */
     static getArrowPosition(position: ConnectedPosition, rtl?: boolean): ArrowPosition | null {
         let _position: ArrowPosition | null = null;
 
@@ -132,6 +134,7 @@ export class PopoverPosition {
         return _position;
     }
 
+    /** Get margin direction */
     static getMarginDirection(position: ArrowPosition): string {
         const resultPosition = position.replace('start', 'left').replace('end', 'right');
         return 'margin-' + resultPosition;

--- a/libs/core/src/lib/shared/utils/form.ts
+++ b/libs/core/src/lib/shared/utils/form.ts
@@ -2,6 +2,7 @@ import { FormStates } from './../interfaces/form-states';
 
 const stateSet = new Set<FormStates>(['success', 'error', 'warning', 'default', 'information']);
 
+/** Checks if the given state is a valid control state. */
 export function isValidControlState(value: any): value is FormStates {
     return stateSet.has(value);
 }

--- a/libs/core/src/lib/shellbar/deprecated-shellbar-compact.directive.ts
+++ b/libs/core/src/lib/shellbar/deprecated-shellbar-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedShellbarCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-shellbar-user-menu');
     }

--- a/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions.component.ts
+++ b/libs/core/src/lib/shellbar/shellbar-actions/shellbar-actions.component.ts
@@ -99,6 +99,7 @@ export class ShellbarActionsComponent {
         }
     }
 
+    /** @hidden */
     public get userItem(): ShellbarUser {
         if (this.userComponent) {
             return this.userComponent.user;

--- a/libs/core/src/lib/side-navigation/side-navigation.component.ts
+++ b/libs/core/src/lib/side-navigation/side-navigation.component.ts
@@ -62,6 +62,7 @@ export class SideNavigationComponent implements AfterContentInit, AfterViewInit,
     @ContentChild(SideNavigationMainDirective)
     sideNavMain: SideNavigationMainDirective;
 
+    /** @hidden */
     @ViewChildren(PreparedNestedListComponent)
     preparedNestedList: QueryList<PreparedNestedListComponent>;
 

--- a/libs/core/src/lib/slider/deprecated-slider-cozy.directive.ts
+++ b/libs/core/src/lib/slider/deprecated-slider-cozy.directive.ts
@@ -7,6 +7,7 @@ import { Directive, forwardRef } from '@angular/core';
     providers: [{ provide: CONTENT_DENSITY_DIRECTIVE, useExisting: forwardRef(() => DeprecatedSliderCozyDirective) }]
 })
 export class DeprecatedSliderCozyDirective extends DeprecatedCozyDirective {
+    /** @hidden */
     constructor() {
         super('fd-slider');
     }

--- a/libs/core/src/lib/slider/slider-position.directive.ts
+++ b/libs/core/src/lib/slider/slider-position.directive.ts
@@ -8,6 +8,7 @@ import { RtlService } from '@fundamental-ngx/core/utils';
     selector: '[fd-slider-position]'
 })
 export class SliderPositionDirective implements OnInit, OnChanges, OnDestroy {
+    /** Position of the slider */
     @Input()
     position: number;
 

--- a/libs/core/src/lib/slider/slider.component.ts
+++ b/libs/core/src/lib/slider/slider.component.ts
@@ -102,13 +102,8 @@ export class SliderComponent
     @Input()
     ariaLabel: Nullable<string>;
 
-    /** Get Minimum value. */
+    /** Minimum value. */
     @Input()
-    get min(): number {
-        return this._min;
-    }
-
-    /** Set Minimum value. */
     set min(value: number) {
         const newValue = coerceNumberProperty(value, this._min);
         if (((this.max - newValue) / this.step) % 1 !== 0) {
@@ -117,14 +112,12 @@ export class SliderComponent
 
         this._min = value;
     }
-
-    /** Get Maximum value. */
-    @Input()
-    get max(): number {
-        return this._max;
+    get min(): number {
+        return this._min;
     }
 
-    /** Set Maximum value. */
+    /** Maximum value. */
+    @Input()
     set max(value: number) {
         const newValue = coerceNumberProperty(value, this._max);
         if (((newValue - this.min) / this.step) % 1 !== 0) {
@@ -133,14 +126,12 @@ export class SliderComponent
 
         this._max = value;
     }
-
-    /** Get Step value. */
-    @Input()
-    get step(): number {
-        return this._step;
+    get max(): number {
+        return this._max;
     }
 
-    /** Set Step value. */
+    /** Step value. */
+    @Input()
     set step(value: number) {
         const newValue = coerceNumberProperty(value, this._step);
         if (((this.max - this.min) / newValue) % 1 !== 0) {
@@ -149,27 +140,26 @@ export class SliderComponent
 
         this._step = value;
     }
+    get step(): number {
+        return this._step;
+    }
 
     /** Jump value. */
     @Input()
+    set jump(value: number) {
+        this._jump = coerceNumberProperty(value, this._jump);
+    }
     get jump(): number {
         return this._jump;
     }
 
-    /** Set Jump value. */
-    set jump(value: number) {
-        this._jump = coerceNumberProperty(value, this._jump);
-    }
-
     /** Put a label on every N-th tickmark. */
     @Input()
-    get tickmarksBetweenLabels(): number {
-        return this._tickmarksBetweenLabels;
-    }
-
-    /** Set Tickmarks Between Labels value. */
     set tickmarksBetweenLabels(value: number) {
         this._tickmarksBetweenLabels = coerceNumberProperty(value, this._tickmarksBetweenLabels);
+    }
+    get tickmarksBetweenLabels(): number {
+        return this._tickmarksBetweenLabels;
     }
 
     /**
@@ -231,17 +221,16 @@ export class SliderComponent
     @Input()
     rangeSliderHandle2CurrentValuePrefix: string;
 
+    /** @hidden */
     _position: number | number[] = 0;
 
     /** Control value */
     @Input()
-    get value(): SliderControlValue {
-        return this._value;
-    }
-
-    /** Set control value */
     set value(value: SliderControlValue) {
         this._setValue(value);
+    }
+    get value(): SliderControlValue {
+        return this._value;
     }
 
     /** @hidden */
@@ -426,13 +415,13 @@ export class SliderComponent
         return this.customValues.length > 0 ? this.customValues[this.max as number].label : this.max;
     }
 
-    @applyCssClass
     /**
      * @hidden
      * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-slider',

--- a/libs/core/src/lib/split-button/deprecated-split-button-compact.directive.ts
+++ b/libs/core/src/lib/split-button/deprecated-split-button-compact.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedSplitButtonCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-split-button');
     }

--- a/libs/core/src/lib/splitter/splitter-pane-container/splitter-pane-container.component.ts
+++ b/libs/core/src/lib/splitter/splitter-pane-container/splitter-pane-container.component.ts
@@ -430,8 +430,10 @@ export class SplitterPaneContainerComponent implements AfterContentInit, AfterVi
 
 @Pipe({ name: 'noDefaultPane' })
 export class NoDefaultPanePipe implements PipeTransform {
+    /** @hidden */
     constructor(private readonly _splitterPaneContainer: SplitterPaneContainerComponent) {}
 
+    /** @hidden */
     transform(value: SplitterSplitPaneComponent[], excludingCondition = true): SplitterSplitPaneComponent[] {
         if (!excludingCondition) {
             return value;

--- a/libs/core/src/lib/status-indicator/status-indicator.component.ts
+++ b/libs/core/src/lib/status-indicator/status-indicator.component.ts
@@ -19,6 +19,7 @@ export type FillingType = 'radial' | 'angled' | 'linearup' | 'lineardown' | 'lin
 export type FillingDirection = 'clockwise' | 'counterclockwise';
 
 export class Point {
+    /** @hidden */
     constructor(public x: number, public y: number) {}
 }
 
@@ -115,6 +116,7 @@ export class StatusIndicatorComponent implements OnChanges, AfterViewInit, CssCl
     @Input()
     labelPosition: LablePosition;
 
+    /** Path for the status indicator */
     @Input()
     path: string[];
 
@@ -130,12 +132,12 @@ export class StatusIndicatorComponent implements OnChanges, AfterViewInit, CssCl
     @Input()
     fillDirection: FillingDirection = 'clockwise';
 
-    get _fillDirection(): FillingDirection {
-        return this.fillDirection;
-    }
-
+    /** @hidden */
     set _fillDirection(direction: FillingDirection) {
         this.fillDirection = direction;
+    }
+    get _fillDirection(): FillingDirection {
+        return this.fillDirection;
     }
 
     /**
@@ -165,8 +167,11 @@ export class StatusIndicatorComponent implements OnChanges, AfterViewInit, CssCl
 
     /** @hidden */
     constructor(private _elementRef: ElementRef<HTMLElement>, private _cd: ChangeDetectorRef) {}
+
+    /** @hidden */
     class: string;
 
+    /** @hidden */
     ngAfterViewInit(): void {
         this._angleCalculation();
         this._cd.detectChanges();
@@ -178,15 +183,17 @@ export class StatusIndicatorComponent implements OnChanges, AfterViewInit, CssCl
         this.buildComponentCssClass();
     }
 
+    /** @hidden */
     public ngOnInit(): void {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-status-indicator',
@@ -200,6 +207,7 @@ export class StatusIndicatorComponent implements OnChanges, AfterViewInit, CssCl
         ];
     }
 
+    /** @hidden */
     elementRef(): ElementRef<any> {
         return this._elementRef;
     }

--- a/libs/core/src/lib/step-input/deprecated-step-input-compact.directive.ts
+++ b/libs/core/src/lib/step-input/deprecated-step-input-compact.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedStepInputCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-step-input');
     }

--- a/libs/core/src/lib/step-input/step-input.component.ts
+++ b/libs/core/src/lib/step-input/step-input.component.ts
@@ -276,6 +276,7 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
     /** @hidden */
     onTouched = (): void => {};
 
+    /** @hidden */
     constructor(
         @Inject(LOCALE_ID) locale,
         private _changeDetectorRef: ChangeDetectorRef,
@@ -298,6 +299,7 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
         this._listenOnButtonsClick();
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this._subscriptions.unsubscribe();
     }

--- a/libs/core/src/lib/switch/deprecated-switch-compact.directive.ts
+++ b/libs/core/src/lib/switch/deprecated-switch-compact.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedSwitchCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-switch');
     }

--- a/libs/core/src/lib/switch/switch.component.ts
+++ b/libs/core/src/lib/switch/switch.component.ts
@@ -131,6 +131,7 @@ export class SwitchComponent implements ControlValueAccessor, OnDestroy, FormIte
     /** @hidden */
     onTouched = (): void => {};
 
+    /** @hidden */
     constructor(
         private readonly _changeDetectorRef: ChangeDetectorRef,
         readonly _contentDensityObserver: ContentDensityObserver
@@ -156,16 +157,14 @@ export class SwitchComponent implements ControlValueAccessor, OnDestroy, FormIte
         return `${this.id}-semantic-label`;
     }
 
-    /** Get the isChecked property of the switch. */
-    get isChecked(): boolean {
-        return this.checked;
-    }
-
-    /** Set the isChecked property of the switch. */
+    /** Checked property of the switch. */
     set isChecked(value) {
         this.checked = value;
         this.onChange(value);
         this.checkedChange.emit(value);
+    }
+    get isChecked(): boolean {
+        return this.checked;
     }
 
     /**

--- a/libs/core/src/lib/table/deprecated-table-compact.directive.ts
+++ b/libs/core/src/lib/table/deprecated-table-compact.directive.ts
@@ -11,6 +11,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedTableCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('table[fd-table]');
     }

--- a/libs/core/src/lib/table/deprecated-table-condensed.directive.ts
+++ b/libs/core/src/lib/table/deprecated-table-condensed.directive.ts
@@ -11,6 +11,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCondensedDirective } from '@fundam
     ]
 })
 export class DeprecatedTableCondensedDirective extends DeprecatedCondensedDirective {
+    /** @hidden */
     constructor() {
         super('table[fd-table]');
     }

--- a/libs/core/src/lib/table/directives/table-icon.directive.ts
+++ b/libs/core/src/lib/table/directives/table-icon.directive.ts
@@ -36,15 +36,16 @@ export class TableIconDirective implements OnChanges, CssClassBuilder, OnInit {
         this.buildComponentCssClass();
     }
 
+    /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-table__icon',

--- a/libs/core/src/lib/table/table-wrapper.component.ts
+++ b/libs/core/src/lib/table/table-wrapper.component.ts
@@ -32,6 +32,7 @@ import { FdTableContentDensityProviderParams } from './table.component';
     providers: [contentDensityObserverProviders(FdTableContentDensityProviderParams)]
 })
 export class TableWrapperComponent implements AfterContentInit, OnDestroy {
+    /** @hidden */
     private _contentDensitySettings: ContentDensityObserverTarget;
 
     /** @hidden */

--- a/libs/core/src/lib/table/table.service.ts
+++ b/libs/core/src/lib/table/table.service.ts
@@ -1,8 +1,10 @@
 import { BehaviorSubject } from 'rxjs';
 
 export class TableService {
+    /** @hidden */
     propagateKeys$: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
 
+    /** @hidden */
     changeKeys(keys: string[]): void {
         if (keys && keys.length > 0) {
             this.propagateKeys$.next([...keys]);

--- a/libs/core/src/lib/tabs/deprecated-tabs-compact.directive.ts
+++ b/libs/core/src/lib/tabs/deprecated-tabs-compact.directive.ts
@@ -5,6 +5,7 @@ import { Directive } from '@angular/core';
     selector: '[fd-tab-nav][compact], fd-tab-list[compact]'
 })
 export class DeprecatedTabsCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('[fd-tab-nav][compact], fd-tab-list');
     }

--- a/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
+++ b/libs/core/src/lib/tabs/tab-item/tab-item.directive.ts
@@ -60,8 +60,8 @@ export class TabItemDirective implements CssClassBuilder, OnChanges, OnInit {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
     /** @hidden */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             this.fdTabItemClass ? 'fd-tabs__item' : '',

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -141,6 +141,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
     @ViewChild('contentContainer', { read: ElementRef, static: true })
     contentContainer: ElementRef;
 
+    /** @hidden */
     @ViewChild(OverflowLayoutComponent)
     private _overflowLayout: OverflowLayoutComponent;
 
@@ -175,6 +176,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
         this._setupTabPanelsChangeListeners();
     }
 
+    /** @hidden */
     ngAfterViewInit(): void {
         this._listenOnPropertiesChange();
     }

--- a/libs/core/src/lib/tabs/tab-nav/tab-nav.component.ts
+++ b/libs/core/src/lib/tabs/tab-nav/tab-nav.component.ts
@@ -105,11 +105,12 @@ export class TabNavComponent implements AfterContentInit, OnChanges, OnInit, OnD
         this._onDestroy$.complete();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [`fd-tabs`, this.mode ? 'fd-tabs--' + this.mode : '', `fd-tabs--${this.size}`, this.class];
     }

--- a/libs/core/src/lib/tabs/tab-panel/tab-panel.component.ts
+++ b/libs/core/src/lib/tabs/tab-panel/tab-panel.component.ts
@@ -25,6 +25,11 @@ import { TabListComponentInterface } from '../tab-list-component.interface';
 let tabPanelUniqueId = 0;
 
 export class TabPanelStateChange {
+    /**
+     * Tab panel state change event
+     * @param target Tab panel that is being changed
+     * @param state New state of the tab panel
+     */
     constructor(public target: TabPanelComponent, public state: boolean) {}
 }
 

--- a/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
+++ b/libs/core/src/lib/tabs/tab-utils/tab-directives.ts
@@ -78,11 +78,11 @@ export class TabIconComponent implements CssClassBuilder, OnChanges {
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-tabs__icon', this.class];
     }

--- a/libs/core/src/lib/tests/element-ref-mock.class.ts
+++ b/libs/core/src/lib/tests/element-ref-mock.class.ts
@@ -1,6 +1,7 @@
 import { ElementRef } from '@angular/core';
 
 export class MockElementRef extends ElementRef {
+    /** @hidden */
     constructor() {
         super(null);
     }

--- a/libs/core/src/lib/tests/when-stable.ts
+++ b/libs/core/src/lib/tests/when-stable.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture } from '@angular/core/testing';
 
+/** Waits for the fixture to be stable, i.e. for async tasks to complete. */
 export async function whenStable(fixture: ComponentFixture<any>): Promise<void> {
     try {
         fixture.changeDetectorRef.markForCheck();

--- a/libs/core/src/lib/theming/theming.module.ts
+++ b/libs/core/src/lib/theming/theming.module.ts
@@ -16,6 +16,7 @@ import { THEMING_CONFIG_TOKEN } from './tokens';
     ]
 })
 export class ThemingModule {
+    /** Module with providers */
     static withConfig(config: Partial<ThemingConfig>): ModuleWithProviders<ThemingModule> {
         return {
             ngModule: ThemingModule,

--- a/libs/core/src/lib/tile/directives/numeric-content.directives.ts
+++ b/libs/core/src/lib/tile/directives/numeric-content.directives.ts
@@ -22,6 +22,7 @@ export class NumericContentDirective implements OnInit, OnChanges, CssClassBuild
     @HostBinding('class.fd-numeric-content')
     baseClass = true;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -34,11 +35,12 @@ export class NumericContentDirective implements OnInit, OnChanges, CssClassBuild
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-numeric-content',
@@ -90,6 +92,7 @@ export class NumericContentLaunchIconDirective implements OnInit, OnChanges, Css
     @Input()
     glyph: string;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -102,11 +105,12 @@ export class NumericContentLaunchIconDirective implements OnInit, OnChanges, Css
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-numeric-content__launch-icon', this.glyph ? 'sap-icon--' + this.glyph : '', this.class];
     }
@@ -144,6 +148,7 @@ export class NumericContentKpiDirective implements OnInit, OnChanges, CssClassBu
     @Input()
     glyph: string;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -156,11 +161,12 @@ export class NumericContentKpiDirective implements OnInit, OnChanges, CssClassBu
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-numeric-content__kpi', this.state ? 'fd-numeric-content__kpi--' + this.state : '', this.class];
     }
@@ -194,6 +200,7 @@ export class NumericContentScaleArrowDirective implements OnInit, OnChanges, Css
     @Input()
     glyph: string;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -206,11 +213,12 @@ export class NumericContentScaleArrowDirective implements OnInit, OnChanges, Css
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-numeric-content__scale-arrow', this.glyph ? 'sap-icon--' + this.glyph : '', this.class];
     }
@@ -234,6 +242,7 @@ export class NumericContentScaleDirective implements OnInit, OnChanges, CssClass
     @Input()
     class: string;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -246,11 +255,12 @@ export class NumericContentScaleDirective implements OnInit, OnChanges, CssClass
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-numeric-content__scale', this.state ? 'fd-numeric-content__scale--' + this.state : '', this.class];
     }

--- a/libs/core/src/lib/tile/directives/tile.directives.ts
+++ b/libs/core/src/lib/tile/directives/tile.directives.ts
@@ -133,6 +133,7 @@ export class TileRefreshDirective implements OnInit, OnChanges, CssClassBuilder 
     @HostBinding('attr.aria-label')
     ariaLabel = 'Refresh';
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -145,11 +146,12 @@ export class TileRefreshDirective implements OnInit, OnChanges, CssClassBuilder 
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-tile__refresh', this.glyph ? 'sap-icon--' + this.glyph : '', this.class];
     }
@@ -290,6 +292,7 @@ export class TileActionCloseDirective implements OnInit, OnChanges, CssClassBuil
     @Input()
     class: string;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -303,11 +306,12 @@ export class TileActionCloseDirective implements OnInit, OnChanges, CssClassBuil
         this._addCloseIcon();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-tile__action-close', this.class];
     }
@@ -332,6 +336,7 @@ export class TileActionIndicatorDirective implements OnInit, OnChanges, CssClass
     @Input()
     class: string;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -345,11 +350,12 @@ export class TileActionIndicatorDirective implements OnInit, OnChanges, CssClass
         this._addIndicatorIcon();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-tile__action-indicator', this.class];
     }

--- a/libs/core/src/lib/tile/tile.component.ts
+++ b/libs/core/src/lib/tile/tile.component.ts
@@ -76,11 +76,12 @@ export class TileComponent implements CssClassBuilder, AfterViewInit, OnChanges 
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [
             'fd-tile',

--- a/libs/core/src/lib/time-picker/deprecated-timepicker-compact.directive.ts
+++ b/libs/core/src/lib/time-picker/deprecated-timepicker-compact.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedTimepickerCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-time-picker');
     }

--- a/libs/core/src/lib/time-picker/errors.ts
+++ b/libs/core/src/lib/time-picker/errors.ts
@@ -1,3 +1,4 @@
+/** Creates an error to be thrown when attempting to use an invalid date implementation. */
 export function createMissingDateImplementationError(provider: string): Error {
     return Error(
         `FdTime: No provider found for ${provider}. You must import one of the following ` +

--- a/libs/core/src/lib/time-picker/time-picker.component.ts
+++ b/libs/core/src/lib/time-picker/time-picker.component.ts
@@ -201,6 +201,7 @@ export class TimePickerComponent<D>
         return this._state ?? 'default';
     }
 
+    /** @hidden */
     private _state: FormStates | null = null;
 
     /**
@@ -302,6 +303,7 @@ export class TimePickerComponent<D>
      */
     _inputTimeValue = '';
 
+    /** @hidden */
     _formValueStateMessageId = `fd-time-picker-form-message-${timePickerCounter++}`;
 
     /** @hidden */
@@ -338,6 +340,7 @@ export class TimePickerComponent<D>
         }
     }
 
+    /** @hidden */
     ngOnInit(): void {
         this._calculateTimeOptions();
         this._formatTimeInputField();
@@ -349,6 +352,7 @@ export class TimePickerComponent<D>
         });
     }
 
+    /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
         if (
             ['displayHours', 'displayMinutes', 'displaySeconds', 'meridian', 'displayFormat'].some(

--- a/libs/core/src/lib/time/deprecated-time-content-density.directive.ts
+++ b/libs/core/src/lib/time/deprecated-time-content-density.directive.ts
@@ -12,6 +12,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class DeprecatedTimeContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-time-column[compact], fd-time');
     }

--- a/libs/core/src/lib/time/errors.ts
+++ b/libs/core/src/lib/time/errors.ts
@@ -1,3 +1,4 @@
+/** Creates an error to be thrown when attempting to use an invalid date implementation. */
 export function createMissingDateImplementationError(provider: string): Error {
     return Error(
         `FdTime: No provider found for ${provider}. You must import one of the following ` +

--- a/libs/core/src/lib/time/i18n/time-i18n.ts
+++ b/libs/core/src/lib/time/i18n/time-i18n.ts
@@ -6,11 +6,13 @@ import { Injectable, isDevMode } from '@angular/core';
  */
 @Injectable()
 export class TimeI18n {
+    /** @hidden */
     constructor() {
         if (isDevMode()) {
             console.warn('TimeI18n is deprecated and will furtherly be removed. Use i18n capabilities instead.');
         }
     }
+
     /** Aria label for entire component */
     componentAriaName = 'Time picker';
 

--- a/libs/core/src/lib/time/models.ts
+++ b/libs/core/src/lib/time/models.ts
@@ -1,6 +1,9 @@
 export class SelectableViewItem<T> {
+    /** Value of the item */
     value: T;
+    /** Label of the item */
     label: string;
+    /** Index of the item */
     index?: number;
 }
 

--- a/libs/core/src/lib/time/time-column/time-column.component.ts
+++ b/libs/core/src/lib/time/time-column/time-column.component.ts
@@ -114,12 +114,11 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
      * In case of having more items in carousel than 1, middle element should be active
      */
     @Input()
-    get offset(): number {
-        return this._offset$.value;
-    }
-
     set offset(value: number) {
         this._offset$.next(value);
+    }
+    get offset(): number {
+        return this._offset$.value;
     }
 
     /**
@@ -150,6 +149,7 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
     @ViewChild('indicator', { read: ElementRef })
     indicator: ElementRef;
 
+    /** @hidden */
     wrapperHeight: number;
 
     /**
@@ -162,6 +162,7 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
     /** @hidden */
     config: CarouselConfig;
 
+    /** @hidden */
     internalTranslationConfig: TimeColumnConfig | null = null;
 
     /** @hidden */
@@ -198,6 +199,7 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
     /** @hidden */
     private _viewInit$ = new BehaviorSubject<boolean>(false);
 
+    /** @hidden */
     private _resize$ = new BehaviorSubject<boolean>(false);
 
     /** @hidden */

--- a/libs/core/src/lib/timeline/components/timeline-node-body/timeline-node-body.component.ts
+++ b/libs/core/src/lib/timeline/components/timeline-node-body/timeline-node-body.component.ts
@@ -12,19 +12,21 @@ import { first } from 'rxjs/operators';
     }
 })
 export class TimelineNodeBodyComponent {
-    /* Text content of timeline node*/
+    /** Text content of timeline node*/
     @Input()
     content: string;
 
-    /*
-      The number of lines to be visible.
-      If user doesn't provide it, all lines will be visible
-    */
+    /**
+     * The number of lines to be visible.
+     * If user doesn't provide it, all lines will be visible
+     */
     @Input()
     maxLines: number;
 
+    /** @hidden */
     constructor(private _ngZone: NgZone, private _timelinePositionControlService: TimelinePositionControlService) {}
 
+    /** @hidden */
     calculatePositions(): void {
         this._ngZone.onStable.pipe(first()).subscribe(() => {
             this._timelinePositionControlService.calculatePositions();

--- a/libs/core/src/lib/timeline/components/timeline-node/timeline-node.component.ts
+++ b/libs/core/src/lib/timeline/components/timeline-node/timeline-node.component.ts
@@ -22,14 +22,15 @@ import { TimelineNodeComponentInterface } from './timeline-node-component.interf
     }
 })
 export class TimelineNodeComponent implements TimelineNodeComponentInterface, OnInit, OnDestroy {
-    /* Glyph of the current timeline node.*/
+    /** Glyph of the current timeline node.*/
     @Input()
     glyph: string;
 
+    /** Aria label for the current timeline node. */
     @Input()
     ariaLabel = 'timelineitem';
 
-    /* Reference to the line of timeline node*/
+    /** Reference to the line of timeline node*/
     @ViewChild('lineEl')
     lineEl: ElementRef;
 

--- a/libs/core/src/lib/timeline/directives/timeline-first-list-outlet.directive.ts
+++ b/libs/core/src/lib/timeline/directives/timeline-first-list-outlet.directive.ts
@@ -4,6 +4,6 @@ import { Directive, ViewContainerRef } from '@angular/core';
     selector: '[fdTimelineFirstListOutlet], [fd-timeline-first-list-outlet]'
 })
 export class TimelineFirstListOutletDirective {
-    /* Ref to ViewContainerRef instance*/
+    /** Ref to ViewContainerRef instance*/
     constructor(public viewContainer: ViewContainerRef) {}
 }

--- a/libs/core/src/lib/timeline/directives/timeline-node-def.directive.ts
+++ b/libs/core/src/lib/timeline/directives/timeline-node-def.directive.ts
@@ -11,6 +11,7 @@ export class TimelineNodeOutletContext<T> {
     /** Length of the number of total dataNodes. */
     count?: number;
 
+    /** @hidden */
     constructor(data: T) {
         this.$implicit = data;
     }

--- a/libs/core/src/lib/timeline/directives/timeline-second-list-outlet.directive.ts
+++ b/libs/core/src/lib/timeline/directives/timeline-second-list-outlet.directive.ts
@@ -4,6 +4,6 @@ import { Directive, ViewContainerRef } from '@angular/core';
     selector: '[fdTimelineSecondListOutlet], [fd-timeline-second-list-outlet]'
 })
 export class TimelineSecondListOutletDirective {
-    /* Ref to ViewContainerRef instance*/
+    /** Ref to ViewContainerRef instance*/
     constructor(public viewContainer: ViewContainerRef) {}
 }

--- a/libs/core/src/lib/timeline/services/position-strategies/position-strategy-factory.ts
+++ b/libs/core/src/lib/timeline/services/position-strategies/position-strategy-factory.ts
@@ -6,6 +6,7 @@ import { HorizontalDoubleSidesStrategy } from './horizontal-double-sides-strateg
 import { VerticalSingleSideStrategy } from './vertical-single-side-strategy';
 
 export class PositionStrategyFactory {
+    /** Get timeline position strategy */
     static getStrategy(strategy: TimeLinePositionStrategy): BaseStrategy {
         switch (strategy) {
             case 'vertical-right':

--- a/libs/core/src/lib/timeline/timeline.component.ts
+++ b/libs/core/src/lib/timeline/timeline.component.ts
@@ -90,8 +90,12 @@ export class TimelineComponent<T> implements OnInit, OnDestroy, OnChanges, After
     /** @hidden */
     _canShowSecondList = true;
 
-    /** Differ used to find the changes in the data provided by the data source. */
+    /** @hidden
+     * Differ used to find the changes in the data provided by the data source.
+     */
     private _dataDifferForFirstList: IterableDiffer<T>;
+
+    /** @hidden */
     private _dataDifferForSecondList: IterableDiffer<T>;
 
     /** @hidden */
@@ -190,6 +194,7 @@ export class TimelineComponent<T> implements OnInit, OnDestroy, OnChanges, After
         );
     }
 
+    /** @hidden */
     private _setPositionStrategy(): void {
         this._timelinePositionControlService.setStrategy(`${this.axis}-${this.layout}` as TimeLinePositionStrategy);
     }

--- a/libs/core/src/lib/title/title.component.ts
+++ b/libs/core/src/lib/title/title.component.ts
@@ -26,16 +26,16 @@ export class TitleComponent extends TitleToken implements OnInit {
     /** The size of the header */
     _headerSize: Nullable<HeaderSizes> = null;
 
-    get headerSize(): Nullable<HeaderSizes> {
-        return this._headerSize;
-    }
-
+    /** Header size of the title. */
     @Input()
     set headerSize(value: Nullable<HeaderSizes>) {
         this._headerSize = value;
         if (this._appliedHeaderSize !== this.headerSize) {
             this._setHeaderSize();
         }
+    }
+    get headerSize(): Nullable<HeaderSizes> {
+        return this._headerSize;
     }
 
     /** Whether or not the title should wrap (truncates by default) */

--- a/libs/core/src/lib/token/deprecated-tokenizer-content-density.directive.ts
+++ b/libs/core/src/lib/token/deprecated-tokenizer-content-density.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedTokenizerContentDensityDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-tokenizer[compact], fd-token');
     }

--- a/libs/core/src/lib/token/token-input.directive.ts
+++ b/libs/core/src/lib/token/token-input.directive.ts
@@ -12,11 +12,12 @@ export class TokenizerInputDirective implements OnInit, OnChanges, CssClassBuild
     @Input()
     class: string;
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return ['fd-tokenizer__input', this.class];
     }

--- a/libs/core/src/lib/token/token.component.ts
+++ b/libs/core/src/lib/token/token.component.ts
@@ -47,21 +47,22 @@ export class TokenComponent implements AfterViewInit, OnDestroy {
     @ViewChild('viewContainer', { read: ViewContainerRef })
     readonly _viewContainer: ViewContainerRef;
 
+    /** @hidden */
     private _selected = false;
 
+    /** @hidden */
     private _subscriptions = new Subscription();
 
     /** Whether the token is selected. */
     @Input()
-    get selected(): boolean {
-        return this._selected;
-    }
-
     set selected(val: boolean) {
         if (this._selected !== val) {
             this._cdRef.markForCheck();
         }
         this._selected = val;
+    }
+    get selected(): boolean {
+        return this._selected;
     }
 
     /** Whether the token is read-only. */
@@ -105,6 +106,7 @@ export class TokenComponent implements AfterViewInit, OnDestroy {
     /** @hidden */
     totalCount: number;
 
+    /** @hidden */
     constructor(
         public elementRef: ElementRef,
         private _cdRef: ChangeDetectorRef,

--- a/libs/core/src/lib/token/tokenizer.component.ts
+++ b/libs/core/src/lib/token/tokenizer.component.ts
@@ -145,25 +145,30 @@ export class TokenizerComponent
     /** @hidden */
     _showOverflowPopover = true;
 
-    /** @hidden */
-    /* Variable which will keep the index of the first token pressed in the tokenizer*/
+    /** @hidden
+     * Variable which will keep the index of the first token pressed in the tokenizer
+     */
     private _firstElementInSelection: number | null = null;
 
-    /** @hidden */
-    /* Variable which will keep the index of the last token pressed in the tokenizer*/
+    /** @hidden
+     * Variable which will keep the index of the last token pressed in the tokenizer
+     */
     private _lastElementInSelection: number | null = null;
 
-    /** @hidden */
-    /* Flag which will say if the last keyboard and click operation they used was using control*/
+    /** @hidden
+     * Flag which will say if the last keyboard and click operation they used was using control
+     */
     private _ctrlPrevious: boolean;
 
-    /** @hidden */
-    /* Flag which will say if they held shift and clicked highlighting elements before or*/
+    /** @hidden
+     * Flag which will say if they held shift and clicked highlighting elements before or
+     */
     private _directionShiftIsRight: boolean | null = null;
 
     /** An RxJS Subject that will kill the data stream upon destruction (for unsubscribing)  */
     private readonly _onDestroy$: Subject<void> = new Subject<void>();
 
+    /** @hidden */
     constructor(
         readonly _contentDensityObserver: ContentDensityObserver,
         private _elementRef: ElementRef,
@@ -232,15 +237,17 @@ export class TokenizerComponent
         this.buildComponentCssClass();
     }
 
-    @applyCssClass
-    /** CssClassBuilder interface implementation
+    /** @hidden
+     * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
      */
+    @applyCssClass
     buildComponentCssClass(): string[] {
         return [this.class];
     }
 
+    /** @hidden */
     elementRef(): ElementRef {
         return this._elementRef;
     }
@@ -527,6 +534,7 @@ export class TokenizerComponent
         elementRef.nativeElement.style.visibility = 'visible';
     }
 
+    /** @hidden */
     private _unsubscribeClicks(): void {
         if (this.tokenListClickSubscriptions && this.tokenListClickSubscriptions.length) {
             this.tokenListClickSubscriptions.forEach((subscription) => {
@@ -535,6 +543,7 @@ export class TokenizerComponent
         }
     }
 
+    /** @hidden */
     private _inputKeydownEvent(): void {
         this.input.elementRef().nativeElement.addEventListener('keydown', (event) => {
             this.handleKeyDown(event, this.tokenList.length);

--- a/libs/core/src/lib/toolbar/deprecated-toolbar-size.directive.ts
+++ b/libs/core/src/lib/toolbar/deprecated-toolbar-size.directive.ts
@@ -23,6 +23,7 @@ export class DeprecatedToolbarSizeDirective
     extends BehaviorSubject<LocalContentDensityMode>
     implements OnDestroy, ModuleDeprecation
 {
+    /** Size of the toolbar. */
     @Input()
     set size(value: ToolbarSize) {
         switch (value) {
@@ -40,12 +41,16 @@ export class DeprecatedToolbarSizeDirective
         }
     }
 
+    /** @hidden */
     readonly message: string;
+
+    /** @hidden */
     readonly alternative = {
         name: 'Use [fdContentDensity] directive instead',
         link: ['/core', 'content-density']
     };
 
+    /** @hidden */
     constructor() {
         super(ContentDensityMode.COMPACT);
         this.message = `Usage of fd-toolbar[size] is deprecated`;
@@ -54,6 +59,7 @@ export class DeprecatedToolbarSizeDirective
         }
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this.complete();
     }

--- a/libs/core/src/lib/toolbar/toolbar-item.directive.ts
+++ b/libs/core/src/lib/toolbar/toolbar-item.directive.ts
@@ -5,5 +5,6 @@ import { Directive, ElementRef } from '@angular/core';
     selector: '[fd-toolbar-item]'
 })
 export class ToolbarItemDirective {
+    /** @hidden */
     constructor(public elementRef: ElementRef) {}
 }

--- a/libs/core/src/lib/toolbar/toolbar-overflow-group.directive.ts
+++ b/libs/core/src/lib/toolbar/toolbar-overflow-group.directive.ts
@@ -12,5 +12,7 @@ import { ToolbarItemDirective } from './toolbar-item.directive';
     selector: '[fdOverflowGroup]'
 })
 export class ToolbarOverflowGroupDirective extends ToolbarItemDirective {
-    @Input() fdOverflowGroup = 0;
+    /** The group number of the item. */
+    @Input()
+    fdOverflowGroup = 0;
 }

--- a/libs/core/src/lib/toolbar/toolbar-overflow-priority.directive.ts
+++ b/libs/core/src/lib/toolbar/toolbar-overflow-priority.directive.ts
@@ -15,5 +15,7 @@ import { OverflowPriority } from '@fundamental-ngx/core/utils';
     selector: '[fdOverflowPriority]'
 })
 export class ToolbarOverflowPriorityDirective extends ToolbarItemDirective {
-    @Input() fdOverflowPriority: OverflowPriority = 'high';
+    /** The priority of the item. */
+    @Input()
+    fdOverflowPriority: OverflowPriority = 'high';
 }

--- a/libs/core/src/lib/toolbar/toolbar-spacer.component.ts
+++ b/libs/core/src/lib/toolbar/toolbar-spacer.component.ts
@@ -27,6 +27,7 @@ export class ToolbarSpacerComponent {
     @Input()
     fixed = false;
 
+    /** @hidden */
     @HostBinding('attr.class')
     get css(): string {
         return `fd-toolbar__spacer ${this.fixed ? 'fd-toolbar__spacer--fixed' : ''} ${this.class}`;

--- a/libs/core/src/lib/toolbar/toolbar.component.ts
+++ b/libs/core/src/lib/toolbar/toolbar.component.ts
@@ -546,10 +546,12 @@ export class ToolbarComponent
         this._changeOverflowVisibleState(false);
     }
 
+    /** @hidden */
     private _changeOverflowVisibleState(visible: boolean): void {
         this.overflowVisibility = of(visible).pipe(debounceTime(1));
     }
 
+    /** @hidden */
     private _changeItemVisibilityState(element: HTMLElement, visible: boolean): void {
         const fadeIn = 'fd-toolbar-fade-in';
         const fadeOut = 'fd-toolbar-fade-out';

--- a/libs/core/src/lib/tree/tree-child.component.ts
+++ b/libs/core/src/lib/tree/tree-child.component.ts
@@ -16,20 +16,27 @@ import { TreeRowObject } from './tree-row-object.model';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TreeChildComponent implements OnInit {
+    /** @hidden */
     @Input() row: TreeRowObject;
 
+    /** @hidden */
     @Input() hideChildren: boolean;
 
+    /** @hidden */
     @Input() displayTreeActions: boolean;
 
+    /** @hidden */
     @Output() editClicked: EventEmitter<any> = new EventEmitter<any>();
 
+    /** @hidden */
     @Output() deleteClicked: EventEmitter<any> = new EventEmitter<any>();
 
+    /** @hidden */
     ngOnInit(): void {
         this.hideChildren = false;
     }
 
+    /** @hidden */
     toggleDisplayChildren(hideAll?): void {
         if (hideAll !== undefined) {
             this.hideChildren = hideAll;
@@ -38,6 +45,7 @@ export class TreeChildComponent implements OnInit {
         }
     }
 
+    /** @hidden */
     typeOf(variable?): string {
         let retVal;
         if (typeof variable === 'string') {
@@ -49,12 +57,14 @@ export class TreeChildComponent implements OnInit {
         return retVal;
     }
 
+    /** @hidden */
     editTreeItem(row?): void {
         if (row) {
             this.editClicked.emit(row);
         }
     }
 
+    /** @hidden */
     deleteTreeItem(row?): void {
         if (row) {
             this.deleteClicked.emit(row);

--- a/libs/core/src/lib/tree/tree.component.ts
+++ b/libs/core/src/lib/tree/tree.component.ts
@@ -20,24 +20,33 @@ import { TreeChildComponent } from './tree-child.component';
     styleUrls: ['./tree.component.scss']
 })
 export class TreeComponent implements OnInit, AfterContentInit {
+    /** @hidden */
     @Input() headers: string[];
 
+    /** @hidden */
     @Input() treeData: TreeRowObject[];
 
+    /** @hidden */
     @Input() hideAll: boolean;
 
+    /** @hidden */
     @Input() displayTreeActions: boolean;
 
+    /** @hidden */
     @Output() editRowClicked: EventEmitter<any> = new EventEmitter<any>();
 
+    /** @hidden */
     @Output() deleteRowClicked: EventEmitter<any> = new EventEmitter<any>();
 
+    /** @hidden */
     @ViewChildren(TreeChildComponent) treeChildren: QueryList<TreeChildComponent>;
 
+    /** @hidden */
     ngOnInit(): void {
         this.hideAll = false;
     }
 
+    /** @hidden */
     ngAfterContentInit(): void {
         if (this.treeData && this.treeData.length) {
             this.treeData.forEach((row) => {
@@ -47,6 +56,7 @@ export class TreeComponent implements OnInit, AfterContentInit {
         }
     }
 
+    /** @hidden */
     toggleDisplayAll(): void {
         this.hideAll = !this.hideAll;
         this.treeChildren.forEach((child) => {
@@ -54,6 +64,7 @@ export class TreeComponent implements OnInit, AfterContentInit {
         });
     }
 
+    /** @hidden */
     getChildDepth(row, depth): void {
         if (depth > 0) {
             row.sublevelClass = 'fd-tree__group--sublevel-' + depth;
@@ -66,6 +77,7 @@ export class TreeComponent implements OnInit, AfterContentInit {
         }
     }
 
+    /** @hidden */
     handleEmptyTrailingCells(row): void {
         if (
             row &&
@@ -94,10 +106,12 @@ export class TreeComponent implements OnInit, AfterContentInit {
         }
     }
 
+    /** @hidden */
     editClicked(row): void {
         this.editRowClicked.emit(row);
     }
 
+    /** @hidden */
     deleteClicked(row): void {
         this.deleteRowClicked.emit(row);
     }

--- a/libs/core/src/lib/upload-collection/upload-collection-form-item/upload-collection-form-item.component.ts
+++ b/libs/core/src/lib/upload-collection/upload-collection-form-item/upload-collection-form-item.component.ts
@@ -29,17 +29,15 @@ export class UploadCollectionFormItemComponent implements ControlValueAccessor {
     @Output()
     readonly fileNameChanged = new EventEmitter<string>();
 
-    /** Get the value of the text input. */
-    get fileName(): string {
-        return this._fileNameValue;
-    }
-
-    /** Set the value of the text input. */
+    /** Value of the text input. */
     set fileName(value) {
         this._fileNameValue = value;
         this.onChange(value);
         this.onTouched();
         this.fileNameChanged.emit(value);
+    }
+    get fileName(): string {
+        return this._fileNameValue;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/upload-collection/upload-collection-item.directive.ts
+++ b/libs/core/src/lib/upload-collection/upload-collection-item.directive.ts
@@ -95,6 +95,7 @@ export class UploadCollectionItemDirective implements AfterContentInit, OnDestro
         this._subscriptions.unsubscribe();
     }
 
+    /** @hidden */
     constructor(public elementRef: ElementRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/upload-collection/upload-collection-simple.directives.ts
+++ b/libs/core/src/lib/upload-collection/upload-collection-simple.directives.ts
@@ -24,6 +24,7 @@ export class UploadCollectionThumbnailDirective {}
     host: { class: 'fd-upload-collection__title' }
 })
 export class UploadCollectionTitleDirective {
+    /** @hidden */
     constructor(public elRef: ElementRef) {}
 }
 
@@ -54,8 +55,10 @@ export class UploadCollectionStatusGroupDirective {}
     host: { class: 'fd-upload-collection__status-group-item' }
 })
 export class UploadCollectionStatusItemDirective implements OnInit {
+    /** @hidden */
     constructor(@Optional() @Inject(ObjectStatusComponent) private _objectStatus: ObjectStatusComponent) {}
 
+    /** @hidden */
     ngOnInit(): void {
         if (this._objectStatus) {
             this._objectStatus._textClass += ' fd-upload-collection__status-group-item-text';

--- a/libs/core/src/lib/utils/abstract-fd-ngx-class.ts
+++ b/libs/core/src/lib/utils/abstract-fd-ngx-class.ts
@@ -10,6 +10,7 @@ import { ElementRef, OnChanges, OnInit, Input, Directive } from '@angular/core';
 /** @hidden */
 @Directive()
 export abstract class AbstractFdNgxClass implements OnInit, OnChanges {
+    /** @hidden */
     private _elementRef: ElementRef;
 
     /** @hidden */
@@ -22,10 +23,12 @@ export abstract class AbstractFdNgxClass implements OnInit, OnChanges {
     /** @hidden */
     abstract _setProperties(): void;
 
+    /** @hidden */
     _setClassToElement(className: string): void {
         (this._elementRef.nativeElement as HTMLElement).classList.value = `${className} ${this.class}`;
     }
 
+    /** @hidden */
     _clearElementClass(): void {
         (this._elementRef.nativeElement as HTMLElement).classList.value = '';
     }

--- a/libs/core/src/lib/utils/directives/auto-complete/auto-complete.directive.ts
+++ b/libs/core/src/lib/utils/directives/auto-complete/auto-complete.directive.ts
@@ -39,15 +39,22 @@ export class AutoCompleteDirective {
     // eslint-disable-next-line @angular-eslint/no-output-on-prefix
     readonly onComplete: EventEmitter<AutoCompleteEvent> = new EventEmitter<AutoCompleteEvent>();
 
+    /** @hidden */
     private readonly _completeKeys: number[] = [ENTER];
 
+    /** @hidden */
     private readonly _fillKeys: number[] = [LEFT_ARROW, RIGHT_ARROW];
 
+    /** @hidden */
     private readonly _stopKeys: number[] = [BACKSPACE, DELETE, ESCAPE];
 
+    /** @hidden */
     private oldValue: string;
+
+    /** @hidden */
     private lastKeyUpEvent: KeyboardEvent;
 
+    /** @hidden */
     constructor(private _elementRef: ElementRef) {}
 
     /** @hidden */
@@ -81,20 +88,24 @@ export class AutoCompleteDirective {
         this.lastKeyUpEvent = event;
     }
 
+    /** @hidden */
     private _typeahead(displayedValue: string): void {
         this._elementRef.nativeElement.value = displayedValue;
         const selectionStartIndex = this.inputText.length;
         this._elementRef.nativeElement.setSelectionRange(selectionStartIndex, displayedValue.length);
     }
 
+    /** @hidden */
     private _isControlKey(event: KeyboardEvent): boolean {
         return KeyUtil.isKeyCode(event, CONTROL) || event.ctrlKey;
     }
 
+    /** @hidden */
     private _defaultDisplay(value: any): string {
         return value;
     }
 
+    /** @hidden */
     private _triggerTypeAhead(): boolean {
         if (
             this.lastKeyUpEvent &&
@@ -107,6 +118,7 @@ export class AutoCompleteDirective {
         }
     }
 
+    /** @hidden */
     private _sendCompleteEvent(forceClose: boolean): void {
         this.onComplete.emit({
             term: this._elementRef.nativeElement.value,

--- a/libs/core/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
+++ b/libs/core/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
@@ -85,6 +85,7 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
     private _originalText: string;
     /** @hidden */
     private windowResize$: Subscription;
+    /** @hidden */
     private _isNativeSupport = true;
     /** @hidden */
     private _lineCount: number;
@@ -133,6 +134,7 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
         this.refreshClamp();
     }
 
+    /** @hidden */
     reset(): void {
         if (this._lineClampTarget && this._originalText) {
             this._lineClampTarget.textContent = this._originalText;
@@ -142,6 +144,7 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
         }
     }
 
+    /** @hidden */
     refreshTarget(event: LineClampTargetDirective): void {
         this._lineClampTarget = event.targetElement;
         this._originalText = event.fdLineClampTargetText;
@@ -149,6 +152,7 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
         this.refreshClamp();
     }
 
+    /** @hidden */
     refreshClamp(): void {
         if (this.fdLineclampState && this._lineCount) {
             this.native();

--- a/libs/core/src/lib/utils/directives/only-digits/only-digits.directive.ts
+++ b/libs/core/src/lib/utils/directives/only-digits/only-digits.directive.ts
@@ -34,6 +34,7 @@ export class OnlyDigitsDirective {
     /** @hidden */
     private _hasDecimalPoint = false;
 
+    /** @hidden */
     constructor(private readonly _el: ElementRef) {
         this._inputElement = this._el.nativeElement;
     }

--- a/libs/core/src/lib/utils/directives/overflow-list/overflow-list-item.directive.ts
+++ b/libs/core/src/lib/utils/directives/overflow-list/overflow-list-item.directive.ts
@@ -4,5 +4,6 @@ import { Directive, ElementRef } from '@angular/core';
     selector: '[fdOverflowListItem], [fd-overflow-list-item]'
 })
 export class OverflowListItemDirective {
+    /** @hidden */
     constructor(public el: ElementRef) {}
 }

--- a/libs/core/src/lib/utils/directives/resize/resize-handle.directive.ts
+++ b/libs/core/src/lib/utils/directives/resize/resize-handle.directive.ts
@@ -4,5 +4,6 @@ import { Directive, ElementRef } from '@angular/core';
     selector: '[fdResizeHandle], [fd-resize-handle]'
 })
 export class ResizeHandleDirective {
+    /** @hidden */
     constructor(public elementRef: ElementRef) {}
 }

--- a/libs/core/src/lib/utils/directives/template/template.directive.ts
+++ b/libs/core/src/lib/utils/directives/template/template.directive.ts
@@ -4,10 +4,14 @@ import { Directive, Input, TemplateRef } from '@angular/core';
     selector: '[fdTemplate]'
 })
 export class TemplateDirective {
-    @Input('fdTemplate') name: string;
+    /** Name of the template */
+    @Input('fdTemplate')
+    name: string;
 
+    /** @hidden */
     constructor(public templateRef: TemplateRef<any>) {}
 
+    /** @hidden */
     getName(): string {
         return this.name;
     }

--- a/libs/core/src/lib/utils/directives/truncate/truncate.directive.ts
+++ b/libs/core/src/lib/utils/directives/truncate/truncate.directive.ts
@@ -32,6 +32,7 @@ export class TruncateDirective implements OnChanges, AfterViewInit {
      */
     private _defaultStyle: string;
 
+    /** @hidden */
     private takeDefaultStyleOnce = true;
 
     /** @hidden
@@ -70,6 +71,7 @@ export class TruncateDirective implements OnChanges, AfterViewInit {
         this._truncate();
     }
 
+    /** @hidden */
     private _truncate(): void {
         this._truncateTarget = this.rootElement;
 

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
@@ -29,6 +29,7 @@ export class DndItemDirective implements DndItem, AfterContentInit, OnDestroy {
     @HostBinding('class.fd-dnd-item')
     applyDragItemClass = true;
 
+    /** Container selector */
     @Input()
     containerSelector?: string;
 
@@ -291,6 +292,7 @@ export class DndItemDirective implements DndItem, AfterContentInit, OnDestroy {
         element.parentNode?.insertBefore(docFrag, element.nextSibling);
     }
 
+    /** @hidden */
     private _listenElementEvents(): void {
         this._subscriptions.add(
             this.released

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-list/dnd-list.directive.ts
@@ -242,6 +242,7 @@ export class DndListDirective<T> implements AfterContentInit, OnDestroy {
         }
     }
 
+    /** @hidden */
     private _changeDraggableState(draggable: boolean): void {
         if (this.dndItems) {
             this.dndItems.forEach((item) => {

--- a/libs/core/src/lib/utils/dynamic-component/dynamic-component-injector.ts
+++ b/libs/core/src/lib/utils/dynamic-component/dynamic-component-injector.ts
@@ -1,12 +1,14 @@
 import { Injector, Type, InjectionToken, InjectFlags } from '@angular/core';
 
 export class DynamicComponentInjector implements Injector {
+    /** @hidden */
     constructor(private _parentInjector: Injector, private _additionalTokens: WeakMap<any, any>) {}
 
     get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
 
     get(token: any, notFoundValue?: any): void;
 
+    /** @hidden */
     get(token: any, notFoundValue?: any, _flags?: any): void {
         const value = this._additionalTokens.get(token);
 

--- a/libs/core/src/lib/utils/dynamic-component/dynamic-component.service.ts
+++ b/libs/core/src/lib/utils/dynamic-component/dynamic-component.service.ts
@@ -84,12 +84,14 @@ export class DynamicComponentService {
         componentRef.destroy();
     }
 
+    /** @hidden */
     private _createDependencyMap(services: any[] = []): WeakMap<any, any> {
         const dependencyMap = new WeakMap();
         services.filter((service) => !!service).forEach((service) => dependencyMap.set(service.constructor, service));
         return dependencyMap;
     }
 
+    /** @hidden */
     private _attachToContainer<V>(componentRef: ComponentRef<V>, config: DynamicComponentConfig): void {
         const configObj = Object.assign({}, config);
         const componentEl = (componentRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement;
@@ -100,6 +102,7 @@ export class DynamicComponentService {
         }
     }
 
+    /** @hidden */
     private _createComponent<V>(
         componentType: Type<V>,
         dependenciesMap: WeakMap<any, any>,
@@ -112,6 +115,7 @@ export class DynamicComponentService {
         return componentRef;
     }
 
+    /** @hidden */
     private _passExternalContent<V>(
         componentRef: ComponentRef<V>,
         content: TemplateRef<any> | Type<any> | string | Record<string, any>

--- a/libs/core/src/lib/utils/functions/get-document-font-size.ts
+++ b/libs/core/src/lib/utils/functions/get-document-font-size.ts
@@ -1,3 +1,4 @@
+/** Get document font size in pixels. */
 export function getDocumentFontSize(): number {
     return document?.documentElement ? parseFloat(getComputedStyle(document.documentElement).fontSize) : 16;
 }

--- a/libs/core/src/lib/utils/functions/module-deprecations-provider.ts
+++ b/libs/core/src/lib/utils/functions/module-deprecations-provider.ts
@@ -1,6 +1,7 @@
 import { FactorySansProvider, Provider } from '@angular/core';
 import { ModuleDeprecations } from '../tokens/module-deprecations.token';
 
+/** Module deprecations provider */
 export function moduleDeprecationsProvider(classRef: any): Provider {
     return {
         provide: ModuleDeprecations,
@@ -9,6 +10,7 @@ export function moduleDeprecationsProvider(classRef: any): Provider {
     };
 }
 
+/** Module deprecations provider factory */
 export function moduleDeprecationsFactory(factory: FactorySansProvider): Provider {
     return {
         provide: ModuleDeprecations,

--- a/libs/core/src/lib/utils/functions/parser-file-size.ts
+++ b/libs/core/src/lib/utils/functions/parser-file-size.ts
@@ -5,6 +5,7 @@ const fileSizeMap = new Map([
     ['TB', 1099511627776]
 ]);
 
+/** Parse file size to bytes */
 export function parserFileSize(fileSize: string): number {
     if (fileSize === '') {
         return 0;

--- a/libs/core/src/lib/utils/functions/uuidv4-generator.ts
+++ b/libs/core/src/lib/utils/functions/uuidv4-generator.ts
@@ -1,3 +1,4 @@
+/** Generate a UUID v4 */
 export function uuidv4(): string {
     const modifier = 16;
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {

--- a/libs/core/src/lib/utils/mixins/apply-mixin.ts
+++ b/libs/core/src/lib/utils/mixins/apply-mixin.ts
@@ -1,3 +1,4 @@
+/** Apply a mixin to a class. */
 export function applyMixins(derivedCtor: any, baseCtors: any[]): any {
     baseCtors.forEach((baseCtor) => {
         Object.getOwnPropertyNames(baseCtor.prototype).forEach((name) => {

--- a/libs/core/src/lib/utils/pipes/displayFn.pipe.ts
+++ b/libs/core/src/lib/utils/pipes/displayFn.pipe.ts
@@ -4,6 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
     name: 'displayFnPipe'
 })
 export class DisplayFnPipe implements PipeTransform {
+    /** Transform value with display function. */
     transform(value: any, displayFn: any, ...args: any): string {
         return displayFn(value, ...args);
     }

--- a/libs/core/src/lib/utils/pipes/is-compact.pipe.ts
+++ b/libs/core/src/lib/utils/pipes/is-compact.pipe.ts
@@ -4,6 +4,7 @@ import { isCompactDensity } from './../functions/is-compact-density';
 
 @Pipe({ name: 'isCompactDensity' })
 export class IsCompactDensityPipe implements PipeTransform {
+    /** Check if the content density is compact. */
     transform(size: ContentDensity): boolean {
         return isCompactDensity(size);
     }

--- a/libs/core/src/lib/utils/pipes/safe.pipe.ts
+++ b/libs/core/src/lib/utils/pipes/safe.pipe.ts
@@ -5,7 +5,10 @@ import { DomSanitizer, SafeHtml, SafeStyle, SafeScript, SafeUrl, SafeResourceUrl
     name: 'safe'
 })
 export class SafePipe implements PipeTransform {
+    /** @hidden */
     constructor(protected sanitizer: DomSanitizer) {}
+
+    /** Sanitize HTML string. */
     public transform(value: any, type: string): SafeHtml | SafeStyle | SafeScript | SafeUrl | SafeResourceUrl {
         switch (type) {
             case 'html':

--- a/libs/core/src/lib/utils/pipes/search-highlight.pipe.ts
+++ b/libs/core/src/lib/utils/pipes/search-highlight.pipe.ts
@@ -5,6 +5,7 @@ import escape from 'lodash-es/escape';
     name: 'highlight'
 })
 export class SearchHighlightPipe implements PipeTransform {
+    /** Highlight search term in string. */
     transform(value: string, args: string, active: boolean = true, includeSpans: boolean = false): string {
         value = escape(value);
         let result: string = value;

--- a/libs/core/src/lib/utils/pipes/truncate.pipe.ts
+++ b/libs/core/src/lib/utils/pipes/truncate.pipe.ts
@@ -4,6 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
     name: 'truncate'
 })
 export class TruncatePipe implements PipeTransform {
+    /** Truncate string to given length. */
     transform(value: string, limit: number = 500): string {
         return value && value.length > limit ? value.substring(0, limit) + '...' : value;
     }

--- a/libs/core/src/lib/utils/pipes/two-digits.pipe.ts
+++ b/libs/core/src/lib/utils/pipes/two-digits.pipe.ts
@@ -4,6 +4,7 @@ import { Pipe, PipeTransform } from '@angular/core';
     name: 'twoDigits'
 })
 export class TwoDigitsPipe implements PipeTransform {
+    /** Transform number to two digits. */
     transform(value: number, enable: boolean = true): string {
         if ((value || value === 0) && enable) {
             return value < 10 ? '0' + value : value.toString();

--- a/libs/core/src/lib/utils/pipes/value-by-path.pipe.ts
+++ b/libs/core/src/lib/utils/pipes/value-by-path.pipe.ts
@@ -3,6 +3,7 @@ import { get } from 'lodash-es';
 
 @Pipe({ name: 'valueByPath' })
 export class ValueByPathPipe implements PipeTransform {
+    /** Get value by path. */
     transform(value: any, key: string): any {
         return get(value, key);
     }

--- a/libs/core/src/lib/utils/services/content-density.service.ts
+++ b/libs/core/src/lib/utils/services/content-density.service.ts
@@ -14,6 +14,7 @@ export class ContentDensityService {
     /** Content Density BehaviourSubject */
     readonly contentDensity = new BehaviorSubject(DEFAULT_CONTENT_DENSITY);
 
+    /** @hidden */
     constructor() {
         if (isDevMode()) {
             console.warn(

--- a/libs/core/src/lib/utils/services/destroyed.service.ts
+++ b/libs/core/src/lib/utils/services/destroyed.service.ts
@@ -3,10 +3,12 @@ import { ReplaySubject } from 'rxjs';
 
 @Injectable()
 export class DestroyedService extends ReplaySubject<void> implements OnDestroy {
+    /** @hidden */
     constructor() {
         super(1);
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this.next();
         this.complete();

--- a/libs/core/src/lib/utils/services/focus-trap.service.ts
+++ b/libs/core/src/lib/utils/services/focus-trap.service.ts
@@ -6,9 +6,8 @@ import { uuidv4 } from '../functions/uuidv4-generator';
     providedIn: 'root'
 })
 export class FocusTrapService {
+    /** @hidden */
     private _focusTrapInstances: Map<any, FocusTrap> = new Map();
-
-    constructor() {}
 
     /**
      * Creates focus trap instance for defined element

--- a/libs/core/src/lib/utils/services/local-storage.service.ts
+++ b/libs/core/src/lib/utils/services/local-storage.service.ts
@@ -20,12 +20,15 @@ class MockStorage {
 
 @Injectable({ providedIn: 'root' })
 export class LocalStorageService {
+    /** @hidden */
     private _storage: Storage;
 
+    /** @hidden */
     constructor() {
         typeof localStorage !== 'undefined' ? (this._storage = localStorage) : (this._storage = new MockStorage());
     }
 
+    /** Get item from local storage. */
     get(key: string): any {
         const value = this._storage.getItem(key);
         if (value) {
@@ -34,6 +37,7 @@ export class LocalStorageService {
         return null;
     }
 
+    /** Set item in local storage. */
     set(key: string, value: any): void {
         this._storage.setItem(key, JSON.stringify(value));
     }

--- a/libs/core/src/lib/utils/services/resize-observer.service.ts
+++ b/libs/core/src/lib/utils/services/resize-observer.service.ts
@@ -10,6 +10,7 @@ interface ObservedElement {
 
 @Injectable({ providedIn: 'root' })
 export class ResizeObserverFactory {
+    /** Factory to create ResizeObserver if it's present in browser.  */
     create(callback: ResizeObserverCallback): ResizeObserver | null {
         return typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(callback);
     }
@@ -17,14 +18,18 @@ export class ResizeObserverFactory {
 
 @Injectable({ providedIn: 'root' })
 export class ResizeObserverService implements OnDestroy {
+    /** @hidden */
     private _observedElements = new Map<Element, ObservedElement>();
 
+    /** @hidden */
     constructor(private _resizeObserverFactory: ResizeObserverFactory) {}
 
+    /** @hidden */
     ngOnDestroy(): void {
         this._observedElements.forEach((_, element) => this._cleanupObserver(element));
     }
 
+    /** Observe the given element and emit whenever its size changes. */
     observe(elementOrRef: Element | ElementRef<Element>): Observable<ResizeObserverEntry[]> {
         const element = coerceElement(elementOrRef);
 

--- a/libs/core/src/lib/utils/services/rtl.service.ts
+++ b/libs/core/src/lib/utils/services/rtl.service.ts
@@ -11,7 +11,10 @@ export const RTL_LANGUAGE = new InjectionToken<string[]>('RtlLanguage');
  * user can overwrite default languages by using injection token RtlLanguageToken
  */
 export class RtlService {
+    /** RTL value */
     rtl: BehaviorSubject<boolean>;
+
+    /** @hidden */
     constructor(@Optional() @Inject(RTL_LANGUAGE) injectedRtlLanguages: string[]) {
         injectedRtlLanguages = injectedRtlLanguages || DefaultRtlLanguages;
 

--- a/libs/core/src/lib/utils/services/tabbable-element.service.ts
+++ b/libs/core/src/lib/utils/services/tabbable-element.service.ts
@@ -4,6 +4,7 @@ import { Inject, Injectable, Optional } from '@angular/core';
 
 @Injectable()
 export class TabbableElementService {
+    /** @hidden */
     constructor(
         private readonly _checker: InteractivityChecker,
         @Optional() @Inject(DOCUMENT) private readonly _document: Document | null

--- a/libs/core/src/lib/utils/services/themes.service.ts
+++ b/libs/core/src/lib/utils/services/themes.service.ts
@@ -76,6 +76,7 @@ export class ThemesService {
     /** @hidden **/
     private readonly _onDestroy$: Subject<void> = new Subject<void>();
 
+    /** @hidden */
     constructor(@Optional() private _activatedRoute: ActivatedRoute, private _sanitizer: DomSanitizer) {}
 
     /**

--- a/libs/core/src/lib/wizard/deprecated-wizard-compact.directive.ts
+++ b/libs/core/src/lib/wizard/deprecated-wizard-compact.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedWizardCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fd-wizard-step-indicator');
     }

--- a/libs/core/src/lib/wizard/wizard-navigation/wizard-navigation.component.ts
+++ b/libs/core/src/lib/wizard/wizard-navigation/wizard-navigation.component.ts
@@ -10,15 +10,16 @@ import { WIZARD, WizardComponentInterface } from '../wizard-injection-token';
 export class WizardNavigationComponent {
     /** Aria label for the wizard navigation component element. */
     @Input()
-    get ariaLabel(): string | undefined {
-        return this._ariaLabel ?? this._wizard?.ariaLabel;
-    }
     set ariaLabel(value: Nullable<string>) {
         this._ariaLabel = value;
+    }
+    get ariaLabel(): string | undefined {
+        return this._ariaLabel ?? this._wizard?.ariaLabel;
     }
 
     /** @hidden */
     private _ariaLabel: Nullable<string>;
 
+    /** @hidden */
     constructor(@Optional() @Inject(WIZARD) private _wizard?: WizardComponentInterface) {}
 }

--- a/libs/core/src/lib/wizard/wizard-step-indicator/wizard-step-indicator.component.ts
+++ b/libs/core/src/lib/wizard/wizard-step-indicator/wizard-step-indicator.component.ts
@@ -31,6 +31,7 @@ export class WizardStepIndicatorComponent implements OnDestroy {
     @Output()
     stepIndicatorItemClicked = new EventEmitter<WizardStepComponent>();
 
+    /** @hidden */
     @ViewChild(ActionSheetComponent)
     actionSheet: ActionSheetComponent;
 
@@ -40,6 +41,7 @@ export class WizardStepIndicatorComponent implements OnDestroy {
     /** @hidden */
     private _subscriptions = new Subscription();
 
+    /** @hidden */
     constructor(private _cdRef: ChangeDetectorRef) {}
 
     /** @hidden */

--- a/libs/core/src/lib/wizard/wizard-step/wizard-step.component.ts
+++ b/libs/core/src/lib/wizard/wizard-step/wizard-step.component.ts
@@ -123,6 +123,7 @@ export class WizardStepComponent implements OnChanges, AfterViewInit, OnDestroy 
     @ViewChild('wizardLabel', { read: ElementRef })
     wizardLabel: ElementRef;
 
+    /** @hidden */
     @ViewChild('progressBarLink', { read: ElementRef })
     progressBarLink: ElementRef;
 

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -90,6 +90,7 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
     @HostBinding('class.fd-wizard--responsive-paddings')
     responsivePaddings = false;
 
+    /** Whether to display a summary step.  */
     @Input()
     displaySummaryStep = false;
 
@@ -138,6 +139,7 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
     /** @hidden */
     private _previousWidth: number;
 
+    /** @hidden */
     constructor(
         private _elRef: ElementRef,
         private readonly _cdRef: ChangeDetectorRef,

--- a/libs/core/src/lib/wizard/wizard.service.ts
+++ b/libs/core/src/lib/wizard/wizard.service.ts
@@ -6,6 +6,7 @@ import { COMPLETED_STEP_STATUS, CURRENT_STEP_STATUS } from './constants';
 
 @Injectable()
 export class WizardService {
+    /** @hidden */
     constructor(@Optional() private _rtlService: RtlService) {}
 
     /** @hidden */

--- a/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.ts
+++ b/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.ts
@@ -28,7 +28,7 @@ export const DAYJS_DATE_TIME_ADAPTER_OPTIONS = new InjectionToken<DayjsDatetimeA
     }
 );
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
+/** @hidden */
 export function DAYJS_DATE_TIME_ADAPTER_OPTIONS_FACTORY(): DayjsDatetimeAdapterOptions {
     return {
         useUtc: false,
@@ -50,8 +50,10 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
     /** @hidden */
     private _localeData: DateLocale;
 
+    /** @hidden */
     fromNow: undefined;
 
+    /** @hidden */
     constructor(
         @Optional() @Inject(LOCALE_ID) localeId: string,
         @Optional() @Inject(DAYJS_DATE_TIME_ADAPTER_OPTIONS) private _options?: DayjsDatetimeAdapterOptions
@@ -69,6 +71,7 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         this.setLocale(localeId || dayjs.locale());
     }
 
+    /** Set locale */
     setLocale(locale: string): void {
         if (locale.toLowerCase() === 'en-us') {
             // Handle English locale name as it's a default one and it is different
@@ -99,50 +102,62 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         super.setLocale(locale);
     }
 
+    /** Get year */
     getYear(date: Dayjs): number {
         return date.year();
     }
 
+    /** Get month */
     getMonth(date: Dayjs): number {
         return date.month() + 1;
     }
 
+    /** Get date */
     getDate(date: Dayjs): number {
         return date.date();
     }
 
+    /** Get day of the week */
     getDayOfWeek(date: Dayjs): number {
         return date.day() + 1;
     }
 
+    /** Get hours */
     getHours(date: Dayjs): number {
         return date.hour();
     }
 
+    /** Get minutes */
     getMinutes(date: Dayjs): number {
         return date.minute();
     }
 
+    /** Get seconds */
     getSeconds(date: Dayjs): number {
         return date.second();
     }
 
+    /** Set hours in date object */
     setHours(date: Dayjs, hours: number): Dayjs {
         return date.hour(hours);
     }
 
+    /** Set minutes in date object */
     setMinutes(date: Dayjs, minutes: number): Dayjs {
         return date.minute(minutes);
     }
 
+    /** Set seconds in date object */
     setSeconds(date: Dayjs, seconds: number): Dayjs {
         return date.second(seconds);
     }
 
+    /** Get week number */
     getWeekNumber(date: Dayjs): number {
         return date.week();
     }
 
+    /** Get months names */
     getMonthNames(style: 'long' | 'short' | 'narrow'): string[] {
         switch (style) {
             case 'narrow':
@@ -155,10 +170,12 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         }
     }
 
+    /** Get date names */
     getDateNames(): string[] {
         return range(31, (i) => this.createDate(2017, 0, i + 1).format('D'));
     }
 
+    /** Get days of week names */
     getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[] {
         switch (style) {
             case 'narrow':
@@ -171,14 +188,17 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         }
     }
 
+    /** Get year name */
     getYearName(date: Dayjs): string {
         return date.format('YYYY');
     }
 
+    /** Get week name */
     getWeekName(date: Dayjs): string {
         return date.week().toLocaleString(this.locale);
     }
 
+    /** Get hour names */
     getHourNames({ meridian, twoDigit }: { twoDigit: boolean; meridian: boolean }): string[] {
         const format: string = meridian ? (twoDigit ? 'hh' : 'h') : twoDigit ? 'HH' : 'H';
         const dayjsDate = this._createDayjsDate();
@@ -186,6 +206,7 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return range(24, (i) => this.clone(dayjsDate).hour(i).format(format));
     }
 
+    /** Get minute names */
     getMinuteNames({ twoDigit }: { twoDigit: boolean }): string[] {
         const format: string = twoDigit ? 'mm' : 'm';
         const dayjsDate = this._createDayjsDate();
@@ -193,6 +214,7 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return range(60, (i) => this.clone(dayjsDate).minute(i).format(format));
     }
 
+    /** Get second names */
     getSecondNames({ twoDigit }: { twoDigit: boolean }): string[] {
         const format: string = twoDigit ? 'ss' : 's';
         const dayjsDate = this._createDayjsDate();
@@ -200,7 +222,10 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return range(60, (i) => this.clone(dayjsDate).second(i).format(format));
     }
 
-    // isLower property is responsible for the lower and upper cases of the result
+    /**
+     *  Get day period names
+     * @param isLower responsible for the lower and upper cases of the result
+     */
     getDayPeriodNames(isLower = false): [string, string] {
         const AM = this._dayjsLocaleData.meridiem?.(6, 0, isLower) ?? (isLower ? 'am' : 'AM');
         const PM = this._dayjsLocaleData.meridiem?.(16, 0, isLower) ?? (isLower ? 'pm' : 'PM');
@@ -208,14 +233,17 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return [AM, PM];
     }
 
+    /** Get first day of the week */
     getFirstDayOfWeek(): number {
         return this._localeData.firstDayOfWeek;
     }
 
+    /** Get number of days in the month */
     getNumDaysInMonth(date: Dayjs): number {
         return date.daysInMonth();
     }
 
+    /** Try to parse a string to a date object */
     parse(value: any, parseFormat: string = ''): Dayjs | null {
         if (value && typeof value === 'string') {
             return this._createDayjsDate(value, parseFormat);
@@ -227,6 +255,7 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return value ? this._createDayjsDate(value).locale(this.locale) : null;
     }
 
+    /** Format a date as a string */
     format(date: Dayjs, displayFormat: string): string {
         if (!date) {
             return '';
@@ -239,6 +268,7 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return date.locale(dayjs.locale()).format(displayFormat);
     }
 
+    /** Create date object from values */
     createDate(year: number, month: number, date: number): Dayjs {
         const result = this._createDayjsDate(new Date(year, month - 1, date));
 
@@ -249,26 +279,32 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return result;
     }
 
+    /** Get today */
     today(): Dayjs {
         return this._createDayjsDate().locale(this.locale).startOf('day');
     }
 
+    /** Get now */
     now(): Dayjs {
         return this._createDayjsDate().locale(this.locale);
     }
 
+    /** Add years to date */
     addCalendarYears(date: Dayjs, years: number): Dayjs {
         return date.add(years, 'year');
     }
 
+    /** Add months to date */
     addCalendarMonths(date: Dayjs, months: number): Dayjs {
         return date.add(months, 'month');
     }
 
+    /** Add days to date */
     addCalendarDays(date: Dayjs, days: number): Dayjs {
         return date.add(days, 'day');
     }
 
+    /** Clone date */
     clone(date: Dayjs): Dayjs {
         if (!date) {
             return date;
@@ -281,6 +317,7 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return date.clone();
     }
 
+    /** Compare if dates are equal */
     datesEqual(date1: Dayjs, date2: Dayjs): boolean {
         if (!date1 || !date2) {
             return false;
@@ -289,6 +326,7 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return date1.isSame(date2, 'day');
     }
 
+    /** Compare if dates and time are equal */
     dateTimesEqual(date1: Dayjs, date2: Dayjs): boolean {
         if (!date1 || !date2) {
             return false;
@@ -297,6 +335,7 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return date1.isSame(date2);
     }
 
+    /** Check if date is in range */
     isBetween(dateToCheck: Dayjs, startDate: Dayjs, endDate: Dayjs): boolean {
         if (!dateToCheck || !startDate || !endDate) {
             return false;
@@ -305,32 +344,38 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         return dateToCheck.isBetween(startDate, endDate);
     }
 
+    /** Check if date is valid date object */
     isValid(date: Nullable<Dayjs>): date is Dayjs {
         return !!date?.isValid();
     }
 
+    /** Convert date to ISO8601 string */
     toIso8601(date: Dayjs): string {
         return date.toISOString();
     }
 
+    /** Check if time format includes day period */
     isTimeFormatIncludesDayPeriod(displayFormat: string): boolean {
         const format = this._prepareFormat(displayFormat);
 
         return !!format.match(/[aA]/);
     }
 
+    /** Check if time format includes hours */
     isTimeFormatIncludesHours(displayFormat: string): boolean {
         const format = this._prepareFormat(displayFormat);
 
         return !!format.match(/[hH]/);
     }
 
+    /** Check if time format includes minutes */
     isTimeFormatIncludesMinutes(displayFormat: string): boolean {
         const format = this._prepareFormat(displayFormat);
 
         return !!format.match(/[m]/);
     }
 
+    /** Check if time format includes seconds */
     isTimeFormatIncludesSeconds(displayFormat: string): boolean {
         const format = this._prepareFormat(displayFormat);
 

--- a/libs/docs/schema/.eslintrc.json
+++ b/libs/docs/schema/.eslintrc.json
@@ -7,7 +7,9 @@
             "extends": ["plugin:@nrwl/nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
             "rules": {
                 "@angular-eslint/directive-selector": ["off"],
-                "@angular-eslint/component-selector": ["off"]
+                "@angular-eslint/component-selector": ["off"],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             }
         },
         {

--- a/libs/docs/shared/.eslintrc.json
+++ b/libs/docs/shared/.eslintrc.json
@@ -7,7 +7,9 @@
             "extends": ["plugin:@nrwl/nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
             "rules": {
                 "@angular-eslint/directive-selector": ["off"],
-                "@angular-eslint/component-selector": ["off"]
+                "@angular-eslint/component-selector": ["off"],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             }
         },
         {

--- a/libs/fn/src/lib/.eslintrc.json
+++ b/libs/fn/src/lib/.eslintrc.json
@@ -15,7 +15,7 @@
                     "error",
                     {
                         "type": "attribute",
-                        "prefix": "fdp",
+                        "prefix": "fn",
                         "style": "camelCase"
                     }
                 ],
@@ -23,10 +23,12 @@
                     "error",
                     {
                         "type": "element",
-                        "prefix": "fdp",
+                        "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/avatar/.eslintrc.json
+++ b/libs/fn/src/lib/avatar/.eslintrc.json
@@ -25,8 +25,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/button/.eslintrc.json
+++ b/libs/fn/src/lib/button/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/cdk/.eslintrc.json
+++ b/libs/fn/src/lib/cdk/.eslintrc.json
@@ -25,8 +25,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/checkbox/.eslintrc.json
+++ b/libs/fn/src/lib/checkbox/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/form/.eslintrc.json
+++ b/libs/fn/src/lib/form/.eslintrc.json
@@ -15,7 +15,7 @@
                     "error",
                     {
                         "type": "attribute",
-                        "prefix": "fd",
+                        "prefix": "fn",
                         "style": "camelCase"
                     }
                 ],
@@ -23,10 +23,12 @@
                     "error",
                     {
                         "type": "element",
-                        "prefix": "fd",
+                        "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/generic-tag/.eslintrc.json
+++ b/libs/fn/src/lib/generic-tag/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/info-label/.eslintrc.json
+++ b/libs/fn/src/lib/info-label/.eslintrc.json
@@ -26,8 +26,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/input/.eslintrc.json
+++ b/libs/fn/src/lib/input/.eslintrc.json
@@ -25,8 +25,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/list/.eslintrc.json
+++ b/libs/fn/src/lib/list/.eslintrc.json
@@ -39,8 +39,11 @@
                     }
                 ],
                 "@angular-eslint/prefer-output-readonly": ["error"],
-                "@angular-eslint/use-component-selector": ["error"]
-            }
+                "@angular-eslint/use-component-selector": ["error"],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/message-strip/.eslintrc.json
+++ b/libs/fn/src/lib/message-strip/.eslintrc.json
@@ -25,8 +25,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/message-toast/.eslintrc.json
+++ b/libs/fn/src/lib/message-toast/.eslintrc.json
@@ -26,8 +26,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/notification/.eslintrc.json
+++ b/libs/fn/src/lib/notification/.eslintrc.json
@@ -26,8 +26,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/object-status/.eslintrc.json
+++ b/libs/fn/src/lib/object-status/.eslintrc.json
@@ -26,8 +26,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/progress-bar/.eslintrc.json
+++ b/libs/fn/src/lib/progress-bar/.eslintrc.json
@@ -25,8 +25,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/radio/.eslintrc.json
+++ b/libs/fn/src/lib/radio/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/search/.eslintrc.json
+++ b/libs/fn/src/lib/search/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/segmented-button/.eslintrc.json
+++ b/libs/fn/src/lib/segmented-button/.eslintrc.json
@@ -10,6 +10,7 @@
                 "../../../../../.eslintrc-overrides.json"
             ],
             "rules": {
+                "@angular-eslint/no-host-metadata-property": "off",
                 "@angular-eslint/directive-selector": [
                     "error",
                     {
@@ -25,8 +26,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/fn/src/lib/select/.eslintrc.json
+++ b/libs/fn/src/lib/select/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/slider/.eslintrc.json
+++ b/libs/fn/src/lib/slider/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/switch/.eslintrc.json
+++ b/libs/fn/src/lib/switch/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/tabs/.eslintrc.json
+++ b/libs/fn/src/lib/tabs/.eslintrc.json
@@ -26,7 +26,9 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/fn/src/lib/utils/.eslintrc.json
+++ b/libs/fn/src/lib/utils/.eslintrc.json
@@ -25,8 +25,11 @@
                         "prefix": "fn",
                         "style": "kebab-case"
                     }
-                ]
-            }
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
+            },
+            "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },
         {
             "files": ["*.html"],

--- a/libs/moment-adapter/.eslintrc.json
+++ b/libs/moment-adapter/.eslintrc.json
@@ -25,7 +25,9 @@
                         "prefix": "fd",
                         "style": "kebab-case"
                     }
-                ]
+                ],
+                "jsdoc/require-jsdoc": "off",
+                "grouped-accessor-pairs": "off"
             },
             "plugins": ["@angular-eslint/eslint-plugin", "@typescript-eslint"]
         },

--- a/libs/platform/src/lib/action-bar/action-bar.component.ts
+++ b/libs/platform/src/lib/action-bar/action-bar.component.ts
@@ -41,12 +41,15 @@ export class ActionBarComponent extends BaseComponent implements OnInit {
     @Output()
     backButtonClick: EventEmitter<void> = new EventEmitter();
 
+    /** @hidden */
     navigationArrow$: Observable<string>;
 
+    /** @hidden */
     constructor(@Optional() private _rtlService: RtlService, _cd: ChangeDetectorRef) {
         super(_cd);
     }
 
+    /** @hidden */
     ngOnInit(): void {
         this.navigationArrow$ = this._rtlService
             ? this._rtlService.rtl.pipe(map((isRtl) => (isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow')))

--- a/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.ts
@@ -223,6 +223,7 @@ export class ApprovalFlowNodeComponent implements OnInit, OnChanges, OnDestroy {
     @ContentChild(GridListItemComponent)
     _gridListItem: GridListItemComponent<ApprovalGraphNode>;
 
+    /** @hidden */
     readonly approvalFlowNodeId = 'fdp-approval-flow-node-' + defaultId++;
 
     /** @hidden */

--- a/libs/platform/src/lib/approval-flow/approval-flow-select-type/approval-flow-select-type.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-select-type/approval-flow-select-type.component.ts
@@ -26,6 +26,7 @@ export class ApprovalFlowSelectTypeComponent {
     /** @hidden */
     _nodeTypes = APPROVAL_FLOW_NODE_TYPES;
 
+    /** @hidden */
     _toNextSerial = false;
 
     /** @hidden */

--- a/libs/platform/src/lib/approval-flow/approval-flow-team-list/approval-flow-team-list.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-team-list/approval-flow-team-list.component.ts
@@ -15,19 +15,24 @@ import { trackByFn } from '../helpers';
     }
 })
 export class ApprovalFlowTeamListComponent {
+    /** Approval flow teams */
     @Input()
     teams: ApprovalTeam[] = [];
 
+    /** Whether in RTL mode */
     @Input()
     isRtl = false;
 
+    /** Selected team ID */
     @Input()
     selectedTeamId: Nullable<string>;
 
+    /** Event emitted on team click */
     @Output()
     // eslint-disable-next-line @angular-eslint/no-output-on-prefix
     onTeamClick = new EventEmitter<ApprovalTeam>();
 
+    /** Event emitted on team selection change */
     @Output()
     // eslint-disable-next-line @angular-eslint/no-output-on-prefix
     onTeamRadioClick = new EventEmitter<ApprovalTeam>();

--- a/libs/platform/src/lib/approval-flow/approval-flow-user-details/approval-flow-user-details.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-user-details/approval-flow-user-details.component.ts
@@ -15,12 +15,15 @@ import { ApprovalUser } from '../interfaces';
     }
 })
 export class ApprovalFlowUserDetailsComponent {
+    /** Approval Flow user */
     @Input()
     user: ApprovalUser;
 
+    /** Approval Flow user details */
     @Input()
     details: Nullable<Observable<any>>;
 
+    /** Approval Flow user details template */
     @Input()
     detailsTemplate: TemplateRef<any>;
 }

--- a/libs/platform/src/lib/approval-flow/approval-flow-user-list/approval-flow-user-list.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-user-list/approval-flow-user-list.component.ts
@@ -38,26 +38,33 @@ const INTERVAL_IN_MS = 10;
     }
 })
 export class ApprovalFlowUserListComponent implements AfterViewInit, OnChanges, OnDestroy {
+    /** Approval flow users */
     @Input()
     users: ApprovalUser[] = [];
 
+    /** Approval flow selected users */
     @Input()
     selectedUsers: ApprovalUser[] = [];
 
+    /** Whether the list is selectable */
     @Input()
     isSelectable = true;
 
+    /** Event emitted on user click */
     @Output()
     // eslint-disable-next-line @angular-eslint/no-output-on-prefix
     onUserClick = new EventEmitter<ApprovalUser>();
 
+    /** Event emitted on selection change */
     @Output()
     // eslint-disable-next-line @angular-eslint/no-output-on-prefix
     onSelectionChange = new EventEmitter<ApprovalUser[]>();
 
+    /** @hidden */
     @ViewChild(ListComponent)
     list: ListComponent<ApprovalUser>;
 
+    /** @hidden */
     @ViewChildren(StandardListItemComponent)
     listItems: QueryList<StandardListItemComponent>;
 

--- a/libs/platform/src/lib/approval-flow/approval-flow.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow.component.ts
@@ -93,6 +93,7 @@ export class ApprovalFlowComponent implements OnInit, OnChanges, OnDestroy {
     /** Title which is displayed in the header of the Approval Flow component. */
     @Input() title: string;
 
+    /** Value of the approval flow component. */
     @Input() value: ApprovalProcess;
 
     /** Data source for the users of Approval Flow component. */
@@ -244,6 +245,7 @@ export class ApprovalFlowComponent implements OnInit, OnChanges, OnDestroy {
     /** @hidden */
     _dragDropInProgress = false;
 
+    /** @hidden */
     readonly approvalFlowUniqueId = `fdp-approval-flow-${++defaultId}`;
 
     /** @hidden */
@@ -311,6 +313,7 @@ export class ApprovalFlowComponent implements OnInit, OnChanges, OnDestroy {
         this._setupDataSourceSubscription();
     }
 
+    /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.value) {
             const process = this.value ?? { watchers: [], nodes: [] };

--- a/libs/platform/src/lib/approval-flow/helpers/index.ts
+++ b/libs/platform/src/lib/approval-flow/helpers/index.ts
@@ -1,42 +1,52 @@
 import { ApprovalGraphNode, ApprovalNode, ApprovalTeam, ApprovalUser } from '../interfaces';
 import { ApprovalFlowGraph } from '../approval-flow-graph';
 
+/** @hidden */
 export function isNodeApproved(node: ApprovalNode): boolean {
     return node.status === 'approved';
 }
 
+/** @hidden */
 export function isNodeStarted(node: ApprovalNode): boolean {
     return node.status !== 'not started';
 }
 
+/** @hidden */
 export function displayTeamFn(team: ApprovalTeam): string {
     return team?.name;
 }
 
+/** @hidden */
 export function displayUserFn(user: ApprovalUser): string {
     return user?.name;
 }
 
+/** @hidden */
 export function userValueFn(user: ApprovalUser): string {
     return user?.id;
 }
 
+/** @hidden */
 export function filterByName(obj: { name: string }, searchString: string): boolean {
     return obj.name.toLowerCase().indexOf(searchString.toLowerCase()) > -1;
 }
 
+/** @hidden */
 export function trackByFn(index: number, item: { id: string }): number | string {
     return item?.id ?? index;
 }
 
+/** @hidden */
 export function getGraphNodes(graph: ApprovalFlowGraph): ApprovalGraphNode[] {
     return graph.columns.reduce((acc, column) => acc.concat(column.nodes), <ApprovalGraphNode[]>[]);
 }
 
+/** @hidden */
 export function getParentNodes(node: ApprovalNode, nodes: ApprovalNode[]): ApprovalNode[] {
     return nodes.filter((_node) => isNodeTargetsIncludeId(_node, node.id));
 }
 
+/** @hidden */
 export function getBlankApprovalGraphNode(): ApprovalGraphNode {
     return {
         id: `blankId${(Math.random() * 1000).toFixed()}`,
@@ -48,6 +58,7 @@ export function getBlankApprovalGraphNode(): ApprovalGraphNode {
     };
 }
 
+/** @hidden */
 export function getSpaceApprovalGraphNode(): ApprovalGraphNode {
     return {
         id: `spaceId${(Math.random() * 1000).toFixed()}`,
@@ -59,6 +70,7 @@ export function getSpaceApprovalGraphNode(): ApprovalGraphNode {
     };
 }
 
+/** @hidden */
 export function isNodeTargetsIncludeId(node: ApprovalNode, id: string): boolean {
     return node.targets.includes(id);
 }

--- a/libs/platform/src/lib/approval-flow/services/approval-flow-add-node-view.service.ts
+++ b/libs/platform/src/lib/approval-flow/services/approval-flow-add-node-view.service.ts
@@ -10,45 +10,57 @@ export enum VIEW_MODES {
 
 @Injectable()
 export class ApprovalFlowAddNodeViewService {
+    /** @hidden */
     onViewChange = new EventEmitter();
 
+    /** @hidden */
     private currentView?: VIEW_MODES;
+    /** @hidden */
     private selectedTeam?: ApprovalTeam;
 
+    /** @hidden */
     get isUserDetailsMode(): boolean {
         return this.currentView === VIEW_MODES.USER_DETAILS;
     }
 
+    /** @hidden */
     get isTeamMembersMode(): boolean {
         return this.currentView === VIEW_MODES.VIEW_TEAM_MEMBERS;
     }
 
+    /** @hidden */
     get isSelectUserMode(): boolean {
         return this.currentView === VIEW_MODES.SELECT_USER;
     }
 
+    /** @hidden */
     get isSelectTeamMode(): boolean {
         return this.currentView === VIEW_MODES.SELECT_TEAM;
     }
 
+    /** @hidden */
     get team(): ApprovalTeam | undefined {
         return this.selectedTeam;
     }
 
+    /** @hidden */
     setCurrentView(view: VIEW_MODES): void {
         this.currentView = view;
         this.onViewChange.emit();
     }
 
+    /** @hidden */
     resetView(): void {
         this.currentView = undefined;
         this.onViewChange.emit();
     }
 
+    /** @hidden */
     selectTeam(team: ApprovalTeam): void {
         this.selectedTeam = team;
     }
 
+    /** @hidden */
     resetTeam(): void {
         this.selectedTeam = undefined;
     }

--- a/libs/platform/src/lib/approval-flow/tests/providers.ts
+++ b/libs/platform/src/lib/approval-flow/tests/providers.ts
@@ -6,6 +6,7 @@ import { DataProvider, ProviderParams } from '@fundamental-ngx/platform/shared';
 import { users, teams } from './data';
 
 export class UserDataProvider extends DataProvider<ApprovalUser> {
+    /** @hidden */
     fetch(params: ProviderParams): Observable<ApprovalUser[]> {
         let result = users;
         const query = params.get('query')?.toLowerCase();
@@ -15,6 +16,7 @@ export class UserDataProvider extends DataProvider<ApprovalUser> {
         return of(cloneDeep(result)).pipe(delay(500));
     }
 
+    /** @hidden */
     getOne(params: ProviderParams): Observable<ApprovalUser & { phone: string; email: string }> {
         const id = params.get('id');
         const found = users.find((user) => user.id === id)!;
@@ -27,6 +29,7 @@ export class UserDataProvider extends DataProvider<ApprovalUser> {
 }
 
 export class TeamDataProvider extends DataProvider<ApprovalTeam> {
+    /** @hidden */
     fetch(params: ProviderParams): Observable<ApprovalTeam[]> {
         let result = teams;
         const query = params.get('query')?.toLowerCase();

--- a/libs/platform/src/lib/button/button.component.ts
+++ b/libs/platform/src/lib/button/button.component.ts
@@ -105,6 +105,7 @@ export class ButtonComponent extends BaseComponent implements AfterViewInit {
     @HostBinding('attr.tabindex')
     tabIndex = '-1';
 
+    /** @hidden */
     constructor(protected _changeDetector: ChangeDetectorRef, private _elementRef: ElementRef) {
         super(_changeDetector);
     }

--- a/libs/platform/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
@@ -6,6 +6,11 @@ import { Nullable } from '@fundamental-ngx/core/shared';
 
 /** Dynamic Page collapse change event */
 export class DynamicPageCollapseChangeEvent {
+    /**
+     * Dynamic Page collapse change event
+     * @param source Dynamic Page component
+     * @param payload Collapse state
+     */
     constructor(public source: DynamicPageHeaderComponent, public payload: boolean) {}
 }
 

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
@@ -32,6 +32,11 @@ import { DynamicPageService } from './dynamic-page.service';
 
 /** Dynamic Page tab change event */
 export class DynamicPageTabChangeEvent {
+    /**
+     * Dynamic Page tab change event
+     * @param source Dynamic Page component
+     * @param payload Tab component
+     */
     constructor(public source: DynamicPageContentComponent, public payload: TabPanelComponent) {}
 }
 
@@ -184,6 +189,7 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
         return this._elementRef;
     }
 
+    /** @hidden */
     _onSelectedTabChange(event: TabPanelComponent): void {
         const content = this.contentComponents.find((contentComponent) => contentComponent.id === event.id);
 

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.config.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.config.ts
@@ -38,6 +38,7 @@ export class DynamicPageConfig extends PlatformConfig {
         return useFactory;
     }
 
+    /** @hidden */
     constructor(platformConfig: PlatformConfig) {
         super();
         this.contentDensity = platformConfig.contentDensity;

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.service.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.service.ts
@@ -3,37 +3,55 @@ import { Subject } from 'rxjs';
 
 @Injectable()
 export class DynamicPageService {
+    /** @hidden */
     private toggle = new Subject<void>();
+    /** @hidden */
     private expand = new Subject<void>();
+    /** @hidden */
     private collapse = new Subject<void>();
+    /** @hidden */
     private collapseValue = new Subject<boolean>();
+    /** @hidden */
     private isCollapsed = false;
 
+    /** @hidden */
     public $toggle = this.toggle.asObservable();
+    /** @hidden */
     public $expand = this.expand.asObservable();
+    /** @hidden */
     public $collapse = this.collapse.asObservable();
+    /** @hidden */
     public $collapseValue = this.collapseValue.asObservable();
 
+    /** @hidden */
     public toggleHeader(): void {
         this.toggle.next();
     }
+
+    /** @hidden */
     public expandHeader(): void {
         this.isCollapsed = false;
         this.expand.next();
     }
+
+    /** @hidden */
     public collapseHeader(): void {
         this.isCollapsed = true;
         this.collapse.next();
     }
+
+    /** @hidden */
     public setCollapseValue(val: boolean): void {
         this.setIsCollapsed(val);
         this.collapseValue.next(val);
     }
 
+    /** @hidden */
     public getIsCollapsed(): boolean {
         return this.isCollapsed;
     }
 
+    /** @hidden */
     public setIsCollapsed(collapsed: boolean): void {
         this.isCollapsed = collapsed;
     }

--- a/libs/platform/src/lib/form/checkbox-group/checkbox-group.component.ts
+++ b/libs/platform/src/lib/form/checkbox-group/checkbox-group.component.ts
@@ -58,25 +58,23 @@ export class CheckboxGroupComponent extends InLineLayoutCollectionBaseInput {
      * value for selected checkboxes.
      */
     @Input()
-    get value(): any[] {
-        return this.getValue();
-    }
-
     set value(selectedValue: any[]) {
         this.setValue(selectedValue);
         this._updateSelectionModelByValue();
+    }
+    get value(): any[] {
+        return this.getValue();
     }
 
     /**
      * To Display multiple checkboxes in a line
      */
     @Input()
-    get isInline(): boolean {
-        return this._inlineCurrentValue$.value;
-    }
-
     set isInline(inline: boolean) {
         this._inlineCurrentValue$.next(inline);
+    }
+    get isInline(): boolean {
+        return this._inlineCurrentValue$.value;
     }
 
     /**
@@ -84,14 +82,13 @@ export class CheckboxGroupComponent extends InLineLayoutCollectionBaseInput {
      * Establishes two way binding, when checkbox group used outside form.
      */
     @Input()
-    get checked(): string[] {
-        warnAboutChecked();
-        return this.value;
-    }
-
     set checked(checkedValues: string[]) {
         warnAboutChecked();
         this.value = checkedValues;
+    }
+    get checked(): string[] {
+        warnAboutChecked();
+        return this.value;
     }
 
     /** Children checkboxes passed as content */
@@ -119,6 +116,7 @@ export class CheckboxGroupComponent extends InLineLayoutCollectionBaseInput {
     /** @hidden */
     readonly _selectionModel = new SelectionModel(true);
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         readonly _responsiveBreakpointsService: ResponsiveBreakpointsService,

--- a/libs/platform/src/lib/form/checkbox/checkbox.component.ts
+++ b/libs/platform/src/lib/form/checkbox/checkbox.component.ts
@@ -74,11 +74,11 @@ export class CheckboxComponent extends BaseInput implements AfterViewInit {
      */
     // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('checked')
-    get value(): any {
-        return this.getValue();
-    }
     set value(selectValue: any) {
         this.setValue(selectValue);
+    }
+    get value(): any {
+        return this.getValue();
     }
 
     /** when true indeterminate state can be selected */
@@ -127,6 +127,7 @@ export class CheckboxComponent extends BaseInput implements AfterViewInit {
     @ViewChild(FdCheckboxComponent)
     coreCheckbox: FdCheckboxComponent;
 
+    /** @hidden */
     constructor(
         @Optional() @Self() ngControl: NgControl,
         @Optional() @SkipSelf() ngForm: NgForm,

--- a/libs/platform/src/lib/form/combobox/combobox-mobile/combobox/combobox-mobile.component.ts
+++ b/libs/platform/src/lib/form/combobox/combobox-mobile/combobox/combobox-mobile.component.ts
@@ -45,6 +45,7 @@ export class ComboboxMobileComponent extends MobileModeBase<ComboboxInterface> i
     /** @hidden */
     private _selectedBackup: string;
 
+    /** @hidden */
     constructor(
         elementRef: ElementRef,
         dialogService: DialogService,
@@ -54,6 +55,7 @@ export class ComboboxMobileComponent extends MobileModeBase<ComboboxInterface> i
         super(elementRef, dialogService, comboboxComponent, MobileModeControl.COMBOBOX, mobileModes);
     }
 
+    /** @hidden */
     ngOnInit(): void {
         this._listenOnMultiInputOpenChange();
     }
@@ -75,6 +77,7 @@ export class ComboboxMobileComponent extends MobileModeBase<ComboboxInterface> i
         this._component.dialogApprove();
     }
 
+    /** @hidden */
     private _toggleDialog(open: boolean): void {
         if (!open) {
             return;

--- a/libs/platform/src/lib/form/combobox/combobox.config.ts
+++ b/libs/platform/src/lib/form/combobox/combobox.config.ts
@@ -32,6 +32,7 @@ export class ComboboxConfig {
         return useFactory;
     }
 
+    /** @hidden */
     constructor(platformConfig: PlatformConfig) {
         this.contentDensity = platformConfig.contentDensity;
     }

--- a/libs/platform/src/lib/form/combobox/combobox/combobox.component.ts
+++ b/libs/platform/src/lib/form/combobox/combobox/combobox.component.ts
@@ -59,6 +59,7 @@ export class ComboboxComponent extends BaseCombobox implements ComboboxInterface
     /** @hidden */
     _selectedElement?: OptionItem;
 
+    /** @hidden */
     constructor(
         readonly cd: ChangeDetectorRef,
         readonly elementRef: ElementRef,

--- a/libs/platform/src/lib/form/combobox/commons/base-combobox.ts
+++ b/libs/platform/src/lib/form/combobox/commons/base-combobox.ts
@@ -63,6 +63,11 @@ export type TextAlignment = 'left' | 'right';
 export type FdpComboBoxDataSource<T> = ComboBoxDataSource<T> | Observable<T[]> | T[];
 
 export class ComboboxSelectionChangeEvent {
+    /**
+     * Combobox selection event
+     * @param source Combobox component
+     * @param payload Selected option
+     */
     constructor(
         public source: ComboboxComponent,
         public payload: any // Contains selected item
@@ -77,14 +82,13 @@ export abstract class BaseCombobox extends CollectionBaseInput implements AfterV
 
     /** Datasource for suggestion list */
     @Input()
-    get dataSource(): FdpComboBoxDataSource<any> {
-        return this._dataSource;
-    }
-
     set dataSource(value: FdpComboBoxDataSource<any>) {
         if (value) {
             this._initializeDataSource(value);
         }
+    }
+    get dataSource(): FdpComboBoxDataSource<any> {
+        return this._dataSource;
     }
 
     /** Whether the autocomplete should be enabled; Enabled by default */
@@ -131,15 +135,15 @@ export abstract class BaseCombobox extends CollectionBaseInput implements AfterV
     @Input()
     autoResize = false;
 
+    /** Value of the combobox */
     @Input()
-    get value(): any {
-        return super.getValue();
-    }
-
     set value(value: any) {
         const selectedItems = coerceArraySafe(value);
         this.setAsSelected(this._convertToOptionItems(selectedItems));
         super.setValue(value);
+    }
+    get value(): any {
+        return super.getValue();
     }
 
     /**
@@ -211,21 +215,20 @@ export abstract class BaseCombobox extends CollectionBaseInput implements AfterV
     /** @hidden */
     _contentDensity: ContentDensity = this.comboboxConfig.contentDensity;
 
-    /** Get the input text of the input. */
-    get inputText(): string {
-        return this._inputTextValue || '';
-    }
-
-    /** Set the input text of the input. */
+    /** Input text of the input. */
     set inputText(value: string) {
         this._inputTextValue = value;
 
         this.onTouched();
     }
+    get inputText(): string {
+        return this._inputTextValue || '';
+    }
 
     /** Whether the combobox is opened. */
     isOpen = false;
 
+    /** Whether a combobox can be closed */
     get canClose(): boolean {
         return !(this.mobile && this.mobileConfig.approveButtonText);
     }
@@ -252,6 +255,7 @@ export abstract class BaseCombobox extends CollectionBaseInput implements AfterV
         return this._suggestions.length === 0;
     }
 
+    /** @hidden */
     protected _dataSource: FdpComboBoxDataSource<any>;
 
     /** @hidden */
@@ -300,6 +304,7 @@ export abstract class BaseCombobox extends CollectionBaseInput implements AfterV
         return value;
     };
 
+    /** @hidden */
     constructor(
         readonly cd: ChangeDetectorRef,
         protected readonly elementRef: ElementRef,

--- a/libs/platform/src/lib/form/date-picker/date-picker.component.ts
+++ b/libs/platform/src/lib/form/date-picker/date-picker.component.ts
@@ -50,12 +50,11 @@ export class PlatformDatePickerComponent<D> extends BaseInput {
      * date-picker value set as controller value
      */
     @Input()
-    get value(): DateRange<D> | D {
-        return super.getValue();
-    }
-
     set value(value: DateRange<D> | D) {
         super.setValue(value);
+    }
+    get value(): DateRange<D> | D {
+        return super.getValue();
     }
 
     /** below code taken from core/date-picker */
@@ -143,15 +142,15 @@ export class PlatformDatePickerComponent<D> extends BaseInput {
      *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
+    set state(state: FormStates) {
+        super.state = state;
+    }
     get state(): FormStates {
         if (this.fdDatePickerComponent?._isInvalidDateInput || !this._datePickerValid) {
             return 'error';
         }
 
         return super.state;
-    }
-    set state(state: FormStates) {
-        super.state = state;
     }
 
     /**
@@ -160,18 +159,17 @@ export class PlatformDatePickerComponent<D> extends BaseInput {
      *  Can be `success`, `error`, `warning`, `information` or blank for default.
      */
     @Input()
-    get datepickerState(): FormStates {
-        if (isDevMode()) {
-            console.warn('"datepickerState" is deprecated. Use "state" instead');
-        }
-        return this.state;
-    }
-
     set datepickerState(state: FormStates) {
         if (isDevMode()) {
             console.warn('"datepickerState" is deprecated. Use "state" instead');
         }
         this.state = state;
+    }
+    get datepickerState(): FormStates {
+        if (isDevMode()) {
+            console.warn('"datepickerState" is deprecated. Use "state" instead');
+        }
+        return this.state;
     }
 
     /**
@@ -295,6 +293,7 @@ export class PlatformDatePickerComponent<D> extends BaseInput {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     disableRangeEndFunction: (value: D) => boolean = () => false;
 
+    /** @hidden */
     constructor(
         protected _changeDetectorRef: ChangeDetectorRef,
         @Optional() @Self() public ngControl: NgControl,
@@ -314,6 +313,7 @@ export class PlatformDatePickerComponent<D> extends BaseInput {
         }
     }
 
+    /** @hidden */
     writeValue(value: D | DateRange<D> | null): void {
         super.writeValue(value);
         this._changeDetectorRef.detectChanges();
@@ -352,19 +352,23 @@ export class PlatformDatePickerComponent<D> extends BaseInput {
         this.isOpenChange.emit(open);
     };
 
+    /** @hidden */
     handleSelectedDateChange = (fdDate: Nullable<D>): void => {
         this.selectedDateChange.emit(fdDate);
     };
 
+    /** @hidden */
     handleSelectedRangeDateChange = (fdRangeDate: DateRange<D>): void => {
         this.selectedRangeDateChange.emit(fdRangeDate);
     };
 
+    /** @hidden */
     handleActiveViewChange = (fdCalendarView: FdCalendarView): void => {
         this.activeViewChange.emit(fdCalendarView);
     };
 }
 
+/** @hidden */
 export function createMissingDateImplementationError(provider: string): Error {
     return Error(
         `FdpDatePicker: No provider found for ${provider}. You must import one of the following ` +

--- a/libs/platform/src/lib/form/datetime-picker/datetime-picker.component.ts
+++ b/libs/platform/src/lib/form/datetime-picker/datetime-picker.component.ts
@@ -34,11 +34,11 @@ export class PlatformDatetimePickerComponent<D> extends BaseInput implements Aft
      * value for datetime
      */
     @Input()
-    get value(): D {
-        return super.getValue();
-    }
     set value(value: D) {
         super.setValue(value);
+    }
+    get value(): D {
+        return super.getValue();
     }
 
     /**
@@ -265,6 +265,7 @@ export class PlatformDatetimePickerComponent<D> extends BaseInput implements Aft
         return !!this.formField?.required;
     }
 
+    /** @hidden */
     constructor(
         protected _cd: ChangeDetectorRef,
         readonly elementRef: ElementRef,

--- a/libs/platform/src/lib/form/datetime-picker/errors.ts
+++ b/libs/platform/src/lib/form/datetime-picker/errors.ts
@@ -1,3 +1,4 @@
+/** @hidden */
 export function createMissingDateImplementationError(provider: string): Error {
     return Error(
         `FdpDatetimePicker: No provider found for ${provider}. You must import one of the following ` +

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control-field.directive.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control-field.directive.ts
@@ -59,8 +59,10 @@ export class DynamicFormControlFieldDirective implements OnInit {
      */
     private _shouldShowFormItem: boolean;
 
+    /** @hidden */
     constructor(private readonly _templateRef: TemplateRef<any>, private readonly _viewContainer: ViewContainerRef) {}
 
+    /** @hidden */
     ngOnInit(): void {
         this._updateView();
     }
@@ -86,6 +88,7 @@ export class DynamicFormControlFieldDirective implements OnInit {
         this._control.updateValueAndValidity({ emitEvent: false });
     }
 
+    /** @hidden */
     private _updateView(): void {
         if (this._shouldShowFormItem && this._componentRemoved) {
             this._viewContainer.createEmbeddedView(this._templateRef);

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
@@ -35,6 +35,7 @@ export class DynamicFormControlDirective implements OnInit {
      */
     @Input() form: FormGroup;
 
+    /** Form group name path */
     @Input() formGroupNamePath: string;
 
     /**
@@ -42,6 +43,7 @@ export class DynamicFormControlDirective implements OnInit {
      */
     @Input() formField: FormField;
 
+    /** @hidden */
     constructor(
         private readonly _formGeneratorService: FormGeneratorService,
         private readonly _vcRef: ViewContainerRef,
@@ -49,6 +51,7 @@ export class DynamicFormControlDirective implements OnInit {
         @Optional() @Inject(CONTENT_DENSITY_DIRECTIVE) private contentDensityDirective: Observable<ContentDensityMode>
     ) {}
 
+    /** @hidden */
     ngOnInit(): void {
         const foundComponent = this._formGeneratorService.getComponentDefinitionByType(this.formItem.type);
 

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control.ts
@@ -10,10 +10,14 @@ export interface DynamicFormGroupControls {
 }
 
 export class DynamicFormControlGroup extends FormGroup {
+    /** @hidden */
     public formItem: DynamicFormFieldGroup;
+    /** @hidden */
     public type = 'group';
+    /** @hidden */
     public controls: DynamicFormGroupControls;
 
+    /** @hidden */
     constructor(
         formItem: DynamicFormFieldGroup,
         controls: DynamicFormGroupControls,
@@ -26,7 +30,9 @@ export class DynamicFormControlGroup extends FormGroup {
 }
 
 export class DynamicFormControl extends FormControl {
+    /** @hidden */
     public formItem: PreparedDynamicFormFieldItem;
+    /** @hidden */
     public type = 'field';
 
     /**

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.ts
@@ -10,6 +10,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../prov
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorCheckboxComponent extends BaseDynamicFormGeneratorControl {
+    /** @hidden */
     constructor() {
         super();
     }

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.ts
@@ -10,6 +10,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../prov
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorDatepickerComponent extends BaseDynamicFormGeneratorControl {
+    /** @hidden */
     constructor() {
         super();
     }

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-editor/dynamic-form-generator-editor.component.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-editor/dynamic-form-generator-editor.component.ts
@@ -10,6 +10,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../prov
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorEditorComponent extends BaseDynamicFormGeneratorControl {
+    /** @hidden */
     constructor() {
         super();
     }

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-input/dynamic-form-generator-input.component.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-input/dynamic-form-generator-input.component.ts
@@ -10,6 +10,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../prov
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorInputComponent extends BaseDynamicFormGeneratorControl {
+    /** @hidden */
     constructor() {
         super();
     }

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-multi-input/dynamic-form-generator-multi-input.component.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-multi-input/dynamic-form-generator-multi-input.component.ts
@@ -10,6 +10,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../prov
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorMultiInputComponent extends BaseDynamicFormGeneratorControl {
+    /** @hidden */
     constructor() {
         super();
     }

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-radio/dynamic-form-generator-radio.component.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-radio/dynamic-form-generator-radio.component.ts
@@ -10,6 +10,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../prov
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorRadioComponent extends BaseDynamicFormGeneratorControl {
+    /** @hidden */
     constructor() {
         super();
     }

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-select/dynamic-form-generator-select.component.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-select/dynamic-form-generator-select.component.ts
@@ -10,6 +10,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../prov
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorSelectComponent extends BaseDynamicFormGeneratorControl {
+    /** @hidden */
     constructor() {
         super();
     }

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-switch/dynamic-form-generator-switch.component.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-switch/dynamic-form-generator-switch.component.ts
@@ -10,6 +10,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../prov
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorSwitchComponent extends BaseDynamicFormGeneratorControl {
+    /** @hidden */
     constructor() {
         super();
     }

--- a/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.ts
@@ -76,10 +76,6 @@ export class FormGeneratorComponent implements OnDestroy, OnChanges {
      * to be rendered in the form.
      */
     @Input()
-    get formItems(): DynamicFormItem[] {
-        return this._formItems;
-    }
-
     set formItems(formItems: DynamicFormItem[]) {
         this._formItems = formItems.map((item, index) => {
             item = { ...item };
@@ -89,6 +85,9 @@ export class FormGeneratorComponent implements OnDestroy, OnChanges {
             return item;
         });
         this._generateForm();
+    }
+    get formItems(): DynamicFormItem[] {
+        return this._formItems;
     }
 
     /**
@@ -120,10 +119,6 @@ export class FormGeneratorComponent implements OnDestroy, OnChanges {
      * Defines form field label placement.
      */
     @Input()
-    get labelLayout(): LabelLayout {
-        return this._labelLayout;
-    }
-
     set labelLayout(value: LabelLayout) {
         if (isDevMode()) {
             console.warn(
@@ -136,6 +131,9 @@ export class FormGeneratorComponent implements OnDestroy, OnChanges {
             this._labelLayout === 'horizontal' ? DefaultHorizontalLabelLayout : DefaultVerticalLabelLayout;
         this.fieldColumnLayout =
             this._labelLayout === 'horizontal' ? DefaultHorizontalFieldLayout : DefaultVerticalFieldLayout;
+    }
+    get labelLayout(): LabelLayout {
+        return this._labelLayout;
     }
 
     /**
@@ -160,6 +158,7 @@ export class FormGeneratorComponent implements OnDestroy, OnChanges {
     @Input()
     unifiedLayout = true;
 
+    /** Inline column layout */
     @Input()
     inlineColumnLayout: ColumnLayout = DefaultVerticalFieldLayout;
 

--- a/libs/platform/src/lib/form/form-generator/helpers.ts
+++ b/libs/platform/src/lib/form/form-generator/helpers.ts
@@ -1,5 +1,6 @@
 import { HintOptions } from '@fundamental-ngx/platform/shared';
 
+/** @hidden */
 export function isHintOptions(opts: string | HintOptions): opts is HintOptions {
     return !!opts && typeof opts !== 'string';
 }

--- a/libs/platform/src/lib/form/form-generator/pipes/get-ordered-form-controls.pipe.ts
+++ b/libs/platform/src/lib/form/form-generator/pipes/get-ordered-form-controls.pipe.ts
@@ -3,6 +3,7 @@ import { DynamicFormControl, DynamicFormControlGroup, DynamicFormGroupControl } 
 
 @Pipe({ name: 'getOrderedFieldControls' })
 export class GetOrderedFieldControlsPipe implements PipeTransform {
+    /** @hidden */
     transform(field: DynamicFormGroupControl): DynamicFormControl[] {
         // casting type explicity to the DynamicFormControl[] as this pipe will be used specifically with this data type
         return Object.values((field as DynamicFormControlGroup).controls).sort((a, b) =>

--- a/libs/platform/src/lib/form/form-group/deprecated-form-group-compact.directive.ts
+++ b/libs/platform/src/lib/form/form-group/deprecated-form-group-compact.directive.ts
@@ -12,6 +12,7 @@ import { Directive, forwardRef } from '@angular/core';
     ]
 })
 export class DeprecatedFormGroupCompactDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fdp-form-group');
     }

--- a/libs/platform/src/lib/form/form-group/form-field/form-field.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-field/form-field.component.ts
@@ -115,10 +115,6 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
      * Define form field label placement
      */
     @Input()
-    get labelLayout(): LabelLayout {
-        return this._labelLayout;
-    }
-
     set labelLayout(value: LabelLayout) {
         if (isDevMode()) {
             console.warn(
@@ -131,6 +127,9 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
             this._labelLayout === 'horizontal' ? DefaultHorizontalLabelLayout : DefaultVerticalLabelLayout;
         this.fieldColumnLayout =
             this._labelLayout === 'horizontal' ? DefaultHorizontalFieldLayout : DefaultVerticalFieldLayout;
+    }
+    get labelLayout(): LabelLayout {
+        return this._labelLayout;
     }
 
     /**
@@ -164,10 +163,6 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
 
     /** object for placing field in column in each screen layout */
     @Input()
-    get columnLayout(): ColumnLayout {
-        return this._columnLayout;
-    }
-
     set columnLayout(layout: ColumnLayout | undefined) {
         if (!layout) {
             return;
@@ -176,15 +171,14 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
         this._isColumnLayoutEnabled = true;
         this._setLayout();
     }
+    get columnLayout(): ColumnLayout {
+        return this._columnLayout;
+    }
 
     /**
      * Defines label's column layout.
      */
     @Input()
-    get labelColumnLayout(): ColumnLayout {
-        return this._labelColumnLayout;
-    }
-
     set labelColumnLayout(value: ColumnLayout | undefined) {
         if (!value) {
             return;
@@ -193,15 +187,14 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
         this._labelColumnLayoutClass = generateColumnClass(this._labelColumnLayout);
         this._labelColumnLayout$.next(this._labelColumnLayout);
     }
+    get labelColumnLayout(): ColumnLayout {
+        return this._labelColumnLayout;
+    }
 
     /**
      * Defines field's column layout.
      */
     @Input()
-    get fieldColumnLayout(): ColumnLayout {
-        return this._fieldColumnLayout;
-    }
-
     set fieldColumnLayout(value: ColumnLayout | undefined) {
         if (!value) {
             return;
@@ -211,15 +204,14 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
         this._fieldColumnLayoutClass = generateColumnClass(this._fieldColumnLayout);
         this._fieldColumnLayout$.next(this._fieldColumnLayout);
     }
+    get fieldColumnLayout(): ColumnLayout {
+        return this._fieldColumnLayout;
+    }
 
     /**
      * Defines gap column layout.
      */
     @Input()
-    get gapColumnLayout(): ColumnLayout {
-        return this._gapColumnLayout;
-    }
-
     set gapColumnLayout(value: ColumnLayout | undefined) {
         if (!value) {
             return;
@@ -228,6 +220,9 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
         this._gapColumnLayout = normalizeColumnLayout(value);
         this._gapColumnLayoutClass = generateColumnClass(this._gapColumnLayout);
         this._gapColumnLayout$.next(this._gapColumnLayout);
+    }
+    get gapColumnLayout(): ColumnLayout {
+        return this._gapColumnLayout;
     }
 
     /**
@@ -239,22 +234,17 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
 
     /** Set when form field is a mandatory one. */
     @Input()
-    get required(): boolean {
-        return this._required;
-    }
-
     set required(value: BooleanInput) {
         this._required = coerceBooleanProperty(value);
+    }
+    get required(): boolean {
+        return this._required;
     }
 
     /**
      * Indicates if field is editable
      */
     @Input()
-    get editable(): boolean {
-        return this._editable;
-    }
-
     set editable(value: BooleanInput) {
         const newVal = coerceBooleanProperty(value);
         if (this._editable !== newVal) {
@@ -262,17 +252,19 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
             this._updateControlProperties();
         }
     }
+    get editable(): boolean {
+        return this._editable;
+    }
 
     /**
      * Form field custom width in columns must be between 1 - 12
      */
     @Input()
-    get columns(): Column {
-        return this._columns;
-    }
-
     set columns(value: Column) {
         this._columns = <Column>coerceNumberProperty(value);
+    }
+    get columns(): Column {
+        return this._columns;
     }
 
     /**
@@ -497,6 +489,7 @@ export class FormFieldComponent implements FormField, AfterContentInit, AfterVie
         this.listenToInlineHelpPlaceRequirementChanges(() => (this.labelColumnLayout ? this : this._groupHost));
     }
 
+    /** @hidden */
     listenToInlineHelpPlaceRequirementChanges(getSource: () => any): void {
         if (this._needsInlineHelpPlaceSubscription) {
             this._needsInlineHelpPlaceSubscription.unsubscribe();

--- a/libs/platform/src/lib/form/form-group/form-group-header/form-group-header.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-group-header/form-group-header.component.ts
@@ -23,9 +23,11 @@ import { Nullable } from '@fundamental-ngx/core/shared';
     }
 })
 export class FormGroupHeaderComponent {
+    /** Fields Group */
     @Input()
     fieldGroup: Nullable<FieldGroup>;
 
+    /** Hint options */
     hintOptions(field: FieldGroup): HintOptions | undefined {
         if (field.hintOptions) {
             return field.hintOptions;

--- a/libs/platform/src/lib/form/form-group/form-group.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-group.component.ts
@@ -174,6 +174,7 @@ type FormGroupField = (FormField | FormFieldGroup) & { hintOptions?: HintOptions
 export class FormGroupComponent
     implements FormGroupContainer, OnInit, AfterContentInit, AfterViewInit, OnDestroy, OnChanges
 {
+    /** Id for the form group element */
     @Input()
     id: string;
 
@@ -206,10 +207,6 @@ export class FormGroupComponent
      * Defines form field label placement.
      */
     @Input()
-    get labelLayout(): LabelLayout {
-        return this._labelLayout;
-    }
-
     set labelLayout(value: LabelLayout) {
         if (isDevMode()) {
             console.warn(
@@ -222,6 +219,9 @@ export class FormGroupComponent
             this._labelLayout === 'horizontal' ? DefaultHorizontalLabelLayout : DefaultVerticalLabelLayout;
         this.fieldColumnLayout =
             this._labelLayout === 'horizontal' ? DefaultHorizontalFieldLayout : DefaultVerticalFieldLayout;
+    }
+    get labelLayout(): LabelLayout {
+        return this._labelLayout;
     }
 
     /**
@@ -292,12 +292,11 @@ export class FormGroupComponent
 
     /** Whether to wrap all the provided content in a `<form>` */
     @Input()
-    get useForm(): boolean {
-        return this._useForm;
-    }
-
     set useForm(value: BooleanInput) {
         this._useForm = coerceBooleanProperty(value);
+    }
+    get useForm(): boolean {
+        return this._useForm;
     }
 
     /**
@@ -391,6 +390,7 @@ export class FormGroupComponent
     /** @hidden */
     private _subscriptions = new Subscription();
 
+    /** @hidden */
     constructor(
         private _cd: ChangeDetectorRef,
         private elementRef: ElementRef,

--- a/libs/platform/src/lib/form/form-group/helpers.ts
+++ b/libs/platform/src/lib/form/form-group/helpers.ts
@@ -1,5 +1,6 @@
 import { ColumnLayout, ColumnLayoutGridClass } from '@fundamental-ngx/platform/shared';
 
+/** @hidden */
 export function normalizeColumnLayout(layout: ColumnLayout, defaultColumn = 12): Required<ColumnLayout> {
     layout['S'] = layout['S'] !== undefined ? layout['S'] : defaultColumn;
     layout['M'] = layout['M'] || layout['S'];
@@ -9,6 +10,7 @@ export function normalizeColumnLayout(layout: ColumnLayout, defaultColumn = 12):
     return layout as Required<ColumnLayout>;
 }
 
+/** @hidden */
 export function generateColumnClass(layout: ColumnLayout): string {
     return Object.entries(layout)
         .reduce((overall, value) => {

--- a/libs/platform/src/lib/form/form-group/pipes/field-group-row-value.pipe.ts
+++ b/libs/platform/src/lib/form/form-group/pipes/field-group-row-value.pipe.ts
@@ -4,6 +4,7 @@ import { FieldColumn, FieldGroup } from '../../form-helpers';
 
 @Pipe({ name: 'fieldGroupRowValue' })
 export class FieldGroupRowValuePipe implements PipeTransform {
+    /** @hidden */
     transform(row: KeyValue<any, FieldColumn | FieldGroup>): FieldColumn {
         return row.value instanceof FieldGroup ? row.value.fields : row.value;
     }

--- a/libs/platform/src/lib/form/form-helpers.ts
+++ b/libs/platform/src/lib/form/form-helpers.ts
@@ -9,22 +9,27 @@ export interface FieldColumn {
     [key: number]: Array<Field>;
 }
 
+/** @hidden */
 export function isFieldChild(child: unknown): child is FormFieldComponent {
     return child instanceof FormFieldComponent;
 }
 
+/** @hidden */
 export function isFieldGroupWrapperChild(child: unknown): child is FormGeneratorFieldComponent {
     return child instanceof FormGeneratorFieldComponent;
 }
 
+/** @hidden */
 export function isFieldGroupChild(child: unknown): child is FormFieldGroupComponent {
     return child instanceof FormFieldGroupComponent;
 }
 
+/** @hidden */
 export function getFormField(field: FormField | FormGeneratorFieldComponent): FormField {
     return isFieldGroupWrapperChild(field) ? field.fieldRenderer : field;
 }
 
+/** @hidden */
 export function getField(field: FormField): Field {
     field = isFieldGroupWrapperChild(field) ? field.fieldRenderer : field;
 
@@ -32,6 +37,7 @@ export function getField(field: FormField): Field {
 }
 
 export class Field {
+    /** @hidden */
     constructor(
         public name?: string,
         public rank?: number,
@@ -41,5 +47,6 @@ export class Field {
 }
 
 export class FieldGroup {
+    /** @hidden */
     constructor(public label: string, public fields: FieldColumn, public hintOptions?: HintOptions) {}
 }

--- a/libs/platform/src/lib/form/input-group/input-group.component.ts
+++ b/libs/platform/src/lib/form/input-group/input-group.component.ts
@@ -52,11 +52,11 @@ import { InputGroupInputComponent } from './input.component';
 export class InputGroupComponent extends BaseInput implements OnInit, AfterContentInit, AfterViewInit {
     /** Input value */
     @Input()
-    get value(): any {
-        return super.getValue();
-    }
     set value(value: any) {
         super.setValue(value);
+    }
+    get value(): any {
+        return super.getValue();
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/form/input-group/input-group.config.ts
+++ b/libs/platform/src/lib/form/input-group/input-group.config.ts
@@ -22,6 +22,7 @@ export class InputGroupConfig {
         return useFactory;
     }
 
+    /** @hidden */
     constructor(platformConfig: PlatformConfig) {
         this.contentDensity = platformConfig.contentDensity;
     }

--- a/libs/platform/src/lib/form/input/input.component.ts
+++ b/libs/platform/src/lib/form/input/input.component.ts
@@ -52,6 +52,7 @@ export type InputType = 'text' | 'number' | 'email' | 'password';
     providers: [{ provide: FormFieldControl, useExisting: InputComponent, multi: true }]
 })
 export class InputComponent extends BaseInput implements OnInit, AfterViewInit {
+    /** Input type */
     @Input()
     type: InputType = 'text';
 
@@ -65,12 +66,11 @@ export class InputComponent extends BaseInput implements OnInit, AfterViewInit {
 
     /** return the value in the text box */
     @Input()
-    get value(): any {
-        return super.getValue();
-    }
-
     set value(value: any) {
         super.setValue(value);
+    }
+    get value(): any {
+        return super.getValue();
     }
 
     /** Emits event on focus change */
@@ -81,6 +81,7 @@ export class InputComponent extends BaseInput implements OnInit, AfterViewInit {
         return this._elementRef;
     }
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() ngControl: NgControl,
@@ -91,6 +92,7 @@ export class InputComponent extends BaseInput implements OnInit, AfterViewInit {
         super(cd, ngControl, ngForm, formField, formControl);
     }
 
+    /** @hidden */
     ngOnInit(): void {
         super.ngOnInit();
         if (!this.type || VALID_INPUT_TYPES.indexOf(this.type) === -1) {

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -73,6 +73,11 @@ export const MAP_LIMIT = new InjectionToken<number>('Map limit≥', { factory: (
 export type FdpMultiComboboxDataSource<T> = MultiComboBoxDataSource<T> | Observable<T[]> | T[];
 
 export class MultiComboboxSelectionChangeEvent {
+    /**
+     * Multi Combobox selection change event
+     * @param source Multi Combobox component
+     * @param selectedItems Selected items
+     */
     constructor(
         public source: BaseMultiCombobox,
         public selectedItems: SelectableOptionItem['value'] // Contains selected items
@@ -147,6 +152,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
     @Input()
     autoResize = false;
 
+    /** Value of the multi combobox */
     @Input()
     set value(value: any) {
         super.setValue(value, true);
@@ -364,6 +370,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
         }
     };
 
+    /** @hidden */
     constructor(
         protected readonly _cd: ChangeDetectorRef,
         protected readonly elementRef: ElementRef,
@@ -378,6 +385,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
         super(_cd, ngControl, ngForm, formField, formControl);
     }
 
+    /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
         const dataSourceChange = changes['dataSource'];
 

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox-mobile/multi-combobox/multi-combobox-mobile.component.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox-mobile/multi-combobox/multi-combobox-mobile.component.ts
@@ -47,6 +47,7 @@ export class MultiComboboxMobileComponent extends MobileModeBase<MultiComboboxIn
     /** @hidden */
     private _selectedBackup: SelectableOptionItem[];
 
+    /** @hidden */
     constructor(
         elementRef: ElementRef,
         dialogService: DialogService,

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox.config.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox.config.ts
@@ -34,6 +34,7 @@ export class MultiComboboxConfig {
         return useFactory;
     }
 
+    /** @hidden */
     constructor(platformConfig: PlatformConfig) {
         this.contentDensity = platformConfig.contentDensity;
     }

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
@@ -83,6 +83,7 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
      */
     _selectedSuggestions: SelectableOptionItem[] = [];
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         readonly elementRef: ElementRef,

--- a/libs/platform/src/lib/form/multi-input/base-multi-input.ts
+++ b/libs/platform/src/lib/form/multi-input/base-multi-input.ts
@@ -61,6 +61,11 @@ import { MultiInputConfig } from './multi-input.config';
 export type FdpMultiInputDataSource<T> = MultiInputDataSource<T> | Observable<T[]> | T[];
 
 export class MultiInputSelectionChangeEvent {
+    /**
+     * Multi Input selection change event
+     * @param source Multi Input component
+     * @param payload Selected value
+     */
     constructor(
         public source: PlatformMultiInputComponent,
         public payload: any // Contains selected item
@@ -75,14 +80,13 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
 
     /** Datasource for suggestion list */
     @Input()
-    get dataSource(): FdpMultiInputDataSource<any> {
-        return this._dataSource;
-    }
-
     set dataSource(value: FdpMultiInputDataSource<any>) {
         if (value) {
             this._initializeDataSource(value);
         }
+    }
+    get dataSource(): FdpMultiInputDataSource<any> {
+        return this._dataSource;
     }
 
     /** Whether the autocomplete should be enabled; Enabled by default */
@@ -140,15 +144,15 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
     @Input()
     autoResize = false;
 
+    /** Value of the multi input */
     @Input()
-    get value(): any {
-        return super.getValue();
-    }
-
     set value(value: any) {
         const selectedItems = Array.isArray(value) ? value : [value];
         this.setAsSelected(this._convertToOptionItems(selectedItems));
         super.setValue(value);
+    }
+    get value(): any {
+        return super.getValue();
     }
 
     /** Event emitted when item is selected. */
@@ -214,6 +218,7 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
     /** Whether the Multi Input is opened. */
     isOpen = false;
 
+    /** @hidden */
     get canClose(): boolean {
         return !(this.mobile && this.mobileConfig.approveButtonText);
     }
@@ -248,6 +253,7 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
     /** @hidden emits whenever there're changes to the inputs, that affect the data creation from data source */
     private readonly _updateDataSourceValues$ = new Subject<void>();
 
+    /** @hidden */
     protected _dataSource: FdpMultiInputDataSource<any>;
 
     /** @hidden */
@@ -285,6 +291,7 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
         }
     };
 
+    /** @hidden */
     constructor(
         readonly cd: ChangeDetectorRef,
         protected readonly elementRef: ElementRef,

--- a/libs/platform/src/lib/form/multi-input/multi-input-mobile/multi-input-mobile.component.ts
+++ b/libs/platform/src/lib/form/multi-input/multi-input-mobile/multi-input-mobile.component.ts
@@ -49,6 +49,7 @@ export class PlatformMultiInputMobileComponent
     /** @hidden */
     private _selectedBackup: any[];
 
+    /** @hidden */
     constructor(
         elementRef: ElementRef,
         dialogService: DialogService,
@@ -58,6 +59,7 @@ export class PlatformMultiInputMobileComponent
         super(elementRef, dialogService, multiInputComponent, MobileModeControl.MULTI_INPUT, mobileModes);
     }
 
+    /** @hidden */
     ngOnInit(): void {
         this._listenOnMultiInputOpenChange();
     }
@@ -86,6 +88,7 @@ export class PlatformMultiInputMobileComponent
             .subscribe((isOpen) => this._toggleDialog(isOpen));
     }
 
+    /** @hidden */
     private _toggleDialog(open: boolean): void {
         if (!open) {
             this._handleApprove();

--- a/libs/platform/src/lib/form/multi-input/multi-input.component.ts
+++ b/libs/platform/src/lib/form/multi-input/multi-input.component.ts
@@ -63,6 +63,7 @@ let uniqueHiddenLabel = 0;
     ]
 })
 export class PlatformMultiInputComponent extends BaseMultiInput implements OnInit, AfterViewInit {
+    /** @hidden */
     protected tokenCountHiddenLabel = `fdp-multi-input-token-count-id-${uniqueHiddenLabel++}`;
 
     /** token  count hidden label */
@@ -77,17 +78,18 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
     @Input()
     autofocus = false;
 
+    /** @hidden */
     @ViewChild(ListComponent)
     listTemplateDD: ListComponent<MultiInputOption>;
 
     /** Selected values from the list items. */
     _selected: any[] = [];
 
+    /** Selected items of the multi input. */
     @Input()
     set selected(selectedValue: any[]) {
         this.value = selectedValue;
     }
-
     get selected(): any[] {
         return this._selected;
     }
@@ -98,6 +100,7 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
     @Input()
     selectionMode: SelectionType = 'none';
 
+    /** Whether the list in byline mode. */
     @Input()
     hasByLine = false;
 
@@ -112,13 +115,13 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
     /** @hidden Whether the input is disabled. */
     protected _disabled = false;
 
+    /** Whether the multi input is disabled. */
     @Input()
-    get disabled(): boolean {
-        return this._disabled;
-    }
-
     set disabled(value) {
         this._disabled = value;
+    }
+    get disabled(): boolean {
+        return this._disabled;
     }
 
     /**
@@ -157,6 +160,7 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
     @ViewChild('listTemplate')
     listTemplate: TemplateRef<any>;
 
+    /** @hidden */
     constructor(
         /** @hidden */
         readonly cd: ChangeDetectorRef,

--- a/libs/platform/src/lib/form/multi-input/multi-input.config.ts
+++ b/libs/platform/src/lib/form/multi-input/multi-input.config.ts
@@ -32,6 +32,7 @@ export class MultiInputConfig {
         return useFactory;
     }
 
+    /** @hidden */
     constructor(platformConfig: PlatformConfig) {
         this.contentDensity = platformConfig.contentDensity;
     }

--- a/libs/platform/src/lib/form/platform-file-uploader/platform-file-uploader.component.ts
+++ b/libs/platform/src/lib/form/platform-file-uploader/platform-file-uploader.component.ts
@@ -19,6 +19,11 @@ import { BaseInput, FormField, FormFieldControl } from '@fundamental-ngx/platfor
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 
 export class FileUploaderInvalidChangeEvent {
+    /**
+     * File Uploader invalid change event
+     * @param source File Uploader component
+     * @param payload Value
+     */
     constructor(
         public source: PlatformFileUploaderComponent,
         public payload: File[] // Contains selected item
@@ -26,6 +31,11 @@ export class FileUploaderInvalidChangeEvent {
 }
 
 export class FileUploaderSelectionChangeEvent {
+    /**
+     * File Uploader invalid change event
+     * @param source File Uploader component
+     * @param payload Value
+     */
     constructor(
         public source: PlatformFileUploaderComponent,
         public payload: File[] // Contains selected item
@@ -75,18 +85,17 @@ export class PlatformFileUploaderComponent extends BaseInput implements OnInit {
      * @deprecated
      * set state of individual checkbox. Used by CBG to set checkbox states */
     @Input()
-    get stateType(): FormStates {
-        if (isDevMode()) {
-            console.warn('"stateType" is deprecated. Use "state" instead');
-        }
-        return super.state;
-    }
-
     set stateType(state: FormStates) {
         if (isDevMode()) {
             console.warn('"stateType" is deprecated. Use "state" instead');
         }
         super.state = state;
+    }
+    get stateType(): FormStates {
+        if (isDevMode()) {
+            console.warn('"stateType" is deprecated. Use "state" instead');
+        }
+        return super.state;
     }
 
     /** Event emitted when valid file is uploded. */
@@ -108,14 +117,14 @@ export class PlatformFileUploaderComponent extends BaseInput implements OnInit {
 
     /** Sets value file data*/
     @Input()
+    set value(value: File) {
+        super.setValue(value);
+    }
     get value(): File {
         return super.getValue();
     }
 
-    set value(value: File) {
-        super.setValue(value);
-    }
-
+    /** @hidden */
     constructor(
         protected _cd: ChangeDetectorRef,
         @Optional() @Self() ngControl: NgControl,

--- a/libs/platform/src/lib/form/radio-group/radio-group.component.ts
+++ b/libs/platform/src/lib/form/radio-group/radio-group.component.ts
@@ -60,22 +60,22 @@ export class RadioGroupComponent
     implements AfterViewInit, AfterContentChecked, OnDestroy
 {
     /** Value of selected radio button */
+    // eslint-disable-next-line @angular-eslint/no-input-rename
     @Input('selected')
-    get value(): any {
-        return super.getValue();
-    }
     set value(newValue: any) {
         super.setValue(newValue);
+    }
+    get value(): any {
+        return super.getValue();
     }
 
     /** To Display Radio buttons in a line */
     @Input()
-    get isInline(): boolean {
-        return this._inlineCurrentValue$.value;
-    }
-
     set isInline(inline: boolean) {
         this._inlineCurrentValue$.next(inline);
+    }
+    get isInline(): boolean {
+        return this._inlineCurrentValue$.value;
     }
 
     /** None value radio button created */
@@ -111,6 +111,7 @@ export class RadioGroupComponent
     /** @hidden FocusKeyManager instance */
     private _keyboardEventsManager: FocusKeyManager<RadioButtonComponent>;
 
+    /** @hidden */
     constructor(
         protected _cd: ChangeDetectorRef,
         readonly _responsiveBreakpointsService: ResponsiveBreakpointsService,

--- a/libs/platform/src/lib/form/radio-group/radio/radio.component.ts
+++ b/libs/platform/src/lib/form/radio-group/radio/radio.component.ts
@@ -41,11 +41,11 @@ export class RadioButtonComponent extends BaseInput implements AfterViewInit, Fo
 
     /** value for Radio button */
     @Input()
-    get value(): any {
-        return super.getValue();
-    }
     set value(newValue: any) {
         this._value = newValue;
+    }
+    get value(): any {
+        return super.getValue();
     }
 
     /**
@@ -53,17 +53,17 @@ export class RadioButtonComponent extends BaseInput implements AfterViewInit, Fo
      * set state of individual radio.Used by RBG to set radio states
      */
     @Input()
-    get stateType(): FormStates {
-        if (isDevMode()) {
-            console.warn('"stateType" is deprecated. Use "state" instead');
-        }
-        return super.state;
-    }
     set stateType(state: FormStates) {
         if (isDevMode()) {
             console.warn('"stateType" is deprecated. Use "state" instead');
         }
         super.state = state;
+    }
+    get stateType(): FormStates {
+        if (isDevMode()) {
+            console.warn('"stateType" is deprecated. Use "state" instead');
+        }
+        return super.state;
     }
 
     /** used for radio button creation if list value present */
@@ -88,6 +88,7 @@ export class RadioButtonComponent extends BaseInput implements AfterViewInit, Fo
     @ViewChild(CoreRadioButtonComponent, { static: false })
     private coreRadioButton: CoreRadioButtonComponent;
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() ngControl: NgControl,

--- a/libs/platform/src/lib/form/select/commons/base-select.ts
+++ b/libs/platform/src/lib/form/select/commons/base-select.ts
@@ -46,6 +46,10 @@ export type FdpSelectData<T> = SelectOptionItem[] | Observable<T[]> | T[];
  * `FdpSelectionChangeEvent` will be removed in future versions in favour of plain value emission
  */
 export class FdpSelectionChangeEvent {
+    /**
+     * Select selection change event
+     * @param payload selected value
+     */
     constructor(
         public payload: any // Contains selected item
     ) {}
@@ -85,9 +89,16 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
     @Input()
     appendTo: ElementRef;
 
+    /** Trigger value */
     @Input()
     triggerValue: string;
 
+    /**
+     * Preset options for the select body width.
+     * * `at-least` will apply a minimum width to the body equivalent to the width of the control.
+     * * `equal` will apply a width to the body equivalent to the width of the control.
+     * * Leave blank for no effect.
+     */
     @Input()
     fillControlMode: PopoverFillMode = 'at-least';
 
@@ -138,6 +149,7 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
     @Input()
     noValueLabel: string;
 
+    /** Whether not to wrap text */
     @Input()
     noWrapText = false;
 
@@ -180,16 +192,16 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
 
     /** Data for suggestion list */
     @Input()
-    get list(): any {
-        return this._optionItems;
-    }
-
     set list(value: any) {
         if (value) {
             this._optionItems = this._convertToOptionItems(value);
         }
     }
+    get list(): any {
+        return this._optionItems;
+    }
 
+    /** @hidden */
     get canClose(): boolean {
         return !(this.mobile && this.mobileConfig.approveButtonText);
     }
@@ -260,6 +272,7 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
     /** @hidden */
     private _secondColumnRatio: number;
 
+    /** @hidden */
     constructor(
         readonly cd: ChangeDetectorRef,
         protected readonly elementRef: ElementRef,
@@ -295,6 +308,7 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
         return this.value.trim().length === 0;
     }
 
+    /** @hidden */
     protected setValue(newValue: any, emitOnChange = true): void {
         if (newValue !== this._value) {
             this.writeValue(newValue);

--- a/libs/platform/src/lib/form/select/select.config.ts
+++ b/libs/platform/src/lib/form/select/select.config.ts
@@ -22,6 +22,7 @@ export class SelectConfig {
         return useFactory;
     }
 
+    /** @hidden */
     constructor(platformConfig: PlatformConfig) {
         this.contentDensity = platformConfig.contentDensity;
     }

--- a/libs/platform/src/lib/form/select/select/select.component.ts
+++ b/libs/platform/src/lib/form/select/select/select.component.ts
@@ -37,17 +37,17 @@ export class SelectComponent extends BaseSelect implements AfterViewInit, AfterV
      * Holds the control state of select
      */
     @Input()
-    get selectState(): FormStates {
-        if (isDevMode()) {
-            console.warn('"selectState" is deprecated. Use "state" instead');
-        }
-        return super.state;
-    }
     set selectState(state: FormStates) {
         if (isDevMode()) {
             console.warn('"selectState" is deprecated. Use "state" instead');
         }
         super.state = state;
+    }
+    get selectState(): FormStates {
+        if (isDevMode()) {
+            console.warn('"selectState" is deprecated. Use "state" instead');
+        }
+        return super.state;
     }
 
     /**
@@ -55,21 +55,22 @@ export class SelectComponent extends BaseSelect implements AfterViewInit, AfterV
      * change detections
      */
     @Input()
-    get value(): any {
-        return this._value;
-    }
-
     set value(newValue: any) {
         this.setValue(newValue);
+    }
+    get value(): any {
+        return this._value;
     }
 
     /** Should select be inlined. */
     @Input()
     inline = true;
 
+    /** @hidden */
     @ViewChild(CoreSelect, { static: true })
     select: CoreSelect;
 
+    /** @hidden */
     constructor(
         readonly cd: ChangeDetectorRef,
         readonly elementRef: ElementRef,

--- a/libs/platform/src/lib/form/step-input/base.step-input.ts
+++ b/libs/platform/src/lib/form/step-input/base.step-input.ts
@@ -11,6 +11,11 @@ import { addAndCutFloatingNumberDistortion, getNumberDecimalLength } from './ste
 
 /** Change event object emitted by Platform Step Input component */
 export class StepInputChangeEvent<T extends StepInputComponent = StepInputComponent, K = number> {
+    /**
+     * Step input selection change event
+     * @param source Step input component
+     * @param payload Selected value
+     */
     constructor(
         /** The source Step Input of the event. */
         public source: T,
@@ -39,14 +44,14 @@ const ALIGN_INPUT_OPTIONS_LIST = [StepInputAlign.Left, StepInputAlign.Center, St
 export abstract class StepInputComponent extends BaseInput implements OnInit {
     /** Sets input value */
     @Input()
-    get value(): Nullable<number> {
-        return super.getValue();
-    }
     set value(value: Nullable<number>) {
         if (value !== this._value) {
             super.setValue(value);
             this._calculateCanDecrementIncrement();
         }
+    }
+    get value(): Nullable<number> {
+        return super.getValue();
     }
 
     /** Sets minimum value boundary */

--- a/libs/platform/src/lib/form/step-input/step-input-decrement.directive.ts
+++ b/libs/platform/src/lib/form/step-input/step-input-decrement.directive.ts
@@ -15,10 +15,12 @@ export class StepInputDecrementDirective extends StepInputActionButton {
         super();
     }
 
+    /** @hidden */
     canHandleAction(): boolean {
         return !!this.stepInput.canChangeValue;
     }
 
+    /** @hidden */
     runAction(): void {
         this.stepInput.decrease();
     }

--- a/libs/platform/src/lib/form/step-input/step-input-increment.directive.ts
+++ b/libs/platform/src/lib/form/step-input/step-input-increment.directive.ts
@@ -15,10 +15,12 @@ export class StepInputIncrementDirective extends StepInputActionButton {
         super();
     }
 
+    /** @hidden */
     canHandleAction(): boolean {
         return !!this.stepInput.canChangeValue;
     }
 
+    /** @hidden */
     runAction(): void {
         this.stepInput.increase();
     }

--- a/libs/platform/src/lib/form/switch/switch/switch.component.ts
+++ b/libs/platform/src/lib/form/switch/switch/switch.component.ts
@@ -49,12 +49,11 @@ export class SwitchComponent extends BaseInput {
     readonly switchChange: EventEmitter<SwitchChangeEvent> = new EventEmitter<SwitchChangeEvent>();
 
     /** value for switch control */
-    get value(): any {
-        return this.getValue();
-    }
-
     set value(selectValue: any) {
         this.setValue(selectValue);
+    }
+    get value(): any {
+        return this.getValue();
     }
 
     /** @hidden
@@ -62,6 +61,7 @@ export class SwitchComponent extends BaseInput {
      */
     switchCurrentValue = false;
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() ngControl: NgControl,

--- a/libs/platform/src/lib/form/text-area/text-area.component.ts
+++ b/libs/platform/src/lib/form/text-area/text-area.component.ts
@@ -105,6 +105,12 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
      * @deprecated
      * set state of individual checkbox. Used by CBG to set checkbox states */
     @Input()
+    set stateType(state: FormStates) {
+        if (isDevMode()) {
+            console.warn('"stateType" is deprecated. Use "state" instead');
+        }
+        super.state = state;
+    }
     get stateType(): FormStates {
         if (isDevMode()) {
             console.warn('"stateType" is deprecated. Use "state" instead');
@@ -112,23 +118,10 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         return super.state;
     }
 
-    set stateType(state: FormStates) {
-        if (isDevMode()) {
-            console.warn('"stateType" is deprecated. Use "state" instead');
-        }
-        super.state = state;
-    }
-
     /**
-     * return: The textarea's value
+     * The textarea's value
      */
-    @Input() get value(): any {
-        return super.getValue();
-    }
-
-    /**
-     * set the textarea value
-     */
+    @Input()
     set value(value: any) {
         if (value) {
             super.setValue(value);
@@ -138,6 +131,9 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
             // reset state by resetting value
             super.setValue('');
         }
+    }
+    get value(): any {
+        return super.getValue();
     }
 
     /** @hidden */
@@ -165,6 +161,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
 
     /** for i18n counter message translation */
     private readonly remainingText = 'remaining';
+    /** for i18n counter message translation */
     private readonly excessText = 'excess';
 
     /**
@@ -180,6 +177,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         return this.maxLength > 0 && !this.showExceededText;
     }
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() ngControl: NgControl,

--- a/libs/platform/src/lib/form/time-picker/time-picker.component.ts
+++ b/libs/platform/src/lib/form/time-picker/time-picker.component.ts
@@ -31,12 +31,11 @@ export class PlatformTimePickerComponent<D> extends BaseInput implements OnInit,
      * @Input date time object representation
      */
     @Input()
-    get value(): D | null {
-        return super.getValue();
-    }
-
     set value(value: D | null) {
         super.setValue(value);
+    }
+    get value(): D | null {
+        return super.getValue();
     }
 
     /**
@@ -158,9 +157,11 @@ export class PlatformTimePickerComponent<D> extends BaseInput implements OnInit,
     @Output()
     readonly isOpenChange = new EventEmitter<boolean>();
 
+    /** @hidden */
     @ViewChild(TimePickerComponent)
     timePickerComponent: TimePickerComponent<D>;
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() ngControl: NgControl,

--- a/libs/platform/src/lib/fundamental-ngx.module.ts
+++ b/libs/platform/src/lib/fundamental-ngx.module.ts
@@ -103,6 +103,7 @@ import { PlatformSmartFilterBarModule } from '@fundamental-ngx/platform/smart-fi
     providers: []
 })
 export class FundamentalNgxPlatformModule {
+    /** @hidden */
     constructor(injector: Injector) {
         PlatformConfig.setInjector(injector);
     }

--- a/libs/platform/src/lib/icon-tab-bar/tests-helper.ts
+++ b/libs/platform/src/lib/icon-tab-bar/tests-helper.ts
@@ -2,6 +2,7 @@ import { IconTabBarItem } from './interfaces/icon-tab-bar-item.interface';
 import { TabConfig } from './interfaces/tab-config.interface';
 import { UNIQUE_KEY_SEPARATOR } from './constants';
 
+/** @hidden */
 export function getGetCenterCoordsOfElement(el: HTMLElement | null): { clientX: number; clientY: number } {
     const rect = el?.getBoundingClientRect();
     return {
@@ -10,6 +11,7 @@ export function getGetCenterCoordsOfElement(el: HTMLElement | null): { clientX: 
     };
 }
 
+/** @hidden */
 export function generateTestConfig(length: number, subTabs: boolean = false): TabConfig[] {
     const items: TabConfig[] = [];
     for (let i = 0; i < length; i++) {
@@ -23,6 +25,7 @@ export function generateTestConfig(length: number, subTabs: boolean = false): Ta
     return items;
 }
 
+/** @hidden */
 export function generateTabBarItems(config: TabConfig[], flatIndexRef = { value: 0 }): IconTabBarItem[] {
     return config.map((item, index) => {
         const result: IconTabBarItem = {

--- a/libs/platform/src/lib/link/link.component.ts
+++ b/libs/platform/src/lib/link/link.component.ts
@@ -59,13 +59,11 @@ export class LinkComponent extends BaseComponent implements OnInit, AfterViewIni
      * sets inverted property.
      */
     @Input()
-    get inverted(): boolean {
-        return this._inverted;
-    }
-
-    /** set incase of Inverted link */
     set inverted(value: boolean) {
         this._inverted = coerceBooleanProperty(value);
+    }
+    get inverted(): boolean {
+        return this._inverted;
     }
 
     /**
@@ -111,6 +109,7 @@ export class LinkComponent extends BaseComponent implements OnInit, AfterViewIni
     // eslint-disable-next-line @angular-eslint/no-output-native
     click: EventEmitter<MouseEvent | KeyboardEvent | TouchEvent> = new EventEmitter();
 
+    /** @hidden */
     @ContentChild(IconComponent)
     icon: IconComponent;
 
@@ -118,10 +117,14 @@ export class LinkComponent extends BaseComponent implements OnInit, AfterViewIni
     @ViewChild('link', { read: ElementRef })
     anchor: ElementRef;
 
+    /** @hidden */
     emphasized = false;
+    /** @hidden */
     subtle = false;
+    /** @hidden */
     private _inverted = false;
 
+    /** @hidden */
     constructor(protected _cd: ChangeDetectorRef, private renderer2: Renderer2) {
         super(_cd);
     }

--- a/libs/platform/src/lib/list/base-list-item.ts
+++ b/libs/platform/src/lib/list/base-list-item.ts
@@ -35,17 +35,21 @@ export interface ItemDef {
 }
 
 export class ActionChangeEvent {
+    /** Action List Item component */
     source: ActionListItemComponent;
 }
 
 export class ModifyItemEvent {
+    /** List Item component */
     source: BaseListItem;
+    /** Action */
     action: 'delete' | 'edit';
 }
 
 @Directive({ selector: '[fdpItemDef]' })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class ListItemDef implements ItemDef {
+    /** @hidden */
     constructor(/** @docs-private */ public templateRef: TemplateRef<any>) {}
 }
 
@@ -244,11 +248,8 @@ export class BaseListItem extends BaseComponent implements OnInit, AfterViewChec
      */
     private _selectionValue: Nullable<string>;
 
+    /** Selection value */
     @Input()
-    get selectionValue(): Nullable<string> {
-        return this._selectionValue;
-    }
-
     set selectionValue(value: Nullable<string>) {
         this._selected = false;
         this._selectionValue = value;
@@ -256,6 +257,10 @@ export class BaseListItem extends BaseComponent implements OnInit, AfterViewChec
             this._selected = this.value === this._selectionValue;
         }
     }
+    get selectionValue(): Nullable<string> {
+        return this._selectionValue;
+    }
+
     /**
      * @hidden
      * Show navigation for single list

--- a/libs/platform/src/lib/list/list.component.ts
+++ b/libs/platform/src/lib/list/list.component.ts
@@ -52,7 +52,9 @@ export type ListType = 'inactive' | 'active' | 'detail';
 export type FdpListDataSource<T> = ListDataSource<T> | Observable<T[]> | T[];
 
 export class SelectionChangeEvent {
+    /** Selected items */
     selectedItems: BaseListItem[];
+    /** Index */
     index: number;
 }
 
@@ -147,22 +149,17 @@ export class ListComponent<T> extends CollectionBaseInput implements OnInit, Aft
     @Input()
     selectionMode: SelectionType = 'none';
 
+    /** setter and getter for radio button and checkbox */
     @Input()
+    set value(value: any) {
+        super.setValue(value);
+    }
     get value(): any {
         return super.getValue();
     }
 
-    /** setter and getter for radio button and checkbox */
-    set value(value: any) {
-        super.setValue(value);
-    }
-
     /** setter and getter for row level Selection */
     @Input()
-    get rowSelection(): boolean {
-        return this._rowSelection;
-    }
-
     set rowSelection(value: boolean) {
         this._rowSelection = value;
         if (this._rowSelection) {
@@ -173,25 +170,23 @@ export class ListComponent<T> extends CollectionBaseInput implements OnInit, Aft
             }
         }
     }
+    get rowSelection(): boolean {
+        return this._rowSelection;
+    }
 
     /** Datasource for suggestion list */
     @Input()
-    get dataSource(): FdpListDataSource<T> {
-        return this._dataSource;
-    }
-
     set dataSource(value: FdpListDataSource<T>) {
         if (value) {
             this._initializeDS(value);
         }
     }
+    get dataSource(): FdpListDataSource<T> {
+        return this._dataSource;
+    }
 
     /** setter and getter for _navigated */
     @Input()
-    get navigated(): boolean {
-        return this._navigated;
-    }
-
     set navigated(value: boolean) {
         this._navigated = value;
 
@@ -202,38 +197,38 @@ export class ListComponent<T> extends CollectionBaseInput implements OnInit, Aft
 
         this._ulElement?.classList.add(...classList);
     }
+    get navigated(): boolean {
+        return this._navigated;
+    }
 
     /** setter and getter for _navigationIndicator */
     @Input()
-    get navigationIndicator(): boolean {
-        return this._navigationIndicator;
-    }
-
     set navigationIndicator(value: boolean) {
         this._navigationIndicator = value;
         this._ulElement?.classList.add('fd-list--navigation-indication');
     }
+    get navigationIndicator(): boolean {
+        return this._navigationIndicator;
+    }
 
     /** setter and getter for hasByLine */
     @Input()
-    get hasByLine(): boolean {
-        return this._hasByLine;
-    }
-
     set hasByLine(value: boolean) {
         this._hasByLine = value;
         this._ulElement?.classList.add('fd-list--byline');
     }
+    get hasByLine(): boolean {
+        return this._hasByLine;
+    }
 
     /** setter and getter for hasObject */
     @Input()
-    get hasObject(): boolean {
-        return this._hasObject;
-    }
-
     set hasObject(value: boolean) {
         this._hasObject = value;
         this._ulElement?.classList.add('fd-object-list');
+    }
+    get hasObject(): boolean {
+        return this._hasObject;
     }
 
     /** Event thrown, when selected item is changed */
@@ -355,6 +350,7 @@ export class ListComponent<T> extends CollectionBaseInput implements OnInit, Aft
      */
     private _dsSubscription: Nullable<Subscription>;
 
+    /** @hidden */
     private _clickSubscription = new Subscription();
 
     /** @hidden */

--- a/libs/platform/src/lib/list/object-list-item/object-list-item.component.ts
+++ b/libs/platform/src/lib/list/object-list-item/object-list-item.component.ts
@@ -73,6 +73,7 @@ export class ObjectListItemComponent extends BaseListItem {
     @Input()
     transparent: boolean;
 
+    /** @hidden */
     @ContentChildren(ObjectListItemRowComponent)
     children: QueryList<ObjectListItemRowComponent>;
 }

--- a/libs/platform/src/lib/menu-button/menu-button.component.ts
+++ b/libs/platform/src/lib/menu-button/menu-button.component.ts
@@ -39,6 +39,7 @@ export class MenuButtonComponent extends BaseComponent {
     @Output()
     buttonClicked: EventEmitter<MouseEvent | KeyboardEvent | TouchEvent> = new EventEmitter();
 
+    /** @hidden */
     constructor(_cd: ChangeDetectorRef) {
         super(_cd);
     }
@@ -53,7 +54,7 @@ export class MenuButtonComponent extends BaseComponent {
         return this.disabled;
     }
 
-    // @hidden tabindex for button.
+    /** @hidden tabindex for button. */
     get tabindex(): number {
         return this.disabled ? -1 : 0;
     }

--- a/libs/platform/src/lib/menu/menu-trigger.directive.ts
+++ b/libs/platform/src/lib/menu/menu-trigger.directive.ts
@@ -30,15 +30,15 @@ import { MenuItemComponent } from './menu-item.component';
 export class MenuTriggerDirective implements OnDestroy, AfterContentInit {
     /** Set Menu Component for which this trigger will be associated. */
     @Input('fdpMenuTriggerFor')
-    get menu(): MenuComponent {
-        return this._menu;
-    }
     set menu(menu: MenuComponent) {
         if (this._menu === menu) {
             return;
         }
         this._menu = menu;
         this._menuCloseSubscription.unsubscribe();
+    }
+    get menu(): MenuComponent {
+        return this._menu;
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/menu/menu.component.ts
+++ b/libs/platform/src/lib/menu/menu.component.ts
@@ -63,15 +63,14 @@ let menuIdCounter = 0;
 export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy {
     /** Menu ID */
     @Input()
-    get id(): string {
-        return this._id;
-    }
-
     set id(id: string) {
         this._id = id;
 
         // Use 'id' property to create menu ID for aria-control purposes.
         this.menuId = MENU_ID_ROOT + id;
+    }
+    get id(): string {
+        return this._id;
     }
 
     /**

--- a/libs/platform/src/lib/page-footer/page-footer.component.ts
+++ b/libs/platform/src/lib/page-footer/page-footer.component.ts
@@ -27,11 +27,15 @@ export class PlatformFooterComponent {
     /** defines the padding and size of the footer based on screen */
     size: footerSize = 'xl';
 
+    /** @hidden */
     public screenWidth: any;
+    /** @hidden */
     public screenHeight: any;
 
+    /** @hidden */
     constructor(private _elRef: ElementRef, private readonly _cdRef: ChangeDetectorRef) {}
 
+    /** @hidden */
     @HostListener('window:resize', ['$event'])
     onResize(): void {
         this.screenWidth = window.innerWidth;

--- a/libs/platform/src/lib/panel/panel-actions/panel-actions.component.ts
+++ b/libs/platform/src/lib/panel/panel-actions/panel-actions.component.ts
@@ -6,5 +6,6 @@ import { Component, ChangeDetectionStrategy, ViewChild, TemplateRef } from '@ang
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PanelActionsComponent {
+    /** @hidden */
     @ViewChild(TemplateRef) contentTemplateRef: TemplateRef<any>;
 }

--- a/libs/platform/src/lib/panel/panel.component.ts
+++ b/libs/platform/src/lib/panel/panel.component.ts
@@ -26,6 +26,11 @@ import {
 
 /** Panel change event instance */
 export class PanelExpandChangeEvent {
+    /**
+     * Panel expand change event
+     * @param source Panel component
+     * @param payload Panel expand state
+     */
     constructor(public source: PanelComponent, public payload: boolean) {}
 }
 

--- a/libs/platform/src/lib/panel/panel.config.ts
+++ b/libs/platform/src/lib/panel/panel.config.ts
@@ -32,6 +32,7 @@ export class PanelConfig {
         return useFactory;
     }
 
+    /** @hidden */
     constructor(platformConfig: PlatformConfig) {
         this.contentDensity = platformConfig.contentDensity;
     }

--- a/libs/platform/src/lib/search-field/search-field-mobile/search-field/search-field-mobile.component.ts
+++ b/libs/platform/src/lib/search-field/search-field-mobile/search-field/search-field-mobile.component.ts
@@ -34,11 +34,13 @@ export class SearchFieldMobileComponent
     extends MobileModeBase<SearchFieldMobileInterface>
     implements OnInit, OnDestroy
 {
+    /** @hidden */
     childContent: SearchFieldChildContent | null = null;
 
     /** @hidden */
     @ViewChild('dialogTemplate') dialogTemplate: TemplateRef<any>;
 
+    /** @hidden */
     constructor(
         elementRef: ElementRef,
         dialogService: DialogService,

--- a/libs/platform/src/lib/search-field/search-field.component.ts
+++ b/libs/platform/src/lib/search-field/search-field.component.ts
@@ -72,8 +72,10 @@ export interface ValueLabelItem {
     }
 })
 export class SearchFieldSuggestionDirective implements FocusableOption {
+    /** @hidden */
     constructor(private element: ElementRef) {}
 
+    /** @hidden */
     focus(): void {
         this.element.nativeElement.focus();
     }
@@ -111,10 +113,6 @@ export class SearchFieldComponent
 
     /** List of string values to populate suggestion dropdown selection. */
     @Input()
-    get suggestions(): SuggestionItem[] | Observable<SuggestionItem[]> {
-        return this._suggestions;
-    }
-
     set suggestions(value: SuggestionItem[] | Observable<SuggestionItem[]>) {
         this._suggestions = value;
         if (Array.isArray(value)) {
@@ -129,17 +127,19 @@ export class SearchFieldComponent
             this._dropdownValues$ = of([]);
         }
     }
+    get suggestions(): SuggestionItem[] | Observable<SuggestionItem[]> {
+        return this._suggestions;
+    }
 
     /** Datasource for suggestion list */
     @Input()
-    get dataSource(): SearchFieldDataSource<any> {
-        return this._dataSource;
-    }
-
     set dataSource(value: SearchFieldDataSource<any>) {
         if (value) {
             this._initializeDataSource(value);
         }
+    }
+    get dataSource(): SearchFieldDataSource<any> {
+        return this._dataSource;
     }
 
     /** Initial input text. */
@@ -148,13 +148,12 @@ export class SearchFieldComponent
 
     /** List of categories. */
     @Input()
-    get categories(): ValueLabelItem[] {
-        return this._categories;
-    }
-
     set categories(value: ValueLabelItem[]) {
         this._categories = value;
         this._showCategoryDropdown = Array.isArray(value) && value.length > 0;
+    }
+    get categories(): ValueLabelItem[] {
+        return this._categories;
     }
 
     /** Current category, value should be present in categories array */
@@ -304,13 +303,29 @@ export class SearchFieldComponent
     /** @hidden */
     private readonly _dataSourceChanged$ = new Subject<void>();
 
-    @ViewChild('categoryDropdown', { static: false }) categoryDropdown: PopoverComponent;
-    @ViewChild('inputGroup', { static: false }) inputGroup: ElementRef<HTMLElement>;
-    @ViewChild('inputField', { static: false }) inputField: ElementRef<HTMLElement>;
+    /** @hidden */
+    @ViewChild('categoryDropdown', { static: false })
+    categoryDropdown: PopoverComponent;
 
-    @ViewChild('inputFieldTemplate') inputFieldTemplate: TemplateRef<any>;
-    @ViewChild('suggestionMenuTemplate', { static: false }) suggestionMenuTemplate: TemplateRef<any>;
-    @ViewChildren(SearchFieldSuggestionDirective) suggestionItems: QueryList<SearchFieldSuggestionDirective>;
+    /** @hidden */
+    @ViewChild('inputGroup', { static: false })
+    inputGroup: ElementRef<HTMLElement>;
+
+    /** @hidden */
+    @ViewChild('inputField', { static: false })
+    inputField: ElementRef<HTMLElement>;
+
+    /** @hidden */
+    @ViewChild('inputFieldTemplate')
+    inputFieldTemplate: TemplateRef<any>;
+
+    /** @hidden */
+    @ViewChild('suggestionMenuTemplate', { static: false })
+    suggestionMenuTemplate: TemplateRef<any>;
+
+    /** @hidden */
+    @ViewChildren(SearchFieldSuggestionDirective)
+    suggestionItems: QueryList<SearchFieldSuggestionDirective>;
 
     /** @hidden */
     get searchFieldValue(): SearchInput {
@@ -320,6 +335,7 @@ export class SearchFieldComponent
         };
     }
 
+    /** @hidden */
     constructor(
         private readonly _overlay: Overlay,
         private readonly _viewContainerRef: ViewContainerRef,
@@ -687,6 +703,7 @@ export class SearchFieldComponent
     name: 'suggestionMatches'
 })
 export class SuggestionMatchesPipe implements PipeTransform {
+    /** @hidden */
     transform(values: string[] | null, match: string, mobile = false): string[] {
         if (!values) {
             values = [];

--- a/libs/platform/src/lib/shared/async-strategy/function-strategy.class.ts
+++ b/libs/platform/src/lib/shared/async-strategy/function-strategy.class.ts
@@ -5,6 +5,7 @@ import { isFunction } from '../utils/lang';
  * @description Executes function and passes returned value into callback function.
  */
 export class FunctionStrategy<T> implements SubscriptionStrategy<T> {
+    /** @hidden */
     createSubscription(fn: () => T, updateLatestValue: (v: T) => any): Promise<void> {
         const result = isFunction(fn) ? fn() : ((<any>fn) as T);
         return Promise.resolve(result).then(updateLatestValue);

--- a/libs/platform/src/lib/shared/async-strategy/observable-strategy.class.ts
+++ b/libs/platform/src/lib/shared/async-strategy/observable-strategy.class.ts
@@ -5,6 +5,7 @@ import { SubscriptionStrategy } from './subscription-strategy.interface';
  * @description Converts observable into Promise and passes returned value into callback function.
  */
 export class ObservableStrategy<T> implements SubscriptionStrategy<T> {
+    /** @hidden */
     createSubscription(async: Observable<T>, updateLatestValue: any): Promise<void> {
         return async.toPromise().then(updateLatestValue, (e) => {
             console.error(e);

--- a/libs/platform/src/lib/shared/async-strategy/promise-strategy.class.ts
+++ b/libs/platform/src/lib/shared/async-strategy/promise-strategy.class.ts
@@ -4,6 +4,7 @@ import { SubscriptionStrategy } from './subscription-strategy.interface';
  * @description awaits for promise to resolve it's value and passes returned value into callback function.
  */
 export class PromiseStrategy<T> implements SubscriptionStrategy<T> {
+    /** @hidden */
     createSubscription(async: Promise<T>, updateLatestValue: (v: T) => any): Promise<void> {
         return async.then(updateLatestValue, (e) => {
             console.error(e);

--- a/libs/platform/src/lib/shared/async-strategy/value-strategy.class.ts
+++ b/libs/platform/src/lib/shared/async-strategy/value-strategy.class.ts
@@ -4,6 +4,7 @@ import { SubscriptionStrategy } from './subscription-strategy.interface';
  * @description Passes value object into callback function.
  */
 export class ValueStrategy<T> implements SubscriptionStrategy<T> {
+    /** @hidden */
     createSubscription(value: T, updateLatestValue: (v: T) => any): Promise<void> {
         return Promise.resolve(value).then(updateLatestValue);
     }

--- a/libs/platform/src/lib/shared/base.ts
+++ b/libs/platform/src/lib/shared/base.ts
@@ -14,7 +14,9 @@ let randomId = 0;
  */
 @Directive()
 export abstract class BaseComponent implements OnDestroy {
+    /** @hidden */
     protected defaultId = `fdp-id-${randomId++}`;
+    /** @hidden */
     protected _disabled = false;
 
     /** Sets the `aria-label` attribute to the element. */
@@ -49,14 +51,14 @@ export abstract class BaseComponent implements OnDestroy {
 
     /** disabled status of the element */
     @Input()
+    set disabled(disabled: boolean) {
+        this._disabled = disabled;
+    }
     get disabled(): boolean {
         return this._disabled;
     }
 
-    set disabled(disabled: boolean) {
-        this._disabled = disabled;
-    }
-
+    /** @hidden */
     constructor(protected _cd: ChangeDetectorRef) {}
 
     /** @hidden */

--- a/libs/platform/src/lib/shared/domain/array-data-source.ts
+++ b/libs/platform/src/lib/shared/domain/array-data-source.ts
@@ -5,24 +5,28 @@ import { ComboBoxDataSource, ListDataSource, MultiComboBoxDataSource, MultiInput
 import { BaseDataProvider } from './base-data-provider';
 
 export class ArrayComboBoxDataSource<T> extends ComboBoxDataSource<T> {
+    /** @hidden */
     constructor(private data: T[]) {
         super(new BaseDataProvider(data));
     }
 }
 
 export class ArrayMultiComboBoxDataSource<T> extends MultiComboBoxDataSource<T> {
+    /** @hidden */
     constructor(private data: T[]) {
         super(new BaseDataProvider(data));
     }
 }
 
 export class ArrayListDataSource<T> extends ListDataSource<T> {
+    /** @hidden */
     constructor(private data: T[]) {
         super(new BaseDataProvider(data));
     }
 }
 
 export class ArrayMultiInputDataSource<T> extends MultiInputDataSource<T> {
+    /** @hidden */
     constructor(private data: T[]) {
         super(new BaseDataProvider(data));
     }

--- a/libs/platform/src/lib/shared/domain/base-data-provider.ts
+++ b/libs/platform/src/lib/shared/domain/base-data-provider.ts
@@ -11,10 +11,12 @@ import { DataProvider, getMatchingStrategyStartsWithPerTermReqexp, MatchBy, Matc
  * In Memory implementation of DataProvider that supports fulltext search
  */
 export class BaseDataProvider<T> extends DataProvider<T> {
+    /** @hidden */
     constructor(protected values: Observable<T[]> | T[]) {
         super();
     }
 
+    /** @hidden */
     fetch(params: Map<string, any>): Observable<T[]> {
         const observable = isObservable(this.values) ? this.values : of(this.values);
 
@@ -65,6 +67,7 @@ export class BaseDataProvider<T> extends DataProvider<T> {
         return matched;
     }
 
+    /** @hidden */
     matchesBy(item: any, pattern: string, matchingBy: MatchBy): boolean {
         const value = isJsObject(item) && matchingBy ? matchingBy(item) : item;
 
@@ -84,6 +87,7 @@ export class BaseDataProvider<T> extends DataProvider<T> {
         }
     }
 
+    /** @hidden */
     protected hasObjectValue(obj: any, pattern: string): boolean {
         const values = objectValues(obj);
         const parentObj = objectToName(obj);
@@ -101,6 +105,7 @@ export class BaseDataProvider<T> extends DataProvider<T> {
         return length2 > 0;
     }
 
+    /** @hidden */
     private withLimit(data: Array<T>, limit?: number): Array<T> {
         if (limit && data.length > limit) {
             return data.slice(0, limit);

--- a/libs/platform/src/lib/shared/domain/data-model.ts
+++ b/libs/platform/src/lib/shared/domain/data-model.ts
@@ -49,6 +49,7 @@ export interface SelectableOptionItem extends OptionItem {
     children?: SelectableOptionItem[];
 }
 
+/** @hidden */
 export function isSelectableItem(item: SelectItem): item is SelectItem {
     return (
         item &&
@@ -58,6 +59,7 @@ export function isSelectableItem(item: SelectItem): item is SelectItem {
     );
 }
 
+/** @hidden */
 export function isSelectItem(item: SelectItem): item is SelectItem {
     return item && item.label !== undefined && item.value !== undefined;
 }

--- a/libs/platform/src/lib/shared/domain/data-source.ts
+++ b/libs/platform/src/lib/shared/domain/data-source.ts
@@ -98,6 +98,7 @@ export function getMatchingStrategyStartsWithPerTermReqexp(value: string): RegEx
     return new RegExp(`(\\s|^)(${value})`, 'gi');
 }
 
+/** @hidden */
 export function isDataSource<T = any>(value: any): value is DataSource<T> {
     return value && typeof value.open === 'function';
 }
@@ -109,8 +110,13 @@ export type ProviderParams = ReadonlyMap<string, any>;
  *
  */
 export abstract class DataProvider<T> {
+    /** @hidden */
     protected _keyPath: string;
+
+    /** @hidden */
     protected _matchingStrategy: MatchingStrategy = MatchingStrategy.STARTS_WITH;
+
+    /** @hidden */
     protected _matchingBy: MatchingBy | null = null;
 
     abstract fetch(params: ProviderParams, start?: number, end?: number): Observable<T[]>;
@@ -125,54 +131,69 @@ export abstract class DataProvider<T> {
 
     // Implement to support CRUD operations.
 
+    /** @hidden */
     getOne(params: ProviderParams): Observable<T> {
         throw new Error('Not supported');
     }
 
+    /** @hidden */
     insert(payload: any, params?: ProviderParams): Observable<T> {
         throw new Error('Not supported');
     }
 
+    /** @hidden */
     remove(params: ProviderParams): Observable<boolean> {
         throw new Error('Not supported');
     }
 
+    /** @hidden */
     update(payload: any, params?: ProviderParams): Observable<T> {
         throw new Error('Not supported');
     }
 
+    /** @hidden */
     setLookupKey(key: string): void {
         this._keyPath = key;
     }
 
+    /** @hidden */
     setMatchingBy(matchingBy: MatchingBy): void {
         this._matchingBy = matchingBy;
     }
 
+    /** @hidden */
     setMatchingStrategy(strategy: MatchingStrategy): void {
         this._matchingStrategy = strategy;
     }
 }
 
 export class ComboBoxDataSource<T> implements DataSource<T> {
+    /** @hidden */
     static readonly MaxLimit = 5;
 
     /** @hidden */
     limitless = false;
 
+    /** @hidden */
     protected readonly _dataChanges: BehaviorSubject<T[]> = new BehaviorSubject<T[]>([]);
+    /** @hidden */
     protected readonly _onDataRequested$ = new Subject<void>();
+    /** @hidden */
     protected readonly _onDataReceived$ = new Subject<void>();
+    /** @hidden */
     protected readonly _onDestroy$ = new Subject<void>();
-
+    /** @hidden */
     protected _dataLoading = false;
 
+    /** @hidden */
     get isDataLoading(): boolean {
         return this._dataLoading;
     }
 
+    /** @hidden */
     constructor(public dataProvider: DataProvider<any>) {}
 
+    /** @hidden */
     match(predicate: string | Map<string, string> = new Map<string, string>(), start = 0, end = Infinity): void {
         this._onDataRequested$.next();
         this._dataLoading = true;
@@ -206,53 +227,64 @@ export class ComboBoxDataSource<T> implements DataSource<T> {
             );
     }
 
+    /** @hidden */
     open(): Observable<T[]> {
         return this._dataChanges.pipe(takeUntil(this._onDestroy$));
     }
 
+    /** @hidden */
     close(): void {
         this._onDestroy$.next();
     }
 
+    /** @hidden */
     onDataRequested(): Observable<void> {
         return this._onDataRequested$.asObservable();
     }
+
+    /** @hidden */
     onDataReceived(): Observable<void> {
         return this._onDataReceived$.asObservable();
     }
 }
 
 export class MultiComboBoxDataSource<T> extends ComboBoxDataSource<T> {
+    /** @hidden */
     constructor(public dataProvider: DataProvider<any>) {
         super(dataProvider);
     }
 }
 
 export class SearchFieldDataSource<T> extends ComboBoxDataSource<T> {
+    /** @hidden */
     constructor(public dataProvider: DataProvider<any>) {
         super(dataProvider);
     }
 }
 
 export class ListDataSource<T> extends ComboBoxDataSource<T> {
+    /** @hidden */
     constructor(public dataProvider: DataProvider<any>) {
         super(dataProvider);
     }
 }
 
 export class MultiInputDataSource<T> extends ComboBoxDataSource<T> {
+    /** @hidden */
     constructor(public dataProvider: DataProvider<any>) {
         super(dataProvider);
     }
 }
 
 export class ApprovalFlowUserDataSource<T> extends ComboBoxDataSource<T> {
+    /** @hidden */
     constructor(public dataProvider: DataProvider<T>) {
         super(dataProvider);
     }
 }
 
 export class ApprovalFlowTeamDataSource<T> extends ComboBoxDataSource<T> {
+    /** @hidden */
     constructor(public dataProvider: DataProvider<T>) {
         super(dataProvider);
     }

--- a/libs/platform/src/lib/shared/domain/observable-data-source.ts
+++ b/libs/platform/src/lib/shared/domain/observable-data-source.ts
@@ -7,24 +7,28 @@ import { ComboBoxDataSource, ListDataSource, MultiComboBoxDataSource, MultiInput
 import { BaseDataProvider } from './base-data-provider';
 
 export class ObservableComboBoxDataSource<T> extends ComboBoxDataSource<T> {
+    /** @hidden */
     constructor(private data: Observable<T[]>) {
         super(new BaseDataProvider(data));
     }
 }
 
 export class ObservableMultiComboBoxDataSource<T> extends MultiComboBoxDataSource<T> {
+    /** @hidden */
     constructor(private data: Observable<T[]>) {
         super(new BaseDataProvider(data));
     }
 }
 
 export class ObservableListDataSource<T> extends ListDataSource<T> {
+    /** @hidden */
     constructor(private data: Observable<T[]>) {
         super(new BaseDataProvider(data));
     }
 }
 
 export class ObservableMultiInputDataSource<T> extends MultiInputDataSource<T> {
+    /** @hidden */
     constructor(private data: Observable<T[]>) {
         super(new BaseDataProvider(data));
     }

--- a/libs/platform/src/lib/shared/form/base.input.ts
+++ b/libs/platform/src/lib/shared/form/base.input.ts
@@ -41,12 +41,18 @@ export abstract class BaseInput
     extends BaseComponent
     implements FormFieldControl<any>, ControlValueAccessor, OnInit, DoCheck, AfterViewInit, OnDestroy
 {
+    /** @hidden */
     protected defaultId = `fdp-input-id-${randomId++}`;
+    /** @hidden */
     protected _disabled: boolean;
+    /** @hidden */
     protected _value: any;
+    /** @hidden */
     protected _editable = true;
+    /** @hidden */
     protected _destroyed = new Subject<void>();
 
+    /** Input placeholder */
     @Input()
     placeholder: string;
 
@@ -57,19 +63,18 @@ export abstract class BaseInput
      * @default 'default'
      */
     @Input()
-    get state(): FormStates {
-        if (this._state) {
-            return this._state;
-        }
-        return this.controlInvalid ? 'error' : 'default';
-    }
-
     set state(state: FormStates | undefined) {
         if (!state || isValidControlState(state)) {
             this._state = state || 'default';
         } else if (isDevMode()) {
             console.warn(`Provided value "${state}" is not a valid option for FormStates type`);
         }
+    }
+    get state(): FormStates {
+        if (this._state) {
+            return this._state;
+        }
+        return this.controlInvalid ? 'error' : 'default';
     }
 
     /** Holds the message with respect to state */
@@ -83,16 +88,16 @@ export abstract class BaseInput
      */
     protected _state: FormStates;
 
+    /** Whether the input is disabled */
     @Input()
+    set disabled(value: boolean) {
+        this.setDisabledState(value);
+    }
     get disabled(): boolean {
         if (this.ngControl && this.ngControl.disabled !== null) {
             return this.ngControl.disabled;
         }
         return this._disabled;
-    }
-
-    set disabled(value: boolean) {
-        this.setDisabledState(value);
     }
 
     /**
@@ -110,18 +115,9 @@ export abstract class BaseInput
     ariaLabel: Nullable<string>;
 
     /**
-     * Tell  the component if we are in editing mode.
-     *
+     * Tell the component if we are in editing mode.
      */
     @Input()
-    get editable(): boolean {
-        return this._editable;
-    }
-
-    /**
-     * Firing CD, as we can keep switching between editable and non-editable mode
-     *
-     */
     set editable(value: BooleanInput) {
         const newVal = coerceBooleanProperty(value);
         if (this._editable !== newVal) {
@@ -129,6 +125,9 @@ export abstract class BaseInput
             this._cd.markForCheck();
             this.stateChanges.next('editable');
         }
+    }
+    get editable(): boolean {
+        return this._editable;
     }
 
     /**
@@ -166,14 +165,19 @@ export abstract class BaseInput
      */
     readonly stateChanges: Subject<any> = new Subject<any>();
 
+    /** @hidden */
     readonly formField: FormField | null = null;
 
     /** set when input field is mandatory form field */
     required: boolean;
 
+    /** @hidden */
     onChange: (value: any) => void = () => {};
+
+    /** @hidden */
     onTouched = (): void => {};
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() readonly ngControl: NgControl,
@@ -197,6 +201,7 @@ export abstract class BaseInput
         this.formField = formField && !formControl ? formField : null;
     }
 
+    /** @hidden */
     ngOnInit(): void {
         if (this.formField) {
             this.formField.registerFormFieldControl(this);
@@ -234,14 +239,17 @@ export abstract class BaseInput
         this._cd.detectChanges();
     }
 
+    /** @hidden */
     registerOnChange(fn: (_: any) => void): void {
         this.onChange = fn;
     }
 
+    /** @hidden */
     registerOnTouched(fn: () => void): void {
         this.onTouched = fn;
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         super.ngOnDestroy();
         this.stateChanges.complete();
@@ -252,6 +260,7 @@ export abstract class BaseInput
         }
     }
 
+    /** @hidden */
     setDisabledState(isDisabled: BooleanInput): void {
         const newState = coerceBooleanProperty(isDisabled);
         this._cd.markForCheck();
@@ -342,6 +351,7 @@ export abstract class BaseInput
         }
     }
 
+    /** @hidden */
     protected getValue(): any {
         return this._value;
     }

--- a/libs/platform/src/lib/shared/form/collection-base.input.ts
+++ b/libs/platform/src/lib/shared/form/collection-base.input.ts
@@ -24,13 +24,14 @@ export abstract class CollectionBaseInput extends BaseInput {
      * because we allow to get labels and values using `displayKey` and `lookupKey` inputs accordingly.
      */
     @Input()
+    set list(value: Array<SelectItem | string | object>) {
+        this._list = value;
+    }
     get list(): Array<SelectItem | string | object> {
         return this._list;
     }
 
-    set list(value: Array<SelectItem | string | object>) {
-        this._list = value;
-    }
+    /** @hidden */
     private _list: Array<SelectItem | string | object>;
 
     /**
@@ -49,6 +50,7 @@ export abstract class CollectionBaseInput extends BaseInput {
     @Input()
     displayKey: string;
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() readonly ngControl: NgControl,
@@ -59,6 +61,7 @@ export abstract class CollectionBaseInput extends BaseInput {
         super(cd, ngControl, ngForm, formField, formControl);
     }
 
+    /** @hidden */
     public lookupValue(item: any): string {
         if (isSelectItem(item)) {
             return this.lookupKey && item ? item.value[this.lookupKey] : item.value;
@@ -67,6 +70,7 @@ export abstract class CollectionBaseInput extends BaseInput {
         }
     }
 
+    /** @hidden */
     public displayValue(item: any): string {
         if (isSelectItem(item)) {
             return item.label;
@@ -79,6 +83,7 @@ export abstract class CollectionBaseInput extends BaseInput {
         }
     }
 
+    /** @hidden */
     public objectGet(obj: any, is: string | string[] | undefined): any {
         if (!isJsObject(obj)) {
             return obj;

--- a/libs/platform/src/lib/shared/form/form-field.ts
+++ b/libs/platform/src/lib/shared/form/form-field.ts
@@ -71,5 +71,8 @@ export abstract class FormField {
      */
     unregisterFormFieldControl: (control: FormFieldControl<any>) => void;
 
+    /**
+     * Set default columns layout
+     */
     setDefaultColumnLayout: () => void;
 }

--- a/libs/platform/src/lib/shared/form/inline-layout-collection-base.input.ts
+++ b/libs/platform/src/lib/shared/form/inline-layout-collection-base.input.ts
@@ -38,8 +38,11 @@ export const RESPONSIVE_BREAKPOINTS_CONFIG = new InjectionToken<ResponsiveBreakP
 
 @Injectable()
 export class ResponsiveBreakPointConfig {
+    /** Large screen */
     L: number = RESPONSIVE_BREAKPOINTS['L'];
+    /** Medium screen */
     M: number = RESPONSIVE_BREAKPOINTS['M'];
+    /** Small screen */
     S: number = RESPONSIVE_BREAKPOINTS['S'];
 }
 
@@ -47,10 +50,15 @@ export class ResponsiveBreakPointConfig {
     providedIn: 'root'
 })
 export class ResponsiveBreakpointsService {
+    /** @hidden */
     breakpoints: Record<string, any> = {};
+    /** @hidden */
     activeBreakpoints: string[];
+    /** @hidden */
     minWidth = 'min-width';
+    /** @hidden */
     maxWidth = 'max-width';
+    /** @hidden */
     unit = 'px';
 
     /** @hidden */
@@ -126,16 +134,15 @@ export class ResponsiveBreakpointsService {
 export abstract class InLineLayoutCollectionBaseInput extends CollectionBaseInput implements OnInit {
     /** object to change isInline property based on screen size */
     @Input()
-    get inlineLayout(): InlineLayout {
-        return this._inlineLayout;
-    }
-
     set inlineLayout(layout: InlineLayout | undefined) {
         if (layout) {
             this._inlineLayout = layout;
             this._isInLineLayoutEnabled = true;
         }
         this._setFieldLayout(layout);
+    }
+    get inlineLayout(): InlineLayout {
+        return this._inlineLayout;
     }
 
     /** @hidden */
@@ -162,6 +169,7 @@ export abstract class InLineLayoutCollectionBaseInput extends CollectionBaseInpu
     /** @hidden */
     private _isInLineLayoutEnabled = false;
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         readonly _responsiveBreakpointsService: ResponsiveBreakpointsService,

--- a/libs/platform/src/lib/shared/pipes/convert-bytes/convert-bytes.pipe.ts
+++ b/libs/platform/src/lib/shared/pipes/convert-bytes/convert-bytes.pipe.ts
@@ -2,8 +2,10 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({ name: 'convertBytes' })
 export class ConvertBytesPipe implements PipeTransform {
+    /** @hidden */
     private readonly _sizes: string[] = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
+    /** @hidden */
     transform(bytes: number): string {
         return this._convertBytes(bytes);
     }

--- a/libs/platform/src/lib/shared/platform-content-density-deprecations/directives/platform-compact-deprecation.directive.ts
+++ b/libs/platform/src/lib/shared/platform-content-density-deprecations/directives/platform-compact-deprecation.directive.ts
@@ -9,6 +9,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedCompactDirective } from '@fundamen
     ]
 })
 export class PlatformCompactDeprecationDirective extends DeprecatedCompactDirective {
+    /** @hidden */
     constructor() {
         super('fdp-table-filter-rule');
     }

--- a/libs/platform/src/lib/shared/platform-content-density-deprecations/directives/platform-content-density-deprecation.directive.ts
+++ b/libs/platform/src/lib/shared/platform-content-density-deprecations/directives/platform-content-density-deprecation.directive.ts
@@ -48,6 +48,7 @@ import { CONTENT_DENSITY_DIRECTIVE, DeprecatedContentDensityDirective } from '@f
     ]
 })
 export class PlatformContentDensityDeprecationDirective extends DeprecatedContentDensityDirective {
+    /** @hidden */
     constructor(private elementRef: ElementRef) {
         super();
         this.selectorBase = elementRef.nativeElement.tagName.toLowerCase();

--- a/libs/platform/src/lib/shared/platform-content-density-deprecations/providers/module-deprecation.provider.ts
+++ b/libs/platform/src/lib/shared/platform-content-density-deprecations/providers/module-deprecation.provider.ts
@@ -2,6 +2,7 @@ import { Provider } from '@angular/core';
 import { DeprecatedContentDensityDirective } from '@fundamental-ngx/core/content-density';
 import { moduleDeprecationsFactory } from '@fundamental-ngx/core/utils';
 
+/** @hidden */
 export function platformContentDensityModuleDeprecationsProvider(selectorBase: string): Provider {
     return moduleDeprecationsFactory({
         useFactory: () => {

--- a/libs/platform/src/lib/shared/platform.config.ts
+++ b/libs/platform/src/lib/shared/platform.config.ts
@@ -7,6 +7,7 @@ import { ContentDensity } from '@fundamental-ngx/core/utils';
  */
 @Injectable({ providedIn: 'root' })
 export class PlatformConfig {
+    /** @hidden */
     private static injector: Injector | null = null;
 
     /**
@@ -14,10 +15,12 @@ export class PlatformConfig {
      */
     contentDensity: ContentDensity;
 
+    /** @hidden */
     static setInjector(injector: Injector): void {
         PlatformConfig.injector = injector;
     }
 
+    /** @hidden */
     static getInjector(): Injector | null {
         return PlatformConfig.injector;
     }

--- a/libs/platform/src/lib/shared/utils/lang.ts
+++ b/libs/platform/src/lib/shared/utils/lang.ts
@@ -1,9 +1,11 @@
 import { Observable } from 'rxjs';
 
+/** @hidden */
 export function objectValues(obj: any): any[] {
     return Object.keys(obj).map((key) => obj[key]);
 }
 
+/** @hidden */
 export function objectToName(target: any): string {
     if (isBlank(target) || (!isStringMap(target) && !isType(target))) {
         throw new Error(' Cannot convert. Uknown object');
@@ -12,52 +14,64 @@ export function objectToName(target: any): string {
     return isType(target) ? target.prototype.constructor.name : target.constructor.name;
 }
 
+/** @hidden */
 export function isJsObject(o: any): boolean {
     return o !== null && (typeof o === 'function' || typeof o === 'object');
 }
 
+/** @hidden */
 export function isPresent(obj: any): boolean {
     return obj !== undefined && obj !== null;
 }
 
+/** @hidden */
 export function isBlank(obj: any): boolean {
     return obj === undefined || obj === null;
 }
 
+/** @hidden */
 export function isBoolean(obj: any): boolean {
     return typeof obj === 'boolean';
 }
 
+/** @hidden */
 export function isNumber(obj: any): boolean {
     return typeof obj === 'number';
 }
 
+/** @hidden */
 export function isString(obj: any): obj is string {
     return typeof obj === 'string';
 }
 
+/** @hidden */
 export function isFunction(obj: any): boolean {
     return typeof obj === 'function';
 }
 
+/** @hidden */
 export function isType(obj: any): boolean {
     return isFunction(obj);
 }
 
+/** @hidden */
 export function isStringMap(obj: any): obj is Record<string, any> {
     return typeof obj === 'object' && obj !== null;
 }
 
+/** @hidden */
 export function isObject<T>(item: T): boolean {
     return typeof item === 'object' && !Array.isArray(item) && item !== null;
 }
 
+/** @hidden */
 export function isPromise<T = any>(obj: any): obj is Promise<T> {
     // allow any Promise/A+ compliant thenable.
     // It's up to the caller to ensure that obj.then conforms to the spec
     return !!obj && isFunction(obj.then);
 }
 
+/** @hidden */
 export function isSubscribable(obj: any | Observable<any>): obj is Observable<any> {
     return !!obj && isFunction(obj.subscribe);
 }

--- a/libs/platform/src/lib/slider/slider.component.ts
+++ b/libs/platform/src/lib/slider/slider.component.ts
@@ -94,6 +94,7 @@ export class SliderComponent extends BaseInput {
     @Output()
     readonly sliderChange = new EventEmitter<SliderChangeEvent>();
 
+    /** @hidden */
     constructor(
         cd: ChangeDetectorRef,
         @Optional() @Self() ngControl: NgControl,
@@ -106,12 +107,11 @@ export class SliderComponent extends BaseInput {
 
     /** value for slider control */
     @Input()
-    get value(): any {
-        return this.getValue();
-    }
-
     set value(selectValue: any) {
         this.setValue(selectValue);
+    }
+    get value(): any {
+        return this.getValue();
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-condition-field/base-smart-filter-bar-condition-field.ts
+++ b/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-condition-field/base-smart-filter-bar-condition-field.ts
@@ -17,6 +17,7 @@ import { isSelectItem, SelectItem } from '@fundamental-ngx/platform/shared';
     providers: [dynamicFormFieldProvider, dynamicFormGroupChildProvider, smartFilterBarProvider]
 })
 export abstract class BaseSmartFilterBarConditionField extends BaseDynamicFormGeneratorControl {
+    /** @hidden */
     protected constructor(
         protected _dialogService: DialogService,
         protected _smartFilterBar: SmartFilterBar,

--- a/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-conditions-dialog/smart-filter-bar-conditions-dialog.component.ts
+++ b/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-conditions-dialog/smart-filter-bar-conditions-dialog.component.ts
@@ -80,6 +80,7 @@ export class SmartFilterBarConditionsDialogComponent {
         this._init();
     }
 
+    /** @hidden */
     private async _init(): Promise<void> {
         this.config = this._dialogRef.data;
 

--- a/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-settings-dialog/data-provider.ts
+++ b/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-settings-dialog/data-provider.ts
@@ -3,6 +3,7 @@ import { FieldFilterItem } from '../../interfaces/smart-filter-bar-field-filter-
 import { SmartFilterBarVisibilityCategory } from '../../interfaces/smart-filter-bar-visibility-category';
 
 export class SmartFilterBarOptionsDataProvider extends ArrayTableDataProvider<FieldFilterItem> {
+    /** @hidden */
     constructor(items: FieldFilterItem[]) {
         super(items);
     }

--- a/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-settings-dialog/smart-filter-bar-settings-dialog.component.ts
+++ b/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-settings-dialog/smart-filter-bar-settings-dialog.component.ts
@@ -56,6 +56,7 @@ export class SmartFilterBarSettingsDialogComponent implements Resettable, AfterV
     /** @hidden */
     loaded = false;
 
+    /** @hidden */
     private readonly _categoryLabelKeys: SmartFilterBarVisibilityCategoryLabels = {
         all: 'settingsCategoryAll',
         visible: 'settingsCategoryVisible',

--- a/libs/platform/src/lib/smart-filter-bar/directives/smart-filter-bar-field-definition.directive.ts
+++ b/libs/platform/src/lib/smart-filter-bar/directives/smart-filter-bar-field-definition.directive.ts
@@ -27,53 +27,51 @@ export class SmartFilterBarFieldDefinitionDirective {
     @Input()
     customFilterType!: string;
 
+    /** Condition strategy */
     @Input()
     conditionStrategy: CollectionFilterGroupStrategy = 'or';
 
     /** @hidden */
     private _smartFilterBarFilterable = true;
 
-    get smartFilterBarFilterable(): boolean {
-        return this._smartFilterBarFilterable;
-    }
-
     /** Whether this field can be filtered. Default value is true. */
     @Input()
     set smartFilterBarFilterable(value: BooleanInput) {
         this._smartFilterBarFilterable = coerceBooleanProperty(value);
     }
+    get smartFilterBarFilterable(): boolean {
+        return this._smartFilterBarFilterable;
+    }
 
     /** @hidden */
     private _required = false;
-
-    get required(): boolean {
-        return this._required;
-    }
 
     /** Whether this field filter is mandatory. */
     @Input()
     set required(value: BooleanInput) {
         this._required = coerceBooleanProperty(value);
     }
+    get required(): boolean {
+        return this._required;
+    }
 
     /** @hidden */
     private _defaultSelected = false;
-
-    get defaultSelected(): boolean {
-        return this._defaultSelected;
-    }
 
     /** Whether this field filter is selected by default. */
     @Input()
     set defaultSelected(value: BooleanInput) {
         this._defaultSelected = coerceBooleanProperty(value);
     }
+    get defaultSelected(): boolean {
+        return this._defaultSelected;
+    }
+
     /** Whether this field has autocomplete options */
     @Input()
     set hasOptions(value: BooleanInput) {
         this._hasOptions = coerceBooleanProperty(value);
     }
-
     get hasOptions(): boolean {
         return this._hasOptions;
     }

--- a/libs/platform/src/lib/smart-filter-bar/directives/smart-filter-bar-subject.directive.ts
+++ b/libs/platform/src/lib/smart-filter-bar/directives/smart-filter-bar-subject.directive.ts
@@ -54,6 +54,7 @@ export class SmartFilterBarSubjectDirective implements AfterViewInit {
         return this.getDataSource().dataProvider.getFieldOptions(field);
     }
 
+    /** @hidden */
     getDefaultFields(): string[] {
         return this.getSubjectFields()
             ?.filter((f) => f.defaultSelected)

--- a/libs/platform/src/lib/smart-filter-bar/helpers.ts
+++ b/libs/platform/src/lib/smart-filter-bar/helpers.ts
@@ -1,5 +1,6 @@
 import { isSelectItem } from '@fundamental-ngx/platform/shared';
 
+/** @hidden */
 export function getSelectItemValue(item: any): any {
     if (Array.isArray(item)) {
         item = item.map((i) => getSelectItemValue(i));

--- a/libs/platform/src/lib/smart-filter-bar/smart-filter-bar.class.ts
+++ b/libs/platform/src/lib/smart-filter-bar/smart-filter-bar.class.ts
@@ -2,6 +2,9 @@ import { SmartFilterBarCondition } from './interfaces/smart-filter-bar-condition
 import { SmartFilterBarStrategyLabels } from './interfaces/strategy-labels.type';
 
 export abstract class SmartFilterBar {
+    /** @hidden */
     defineStrategyLabels?: SmartFilterBarStrategyLabels;
+
+    /** @hidden */
     getDisplayValue!: (condition: SmartFilterBarCondition, filterType: string) => Promise<string>;
 }

--- a/libs/platform/src/lib/split-menu-button/split-menu-button.component.ts
+++ b/libs/platform/src/lib/split-menu-button/split-menu-button.component.ts
@@ -96,11 +96,12 @@ export class SplitMenuButtonComponent extends BaseComponent implements OnInit, A
         return this.type ? `fd-button-split--${this.type}` : '';
     }
 
+    /** @hidden */
     constructor(protected _cd: ChangeDetectorRef, @Optional() private _rtlService: RtlService) {
         super(_cd);
     }
 
-    // tabindex for button.
+    /** Tabindex for button. */
     get tabindex(): number {
         return this.disabled ? -1 : 0;
     }

--- a/libs/platform/src/lib/table/components/reset-button/reset-button.component.ts
+++ b/libs/platform/src/lib/table/components/reset-button/reset-button.component.ts
@@ -27,5 +27,6 @@ export const RESETTABLE_TOKEN = new InjectionToken<Resettable>('Resettable');
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ResetButtonComponent {
+    /** @hidden */
     constructor(@Inject(RESETTABLE_TOKEN) public resettable: Resettable) {}
 }

--- a/libs/platform/src/lib/table/components/table-column/table-column.component.ts
+++ b/libs/platform/src/lib/table/components/table-column/table-column.component.ts
@@ -88,12 +88,12 @@ export class TableColumnComponent extends TableColumn implements OnInit, OnChang
 
     /** Width of the column cells. */
     @Input()
-    get width(): string {
-        return this._width;
-    }
     set width(value: string) {
         this._width = value;
         this._tableColumnResizeService.setCustomWidth(this.name, value);
+    }
+    get width(): string {
+        return this._width;
     }
 
     /** Whether the text should wrap, when text is too long for 1 line */
@@ -113,6 +113,7 @@ export class TableColumnComponent extends TableColumn implements OnInit, OnChang
     /** Column header template */
     headerCellTemplate: TemplateRef<any>;
 
+    /** @hidden */
     @ContentChild(FdpCellDef)
     set fdpCellDef(fdpCellDef: FdpCellDef) {
         this.columnCellTemplate = fdpCellDef?.templateRef;
@@ -124,6 +125,7 @@ export class TableColumnComponent extends TableColumn implements OnInit, OnChang
         this.editableColumnCellTemplate = fdpEditableCellDef?.templateRef;
     }
 
+    /** @hidden */
     @ContentChild(FdpHeaderCellDef)
     set fdpHeaderCellDef(fdpHeaderCellDef: FdpHeaderCellDef) {
         this.headerCellTemplate = fdpHeaderCellDef?.templateRef;

--- a/libs/platform/src/lib/table/components/table-p13-dialog/columns/columns.component.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/columns/columns.component.ts
@@ -77,6 +77,7 @@ export class P13ColumnsDialogComponent implements Resettable, OnInit, OnDestroy 
 
     /** Flag to track disabled state for move-down move-up buttons */
     _moveUpDisabled = true;
+    /** Flag to track disabled state for move-down move-up buttons */
     _moveDownDisabled = true;
 
     /** @hidden */

--- a/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filter-rule.component.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filter-rule.component.ts
@@ -23,11 +23,15 @@ export class FilterRuleComponent implements OnDestroy {
     /** Emits when rule state is changed */
     @Output() ruleStateChange: EventEmitter<boolean> = new EventEmitter();
 
+    /** @hidden */
     readonly FILTER_STRATEGY = FILTER_STRATEGY;
 
+    /** @hidden */
     readonly DATA_TYPE = FilterableColumnDataType;
 
-    @ViewChild(NgForm) set ngForm(ngForm: NgForm) {
+    /** @hidden */
+    @ViewChild(NgForm)
+    set ngForm(ngForm: NgForm) {
         if (!ngForm) {
             return;
         }

--- a/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filtering.model.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filtering.model.ts
@@ -39,6 +39,7 @@ export class FilterRule<T = any> {
         return this.valueExists(this.value) || this.valueExists(this.value2);
     }
 
+    /** @hidden */
     constructor(
         readonly columns: ReadonlyArray<FilterableColumn>,
         /** Column key the rule belongs to */
@@ -61,22 +62,27 @@ export class FilterRule<T = any> {
         }
     }
 
+    /** @hidden */
     setValid(isValid: boolean): void {
         this.isValid = isValid;
     }
 
+    /** @hidden */
     setValue(value: T | null): void {
         this.value = value;
     }
 
+    /** @hidden */
     setValue2(value: T | null): void {
         this.value2 = value;
     }
 
+    /** @hidden */
     setStrategy(strategy: FilterStrategy): void {
         this.strategy = strategy;
     }
 
+    /** @hidden */
     setStrategiesByColumnKey(columnKey?: string): void {
         const dataType = this.columns.find((column) => column.key === columnKey)?.dataType;
         if (!dataType) {
@@ -96,6 +102,7 @@ export class FilterRule<T = any> {
         }
     }
 
+    /** @hidden */
     setColumnKey(columnKey: string): void {
         if (columnKey === this.columnKey) {
             return;
@@ -113,6 +120,7 @@ export class FilterRule<T = any> {
         this.setStrategiesByColumnKey(columnKey);
     }
 
+    /** @hidden */
     setDataTypeByColumnKey(columnKey?: string): void {
         const dataType = this.columns.find((column) => column.key === columnKey)?.dataType;
 
@@ -123,6 +131,7 @@ export class FilterRule<T = any> {
         this.dataType = dataType;
     }
 
+    /** @hidden */
     private valueExists(value: any): boolean {
         return !!value || value === 0;
     }

--- a/libs/platform/src/lib/table/components/table-p13-dialog/sorting/sorting.component.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/sorting/sorting.component.ts
@@ -178,6 +178,7 @@ export class P13SortingDialogComponent implements Resettable {
 
 @Pipe({ name: 'getAvailableSortColumns', pure: false })
 export class GetAvailableSortColumnsPipe implements PipeTransform {
+    /** @hidden */
     transform(columns: SortDialogColumn[], rules: SortRule[], currentKey: string | null): SortDialogColumn[] {
         const usedKeys = new Set(rules.map((r) => r.columnKey));
         return columns.filter((c) => !usedKeys.has(c.key) || currentKey === c.key);

--- a/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -99,6 +99,7 @@ export class TableP13DialogComponent implements OnDestroy {
     /** @hidden */
     _table: Table;
 
+    /** @hidden */
     constructor(private readonly _dialogService: DialogService) {}
 
     /** @hidden */

--- a/libs/platform/src/lib/table/components/table-toolbar/table-toolbar-actions.component.ts
+++ b/libs/platform/src/lib/table/components/table-toolbar/table-toolbar-actions.component.ts
@@ -19,6 +19,7 @@ import { ChangeDetectionStrategy, Component, TemplateRef, ViewChild } from '@ang
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TableToolbarActionsComponent {
+    /** @hidden */
     @ViewChild(TemplateRef)
     contentTemplateRef: TemplateRef<any>;
 }

--- a/libs/platform/src/lib/table/components/table-view-settings-dialog/filtering/filter-custom.component.ts
+++ b/libs/platform/src/lib/table/components/table-view-settings-dialog/filtering/filter-custom.component.ts
@@ -60,6 +60,7 @@ export class FilterCustomComponent implements DoCheck {
      */
     _valueLastEmitted: Record<string, any>;
 
+    /** @hidden */
     constructor(private contentDensityObserver: ContentDensityObserver) {}
 
     /** @hidden */

--- a/libs/platform/src/lib/table/components/table-view-settings-dialog/filtering/filter-single-select.component.ts
+++ b/libs/platform/src/lib/table/components/table-view-settings-dialog/filtering/filter-single-select.component.ts
@@ -30,6 +30,7 @@ export class FilterSingleSelectComponent {
     @Output()
     valueChange: EventEmitter<any[]> = new EventEmitter();
 
+    /** @hidden */
     readonly NOT_FILTERED_OPTION_VALUE = NOT_FILTERED_OPTION_VALUE;
 
     /**

--- a/libs/platform/src/lib/table/directives/table-cell-resizable.directive.ts
+++ b/libs/platform/src/lib/table/directives/table-cell-resizable.directive.ts
@@ -51,6 +51,7 @@ export class PlatformTableCellResizableDirective implements AfterViewInit, OnDes
         this._tableColumnResizeService?.registerColumnCell(this.columnName, this._elRef);
     }
 
+    /** @hidden */
     ngOnDestroy(): void {
         this._tableColumnResizeService?.unregisterColumnCell(this.columnName, this._elRef);
     }

--- a/libs/platform/src/lib/table/directives/table-cell.directive.ts
+++ b/libs/platform/src/lib/table/directives/table-cell.directive.ts
@@ -20,6 +20,7 @@ export class FdpTableCell {}
 @Directive({ selector: '[fdpCellDef]' })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class FdpCellDef {
+    /** @hidden */
     constructor(public templateRef: TemplateRef<FdpCellDefContext>) {}
 
     /** @hidden */
@@ -31,6 +32,7 @@ export class FdpCellDef {
 @Directive({ selector: '[fdpEditableCellDef]' })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class FdpEditableCellDef {
+    /** @hidden */
     constructor(public templateRef: TemplateRef<any>) {}
 }
 
@@ -39,5 +41,6 @@ export class FdpEditableCellDef {
     providers: [{ provide: EditableTableCell, useExisting: FdpEditableCellFormDirective }]
 })
 export class FdpEditableCellFormDirective implements EditableTableCell {
+    /** @hidden */
     constructor(public form: NgForm) {}
 }

--- a/libs/platform/src/lib/table/directives/table-header.directive.ts
+++ b/libs/platform/src/lib/table/directives/table-header.directive.ts
@@ -13,5 +13,6 @@ export class FdpTableHeader {}
 @Directive({ selector: '[fdpHeaderCellDef]' })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class FdpHeaderCellDef {
+    /** @hidden */
     constructor(public templateRef: TemplateRef<any>) {}
 }

--- a/libs/platform/src/lib/table/directives/table-view-settings-filter-custom.directive.ts
+++ b/libs/platform/src/lib/table/directives/table-view-settings-filter-custom.directive.ts
@@ -18,5 +18,6 @@ export class FdpViewSettingsFilterCustomDef {
         return true;
     }
 
+    /** @hidden */
     constructor(public templateRef: TemplateRef<FdpViewSettingsFilterCustomDefContext>) {}
 }

--- a/libs/platform/src/lib/table/domain/array-data-source.ts
+++ b/libs/platform/src/lib/table/domain/array-data-source.ts
@@ -50,6 +50,7 @@ export class ArrayTableDataProvider<T> extends TableDataProvider<T> {
 }
 
 export class ArrayTableDataSource<T> extends TableDataSource<T> {
+    /** @hidden */
     constructor(data: T[], dateTimeAdapter?: DatetimeAdapter<any>) {
         super(new ArrayTableDataProvider(data, dateTimeAdapter));
     }

--- a/libs/platform/src/lib/table/domain/observable-data-source.ts
+++ b/libs/platform/src/lib/table/domain/observable-data-source.ts
@@ -49,6 +49,7 @@ export class ObservableTableDataProvider<T> extends TableDataProvider<T> {
 }
 
 export class ObservableTableDataSource<T> extends TableDataSource<T> {
+    /** @hidden */
     constructor(data: Observable<T[]>, dateTimeAdapter?: DatetimeAdapter<any>) {
         super(new ObservableTableDataProvider(data, dateTimeAdapter));
     }

--- a/libs/platform/src/lib/table/domain/table-data-provider.ts
+++ b/libs/platform/src/lib/table/domain/table-data-provider.ts
@@ -104,6 +104,7 @@ export class TableDataProvider<T> {
         );
     }
 
+    /** @hidden */
     getSelectItemValue(item: any): any {
         return isSelectItem(item) ? item.value : item;
     }

--- a/libs/platform/src/lib/table/mocks/table-column-resize-mock.service.ts
+++ b/libs/platform/src/lib/table/mocks/table-column-resize-mock.service.ts
@@ -1,13 +1,18 @@
 import { of } from 'rxjs';
 
 export class TableColumnResizeServiceMock {
+    /** @hidden */
     resizerPosition = null;
 
+    /** @hidden */
     resizeInProgress = false;
 
+    /** @hidden */
     markForCheck = of(null);
 
+    /** @hidden */
     startResize(): void {}
 
+    /** @hidden */
     finishResize(): void {}
 }

--- a/libs/platform/src/lib/table/models/column-freeze-event.model.ts
+++ b/libs/platform/src/lib/table/models/column-freeze-event.model.ts
@@ -6,5 +6,11 @@ export interface FreezeChange {
 }
 
 export class TableColumnFreezeEvent {
+    /**
+     * Table column freeze event
+     * @param source Table component
+     * @param current Current freezeTo column
+     * @param previous Previous freezeTo column
+     */
     constructor(public source: Table, public current: string, public previous: string | null) {}
 }

--- a/libs/platform/src/lib/table/models/columns-change-event.model.ts
+++ b/libs/platform/src/lib/table/models/columns-change-event.model.ts
@@ -1,10 +1,21 @@
 import { Table } from '../table';
 
 export class ColumnsChange {
+    /**
+     * Columns change event
+     * @param current Current columns
+     * @param previous Previous columns
+     */
     constructor(public current: string[], public previous: string[]) {}
 }
 
 export class TableColumnsChangeEvent extends ColumnsChange {
+    /**
+     * Table columns change event
+     * @param source Table component
+     * @param current Current columns
+     * @param previous Previous columns
+     */
     constructor(public source: Table, current: string[], previous: string[]) {
         super(current, previous);
     }

--- a/libs/platform/src/lib/table/models/filter-change-event.model.ts
+++ b/libs/platform/src/lib/table/models/filter-change-event.model.ts
@@ -7,5 +7,11 @@ export interface FilterChange {
 }
 
 export class TableFilterChangeEvent {
+    /**
+     * Table filter change event
+     * @param source Table component
+     * @param current Current filters
+     * @param previous Previous filters
+     */
     constructor(public source: Table, public current: CollectionFilter[], public previous: CollectionFilter[]) {}
 }

--- a/libs/platform/src/lib/table/models/group-change-event.model.ts
+++ b/libs/platform/src/lib/table/models/group-change-event.model.ts
@@ -7,5 +7,11 @@ export interface GroupChange {
 }
 
 export class TableGroupChangeEvent {
+    /**
+     * Table group change event
+     * @param source Table component
+     * @param current Current groups
+     * @param previous Previous groups
+     */
     constructor(public source: Table, public current: CollectionGroup[], public previous: CollectionGroup[]) {}
 }

--- a/libs/platform/src/lib/table/models/page-change-event.model.ts
+++ b/libs/platform/src/lib/table/models/page-change-event.model.ts
@@ -2,10 +2,21 @@ import { CollectionPage } from '../interfaces';
 import { Table } from '../table';
 
 export class PageChange {
+    /**
+     * Page change event
+     * @param current Current page
+     * @param previous Previous page
+     */
     constructor(public current: CollectionPage, public previous: CollectionPage) {}
 }
 
 export class TablePageChangeEvent extends PageChange {
+    /**
+     * Table page change event
+     * @param source Table component
+     * @param current Current page
+     * @param previous Previous page
+     */
     constructor(public source: Table, current: CollectionPage, previous: CollectionPage) {
         super(current, previous);
     }

--- a/libs/platform/src/lib/table/models/search-change-event.model.ts
+++ b/libs/platform/src/lib/table/models/search-change-event.model.ts
@@ -7,5 +7,11 @@ export interface SearchChange {
 }
 
 export class TableSearchChangeEvent {
+    /**
+     * Table search change event
+     * @param source Table component
+     * @param current Current search (fields, directions)
+     * @param previous Previous search (fields, directions)
+     */
     constructor(public source: Table, public current: SearchInput, public previous: SearchInput) {}
 }

--- a/libs/platform/src/lib/table/models/selection-change-event.model.ts
+++ b/libs/platform/src/lib/table/models/selection-change-event.model.ts
@@ -1,12 +1,17 @@
 import { Table } from '../table';
 
 export class TableSelectionChangeEvent<T> {
-    selection: T[]; // currently selected items
-    added: T[]; // items added
-    removed: T[]; // items removed
-    index: number[]; // indexes location of additions or removals
+    /** currently selected items */
+    selection: T[];
+    /** Items added */
+    added: T[]; //
+    /** Items removed */
+    removed: T[];
+    /** Indexes location of additions or removals */
+    index: number[];
 }
 
 export class TableRowSelectionChangeEvent<T> extends TableSelectionChangeEvent<T> {
+    /** Table component */
     source: Table;
 }

--- a/libs/platform/src/lib/table/models/sort-change-event.model.ts
+++ b/libs/platform/src/lib/table/models/sort-change-event.model.ts
@@ -7,5 +7,11 @@ export interface SortChange {
 }
 
 export class TableSortChangeEvent {
+    /**
+     * Table sort change event
+     * @param source Table component
+     * @param current Current sort (fields, directions)
+     * @param previous Previous sort (fields, directions)
+     */
     constructor(public source: Table, public current: CollectionSort[], public previous: CollectionSort[]) {}
 }

--- a/libs/platform/src/lib/table/models/table-row-activate-event.model.ts
+++ b/libs/platform/src/lib/table/models/table-row-activate-event.model.ts
@@ -1,3 +1,8 @@
 export class TableRowActivateEvent<T> {
+    /**
+     * Table row activate event
+     * @param index Index of the row
+     * @param row Row that was activated
+     */
     constructor(public index: number, public row: T) {}
 }

--- a/libs/platform/src/lib/table/models/table-row-toggle-open-state-event.model.ts
+++ b/libs/platform/src/lib/table/models/table-row-toggle-open-state-event.model.ts
@@ -1,3 +1,9 @@
 export class TableRowToggleOpenStateEvent<T> {
+    /**
+     * Table row toggle open state event
+     * @param index Index of the row
+     * @param row Row that was toggled
+     * @param expanded Expanded state of the row
+     */
     constructor(public index: number, public row: T, public expanded: boolean) {}
 }

--- a/libs/platform/src/lib/table/models/table-row.model.ts
+++ b/libs/platform/src/lib/table/models/table-row.model.ts
@@ -7,6 +7,10 @@ export type TableRowState = 'editable' | 'readonly';
  * Used to represent table row in the template
  */
 export class TableRow<T = any> {
+    /**
+     * Table row entity
+     * Used to represent table row in the template
+     */
     constructor(
         /**
          * Row semantic type

--- a/libs/platform/src/lib/table/models/table-rows-rearrange-event.model.ts
+++ b/libs/platform/src/lib/table/models/table-rows-rearrange-event.model.ts
@@ -1,3 +1,10 @@
 export class TableRowsRearrangeEvent<T> {
+    /**
+     * Table rows rearrange event
+     * @param row Row that was rearranged
+     * @param previousIndex Previous index of the row
+     * @param newIndex New index of the row
+     * @param rows All rows of the table
+     */
     constructor(public row: T, public previousIndex: number, public newIndex: number, public rows: T[]) {}
 }

--- a/libs/platform/src/lib/table/pipes/cell-styles.pipe.ts
+++ b/libs/platform/src/lib/table/pipes/cell-styles.pipe.ts
@@ -4,6 +4,7 @@ import { TableColumn } from '../components/table-column/table-column';
 
 @Pipe({ name: 'tableCellStyles' })
 export class TableCellStylesPipe implements PipeTransform {
+    /** @hidden */
     transform(
         column: TableColumn,
         isRtl: boolean,

--- a/libs/platform/src/lib/table/pipes/column-resizable-side.pipe.ts
+++ b/libs/platform/src/lib/table/pipes/column-resizable-side.pipe.ts
@@ -3,6 +3,7 @@ import { TableColumnResizableSide } from './../directives/table-cell-resizable.d
 
 @Pipe({ name: 'columnResizableSide' })
 export class ColumnResizableSidePipe implements PipeTransform {
+    /** @hidden */
     transform(
         columnIndex: number,
         visibleColumnsLength: number,

--- a/libs/platform/src/lib/table/pipes/row-classes.pipe.ts
+++ b/libs/platform/src/lib/table/pipes/row-classes.pipe.ts
@@ -5,6 +5,7 @@ import { TableRow, TableRowClass } from '../models';
 
 @Pipe({ name: 'rowClasses' })
 export class RowClassesPipe implements PipeTransform {
+    /** @hidden */
     transform(row: TableRow, rowsClass: TableRowClass): string {
         const treeRowClass = row.type === TableRowType.TREE ? 'fdp-table__row--tree' : '';
         const rowClasses = this._getRowCustomCssClasses(row, rowsClass);

--- a/libs/platform/src/lib/table/pipes/selection-cell-styles.pipe.ts
+++ b/libs/platform/src/lib/table/pipes/selection-cell-styles.pipe.ts
@@ -5,6 +5,7 @@ import { Nullable } from '@fundamental-ngx/core/shared';
 
 @Pipe({ name: 'selectionCellStyles' })
 export class SelectionCellStylesPipe implements PipeTransform {
+    /** @hidden */
     transform(
         contentDensity: Nullable<ContentDensityMode>,
         rtl: boolean,

--- a/libs/platform/src/lib/table/table-column-resize.service.ts
+++ b/libs/platform/src/lib/table/table-column-resize.service.ts
@@ -168,6 +168,7 @@ export class TableColumnResizeService implements OnDestroy {
         this._columnsCellMap.set(columnName, [cellElRef, ...columnCells]);
     }
 
+    /** Unregister column's cell. */
     unregisterColumnCell(columnName: string, cellElRef: ElementRef): void {
         const columnCells = this._columnsCellMap.get(columnName) || [];
         const elmIndex = columnCells.findIndex((e) => e.nativeElement === cellElRef.nativeElement);

--- a/libs/platform/src/lib/table/table-scroll-dispatcher.service.ts
+++ b/libs/platform/src/lib/table/table-scroll-dispatcher.service.ts
@@ -31,11 +31,16 @@ export const TABLE_SCROLLABLE = new InjectionToken<TableScrollable>('Table Scrol
 
 @Injectable()
 export class TableScrollDispatcherService implements OnDestroy {
+    /** @hidden */
     private _scrollSubject: Subject<TableScrollable> = new Subject();
+    /** @hidden */
     private _verticalScrollSubject: Subject<TableScrollable> = new Subject();
+    /** @hidden */
     private _horizontalScrollSubject: Subject<TableScrollable> = new Subject();
+    /** @hidden */
     private _scrollableSubscriptionsMap: Map<TableScrollable, Subscription> = new Map();
 
+    /** @hidden */
     register(scrollable: TableScrollable): void {
         if (this._scrollableSubscriptionsMap.has(scrollable)) {
             return;
@@ -49,6 +54,7 @@ export class TableScrollDispatcherService implements OnDestroy {
         this._scrollableSubscriptionsMap.set(scrollable, sub);
     }
 
+    /** @hidden */
     deregister(scrollable: TableScrollable): void {
         if (!this._scrollableSubscriptionsMap.has(scrollable)) {
             return;

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -605,6 +605,7 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
      */
     private _checkedAny = false;
 
+    /** @hidden */
     get checkedState(): boolean | null {
         if (this._checkedAll) {
             return true;

--- a/libs/platform/src/lib/table/table.service.ts
+++ b/libs/platform/src/lib/table/table.service.ts
@@ -19,16 +19,26 @@ export class TableService {
     /** @hidden */
     private _detectChanges$: Subject<void> = new Subject<void>();
 
+    /** @hidden */
     readonly tableState$ = this._tableStateSubject$.asObservable();
+    /** @hidden */
     readonly tableLoading$ = this._tableLoadingSubject$.asObservable();
+    /** @hidden */
     readonly tableStateChanges$ = this.tableState$.pipe(skip(1));
 
+    /** @hidden */
     readonly searchChange: EventEmitter<SearchChange> = new EventEmitter<SearchChange>();
+    /** @hidden */
     readonly sortChange: EventEmitter<SortChange> = new EventEmitter<SortChange>();
+    /** @hidden */
     readonly filterChange: EventEmitter<FilterChange> = new EventEmitter<FilterChange>();
+    /** @hidden */
     readonly groupChange: EventEmitter<GroupChange> = new EventEmitter<GroupChange>();
+    /** @hidden */
     readonly freezeChange: EventEmitter<FreezeChange> = new EventEmitter<FreezeChange>();
+    /** @hidden */
     readonly columnsChange: EventEmitter<ColumnsChange> = new EventEmitter<ColumnsChange>();
+    /** @hidden */
     readonly pageChange: EventEmitter<PageChange> = new EventEmitter<PageChange>();
 
     /** Listen for soft changes in table subcomponents (mostly table column) */

--- a/libs/platform/src/lib/table/utils.ts
+++ b/libs/platform/src/lib/table/utils.ts
@@ -123,6 +123,7 @@ export const getScrollBarWidth = (document: Document): number => {
     return scrollbarWidth;
 };
 
+/** @hidden */
 export function isCollectionFilter(item: any): item is CollectionFilter {
     return item.type !== undefined && item.strategy !== undefined && item.value !== undefined;
 }

--- a/libs/platform/src/lib/thumbnail/thumbnail-image/thumbnail-image.component.ts
+++ b/libs/platform/src/lib/thumbnail/thumbnail-image/thumbnail-image.component.ts
@@ -40,6 +40,7 @@ export class ThumbnailImageComponent implements OnChanges, OnInit {
     @Input()
     roleDescription: string;
 
+    /** Thumbnail element ID */
     @Input()
     thumbnailId: string;
 
@@ -47,6 +48,7 @@ export class ThumbnailImageComponent implements OnChanges, OnInit {
     @Output()
     thumbnailClicked: EventEmitter<Media> = new EventEmitter();
 
+    /** Event emitted when the thumbnail image is clicked and dialog opened */
     @Output()
     openDetailsDialog = new EventEmitter<Media>();
 
@@ -99,12 +101,14 @@ export class ThumbnailImageComponent implements OnChanges, OnInit {
         return this._rtlService?.rtl.getValue();
     }
 
+    /** @hidden */
     private _setOverlay(): void {
         if (this.mediaList.length > this.maxImages) {
             this.mediaList[this.maxImages - 1].overlayRequired = true;
         }
     }
 
+    /** Open thumbanail image */
     openImage(image: Media, event?: Event): void {
         image.overlayRequired ? this.openDialog(image) : this.thumbnailClick(image, event);
     }

--- a/libs/platform/src/lib/thumbnail/thumbnail.component.ts
+++ b/libs/platform/src/lib/thumbnail/thumbnail.component.ts
@@ -22,6 +22,11 @@ import { Media } from './thumbnail.interfaces';
 let uniqueId = 0;
 
 export class ThumbnailClickedEvent<T extends ThumbnailComponent = ThumbnailComponent, K = Media> {
+    /**
+     * Thumbnail click event
+     * @param source ThumbnailComponent
+     * @param payload Media
+     */
     constructor(
         /** The source Thumbnail Component of the event. */
         public source: T,
@@ -45,6 +50,7 @@ export class ThumbnailComponent extends BaseComponent implements OnInit {
     @Input()
     isHorizontal = false;
 
+    /** Max images to display */
     @Input()
     maxImagesDisplay = 5;
 
@@ -83,11 +89,13 @@ export class ThumbnailComponent extends BaseComponent implements OnInit {
         this._setOverlay();
     }
 
+    /** @hidden */
     thumbnailClickHandle(selectedMedia: Media): void {
         this.selectedMedia = selectedMedia;
         this.thumbnailClicked.emit(this._createClickEvent(this.selectedMedia));
     }
 
+    /** @hidden */
     openDialog(media: Media = this.selectedMedia): void {
         this.mediaList.forEach((item) => (item.overlayRequired = false));
         this._dialogService.open(ThumbnailDetailsComponent, {

--- a/libs/platform/src/lib/upload-collection/dialogs/move-to/move-to.component.ts
+++ b/libs/platform/src/lib/upload-collection/dialogs/move-to/move-to.component.ts
@@ -57,12 +57,14 @@ export class MoveToComponent implements OnInit {
     /** @hidden */
     _foldersList: UploadCollectionFolder[] = [];
 
+    /** @hidden */
     constructor(
         public readonly dialogRef: DialogRef<MoveToComponentDialogData>,
         private readonly _dialogService: DialogService,
         private readonly _cd: ChangeDetectorRef
     ) {}
 
+    /** @hidden */
     ngOnInit(): void {
         this._init(this._currentFolder ? this._currentFolder.files : this.items);
     }

--- a/libs/platform/src/lib/upload-collection/dialogs/new-folder/new-folder.component.ts
+++ b/libs/platform/src/lib/upload-collection/dialogs/new-folder/new-folder.component.ts
@@ -31,8 +31,10 @@ export class NewFolderComponent implements AfterViewInit {
     @ViewChild(FormControlComponent)
     private readonly formControl: FormControlComponent;
 
+    /** @hidden */
     constructor(public readonly dialogRef: DialogRef) {}
 
+    /** @hidden */
     ngAfterViewInit(): void {
         const el = this.formControl.elementRef().nativeElement as HTMLInputElement;
         if (el) {

--- a/libs/platform/src/lib/upload-collection/directives/upload-collection-dragndrop.directive.ts
+++ b/libs/platform/src/lib/upload-collection/directives/upload-collection-dragndrop.directive.ts
@@ -73,6 +73,7 @@ export class UploadCollectionDragnDropDirective {
     /** @hidden */
     private elementSelector: string;
 
+    /** @hidden */
     constructor(
         private readonly _elementRef: ElementRef,
         private readonly _filesValidatorService: FilesValidatorService

--- a/libs/platform/src/lib/upload-collection/domain/upload-collection-data-provider.ts
+++ b/libs/platform/src/lib/upload-collection/domain/upload-collection-data-provider.ts
@@ -25,7 +25,9 @@ import {
  * In Memory implementation of DataProvider that supports fulltext search
  */
 export abstract class UploadCollectionDataProvider extends DataProvider<UploadCollectionItem> {
+    /** @hidden */
     totalItems = 0;
+    /** @hidden */
     list: UploadCollectionItem[] = [];
 
     abstract items: UploadCollectionItem[];
@@ -57,6 +59,7 @@ export abstract class UploadCollectionDataProvider extends DataProvider<UploadCo
     /** The method is triggered when Cancel button is pressed */
     abstract cancelUploadNewFile(data: CancelUploadNewFileEvent): Observable<UploadCollectionItem[]>;
 
+    /** @hidden */
     fetch(params: Map<string, string | number>): Observable<UploadCollectionItem[]> {
         let currentItems: UploadCollectionItem[] = this.items;
 
@@ -88,6 +91,7 @@ export abstract class UploadCollectionDataProvider extends DataProvider<UploadCo
         return of(_list);
     }
 
+    /** @hidden */
     private _getItemsByPage(items: UploadCollectionItem[], page: number, limit: number): UploadCollectionItem[] {
         const firstDisplayedRow = (page - 1) * limit;
         const _visibleList = items.slice(firstDisplayedRow, firstDisplayedRow + limit);
@@ -99,6 +103,7 @@ export abstract class UploadCollectionDataProvider extends DataProvider<UploadCo
         return _visibleList;
     }
 
+    /** @hidden */
     private _defaultSorting(list: UploadCollectionItem[]): UploadCollectionItem[] {
         let _list: UploadCollectionItem[] = [];
         const groupByType: GroupByType = list.reduce((res: GroupByType, item: UploadCollectionItem) => {

--- a/libs/platform/src/lib/upload-collection/domain/upload-collection-data-source.ts
+++ b/libs/platform/src/lib/upload-collection/domain/upload-collection-data-source.ts
@@ -19,16 +19,21 @@ export class UploadCollectionDataSource implements DataSource<UploadCollectionIt
     /** Max items for response */
     static readonly MaxLimit = Number.MAX_SAFE_INTEGER;
 
+    /** @hidden */
     protected _dataChanges = new BehaviorSubject<UploadCollectionItem[]>([]);
+    /** @hidden */
     protected _onDataRequested$ = new Subject<void>();
+    /** @hidden */
     protected _onDataReceived$ = new Subject<void>();
-
+    /** @hidden */
     protected _dataLoading = false;
 
+    /** @hidden */
     get isDataLoading(): boolean {
         return this._dataLoading;
     }
 
+    /** @hidden */
     constructor(public readonly dataProvider: UploadCollectionDataProvider) {}
 
     /** Filtering data */
@@ -104,16 +109,20 @@ export class UploadCollectionDataSource implements DataSource<UploadCollectionIt
         return this.dataProvider.cancelUploadNewFile(data).pipe(take(1));
     }
 
+    /** @hidden */
     open(): Observable<UploadCollectionItem[]> {
         return this._dataChanges.asObservable();
     }
 
+    /** @hidden */
     close(): void {}
 
+    /** @hidden */
     onDataRequested(): Observable<void> {
         return this._onDataRequested$.asObservable();
     }
 
+    /** @hidden */
     onDataReceived(): Observable<void> {
         return this._onDataReceived$.asObservable();
     }

--- a/libs/platform/src/lib/upload-collection/helpers/generate-message-stripe-data.ts
+++ b/libs/platform/src/lib/upload-collection/helpers/generate-message-stripe-data.ts
@@ -18,6 +18,7 @@ function _groupByTypeAndCount(items: UploadCollectionItem[]): MessageItemsCount 
     );
 }
 
+/** @hidden */
 export function generateMessageStripeData(type: MessageType, options: MessageOptions): Message {
     const newMessage: Message = {
         messageType: type,

--- a/libs/platform/src/lib/upload-collection/models/upload-collection-events.models.ts
+++ b/libs/platform/src/lib/upload-collection/models/upload-collection-events.models.ts
@@ -58,6 +58,11 @@ export interface FilenameLengthExceedEventPayload {
 }
 
 export class FilenameLengthExceedEvent {
+    /**
+     * Filename length exceed event payload
+     * @param source Upload Collection component
+     * @param payload Files
+     */
     constructor(public source: UploadCollectionComponent, public payload: FilenameLengthExceedEventPayload) {}
 }
 
@@ -66,6 +71,11 @@ export interface TypeMismatchEventPayload {
 }
 
 export class TypeMismatchEvent {
+    /**
+     * Type mismatch event
+     * @param source Upload Collection component
+     * @param payload Files
+     */
     constructor(public source: UploadCollectionComponent, public payload: TypeMismatchEventPayload) {}
 }
 
@@ -74,6 +84,11 @@ export interface FileSizeExceedEventPayload {
 }
 
 export class FileSizeExceedEvent {
+    /**
+     * Filesize exceed event
+     * @param source Upload Collection component
+     * @param payload Files
+     */
     constructor(public source: UploadCollectionComponent, public payload: FileSizeExceedEventPayload) {}
 }
 

--- a/libs/platform/src/lib/upload-collection/upload-collection/upload-collection-data-provider-test.ts
+++ b/libs/platform/src/lib/upload-collection/upload-collection/upload-collection-data-provider-test.ts
@@ -62,7 +62,10 @@ const dataSource: UploadCollectionItem[] = [
 ];
 
 export class UploadCollectionDataProviderTest extends UploadCollectionDataProvider {
+    /** @hidden */
     items: UploadCollectionItem[] = dataSource.map((item) => ({ ...item }));
+
+    /** @hidden */
     private _cancelUploadNewFileIds: (string | number)[] = [];
 
     /** The method is triggered when valid files are selected in the file uploader dialog. */
@@ -227,6 +230,7 @@ export class UploadCollectionDataProviderTest extends UploadCollectionDataProvid
         );
     }
 
+    /** @hidden */
     runAfterFail({ parentFolderId, items }: UploadEvent): Observable<UploadCollectionItem[]> {
         console.log('runAfterFail', parentFolderId, items);
         const item = items[0];

--- a/libs/platform/src/lib/upload-collection/upload-collection/upload-collection.component.ts
+++ b/libs/platform/src/lib/upload-collection/upload-collection/upload-collection.component.ts
@@ -54,15 +54,12 @@ let randomId = 0;
     encapsulation: ViewEncapsulation.None
 })
 export class UploadCollectionComponent implements OnChanges, OnDestroy {
+    /** ID of the upload collection element. If none is provided, one will be generated. */
     @Input()
     id = `fdp-upload-collection-id-${randomId++}`;
 
     /** Defines the number of items on the page */
     @Input()
-    get itemsPerPage(): number | ItemPerPage[] {
-        return this._itemsPerPage;
-    }
-
     set itemsPerPage(value: number | ItemPerPage[]) {
         if (typeof value === 'number') {
             this._itemsPerPage = value;
@@ -85,17 +82,19 @@ export class UploadCollectionComponent implements OnChanges, OnDestroy {
 
         this._match();
     }
+    get itemsPerPage(): number | ItemPerPage[] {
+        return this._itemsPerPage;
+    }
 
     /** List of items */
     @Input()
-    get dataSource(): FdpUploadCollectionDataSource {
-        return this._dataSource;
-    }
-
     set dataSource(value: FdpUploadCollectionDataSource) {
         if (value) {
             this._initializeDS(value);
         }
+    }
+    get dataSource(): FdpUploadCollectionDataSource {
+        return this._dataSource;
     }
 
     /**
@@ -318,6 +317,7 @@ export class UploadCollectionComponent implements OnChanges, OnDestroy {
     /** @hidden */
     private readonly _onDestroy$ = new Subject<void>();
 
+    /** @hidden */
     constructor(
         private readonly _dialogService: DialogService,
         private readonly _filesValidatorService: FilesValidatorService,
@@ -1076,6 +1076,7 @@ export class UploadCollectionComponent implements OnChanges, OnDestroy {
         return undefined;
     }
 
+    /** @hidden */
     private _match(): void {
         const query = new Map();
 

--- a/libs/platform/src/lib/value-help-dialog/components/base-tab/vhd-base-tab.component.ts
+++ b/libs/platform/src/lib/value-help-dialog/components/base-tab/vhd-base-tab.component.ts
@@ -24,5 +24,6 @@ export class VhdBaseTab {
         return VhdTab.defineConditions;
     }
 
+    /** @hidden */
     constructor(readonly _changeDetectorRef: ChangeDetectorRef) {}
 }

--- a/libs/platform/src/lib/value-help-dialog/components/define-tab/define-tab.component.ts
+++ b/libs/platform/src/lib/value-help-dialog/components/define-tab/define-tab.component.ts
@@ -41,7 +41,9 @@ let titleUniqueId = 0;
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DefineTabComponent extends VhdBaseTab implements OnChanges, AfterViewInit {
+    /** @hidden */
     protected defaultId = `fd-title-id-${titleUniqueId++}`;
+    /** @hidden */
     protected defaultSelectId = `fd-select-title-id-${titleUniqueId++}`;
 
     /** title id for the table  */
@@ -52,29 +54,36 @@ export class DefineTabComponent extends VhdBaseTab implements OnChanges, AfterVi
     @Input()
     selectedId: string = this.defaultSelectId;
 
+    /** @hidden */
     @Input()
     conditions: ExtendedBaseEntity[] = [];
 
-    /** depricated */
+    /** @depricated */
     @Input()
     included: ExtendedIncludedEntity[] = [];
 
-    /** depricated */
+    /** @depricated */
     @Input()
     excluded: ExtendedExcludedEntity[] = [];
+
+    /** @hidden */
     @Input()
     strategyLabels: { [key in keyof (typeof VhdDefineIncludeStrategy | typeof VhdDefineExcludeStrategy)]?: string } =
         {};
 
+    /** @hidden */
     @Output()
     includeChange: EventEmitter<ExtendedIncludedEntity[]> = new EventEmitter<ExtendedIncludedEntity[]>();
 
+    /** @hidden */
     @Output()
     excludeChange: EventEmitter<ExtendedExcludedEntity[]> = new EventEmitter<ExtendedExcludedEntity[]>();
 
+    /** @hidden */
     @Output()
     conditionChange: EventEmitter<BaseEntity[]> = new EventEmitter<BaseEntity[]>();
 
+    /** @hidden */
     _conditions: ExtendedBaseEntity[] = [];
 
     /** @hidden */
@@ -110,6 +119,7 @@ export class DefineTabComponent extends VhdBaseTab implements OnChanges, AfterVi
         }
     }
 
+    /** @hidden */
     ngAfterViewInit(): void {
         this._refreshStrategies();
     }

--- a/libs/platform/src/lib/value-help-dialog/components/select-tab/select-tab.component.ts
+++ b/libs/platform/src/lib/value-help-dialog/components/select-tab/select-tab.component.ts
@@ -25,15 +25,20 @@ let titleUniqueId = 0;
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SelectTabComponent<T> extends VhdBaseTab implements OnChanges, AfterViewInit {
+    /** @hidden */
     protected defaultTitleId = `fd-select-tab-title-id-${titleUniqueId++}`;
+    /** @hidden */
     protected defaultCountId = `fd-select-tab-title-count-id-${titleUniqueId++}`;
 
+    /** Select tab title element ID */
     @Input()
     selectTabTitleId: string = this.defaultTitleId;
 
+    /** Select tab count element ID */
     @Input()
     selectTabCountId: string = this.defaultCountId;
 
+    /** Selected items */
     @Input()
     selected: T[] = [];
 
@@ -64,8 +69,8 @@ export class SelectTabComponent<T> extends VhdBaseTab implements OnChanges, Afte
     @Input()
     defaultMobileHeaders = 2;
 
-    @Input()
     /** Displayed data for search table */
+    @Input()
     displayedData: T[] = [];
 
     /** Event emitted when row was selected. */
@@ -73,6 +78,7 @@ export class SelectTabComponent<T> extends VhdBaseTab implements OnChanges, Afte
     // eslint-disable-next-line @angular-eslint/no-output-native
     select = new EventEmitter<T[]>();
 
+    /** @hidden */
     @ViewChild(InfiniteScrollDirective) infiniteScrollTable: InfiniteScrollDirective;
 
     /** @hidden indeterminate flag for `select all` checkbox */
@@ -106,13 +112,16 @@ export class SelectTabComponent<T> extends VhdBaseTab implements OnChanges, Afte
     get isSingleSelection(): boolean {
         return this.selection === 'single';
     }
+    /** Selection type getters */
     get isOnceSelection(): boolean {
         return this.selection === 'once';
     }
+    /** Selection type getters */
     get isMultiSelection(): boolean {
         return this.selection === 'multi';
     }
 
+    /** @hidden */
     ngAfterViewInit(): void {
         Promise.resolve(true).then(() => this._checkScrollAndShowMore());
     }
@@ -198,6 +207,7 @@ export class SelectTabComponent<T> extends VhdBaseTab implements OnChanges, Afte
         this._refreshTristate();
     }
 
+    /** @hidden */
     private _checkScrollAndShowMore(): void {
         if (this.mobile) {
             return;

--- a/libs/platform/src/lib/value-help-dialog/components/value-help-dialog-search/value-help-dialog-search.component.ts
+++ b/libs/platform/src/lib/value-help-dialog/components/value-help-dialog-search/value-help-dialog-search.component.ts
@@ -31,6 +31,7 @@ export class VhdSearchComponent {
     @Input()
     hideAllAdvancedSearchLabel = 'Hide all filters';
 
+    /** @hidden */
     constructor() {
         console.warn(
             '"VhdSearchComponent" is deprecated. Messages from it is no longer in use. ' +

--- a/libs/platform/src/lib/value-help-dialog/directives/condition-count-message.directive.ts
+++ b/libs/platform/src/lib/value-help-dialog/directives/condition-count-message.directive.ts
@@ -8,25 +8,32 @@ import { AbstractControl, FormControl, NG_VALIDATORS, ValidationErrors, Validato
     providers: [{ provide: NG_VALIDATORS, useExisting: ConditionCountMessageDirective, multi: true }]
 })
 export class ConditionCountMessageDirective {
+    /** Max characters allowed */
     @Input()
-    get maxCharacters(): number {
-        return this._maxCharacters;
-    }
     set maxCharacters(value: number) {
         this._maxCharacters = <number>coerceNumberProperty(value);
     }
+    get maxCharacters(): number {
+        return this._maxCharacters;
+    }
 
+    /** @hidden */
     private _maxCharacters = Number.MAX_SAFE_INTEGER;
+
+    /** @hidden */
     private readonly validator: ValidatorFn;
 
+    /** @hidden */
     constructor() {
         this.validator = this.checkError();
     }
 
+    /** @hidden */
     validate(control: FormControl): ValidationErrors | null {
         return this.validator(control);
     }
 
+    /** @hidden */
     private checkError(): ValidatorFn {
         return (control: AbstractControl) => {
             if (control.dirty && control.value && control.value.length > this.maxCharacters) {

--- a/libs/platform/src/lib/value-help-dialog/models/vhd-data.source.ts
+++ b/libs/platform/src/lib/value-help-dialog/models/vhd-data.source.ts
@@ -4,17 +4,25 @@ import { take } from 'rxjs/operators';
 import { BaseDataProvider, DataProvider, DataSource } from '@fundamental-ngx/platform/shared';
 
 export class ValueHelpDialogDataSource<T> implements DataSource<T> {
+    /** @hidden */
     protected _dataChanges: BehaviorSubject<T[]> = new BehaviorSubject<T[]>([]);
+    /** @hidden */
     protected _onDataRequested$ = new Subject<void>();
+    /** @hidden */
     protected _onDataReceived$ = new Subject<void>();
 
+    /** @hidden */
     protected _dataLoading = false;
 
+    /** @hidden */
     get isDataLoading(): boolean {
         return this._dataLoading;
     }
 
+    /** @hidden */
     constructor(public dataProvider: DataProvider<T>) {}
+
+    /** @hidden */
     match(predicate?: string | Map<string, string>): void {
         this._onDataRequested$.next();
         this._dataLoading = true;
@@ -42,37 +50,46 @@ export class ValueHelpDialogDataSource<T> implements DataSource<T> {
             );
     }
 
+    /** @hidden */
     open(): Observable<T[]> {
         return this._dataChanges.asObservable();
     }
 
+    /** @hidden */
     onDataRequested(): Observable<void> {
         return this._onDataRequested$.asObservable();
     }
 
+    /** @hidden */
     onDataReceived(): Observable<void> {
         return this._onDataReceived$.asObservable();
     }
 
+    /** @hidden */
     close(): void {}
 }
 
 export class ArrayValueHelpDialogDataSource<T> extends ValueHelpDialogDataSource<T> {
+    /** @hidden */
     constructor(data: T[]) {
         super(new BaseDataProvider(data));
     }
 }
 
 export class ObservableValueHelpDialogDataSource<T> extends ValueHelpDialogDataSource<T> {
+    /** @hidden */
     constructor(data: Observable<T[]>) {
         super(new BaseDataProvider(data));
     }
 }
 
 export class VhdDataProvider<R> extends DataProvider<R> {
+    /** @hidden */
     constructor(public values: R[]) {
         super();
     }
+
+    /** @hidden */
     fetch(params: Map<string, string>): Observable<R[]> {
         let data = this.values;
         const arrayParams = Array.from(params);

--- a/libs/platform/src/lib/value-help-dialog/models/vhd-filter-rule.model.ts
+++ b/libs/platform/src/lib/value-help-dialog/models/vhd-filter-rule.model.ts
@@ -10,14 +10,22 @@ export interface VhdDefineEntityRule {
 }
 
 export class BaseEntity implements VhdDefineEntityRule {
+    /** @hidden */
     type: VhdDefineType;
+    /** @hidden */
     key = '*';
+    /** @hidden */
     label?: string;
+    /** @hidden */
     strategy: VhdDefineIncludeStrategy | VhdDefineExcludeStrategy;
+    /** @hidden */
     value = '';
+    /** @hidden */
     valueTo = '';
+    /** @hidden */
     valid: boolean;
 
+    /** @hidden */
     constructor(strategy?: VhdDefineIncludeStrategy | VhdDefineExcludeStrategy, key?: string) {
         if (key) {
             this.key = key;
@@ -26,8 +34,10 @@ export class BaseEntity implements VhdDefineEntityRule {
     }
 }
 export class VhdIncludedEntity extends BaseEntity {
+    /** @hidden */
     type: VhdDefineType = VhdDefineType.include;
 }
 export class VhdExcludedEntity extends BaseEntity {
+    /** @hidden */
     type: VhdDefineType = VhdDefineType.exclude;
 }

--- a/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.ts
+++ b/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.ts
@@ -82,13 +82,13 @@ export class PlatformValueHelpDialogComponent<T = any> implements OnChanges, OnD
 
     /** Data source */
     @Input()
-    get dataSource(): FdpValueHelpDialogDataSource<any> | undefined {
-        return this._dataSource;
-    }
     set dataSource(value: FdpValueHelpDialogDataSource<any> | undefined) {
         if (value) {
             this._dataSource = this.toDataStream(value);
         }
+    }
+    get dataSource(): FdpValueHelpDialogDataSource<any> | undefined {
+        return this._dataSource;
     }
 
     /** Dialog's custom config */
@@ -321,6 +321,7 @@ export class PlatformValueHelpDialogComponent<T = any> implements OnChanges, OnD
         return this._currentValue.conditions || [];
     }
 
+    /** @hidden */
     get validConditions(): BaseEntity[] {
         return this._getValidCondition(this.conditionItems);
     }
@@ -335,6 +336,7 @@ export class PlatformValueHelpDialogComponent<T = any> implements OnChanges, OnD
         return this._elementRef;
     }
 
+    /** @hidden */
     get isShowAllFilters(): boolean {
         return this.filters.length > this.maxShownInitialFilters && this.shownFilterCount > this.maxShownInitialFilters;
     }
@@ -527,6 +529,7 @@ export class PlatformValueHelpDialogComponent<T = any> implements OnChanges, OnD
         this._changeDetectorRef.markForCheck();
     }
 
+    /** @hidden */
     toggleShownFilters(): void {
         this.shownFilterCount =
             this.maxShownInitialFilters === this.shownFilterCount ? Infinity : this.maxShownInitialFilters;

--- a/libs/platform/src/lib/wizard-generator/base-wizard-generator.ts
+++ b/libs/platform/src/lib/wizard-generator/base-wizard-generator.ts
@@ -60,22 +60,17 @@ export class BaseWizardGenerator implements OnDestroy {
      * @description Button labels to be used in Wizard navigation
      */
     @Input()
-    get navigationButtonLabels(): WizardNavigationButtons {
-        return this._navigationButtonLabels;
-    }
-
     set navigationButtonLabels(value: WizardNavigationButtons) {
         this._navigationButtonLabels = Object.assign({}, DEFAULT_WIZARD_NAVIGATION_BUTTONS, value);
+    }
+    get navigationButtonLabels(): WizardNavigationButtons {
+        return this._navigationButtonLabels;
     }
 
     /**
      * @description Array of Wizard Steps.
      */
     @Input()
-    get items(): WizardGeneratorItem[] {
-        return this._items;
-    }
-
     set items(items: WizardGeneratorItem[]) {
         this.wizardCreated = false;
         this._wizardGeneratorService.clearWizardStepComponents();
@@ -86,6 +81,9 @@ export class BaseWizardGenerator implements OnDestroy {
             this.wizardCreated = true;
             this._cd.detectChanges();
         });
+    }
+    get items(): WizardGeneratorItem[] {
+        return this._items;
     }
 
     /**
@@ -145,12 +143,11 @@ export class BaseWizardGenerator implements OnDestroy {
     /**
      * @description Array of visible Wizard Steps.
      */
-    get visibleItems(): PreparedWizardGeneratorItem[] {
-        return this._visibleItems || this._items;
-    }
-
     set visibleItems(items: PreparedWizardGeneratorItem[]) {
         this._visibleItems = items;
+    }
+    get visibleItems(): PreparedWizardGeneratorItem[] {
+        return this._visibleItems || this._items;
     }
 
     /**
@@ -185,6 +182,7 @@ export class BaseWizardGenerator implements OnDestroy {
         return nextStep?.summary === true;
     }
 
+    /** Whether the current step is completed */
     get isCurrentStepCompleted(): boolean {
         const currentIndex = this._wizardGeneratorService.getCurrentStepIndex();
         return this._visibleItems[currentIndex]?.completed === true;

--- a/libs/platform/src/lib/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.ts
+++ b/libs/platform/src/lib/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.ts
@@ -23,6 +23,7 @@ import { WizardGeneratorService } from '../../wizard-generator.service';
     providers: [WizardGeneratorService, FormGeneratorService]
 })
 export class DialogWizardGeneratorComponent extends BaseWizardGenerator {
+    /** @hidden */
     @ViewChild('defaultConfirmationDialogTemplate') defaultConfirmationDialogTemplate: TemplateRef<HTMLElement>;
 
     /**

--- a/libs/platform/src/lib/wizard-generator/components/wizard-body/wizard-body.component.ts
+++ b/libs/platform/src/lib/wizard-generator/components/wizard-body/wizard-body.component.ts
@@ -133,12 +133,11 @@ export class WizardBodyComponent implements OnInit, OnDestroy {
     /**
      * @description Array of visible Wizard Steps.
      */
-    get visibleItems(): PreparedWizardGeneratorItem[] {
-        return this._visibleItems || this._wizardGeneratorService.items;
-    }
-
     set visibleItems(items: PreparedWizardGeneratorItem[]) {
         this._visibleItems = items;
+    }
+    get visibleItems(): PreparedWizardGeneratorItem[] {
+        return this._visibleItems || this._wizardGeneratorService.items;
     }
 
     /**
@@ -228,6 +227,7 @@ export class WizardBodyComponent implements OnInit, OnDestroy {
         };
     }
 
+    /** @hidden */
     stepClicked(stepId: string): void {
         const stepIndex = this._wizardGeneratorService.getStepIndex(stepId);
         this._wizardGeneratorService.setNextStepIndex(stepIndex + 1);

--- a/libs/platform/src/lib/wizard-generator/wizard-generator.service.ts
+++ b/libs/platform/src/lib/wizard-generator/wizard-generator.service.ts
@@ -46,6 +46,7 @@ export interface StepDependencyFields {
  */
 @Injectable()
 export class WizardGeneratorService {
+    /** @hidden */
     items: PreparedWizardGeneratorItem[];
 
     /**
@@ -90,6 +91,7 @@ export class WizardGeneratorService {
     /** @hidden */
     private _submittedFormRawValues: WizardGeneratorFormsValue = {};
 
+    /** @hidden */
     private _wizardStepIds: string[] = [];
 
     /** @hidden */


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

* [`require-jsdoc`](https://github.com/gajus/eslint-plugin-jsdoc#user-content-eslint-plugin-jsdoc-rules-require-jsdoc) eslint rule enabled for everything, disabled for docs, docs-e2e, e2e.
* [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs) rule enabled for everything, disabled for docs, docs-e2e, e2e.

_In conjunction with `require-jsdoc` settings, it gives us the ability to write typedocs only above setter if both are present. 
 It also ensures that the order of setter-getter pair is always the same, what's neat by itself._

* missing typedocs added in core, platform.