### PR TITLE
fix(core): fix combobox glyph issue

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -493,7 +493,7 @@ export class ComboboxComponent
 
     /** Get the glyph value based on whether the combobox is used as a search field or not. */
     get glyphValue(): string {
-        return this.isSearch ? 'search' : 'navigation-down-arrow';
+        return this.isSearch ? 'search' : this.glyph;
     }
 
     /** @hidden */


### PR DESCRIPTION
## Related Issue(s)

closes #8655 

## Description
Issue was: Passing custom `@Input glyph` in combobox wasn't working. 