### PR TITLE
fix(core,platform): improve reactive form onTouched handling

### DIFF
--- a/libs/core/src/lib/calendar/calendar.component.ts
+++ b/libs/core/src/lib/calendar/calendar.component.ts
@@ -2,6 +2,7 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    ElementRef,
     EventEmitter,
     forwardRef,
     HostBinding,
@@ -78,7 +79,7 @@ let calendarUniqueId = 0;
         })
     ],
     host: {
-        '(focusout)': 'onTouched()',
+        '(focusout)': '_focusOut($event)',
         '[attr.id]': 'id',
         class: 'fd-calendar fd-has-display-block'
     },
@@ -284,6 +285,7 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
 
     /** @hidden */
     constructor(
+        private _elementRef: ElementRef,
         private _changeDetectorRef: ChangeDetectorRef,
         private _contentDensityObserver: ContentDensityObserver,
         // Use @Optional to avoid angular injection error message and throw our own which is more precise one
@@ -684,5 +686,12 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
             typeof this.nextButtonDisableFunction === 'function' &&
             this.nextButtonDisableFunction(this.selectedDate, this._currentlyDisplayed, this.activeView);
         this._changeDetectorRef.markForCheck();
+    }
+
+    /** @hidden */
+    private _focusOut(event: FocusEvent): void {
+        if (!this._elementRef.nativeElement.contains(event.relatedTarget)) {
+            this.onTouched();
+        }
     }
 }

--- a/libs/core/src/lib/calendar/calendar.component.ts
+++ b/libs/core/src/lib/calendar/calendar.component.ts
@@ -78,7 +78,7 @@ let calendarUniqueId = 0;
         })
     ],
     host: {
-        '(blur)': 'onTouched()',
+        '(focusout)': 'onTouched()',
         '[attr.id]': 'id',
         class: 'fd-calendar fd-has-display-block'
     },
@@ -425,7 +425,6 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
         this.selectedDate = date;
         this._setNavigationButtonsStates();
         this.onChange(date);
-        this.onTouched();
         this.selectedDateChange.emit(date);
         this.closeCalendar.emit();
     }
@@ -439,7 +438,6 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
             this.selectedRangeDate = { start: dates.start, end: dates.end ? dates.end : dates.start };
             this.selectedRangeDateChange.emit(this.selectedRangeDate);
             this.onChange(this.selectedRangeDate);
-            this.onTouched();
             this.closeCalendar.emit();
         }
     }
@@ -460,7 +458,6 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
                 this.displayNextYearsList();
                 break;
         }
-        this.onTouched();
         this._setNavigationButtonsStates();
     }
 
@@ -480,7 +477,6 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
                 this.displayPreviousYearsList();
                 break;
         }
-        this.onTouched();
         this._setNavigationButtonsStates();
     }
 

--- a/libs/core/src/lib/combobox/combobox.component.html
+++ b/libs/core/src/lib/combobox/combobox.component.html
@@ -85,7 +85,6 @@
             (onComplete)="handleAutoComplete($event)"
             (keydown)="onInputKeydownHandler($event)"
             (ngModelChange)="handleSearchTermChange()"
-            (focus)="onTouched()"
             (blur)="handleBlur()"
         />
         <span

--- a/libs/core/src/lib/combobox/combobox.component.spec.ts
+++ b/libs/core/src/lib/combobox/combobox.component.spec.ts
@@ -46,10 +46,8 @@ describe('ComboboxComponent', () => {
 
     it('should set inputText', () => {
         spyOn(component, 'onChange');
-        spyOn(component, 'onTouched');
         component.inputText = 'someValue';
         expect(component.onChange).toHaveBeenCalledWith('someValue');
-        expect(component.onTouched).toHaveBeenCalled();
     });
 
     it('should write value not on dropdown mode', () => {

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -489,7 +489,6 @@ export class ComboboxComponent
         if (!this.mobile) {
             this._propagateChange();
         }
-        this.onTouched();
     }
 
     /** Get the glyph value based on whether the combobox is used as a search field or not. */
@@ -506,7 +505,6 @@ export class ComboboxComponent
         if (!this.mobile) {
             this._propagateChange();
         }
-        this.onTouched();
         this._cdRef.detectChanges();
     }
 
@@ -569,7 +567,6 @@ export class ComboboxComponent
         }
         if (this.open !== isOpen) {
             this.open = isOpen;
-            this.onTouched();
             this.openChange.emit(isOpen);
         }
 
@@ -600,6 +597,7 @@ export class ComboboxComponent
 
     /** @hidden */
     handleBlur(): void {
+        this.onTouched();
         if (!this.open) {
             this.handleAutoComplete({
                 term: this.searchInputElement.nativeElement.value,

--- a/libs/core/src/lib/date-picker/date-picker.component.html
+++ b/libs/core/src/lib/date-picker/date-picker.component.html
@@ -39,7 +39,7 @@
                 [ngModel]="_inputFieldDate"
                 (keyup.enter)="handleInputChange($any($event.target).value, false)"
                 (ngModelChange)="handleInputChange($event, true)"
-                (blur)="handleInputChange($any($event.target).value, false)"
+                (blur)="onTouched(); handleInputChange($any($event.target).value, false)"
             />
         </fd-input-group>
     </fd-popover-control>

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -54,7 +54,7 @@ let datePickerCounter = 0;
     templateUrl: './date-picker.component.html',
     styleUrls: ['./date-picker.component.scss'],
     host: {
-        '(blur)': 'onTouched()',
+        '(focusout)': 'onTouched()',
         '[class.fd-date-picker]': 'true',
         '[class.fd-date-picker-custom]': 'inline'
     },
@@ -487,7 +487,6 @@ export class DatePickerComponent<D>
     /** Opens the calendar */
     openCalendar(): void {
         if (!this.disabled) {
-            this.onTouched();
             this.isOpen = true;
             this.isOpenChange.emit(this.isOpen);
             this._changeMessageVisibility();
@@ -496,9 +495,11 @@ export class DatePickerComponent<D>
 
     /** Toggles the calendar open or closed */
     public toggleCalendar(): void {
-        this.onTouched();
         this.isOpen = !this.isOpen;
         this.isOpenChange.emit(this.isOpen);
+        if (!this.isOpen) {
+            this.onTouched();
+        }
         this._changeMessageVisibility();
     }
 

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -54,7 +54,7 @@ let datePickerCounter = 0;
     templateUrl: './date-picker.component.html',
     styleUrls: ['./date-picker.component.scss'],
     host: {
-        '(focusout)': 'onTouched()',
+        '(blur)': 'onTouched()',
         '[class.fd-date-picker]': 'true',
         '[class.fd-date-picker-custom]': 'inline'
     },
@@ -480,6 +480,7 @@ export class DatePickerComponent<D>
     /** @hidden */
     public closeFromCalendar(): void {
         if (this.type === 'single' && this.closeOnDateChoose) {
+            this.onTouched();
             this.closeCalendar();
         }
     }

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -43,7 +43,7 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
     templateUrl: './datetime-picker.component.html',
     styleUrls: ['./datetime-picker.component.scss'],
     host: {
-        '(blur)': 'handleOnTouched()'
+        '(focusout)': 'handleOnTouched()'
     },
     providers: [
         {
@@ -504,9 +504,9 @@ export class DatetimePickerComponent<D>
 
     /** Toggles the popover. */
     togglePopover(): void {
-        this.handleOnTouched();
         if (this.isOpen) {
             this.closePopover();
+            this.handleOnTouched();
         } else {
             this.openPopover();
         }
@@ -532,7 +532,6 @@ export class DatetimePickerComponent<D>
     /** Opens the popover. */
     openPopover(): void {
         if (!this.isOpen && !this.disabled) {
-            this.handleOnTouched();
             this.isOpen = true;
             this._onOpenStateChanged(this.isOpen);
         }

--- a/libs/core/src/lib/file-uploader/file-uploader.component.ts
+++ b/libs/core/src/lib/file-uploader/file-uploader.component.ts
@@ -34,7 +34,7 @@ let fileUploaderInputUniqueId = 0;
     templateUrl: './file-uploader.component.html',
     styleUrls: ['./file-uploader.component.scss'],
     host: {
-        '(blur)': 'onTouched()'
+        '(focusout)': 'onTouched()'
     },
     providers: [
         {

--- a/libs/core/src/lib/micro-process-flow/micro-process-flow-focusable-item.directive.ts
+++ b/libs/core/src/lib/micro-process-flow/micro-process-flow-focusable-item.directive.ts
@@ -39,7 +39,7 @@ export class MicroProcessFlowFocusableItemDirective implements OnInit {
         this._microProcessFlow?.canItemsReceiveFocus.next(false);
     }
 
-    @HostListener('blur')
+    @HostListener('focusout')
     onBlur(): void {
         this._microProcessFlow?.canItemsReceiveFocus.next(true);
     }

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -60,7 +60,7 @@ import { ContentDensityObserver, contentDensityObserverProviders } from '@fundam
     templateUrl: './multi-input.component.html',
     styleUrls: ['./multi-input.component.scss'],
     host: {
-        '(blur)': 'onTouched()'
+        '(focusout)': 'onTouched()'
     },
     providers: [
         {

--- a/libs/core/src/lib/segmented-button/segmented-button.component.ts
+++ b/libs/core/src/lib/segmented-button/segmented-button.component.ts
@@ -38,7 +38,8 @@ export type SegmentedButtonValue = string | (string | null)[] | null;
     templateUrl: './segmented-button.component.html',
     styleUrls: ['./segmented-button.component.scss'],
     host: {
-        role: 'group'
+        role: 'group',
+        '(focusout)': 'onTouched()'
     },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/core/src/lib/splitter/splitter-resizer/splitter-resizer.component.ts
+++ b/libs/core/src/lib/splitter/splitter-resizer/splitter-resizer.component.ts
@@ -166,7 +166,7 @@ export class SplitterResizerComponent implements OnDestroy {
     }
 
     /** @hidden */
-    @HostListener('blur')
+    @HostListener('focusout')
     _onBlur(): void {
         this._isInFocus = false;
 

--- a/libs/core/src/lib/step-input/step-input.component.html
+++ b/libs/core/src/lib/step-input/step-input.component.html
@@ -19,7 +19,7 @@
             [disabled]="!canDecrement"
             [title]="decrementButtonTitle || ('coreStepInput.decrementButtonTitle' | fdTranslate)"
             [glyph]="decrementButtonIcon"
-            (click)="onTouched()"
+            (blur)="onTouched()"
             [attr.aria-label]="decrementButtonTitle || ('coreStepInput.decrementButtonTitle' | fdTranslate)"
             [attr.aria-controls]="inputId"
         ></button>
@@ -62,7 +62,7 @@
             [disabled]="!canIncrement"
             [title]="incrementButtonTitle || ('coreStepInput.incrementButtonTitle' | fdTranslate)"
             [glyph]="incrementButtonIcon"
-            (click)="onTouched()"
+            (blur)="onTouched()"
             [attr.aria-label]="incrementButtonTitle || ('coreStepInput.incrementButtonTitle' | fdTranslate)"
             [attr.aria-controls]="inputId"
         ></button>

--- a/libs/core/src/lib/step-input/step-input.component.spec.ts
+++ b/libs/core/src/lib/step-input/step-input.component.spec.ts
@@ -167,13 +167,13 @@ describe('StepInputComponent', () => {
         component.handleFocusIn();
 
         expect(component.focused).toBeTrue();
-        expect(onTouchedSpy).toHaveBeenCalled();
         expect(focusInEventSpy).toHaveBeenCalled();
 
         component.handleFocusOut();
 
         expect(component.focused).toBeFalse();
         expect(focusOutEventSpy).toHaveBeenCalled();
+        expect(onTouchedSpy).toHaveBeenCalled();
     });
 
     it('should display in compact mode', async () => {

--- a/libs/core/src/lib/switch/switch.component.ts
+++ b/libs/core/src/lib/switch/switch.component.ts
@@ -40,7 +40,8 @@ let warnedAboutAriaLabeledBy = false;
     ],
     host: {
         class: 'fd-form__item fd-form__item--check fd-switch-custom',
-        '[attr.id]': 'id'
+        '[attr.id]': 'id',
+        '(focusout)': 'onTouched()'
     },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -164,7 +165,6 @@ export class SwitchComponent implements ControlValueAccessor, OnDestroy, FormIte
     set isChecked(value) {
         this.checked = value;
         this.onChange(value);
-        this.onTouched();
         this.checkedChange.emit(value);
     }
 

--- a/libs/core/src/lib/time-picker/time-picker.component.ts
+++ b/libs/core/src/lib/time-picker/time-picker.component.ts
@@ -36,7 +36,7 @@ let timePickerCounter = 0;
     selector: 'fd-time-picker',
     templateUrl: './time-picker.component.html',
     host: {
-        '(blur)': 'onTouched()',
+        '(focusout)': 'onTouched()',
         class: 'fd-time-picker fd-timepicker-custom'
     },
     providers: [

--- a/libs/core/src/lib/time/time.component.ts
+++ b/libs/core/src/lib/time/time.component.ts
@@ -41,7 +41,7 @@ type MeridianViewItem = SelectableViewItem<Meridian>;
     templateUrl: './time.component.html',
     styleUrls: ['./time.component.scss'],
     host: {
-        '(blur)': 'onTouched()'
+        '(focusout)': 'onTouched()'
     },
     providers: [
         {

--- a/libs/docs/core/checkbox/examples/checkbox-reactive-forms-example.component.ts
+++ b/libs/docs/core/checkbox/examples/checkbox-reactive-forms-example.component.ts
@@ -21,7 +21,10 @@ import { map } from 'rxjs/operators';
 
         <br />
 
-        Form value: {{ registrationForm.getRawValue() | json }}
+        Form value: {{ registrationForm.getRawValue() | json }}<br />
+        Touched: {{ registrationForm.touched }}<br />
+        Dirty: {{ registrationForm.dirty }}<br />
+        Valid: {{ registrationForm.valid }}<br />
     `
 })
 export class CheckboxReactiveFormsExampleComponent implements OnInit {

--- a/libs/fn/src/lib/select/select.component.ts
+++ b/libs/fn/src/lib/select/select.component.ts
@@ -42,6 +42,9 @@ export type InputState = 'positive' | 'critical' | 'negative' | 'info';
             useExisting: SelectComponent
         }
     ],
+    host: {
+        '(focusout)': 'onTouched()'
+    },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -161,7 +164,6 @@ export class SelectComponent implements AfterContentInit, OnDestroy, ControlValu
     /** Function called when the select input is clicked. */
     selectInputClicked(event: MouseEvent | KeyboardEvent): void {
         event.preventDefault();
-        this.onTouched();
         this.selectInput.nativeElement.focus();
         this.opened = !this.opened;
     }

--- a/libs/fn/src/lib/slider/slider.component.ts
+++ b/libs/fn/src/lib/slider/slider.component.ts
@@ -49,7 +49,8 @@ let sliderId = 0;
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [SLIDER_VALUE_ACCESSOR],
     host: {
-        class: 'fn-slider'
+        class: 'fn-slider',
+        '(focusout)': 'onTouched()'
     }
 })
 export class SliderComponent implements OnInit, OnChanges, OnDestroy, ControlValueAccessor {
@@ -205,7 +206,6 @@ export class SliderComponent implements OnInit, OnChanges, OnDestroy, ControlVal
         this._value = value;
 
         this.onChange(value);
-        this.onTouched();
     }
 
     /** @hidden */

--- a/libs/fn/src/lib/switch/switch.component.ts
+++ b/libs/fn/src/lib/switch/switch.component.ts
@@ -37,7 +37,8 @@ let switchUniqueId = 0;
     ],
     host: {
         class: 'fn-form__item fn-form__item--check fn-switch-custom',
-        '[attr.id]': 'id'
+        '[attr.id]': 'id',
+        '(focusout)': 'onTouched()'
     },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -167,7 +168,6 @@ export class SwitchComponent implements ControlValueAccessor, OnInit, OnDestroy 
     set isChecked(value) {
         this.checked = value;
         this.onChange(value);
-        this.onTouched();
         this.checkedChange.emit(value);
     }
 

--- a/libs/platform/src/lib/form/auto-complete/auto-complete.directive.ts
+++ b/libs/platform/src/lib/form/auto-complete/auto-complete.directive.ts
@@ -58,7 +58,7 @@ export class AutoCompleteDirective {
     constructor(private readonly _elementRef: ElementRef<HTMLInputElement>) {}
 
     /** @hidden */
-    @HostListener('blur')
+    @HostListener('focusout')
     handleBlur(): void {
         if (Boolean(this.inputText) && !this.mobile) {
             this._element.value = this.inputText;

--- a/libs/platform/src/lib/form/combobox/combobox/combobox.component.html
+++ b/libs/platform/src/lib/form/combobox/combobox/combobox.component.html
@@ -69,7 +69,7 @@
                 (ngModelChange)="searchTermChanged($event)"
                 [placeholder]="placeholder"
                 (focus)="onTouched()"
-                (blur)="_onBlur($event)"
+                (blur)="_onInputBlur($event)"
                 [attr.aria-expanded]="isOpen && _suggestions.length > 0"
                 [readonly]="readonly"
                 [attr.aria-readonly]="readonly"

--- a/libs/platform/src/lib/form/combobox/combobox/combobox.component.ts
+++ b/libs/platform/src/lib/form/combobox/combobox/combobox.component.ts
@@ -95,7 +95,7 @@ export class ComboboxComponent extends BaseCombobox implements ComboboxInterface
     }
 
     /** @hidden */
-    _onBlur(event: FocusEvent): void {
+    _onInputBlur(event: FocusEvent): void {
         if (this.mobile) {
             return;
         }

--- a/libs/platform/src/lib/form/date-picker/date-picker.component.ts
+++ b/libs/platform/src/lib/form/date-picker/date-picker.component.ts
@@ -40,10 +40,7 @@ import { FormFieldControl, BaseInput, FormField } from '@fundamental-ngx/platfor
     templateUrl: './date-picker.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [{ provide: FormFieldControl, useExisting: PlatformDatePickerComponent, multi: true }],
-    host: {
-        '(blur)': 'onTouched()'
-    }
+    providers: [{ provide: FormFieldControl, useExisting: PlatformDatePickerComponent, multi: true }]
 })
 export class PlatformDatePickerComponent<D> extends BaseInput {
     /**

--- a/libs/platform/src/lib/form/step-input/step-input-control.directive.ts
+++ b/libs/platform/src/lib/form/step-input/step-input-control.directive.ts
@@ -53,7 +53,7 @@ export class StepInputControlDirective {
      * @hidden
      * Handle "blur" event
      */
-    @HostListener('blur')
+    @HostListener('focusout')
     onBlur(): void {
         this.stepInput.onBlur();
     }

--- a/libs/platform/src/lib/shared/form/base.input.ts
+++ b/libs/platform/src/lib/shared/form/base.input.ts
@@ -5,6 +5,7 @@ import {
     DoCheck,
     ElementRef,
     Host,
+    HostListener,
     Input,
     isDevMode,
     OnDestroy,
@@ -344,5 +345,11 @@ export abstract class BaseInput
 
     protected getValue(): any {
         return this._value;
+    }
+
+    /** @hidden */
+    @HostListener('focusout')
+    _onBlur(): void {
+        this.onTouched();
     }
 }


### PR DESCRIPTION
Fixes #8677 

It was pointed out that step input, when used in a reactive form, would set it's "onTouched" mode to "true" too early. After combing through the library, this was true for many components that could be used in a form. This PR adjusts all components to set its touched mode to true on blur or focusout, rather than on focusin.