### PR TITLE
fix(core): select custom width & refactoring

### DIFF
--- a/libs/core/src/lib/select/option/option.component.html
+++ b/libs/core/src/lib/select/option/option.component.html
@@ -1,5 +1,3 @@
 <span fd-list-title>
-    <span fd-list-title-text>
-        <ng-content></ng-content>
-    </span>
+    <ng-content></ng-content>
 </span>

--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -1,34 +1,29 @@
 <ng-container *ngTemplateOutlet="mobile ? mobileTemplate : desktopTemplate"></ng-container>
 
 <ng-template #desktopTemplate>
-    <div
-        class="fd-select"
-        [class.fd-select--compact]="_contentDensityObserver.isCompact"
-        (keydown)="_handleKeydown($event)"
-        (click)="toggle()"
+    <!-- @deprecated class fd-popover-custom-list -->
+    <fd-popover
+        additionalBodyClass="fd-select-dropdown fd-popover-custom-list"
+        [isOpen]="_isOpen"
+        [triggers]="[]"
+        [focusTrapped]="true"
+        [disabled]="disabled || readonly"
+        [appendTo]="appendTo"
+        [closeOnEscapeKey]="true"
+        [fillControlMode]="fillControlMode"
+        [maxWidth]="600"
+        [closeOnOutsideClick]="closeOnOutsideClick"
+        (isOpenChange)="_popoverOpenChangeHandle($event)"
     >
-        <fd-popover
-            additionalBodyClass="fd-popover-custom-list"
-            [isOpen]="_isOpen"
-            [triggers]="[]"
-            [focusTrapped]="true"
-            [disabled]="disabled || readonly"
-            [appendTo]="appendTo"
-            [closeOnEscapeKey]="true"
-            [fillControlMode]="fillControlMode"
-            [maxWidth]="600"
-            [closeOnOutsideClick]="closeOnOutsideClick"
-            (isOpenChange)="_popoverOpenChangeHandle($event)"
-        >
-            <fd-popover-control>
-                <ng-container [ngTemplateOutlet]="selectInputControlTemplate"></ng-container>
-            </fd-popover-control>
+        <fd-popover-control>
+            <ng-container [ngTemplateOutlet]="selectInputControlTemplate"></ng-container>
+        </fd-popover-control>
 
-            <fd-popover-body class="fd-popover-custom-select-body">
-                <ng-container [ngTemplateOutlet]="selectOptionsListTemplate"></ng-container>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
+        <!-- @deprecated class fd-popover-custom-select-body -->
+        <fd-popover-body class="fd-popover-custom-select-body">
+            <ng-container [ngTemplateOutlet]="selectOptionsListTemplate"></ng-container>
+        </fd-popover-body>
+    </fd-popover>
 </ng-template>
 
 <ng-template #selectInputControlTemplate>
@@ -110,14 +105,7 @@
 </ng-template>
 
 <ng-template #mobileTemplate>
-    <div
-        class="fd-select"
-        [class.fd-select--compact]="_contentDensityObserver.isCompact"
-        (keydown)="_handleKeydown($event)"
-        (click)="toggle()"
-    >
-        <ng-container [ngTemplateOutlet]="selectInputControlTemplate"></ng-container>
-    </div>
+    <ng-container [ngTemplateOutlet]="selectInputControlTemplate"></ng-container>
 
     <div #dialogContainer></div>
 </ng-template>

--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngTemplateOutlet="mobile ? mobileTemplate : desktopTemplate"></ng-container>
 
 <ng-template #desktopTemplate>
-    <!-- @deprecated class fd-popover-custom-list -->
+    <!-- @deprecated leaving class fd-popover-custom-list to support backwards compatibility-->
     <fd-popover
         additionalBodyClass="fd-select-dropdown fd-popover-custom-list"
         [isOpen]="_isOpen"
@@ -19,7 +19,7 @@
             <ng-container [ngTemplateOutlet]="selectInputControlTemplate"></ng-container>
         </fd-popover-control>
 
-        <!-- @deprecated class fd-popover-custom-select-body -->
+        <!-- @deprecated leaving class fd-popover-custom-select-body to support backwards compatibility-->
         <fd-popover-body class="fd-popover-custom-select-body">
             <ng-container [ngTemplateOutlet]="selectOptionsListTemplate"></ng-container>
         </fd-popover-body>

--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -3,23 +3,15 @@
 
 @include cdk.a11y-visually-hidden();
 
-.fd-popover__body > :first-child {
-    border-radius: 0;
-}
-
-// TODO: Remove after issue on styles addressed.
-.fd-select__text-content {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: 1rem;
+.fd-select {
     display: block;
-}
-
-.fd-select-custom-class {
-    display: inline-block;
     max-width: 100%;
-}
 
-.fd-popover-custom-select-body {
-    max-width: 100%;
+    .fd-popover-custom {
+        min-width: 100%;
+    }
+
+    &--inline {
+        display: inline-block;
+    }
 }

--- a/libs/core/src/lib/select/select.component.spec.ts
+++ b/libs/core/src/lib/select/select.component.spec.ts
@@ -417,7 +417,7 @@ describe('SelectComponent', () => {
             element = fixtureFilter.componentInstance.selectElement;
             fixtureFilter.detectChanges();
 
-            triggerControl = fixtureFilter.nativeElement.querySelector('div.fd-select');
+            triggerControl = fixtureFilter.nativeElement.querySelector('fd-select');
         });
 
         it('should make active second option "bbb" when start typing "b"', fakeAsync(() => {

--- a/libs/core/src/lib/select/select.component.ts
+++ b/libs/core/src/lib/select/select.component.ts
@@ -33,7 +33,7 @@ import { defer, merge, Observable, Subject, Subscription } from 'rxjs';
 import { startWith, switchMap, takeUntil } from 'rxjs/operators';
 
 import { FormStates, Nullable, PopoverFillMode } from '@fundamental-ngx/core/shared';
-import { DynamicComponentService, KeyUtil, RtlService } from '@fundamental-ngx/core/utils';
+import { DynamicComponentService, KeyUtil, ModuleDeprecation, RtlService } from '@fundamental-ngx/core/utils';
 import { MobileModeConfig } from '@fundamental-ngx/core/mobile-mode';
 import { FormItemControl, registerFormItemControl } from '@fundamental-ngx/core/form';
 
@@ -71,9 +71,9 @@ export const SELECT_ITEM_HEIGHT_EM = 4;
         class: 'fd-select',
         '[class.fd-select--inline]': 'inline',
         '[class.fd-select--compact]': '_contentDensityObserver.isCompact',
-        // @deprecated
+        // @deprecated leaving class fd-select-custom-class for backwards compatibility
         '[class.fd-select-custom-class]': 'inline',
-        // @deprecated
+        // @deprecated leaving class fd-select-custom-class--mobile for backwards compatibility
         '[class.fd-select-custom-class--mobile]': 'mobile'
     },
     providers: [
@@ -782,4 +782,15 @@ export class SelectComponent
             injector
         );
     }
+}
+
+export class DeprecatedSelectCSSClasses implements ModuleDeprecation {
+    /** @hidden */
+    message = `Select CSS classes fd-select--compact, fd-select--compact--mobile, fd-popover-custom-select-body, fd-popover-custom-list are deprecated`;
+
+    /** @hidden */
+    alternative = {
+        name: 'Inspect the elements of the Select component to see the new classes',
+        link: ['/core', 'select']
+    };
 }

--- a/libs/core/src/lib/select/select.component.ts
+++ b/libs/core/src/lib/select/select.component.ts
@@ -68,7 +68,12 @@ export const SELECT_ITEM_HEIGHT_EM = 4;
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
+        class: 'fd-select',
+        '[class.fd-select--inline]': 'inline',
+        '[class.fd-select--compact]': '_contentDensityObserver.isCompact',
+        // @deprecated
         '[class.fd-select-custom-class]': 'inline',
+        // @deprecated
         '[class.fd-select-custom-class--mobile]': 'mobile'
     },
     providers: [
@@ -441,6 +446,7 @@ export class SelectComponent
     onTouched = (): void => {};
 
     /** Toggles the open state of the select. */
+    @HostListener('click')
     toggle(): void {
         this._isOpen ? this.close() : this.open();
     }
@@ -648,6 +654,7 @@ export class SelectComponent
     }
 
     /** @hidden */
+    @HostListener('keydown', ['$event'])
     _handleKeydown(event: KeyboardEvent): void {
         if (!this.disabled && !this.readonly) {
             this._isOpen

--- a/libs/docs/core/select/select-docs.module.ts
+++ b/libs/docs/core/select/select-docs.module.ts
@@ -15,7 +15,11 @@ import { SelectSemanticStateExampleComponent } from './examples/select-semantic-
 import { SelectModeExampleComponent } from './examples/select-mode-example/select-mode-example.component';
 import { SelectMobileExampleComponent } from './examples/select-mobile-example/select-mobile-example.component';
 import { SelectCustomComparatorExample } from './examples/select-custom-comparator-example/select-custom-comparator-example.component';
-import { DeprecatedSelectCompactDirective, SelectModule } from '@fundamental-ngx/core/select';
+import {
+    DeprecatedSelectCompactDirective,
+    DeprecatedSelectCSSClasses,
+    SelectModule
+} from '@fundamental-ngx/core/select';
 import { DialogModule } from '@fundamental-ngx/core/dialog';
 import { ListModule } from '@fundamental-ngx/core/list';
 import { FormModule } from '@fundamental-ngx/core/form';
@@ -56,6 +60,10 @@ const routes: Routes = [
         SelectSemanticStateExampleComponent,
         SelectCustomComparatorExample
     ],
-    providers: [moduleDeprecationsProvider(DeprecatedSelectCompactDirective), currentComponentProvider('select')]
+    providers: [
+        moduleDeprecationsProvider(DeprecatedSelectCompactDirective),
+        moduleDeprecationsProvider(DeprecatedSelectCSSClasses),
+        currentComponentProvider('select')
+    ]
 })
 export class SelectDocsModules {}


### PR DESCRIPTION
## Related Issue(s)

Closes https://github.com/SAP/fundamental-ngx/issues/8995
Refers to `dxp/backlog/issues/720`

## Description

Select component fixes & refactoring to be able to set custom width easily.

**Before**
```CSS
.my-custom-select {
  width: 500px;
}

::ng-deep .fd-select .fd-popover-custom {
  min-width: 100%;
}
```

**After**
```CSS
.my-custom-select {
  width: 500px;
}
```

## Screenshots

No visual changes.