### PR TITLE
fix(core): change year-range on next/previous button clicks in calendar

### DIFF
--- a/libs/core/src/lib/calendar/calendar.component.ts
+++ b/libs/core/src/lib/calendar/calendar.component.ts
@@ -519,11 +519,19 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
     /** Function that allows to switch actually displayed list of year to next year list*/
     displayNextYearList(): void {
         this._yearViewComponent.loadNextYearList();
+        this._currentlyDisplayed = {
+            month: this._currentlyDisplayed.month,
+            year: this._yearViewComponent._firstYearInList
+        };
     }
 
     /** Function that allows to switch actually displayed list of year to previous year list*/
     displayPreviousYearList(): void {
         this._yearViewComponent.loadPreviousYearList();
+        this._currentlyDisplayed = {
+            month: this._currentlyDisplayed.month,
+            year: this._yearViewComponent._firstYearInList
+        };
     }
 
     /** Function that allows to switch actually displayed list of year to next year list*/


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #8835 
 
## Description

fix: Year-range in calendar header wasn't changing according to years-grid. 
