### PR TITLE
fix(core): breadcrumb overflow icon

### DIFF
--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -64,7 +64,7 @@
                 (keydown.enter)="_keyDownHandle($event)"
                 (keydown.space)="_keyDownHandle($event)"
             >
-                …
+                <fd-icon glyph="overflow"></fd-icon>
                 <fd-icon glyph="slim-arrow-down"></fd-icon>
             </a>
         </span>


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

Breadcrumb overflow icon to better match with specs.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

<img width="73" alt="CleanShot 2022-12-27 at 15 40 04@2x" src="https://user-images.githubusercontent.com/20265336/209682012-581fbb66-7d68-46cc-9c3b-dda6621e1cab.png">

### After:

<img width="59" alt="CleanShot 2022-12-27 at 15 40 11@2x" src="https://user-images.githubusercontent.com/20265336/209682024-a936be00-12c8-43a5-9ed7-0a8c35c67afb.png">