### PR TITLE
fix(core): minor CSS bug that is only visible with certain styles RC

### DIFF
--- a/libs/core/src/lib/multi-input/multi-input.component.scss
+++ b/libs/core/src/lib/multi-input/multi-input.component.scss
@@ -28,10 +28,6 @@
 .fd-multi-input-popover-custom.fd-popover-custom {
     max-width: 100%;
     display: block;
-
-    .fd-tokenizer {
-        height: 100%;
-    }
 }
 
 .fd-multi-input-menu-overflow {


### PR DESCRIPTION
fixes none

Fixes an issue with multi-input that only became apparent with fundamental-styles v. 0.25.0-rc.31 but will be fixed in later styles versions. But regardless is unused code

screenshot:
<img width="661" alt="Screen Shot 2022-10-04 at 9 54 35 PM" src="https://user-images.githubusercontent.com/2471874/193978231-af66a451-9b53-4f8f-bf9b-25def38c2c22.png">
