### PR TITLE
fix: removed not recommended aria attribute on `div`

### DIFF
--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -43,7 +43,6 @@
         [attr.aria-selected]="selected?.selected"
         [attr.aria-expanded]="_isOpen"
         [attr.aria-disabled]="disabled"
-        [attr.aria-readonly]="readonly"
         [attr.aria-controls]="controlId + '-list-box'"
         [attr.aria-haspopup]="!(this.readonly || this.disabled)"
         [attr.aria-required]="required"

--- a/libs/docs/platform/select/e2e/select.e2e-spec.ts
+++ b/libs/docs/platform/select/e2e/select.e2e-spec.ts
@@ -74,7 +74,7 @@ describe('Select test suite', () => {
         });
 
         it('verify select in read only mode', async () => {
-            await expect(await getAttributeByName(selectModeExample + displayText, 'aria-readonly', 3)).toBe('true');
+            await expect(await getElementClass(selectModeExample + displayText, 3)).toContain('is-readonly');
         });
 
         it('should check compact select be smaller than basic select', async () => {


### PR DESCRIPTION
## Related Issue(s)

closes #9024

## Description

removed not recommended attribute from select div
