### PR TITLE
fix(docs): fix wrong margin for icon in RTL menu

### DIFF
--- a/libs/docs/core/menu/examples/menu-addon-example.component.scss
+++ b/libs/docs/core/menu/examples/menu-addon-example.component.scss
@@ -1,5 +1,4 @@
 .fd-menu__addon-after {
     text-align: center;
     flex: 0 0 auto;
-    margin: 0 -1rem 0 0;
 }


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #8430 

## Description

Remove margin from example file.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
RTL
![image](https://user-images.githubusercontent.com/65063487/193978091-c674e750-feeb-4667-b05d-039d145a2264.png)

### After:
RTL
![image](https://user-images.githubusercontent.com/65063487/193978229-63012ad4-fdf0-4cf4-bac7-46174a00100c.png)
