### PR TITLE
fix(docs): fixed asset urls so now links work properly

### DIFF
--- a/apps/docs/src/index.html
+++ b/apps/docs/src/index.html
@@ -6,9 +6,8 @@
             name="description"
             content="Fundamental Library for Angular is a themable Fiori Angular component library"
         />
-        <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon.png" />
         <title>Fundamental Library for Angular</title>
-        <base href="fundamental-ngx" />
+        <base href="" />
 
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/e2e/wdio/core-base-component.po.ts
+++ b/e2e/wdio/core-base-component.po.ts
@@ -67,6 +67,6 @@ export class CoreBaseComponentPo {
     }
 
     async open(url: string): Promise<void> {
-        return open('fundamental-ngx#/core' + url);
+        return open('#/core' + url);
     }
 }

--- a/e2e/wdio/platform-base-component.po.ts
+++ b/e2e/wdio/platform-base-component.po.ts
@@ -68,6 +68,6 @@ export class PlatformBaseComponentPo {
     }
 
     async open(url: string): Promise<void> {
-        return open('fundamental-ngx#/platform' + url);
+        return open('#/platform' + url);
     }
 }

--- a/libs/docs/platform/approval-flow/e2e/approval-flow.e2e-spec.ts
+++ b/libs/docs/platform/approval-flow/e2e/approval-flow.e2e-spec.ts
@@ -80,8 +80,6 @@ describe('Approval flow', () => {
         detailsDialogUserTeamButton,
         detailsDialogParallelSerialSelectOption,
         messageStrip,
-        messageStripUndoLink,
-        messageStripCancelUndoMessage,
         topActionButtons,
         approvalFlowNodeActionMenu,
         approvalFlowNodeActionMenuItem,
@@ -453,47 +451,6 @@ describe('Approval flow', () => {
             await click(footerButtons);
 
             await expect(await getElementArrayLength(nodeCardInfo)).toEqual(startingNodeCount + 1);
-        });
-
-        // skip due to found issue https://github.com/SAP/fundamental-ngx/issues/6903
-        xit('should be able to undo added approval node', async () => {
-            const approvalFlowNodeCountBefore = await getElementArrayLength(approvalFlowNode);
-
-            await click(editExampleButton);
-            await waitForElDisplayed(addNode);
-            await click(addNode);
-            await click(detailsDialogUserTeamButton);
-            await waitForElDisplayed(detailsDialogTeamMemberCheckBox);
-            await click(detailsDialogTeamMemberCheckBox, 4);
-            await click(detailsDialogSendReminderBtn);
-            await waitForElDisplayed(detailsDialogSendReminderBtn);
-            await click(detailsDialogSendReminderBtn);
-            const approvalFlowNodeCountAfterAdding = await getElementArrayLength(approvalFlowNode);
-            await waitForElDisplayed(messageStripUndoLink);
-            await click(messageStripUndoLink);
-            await waitForNotDisplayed(messageStripUndoLink);
-
-            const approvalFlowNodeCountAfterUndo = await getElementArrayLength(approvalFlowNode);
-
-            await expect(approvalFlowNodeCountBefore).toBe(approvalFlowNodeCountAfterAdding - 1);
-            await expect(approvalFlowNodeCountBefore).toBe(approvalFlowNodeCountAfterUndo);
-        });
-
-        // skip due to https://github.com/SAP/fundamental-ngx/issues/6903
-        xit('should be able to cancel undo', async () => {
-            await click(editExampleButton);
-            await waitForElDisplayed(addNode);
-            await click(addNode);
-            await click(detailsDialogUserTeamButton);
-            await waitForElDisplayed(detailsDialogTeamMemberCheckBox);
-            await click(detailsDialogTeamMemberCheckBox, 4);
-            await click(detailsDialogSendReminderBtn);
-            await waitForElDisplayed(detailsDialogSendReminderBtn);
-            await click(detailsDialogSendReminderBtn);
-            await waitForElDisplayed(messageStripCancelUndoMessage);
-            await click(messageStripCancelUndoMessage);
-
-            await expect(await doesItExist(messageStrip)).toBe(false);
         });
     });
 

--- a/libs/docs/shared/src/lib/getAsset.ts
+++ b/libs/docs/shared/src/lib/getAsset.ts
@@ -23,7 +23,7 @@ export const getAssetFromModuleAssets = (
     currentLib: string = inject(CURRENT_LIB),
     currentComponent: string = inject(CURRENT_COMPONENT)
 ): Promise<string> => {
-    const path = `/docs/${currentLib}/${currentComponent}/examples/${fileName}`;
+    const path = `docs/${currentLib}/${currentComponent}/examples/${fileName}`;
     return getAsset(path);
 };
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "scr": "nx workspace-generator sap-component --name=poster-editor --project=cx --dry-run --verbose",
     "preinstall": "npx only-allow yarn",
     "build": "echo Building default app && nx build",
-    "build-docs-netlify": "yarn run build -- --configuration=\"production-unoptimized\" --base-href=\"/\"",
+    "build-docs-netlify": "yarn run build --configuration=production-unoptimized",
     "build:umbrella": "echo Building umbrella libraries && nx run-many --target=build-umbrella --all",
     "build:umbrella:prod": "echo Building umbrella libraries PROD && yarn run build:umbrella -- --configuration=production",
     "build:prepare": "echo Building libraries and preparing for publishing && nx run-many --target=prepare --all --pack --configuration=production",


### PR DESCRIPTION
## Description

Removed `fundamental-ngx` prefix so now nothing(firebase, netlify, gh pages) has prefix. Fixed URLs to example files so that they are coming from `currentUrl/` and not from `/`. Removed base URL from e2e test URLs 
