### PR TITLE
chore(docs): update versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,6 @@
 [
+    { "id": "0.38.0", "url": "https://63988a2b3d00c6000894ba6b--fundamental-ngx.netlify.app/" },
+    { "id": "0.37.1", "url": "https://639481c052f12500083fa373--fundamental-ngx.netlify.app/" },
     { "id": "0.36.2", "url": "https://635720a7e34ffc00087a288e--fundamental-ngx.netlify.app/" },
     { "id": "0.35.4", "url": "https://62e4858ae62a5c0009e9e7c5--fundamental-ngx.netlify.app/" },
     { "id": "0.34.2", "url": "https://624793d2f1d02d000925c339--fundamental-ngx.netlify.app/" },


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

"Update `versions.json`" workflow was disabled because it was broken, but then when I fixed it, I forgot to enable it. Here are versions we released which are not present in `versions.json` because workflow was disabled. From now, updating `versions.json` will be done automatically when we publish a new stable release.
