### PR TITLE
fix(platform): dynamic page tabs padding

### DIFF
--- a/libs/core/src/lib/tabs/tab-list.component.scss
+++ b/libs/core/src/lib/tabs/tab-list.component.scss
@@ -4,11 +4,11 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-}
 
-.is-disabled {
-    pointer-events: none;
-    opacity: 0.4;
+    .is-disabled {
+        pointer-events: none;
+        opacity: 0.4;
+    }
 }
 
 .fd-tabs {
@@ -59,33 +59,5 @@
                 }
             }
         }
-    }
-}
-
-// Temporary solution until the next styles release
-.fd-tabs__item--success .fd-tabs__link .fd-tabs__tag {
-    color: #107e3e;
-    color: var(--sapSuccessColor, #107e3e);
-}
-.fd-tabs__item--error .fd-tabs__link .fd-tabs__tag {
-    color: #b00;
-    color: var(--sapErrorColor, #b00);
-}
-.fd-tabs__item--warning .fd-tabs__link .fd-tabs__tag {
-    color: #e9730c;
-    color: var(--sapWarningColor, #e9730c);
-}
-.fd-tabs__item--information .fd-tabs__link .fd-tabs__tag {
-    color: #0a6ed1;
-    color: var(--sapInformationColor, #0a6ed1);
-}
-.fd-tabs__item--neutral .fd-tabs__link .fd-tabs__tag {
-    border-right-color: #6a6d70;
-    border-right-color: var(--sapNeutralBorderColor, #6a6d70);
-}
-.fd-tabs--filter .fd-tabs__link.is-selected {
-    &::after {
-        background-color: #0854a0;
-        background-color: var(--fdTabs_Selected_Color, var(--sapSelectedColor, #0854a0));
     }
 }

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
@@ -14,12 +14,13 @@ import {
     OnDestroy,
     Output,
     QueryList,
+    ViewChild,
     ViewChildren,
     ViewEncapsulation
 } from '@angular/core';
 import { startWith } from 'rxjs/operators';
 
-import { TabPanelComponent } from '@fundamental-ngx/core/tabs';
+import { TabListComponent, TabPanelComponent } from '@fundamental-ngx/core/tabs';
 import { Nullable } from '@fundamental-ngx/core/shared';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
 import { DynamicPageBackgroundType, DynamicPageResponsiveSize } from './constants';
@@ -124,6 +125,10 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
     @ContentChildren(DynamicPageContentComponent, { descendants: true })
     contentComponents: QueryList<DynamicPageContentComponent>;
 
+    /** @hidden */
+    @ViewChild(TabListComponent)
+    _tabListComponent: TabListComponent;
+
     /** Reference to tab items components */
     @ViewChildren(TabPanelComponent)
     dynamicPageTabs: QueryList<TabPanelComponent>;
@@ -157,6 +162,8 @@ export class DynamicPageComponent extends BaseComponent implements AfterContentI
     /** @hidden */
     ngAfterViewInit(): void {
         this._cd.detectChanges();
+
+        this._tabListComponent?.headerContainer.nativeElement.classList.add('fd-dynamic-page__tabs');
     }
 
     /** @hidden */


### PR DESCRIPTION
PR in styles https://github.com/SAP/fundamental-styles/pull/4058

## Related Issue(s)

Closes https://github.com/SAP/fundamental-ngx/issues/8011
Refers to `dxp/organization/issues/87`

## Description

Tabs in fdp dynamic page padding issue fix.

## Screenshots

### Before:

<img width="154" alt="CleanShot 2022-11-30 at 11 07 49@2x" src="https://user-images.githubusercontent.com/20265336/204767914-e112aa8c-adac-4039-a610-21322e97f96d.png">

### After:

<img width="167" alt="CleanShot 2022-11-30 at 11 41 26@2x" src="https://user-images.githubusercontent.com/20265336/204775180-1dbce6e7-c350-47ce-8e89-93bc1a4f6552.png">


