### PR TITLE
fix(docs): fix wizard example overlap

### DIFF
--- a/libs/docs/core/wizard/examples/wizard-example.component.scss
+++ b/libs/docs/core/wizard/examples/wizard-example.component.scss
@@ -25,7 +25,7 @@
         height: 100%;
         width: 0;
         position: fixed;
-        z-index: 1001;
+        z-index: 1004;
         top: 0;
         left: 0;
         background-color: rgb(255, 255, 255);
@@ -62,5 +62,5 @@
 
 /** this is only necessary due to the overlay z-index used in the wizard examples */
 .fd-dialog {
-    z-index: 1002 !important;
+    z-index: 1005 !important;
 }


### PR DESCRIPTION
## Related Issue(s)

part of #8557

## Description

solves [this](https://github.com/SAP/fundamental-ngx/issues/8557#issuecomment-1216778888): Wizard example overlap

## Screenshots

### Before:
[Wizard Example](https://fundamental-ngx.netlify.app/#/core/wizard#customizable)

![image](https://user-images.githubusercontent.com/65063487/190715130-d68eacd9-412c-4b20-a43d-71c489a35181.png)

### After:
![image](https://user-images.githubusercontent.com/65063487/190714839-5c60ce75-6ed7-4fde-b0a9-c84f6687dc7b.png)
