### PR TITLE
fix(core,platform): schematics and deps

### DIFF
--- a/libs/core/schematics/migrations/migration-0-37/index.ts
+++ b/libs/core/schematics/migrations/migration-0-37/index.ts
@@ -19,10 +19,27 @@ function removeStylesFromConfig(): Rule {
                         return;
                     }
 
+                    const themes = [
+                        'sap_horizon',
+                        'sap_horizon_dark',
+                        'sap_horizon_hcb',
+                        'sap_horizon_hcw',
+                        'sap_fiori_3',
+                        'sap_fiori_3_dark',
+                        'sap_fiori_3_hcb',
+                        'sap_fiori_3_hcw',
+                        'sap_fiori_3_light_dark'
+                    ];
+
                     const stylesToRemove = [
                         'node_modules/fundamental-styles/dist/icon.css',
                         './node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_fiori_3/css_variables.css',
-                        './node_modules/fundamental-styles/dist/theming/sap_fiori_3.css'
+                        './node_modules/fundamental-styles/dist/theming/sap_fiori_3.css',
+                        ...themes.map(
+                            (theme) =>
+                                `./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/${theme}/css_variables.css`
+                        ),
+                        ...themes.map((theme) => `./node_modules/fundamental-styles/dist/theming/${theme}.css`)
                     ];
 
                     stylesToRemove.forEach((styleToRemove) => {

--- a/libs/core/schematics/ng-add/index.ts
+++ b/libs/core/schematics/ng-add/index.ts
@@ -234,14 +234,14 @@ function addAssetsToConfig(options: Schema): Rule {
 function addTheming(options: Schema): Rule {
     return (tree, context) =>
         updateWorkspace(async (workspace) => {
+            if (options.theme === 'custom') {
+                return;
+            }
+
             context.logger.info(
                 `⚠️ Currently, we don't automatically remove the deprecated Themes approach. If you have it applied you have to remove it by yourself.
 [Instructions: https://sap.github.io/fundamental-ngx/#/core/theming]`
             );
-
-            if (options.theme === 'custom') {
-                return;
-            }
 
             const targetOptions = getProjectTargetOptions(workspace.projects.get(options.project)!, 'build');
             const styles = targetOptions.styles as (string | { input: string })[];

--- a/libs/core/src/lib/ng-package.json
+++ b/libs/core/src/lib/ng-package.json
@@ -2,7 +2,7 @@
     "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
     "dest": "../../../../dist/libs/core",
     "deleteDestPath": true,
-    "assets": ["./assets/**/*"],
+    "assets": ["./assets/**/*", "./styles/*.*"],
     "lib": {
         "entryFile": "./public_api.ts"
     },

--- a/libs/core/src/lib/package.json
+++ b/libs/core/src/lib/package.json
@@ -17,6 +17,7 @@
   },
   "peerDependencies": {
     "@angular/common": "ANGULAR_VER_PLACEHOLDER",
+    "@angular/platform-browser": "ANGULAR_VER_PLACEHOLDER",
     "@angular/core": "ANGULAR_VER_PLACEHOLDER",
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
     "@angular/animations": "ANGULAR_VER_PLACEHOLDER",

--- a/libs/core/src/lib/package.json
+++ b/libs/core/src/lib/package.json
@@ -35,8 +35,8 @@
     "compare-versions": "COMPARE_VERSIONS_VER_PLACEHOLDER"
   },
   "exports": {
-    ".": {
-      "sass": "./styles/fundamental-ngx-core.scss"
+    "./styles/fundamental-ngx-core.css": {
+      "style": "./styles/fundamental-ngx-core.css"
     }
   }
 }

--- a/libs/cx/src/lib/package.json
+++ b/libs/cx/src/lib/package.json
@@ -14,6 +14,7 @@
   },
   "peerDependencies": {
     "@angular/common": "ANGULAR_VER_PLACEHOLDER",
+    "@angular/platform-browser": "ANGULAR_VER_PLACEHOLDER",
     "@angular/core": "ANGULAR_VER_PLACEHOLDER",
     "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
     "@angular/animations": "ANGULAR_VER_PLACEHOLDER",

--- a/libs/datetime-adapter/package.json
+++ b/libs/datetime-adapter/package.json
@@ -15,8 +15,6 @@
         "postbuild": "npm run && npm run copy:collection"
       },
     "peerDependencies": {
-        "@angular/common": "ANGULAR_VER_PLACEHOLDER",
-        "@angular/core": "ANGULAR_VER_PLACEHOLDER",
         "@fundamental-ngx/core": "VERSION_PLACEHOLDER",
         "dayjs": "DAYJS_VER_PLACEHOLDER"
     },

--- a/libs/moment-adapter/package.json
+++ b/libs/moment-adapter/package.json
@@ -16,8 +16,6 @@
     "postbuild": "npm run && npm run copy:collection"
   },
   "peerDependencies": {
-    "@angular/common": "ANGULAR_VER_PLACEHOLDER",
-    "@angular/core": "ANGULAR_VER_PLACEHOLDER",
     "@fundamental-ngx/core": "VERSION_PLACEHOLDER",
     "moment": "^2.18.1"
   },

--- a/libs/platform/src/lib/package.json
+++ b/libs/platform/src/lib/package.json
@@ -13,15 +13,6 @@
     "node": ">= 10"
   },
   "peerDependencies": {
-    "@angular/common": "ANGULAR_VER_PLACEHOLDER",
-    "@angular/core": "ANGULAR_VER_PLACEHOLDER",
-    "@angular/forms": "ANGULAR_VER_PLACEHOLDER",
-    "@angular/animations": "ANGULAR_VER_PLACEHOLDER",
-    "@angular/router": "ANGULAR_VER_PLACEHOLDER",
-    "@angular/cdk": "ANGULAR_VER_PLACEHOLDER",
-    "rxjs": "RXJS_VER_PLACEHOLDER",
-    "fundamental-styles": "FDSTYLES_VER_PLACEHOLDER",
-    "@sap-theming/theming-base-content": "THEMING_VER_PLACEHOLDER",
     "@fundamental-ngx/core": "VERSION_PLACEHOLDER"
   },
   "dependencies": {


### PR DESCRIPTION
## Related Issue(s)

Closes none, 
Follows-up https://github.com/SAP/fundamental-ngx/pull/8479

## Description

* fix: schematics migration issue when previously set theme CSS files hasn't been removed.
* fix: issue when `fundamental-ngx-core.css` hasn't been included in the build.
* fix: deps issue.

  *Deps error*
  ```
  ./node_modules/@fundamental-ngx/core/node_modules/@angular/platform-browser/fesm2020/platform-browser.mjs:1318:9-38 - Error: export 'ɵinternalBootstrapApplication' (imported as 'ɵinternalBootstrapApplication') was not found in '@angular/core' (possible exports: ANALYZE_FOR_ENTRY_COMPONENTS...
  ```