### PR TITLE
fix(e2e): removing cross-env from e2e workflow

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -8,8 +8,5 @@
         "target": "esnext",
         "types": ["node", "webdriverio/async", "@wdio/jasmine-framework", "wdio-image-comparison-service", "axe-core"]
     },
-    "ts-node": {
-        "require": ["tsconfig-paths/register"]
-    },
     "includes": ["wdio/**/*.ts"]
 }

--- a/e2e/wdio.base-config.js
+++ b/e2e/wdio.base-config.js
@@ -1,9 +1,16 @@
 /* eslint-disable no-undef */
+const tsConfig = require('../tsconfig.base.json');
+const tsNode = require('ts-node');
+const tsConfigPaths = require('tsconfig-paths');
+const allureReporter = require('@wdio/allure-reporter').default;
+
 module.exports = ({ runner, specs, projectName }) => {
-    require('ts-node').register({ transpileOnly: true, files: true, project: './e2e/tsconfig.json' });
-    const AllureReporter = require('@wdio/allure-reporter').default;
+    tsNode.register({ transpileOnly: true, files: true, project: './e2e/tsconfig.json' });
+    tsConfigPaths.register({ baseUrl: './', paths: tsConfig.compilerOptions.paths });
+
     runner = runner || 'local';
     projectName = projectName.split(':').join('/');
+
     return {
         runner,
         specs,
@@ -80,7 +87,7 @@ module.exports = ({ runner, specs, projectName }) => {
         afterTest: async function (test, context, { error, result, duration, passed, retries }) {
             if (error !== undefined) {
                 const html = await browser.getPageSource();
-                AllureReporter.addAttachment('page.html', html, 'text/html');
+                allureReporter.addAttachment('page.html', html, 'text/html');
             }
         }
     };

--- a/libs/plugins/wdio/executors/utils/run-wdio.ts
+++ b/libs/plugins/wdio/executors/utils/run-wdio.ts
@@ -15,7 +15,7 @@ module.exports.config = require('./e2e/wdio.base-config.js')({
 `
     );
     const flags = ` ${baseUrl ? `--baseUrl ${baseUrl}` : ''}`;
-    const command = `npx cross-env TS_NODE_PROJECT=./e2e/tsconfig.json npx wdio ${wdioConfig} ${flags}`;
+    const command = `npx wdio ${wdioConfig} ${flags}`;
     logger.info(`Running command ${command}`);
     return new Promise((resolve, reject) => {
         const testProcess = spawn(command, [], { shell: true });


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

Removing `cross-env` package usage from e2e ci workflow to get rid of the following error

```
sh: 1: cross-env: Permission denied
```
