### PR TITLE
fix(core): fix dialog positioning when hasBrackdrop is false

### DIFF
--- a/libs/core/src/lib/dialog/dialog.component.ts
+++ b/libs/core/src/lib/dialog/dialog.component.ts
@@ -175,7 +175,7 @@ export class DialogComponent
     buildComponentCssClass(): string[] {
         return [
             this.dialogConfig.hasBackdrop ? 'fd-dialog' : 'fd-dialog--no-backdrop',
-            this.dialogConfig.container !== 'body' ? 'fd-dialog--targeted' : '',
+            this.dialogConfig.container !== 'body' || this.dialogConfig.position ? 'fd-dialog--targeted' : '',
             this.showDialogWindow ? 'fd-dialog--active' : '',
             this._class,
             this.dialogConfig.backdropClass ? this.dialogConfig.backdropClass : ''


### PR DESCRIPTION
fixes #8059

Before
![image](https://user-images.githubusercontent.com/2471874/188204238-c8f4df25-1a27-4e20-8781-7b5ceadb2276.png)

After
![image](https://user-images.githubusercontent.com/2471874/188204257-287c1de4-d66a-48e2-a261-faf6bd5506e5.png)
