### PR TITLE
feat(core): multi input dropdown width

### DIFF
--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -10,7 +10,7 @@
                 (isOpenChange)="openChangeHandle($event)"
                 (input)="!open && openChangeHandle(true)"
                 [triggers]="[]"
-                [maxWidth]="bodyMaxWidth"
+                [maxWidth]="_popoverMaxWidth"
                 [focusTrapped]="true"
                 [disabled]="disabled"
                 [fillControlMode]="fillControlMode"
@@ -135,7 +135,7 @@
         <span
             *ngIf="!itemTemplate"
             fd-list-title
-            [innerHtml]="option.label | highlight: _searchTermCtrl.value || '':highlight"
+            [innerHtml]="option.label | highlight : _searchTermCtrl.value || '' : highlight"
         ></span>
 
         <ng-container *ngIf="itemTemplate">

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -227,7 +227,12 @@ export class MultiInputComponent
     @Input()
     showAllButton = true;
 
-    /** Max width of multi input body in PX */
+    /**
+     * Max width of multi input body.
+     * `none` will not limit width of the dropdown.
+     * `container` will limit width of the dropdown to the width of the multi-input itself.
+     * `number` will limit width of the dropdown by provided number in pixels.
+     */
     @Input()
     bodyMaxWidth: 'none' | 'container' | number = 'none';
 

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -6,6 +6,7 @@ import {
     ElementRef,
     EventEmitter,
     forwardRef,
+    HostListener,
     Injector,
     Input,
     OnChanges,
@@ -59,9 +60,6 @@ import { ContentDensityObserver, contentDensityObserverProviders } from '@fundam
     selector: 'fd-multi-input',
     templateUrl: './multi-input.component.html',
     styleUrls: ['./multi-input.component.scss'],
-    host: {
-        '(focusout)': '_focusOut($event)'
-    },
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
@@ -231,7 +229,20 @@ export class MultiInputComponent
 
     /** Max width of multi input body in PX */
     @Input()
-    bodyMaxWidth: Nullable<number>;
+    bodyMaxWidth: 'none' | 'container' | number = 'none';
+
+    /** @hidden */
+    get _popoverMaxWidth(): Nullable<number> {
+        if (this.bodyMaxWidth === 'none') {
+            return null;
+        }
+
+        if (typeof this.bodyMaxWidth === 'number') {
+            return this.bodyMaxWidth;
+        }
+
+        return this._elementRef.nativeElement.getBoundingClientRect().width;
+    }
 
     /** Multi Input Mobile Configuration, it's applied only, when mobile is enabled */
     @Input()
@@ -339,7 +350,7 @@ export class MultiInputComponent
     /** @hidden */
     constructor(
         readonly _contentDensityObserver: ContentDensityObserver,
-        private readonly _elementRef: ElementRef,
+        private readonly _elementRef: ElementRef<HTMLElement>,
         private readonly _changeDetRef: ChangeDetectorRef,
         private readonly _dynamicComponentService: DynamicComponentService,
         private readonly _injector: Injector,
@@ -825,8 +836,9 @@ export class MultiInputComponent
     }
 
     /** @hidden */
+    @HostListener('focusout', ['$event'])
     private _focusOut(event: FocusEvent): void {
-        if (!this._elementRef.nativeElement.contains(event.relatedTarget)) {
+        if (!this._elementRef.nativeElement.contains(event.relatedTarget as Node)) {
             this.onTouched();
         }
     }

--- a/libs/docs/core/multi-input/examples/multi-input-dropdown-width-example/multi-input-dropdown-width-example.component.html
+++ b/libs/docs/core/multi-input/examples/multi-input-dropdown-width-example/multi-input-dropdown-width-example.component.html
@@ -1,0 +1,67 @@
+<label fd-label for="dropdownExampleInput1">Default Multi Input</label>
+<fd-multi-input
+    inputId="dropdownExampleInput1"
+    [dropdownValues]="[
+        'SomeLongTextToShowThatWidthWillGrowWithTheContent',
+        'Banana',
+        'Pineapple',
+        'Tomato',
+        'Kiwi',
+        'Strawberry',
+        'Blueberry',
+        'Orange'
+    ]"
+    placeholder="Search here..."
+    [(ngModel)]="selected"
+    style="width: 200px"
+></fd-multi-input>
+
+Selected: {{ selected | json }}
+
+<br /><br />
+
+<label fd-label for="dropdownExampleInput2">Strict Multi Input dropdown width</label>
+<fd-multi-input
+    inputId="dropdownExampleInput2"
+    [dropdownValues]="[
+        'SomeLongTextToShowThatWidthWillGrowWithTheContent',
+        'Banana',
+        'Pineapple',
+        'Tomato',
+        'Kiwi',
+        'Strawberry',
+        'Blueberry',
+        'Orange'
+    ]"
+    placeholder="Search here..."
+    [bodyMaxWidth]="200"
+    [(ngModel)]="selected"
+    style="width: 200px"
+></fd-multi-input>
+
+Selected: {{ selected | json }}
+
+<br /><br />
+
+<label fd-label for="dropdownExampleInput3">Dynamic Multi Input dropdown width</label>
+<fd-multi-input
+    inputId="dropdownExampleInput3"
+    [dropdownValues]="[
+        'SomeLongTextToShowThatWidthWillGrowWithTheContent',
+        'Banana',
+        'Pineapple',
+        'Tomato',
+        'Kiwi',
+        'Strawberry',
+        'Blueberry',
+        'Orange'
+    ]"
+    placeholder="Search here..."
+    [bodyMaxWidth]="'container'"
+    [(ngModel)]="selected"
+    style="width: 250px"
+></fd-multi-input>
+
+Selected: {{ selected | json }}
+
+<br /><br />

--- a/libs/docs/core/multi-input/examples/multi-input-dropdown-width-example/multi-input-dropdown-width-example.component.ts
+++ b/libs/docs/core/multi-input/examples/multi-input-dropdown-width-example/multi-input-dropdown-width-example.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+    selector: 'fd-multi-input-dropdown-width-example',
+    templateUrl: './multi-input-dropdown-width-example.component.html',
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MultiInputDropdownWidthExampleComponent {
+    selected = [
+        'SomeLongTextToShowThatWidthWillGrowWithTheContent',
+        'Banana',
+        'Pineapple',
+        'Tomato',
+        'Kiwi',
+        'Strawberry',
+        'Blueberry'
+    ];
+}

--- a/libs/docs/core/multi-input/multi-input-docs.component.html
+++ b/libs/docs/core/multi-input/multi-input-docs.component.html
@@ -138,3 +138,21 @@
     <fd-multi-input-custom-item-example></fd-multi-input-custom-item-example>
 </component-example>
 <code-example [exampleFiles]="customItem"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="dropdown-width" componentName="multi-input">
+    Predefined dropdown width
+</fd-docs-section-title>
+<description>
+    <p>By default, Multi Input component doesn't limit the width of the dropdown.</p>
+    <p>This means that the dropdown will grow depending on the inner items width.</p>
+    <p>
+        Developers can change this behaviour with two options: by providing width of the dropdown in pixels, or by
+        setting the max width of the dropdown equal to the Multi Input component itself.
+    </p>
+</description>
+<component-example>
+    <fd-multi-input-dropdown-width-example></fd-multi-input-dropdown-width-example>
+</component-example>
+<code-example [exampleFiles]="customWidth"></code-example>

--- a/libs/docs/core/multi-input/multi-input-docs.component.ts
+++ b/libs/docs/core/multi-input/multi-input-docs.component.ts
@@ -32,6 +32,9 @@ const mobileT = 'multi-input-mobile-example/multi-input-mobile-example.component
 const customH = 'multi-input-custom-item-example/multi-input-custom-item-example.component.html';
 const customT = 'multi-input-custom-item-example/multi-input-custom-item-example.component.ts';
 
+const widthH = 'multi-input-dropdown-width-example/multi-input-dropdown-width-example.component.html';
+const widthT = 'multi-input-dropdown-width-example/multi-input-dropdown-width-example.component.ts';
+
 @Component({
     selector: 'app-multi-input-docs',
     templateUrl: './multi-input-docs.component.html',
@@ -175,6 +178,20 @@ export class MultiInputDocsComponent {
             component: 'MultiInputCustomItemExampleComponent',
             code: getAssetFromModuleAssets(customT),
             fileName: 'multi-input-custom-item-example'
+        }
+    ];
+
+    customWidth: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(widthH),
+            fileName: 'multi-input-dropdown-width-example'
+        },
+        {
+            language: 'typescript',
+            component: 'MultiInputDropdownWidthExampleComponent',
+            code: getAssetFromModuleAssets(widthT),
+            fileName: 'multi-input-dropdown-width-example'
         }
     ];
 }

--- a/libs/docs/core/multi-input/multi-input-docs.module.ts
+++ b/libs/docs/core/multi-input/multi-input-docs.module.ts
@@ -19,6 +19,7 @@ import { DeprecatedMultiInputCompactDirective, MultiInputModule } from '@fundame
 import { IconModule } from '@fundamental-ngx/core/icon';
 import { ListModule } from '@fundamental-ngx/core/list';
 import { moduleDeprecationsProvider } from '@fundamental-ngx/core/utils';
+import { MultiInputDropdownWidthExampleComponent } from './examples/multi-input-dropdown-width-example/multi-input-dropdown-width-example.component';
 
 const routes: Routes = [
     {
@@ -53,7 +54,8 @@ const routes: Routes = [
         MultiInputNewTokensExampleComponent,
         MultiInputMobileExampleComponent,
         MultiInputIncludesExampleComponent,
-        MultiInputCustomItemExampleComponent
+        MultiInputCustomItemExampleComponent,
+        MultiInputDropdownWidthExampleComponent
     ],
     providers: [
         moduleDeprecationsProvider(DeprecatedMultiInputCompactDirective),


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #9047 

## Description
Changed `bodyMaxWidth` signature. Not it accepts: 'none' | 'container' | 'number'.
If none selected, width is not limited.
If container selected, width will be limited by the width of the multi input component.
If number passed, width will be limited by this number in px.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![image](https://user-images.githubusercontent.com/6586561/208648529-4b0b0b35-353c-41de-aad7-944023c156a6.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/208648571-b6189449-df2e-4225-ad90-052bb5d30e6a.png)

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [x] update `README.md`
-   [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
