### PR TITLE
fix(core): dialog's fund-styles refactoring adoption

### DIFF
--- a/libs/core/src/lib/dialog/dialog.component.html
+++ b/libs/core/src/lib/dialog/dialog.component.html
@@ -15,12 +15,10 @@
     [class.fd-dialog__content--m]="dialogPaddingSize === 'md'"
     [class.fd-dialog__content--l]="dialogPaddingSize === 'lg'"
     [class.fd-dialog__content--xl]="dialogPaddingSize === 'xl'"
-    [class.fd-dialog__content--mobile]="dialogConfig.mobile"
-    [class.fd-dialog__content--full-screen]="dialogConfig.fullScreen"
+    [class.fd-dialog__content--mobile]="dialogConfig.mobile || dialogConfig.fullScreen"
     [class.fd-dialog__content--no-mobile-stretch]="dialogConfig.mobileOuterSpacing"
     [class.fd-dialog__content--draggable-grab]="dialogConfig.draggable && !isDragged"
     [class.fd-dialog__content--draggable-grabbing]="dialogConfig.draggable && isDragged"
-    [class.fd-dialog__content--with-header]="headerWrapper.children.length"
     [cdkDragDisabled]="!dialogConfig.draggable"
     [fdResizeDisabled]="!dialogConfig.resizable"
     [@dialog-fade]
@@ -35,7 +33,7 @@
 >
     <span fdResizeHandle *ngIf="dialogConfig.resizable" class="fd-dialog__resize-handle"></span>
 
-    <div #headerWrapper cdkDragHandle [cdkDragHandleDisabled]="!dialogConfig.draggable">
+    <div cdkDragHandle [cdkDragHandleDisabled]="!dialogConfig.draggable">
         <ng-content select="fd-dialog-header"></ng-content>
     </div>
 

--- a/libs/core/src/lib/dialog/dialog.component.scss
+++ b/libs/core/src/lib/dialog/dialog.component.scss
@@ -7,24 +7,3 @@
 .fd-dialog__resize-handle {
     z-index: 1001;
 }
-
-.fd-dialog__content {
-    &--full-screen {
-        width: 100vw;
-        height: 100vh;
-        max-width: 100vw;
-        max-height: 100vh;
-    }
-
-    &--with-header {
-        .fd-dialog__body {
-            border-top-left-radius: 0;
-            border-top-right-radius: 0;
-        }
-    }
-
-    .fd-dialog__body--no-horizontal-padding {
-        padding-left: 0;
-        padding-right: 0;
-    }
-}

--- a/libs/core/src/lib/dialog/dialog.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog.component.spec.ts
@@ -163,15 +163,6 @@ describe('DialogComponent', () => {
         expect(fixture.nativeElement.querySelector('.fd-dialog__content')).toHaveClass('fd-dialog__content--mobile');
     });
 
-    it('should display in mobile mode', async () => {
-        const customDialogConfig = { ...new DialogConfig(), fullScreen: true };
-        await setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);
-
-        expect(fixture.nativeElement.querySelector('.fd-dialog__content')).toHaveClass(
-            'fd-dialog__content--full-screen'
-        );
-    });
-
     it('should display in mobile mode with no stretch', async () => {
         const customDialogConfig = { ...new DialogConfig(), mobileOuterSpacing: true };
         await setup([{ token: DialogConfig, provider: { useValue: customDialogConfig } }]);

--- a/libs/core/src/lib/dialog/utils/dialog-config.class.ts
+++ b/libs/core/src/lib/dialog/utils/dialog-config.class.ts
@@ -9,7 +9,7 @@ export const DIALOG_DEFAULT_CONFIG = new InjectionToken<DialogConfig>('Default D
 
 @Injectable()
 export class DialogConfig<T = any> extends DialogConfigBase<T> {
-    /** Whether the dialog should be displayed in full screen mode. */
+    /** @deprecated Use 'mobile' to set the dialog to full-screen mode. */
     fullScreen?: boolean;
 
     /** Whether the dialog should be draggable. */

--- a/libs/docs/core/dialog/e2e/dialog-contents.ts
+++ b/libs/docs/core/dialog/e2e/dialog-contents.ts
@@ -10,7 +10,6 @@ export const mobileProperty = 'fd-dialog__content--mobile';
 export const defaultPrice = 'Total price: 0€';
 export const customClass = 'custom';
 export const outlineProperty = 'outline-style';
-export const fullscreenClass = 'full-screen';
 export const mobileClass = 'mobile';
 export const noMobileSpacingClass = 'no-mobile-stretch';
 export const topPaddingProperty = 'padding-top';

--- a/libs/docs/core/dialog/e2e/dialog.e2e-spec.ts
+++ b/libs/docs/core/dialog/e2e/dialog.e2e-spec.ts
@@ -39,7 +39,6 @@ import {
     dismissedStatus,
     emptyValuesArr,
     escapeStatus,
-    fullscreenClass,
     mobileClass,
     mobileProperty,
     noMobileSpacingClass,
@@ -379,18 +378,6 @@ describe('dialog test suite', () => {
             await sendKeys('Escape');
 
             await expect(await doesItExist(dialog)).toBe(true, 'dialog is closed when it should be open');
-        });
-
-        it('should check dialog fullScreen option', async () => {
-            await openDialog(playgroundDialog);
-
-            await expect(await getAttributeByName(dialogContainer2, classAttribute)).not.toContain(fullscreenClass);
-
-            await closeDialog();
-            await click(playgroundDialog + checkboxes, 4);
-            await openDialog(playgroundDialog);
-
-            await expect(await getAttributeByName(dialogContainer2, classAttribute)).toContain(fullscreenClass);
         });
 
         it('should check dialog mobile option', async () => {


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

In https://github.com/SAP/fundamental-styles/pull/3957 refactoring of the dialog was done, so we can get rid of some hardcoded styles.

## Screenshots

No visual changes.