### PR TITLE
fix(core): set touched state of segmented-button on click/key down

### DIFF
--- a/libs/core/src/lib/segmented-button/segmented-button.component.ts
+++ b/libs/core/src/lib/segmented-button/segmented-button.component.ts
@@ -40,7 +40,7 @@ export type SegmentedButtonValue = string | (string | null)[] | null;
     styleUrls: ['./segmented-button.component.scss'],
     host: {
         role: 'group',
-        '(focusout)': '_focusOut($event)'
+        '(click)': '_click($event)'
     },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -129,7 +129,7 @@ export class SegmentedButtonComponent implements AfterContentInit, ControlValueA
     }
 
     /** @hidden */
-    private _focusOut(event: FocusEvent): void {
+    private _click(event: MouseEvent): void {
         if (!this._elementRef.nativeElement.contains(event.relatedTarget)) {
             this.onTouched();
         }
@@ -159,7 +159,10 @@ export class SegmentedButtonComponent implements AfterContentInit, ControlValueA
             fromEvent(htmlElement, 'click'),
             fromEvent<KeyboardEvent>(htmlElement, 'keydown').pipe(
                 filter((event) => KeyUtil.isKeyCode(event, [ENTER, SPACE])),
-                tap((event) => event.preventDefault())
+                tap((event) => {
+                    event.preventDefault();
+                    this.onTouched();
+                })
             )
         );
 


### PR DESCRIPTION
## Related Issue(s)

closes #8791 

## Description

Set touched state of segmented-button on click and  `space`/`enter `keydown.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
Gets touched state on blur:
![msedge_DZQBUpMpUA](https://user-images.githubusercontent.com/65063487/198137661-63faa141-2ffc-433b-8517-75b604cb1b9f.gif)

### After:
Gets touched state on click or  `space`/`enter `keydown:
![msedge_7jtc2xOnGX](https://user-images.githubusercontent.com/65063487/198140813-54a73dd1-37c9-4695-8966-e9e2c290b3e5.gif)
