### PR TITLE
fix: the API documentation colors for dark modes

### DIFF
--- a/apps/docs/src/styles.scss
+++ b/apps/docs/src/styles.scss
@@ -219,9 +219,18 @@ a:not(.fd-link):focus {
     text-decoration: none;
 }
 
-.fd-playground--markdown {
+.fd-playground--markdown,
+.api-main-header,
+.fd-tsdoc-container {
     color: var(--sapTextColor);
+}
 
+.fd-tsdoc-container .tsd-panel {
+    background-color: var(--sapBaseColor);
+    box-shadow: var(--sapContent_Shadow0);
+}
+
+.fd-playground--markdown {
     #fundamental-ngx {
         margin-top: calc(2rem + 10px);
         font-size: 2.2rem;


### PR DESCRIPTION
fixes none. Some additional updates to the documentation to make the API page look better in the dark modes

<img width="1268" alt="Screen Shot 2022-10-18 at 3 54 00 PM" src="https://user-images.githubusercontent.com/2471874/196552219-9761b5e2-b17a-44cf-8a9f-d0e3c663a637.png">

