### PR TITLE
feat(docs): added pure example file type

### DIFF
--- a/libs/docs/shared/src/lib/core-helpers/code-example/example-file.ts
+++ b/libs/docs/shared/src/lib/core-helpers/code-example/example-file.ts
@@ -6,6 +6,7 @@ export interface ExampleFile<
     code: ProvidedCodeType;
     scssFileCode?: ProvidedScssCodeType;
     standalone?: boolean;
+    pure?: boolean;
     language: string;
     fileName?: string;
     entryComponent?: boolean;

--- a/libs/docs/shared/src/lib/core-helpers/stackblitz/stackblitz.service.ts
+++ b/libs/docs/shared/src/lib/core-helpers/stackblitz/stackblitz.service.ts
@@ -96,7 +96,9 @@ export class StackblitzService {
 
             if (generatedFiles?.ts) {
                 defaultProjectInfo.files[generatedFiles.ts.path] = generatedFiles.ts.code;
-                stackBlitzFiles.push(this.getStackBlitzTsFile(example, mainComponent));
+                if (!example.pure) {
+                    stackBlitzFiles.push(this.getStackBlitzTsFile(example, mainComponent));
+                }
             }
         }
 
@@ -159,11 +161,14 @@ export class ${componentName} {}`;
     private getFileBasis(file: ExampleFile): string {
         if (file.service) {
             return file.fileName + '.service';
-        } else if (file.pipe) {
-            return file.fileName + '.pipe';
-        } else {
-            return file.fileName + '.component';
         }
+        if (file.pipe) {
+            return file.fileName + '.pipe';
+        }
+        if (file.pure) {
+            return file.fileName + '';
+        }
+        return file.fileName + '.component';
     }
 
     /** this function transform that-word, or that_word to ThatWord */

--- a/libs/docs/shared/src/lib/getAsset.ts
+++ b/libs/docs/shared/src/lib/getAsset.ts
@@ -31,7 +31,7 @@ export const getExampleFile = (exampleFileName: string, exampleFile: Partial<Exa
     const fileExtension = getFileExtensionFromName(exampleFileName);
     const language = fileExtensionToLanguage[fileExtension] || fileExtension;
     return {
-        fileName: exampleFileName.replace(new RegExp(`(.)?(component|directive)?.${fileExtension}$`), ''),
+        fileName: exampleFileName.replace(new RegExp(`.(component.|directive.)?${fileExtension}$`), ''),
         name: exampleFileName,
         language,
         code: getAssetFromModuleAssets(exampleFileName),


### PR DESCRIPTION
## Related Issue(s)

closes #5351

## Description
Finally, here it is. Now you can use the `pure` type in examples and those example files will not end up in the module
