### PR TITLE
fix(core): added i18n package installation in core's ng-add

### DIFF
--- a/libs/core/schematics/add-dependencies/index.ts
+++ b/libs/core/schematics/add-dependencies/index.ts
@@ -67,6 +67,19 @@ function addExternalLibraries(options: Schema): Rule {
             });
         }
 
+        if (
+            !hasPackage(tree, '@fundamental-ngx/i18n') ||
+            checkPackageVersion(tree, '@fundamental-ngx/i18n', 'VERSION_PLACEHOLDER', '<')
+        ) {
+            dependencies.push({
+                type: NodeDependencyType.Default,
+                // Will be replaced with the real version during sync-version script run
+                version: `VERSION_PLACEHOLDER`,
+                name: '@fundamental-ngx/i18n',
+                overwrite: true
+            });
+        }
+
         dependencies.forEach((dependency) => {
             addPackageJsonDependency(tree, dependency);
 


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

i18n package should be added alongside core, so when there are both platform and core packages in client's application, without this, with npm duplications of the i18n package occur and it messes up with angular DI, as a result platform modules, which use i18n fail to initialize
