### PR TITLE
fix: fixed i18n package dependencies

### DIFF
--- a/libs/i18n/project.json
+++ b/libs/i18n/project.json
@@ -21,7 +21,8 @@
             "executor": "@nrwl/angular:package",
             "outputs": ["{workspaceRoot}/dist/libs/i18n"],
             "options": {
-                "project": "libs/i18n/ng-package.json"
+                "project": "libs/i18n/ng-package.json",
+                "updateBuildableProjectDepsInPackageJson": false
             },
             "configurations": {
                 "production": {
@@ -37,7 +38,8 @@
             "executor": "@nrwl/angular:package",
             "outputs": ["{workspaceRoot}/dist/libs/i18n"],
             "options": {
-                "project": "libs/i18n/ng-package.json"
+                "project": "libs/i18n/ng-package.json",
+                "updateBuildableProjectDepsInPackageJson": false
             },
             "configurations": {
                 "production": {


### PR DESCRIPTION
## Related Issue(s)

closes #9138

## Description

This is a follow up PR to https://github.com/SAP/fundamental-ngx/pull/9144 and https://github.com/SAP/fundamental-ngx/pull/9145

Set `updateBuildableProjectDepsInPackageJson` to `false`. Previously deps zonejs and platform-browser dependencies were ending up in output package.json, because they were mentioned in the files outside of src and in testing files.