### PR TITLE
feat(core): add scrollbar to menu

### DIFF
--- a/libs/core/src/lib/action-sheet/action-sheet.component.html
+++ b/libs/core/src/lib/action-sheet/action-sheet.component.html
@@ -7,6 +7,7 @@
     [focusTrapped]="true"
     [triggers]="[]"
     [focusAutoCapture]="true"
+    [tabbableScrollbar]="false"
 >
     <fd-popover-control>
         <ng-container *ngTemplateOutlet="actionSheetControl"></ng-container>

--- a/libs/core/src/lib/menu/menu.component.html
+++ b/libs/core/src/lib/menu/menu.component.html
@@ -3,8 +3,6 @@
 <ng-template #menuRootTemplate>
     <nav
         class="fd-menu"
-        fdInitialFocus
-        [enabled]="focusTrapped"
         [id]="id"
         [attr.aria-labelledby]="ariaLabelledby"
         [attr.aria-label]="ariaLabel"

--- a/libs/core/src/lib/menu/menu.component.scss
+++ b/libs/core/src/lib/menu/menu.component.scss
@@ -10,9 +10,3 @@ fd-menu {
         flex-wrap: nowrap;
     }
 }
-
-.fd-popover--menu {
-    .fd-scrollbar {
-        overflow: visible !important;
-    }
-}

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -72,6 +72,17 @@ export class MenuComponent
     @Input()
     focusTrapped = true;
 
+    /**
+     * Whether the popover should automatically move focus into the trapped region upon
+     * initialization and return focus to the previous activeElement upon destruction.
+     */
+    @Input()
+    focusAutoCapture = true;
+
+    /** Should fd-scrollbar have tabindex*/
+    @Input()
+    tabbableScrollbar = false;
+
     /** Open submenu on hover after given milliseconds */
     @Input()
     openOnHoverTime = 0;

--- a/libs/core/src/lib/menu/menu.component.ts
+++ b/libs/core/src/lib/menu/menu.component.ts
@@ -283,13 +283,17 @@ export class MenuComponent
     private _listenOnMenuItemsChange(): void {
         this._subscriptions.add(this._menuItems.changes.subscribe(() => this._menuService.rebuildMenu()));
 
+        // Whether menu have submenu or not.
+        let isSubmenu = false;
         this._menuItems.forEach((menuItem) => {
             if (menuItem.submenu?.menuItems) {
+                isSubmenu = true;
                 this._subscriptions.add(
                     menuItem.submenu._menuItemsChange$.subscribe(() => this._menuService.rebuildMenu())
                 );
             }
         });
+        this.disableScrollbar = isSubmenu;
     }
 
     /**

--- a/libs/core/src/lib/popover/base/base-popover.class.ts
+++ b/libs/core/src/lib/popover/base/base-popover.class.ts
@@ -33,6 +33,10 @@ export class BasePopoverClass {
     @Input()
     closeOnEscapeKey = true;
 
+    /** Whether to wrap content with fd-scrollbar directive. */
+    @Input()
+    disableScrollbar = false;
+
     /**
      * The placement of the popover.
      * It can be one of:

--- a/libs/core/src/lib/popover/base/base-popover.class.ts
+++ b/libs/core/src/lib/popover/base/base-popover.class.ts
@@ -37,6 +37,10 @@ export class BasePopoverClass {
     @Input()
     disableScrollbar = false;
 
+    /** Should fd-scrollbar have tabindex*/
+    @Input()
+    tabbableScrollbar = true;
+
     /**
      * The placement of the popover.
      * It can be one of:

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.html
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.html
@@ -9,7 +9,7 @@
     [style.min-width.px]="_popoverBodyMinWidth"
     [style.width.px]="_popoverBodyWidth"
 >
-    <div fd-scrollbar *ngIf="!_disableScrollbar; else rendererWithoutScrollbar">
+    <div fd-scrollbar [overrideTabindex]="_tabbableScrollbar" *ngIf="!_disableScrollbar; else rendererWithoutScrollbar">
         <ng-container *ngTemplateOutlet="renderer"></ng-container>
     </div>
 </div>

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.html
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.html
@@ -9,7 +9,7 @@
     [style.min-width.px]="_popoverBodyMinWidth"
     [style.width.px]="_popoverBodyWidth"
 >
-    <div fd-scrollbar *ngIf="!disableScrollbar; else rendererWithoutScrollbar">
+    <div fd-scrollbar *ngIf="!_disableScrollbar; else rendererWithoutScrollbar">
         <ng-container *ngTemplateOutlet="renderer"></ng-container>
     </div>
 </div>

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.ts
@@ -47,6 +47,9 @@ export class PopoverBodyComponent {
     /** Whether to wrap content with fd-scrollbar directive. */
     _disableScrollbar = false;
 
+    /** Should fd-scrollbar have tabindex*/
+    _tabbableScrollbar = true;
+
     /** @hidden */
     @ViewChild(CdkTrapFocus)
     _cdkTrapFocus: CdkTrapFocus;

--- a/libs/core/src/lib/popover/popover-body/popover-body.component.ts
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.ts
@@ -4,7 +4,6 @@ import {
     Component,
     ElementRef,
     HostListener,
-    Input,
     Renderer2,
     TemplateRef,
     ViewChild,
@@ -46,8 +45,7 @@ import { ContentDensityObserver, contentDensityObserverProviders } from '@fundam
 })
 export class PopoverBodyComponent {
     /** Whether to wrap content with fd-scrollbar directive. */
-    @Input()
-    disableScrollbar = false;
+    _disableScrollbar = false;
 
     /** @hidden */
     @ViewChild(CdkTrapFocus)

--- a/libs/core/src/lib/popover/popover-service/popover.service.ts
+++ b/libs/core/src/lib/popover/popover-service/popover.service.ts
@@ -407,6 +407,7 @@ export class PopoverService extends BasePopoverClass {
         body._noArrow = this.noArrow;
         body._focusAutoCapture = this.focusAutoCapture;
         body._disableScrollbar = this.disableScrollbar;
+        body._tabbableScrollbar = this.tabbableScrollbar;
         body._templateToDisplay = this.templateContent!;
         body._closeOnEscapeKey = this.closeOnEscapeKey;
         this._detectChanges();

--- a/libs/core/src/lib/popover/popover-service/popover.service.ts
+++ b/libs/core/src/lib/popover/popover-service/popover.service.ts
@@ -406,6 +406,7 @@ export class PopoverService extends BasePopoverClass {
         body._maxWidth = this.maxWidth;
         body._noArrow = this.noArrow;
         body._focusAutoCapture = this.focusAutoCapture;
+        body._disableScrollbar = this.disableScrollbar;
         body._templateToDisplay = this.templateContent!;
         body._closeOnEscapeKey = this.closeOnEscapeKey;
         this._detectChanges();

--- a/libs/docs/core/menu/examples/menu-scrollbar-example.component.html
+++ b/libs/docs/core/menu/examples/menu-scrollbar-example.component.html
@@ -1,19 +1,9 @@
 <button fd-button label="Menu" [fdMenuTrigger]="menu"></button>
 
 <fd-menu #menu>
-    <li fd-menu-item>
+    <li fd-menu-item *ngFor="let option of options">
         <a href="#" fd-menu-interactive>
             <span fd-menu-title>Option 1</span>
-        </a>
-    </li>
-    <li fd-menu-item>
-        <a href="#" fd-menu-interactive>
-            <span fd-menu-title>Option 2</span>
-        </a>
-    </li>
-    <li fd-menu-item>
-        <a href="#" fd-menu-interactive>
-            <span fd-menu-title>Option 3</span>
         </a>
     </li>
 </fd-menu>

--- a/libs/docs/core/menu/examples/menu-scrollbar-example.component.html
+++ b/libs/docs/core/menu/examples/menu-scrollbar-example.component.html
@@ -1,0 +1,19 @@
+<button fd-button label="Menu" [fdMenuTrigger]="menu"></button>
+
+<fd-menu #menu>
+    <li fd-menu-item>
+        <a href="#" fd-menu-interactive>
+            <span fd-menu-title>Option 1</span>
+        </a>
+    </li>
+    <li fd-menu-item>
+        <a href="#" fd-menu-interactive>
+            <span fd-menu-title>Option 2</span>
+        </a>
+    </li>
+    <li fd-menu-item>
+        <a href="#" fd-menu-interactive>
+            <span fd-menu-title>Option 3</span>
+        </a>
+    </li>
+</fd-menu>

--- a/libs/docs/core/menu/examples/menu-scrollbar-example.component.ts
+++ b/libs/docs/core/menu/examples/menu-scrollbar-example.component.ts
@@ -4,4 +4,47 @@ import { Component } from '@angular/core';
     selector: 'fd-menu-scrollbar-example',
     templateUrl: './menu-scrollbar-example.component.html'
 })
-export class MenuScrollbarExampleComponent {}
+export class MenuScrollbarExampleComponent {
+    options = [
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option',
+        'Option'
+    ];
+}

--- a/libs/docs/core/menu/examples/menu-scrollbar-example.component.ts
+++ b/libs/docs/core/menu/examples/menu-scrollbar-example.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'fd-menu-scrollbar-example',
+    templateUrl: './menu-scrollbar-example.component.html'
+})
+export class MenuScrollbarExampleComponent {}

--- a/libs/docs/core/menu/menu-docs.component.html
+++ b/libs/docs/core/menu/menu-docs.component.html
@@ -47,6 +47,15 @@
 
 <separator></separator>
 
+<fd-docs-section-title id="scrollbar" componentName="menu"> Menu with Scrollbar </fd-docs-section-title>
+<description>Menu handles overflow using <code>fd-scrollbar</code> </description>
+<component-example>
+    <fd-menu-scrollbar-example></fd-menu-scrollbar-example>
+</component-example>
+<code-example [exampleFiles]="menuScrollbar"></code-example>
+
+<separator></separator>
+
 <fd-docs-section-title id="with-submenu" componentName="menu"> Menu with submenu </fd-docs-section-title>
 <description>
     Each Menu item can have its submenu. To create a submenu, do the following:

--- a/libs/docs/core/menu/menu-docs.component.ts
+++ b/libs/docs/core/menu/menu-docs.component.ts
@@ -7,6 +7,7 @@ const menuAddonHtml = 'menu-addon-example.component.html';
 const menuMobileTs = 'menu-mobile-example.component.ts';
 const menuMobileHtml = 'menu-mobile-example.component.html';
 const menuSeparatorHtml = 'menu-separator-example.component.html';
+const menuScrollbarHtml = 'menu-scrollbar-example.component.html';
 const menuWithSubmenuHtml = 'menu-with-submenu-example.component.html';
 const menuWithSubmenuTs = 'menu-with-submenu-example.component.ts';
 
@@ -35,6 +36,14 @@ export class MenuDocsComponent {
             language: 'html',
             code: getAssetFromModuleAssets(menuSeparatorHtml),
             fileName: 'menu-separator-example'
+        }
+    ];
+
+    menuScrollbar: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(menuScrollbarHtml),
+            fileName: 'menu-scrollbar-example'
         }
     ];
 

--- a/libs/docs/core/menu/menu-docs.module.ts
+++ b/libs/docs/core/menu/menu-docs.module.ts
@@ -14,6 +14,7 @@ import { MenuWithSubmenuExampleComponent } from './examples/menu-with-submenu-ex
 import { DeprecatedMenuCompactDirective, MenuModule } from '@fundamental-ngx/core/menu';
 import { MenuMobileExampleComponent } from './examples/menu-mobile-example.component';
 import { moduleDeprecationsProvider } from '@fundamental-ngx/core/utils';
+import { MenuScrollbarExampleComponent } from './examples/menu-scrollbar-example.component';
 
 const routes: Routes = [
     {
@@ -36,7 +37,8 @@ const routes: Routes = [
         MenuAddonExampleComponent,
         MenuMobileExampleComponent,
         MenuSeparatorExampleComponent,
-        MenuWithSubmenuExampleComponent
+        MenuWithSubmenuExampleComponent,
+        MenuScrollbarExampleComponent
     ],
     providers: [moduleDeprecationsProvider(DeprecatedMenuCompactDirective), currentComponentProvider('menu')]
 })

--- a/libs/platform/src/lib/message-popover/message-popover.component.html
+++ b/libs/platform/src/lib/message-popover/message-popover.component.html
@@ -4,6 +4,7 @@
     *ngIf="_errorTypes.length > 0"
     [focusTrapped]="true"
     [focusAutoCapture]="true"
+    [disableScrollbar]="true"
 >
     <fd-popover-control>
         <button
@@ -15,7 +16,7 @@
             [label]="_priorityStateItemsCount.toString()"
         ></button>
     </fd-popover-control>
-    <fd-popover-body [disableScrollbar]="true">
+    <fd-popover-body>
         <div fd-popover-body-header>
             <div fd-bar barDesign="header" class="fd-bar--growing">
                 <div fd-bar-left>


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #8929 
closes #8969

## Description

feat: Added scrollbar to Menu. (https://github.com/SAP/fundamental-ngx/pull/8964/commits/3e8624c3a5edddf0ad83bf0147611c8e6ad8c251)
feat: Added a property to popover to make `fd-scrollbar` `tabbable` or not. (https://github.com/SAP/fundamental-ngx/pull/8964/commits/84b0f9b6e70c7de2e929fd380efa8a16e948a082)
fix: Made `fd-scrollbar` un-tabbable for popover in Action sheet. So it can focus first element on open. (https://github.com/SAP/fundamental-ngx/pull/8964/commits/2ffb57107b13c7bb59ba6ba6d10311ba58eeb2b0)
fix: Merged logic from https://github.com/SAP/fundamental-ngx/pull/8926 that make use of `focusAutoCapture` to focus first menu-item in Menu instead using `initial-focus` directive, (https://github.com/SAP/fundamental-ngx/pull/8964/commits/7d1317b79094156f2e4f05a69b2d4d35774f40a0)
## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
**Menu:** Without scrollbar

<img src="https://user-images.githubusercontent.com/65063487/202045328-8457a278-5e6d-4194-9dc2-64425e4563d3.png" width="200">

**Action Sheet**: First element is not focused.

![image](https://user-images.githubusercontent.com/65063487/202240506-57986d60-4c86-4eff-aea3-07c0acc40012.png)

### After:
**Menu:** With scrollbar

<img src="https://user-images.githubusercontent.com/65063487/202045333-81c2684c-419b-40cc-9d45-6918912a3776.png" width="200">

**Action Sheet**: Focuses first element.

![image](https://user-images.githubusercontent.com/65063487/202241759-7427b231-0e18-4ea4-ae8e-d920b7dc09fb.png)

