### PR TITLE
chore(core,platform): bump styles to 0.26.0-rc.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "fast-deep-equal": "3.1.3",
     "focus-trap": "6.7.3",
     "focus-visible": "5.2.0",
-    "fundamental-styles": "0.25.1-rc.16",
+    "fundamental-styles": "0.26.0-rc.5",
     "highlight.js": "10.7.2",
     "intl": "1.2.5",
     "jasminewd2": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9254,6 +9254,11 @@ fundamental-styles@0.25.1-rc.16:
   resolved "https://registry.yarnpkg.com/fundamental-styles/-/fundamental-styles-0.25.1-rc.16.tgz#8560a5e1411ac3dfbf6d593ba4cd7b1f3124f3d5"
   integrity sha512-/ETPbzv98pMtqT5nNODkamxDBJsDPJ4KG/f5XEAvExvdx0+IvESuZQES6n1F3He1o1zMGLJj4HVqp4UJFiRGsQ==
 
+fundamental-styles@0.26.0-rc.5:
+  version "0.26.0-rc.5"
+  resolved "https://registry.yarnpkg.com/fundamental-styles/-/fundamental-styles-0.26.0-rc.5.tgz#0bde3e505c8606e542db78963d21c3e3670a656a"
+  integrity sha512-tdLIztvrx4jmxILdKiv/s0lApKfWN1p92uYFgNk2edpgqqpkP2rfwyHldSZnNQqc2ALaxZatM3zW9AdrhwxZnQ==
+
 gauge@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

Recently a new minor version of fund-styles was released, so we have to bump the version manually to process breaking changes.

Breaking changes were related to applying `fd-button--toggled` in segmented button component. Luckily, we're already doing things in the right way, nothing needed to be updated.

