### PR TITLE
fix(core): combobox: set value to null on clear button

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.spec.ts
+++ b/libs/core/src/lib/combobox/combobox.component.spec.ts
@@ -212,8 +212,8 @@ describe('ComboboxComponent', () => {
         expect(addOns.length).toBe(1);
         component.isSearch = true;
         component.communicateByObject = true;
-        component.displayFn = (item: any): string => item.displayedValue;
-        component.inputText = 'displayedValue2';
+        component.displayFn = (item: any): string => item?.displayedValue ?? '';
+        component.inputText = 'test';
         (<any>component)._cdRef.detectChanges();
         addOns = fixture.nativeElement.querySelectorAll('button');
         expect(addOns.length).toBe(2);

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -699,10 +699,14 @@ export class ComboboxComponent
 
     /** @hidden */
     private _propagateChange(): void {
-        if (!this.communicateByObject) {
-            this.onChange(this.inputText);
-        } else {
+        if (this.communicateByObject) {
+            const value = this._getOptionObjectByDisplayedValue(this.inputText);
+            if (this.displayFn(value) !== this.displayFn(this.getValue())) {
+                this.setValue(value);
+            }
             this.onChange(this.getValue());
+        } else {
+            this.onChange(this.inputText);
         }
     }
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #8858 

## Description

Set value to null on clear button in Combobox.

