### PR TITLE
fix(docs): remove color from pre tag

### DIFF
--- a/apps/docs/src/styles.scss
+++ b/apps/docs/src/styles.scss
@@ -158,7 +158,6 @@ pre {
     padding: 1rem;
     font-size: 13px;
     line-height: 1.42857143;
-    color: #333;
     word-break: break-all;
 
     code {
@@ -241,7 +240,6 @@ a:not(.fd-link):focus {
         padding: 1rem;
         font-size: 13px;
         line-height: 1.42857143;
-        color: #333;
         word-break: break-all;
         border: 1px solid #ccc;
         border-radius: 4px;


### PR DESCRIPTION
## Related Issue(s)

Part of #8557 

## Description

Solves one of [these](https://github.com/SAP/fundamental-ngx/issues/8557#issuecomment-1215609973): 
Removed black color from pre tag.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![image](https://user-images.githubusercontent.com/65063487/193696160-44eb6923-56dd-4970-81d8-c786aff1b9e8.png)

### After:
![image](https://user-images.githubusercontent.com/65063487/193696240-f510b3ad-5a03-48cd-8a92-81540303cb9b.png)

