### PR TITLE
fix(core,platform): hiding live announcer element

### DIFF
--- a/libs/core/src/lib/message-toast/message-toast.component.scss
+++ b/libs/core/src/lib/message-toast/message-toast.component.scss
@@ -1,4 +1,7 @@
+@use '@angular/cdk';
 @import '~fundamental-styles/dist/message-toast';
+
+@include cdk.a11y-visually-hidden();
 
 .fd-message-toast {
     display: block;

--- a/libs/core/src/lib/pagination/pagination.component.scss
+++ b/libs/core/src/lib/pagination/pagination.component.scss
@@ -1,4 +1,7 @@
+@use '@angular/cdk';
 @import '~fundamental-styles/dist/pagination';
+
+@include cdk.a11y-visually-hidden();
 
 $block: fd-pagination;
 

--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -1,4 +1,7 @@
+@use '@angular/cdk';
 @import '~fundamental-styles/dist/select';
+
+@include cdk.a11y-visually-hidden();
 
 .fd-popover__body > :first-child {
     border-radius: 0;

--- a/libs/core/src/lib/slider/slider.component.scss
+++ b/libs/core/src/lib/slider/slider.component.scss
@@ -1,5 +1,8 @@
+@use '@angular/cdk';
 @import '~fundamental-styles/dist/slider';
 @import '~fundamental-styles/dist/input';
+
+@include cdk.a11y-visually-hidden();
 
 .fd-popover--slider {
     display: block !important;

--- a/libs/core/src/lib/step-input/step-input.component.scss
+++ b/libs/core/src/lib/step-input/step-input.component.scss
@@ -1,5 +1,8 @@
+@use '@angular/cdk';
 @import '~fundamental-styles/dist/input';
 @import '~fundamental-styles/dist/step-input';
+
+@include cdk.a11y-visually-hidden();
 
 .fd-input {
     &.fd-step-input__input.is-hover,

--- a/libs/core/src/lib/table/table.component.scss
+++ b/libs/core/src/lib/table/table.component.scss
@@ -1,4 +1,7 @@
+@use '@angular/cdk';
 @import '~fundamental-styles/dist/table';
+
+@include cdk.a11y-visually-hidden();
 
 .fd-table__popover--custom {
     width: 100%;

--- a/libs/docs/shared/src/lib/core-helpers/stackblitz/code-example-stack/styles.scss
+++ b/libs/docs/shared/src/lib/core-helpers/stackblitz/code-example-stack/styles.scss
@@ -51,13 +51,3 @@
 body {
     font-family: '72', sans-serif;
 }
-
-.cdk-live-announcer-element {
-    position: absolute !important; /* Outside the DOM flow */
-    height: 1px;
-    width: 1px; /* Nearly collapsed */
-    overflow: hidden;
-    opacity: 0;
-    clip: rect(1px 1px 1px 1px); /* IE 7+ only support clip without commas */
-    clip: rect(1px, 1px, 1px, 1px); /* All other browsers */
-}

--- a/libs/fn/src/lib/slider/slider.component.scss
+++ b/libs/fn/src/lib/slider/slider.component.scss
@@ -1,4 +1,7 @@
+@use '@angular/cdk';
 @import '~@fundamental-styles/fn/dist/fn-slider';
+
+@include cdk.a11y-visually-hidden();
 
 .fn-slider {
     display: block;

--- a/libs/platform/src/lib/search-field/search-field.component.scss
+++ b/libs/platform/src/lib/search-field/search-field.component.scss
@@ -1,6 +1,9 @@
+@use '@angular/cdk';
 @import '~fundamental-styles/dist/button';
 @import '~fundamental-styles/dist/input';
 @import '~fundamental-styles/dist/input-group';
+
+@include cdk.a11y-visually-hidden();
 
 .fdp-search-field {
     /* Remove clear "x" from search field for IE browsers */

--- a/libs/platform/src/lib/table/table.component.scss
+++ b/libs/platform/src/lib/table/table.component.scss
@@ -1,4 +1,7 @@
+@use '@angular/cdk';
 @import '~fundamental-styles/dist/scrollbar';
+
+@include cdk.a11y-visually-hidden();
 
 $block: fdp-table;
 


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

Previously we were hiding live announcer element only on the the docs app level, not on the component level. So anywhere on the client side this element was visible, here is the fix. 

## Screenshots

### Before

<img width="200" alt="image" src="https://user-images.githubusercontent.com/20265336/193874700-f5a0210e-5765-4626-8449-17f591d46877.png">

### After

<img width="332" alt="image" src="https://user-images.githubusercontent.com/20265336/193874781-61e466cf-05ba-4f69-8358-16dcd48ec8c3.png">
