### PR TITLE
fix(core): overflow layout nested struct directives

### DIFF
--- a/libs/core/src/lib/overflow-layout/overflow-layout.component.spec.ts
+++ b/libs/core/src/lib/overflow-layout/overflow-layout.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { OverflowLayoutItemDirective } from './directives/overflow-layout-item.directive';
 import { OverflowLayoutComponent } from './overflow-layout.component';
@@ -65,24 +65,27 @@ describe('OverflowLayoutComponent', () => {
         expect(component).toBeTruthy();
     });
 
-    it('should render needed amount of items', () => {
+    it('should render needed amount of items', async () => {
+        await fixture.whenStable();
+
         expect(fixture.debugElement.queryAll(By.directive(OverflowLayoutItemDirective)).length).toEqual(
             component.maxItems
         );
     });
 
-    it('should render automatic amount of items', fakeAsync(() => {
-        tick(1000);
+    it('should render automatic amount of items', async () => {
+        await fixture.whenStable();
+
         const expectedAmount = Math.floor(component.containerWidth / component.elementsWidth);
         const visibleItemsCountSpy = spyOn(component.overflowLayout.visibleItemsCount, 'emit').and.callThrough();
+
         component.maxItems = Infinity;
         fixture.detectChanges();
-
-        tick(1000);
+        await fixture.whenStable();
 
         expect(visibleItemsCountSpy).toHaveBeenCalledWith(expectedAmount);
         expect(fixture.debugElement.queryAll(By.directive(OverflowLayoutItemDirective)).length).toEqual(expectedAmount);
-    }));
+    });
 
     it('should react on items resize', async () => {
         component.elementsWidth = 300;

--- a/libs/core/src/lib/overflow-layout/overflow-layout.component.ts
+++ b/libs/core/src/lib/overflow-layout/overflow-layout.component.ts
@@ -176,13 +176,32 @@ export class OverflowLayoutComponent implements OnInit, AfterViewInit, OnDestroy
     moreItemsButtonText: (hiddenItemsCount: number) => string = (count) => `${count} more`;
 
     /** @hidden */
+    private get _config(): OverflowLayoutConfig {
+        return {
+            visibleItems: this._visibleItems,
+            items: this._items,
+            focusableItems: this._focusableOverflowItems,
+            itemsWrapper: this._itemsWrapper.nativeElement,
+            showMoreContainer: this._showMoreContainer.nativeElement,
+            layoutContainerElement: this._layoutContainer.nativeElement,
+            maxVisibleItems: this.maxVisibleItems,
+            direction: this.showMorePosition,
+            enableKeyboardNavigation: this.enableKeyboardNavigation,
+            reverseHiddenItems: this.reverseHiddenItems
+        };
+    }
+
+    /** @hidden */
     constructor(
         private readonly _elementRef: ElementRef<HTMLElement>,
         protected _cdr: ChangeDetectorRef,
         protected _overflowLayoutService: OverflowLayoutService
     ) {
         this._subscription.add(
-            this._fillTrigger$.pipe(debounceTime(30)).subscribe(() => this._overflowLayoutService.fitVisibleItems())
+            this._fillTrigger$.pipe(debounceTime(30)).subscribe(() => {
+                this._overflowLayoutService.setConfig(this._config);
+                this._overflowLayoutService.fitVisibleItems();
+            })
         );
     }
 
@@ -221,7 +240,7 @@ export class OverflowLayoutComponent implements OnInit, AfterViewInit, OnDestroy
 
         this._subscription.add(
             intersectionObservable(this._elementRef.nativeElement).subscribe(() => {
-                this._overflowLayoutService.startListening(this._getConfig());
+                this._overflowLayoutService.startListening(this._config);
 
                 this._canListenToResize = true;
             })
@@ -241,7 +260,6 @@ export class OverflowLayoutComponent implements OnInit, AfterViewInit, OnDestroy
             return;
         }
 
-        this._overflowLayoutService.setConfig(this._getConfig());
         this._fillTrigger$.next();
     }
 
@@ -275,22 +293,6 @@ export class OverflowLayoutComponent implements OnInit, AfterViewInit, OnDestroy
         if (opened) {
             this._overflowPopoverContent?.focusFirstTabbableElement();
         }
-    }
-
-    /** @hidden */
-    private _getConfig(): OverflowLayoutConfig {
-        return {
-            visibleItems: this._visibleItems,
-            items: this._items,
-            focusableItems: this._focusableOverflowItems,
-            itemsWrapper: this._itemsWrapper.nativeElement,
-            showMoreContainer: this._showMoreContainer.nativeElement,
-            layoutContainerElement: this._layoutContainer.nativeElement,
-            maxVisibleItems: this.maxVisibleItems,
-            direction: this.showMorePosition,
-            enableKeyboardNavigation: this.enableKeyboardNavigation,
-            reverseHiddenItems: this.reverseHiddenItems
-        };
     }
 
     /** @hidden */

--- a/libs/core/src/lib/overflow-layout/overflow-layout.service.ts
+++ b/libs/core/src/lib/overflow-layout/overflow-layout.service.ts
@@ -5,7 +5,6 @@ import { debounceTime, distinctUntilChanged, filter, Observable, skip, Subject, 
 import { OverflowLayoutItemContainerDirective } from './directives/overflow-layout-item-container.directive';
 import { OverflowLayoutFocusableItem } from './interfaces/overflow-focusable-item.interface';
 import { OverflowItemRef } from './interfaces/overflow-item-ref.interface';
-import { OverflowItem } from './interfaces/overflow-item.interface';
 
 export interface OverflowLayoutConfig {
     items: QueryList<OverflowItemRef>;
@@ -53,9 +52,6 @@ export class OverflowLayoutService implements OnDestroy {
 
     /** @hidden */
     private _hiddenItems: OverflowItemRef[] = [];
-
-    /** @hidden */
-    private _overflowItems: OverflowItem[] = [];
 
     /** @hidden */
     private _detectChanges$ = new Subject<void>();


### PR DESCRIPTION
## Related Issue(s)

Refers to dxp/search/issues/556

## Description

* overflow layout edge case fixed when placed inside nested template directives (ngIf, ngFor, etc).

## Screenshots

### Before:

<img width="627" alt="image" src="https://user-images.githubusercontent.com/20265336/188676794-f31acb59-7ab1-44ff-844c-7dd521255f36.png">

### After:

<img width="632" alt="image" src="https://user-images.githubusercontent.com/20265336/188676446-c2f176a2-dc45-44fd-a492-48e162950b29.png">
