### PR TITLE
fix(docs): fix broken platform docs of info-label

### DIFF
--- a/libs/docs/platform/info-label/platform-info-label-docs-module.ts
+++ b/libs/docs/platform/info-label/platform-info-label-docs-module.ts
@@ -2,7 +2,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { NgModule } from '@angular/core';
 
 import { API_FILES } from '@fundamental-ngx/docs/platform/shared';
-import { ApiComponent, SharedDocumentationPageModule } from '@fundamental-ngx/docs/shared';
+import { ApiComponent, currentComponentProvider, SharedDocumentationPageModule } from '@fundamental-ngx/docs/shared';
 
 import { PlatformInfoLabelModule } from '@fundamental-ngx/platform/info-label';
 import { PlatformInfoLabelDocsComponent } from './platform-info-label-docs.component';
@@ -37,6 +37,7 @@ const routes: Routes = [
         PlatformInfoLableTextExampleComponent,
         PlatformInfoLableTextIconExampleComponent,
         PlatformInfoLableAriaLabelExampleComponent
-    ]
+    ],
+    providers: [currentComponentProvider('info-label')]
 })
 export class PlatformInfoLabelDocsModule {}


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #8798 

## Description

Added `currentComponentProvider` for  info-label.