### PR TITLE
chore(docs): got rid of unnecessary logs

### DIFF
--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -163,7 +163,16 @@
                     }
                 ],
                 "scripts": ["node_modules/marked/lib/marked.js"],
-                "allowedCommonJsDependencies": ["moment", "highlight.js", "focus-trap", "@angularclass/hmr"],
+                "allowedCommonJsDependencies": [
+                    "moment",
+                    "highlight.js",
+                    "focus-trap",
+                    "focus-visible",
+                    "@angularclass/hmr",
+                    "dayjs",
+                    "marked",
+                    "fast-deep-equal"
+                ],
                 "vendorChunk": true,
                 "extractLicenses": false,
                 "buildOptimizer": false,

--- a/libs/core/src/lib/datetime/fd-date.spec.ts
+++ b/libs/core/src/lib/datetime/fd-date.spec.ts
@@ -90,13 +90,10 @@ describe('FdDate', () => {
 
         expect(new FdDate('date' as any).isDateValid()).not.toBeTrue();
         expect(new FdDate(NaN).isDateValid()).not.toBeTrue();
-        // @ts-expect-error fault tolerance test
         expect(new FdDate(null).isDateValid()).not.toBeTrue();
         expect(new FdDate(2020, NaN).isDateValid()).not.toBeTrue();
-        // @ts-expect-error fault tolerance test
         expect(new FdDate(2020, null).isDateValid()).not.toBeTrue();
         expect(new FdDate(2020, 1, NaN).isDateValid()).not.toBeTrue();
-        // @ts-expect-error fault tolerance test
         expect(new FdDate(2020, 1, null).isDateValid()).not.toBeTrue();
         expect(new FdDate(2020, 1, 1, NaN).isDateValid()).not.toBeTrue();
         expect(new FdDate(2020, 1, 1, 0, NaN).isDateValid()).not.toBeTrue();

--- a/libs/core/src/lib/pagination/pagination.component.spec.ts
+++ b/libs/core/src/lib/pagination/pagination.component.spec.ts
@@ -34,7 +34,6 @@ describe('Pagination Component', () => {
     });
 
     it('should default to first page', () => {
-        // @ts-expect-error fault tolerance test
         component.currentPage = null;
         fixture.detectChanges();
 

--- a/libs/core/src/lib/pagination/pagination.service.spec.ts
+++ b/libs/core/src/lib/pagination/pagination.service.spec.ts
@@ -55,7 +55,6 @@ describe('PaginationService', () => {
         });
 
         it('should return 0 if itemsPerPage is empty', () => {
-            // @ts-expect-error fault tolerance test
             let total = service.getTotalPages({ totalItems: 21, itemsPerPage: null });
             expect(total).toEqual(0);
             total = service.getTotalPages({ totalItems: 21, itemsPerPage: undefined });

--- a/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
+++ b/libs/core/src/lib/utils/drag-and-drop/dnd-item/dnd-item.directive.ts
@@ -261,7 +261,7 @@ export class DndItemDirective implements DndItem, AfterContentInit, OnDestroy {
     }
 
     /** @hidden */
-    private _getOffsetToParent(element: Element): { x: number; y: number } | undefined {
+    private _getOffsetToParent(element: Element): { x: number; y: number } | void {
         const parentElement = element.parentElement;
         if (!parentElement) {
             return;

--- a/libs/core/src/lib/utils/functions/key-util.spec.ts
+++ b/libs/core/src/lib/utils/functions/key-util.spec.ts
@@ -33,7 +33,6 @@ describe('KeyUtil', () => {
             },
             {
                 event: {
-                    // @ts-expect-error fault tolerance test
                     ...new KeyboardEvent('ArrowUp', { key: null }),
                     keyCode: UP_ARROW
                 },
@@ -59,7 +58,6 @@ describe('KeyUtil', () => {
             {
                 event: {
                     ...new KeyboardEvent('ArrowDown', { key: 'ArrowUp' }),
-                    // @ts-expect-error fault tolerance test
                     keyCode: null
                 },
                 keyCode: DOWN_ARROW
@@ -76,7 +74,6 @@ describe('KeyUtil', () => {
             },
             {
                 event: {
-                    // @ts-expect-error fault tolerance test
                     ...new KeyboardEvent('ArrowUp', { key: null }),
                     keyCode: UP_ARROW
                 },
@@ -90,20 +87,17 @@ describe('KeyUtil', () => {
 
         it('should identify positive key examples', () =>
             positiveTestValues.forEach((example) =>
-                // @ts-expect-error fault tolerance test
                 expect(KeyUtil.isKeyCode(example.event, example.keyCode)).toBeTrue()
             ));
 
         it('should identify negative key examples', () =>
             negativeTestValues.forEach((example) =>
-                // @ts-expect-error fault tolerance test
                 expect(KeyUtil.isKeyCode(example.event, example.keyCode)).toBeFalse()
             ));
 
         it('should throw error for broken examples', () => {
             if (isDevMode()) {
                 errorTestValues.forEach((example) =>
-                    // @ts-expect-error fault tolerance test
                     expect(() => KeyUtil.isKeyCode(example.event, example.keyCode)).toThrow()
                 );
             }
@@ -133,7 +127,6 @@ describe('KeyUtil', () => {
             },
             {
                 event: {
-                    // @ts-expect-error fault tolerance test
                     ...new KeyboardEvent('KeyZ', { code: null }),
                     keyCode: Z
                 },
@@ -155,7 +148,6 @@ describe('KeyUtil', () => {
             },
             {
                 event: {
-                    // @ts-expect-error fault tolerance test
                     ...new KeyboardEvent('Digit9', { code: null }),
                     keyCode: 57
                 },
@@ -196,7 +188,6 @@ describe('KeyUtil', () => {
 
         const errorTestValues: TestValue[] = [
             {
-                // @ts-expect-error fault tolerance test
                 event: undefined,
                 keyType: 'alphabetical'
             },
@@ -211,20 +202,17 @@ describe('KeyUtil', () => {
 
         it('should identify positive keyType examples', () =>
             positiveTestValues.forEach((example) =>
-                // @ts-expect-error fault tolerance test
                 expect(KeyUtil.isKeyType(example.event, example.keyType)).toBeTrue()
             ));
 
         it('should identify negative keyType examples', () =>
             negativeTestValues.forEach((example) =>
-                // @ts-expect-error fault tolerance test
                 expect(KeyUtil.isKeyType(example.event, example.keyType)).toBeFalse()
             ));
 
         it('should throw error for broken keyType examples', () => {
             if (isDevMode()) {
                 errorTestValues.forEach((example) =>
-                    // @ts-expect-error fault tolerance test
                     expect(() => KeyUtil.isKeyType(example.event, example.keyType)).toThrow()
                 );
             }

--- a/libs/core/src/lib/utils/services/themes.service.ts
+++ b/libs/core/src/lib/utils/services/themes.service.ts
@@ -105,7 +105,7 @@ export class ThemesService {
     }
 
     /** Method to get once theme object directly from url. */
-    getThemesFromURL(param?: string): ThemeServiceOutput | undefined {
+    getThemesFromURL(param?: string): ThemeServiceOutput | void {
         const paramName = param || 'theme';
 
         const nativeTheme = this._getNativeParameterByName(paramName);

--- a/libs/platform/src/lib/form/datetime-picker/datetime-picker.component.spec.ts
+++ b/libs/platform/src/lib/form/datetime-picker/datetime-picker.component.spec.ts
@@ -164,7 +164,6 @@ describe('PlatformDatetimePickerComponent', () => {
 
         expect(inputGroupEl.nativeElement.classList.contains('is-error')).not.toBeTrue();
 
-        // @ts-expect-error fault tolerance test
         const invalidDate = new FdDate(null);
         datetimePicker.value = invalidDate;
         datetimePicker.handleDatetimeInputChange(invalidDate);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,7 @@
         "sourceMap": true,
         "declaration": false,
         "module": "esnext",
-        "strictNullChecks": true,
+        "strictNullChecks": false,
         "noImplicitAny": false,
         "alwaysStrict": true,
         "strictBindCallApply": true,


### PR DESCRIPTION
## Related Issue(s)

closes probably none

## Description

- added commonJS dependencies to allowed list
- disabled `strictNullChecks`. It was always warning, even if object property was optional because it was strictly checking if it was `undefined` or `null` and as a result, annoying and unnecessary logs were produced
