### PR TITLE
fix(platform): fixed data source limitation of 5 items in the list

### DIFF
--- a/libs/docs/platform/list/examples/platform-list-border-less-example.component.html
+++ b/libs/docs/platform/list/examples/platform-list-border-less-example.component.html
@@ -1,6 +1,6 @@
 <h3>Imperative Approach</h3>
 <h5>Cozy Mode</h5>
-<fdp-list [noBorder]="true" [dataSource]="_dataSource" id="cozy-list">
+<fdp-list [noBorder]="true" [dataSource]="_itemsArr" id="cozy-list">
     <fdp-standard-list-item *fdpItemDef="let address; let i" [title]="address.name" [ariaLabel]="address.name">
     </fdp-standard-list-item>
 </fdp-list>

--- a/libs/docs/platform/list/examples/platform-list-border-less-example.component.ts
+++ b/libs/docs/platform/list/examples/platform-list-border-less-example.component.ts
@@ -3,13 +3,15 @@ import { Observable, of } from 'rxjs';
 
 import { ListDataSource, DataProvider } from '@fundamental-ngx/platform/shared';
 
-const LIST_ELEMENTS: Address[] = [{ name: 'Name1' }, { name: 'Name2' }, { name: 'Name3' }, { name: 'Name4' }];
+const LIST_ELEMENTS: Address[] = new Array(6).fill(undefined).map((_, i) => ({ name: `Name${i + 1}` }));
+
 @Component({
     selector: 'fdp-platform-list-border-less-example',
     templateUrl: './platform-list-border-less-example.component.html'
 })
 export class PlatformListBorderLessExampleComponent {
     _dataSource = new ListDataSource<Address>(new ListDataProvider());
+    _itemsArr: Address[] = LIST_ELEMENTS;
 }
 // it is from application point of to show as example,they refer internal structurs in general
 export interface Address {

--- a/libs/platform/src/lib/list/list.component.ts
+++ b/libs/platform/src/lib/list/list.component.ts
@@ -365,10 +365,7 @@ export class ListComponent<T> extends CollectionBaseInput implements OnInit, Aft
     private _language: FdLanguage;
 
     /** @hidden */
-    private _canRenderItems$ = new BehaviorSubject(false);
-
-    /** @hidden */
-    private _canRenderItems = this._canRenderItems$.asObservable();
+    private _afterViewInit$ = new BehaviorSubject(false);
 
     /** @hidden */
     constructor(
@@ -426,7 +423,7 @@ export class ListComponent<T> extends CollectionBaseInput implements OnInit, Aft
      * Keyboard manager on list items, set values when passed via array
      */
     ngAfterViewInit(): void {
-        this._canRenderItems$.next(true);
+        this._afterViewInit$.next(true);
         this._keyManager = new FocusKeyManager<BaseListItem>(this.listItems).withWrap();
 
         this._updateListItems();
@@ -655,15 +652,11 @@ export class ListComponent<T> extends CollectionBaseInput implements OnInit, Aft
             .open()
             .pipe(
                 // Set new items when component is fully initiated and all child components are available.
-                switchMap((data) =>
-                    this._canRenderItems.pipe(
-                        filter((canRender) => canRender),
-                        map(() => data)
-                    )
-                ),
+                this._waitForViewInit(),
                 takeUntil(this._destroyed)
             )
             .subscribe((data) => {
+                console.log({ data });
                 this._dsItems = data || [];
                 this.stateChanges.next(this._dsItems);
                 this._setItems();
@@ -841,5 +834,18 @@ export class ListComponent<T> extends CollectionBaseInput implements OnInit, Aft
 
             this.stateChanges.next(item);
         });
+    }
+
+    /** @hidden */
+    private _waitForViewInit<SourceDataType>() {
+        return (source: Observable<SourceDataType>): Observable<SourceDataType> =>
+            source.pipe(
+                switchMap((src) =>
+                    this._afterViewInit$.pipe(
+                        filter((afterViewInit) => afterViewInit),
+                        map(() => src)
+                    )
+                )
+            );
     }
 }

--- a/libs/platform/src/lib/list/list.component.ts
+++ b/libs/platform/src/lib/list/list.component.ts
@@ -656,7 +656,6 @@ export class ListComponent<T> extends CollectionBaseInput implements OnInit, Aft
                 takeUntil(this._destroyed)
             )
             .subscribe((data) => {
-                console.log({ data });
                 this._dsItems = data || [];
                 this.stateChanges.next(this._dsItems);
                 this._setItems();

--- a/libs/platform/src/lib/shared/domain/data-source.ts
+++ b/libs/platform/src/lib/shared/domain/data-source.ts
@@ -264,6 +264,8 @@ export class SearchFieldDataSource<T> extends ComboBoxDataSource<T> {
 
 export class ListDataSource<T> extends ComboBoxDataSource<T> {
     /** @hidden */
+    limitless = true;
+    /** @hidden */
     constructor(public dataProvider: DataProvider<any>) {
         super(dataProvider);
     }


### PR DESCRIPTION
## Related Issue(s)

closes #8996

## Description
`ListDataSource` extends from `ComboBoxDataSource`, which would add limitation to the items. Now ListDataSource is considered to have a limitless amount of the items. If chunking is needed, list has `itemSize`, which will load only certain amount of items