### PR TITLE
fix(core): need to run setTimeout in line clamp logic to force recheck of parents

### DIFF
--- a/libs/core/src/lib/text/text.component.spec.ts
+++ b/libs/core/src/lib/text/text.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { TextComponent } from './text.component';
 import { TextModule } from './text.module';
@@ -69,7 +69,7 @@ describe('TextComponent', () => {
         expect(Number(target.style.webkitLineClamp)).toEqual(maxLines);
     });
 
-    it(`should set labels for more and less buttons`, async () => {
+    it(`should set labels for more and less buttons`, fakeAsync(() => {
         const moreLabel = 'label more'.toLowerCase();
         const lessLabel = 'label less'.toLowerCase();
 
@@ -80,7 +80,7 @@ describe('TextComponent', () => {
         component.moreLabel = moreLabel;
         component.lessLabel = lessLabel;
         fixture.detectChanges();
-        await fixture.whenStable();
+        tick();
 
         const button = fixture.nativeElement.querySelector('.fd-text__link--more');
 
@@ -88,10 +88,10 @@ describe('TextComponent', () => {
 
         component.isCollapsed = false;
         fixture.detectChanges();
-        await fixture.whenStable();
+        tick();
 
         expect(button.innerText.toLowerCase()).toEqual(lessLabel);
-    });
+    }));
 
     it('should have ability to toggle text view', () => {
         component.expandable = true;

--- a/libs/core/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
+++ b/libs/core/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
@@ -97,6 +97,7 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
         return this._elementRef.nativeElement;
     }
 
+    /** @hidden */
     constructor(
         private readonly _elementRef: ElementRef,
         private readonly _renderer: Renderer2,

--- a/libs/core/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
+++ b/libs/core/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
@@ -8,7 +8,8 @@ import {
     OnDestroy,
     OnChanges,
     Output,
-    Renderer2
+    Renderer2,
+    ChangeDetectorRef
 } from '@angular/core';
 import { fromEvent, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
@@ -89,8 +90,6 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
     private _lineCount: number;
 
     /** @hidden */
-    constructor(private readonly _elementRef: ElementRef, private readonly _renderer: Renderer2) {}
-
     /**
      * Root native element of clamping box
      */
@@ -98,19 +97,26 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
         return this._elementRef.nativeElement;
     }
 
+    constructor(
+        private readonly _elementRef: ElementRef,
+        private readonly _renderer: Renderer2,
+        private readonly _cdRef: ChangeDetectorRef
+    ) {}
+
     /** @hidden */
     ngAfterViewInit(): void {
         this._isNativeSupport = typeof this.rootElement.style.webkitLineClamp !== 'undefined';
 
-        if (this.rootElement) {
+        // need to use setTimeout to force recheck of parent elements
+        setTimeout(() => {
             this._checkLineCount();
+        });
 
-            this.windowResize$ = fromEvent(window, 'resize')
-                .pipe(distinctUntilChanged(), debounceTime(200))
-                .subscribe({
-                    next: () => this._checkLineCount()
-                });
-        }
+        this.windowResize$ = fromEvent(window, 'resize')
+            .pipe(distinctUntilChanged(), debounceTime(200))
+            .subscribe({
+                next: () => this._checkLineCount()
+            });
     }
 
     /** @hidden */


### PR DESCRIPTION
fixes #8867 

Fixes a bug where line clamp directive was not displaying "MORE" text when fd-text elements were placed inside the fd-layout-grid, until after a window resize.

Maybe this is not the best solution - I initially thought some sort of eventing (from line clamp to fd-text to fd-layout-grid, and back) could be more performant, but would introduce coupling between unrelated components. So I am open to suggestions.