### PR TITLE
fix(platform): wizard generator hidden form groups visible

### DIFF
--- a/libs/platform/src/lib/wizard-generator/components/wizard-generator-step/wizard-generator-step.component.ts
+++ b/libs/platform/src/lib/wizard-generator/components/wizard-generator-step/wizard-generator-step.component.ts
@@ -197,18 +197,15 @@ export class WizardGeneratorStepComponent implements OnInit, OnDestroy, OnChange
     }
 
     /**
-     * @returns Step submitted forms values.
+     * Returns visible forms in the step.
      */
-    getFormValues(): WizardStepSubmittedForms {
-        return this._submittedForms;
-    }
-
-    /**
-     *
-     * @returns component
-     */
-    getForms(): WizardStepForms {
-        return this._forms;
+    getVisibleForms(): WizardStepForms {
+        return Object.keys(this._forms).reduce((acc, key) => {
+            if (this._visibleFormGroupIds[key] || this._visibleFormGroupIds[key] === undefined) {
+                acc[key] = this._forms[key];
+            }
+            return acc;
+        }, {});
     }
 
     /**

--- a/libs/platform/src/lib/wizard-generator/components/wizard-summary-step/wizard-summary-step.component.ts
+++ b/libs/platform/src/lib/wizard-generator/components/wizard-summary-step/wizard-summary-step.component.ts
@@ -110,7 +110,7 @@ export class WizardSummaryStepComponent {
 
         for (const step of this._wizardSteps) {
             const component = this._wizardGeneratorService.stepsComponents.get(step.id);
-            const componentForms = component?.getForms();
+            const componentForms = component?.getVisibleForms();
 
             if (!componentForms) {
                 continue;

--- a/libs/platform/src/lib/wizard-generator/wizard-generator.service.ts
+++ b/libs/platform/src/lib/wizard-generator/wizard-generator.service.ts
@@ -342,9 +342,13 @@ export class WizardGeneratorService {
                 continue;
             }
 
-            const forms = component.getForms();
+            const forms = component.getVisibleForms();
 
             for (const form of item?.formGroups ?? []) {
+                if (!forms[form.id]) {
+                    continue;
+                }
+
                 wizardFormValue[item.id][form.id] = formatted
                     ? await this._formGeneratorService.getFormValue(forms[form.id]?.form)
                     : this._formGeneratorService._getFormValueWithoutUngrouped(cloneDeep(forms[form.id]?.form.value));


### PR DESCRIPTION
## Related Issue(s)

Refers to DXP.
Closes https://github.com/SAP/fundamental-ngx/issues/8728

## Description

Fix for the issue when hidden form groups being shown on the summary step and in the resulting object.

Prerequisite
<img width="792" alt="Screenshot 2022-10-24 at 15 04 42" src="https://user-images.githubusercontent.com/20265336/197533469-02bddc56-8541-4bec-aafe-528d5e25fb7b.png">

## Screenshots

### Before:
<img width="674" alt="Screenshot 2022-10-24 at 15 04 51" src="https://user-images.githubusercontent.com/20265336/197533517-33acb2ae-9f0a-4e1e-9038-3da781fb4306.png">

### After:
<img width="674" alt="Screenshot 2022-10-24 at 15 09 20" src="https://user-images.githubusercontent.com/20265336/197533528-6c721fda-8a18-4d12-9e0f-fb722ebf54cf.png">
