### PR TITLE
fix(ci): npm publish always set to public and added gh publish for hotfix latest

### DIFF
--- a/.github/actions/npm-publish/index.js
+++ b/.github/actions/npm-publish/index.js
@@ -19,7 +19,8 @@ const run = async () => {
         const result = await npmPublish({
             package: packageJsonPath,
             token: npmToken,
-            tag
+            tag,
+            access: 'public'
         });
         info(`Published ${result.package}@${result.version}`);
     }

--- a/.github/workflows/create-hotfix.yml
+++ b/.github/workflows/create-hotfix.yml
@@ -108,7 +108,30 @@ jobs:
                   name: ${{ secrets.GH_NAME }}
                   email: ${{ secrets.GH_EMAIL }}
                   token: ${{ secrets.GHACTIONS }}
+    gh_pages:
+        name: Github Pages deploy
+        runs-on: ubuntu-latest
+        needs: run-release
+        if: ${{ jobs.run-release.steps.ciEnv.outputs.isLatest }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                  ref: main # always fetch from main branch
+                  token: ${{ secrets.GHACTIONS }}
 
+            - name: Setup Node.js and Cache
+              uses: ./.github/actions/nodejs
+
+            - name: Run build prod
+              run: npx nx run-many --target=build --projects=docs --configuration=production
+
+            - name: Publish to gh-pages
+              uses: JamesIves/github-pages-deploy-action@v4
+              with:
+                  folder: dist/apps/docs
+                  token: ${{ secrets.GHACTIONS }}
+                  repository-name: ${{ github.repository }}
     stop_agents:
         if: ${{ always() }}
         needs: run-release


### PR DESCRIPTION
## Related Issue(s)

closes none hopefully

## Description

- NPM publish sometimes would fail because it encountered 402 from npm. Public access fixes that
- Previously NPM publish would fail silently, without causing breaking of the entire pipeline, but looks like that is not a good way. So now I added retry logic in case of failure
- Hotfix latest publish was lacking the GH pages deploy script
