### PR TITLE
fix(core): fix label for hour and sec

### DIFF
--- a/libs/core/src/lib/time/time-column/time-column.component.ts
+++ b/libs/core/src/lib/time/time-column/time-column.component.ts
@@ -505,7 +505,7 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
     /** @hidden */
     private _updateInternalTranslationConfig(): void {
         switch (this.columnTranslationsPreset) {
-            case 'seconds':
+            case 'hours':
                 this.internalTranslationConfig = {
                     increaseLabel: 'coreTime.increaseHoursLabel',
                     label: 'coreTime.hoursLabel',
@@ -521,7 +521,7 @@ export class TimeColumnComponent<K, T extends SelectableViewItem<K> = Selectable
                     navigationInstruction: 'coreTime.navigationInstruction'
                 };
                 break;
-            case 'hours':
+            case 'seconds':
                 this.internalTranslationConfig = {
                     increaseLabel: 'coreTime.increaseSecondsLabel',
                     label: 'coreTime.secondsLabel',


### PR DESCRIPTION
## Related Issue(s)

part of #8557 

## Description
solves [this](https://github.com/SAP/fundamental-ngx/issues/8557#issuecomment-1247309526) : Wrong label for hours and seconds in time column.
