### PR TITLE
fix: invalidate nx cache on package.json change

### DIFF
--- a/libs/docs/core/flexible-column-layout/e2e/flexible-column-layout.e2e-spec.ts
+++ b/libs/docs/core/flexible-column-layout/e2e/flexible-column-layout.e2e-spec.ts
@@ -110,11 +110,6 @@ describe('Flexible column layout component test', () => {
         await flexibleColumnLayoutPage.checkRtlSwitch();
     });
 
-    xit('should check examples visual regression', async () => {
-        await flexibleColumnLayoutPage.saveExampleBaselineScreenshot();
-        await expect(await flexibleColumnLayoutPage.compareWithBaseline()).toBeLessThan(5);
-    });
-
     async function checkColumnWidth(section: string): Promise<void> {
         await click(section + button);
         await expect(await getAttributeByName(column, 'style', 0)).toContain('width: 100%');

--- a/nx.json
+++ b/nx.json
@@ -76,7 +76,12 @@
     },
     "namedInputs": {
         "default": ["{projectRoot}/**/*", "sharedGlobals"],
-        "sharedGlobals": ["{workspaceRoot}/angular.json", "{workspaceRoot}/tsconfig.json", "{workspaceRoot}/nx.json"],
+        "sharedGlobals": [
+            "{workspaceRoot}/package.json",
+            "{workspaceRoot}/angular.json",
+            "{workspaceRoot}/tsconfig.json",
+            "{workspaceRoot}/nx.json"
+        ],
         "production": [
             "default",
             "!{projectRoot}/**/*.spec.[jt]s",


### PR DESCRIPTION
## Related Issue(s)

closes probably none

## Description
Added previous default behavior. When package json is changed(version changed for example), build should begin from scratch