### PR TITLE
fix(core): do not disable step input increment/decrement when value is null

### DIFF
--- a/libs/core/src/lib/step-input/step-input.component.spec.ts
+++ b/libs/core/src/lib/step-input/step-input.component.spec.ts
@@ -387,14 +387,16 @@ describe('StepInputComponent', () => {
         component.writeValue(null);
         component.decrement();
         expect(component.value).toBe(99);
-        component.writeValue(105);
-        component.max = 105;
+    });
+
+    it('should handle increment/decrement when initial value is max value and input is cleared', () => {
+        component.max = 100;
+        component.min = 100;
         component.writeValue(null);
         component.increment();
-        expect(component.value).toBe(105);
-        component.min = 95;
+        expect(component.value).toBe(100);
         component.writeValue(null);
         component.decrement();
-        expect(component.value).toBe(95);
+        expect(component.value).toBe(100);
     });
 });

--- a/libs/core/src/lib/step-input/step-input.component.spec.ts
+++ b/libs/core/src/lib/step-input/step-input.component.spec.ts
@@ -169,7 +169,7 @@ describe('StepInputComponent', () => {
         expect(component.focused).toBeTrue();
         expect(focusInEventSpy).toHaveBeenCalled();
 
-        component.handleFocusOut();
+        component.handleFocusOut(new FocusEvent('blur'));
 
         expect(component.focused).toBeFalse();
         expect(focusOutEventSpy).toHaveBeenCalled();
@@ -378,5 +378,23 @@ describe('StepInputComponent', () => {
 
         component.handleKeyDown.call(context, keyDownEvent);
         expect(decrementSpy).toHaveBeenCalled();
+    });
+
+    it('should handle the increment/decrement buttons when the input is set to null', () => {
+        component.writeValue(null);
+        component.increment();
+        expect(component.value).toBe(101);
+        component.writeValue(null);
+        component.decrement();
+        expect(component.value).toBe(99);
+        component.writeValue(105);
+        component.max = 105;
+        component.writeValue(null);
+        component.increment();
+        expect(component.value).toBe(105);
+        component.min = 95;
+        component.writeValue(null);
+        component.decrement();
+        expect(component.value).toBe(95);
     });
 });

--- a/libs/core/src/lib/step-input/step-input.component.ts
+++ b/libs/core/src/lib/step-input/step-input.component.ts
@@ -342,6 +342,9 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
         if (this.canIncrement) {
             if (this.value == null && this._firstEmittedValue) {
                 this._value = this._firstEmittedValue;
+                if (this._firstEmittedValue === this.max) {
+                    this._value = this.max;
+                }
             }
             this._value = this._cutFloatingNumberDistortion(this.value!, this.step);
             this._emitChangedValue();
@@ -354,6 +357,9 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
         if (this.canDecrement) {
             if (this.value == null && this._firstEmittedValue) {
                 this._value = this._firstEmittedValue;
+                if (this._firstEmittedValue === this.min) {
+                    this._value = this.min;
+                }
             }
             this._value = this._cutFloatingNumberDistortion(this.value!, -this.step);
             this._emitChangedValue();

--- a/libs/core/src/lib/step-input/step-input.component.ts
+++ b/libs/core/src/lib/step-input/step-input.component.ts
@@ -340,13 +340,17 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
     /** Increment input value by step value */
     increment(): void {
         if (this.canIncrement) {
+            let _shouldIncrement = true;
             if (this.value == null && this._firstEmittedValue) {
                 this._value = this._firstEmittedValue;
                 if (this._firstEmittedValue === this.max) {
                     this._value = this.max;
+                    _shouldIncrement = true;
                 }
             }
-            this._value = this._cutFloatingNumberDistortion(this.value!, this.step);
+            if (_shouldIncrement) {
+                this._value = this._cutFloatingNumberDistortion(this.value!, this.step);
+            }
             this._emitChangedValue();
             this._updateViewValue();
         }
@@ -355,13 +359,17 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
     /** Decrement input value by step value */
     decrement(): void {
         if (this.canDecrement) {
+            let _shouldDecrement = true;
             if (this.value == null && this._firstEmittedValue) {
                 this._value = this._firstEmittedValue;
                 if (this._firstEmittedValue === this.min) {
                     this._value = this.min;
+                    _shouldDecrement = false;
                 }
             }
-            this._value = this._cutFloatingNumberDistortion(this.value!, -this.step);
+            if (_shouldDecrement) {
+                this._value = this._cutFloatingNumberDistortion(this.value!, -this.step);
+            }
             this._emitChangedValue();
             this._updateViewValue();
         }

--- a/libs/core/src/lib/step-input/step-input.component.ts
+++ b/libs/core/src/lib/step-input/step-input.component.ts
@@ -124,6 +124,9 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
             this._value = this._checkValueLimits(value);
         }
         this.lastEmittedValue = this._value;
+        if (!this._firstEmittedValue && this._value) {
+            this._firstEmittedValue = this._value;
+        }
         if (this._numberFormat) {
             this._updateViewValue();
         }
@@ -265,6 +268,9 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
     private _index: any;
 
     /** @hidden */
+    private _firstEmittedValue: number;
+
+    /** @hidden */
     onChange: (value: Nullable<number>) => void = () => {};
 
     /** @hidden */
@@ -318,18 +324,12 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
 
     /** @hidden */
     get canIncrement(): boolean {
-        if (this.value == null) {
-            return false;
-        }
-        return this.value + this.step <= this._max;
+        return this.value == null || this.value + this.step <= this._max;
     }
 
     /** @hidden */
     get canDecrement(): boolean {
-        if (this.value == null) {
-            return false;
-        }
-        return this.value - this.step >= this._min;
+        return this.value == null || this.value - this.step >= this._min;
     }
 
     /** @hidden */
@@ -340,6 +340,9 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
     /** Increment input value by step value */
     increment(): void {
         if (this.canIncrement) {
+            if (this.value == null && this._firstEmittedValue) {
+                this._value = this._firstEmittedValue;
+            }
             this._value = this._cutFloatingNumberDistortion(this.value!, this.step);
             this._emitChangedValue();
             this._updateViewValue();
@@ -349,6 +352,9 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
     /** Decrement input value by step value */
     decrement(): void {
         if (this.canDecrement) {
+            if (this.value == null && this._firstEmittedValue) {
+                this._value = this._firstEmittedValue;
+            }
             this._value = this._cutFloatingNumberDistortion(this.value!, -this.step);
             this._emitChangedValue();
             this._updateViewValue();


### PR DESCRIPTION
fixes #8831 

Now matches the functionality of the ui5 web component step input when clearing the input