### PR TITLE
fix(docs): netlify update to ubuntu 20.04

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,6 @@
 
 [build]
   ignore = 'sh ./ignore.sh'
-  environment = { NODE_VERSION = "16.15.1", PYTHON_VERSION="3.7", YARN_FLAGS="--frozen-lockfile" }
+  environment = { NODE_VERSION = "16.15.1", PYTHON_VERSION="3.8", YARN_FLAGS="--frozen-lockfile" }
   publish = "dist/apps/docs"
   command = "NODE_OPTIONS=--max_old_space_size=8192 npx nx run-many --target=build --projects=docs --parallel=4 --configuration=\"production-unoptimized\" --base-href=\"/\""


### PR DESCRIPTION
`IMPORTANT` When merging this one setting 'Build image' should be changed to 'Ubuntu Focal 20.04 (default)' in netlify settings.

## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

Relates to https://github.com/SAP/fundamental-ngx/issues/8758

## Description

Python version changed to 3.8 (default for ubuntu 20.04).

