### PR TITLE
fix(core): quick view should not use fd-input and should be focus trapped in popovers

### DIFF
--- a/libs/core/src/lib/quick-view/quick-view-group-item-content/quick-view-group-item-content-element.directive.ts
+++ b/libs/core/src/lib/quick-view/quick-view-group-item-content/quick-view-group-item-content-element.directive.ts
@@ -4,7 +4,7 @@ import { Directive } from '@angular/core';
     // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[fd-quick-view-group-item-content-element]',
     host: {
-        class: `${QuickViewGroupItemContentElementDirective.class} fd-input`
+        class: `${QuickViewGroupItemContentElementDirective.class}`
     }
 })
 export class QuickViewGroupItemContentElementDirective {

--- a/libs/docs/core/quick-view/examples/quick-view-popover-example.component.html
+++ b/libs/docs/core/quick-view/examples/quick-view-popover-example.component.html
@@ -3,6 +3,7 @@
         placement="right-start"
         [noArrow]="false"
         [focusAutoCapture]="true"
+        [focusTrapped]="true"
         (isOpenChange)="isOpenChangePopover1($event)"
     >
         <fd-popover-control>
@@ -73,6 +74,7 @@
         placement="right-start"
         [noArrow]="false"
         [focusAutoCapture]="true"
+        [focusTrapped]="true"
         (isOpenChange)="isOpenChangePopover2($event)"
     >
         <fd-popover-control>


### PR DESCRIPTION
part of defect hunting 94, this comment: https://github.com/SAP/fundamental-ngx/issues/8557#issuecomment-1215401360

Also relies on https://github.com/SAP/fundamental-styles/pull/3896 