### PR TITLE
fix(core): popover overflow

### DIFF
--- a/libs/core/src/lib/popover/popover-body/popover-body.component.html
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.html
@@ -1,4 +1,5 @@
 <div
+    fd-scrollbar
     class="fd-popover__popper"
     [class.fd-popover__popper--no-arrow]="_noArrow"
     [class.fd-popover__popper--compact]="_contentDensityObserver.isCompact$ | async"

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.scss
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.scss
@@ -9,6 +9,11 @@ $fd-popover-border-radius: var(--fdPopover_Border_Radius);
     border-#{$position}-left-radius: $radius;
 }
 
+fd-popover-body {
+    max-width: 100%;
+    max-height: 100%;
+}
+
 .#{$block} {
     &-custom {
         display: inline-block;
@@ -28,6 +33,10 @@ $fd-popover-border-radius: var(--fdPopover_Border_Radius);
     }
 
     &__popper {
+        max-height: 100%;
+        max-width: 100%;
+        overflow: auto;
+
         .fd-list {
             border-radius: $fd-popover-border-radius;
 
@@ -93,6 +102,7 @@ $fd-popover-border-radius: var(--fdPopover_Border_Radius);
     }
 
     &-pane {
-        max-height: initial;
+        max-width: 100%;
+        max-height: 100%;
     }
 }

--- a/libs/core/src/lib/popover/popover.module.ts
+++ b/libs/core/src/lib/popover/popover.module.ts
@@ -11,6 +11,7 @@ import { PopoverComponent } from './popover.component';
 import { A11yModule } from '@angular/cdk/a11y';
 import { PopoverTriggerDirective } from './popover-trigger.directive';
 import { PopoverContainerDirective } from './popover-container/popover-container.directive';
+import { ScrollbarModule } from '@fundamental-ngx/core/scrollbar';
 
 @NgModule({
     declarations: [
@@ -22,7 +23,7 @@ import { PopoverContainerDirective } from './popover-container/popover-container
         PopoverTriggerDirective,
         PopoverContainerDirective
     ],
-    imports: [CommonModule, OverlayModule, A11yModule],
+    imports: [CommonModule, OverlayModule, A11yModule, ScrollbarModule],
     exports: [
         PopoverControlComponent,
         PopoverBodyComponent,


### PR DESCRIPTION
## Related Issue(s)

Closes https://github.com/SAP/fundamental-ngx/issues/7445


## Description

Scrollbars for the popover body when it's too big for the viewport.

## Screenshots

### Before:

<img width="366" alt="image" src="https://user-images.githubusercontent.com/20265336/193033679-bb46a68d-e6c7-495e-80af-28dbb2553aa1.png">

### After:

<img width="359" alt="image" src="https://user-images.githubusercontent.com/20265336/193033385-49e8966d-281d-447d-9a7a-c80815256d73.png">

_Note: Firefox doesn't support custom scrollbars, default ones are shown._
