### PR TITLE
fix(platform): fix unread issue in standard list with nav indicator

### DIFF
--- a/libs/platform/src/lib/list/standard-list-item/standard-list-item.component.html
+++ b/libs/platform/src/lib/list/standard-list-item/standard-list-item.component.html
@@ -2,7 +2,7 @@
 <ng-container *ngIf="navigationIndicator || (navigated && !(noDataText !== null && noDataText !== undefined))">
     <li
         #listItem
-        [class.fd-list-title__unread]="unRead"
+        [class.fd-list__item--unread]="unRead"
         fd-list-item
         [attr.id]="id"
         [selected]="_selected"


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #8756

## Description

Solved: `unread="true"` wasn't making list title bold in Standard list with navigation indicator.

## Screenshots

### After:
First Item with `unread="true"`:

![image](https://user-images.githubusercontent.com/65063487/194641819-cd4dd3d8-4593-4c57-a6f0-68ec83b78b08.png)

