### PR TITLE
docs(core): demonstrate how to update datetimepicker locale

### DIFF
--- a/libs/docs/core/datetime-picker/datetime-picker-docs.component.html
+++ b/libs/docs/core/datetime-picker/datetime-picker-docs.component.html
@@ -86,8 +86,11 @@
 <description>
     <fd-datetime-important componentName="DatetimePicker"></fd-datetime-important>
     <p>
-        To change a locale option in <code>DatePicker</code> component, it is needed to set a locale via
-        <code>DatetimeAdapter.setLocale</code> method.
+        In order to change the locale of the DatetimePicker, both the calendar will need to set its locale via the
+        <code>DatetimeAdapter</code> and the remaining pieces of the component (such as OK/Cancel buttons, "Hrs/Min/Sec"
+        labels) will need to be translated via the <code>fundamental-ngx/i18n</code> module. This is because the
+        <code>CalendarComponent</code> utilizes different localization strategies than the other components of the
+        library. Note the <code>TypeScript</code> example code below to see how this is done.
     </p>
 </description>
 <component-example>

--- a/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
+++ b/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
@@ -6,7 +6,7 @@
         [(value)]="locale"
         ariaLabelledBy="lang-select"
     >
-        <li fd-option *ngFor="let option of ['en-ca', 'fr', 'bg', 'zh']" [value]="option">
+        <li fd-option *ngFor="let option of ['en-ca', 'fr', 'bg', 'pl', 'zh']" [value]="option">
             {{ option }}
         </li>
     </fd-select>

--- a/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
+++ b/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
@@ -6,7 +6,7 @@
         [(value)]="locale"
         ariaLabelledBy="lang-select"
     >
-        <li fd-option *ngFor="let option of ['en-ca', 'fr', 'de', 'bg', 'ar-eg', 'zh']" [value]="option">
+        <li fd-option *ngFor="let option of ['en-ca', 'fr', 'bg', 'zh']" [value]="option">
             {{ option }}
         </li>
     </fd-select>

--- a/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -10,6 +10,7 @@ import { DatetimePickerComponent } from '@fundamental-ngx/core/datetime-picker';
 import {
     FD_LANGUAGE,
     FD_LANGUAGE_BULGARIAN,
+    FD_LANGUAGE_CHINESE,
     FD_LANGUAGE_ENGLISH,
     FD_LANGUAGE_FRENCH,
     FD_LANGUAGE_POLISH,
@@ -71,6 +72,8 @@ export class DatetimePickerComplexI18nExampleComponent {
             this.langSubject$.next(FD_LANGUAGE_BULGARIAN);
         } else if (locale === 'pl') {
             this.langSubject$.next(FD_LANGUAGE_POLISH);
+        } else if (locale === 'zh') {
+            this.langSubject$.next(FD_LANGUAGE_CHINESE);
         }
     }
 }

--- a/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, LOCALE_ID, ViewChild } from '@angular/core';
+import { Component, Inject, LOCALE_ID, ViewChild } from '@angular/core';
 import {
     DATE_TIME_FORMATS,
     DatetimeAdapter,
@@ -7,12 +7,20 @@ import {
     FdDatetimeAdapter
 } from '@fundamental-ngx/core/datetime';
 import { DatetimePickerComponent } from '@fundamental-ngx/core/datetime-picker';
+import {
+    FD_LANGUAGE,
+    FD_LANGUAGE_BULGARIAN,
+    FD_LANGUAGE_ENGLISH,
+    FD_LANGUAGE_FRENCH,
+    FD_LANGUAGE_POLISH,
+    FdLanguage
+} from '@fundamental-ngx/i18n';
+import { BehaviorSubject } from 'rxjs';
 
 const placeholders = new Map([
     ['en-ca', 'mm/dd/yyyy, hh:mm a'],
     ['fr', 'dd/mm/yyyy  hh:mm'],
     ['bg', 'дд.мм.гг чч:мм'],
-    ['de', 'dd.mm.yy, hh:mm'],
     ['pl', 'dd.mm.yyyy, hh:mm']
 ]);
 
@@ -46,11 +54,23 @@ export class DatetimePickerComplexI18nExampleComponent {
 
     @ViewChild(DatetimePickerComponent) datetimePickerComponent: DatetimePickerComponent<FdDate>;
 
-    constructor(private datetimeAdapter: DatetimeAdapter<FdDate>) {}
+    constructor(
+        private datetimeAdapter: DatetimeAdapter<FdDate>,
+        @Inject(FD_LANGUAGE) private langSubject$: BehaviorSubject<FdLanguage>
+    ) {}
 
     public setLocale(locale: string): void {
         this.locale = locale;
         this.datetimeAdapter.setLocale(locale);
         this.placeholder = placeholders.get(this.locale) as string;
+        if (locale === 'en-ca') {
+            this.langSubject$.next(FD_LANGUAGE_ENGLISH);
+        } else if (locale === 'fr') {
+            this.langSubject$.next(FD_LANGUAGE_FRENCH);
+        } else if (locale === 'bg') {
+            this.langSubject$.next(FD_LANGUAGE_BULGARIAN);
+        } else if (locale === 'pl') {
+            this.langSubject$.next(FD_LANGUAGE_POLISH);
+        }
     }
 }


### PR DESCRIPTION
Part of #8717 

This updates core's datetime picker documentation to show how to localize all child components of the DatetimePicker pattern component. See linked issue above for more details