### PR TITLE
test: alternative name for build

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -66,7 +66,7 @@ jobs:
               uses: ./.github/actions/parallel-commands
               with:
                   parallel-commands: |
-                      npx nx affected --target=build --base=origin/${{ github.event.pull_request.base.ref }} --head=HEAD --exclude=docs --parallel=3
+                      npx nx affected --target=build-umbrella --base=origin/${{ github.event.pull_request.base.ref }} --head=HEAD --parallel=3
                       npx nx affected --target=test --base=origin/${{ github.event.pull_request.base.ref }} --head=HEAD --exclude=workspace-tools --parallel=3
                       npx nx affected --target=lint --base=origin/${{ github.event.pull_request.base.ref }} --head=HEAD --exclude=core,platform,fn,cx --parallel=3
                       npx nx run workspace-tools:test --skip-nx-cache

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -70,7 +70,7 @@ jobs:
               uses: ./.github/actions/parallel-commands
               with:
                   parallel-commands: |
-                      npx nx run-many --target=build --exclude=docs --parallel=3
+                      npx nx run-many --target=build-umbrella --parallel=3
                       npx nx run-many --target=test --exclude=workspace-tools --parallel=3
                       npx nx run-many --target=lint --exclude=core,platform,fn --parallel=3
                       npx nx run-many workspace-tools:test --skip-nx-cache

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -9,6 +9,12 @@
         }
     },
     "targets": {
+        "something": {
+            "executor": "nx:run-commands",
+            "options": {
+                "command": "echo This should not be called && exit 1"
+            }
+        },
         "e2e-app": {
             "executor": "@fundamental-ngx/wdio:e2e-test-app",
             "configurations": {
@@ -215,7 +221,7 @@
             },
             "outputs": ["{options.outputPath}"],
             "defaultConfiguration": "development",
-            "dependsOn": ["^build", "generate-typedoc"]
+            "dependsOn": ["^build-umbrella", "generate-typedoc"]
         },
         "serve": {
             "executor": "@nrwl/angular:webpack-dev-server",

--- a/libs/core/src/lib/action-bar/project.json
+++ b/libs/core/src/lib/action-bar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/action-bar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/action-bar/tsconfig.lib.json",
-                "project": "libs/core/src/lib/action-bar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/action-bar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/action-sheet/project.json
+++ b/libs/core/src/lib/action-sheet/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/action-sheet"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/action-sheet/tsconfig.lib.json",
-                "project": "libs/core/src/lib/action-sheet/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/action-sheet/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/alert/project.json
+++ b/libs/core/src/lib/alert/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/alert"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/alert/tsconfig.lib.json",
-                "project": "libs/core/src/lib/alert/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/alert/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/avatar-group/project.json
+++ b/libs/core/src/lib/avatar-group/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/avatar-group"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/avatar-group/tsconfig.lib.json",
-                "project": "libs/core/src/lib/avatar-group/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/avatar-group/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/avatar/project.json
+++ b/libs/core/src/lib/avatar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/avatar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/avatar/tsconfig.lib.json",
-                "project": "libs/core/src/lib/avatar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/avatar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/bar/project.json
+++ b/libs/core/src/lib/bar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/bar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/bar/tsconfig.lib.json",
-                "project": "libs/core/src/lib/bar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/bar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/breadcrumb/project.json
+++ b/libs/core/src/lib/breadcrumb/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/breadcrumb"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/breadcrumb/tsconfig.lib.json",
-                "project": "libs/core/src/lib/breadcrumb/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/breadcrumb/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/busy-indicator/project.json
+++ b/libs/core/src/lib/busy-indicator/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/busy-indicator"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/busy-indicator/tsconfig.lib.json",
-                "project": "libs/core/src/lib/busy-indicator/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/busy-indicator/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/button/project.json
+++ b/libs/core/src/lib/button/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/button"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/button/tsconfig.lib.json",
-                "project": "libs/core/src/lib/button/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/button/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/calendar/project.json
+++ b/libs/core/src/lib/calendar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/calendar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/calendar/tsconfig.lib.json",
-                "project": "libs/core/src/lib/calendar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/calendar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/card/project.json
+++ b/libs/core/src/lib/card/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/card"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/card/tsconfig.lib.json",
-                "project": "libs/core/src/lib/card/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/card/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/carousel/project.json
+++ b/libs/core/src/lib/carousel/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/carousel"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/carousel/tsconfig.lib.json",
-                "project": "libs/core/src/lib/carousel/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/carousel/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/checkbox/project.json
+++ b/libs/core/src/lib/checkbox/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/checkbox"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/checkbox/tsconfig.lib.json",
-                "project": "libs/core/src/lib/checkbox/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/checkbox/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/combobox/project.json
+++ b/libs/core/src/lib/combobox/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/combobox"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/combobox/tsconfig.lib.json",
-                "project": "libs/core/src/lib/combobox/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/combobox/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/content-density/project.json
+++ b/libs/core/src/lib/content-density/project.json
@@ -5,20 +5,10 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/content-density"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/core/src/lib/content-density/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/content-density/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/core/src/lib/content-density/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/core/src/lib/date-picker/project.json
+++ b/libs/core/src/lib/date-picker/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/date-picker"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/date-picker/tsconfig.lib.json",
-                "project": "libs/core/src/lib/date-picker/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/date-picker/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/datetime-picker/project.json
+++ b/libs/core/src/lib/datetime-picker/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/datetime-picker"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/datetime-picker/tsconfig.lib.json",
-                "project": "libs/core/src/lib/datetime-picker/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/datetime-picker/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/datetime/project.json
+++ b/libs/core/src/lib/datetime/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/datetime"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/datetime/tsconfig.lib.json",
-                "project": "libs/core/src/lib/datetime/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/datetime/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/dialog/project.json
+++ b/libs/core/src/lib/dialog/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/dialog"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/dialog/tsconfig.lib.json",
-                "project": "libs/core/src/lib/dialog/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/dialog/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/dynamic-page/project.json
+++ b/libs/core/src/lib/dynamic-page/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/dynamic-page"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/dynamic-page/tsconfig.lib.json",
-                "project": "libs/core/src/lib/dynamic-page/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/dynamic-page/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/dynamic-side-content/project.json
+++ b/libs/core/src/lib/dynamic-side-content/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/dynamic-side-content"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/dynamic-side-content/tsconfig.lib.json",
-                "project": "libs/core/src/lib/dynamic-side-content/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/dynamic-side-content/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/facets/project.json
+++ b/libs/core/src/lib/facets/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/facets"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/facets/tsconfig.lib.json",
-                "project": "libs/core/src/lib/facets/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/facets/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/feed-input/project.json
+++ b/libs/core/src/lib/feed-input/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/feed-input"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/feed-input/tsconfig.lib.json",
-                "project": "libs/core/src/lib/feed-input/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/feed-input/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/feed-list-item/components/item/feed-list-item.component.html
+++ b/libs/core/src/lib/feed-list-item/components/item/feed-list-item.component.html
@@ -34,7 +34,7 @@
                 target="_blank"
                 fd-link
                 [attr.title]="authorTitle"
-                [attr.href]="authorLink | safe: 'url'"
+                [attr.href]="authorLink | safe : 'url'"
                 [emphasized]="true"
             >
                 <ng-container *ngTemplateOutlet="authorTitleTemplate"></ng-container>
@@ -49,7 +49,7 @@
 <ng-template #feedContent let-param>
     <ng-container *ngTemplateOutlet="param"></ng-container>
     <span>
-        {{ isCollapsed ? (text | truncate: maxChars) : text }}
+        {{ isCollapsed ? (text | truncate : maxChars) : text }}
     </span>
     <a
         fd-link

--- a/libs/core/src/lib/feed-list-item/project.json
+++ b/libs/core/src/lib/feed-list-item/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/feed-list-item"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/feed-list-item/tsconfig.lib.json",
-                "project": "libs/core/src/lib/feed-list-item/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/feed-list-item/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/file-uploader/project.json
+++ b/libs/core/src/lib/file-uploader/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/file-uploader"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/file-uploader/tsconfig.lib.json",
-                "project": "libs/core/src/lib/file-uploader/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/file-uploader/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/fixed-card-layout/project.json
+++ b/libs/core/src/lib/fixed-card-layout/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/fixed-card-layout"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/fixed-card-layout/tsconfig.lib.json",
-                "project": "libs/core/src/lib/fixed-card-layout/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/fixed-card-layout/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/flexible-column-layout/project.json
+++ b/libs/core/src/lib/flexible-column-layout/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/flexible-column-layout"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/flexible-column-layout/tsconfig.lib.json",
-                "project": "libs/core/src/lib/flexible-column-layout/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/flexible-column-layout/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/form/project.json
+++ b/libs/core/src/lib/form/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/form"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/form/tsconfig.lib.json",
-                "project": "libs/core/src/lib/form/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/form/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/formatted-text/project.json
+++ b/libs/core/src/lib/formatted-text/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/formatted-text"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/formatted-text/tsconfig.lib.json",
-                "project": "libs/core/src/lib/formatted-text/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/formatted-text/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
+++ b/libs/core/src/lib/grid-list/components/grid-list-item/grid-list-item.component.html
@@ -28,7 +28,7 @@
         [class.fd-grid-list__highlight--negative]="status === 'warning'"
         [class.fd-grid-list__highlight--critical]="status === 'error'"
         [class.fd-grid-list__highlight--neutral]="status === 'neutral'"
-        [attr.aria-label]="'coreGridList.listItemStatusAriaLabel' | fdTranslate: { status: status }"
+        [attr.aria-label]="'coreGridList.listItemStatusAriaLabel' | fdTranslate : { status: status }"
     ></span>
 
     <ng-container *ngIf="selectionMode === 'singleSelect'">
@@ -63,7 +63,7 @@
         <span
             *ngIf="counter"
             class="fd-grid-list__item-counter"
-            [attr.aria-label]="'coreGridList.listItemCounterAriaLabel' | fdTranslate: { count: counter }"
+            [attr.aria-label]="'coreGridList.listItemCounterAriaLabel' | fdTranslate : { count: counter }"
             [innerText]="counter"
         ></span>
 

--- a/libs/core/src/lib/grid-list/project.json
+++ b/libs/core/src/lib/grid-list/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/grid-list"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/grid-list/tsconfig.lib.json",
-                "project": "libs/core/src/lib/grid-list/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/grid-list/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/icon/project.json
+++ b/libs/core/src/lib/icon/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/icon"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/icon/tsconfig.lib.json",
-                "project": "libs/core/src/lib/icon/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/icon/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/illustrated-message/project.json
+++ b/libs/core/src/lib/illustrated-message/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/illustrated-message"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/illustrated-message/tsconfig.lib.json",
-                "project": "libs/core/src/lib/illustrated-message/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/illustrated-message/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/infinite-scroll/project.json
+++ b/libs/core/src/lib/infinite-scroll/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/infinite-scroll"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/infinite-scroll/tsconfig.lib.json",
-                "project": "libs/core/src/lib/infinite-scroll/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/infinite-scroll/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/info-label/project.json
+++ b/libs/core/src/lib/info-label/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/info-label"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/info-label/tsconfig.lib.json",
-                "project": "libs/core/src/lib/info-label/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/info-label/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/inline-help/project.json
+++ b/libs/core/src/lib/inline-help/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/inline-help"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/inline-help/tsconfig.lib.json",
-                "project": "libs/core/src/lib/inline-help/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/inline-help/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/input-group/project.json
+++ b/libs/core/src/lib/input-group/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/input-group"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/input-group/tsconfig.lib.json",
-                "project": "libs/core/src/lib/input-group/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/input-group/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/layout-grid/project.json
+++ b/libs/core/src/lib/layout-grid/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/layout-grid"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/layout-grid/tsconfig.lib.json",
-                "project": "libs/core/src/lib/layout-grid/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/layout-grid/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/layout-panel/project.json
+++ b/libs/core/src/lib/layout-panel/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/layout-panel"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/layout-panel/tsconfig.lib.json",
-                "project": "libs/core/src/lib/layout-panel/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/layout-panel/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/link/project.json
+++ b/libs/core/src/lib/link/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/link"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/link/tsconfig.lib.json",
-                "project": "libs/core/src/lib/link/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/link/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/list/project.json
+++ b/libs/core/src/lib/list/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/list"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/list/tsconfig.lib.json",
-                "project": "libs/core/src/lib/list/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/list/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/menu/project.json
+++ b/libs/core/src/lib/menu/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/menu"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/menu/tsconfig.lib.json",
-                "project": "libs/core/src/lib/menu/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/menu/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/message-box/project.json
+++ b/libs/core/src/lib/message-box/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/message-box"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/message-box/tsconfig.lib.json",
-                "project": "libs/core/src/lib/message-box/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/message-box/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/message-page/project.json
+++ b/libs/core/src/lib/message-page/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/message-page"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/message-page/tsconfig.lib.json",
-                "project": "libs/core/src/lib/message-page/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/message-page/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/message-strip/project.json
+++ b/libs/core/src/lib/message-strip/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/message-strip"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/message-strip/tsconfig.lib.json",
-                "project": "libs/core/src/lib/message-strip/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/message-strip/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/message-toast/project.json
+++ b/libs/core/src/lib/message-toast/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/message-toast"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/message-toast/tsconfig.lib.json",
-                "project": "libs/core/src/lib/message-toast/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/message-toast/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/micro-process-flow/project.json
+++ b/libs/core/src/lib/micro-process-flow/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/micro-process-flow"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/micro-process-flow/tsconfig.lib.json",
-                "project": "libs/core/src/lib/micro-process-flow/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/micro-process-flow/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/mobile-mode/project.json
+++ b/libs/core/src/lib/mobile-mode/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/mobile-mode"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/mobile-mode/tsconfig.lib.json",
-                "project": "libs/core/src/lib/mobile-mode/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/mobile-mode/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/multi-input/project.json
+++ b/libs/core/src/lib/multi-input/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/multi-input"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/multi-input/tsconfig.lib.json",
-                "project": "libs/core/src/lib/multi-input/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/multi-input/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/nested-list/project.json
+++ b/libs/core/src/lib/nested-list/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/nested-list"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/nested-list/tsconfig.lib.json",
-                "project": "libs/core/src/lib/nested-list/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/nested-list/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/notification/project.json
+++ b/libs/core/src/lib/notification/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/notification"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/notification/tsconfig.lib.json",
-                "project": "libs/core/src/lib/notification/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/notification/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/object-identifier/project.json
+++ b/libs/core/src/lib/object-identifier/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/object-identifier"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/object-identifier/tsconfig.lib.json",
-                "project": "libs/core/src/lib/object-identifier/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/object-identifier/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/object-marker/project.json
+++ b/libs/core/src/lib/object-marker/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/object-marker"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/object-marker/tsconfig.lib.json",
-                "project": "libs/core/src/lib/object-marker/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/object-marker/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/object-number/object-number.component.html
+++ b/libs/core/src/lib/object-number/object-number.component.html
@@ -1,4 +1,4 @@
 <span class="fd-object-number__text" [class.fd-object-number__text--bold]="!large && emphasized">
-    {{ number | number: (decimal ? _numberPipeConfig : '1.0-0') }}
+    {{ number | number : (decimal ? _numberPipeConfig : '1.0-0') }}
 </span>
 <span class="fd-object-number__unit">{{ unit }}</span>

--- a/libs/core/src/lib/object-number/project.json
+++ b/libs/core/src/lib/object-number/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/object-number"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/object-number/tsconfig.lib.json",
-                "project": "libs/core/src/lib/object-number/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/object-number/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/object-status/project.json
+++ b/libs/core/src/lib/object-status/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/object-status"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/object-status/tsconfig.lib.json",
-                "project": "libs/core/src/lib/object-status/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/object-status/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/overflow-layout/overflow-layout.component.html
+++ b/libs/core/src/lib/overflow-layout/overflow-layout.component.html
@@ -46,7 +46,7 @@
             >
                 <fd-popover-control>
                     <button fd-button [fdMenu]="true" fdType="transparent">
-                        {{ 'coreOverflowLayout.moreItemsButton' | fdTranslate: { count: _hiddenItems.length } }}
+                        {{ 'coreOverflowLayout.moreItemsButton' | fdTranslate : { count: _hiddenItems.length } }}
                     </button>
                 </fd-popover-control>
                 <fd-popover-body>

--- a/libs/core/src/lib/overflow-layout/project.json
+++ b/libs/core/src/lib/overflow-layout/project.json
@@ -5,20 +5,10 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/overflow-layout"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/core/src/lib/overflow-layout/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/overflow-layout/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/core/src/lib/overflow-layout/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/core/src/lib/pagination/pagination.component.html
+++ b/libs/core/src/lib/pagination/pagination.component.html
@@ -57,9 +57,11 @@
                 fd-button
                 fdType="transparent"
                 [ariaLabel]="
-                    pageLabel ? pageLabel(page) : ('corePagination.pageLabel' | fdTranslate: { pageNumber: page })
+                    pageLabel ? pageLabel(page) : ('corePagination.pageLabel' | fdTranslate : { pageNumber: page })
                 "
-                [title]="pageLabel ? pageLabel(page) : ('corePagination.pageLabel' | fdTranslate: { pageNumber: page })"
+                [title]="
+                    pageLabel ? pageLabel(page) : ('corePagination.pageLabel' | fdTranslate : { pageNumber: page })
+                "
                 class="fd-pagination__link"
                 (click)="goToPage(page)"
                 (keyup.enter)="goToPage(page, $event)"
@@ -78,7 +80,7 @@
             [ariaLabel]="
                 pageLabel
                     ? pageLabel(currentPage)
-                    : ('corePagination.pageLabel' | fdTranslate: { pageNumber: currentPage })
+                    : ('corePagination.pageLabel' | fdTranslate : { pageNumber: currentPage })
             "
             class="fd-pagination__link is-active"
             [attr.aria-current]="true"
@@ -91,7 +93,7 @@
                 labelBeforeInputMobile
                     ? labelBeforeInputMobile + ':'
                     : ('corePagination.labelBeforeInputMobile'
-                      | fdTranslate: { pageNumber: currentPage, totalCount: totalItems })
+                      | fdTranslate : { pageNumber: currentPage, totalCount: totalItems })
             }}
         </label>
 
@@ -113,7 +115,7 @@
                 inputAriaLabel
                     ? inputAriaLabel(currentPage, totalItems)
                     : ('corePagination.inputAriaLabel'
-                      | fdTranslate: { pageNumber: currentPage, totalCount: totalItems })
+                      | fdTranslate : { pageNumber: currentPage, totalCount: totalItems })
             "
             (keydown.enter)="goToPage(currentPageModel.value)"
             (keydown.space)="goToPage(currentPageModel.value)"
@@ -125,7 +127,7 @@
                 labelAfterInputMobile
                     ? labelAfterInputMobile(_lastPage)
                     : ('corePagination.labelAfterInputMobile'
-                      | fdTranslate: { pageNumber: currentPage, totalCount: totalItems })
+                      | fdTranslate : { pageNumber: currentPage, totalCount: totalItems })
             }}
         </label>
 
@@ -137,9 +139,11 @@
                 fd-button
                 fdType="transparent"
                 [ariaLabel]="
-                    pageLabel ? pageLabel(page) : ('corePagination.pageLabel' | fdTranslate: { pageNumber: page })
+                    pageLabel ? pageLabel(page) : ('corePagination.pageLabel' | fdTranslate : { pageNumber: page })
                 "
-                [title]="pageLabel ? pageLabel(page) : ('corePagination.pageLabel' | fdTranslate: { pageNumber: page })"
+                [title]="
+                    pageLabel ? pageLabel(page) : ('corePagination.pageLabel' | fdTranslate : { pageNumber: page })
+                "
                 class="fd-pagination__link"
                 (click)="goToPage(page)"
                 (keyup.enter)="goToPage(page, $event)"
@@ -203,7 +207,7 @@
 
 <ng-template #total let-showing="showing">
     <span fd-form-label class="fd-pagination__total-label">
-        {{ 'corePagination.totalResultsLabel' | fdTranslate: _currentShowing }}
+        {{ 'corePagination.totalResultsLabel' | fdTranslate : _currentShowing }}
     </span>
 </ng-template>
 

--- a/libs/core/src/lib/pagination/project.json
+++ b/libs/core/src/lib/pagination/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/pagination"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/pagination/tsconfig.lib.json",
-                "project": "libs/core/src/lib/pagination/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/pagination/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/panel/project.json
+++ b/libs/core/src/lib/panel/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/panel"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/panel/tsconfig.lib.json",
-                "project": "libs/core/src/lib/panel/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/panel/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/popover/project.json
+++ b/libs/core/src/lib/popover/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/popover"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/popover/tsconfig.lib.json",
-                "project": "libs/core/src/lib/popover/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/popover/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/product-switch/project.json
+++ b/libs/core/src/lib/product-switch/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/product-switch"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/product-switch/tsconfig.lib.json",
-                "project": "libs/core/src/lib/product-switch/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/product-switch/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/progress-indicator/project.json
+++ b/libs/core/src/lib/progress-indicator/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/progress-indicator"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/progress-indicator/tsconfig.lib.json",
-                "project": "libs/core/src/lib/progress-indicator/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/progress-indicator/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/quick-view/project.json
+++ b/libs/core/src/lib/quick-view/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/quick-view"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/quick-view/tsconfig.lib.json",
-                "project": "libs/core/src/lib/quick-view/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/quick-view/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/radio/project.json
+++ b/libs/core/src/lib/radio/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/radio"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/radio/tsconfig.lib.json",
-                "project": "libs/core/src/lib/radio/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/radio/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/rating-indicator/components/rating-indicator.component.html
+++ b/libs/core/src/lib/rating-indicator/components/rating-indicator.component.html
@@ -5,7 +5,7 @@
     <!-- Available rate values -->
     <ng-container *ngFor="let rate of _rates; index as i; trackBy: trackByFn">
         <input
-            [attr.aria-label]="i | ratingStarLabel: _rates.length:allowHalves"
+            [attr.aria-label]="i | ratingStarLabel : _rates.length : allowHalves"
             role="button"
             type="radio"
             class="fd-rating-indicator__input"

--- a/libs/core/src/lib/rating-indicator/project.json
+++ b/libs/core/src/lib/rating-indicator/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/rating-indicator"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/rating-indicator/tsconfig.lib.json",
-                "project": "libs/core/src/lib/rating-indicator/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/rating-indicator/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/resizable-card-layout/project.json
+++ b/libs/core/src/lib/resizable-card-layout/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/resizable-card-layout"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/resizable-card-layout/tsconfig.lib.json",
-                "project": "libs/core/src/lib/resizable-card-layout/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/resizable-card-layout/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/scroll-spy/project.json
+++ b/libs/core/src/lib/scroll-spy/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/scroll-spy"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/scroll-spy/tsconfig.lib.json",
-                "project": "libs/core/src/lib/scroll-spy/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/scroll-spy/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/scrollbar/project.json
+++ b/libs/core/src/lib/scrollbar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/scrollbar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/scrollbar/tsconfig.lib.json",
-                "project": "libs/core/src/lib/scrollbar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/scrollbar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/segmented-button/project.json
+++ b/libs/core/src/lib/segmented-button/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/segmented-button"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/segmented-button/tsconfig.lib.json",
-                "project": "libs/core/src/lib/segmented-button/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/segmented-button/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/select/project.json
+++ b/libs/core/src/lib/select/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/select"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/select/tsconfig.lib.json",
-                "project": "libs/core/src/lib/select/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/select/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/shared/project.json
+++ b/libs/core/src/lib/shared/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/shared"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/shared/tsconfig.lib.json",
-                "project": "libs/core/src/lib/shared/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/shared/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/shellbar/project.json
+++ b/libs/core/src/lib/shellbar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/shellbar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/shellbar/tsconfig.lib.json",
-                "project": "libs/core/src/lib/shellbar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/shellbar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/side-navigation/project.json
+++ b/libs/core/src/lib/side-navigation/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/side-navigation"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/side-navigation/tsconfig.lib.json",
-                "project": "libs/core/src/lib/side-navigation/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/side-navigation/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/skeleton/project.json
+++ b/libs/core/src/lib/skeleton/project.json
@@ -5,20 +5,10 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:package",
-            "outputs": ["{workspaceRoot}/dist/libs/core/skeleton"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/core/src/lib/skeleton/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/skeleton/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/core/src/lib/skeleton/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/core/src/lib/slider/project.json
+++ b/libs/core/src/lib/slider/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/slider"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/slider/tsconfig.lib.json",
-                "project": "libs/core/src/lib/slider/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/slider/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/slider/slider.component.html
+++ b/libs/core/src/lib/slider/slider.component.html
@@ -60,22 +60,22 @@
         [attr.tabindex]="disabled ? -1 : 0"
         role="slider"
         [attr.aria-label]="
-            ariaLabel || 'coreSlider.singleMinMaxDetails' | fdTranslate: { min: minValue, max: maxValue }
+            ariaLabel || 'coreSlider.singleMinMaxDetails' | fdTranslate : { min: minValue, max: maxValue }
         "
         [attr.aria-labelledby]="ariaLabelledBy"
         [fdPopoverTrigger]="tooltipMode ? singleSliderPopover : null"
-        [attr.aria-valuemin]="'coreSlider.singleValueminDetails' | fdTranslate: { value: minValue }"
-        [attr.aria-valuemax]="'coreSlider.singleValuemaxDetails' | fdTranslate: { value: maxValue }"
+        [attr.aria-valuemin]="'coreSlider.singleValueminDetails' | fdTranslate : { value: minValue }"
+        [attr.aria-valuemax]="'coreSlider.singleValuemaxDetails' | fdTranslate : { value: maxValue }"
         [attr.aria-valuenow]="
             _useSliderValuePrefix
                 ? ('coreSlider.singleValueNowDetails'
-                  | fdTranslate: { value: getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER) })
+                  | fdTranslate : { value: getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER) })
                 : getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER)
         "
         [attr.aria-valuetext]="
             _useSliderValuePrefix
                 ? ('coreSlider.singleValueNowDetails'
-                  | fdTranslate: { value: getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER) })
+                  | fdTranslate : { value: getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER) })
                 : getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER)
         "
         fd-slider-position
@@ -113,22 +113,22 @@
         [attr.tabindex]="disabled ? -1 : 0"
         role="slider"
         [attr.aria-label]="
-            ariaLabel || 'coreSlider.multipleHandle1MinMaxDetails' | fdTranslate: { min: minValue, max: maxValue }
+            ariaLabel || 'coreSlider.multipleHandle1MinMaxDetails' | fdTranslate : { min: minValue, max: maxValue }
         "
         [attr.aria-labelledby]="ariaLabelledBy"
         [fdPopoverTrigger]="tooltipMode ? rangeSliderPopover1 : null"
-        [attr.aria-valuemin]="'coreSlider.multipleHandle1ValueminDetails' | fdTranslate: { value: minValue }"
-        [attr.aria-valuemax]="'coreSlider.multipleHandle1ValuemaxDetails' | fdTranslate: { value: maxValue }"
+        [attr.aria-valuemin]="'coreSlider.multipleHandle1ValueminDetails' | fdTranslate : { value: minValue }"
+        [attr.aria-valuemax]="'coreSlider.multipleHandle1ValuemaxDetails' | fdTranslate : { value: maxValue }"
         [attr.aria-valuenow]="
             _useSliderValuePrefix
                 ? ('coreSlider.multipleHandle1ValueNowDetails'
-                  | fdTranslate: { value: getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1) })
+                  | fdTranslate : { value: getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1) })
                 : getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1)
         "
         [attr.aria-valuetext]="
             _useSliderValuePrefix
                 ? ('coreSlider.multipleHandle1ValueNowDetails'
-                  | fdTranslate: { value: getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1) })
+                  | fdTranslate : { value: getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1) })
                 : getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1)
         "
         fd-slider-position
@@ -146,22 +146,22 @@
         [attr.tabindex]="disabled ? -1 : 0"
         role="slider"
         [attr.aria-label]="
-            ariaLabel || 'coreSlider.multipleHandle2MinMaxDetails' | fdTranslate: { min: minValue, max: maxValue }
+            ariaLabel || 'coreSlider.multipleHandle2MinMaxDetails' | fdTranslate : { min: minValue, max: maxValue }
         "
         [attr.aria-labelledby]="ariaLabelledBy"
         [fdPopoverTrigger]="tooltipMode ? rangeSliderPopover2 : null"
-        [attr.aria-valuemin]="'coreSlider.multipleHandle2ValueminDetails' | fdTranslate: { value: minValue }"
-        [attr.aria-valuemax]="'coreSlider.multipleHandle2ValuemaxDetails' | fdTranslate: { value: maxValue }"
+        [attr.aria-valuemin]="'coreSlider.multipleHandle2ValueminDetails' | fdTranslate : { value: minValue }"
+        [attr.aria-valuemax]="'coreSlider.multipleHandle2ValuemaxDetails' | fdTranslate : { value: maxValue }"
         [attr.aria-valuenow]="
             _useSliderValuePrefix
                 ? ('coreSlider.multipleHandle2ValueNowDetails'
-                  | fdTranslate: { value: getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2) })
+                  | fdTranslate : { value: getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2) })
                 : getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2)
         "
         [attr.aria-valuetext]="
             _useSliderValuePrefix
                 ? ('coreSlider.multipleHandle2ValueNowDetails'
-                  | fdTranslate: { value: getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2) })
+                  | fdTranslate : { value: getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2) })
                 : getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2)
         "
         fd-slider-position

--- a/libs/core/src/lib/split-button/project.json
+++ b/libs/core/src/lib/split-button/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/split-button"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/split-button/tsconfig.lib.json",
-                "project": "libs/core/src/lib/split-button/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/split-button/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/splitter/project.json
+++ b/libs/core/src/lib/splitter/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/splitter"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/splitter/tsconfig.lib.json",
-                "project": "libs/core/src/lib/splitter/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/splitter/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/splitter/splitter-pane-container/splitter-pane-container.component.html
+++ b/libs/core/src/lib/splitter/splitter-pane-container/splitter-pane-container.component.html
@@ -15,7 +15,7 @@
                 *ngTemplateOutlet="
                     panesTemplate;
                     context: {
-                        panes: _activePanes | noDefaultPane: _defaultPane?.isOnCanvas && _activePanes.length > 1
+                        panes: _activePanes | noDefaultPane : _defaultPane?.isOnCanvas && _activePanes.length > 1
                     }
                 "
             ></ng-container>

--- a/libs/core/src/lib/status-indicator/project.json
+++ b/libs/core/src/lib/status-indicator/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/status-indicator"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/status-indicator/tsconfig.lib.json",
-                "project": "libs/core/src/lib/status-indicator/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/status-indicator/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/step-input/project.json
+++ b/libs/core/src/lib/step-input/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/step-input"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/step-input/tsconfig.lib.json",
-                "project": "libs/core/src/lib/step-input/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/step-input/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/switch/project.json
+++ b/libs/core/src/lib/switch/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/switch"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/switch/tsconfig.lib.json",
-                "project": "libs/core/src/lib/switch/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/switch/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/table/project.json
+++ b/libs/core/src/lib/table/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/table"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/table/tsconfig.lib.json",
-                "project": "libs/core/src/lib/table/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/table/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/tabs/project.json
+++ b/libs/core/src/lib/tabs/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/tabs"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/tabs/tsconfig.lib.json",
-                "project": "libs/core/src/lib/tabs/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/tabs/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/tests/project.json
+++ b/libs/core/src/lib/tests/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/tests"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/tests/tsconfig.lib.json",
-                "project": "libs/core/src/lib/tests/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/tests/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/text/project.json
+++ b/libs/core/src/lib/text/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/text"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/text/tsconfig.lib.json",
-                "project": "libs/core/src/lib/text/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/text/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/theming/project.json
+++ b/libs/core/src/lib/theming/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/theming"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/theming/tsconfig.lib.json",
-                "project": "libs/core/src/lib/theming/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/theming/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/tile/project.json
+++ b/libs/core/src/lib/tile/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/tile"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/tile/tsconfig.lib.json",
-                "project": "libs/core/src/lib/tile/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/tile/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/time-picker/project.json
+++ b/libs/core/src/lib/time-picker/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/time-picker"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/time-picker/tsconfig.lib.json",
-                "project": "libs/core/src/lib/time-picker/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/time-picker/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/time/project.json
+++ b/libs/core/src/lib/time/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/time"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/time/tsconfig.lib.json",
-                "project": "libs/core/src/lib/time/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/time/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/timeline/project.json
+++ b/libs/core/src/lib/timeline/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/timeline"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/timeline/tsconfig.lib.json",
-                "project": "libs/core/src/lib/timeline/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/timeline/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/title/project.json
+++ b/libs/core/src/lib/title/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/title"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/title/tsconfig.lib.json",
-                "project": "libs/core/src/lib/title/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/title/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/token/project.json
+++ b/libs/core/src/lib/token/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/token"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/token/tsconfig.lib.json",
-                "project": "libs/core/src/lib/token/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/token/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/token/tokenizer.component.html
+++ b/libs/core/src/lib/token/tokenizer.component.html
@@ -62,10 +62,10 @@
         tabindex="0"
     >
         <ng-container *ngIf="compact || compactCollapse">
-            {{ 'coreTokenizer.moreLabel' | fdTranslate: { count: moreTokensLeft.length + moreTokensRight.length } }}
+            {{ 'coreTokenizer.moreLabel' | fdTranslate : { count: moreTokensLeft.length + moreTokensRight.length } }}
         </ng-container>
         <ng-container *ngIf="!compact && !compactCollapse">
-            {{ 'coreTokenizer.moreLabel' | fdTranslate: { count: hiddenCozyTokenCount } }}
+            {{ 'coreTokenizer.moreLabel' | fdTranslate : { count: hiddenCozyTokenCount } }}
         </ng-container>
     </span>
 </ng-template>

--- a/libs/core/src/lib/toolbar/project.json
+++ b/libs/core/src/lib/toolbar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/toolbar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/toolbar/tsconfig.lib.json",
-                "project": "libs/core/src/lib/toolbar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/toolbar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/tree/project.json
+++ b/libs/core/src/lib/tree/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/tree"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/tree/tsconfig.lib.json",
-                "project": "libs/core/src/lib/tree/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/tree/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/tree/tree.component.html
+++ b/libs/core/src/lib/tree/tree.component.html
@@ -10,7 +10,7 @@
             ></button>
             {{ headers[0] }}
         </div>
-        <div class="fd-tree__col" *ngFor="let header of headers | slice: 1">
+        <div class="fd-tree__col" *ngFor="let header of headers | slice : 1">
             {{ header }}
         </div>
         <div class="fd-tree__col fd-tree__col--actions"></div>

--- a/libs/core/src/lib/upload-collection/project.json
+++ b/libs/core/src/lib/upload-collection/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/upload-collection"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/upload-collection/tsconfig.lib.json",
-                "project": "libs/core/src/lib/upload-collection/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/upload-collection/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/utils/project.json
+++ b/libs/core/src/lib/utils/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/utils"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/utils/tsconfig.lib.json",
-                "project": "libs/core/src/lib/utils/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/utils/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/vertical-navigation/project.json
+++ b/libs/core/src/lib/vertical-navigation/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/vertical-navigation"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/vertical-navigation/tsconfig.lib.json",
-                "project": "libs/core/src/lib/vertical-navigation/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/vertical-navigation/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/core/src/lib/wizard/project.json
+++ b/libs/core/src/lib/wizard/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/core/wizard"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/core/src/lib/wizard/tsconfig.lib.json",
-                "project": "libs/core/src/lib/wizard/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/core/src/lib/wizard/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/datetime-adapter/project.json
+++ b/libs/datetime-adapter/project.json
@@ -18,21 +18,10 @@
             "outputs": ["{options.outputPath}"]
         },
         "build": {
-            "executor": "@nrwl/angular:package",
-            "outputs": ["{workspaceRoot}/dist/libs/datetime-adapter"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/datetime-adapter/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/datetime-adapter/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/datetime-adapter/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "build-umbrella": {
             "executor": "@nrwl/angular:package",

--- a/libs/docs/core/avatar-group/examples/avatar-group-individual-type-example.component.html
+++ b/libs/docs/core/avatar-group/examples/avatar-group-individual-type-example.component.html
@@ -188,7 +188,7 @@
                     <ng-container *ngIf="overflowPopoverStage === 'main'">
                         <div
                             *ngFor="
-                                let person of people | slice: -1 * avatarGroup_IndividualType.overflowItemsCount;
+                                let person of people | slice : -1 * avatarGroup_IndividualType.overflowItemsCount;
                                 let idx = index
                             "
                             fd-avatar-group-overflow-item

--- a/libs/docs/core/calendar/examples/calendar-mark-hover/calendar-mark-hover.component.html
+++ b/libs/docs/core/calendar/examples/calendar-mark-hover/calendar-mark-hover.component.html
@@ -2,7 +2,7 @@
 <br />
 <br />
 Start:
-{{ rangeDate.start?.toDate() | date: 'shortDate' }}
+{{ rangeDate.start?.toDate() | date : 'shortDate' }}
 <br />
 End:
-{{ rangeDate.end?.toDate() | date: 'shortDate' }}
+{{ rangeDate.end?.toDate() | date : 'shortDate' }}

--- a/libs/docs/core/calendar/examples/calendar-programmatically-change-example.component.ts
+++ b/libs/docs/core/calendar/examples/calendar-programmatically-change-example.component.ts
@@ -12,7 +12,7 @@ import {
     template: `
         <fd-calendar calType="single" [(ngModel)]="date"> </fd-calendar>
         <br />
-        <div>Selected Date: {{ date.toDate() | date: 'shortDate' }}</div>
+        <div>Selected Date: {{ date.toDate() | date : 'shortDate' }}</div>
         <button fd-button label="Next Day" (click)="changeDay()"></button>
     `,
     styles: [

--- a/libs/docs/core/calendar/examples/calendar-range-example.component.ts
+++ b/libs/docs/core/calendar/examples/calendar-range-example.component.ts
@@ -19,9 +19,9 @@ import { DateRange } from '@fundamental-ngx/core/calendar';
         >
         </fd-calendar>
         <br />
-        <div>Selected First Date: {{ selected.start?.toDate() | date: 'shortDate' }}</div>
+        <div>Selected First Date: {{ selected.start?.toDate() | date : 'shortDate' }}</div>
         <br />
-        <div>Selected Last Date: {{ selected.end?.toDate() | date: 'shortDate' }}</div>`,
+        <div>Selected Last Date: {{ selected.end?.toDate() | date : 'shortDate' }}</div>`,
     providers: [
         {
             provide: DatetimeAdapter,

--- a/libs/docs/core/calendar/examples/calendar-single-example.component.ts
+++ b/libs/docs/core/calendar/examples/calendar-single-example.component.ts
@@ -12,7 +12,7 @@ import {
     template: `
         <fd-calendar calType="single" [(ngModel)]="date" [disableFunction]="myDisableFunction"></fd-calendar>
         <br />
-        <div>Selected Date: {{ date.toDate() | date: 'shortDate' }}</div>
+        <div>Selected Date: {{ date.toDate() | date : 'shortDate' }}</div>
         <button fd-button label="Disable Wednesday" (click)="disableWednesday()"></button>
     `,
     styles: [

--- a/libs/docs/core/datetime-picker/examples/datetime-format-example/datetime-format-example.component.html
+++ b/libs/docs/core/datetime-picker/examples/datetime-format-example/datetime-format-example.component.html
@@ -2,4 +2,4 @@
 <br />
 <br />
 <br />
-Selected: {{ date | dateTimeFormat: 'null' }}
+Selected: {{ date | dateTimeFormat : 'null' }}

--- a/libs/docs/core/table/examples/table-column-sorting-example.component.html
+++ b/libs/docs/core/table/examples/table-column-sorting-example.component.html
@@ -43,7 +43,10 @@
         </tr>
     </thead>
     <tbody fd-table-body>
-        <tr *ngFor="let row of displayedRows | filter: filterVal:'column1' | sortBy: ascending:'column1'" fd-table-row>
+        <tr
+            *ngFor="let row of displayedRows | filter : filterVal : 'column1' | sortBy : ascending : 'column1'"
+            fd-table-row
+        >
             <td fd-table-cell class="fd-has-font-weight-semi">
                 <a fd-link href="#">{{ row.column1 }}</a>
             </td>
@@ -109,7 +112,7 @@
     </thead>
     <tbody fd-table-body>
         <tr
-            *ngFor="let row of displayedRows2 | filter: filterVal2:'column1' | sortBy: ascending2:'column1'"
+            *ngFor="let row of displayedRows2 | filter : filterVal2 : 'column1' | sortBy : ascending2 : 'column1'"
             fd-table-row
         >
             <td fd-table-cell class="fd-has-font-weight-semi">

--- a/libs/docs/core/table/examples/table-custom-columns-example/table-custom-dialog.component.ts
+++ b/libs/docs/core/table/examples/table-custom-columns-example/table-custom-dialog.component.ts
@@ -50,7 +50,7 @@ import { DialogRef } from '@fundamental-ngx/core/dialog';
                     </li>
 
                     <li
-                        *ngFor="let column of columns | filter: filterPhrase:'key'"
+                        *ngFor="let column of columns | filter : filterPhrase : 'key'"
                         cdkDrag
                         fd-list-item
                         [selected]="column.checked"

--- a/libs/docs/core/time-picker/examples/time-picker-allow-null-example.component.html
+++ b/libs/docs/core/time-picker/examples/time-picker-allow-null-example.component.html
@@ -2,7 +2,7 @@
 <br />
 
 Selected Time:
-<ng-container *ngIf="timeObject.value">{{ timeObject.value?.toDate() | date: 'shortTime' }} </ng-container>
+<ng-container *ngIf="timeObject.value">{{ timeObject.value?.toDate() | date : 'shortTime' }} </ng-container>
 
 <br />
 <br />

--- a/libs/docs/core/time-picker/examples/time-picker-compact-example.component.html
+++ b/libs/docs/core/time-picker/examples/time-picker-compact-example.component.html
@@ -1,4 +1,4 @@
 <fd-time-picker fdCompact [(ngModel)]="timeObject"></fd-time-picker>
 <br />
 Selected Time:
-<ng-container *ngIf="timeObject">{{ timeObject.toDate() | date: 'shortTime' }}</ng-container>
+<ng-container *ngIf="timeObject">{{ timeObject.toDate() | date : 'shortTime' }}</ng-container>

--- a/libs/docs/core/time-picker/examples/time-picker-disabled-example.component.html
+++ b/libs/docs/core/time-picker/examples/time-picker-disabled-example.component.html
@@ -1,4 +1,4 @@
 <fd-time-picker [disabled]="true" [(ngModel)]="timeObject"></fd-time-picker>
 <br />
 Selected Time:
-<ng-container *ngIf="timeObject">{{ timeObject.toDate() | date: 'shortTime' }}</ng-container>
+<ng-container *ngIf="timeObject">{{ timeObject.toDate() | date : 'shortTime' }}</ng-container>

--- a/libs/docs/core/time-picker/examples/time-picker-example.component.html
+++ b/libs/docs/core/time-picker/examples/time-picker-example.component.html
@@ -2,4 +2,4 @@
 <fd-time-picker inputId="timePicker" [(ngModel)]="timeObject"></fd-time-picker>
 <br />
 Selected Time:
-<ng-container *ngIf="timeObject">{{ timeObject.toDate() | date: 'shortTime' }}</ng-container>
+<ng-container *ngIf="timeObject">{{ timeObject.toDate() | date : 'shortTime' }}</ng-container>

--- a/libs/docs/core/time-picker/examples/time-picker-form-example.component.html
+++ b/libs/docs/core/time-picker/examples/time-picker-form-example.component.html
@@ -13,7 +13,7 @@
         <small
             >Selected Time:
             <span *ngIf="customForm.controls.time.value">
-                {{ customForm.controls.time.value?.toDate() | date: 'shortTime' }}
+                {{ customForm.controls.time.value?.toDate() | date : 'shortTime' }}
             </span>
         </small>
         <small>Touched: {{ customForm.controls.time.touched }}</small>
@@ -32,7 +32,7 @@
         <small
             >Selected Time:
             <span *ngIf="customForm.controls.disabledTime.value">
-                {{ customForm.controls.disabledTime.value?.toDate() | date: 'shortTime' }}
+                {{ customForm.controls.disabledTime.value?.toDate() | date : 'shortTime' }}
             </span>
         </small>
         <small>Disabled: {{ customForm.controls.disabledTime.disabled }}</small>

--- a/libs/docs/core/time-picker/examples/time-picker-format-example.component.html
+++ b/libs/docs/core/time-picker/examples/time-picker-format-example.component.html
@@ -1,4 +1,4 @@
 <fd-time-picker [(ngModel)]="time" [displayFormat]="displayFormat"></fd-time-picker>
 <br />
 Selected Time:
-<ng-container *ngIf="time"> {{ time.toDate() | date: 'shortTime' }} </ng-container>
+<ng-container *ngIf="time"> {{ time.toDate() | date : 'shortTime' }} </ng-container>

--- a/libs/docs/core/time-picker/examples/time-picker-locale-example/time-picker-locale-example.component.html
+++ b/libs/docs/core/time-picker/examples/time-picker-locale-example/time-picker-locale-example.component.html
@@ -16,4 +16,4 @@
 
 <br />
 Selected Time:
-<ng-container *ngIf="time"> {{ time.toDate() | date: 'shortTime' }} </ng-container>
+<ng-container *ngIf="time"> {{ time.toDate() | date : 'shortTime' }} </ng-container>

--- a/libs/docs/core/timeline/examples/timeline-basic-example/timeline-basic-example.component.html
+++ b/libs/docs/core/timeline/examples/timeline-basic-example/timeline-basic-example.component.html
@@ -12,7 +12,7 @@
                     <fd-timeline-node-header-info>
                         <span fd-timeline-node-header-info-title>{{ node.user.name }}</span>
                         <span fd-timeline-node-header-info-text>{{ node.title }}</span>
-                        <div fd-timeline-header-info-sub-title>{{ node.date | date: 'short' }}</div>
+                        <div fd-timeline-header-info-sub-title>{{ node.date | date : 'short' }}</div>
                     </fd-timeline-node-header-info>
                 </fd-timeline-node-header>
 
@@ -39,7 +39,7 @@
                     <fd-timeline-node-header-info>
                         <span fd-timeline-node-header-info-title>{{ node.user.name }}</span>
                         <span fd-timeline-node-header-info-text>{{ node.title }}</span>
-                        <div fd-timeline-header-info-sub-title>{{ node.date | date: 'short' }}</div>
+                        <div fd-timeline-header-info-sub-title>{{ node.date | date : 'short' }}</div>
                     </fd-timeline-node-header-info>
                 </fd-timeline-node-header>
 

--- a/libs/docs/core/truncate/examples/truncate-text-example.component.ts
+++ b/libs/docs/core/truncate/examples/truncate-text-example.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
     selector: 'fd-truncate-text-example',
-    template: ` <p>{{ text | truncate: 30 }}</p> `
+    template: ` <p>{{ text | truncate : 30 }}</p> `
 })
 export class TruncateTextExampleComponent {
     text =

--- a/libs/docs/platform/datetime-picker/examples/platform-datetime-picker-update-on-blur-example.component.ts
+++ b/libs/docs/platform/datetime-picker/examples/platform-datetime-picker-update-on-blur-example.component.ts
@@ -18,7 +18,7 @@ import {
             [processInputOnBlur]="true"
         ></fdp-datetime-picker>
         <br />
-        <div>Selected Date: {{ date.toDate() | date: 'MM/dd/YYYY, hh:mm aa' }}</div> `,
+        <div>Selected Date: {{ date.toDate() | date : 'MM/dd/YYYY, hh:mm aa' }}</div> `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
         // Note that this is usually provided in the root of your application.

--- a/libs/docs/shared/src/lib/core-helpers/sections-toolbar/sections-toolbar.component.html
+++ b/libs/docs/shared/src/lib/core-helpers/sections-toolbar/sections-toolbar.component.html
@@ -31,7 +31,7 @@
                         <ul fd-nested-list>
                             <ng-container
                                 *ngFor="
-                                    let item of $asSectionNestedContent(section.content) | sortBy: true:'name';
+                                    let item of $asSectionNestedContent(section.content) | sortBy : true : 'name';
                                     trackBy: trackBySectionContent
                                 "
                             >

--- a/libs/fn/src/lib/avatar/project.json
+++ b/libs/fn/src/lib/avatar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/avatar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/avatar/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/avatar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/avatar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/button/project.json
+++ b/libs/fn/src/lib/button/project.json
@@ -5,17 +5,9 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/button"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/button/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/button/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/button/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/cdk/project.json
+++ b/libs/fn/src/lib/cdk/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/cdk"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/cdk/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/cdk/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/cdk/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/checkbox/project.json
+++ b/libs/fn/src/lib/checkbox/project.json
@@ -5,17 +5,9 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/checkbox"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/checkbox/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/checkbox/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/checkbox/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/form/project.json
+++ b/libs/fn/src/lib/form/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/form"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/form/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/form/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/form/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/generic-tag/project.json
+++ b/libs/fn/src/lib/generic-tag/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/generic-tag"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/generic-tag/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/generic-tag/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/generic-tag/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/info-label/project.json
+++ b/libs/fn/src/lib/info-label/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/info-label"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/info-label/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/info-label/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/info-label/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/input/project.json
+++ b/libs/fn/src/lib/input/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/input"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/input/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/input/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/input/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/list/project.json
+++ b/libs/fn/src/lib/list/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/list"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/list/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/list/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/list/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/message-strip/project.json
+++ b/libs/fn/src/lib/message-strip/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/message-strip"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/message-strip/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/message-strip/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/message-strip/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/message-toast/project.json
+++ b/libs/fn/src/lib/message-toast/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/message-toast"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/message-toast/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/message-toast/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/message-toast/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/notification/project.json
+++ b/libs/fn/src/lib/notification/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/notification"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/notification/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/notification/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/notification/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/object-status/project.json
+++ b/libs/fn/src/lib/object-status/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/object-status"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/object-status/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/object-status/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/object-status/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/progress-bar/project.json
+++ b/libs/fn/src/lib/progress-bar/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/progress-bar"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/progress-bar/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/progress-bar/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/progress-bar/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/radio/project.json
+++ b/libs/fn/src/lib/radio/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/radio"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/radio/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/radio/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/radio/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/search/project.json
+++ b/libs/fn/src/lib/search/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/search"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/search/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/search/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/search/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/segmented-button/project.json
+++ b/libs/fn/src/lib/segmented-button/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/segmented-button"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/segmented-button/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/segmented-button/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/segmented-button/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/fn/src/lib/select/project.json
+++ b/libs/fn/src/lib/select/project.json
@@ -5,17 +5,9 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/select"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/select/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/select/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/select/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/slider/project.json
+++ b/libs/fn/src/lib/slider/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/slider"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/slider/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/slider/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/slider/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/slider/slider.component.html
+++ b/libs/fn/src/lib/slider/slider.component.html
@@ -8,20 +8,20 @@
         <fn-slider-handle
             (mousedown)="onHandleClick($event)"
             (keydown)="onKeyDown($event)"
-            [ariaLabel]="ariaLabel || 'fnSlider.minMaxDetails' | fdTranslate: { min: minValue, max: maxValue }"
-            [ariaValueMax]="'fnSlider.valuemaxDetails' | fdTranslate: { value: maxValue }"
-            [ariaValueMin]="'fnSlider.valueminDetails' | fdTranslate: { value: minValue }"
+            [ariaLabel]="ariaLabel || 'fnSlider.minMaxDetails' | fdTranslate : { min: minValue, max: maxValue }"
+            [ariaValueMax]="'fnSlider.valuemaxDetails' | fdTranslate : { value: maxValue }"
+            [ariaValueMin]="'fnSlider.valueminDetails' | fdTranslate : { value: minValue }"
             [ariaLabelledBy]="ariaLabelledBy"
             [ariaValueNow]="
                 _useSliderValuePrefix
                     ? ('fnSlider.valueNowDetails'
-                      | fdTranslate: { value: getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER) })
+                      | fdTranslate : { value: getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER) })
                     : getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER)
             "
             [ariaValueText]="
                 _useSliderValuePrefix
                     ? ('fnSlider.valueNowDetails'
-                      | fdTranslate: { value: getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER) })
+                      | fdTranslate : { value: getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER) })
                     : getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER)
             "
         ></fn-slider-handle>
@@ -39,20 +39,20 @@
             #rangeHandle1
             (mousedown)="onHandleClick($event)"
             (keydown)="onKeyDown($event)"
-            [ariaLabel]="ariaLabel || 'fnSlider.minMaxDetails' | fdTranslate: { min: minValue, max: maxValue }"
-            [ariaValueMax]="'fnSlider.valuemaxDetails' | fdTranslate: { value: maxValue }"
-            [ariaValueMin]="'fnSlider.valueminDetails' | fdTranslate: { value: minValue }"
+            [ariaLabel]="ariaLabel || 'fnSlider.minMaxDetails' | fdTranslate : { min: minValue, max: maxValue }"
+            [ariaValueMax]="'fnSlider.valuemaxDetails' | fdTranslate : { value: maxValue }"
+            [ariaValueMin]="'fnSlider.valueminDetails' | fdTranslate : { value: minValue }"
             [ariaLabelledBy]="ariaLabelledBy"
             [ariaValueNow]="
                 _useSliderValuePrefix
                     ? ('fnSlider.valueNowDetails'
-                      | fdTranslate: { value: getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1) })
+                      | fdTranslate : { value: getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1) })
                     : getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER)
             "
             [ariaValueText]="
                 _useSliderValuePrefix
                     ? ('fnSlider.valueNowDetails'
-                      | fdTranslate: { value: getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1) })
+                      | fdTranslate : { value: getValuenow(_handle1Value, _sliderValueTargets.RANGE_SLIDER1) })
                     : getValuenow(_position, _sliderValueTargets.SINGLE_SLIDER)
             "
         ></fn-slider-handle>
@@ -61,20 +61,20 @@
             #rangeHandle2
             (mousedown)="onHandleClick($event)"
             (keydown)="onKeyDown($event)"
-            [ariaLabel]="ariaLabel || 'fnSlider.minMaxDetails' | fdTranslate: { min: minValue, max: maxValue }"
-            [ariaValueMax]="'fnSlider.valuemaxDetails' | fdTranslate: { value: maxValue }"
-            [ariaValueMin]="'fnSlider.valueminDetails' | fdTranslate: { value: minValue }"
+            [ariaLabel]="ariaLabel || 'fnSlider.minMaxDetails' | fdTranslate : { min: minValue, max: maxValue }"
+            [ariaValueMax]="'fnSlider.valuemaxDetails' | fdTranslate : { value: maxValue }"
+            [ariaValueMin]="'fnSlider.valueminDetails' | fdTranslate : { value: minValue }"
             [ariaLabelledBy]="ariaLabelledBy"
             [ariaValueNow]="
                 _useSliderValuePrefix
                     ? ('fnSlider.valueNowDetails'
-                      | fdTranslate: { value: getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2) })
+                      | fdTranslate : { value: getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2) })
                     : getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2)
             "
             [ariaValueText]="
                 _useSliderValuePrefix
                     ? ('fnSlider.valueNowDetails'
-                      | fdTranslate: { value: getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2) })
+                      | fdTranslate : { value: getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2) })
                     : getValuenow(_handle2Value, _sliderValueTargets.RANGE_SLIDER2)
             "
         ></fn-slider-handle>

--- a/libs/fn/src/lib/switch/project.json
+++ b/libs/fn/src/lib/switch/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/switch"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/switch/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/switch/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/switch/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/tabs/project.json
+++ b/libs/fn/src/lib/tabs/project.json
@@ -5,17 +5,9 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/tabs"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/fn/src/lib/tabs/tsconfig.lib.json",
-                "project": "libs/fn/src/lib/tabs/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/tabs/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/fn/src/lib/utils/project.json
+++ b/libs/fn/src/lib/utils/project.json
@@ -5,20 +5,10 @@
     "prefix": "fn",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/fn/utils"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/fn/src/lib/utils/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/fn/src/lib/utils/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/fn/src/lib/utils/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/i18n/project.json
+++ b/libs/i18n/project.json
@@ -18,21 +18,10 @@
             "outputs": ["{options.outputPath}"]
         },
         "build": {
-            "executor": "@nrwl/angular:package",
-            "outputs": ["{workspaceRoot}/dist/libs/i18n"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/i18n/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/i18n/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/i18n/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "build-umbrella": {
             "executor": "@nrwl/angular:package",

--- a/libs/moment-adapter/project.json
+++ b/libs/moment-adapter/project.json
@@ -22,19 +22,10 @@
             "outputs": ["{options.outputPath}"]
         },
         "build": {
-            "executor": "@nrwl/angular:package",
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/moment-adapter/tsconfig.lib.json",
-                "project": "libs/moment-adapter/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/moment-adapter/tsconfig.lib.prod.json"
-                }
-            },
-            "outputs": ["{workspaceRoot}/dist/libs/moment-adapter"],
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "build-umbrella": {
             "executor": "@nrwl/angular:package",

--- a/libs/platform/src/lib/action-bar/project.json
+++ b/libs/platform/src/lib/action-bar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/action-bar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/action-bar/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/action-bar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/action-bar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/action-button-group/project.json
+++ b/libs/platform/src/lib/action-button-group/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/action-button-group"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/action-button-group/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/action-button-group/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/action-button-group/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.html
+++ b/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.html
@@ -49,7 +49,7 @@
             </ng-container>
 
             <ng-template #multipleApprovers>
-                {{ 'platformApprovalFlow.nodeMembersCount' | fdTranslate: { count: node.approvers.length } }}
+                {{ 'platformApprovalFlow.nodeMembersCount' | fdTranslate : { count: node.approvers.length } }}
             </ng-template>
         </div>
 
@@ -86,14 +86,14 @@
 
                 <ng-container *ngIf="_dueIn < dueDateThreshold">
                     {{
-                        'platformApprovalFlow.nodeStatusDueInXDays' | fdTranslate: { count: dueDateThreshold - _dueIn }
+                        'platformApprovalFlow.nodeStatusDueInXDays' | fdTranslate : { count: dueDateThreshold - _dueIn }
                     }}
                 </ng-container>
 
                 <ng-container *ngIf="_dueIn > dueDateThreshold">
                     {{
                         'platformApprovalFlow.nodeStatusXDaysOverdue'
-                            | fdTranslate: { count: _dueIn - dueDateThreshold }
+                            | fdTranslate : { count: _dueIn - dueDateThreshold }
                     }}
                 </ng-container>
             </ng-container>

--- a/libs/platform/src/lib/approval-flow/approval-flow-user-list/approval-flow-user-list.component.html
+++ b/libs/platform/src/lib/approval-flow/approval-flow-user-list/approval-flow-user-list.component.html
@@ -4,7 +4,7 @@
     </ng-container>
 
     <ng-template #multipleItems>
-        {{ 'platformApprovalFlow.userListSelectedItemsCountPlural' | fdTranslate: { count: _selectedItems.length } }}
+        {{ 'platformApprovalFlow.userListSelectedItemsCountPlural' | fdTranslate : { count: _selectedItems.length } }}
     </ng-template>
 </div>
 

--- a/libs/platform/src/lib/approval-flow/project.json
+++ b/libs/platform/src/lib/approval-flow/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/approval-flow"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/approval-flow/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/approval-flow/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/approval-flow/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/button/project.json
+++ b/libs/platform/src/lib/button/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/button"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/button/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/button/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/button/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/dynamic-page/project.json
+++ b/libs/platform/src/lib/dynamic-page/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/dynamic-page"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/dynamic-page/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/dynamic-page/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/dynamic-page/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/feed-input/project.json
+++ b/libs/platform/src/lib/feed-input/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/feed-input"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/feed-input/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/feed-input/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/feed-input/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/form/combobox/combobox/combobox.component.html
+++ b/libs/platform/src/lib/form/combobox/combobox/combobox.component.html
@@ -81,7 +81,7 @@
                     (count === 1
                         ? 'platformCombobox.countListResultsSingular'
                         : 'platformCombobox.countListResultsPlural'
-                    ) | fdTranslate: { count: count }
+                    ) | fdTranslate : { count: count }
                 }}
             </ng-container>
         </div>
@@ -187,7 +187,7 @@
 
 <ng-template let-optionItem="optionItem" let-index="index" #optionItemSource>
     <ng-container *ngIf="!optionItemTemplate">
-        <span [attr.title]="optionItem.label" [innerHTML]="optionItem.label | highlight: inputText"></span>
+        <span [attr.title]="optionItem.label" [innerHTML]="optionItem.label | highlight : inputText"></span>
     </ng-container>
 
     <ng-container *ngIf="optionItemTemplate">
@@ -205,7 +205,7 @@
                 [style.text-align]="secondaryTextAlignment"
                 fd-list-secondary
                 [attr.title]="optionItem.secondaryText"
-                [innerHTML]="optionItem.secondaryText | highlight: inputText"
+                [innerHTML]="optionItem.secondaryText | highlight : inputText"
             ></span>
         </ng-container>
 

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.html
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.html
@@ -250,7 +250,7 @@
         <span
             fd-list-title
             [attr.title]="optionItem.label"
-            [innerHTML]="optionItem.label | highlight: inputText"
+            [innerHTML]="optionItem.label | highlight : inputText"
         ></span>
     </ng-container>
 
@@ -269,7 +269,7 @@
                 [style.text-align]="secondaryTextAlignment"
                 fd-list-secondary
                 [attr.title]="optionItem.secondaryText"
-                [innerHTML]="optionItem.secondaryText | highlight: inputText"
+                [innerHTML]="optionItem.secondaryText | highlight : inputText"
             ></span>
         </ng-container>
 

--- a/libs/platform/src/lib/form/multi-input/multi-input.component.html
+++ b/libs/platform/src/lib/form/multi-input/multi-input.component.html
@@ -58,7 +58,7 @@
                 [attr.aria-posinset]="i"
                 [attr.aria-setsize]="selected.length"
             >
-                <span [innerText]="token.label | displayFnPipe: displayFn"></span>
+                <span [innerText]="token.label | displayFnPipe : displayFn"></span>
             </fd-token>
 
             <input

--- a/libs/platform/src/lib/form/platform-file-uploader/platform-file-uploader.component.ts
+++ b/libs/platform/src/lib/form/platform-file-uploader/platform-file-uploader.component.ts
@@ -101,10 +101,12 @@ export class PlatformFileUploaderComponent extends BaseInput implements OnInit {
 
     /** Event emitted when valid file is uploded. */
     @Output()
-    selectionChange: EventEmitter<FileUploaderSelectionChangeEvent> = new EventEmitter<FileUploaderSelectionChangeEvent>();
+    selectionChange: EventEmitter<FileUploaderSelectionChangeEvent> =
+        new EventEmitter<FileUploaderSelectionChangeEvent>();
     /** Event emitted when invalid file is uploded. */
     @Output()
-    invalidFileChange: EventEmitter<FileUploaderInvalidChangeEvent> = new EventEmitter<FileUploaderInvalidChangeEvent>();
+    invalidFileChange: EventEmitter<FileUploaderInvalidChangeEvent> =
+        new EventEmitter<FileUploaderInvalidChangeEvent>();
 
     /** Files upladed hidden field to store file data */
     files: File[];

--- a/libs/platform/src/lib/form/project.json
+++ b/libs/platform/src/lib/form/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/form"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/form/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/form/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/form/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/form/text-area/text-area.component.html
+++ b/libs/platform/src/lib/form/text-area/text-area.component.html
@@ -36,7 +36,7 @@
                 (exceededCharCount === 1
                     ? 'platformTextarea.counterMessageCharactersOverTheLimitSingular'
                     : 'platformTextarea.counterMessageCharactersOverTheLimitPlural'
-                ) | fdTranslate: { count: exceededCharCount }:'&nbsp;&nbsp;'
+                ) | fdTranslate : { count: exceededCharCount } : '&nbsp;&nbsp;'
             "
         ></span>
     </ng-container>
@@ -46,7 +46,7 @@
                 (exceededCharCount === 1
                     ? 'platformTextarea.counterMessageCharactersRemainingSingular'
                     : 'platformTextarea.counterMessageCharactersRemainingPlural'
-                ) | fdTranslate: { count: exceededCharCount }:'&nbsp;&nbsp;'
+                ) | fdTranslate : { count: exceededCharCount } : '&nbsp;&nbsp;'
             "
         ></span>
     </ng-template>

--- a/libs/platform/src/lib/icon-tab-bar/components/icon-tab-bar-filter-type/icon-tab-bar-filter-type.component.html
+++ b/libs/platform/src/lib/icon-tab-bar/components/icon-tab-bar-filter-type/icon-tab-bar-filter-type.component.html
@@ -23,7 +23,7 @@
         </a>
     </li>
     <li
-        *ngFor="let item of _tabs | slice: 1; let idx = index; trackBy: _trackByTab"
+        *ngFor="let item of _tabs | slice : 1; let idx = index; trackBy: _trackByTab"
         [class]="item.cssClasses"
         class="fd-icon-tab-bar__item"
         role="presentation"

--- a/libs/platform/src/lib/icon-tab-bar/project.json
+++ b/libs/platform/src/lib/icon-tab-bar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fd",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/icon-tab-bar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/icon-tab-bar/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/icon-tab-bar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/icon-tab-bar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/info-label/project.json
+++ b/libs/platform/src/lib/info-label/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/info-label"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/info-label/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/info-label/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/info-label/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/link/link.component.html
+++ b/libs/platform/src/lib/link/link.component.html
@@ -22,7 +22,7 @@
     (mouseleave)="onMouseLeave($event)"
     (click)="clicked($event)"
     [attr.aria-roledescription]="
-        media ? ('platformLink.roleDescriptionWithMedia' | fdTranslate: { media: media }) : null
+        media ? ('platformLink.roleDescriptionWithMedia' | fdTranslate : { media: media }) : null
     "
 >
     <ng-content></ng-content>

--- a/libs/platform/src/lib/link/project.json
+++ b/libs/platform/src/lib/link/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/link"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/link/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/link/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/link/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/list/project.json
+++ b/libs/platform/src/lib/list/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/list"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/list/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/list/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/list/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/menu-button/project.json
+++ b/libs/platform/src/lib/menu-button/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/menu-button"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/menu-button/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/menu-button/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/menu-button/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/menu/project.json
+++ b/libs/platform/src/lib/menu/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/menu"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/menu/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/menu/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/menu/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/message-popover/components/message-view/message-view.component.html
+++ b/libs/platform/src/lib/message-popover/components/message-view/message-view.component.html
@@ -12,7 +12,7 @@
         ></ng-template>
     </ng-template>
     <ng-template #stringHeading>
-        {{ item.heading.message | fdTranslate: { error: item.heading.error }:item.heading.message }}
+        {{ item.heading.message | fdTranslate : { error: item.heading.error } : item.heading.message }}
     </ng-template>
     <ng-template
         [ngTemplateOutlet]="
@@ -39,7 +39,7 @@
         ></ng-template>
     </ng-template>
     <ng-template #stringDescription>
-        {{ item.description.message | fdTranslate: { error: item.description.error }:item.description.message }}
+        {{ item.description.message | fdTranslate : { error: item.description.error } : item.description.message }}
     </ng-template>
     <ng-template
         [ngTemplateOutlet]="

--- a/libs/platform/src/lib/message-popover/project.json
+++ b/libs/platform/src/lib/message-popover/project.json
@@ -5,20 +5,10 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:package",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/message-popover"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/platform/src/lib/message-popover/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/message-popover/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/platform/src/lib/message-popover/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/platform/src/lib/object-attribute/project.json
+++ b/libs/platform/src/lib/object-attribute/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/object-attribute"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/object-attribute/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/object-attribute/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/object-attribute/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/object-marker/project.json
+++ b/libs/platform/src/lib/object-marker/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/object-marker"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/object-marker/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/object-marker/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/object-marker/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/object-status/project.json
+++ b/libs/platform/src/lib/object-status/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/object-status"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/object-status/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/object-status/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/object-status/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/page-footer/project.json
+++ b/libs/platform/src/lib/page-footer/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/page-footer"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/page-footer/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/page-footer/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/page-footer/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/panel/project.json
+++ b/libs/platform/src/lib/panel/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/panel"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/panel/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/panel/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/panel/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/search-field/project.json
+++ b/libs/platform/src/lib/search-field/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/search-field"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/search-field/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/search-field/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/search-field/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/shared/project.json
+++ b/libs/platform/src/lib/shared/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/shared"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/shared/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/shared/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/shared/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/slider/project.json
+++ b/libs/platform/src/lib/slider/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/slider"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/slider/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/slider/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/slider/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/smart-filter-bar/project.json
+++ b/libs/platform/src/lib/smart-filter-bar/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/smart-filter-bar"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/smart-filter-bar/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/smart-filter-bar/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/smart-filter-bar/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/split-menu-button/project.json
+++ b/libs/platform/src/lib/split-menu-button/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/split-menu-button"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/split-menu-button/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/split-menu-button/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/split-menu-button/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filtering.component.html
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filtering.component.html
@@ -22,7 +22,7 @@
                     (_validIncludeRulesCount > 0
                         ? 'platformTable.P13FilterDialogIncludePanelTitleWithCount'
                         : 'platformTable.P13FilterDialogIncludePanelTitleWithoutCount'
-                    ) | fdTranslate: { count: _validIncludeRulesCount }
+                    ) | fdTranslate : { count: _validIncludeRulesCount }
                 }}
             </div>
             <div fd-panel-content>
@@ -66,7 +66,7 @@
                     (_validExcludeRulesCount > 0
                         ? 'platformTable.P13FilterDialogExcludePanelTitleWithCount'
                         : 'platformTable.P13FilterDialogExcludePanelTitleWithoutCount'
-                    ) | fdTranslate: { count: _validExcludeRulesCount }
+                    ) | fdTranslate : { count: _validExcludeRulesCount }
                 }}
             </div>
             <div fd-panel-content>

--- a/libs/platform/src/lib/table/components/table-p13-dialog/sorting/sorting.component.html
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/sorting/sorting.component.html
@@ -26,7 +26,7 @@
             >
                 <li
                     fd-option
-                    *ngFor="let column of columns | getAvailableSortColumns: rules:rule.columnKey"
+                    *ngFor="let column of columns | getAvailableSortColumns : rules : rule.columnKey"
                     [value]="column.key"
                 >
                     {{ column.label }}

--- a/libs/platform/src/lib/table/components/table-view-settings-dialog/filtering/filter-step.component.html
+++ b/libs/platform/src/lib/table/components/table-view-settings-dialog/filtering/filter-step.component.html
@@ -1,7 +1,7 @@
 <ng-template #titleTemplate>
     <button fd-button fdType="transparent" glyph="navigation-left-arrow" (click)="back.emit()"></button>
     <h4 fd-title [headerSize]="4">
-        {{ 'platformTable.filterDialogFilterByLabel' | fdTranslate: { filterLabel: filter.label } }}
+        {{ 'platformTable.filterDialogFilterByLabel' | fdTranslate : { filterLabel: filter.label } }}
     </h4>
 </ng-template>
 

--- a/libs/platform/src/lib/table/project.json
+++ b/libs/platform/src/lib/table/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/table"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/table/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/table/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/table/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/thumbnail/project.json
+++ b/libs/platform/src/lib/thumbnail/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/thumbnail"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/thumbnail/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/thumbnail/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/thumbnail/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/thumbnail/thumbnail-image/thumbnail-image.component.html
+++ b/libs/platform/src/lib/thumbnail/thumbnail-image/thumbnail-image.component.html
@@ -1,7 +1,7 @@
 <div class="fdp-thumbnail-image-container" role="listbox">
     <div
         #thumbnailImage
-        *ngFor="let image of mediaList | slice: 0:maxImages; let i = index"
+        *ngFor="let image of mediaList | slice : 0 : maxImages; let i = index"
         [class]="isHorizontal ? 'fdp-thumbnail-image--horizontal' : 'fdp-thumbnail-image'"
         [class.fdp-thumbnail-image--selected]="image.selected"
         [class.fdp-thumbnail-image--overlay]="image.overlayRequired"

--- a/libs/platform/src/lib/upload-collection/dialogs/new-folder/new-folder.component.html
+++ b/libs/platform/src/lib/upload-collection/dialogs/new-folder/new-folder.component.html
@@ -12,7 +12,7 @@
                     (_currentFolder
                         ? 'platformUploadCollection.newFolderAtFolderInputLabel'
                         : 'platformUploadCollection.newFolderAtRootInputLabel'
-                    ) | fdTranslate: { folderName: _currentFolder?.name || '' }
+                    ) | fdTranslate : { folderName: _currentFolder?.name || '' }
                 }}:
             </label>
             <input

--- a/libs/platform/src/lib/upload-collection/project.json
+++ b/libs/platform/src/lib/upload-collection/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/upload-collection"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/upload-collection/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/upload-collection/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/upload-collection/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/upload-collection/upload-collection/upload-collection.component.html
+++ b/libs/platform/src/lib/upload-collection/upload-collection/upload-collection.component.html
@@ -26,7 +26,7 @@
                         <span>
                             {{
                                 'platformUploadCollection.breadcrumbLabelAllFilesWithTotal'
-                                    | fdTranslate: { total: _totalItems }
+                                    | fdTranslate : { total: _totalItems }
                             }}
                         </span>
                     </ng-template>
@@ -207,7 +207,7 @@
                 <fdp-column name="uploadedOn" label="Uploaded on" width="5rem">
                     <fdp-table-cell
                         *fdpCellDef="let item"
-                        [innerText]="item.uploadedOn | date: 'shortDate'"
+                        [innerText]="item.uploadedOn | date : 'shortDate'"
                     ></fdp-table-cell>
                 </fdp-column>
 
@@ -316,7 +316,7 @@
                 <span [id]="id + '-pagination'" class="fdp-upload-collection__pagination--total">
                     {{
                         'platformUploadCollection.paginationTotal'
-                            | fdTranslate: { from: _countShowedItems, to: _countNotShowedItems, total: _totalItems }
+                            | fdTranslate : { from: _countShowedItems, to: _countNotShowedItems, total: _totalItems }
                     }}
                 </span>
                 <fd-pagination
@@ -514,19 +514,19 @@
 
 <ng-template #messageNewFolder let-payload="payload" let-messageStripType="messageStripType">
     <ng-container *ngIf="messageStripType === 'error'; else foldersCreated">
-        {{ 'platformUploadCollection.messageCreateFailed' | fdTranslate: { folderName: payload.folder.name } }}
+        {{ 'platformUploadCollection.messageCreateFailed' | fdTranslate : { folderName: payload.folder.name } }}
     </ng-container>
     <ng-template #foldersCreated>
-        {{ 'platformUploadCollection.messageCreateSuccess' | fdTranslate: { folderName: payload.folder.name } }}
+        {{ 'platformUploadCollection.messageCreateSuccess' | fdTranslate : { folderName: payload.folder.name } }}
     </ng-template>
 </ng-template>
 
 <ng-template #messageUpdateVersion let-payload="payload" let-messageStripType="messageStripType">
     <ng-container *ngIf="messageStripType === 'error'; else versionUpdated">
-        {{ 'platformUploadCollection.messageUpdateVersionFailed' | fdTranslate: { folderName: payload.item.name } }}
+        {{ 'platformUploadCollection.messageUpdateVersionFailed' | fdTranslate : { folderName: payload.item.name } }}
     </ng-container>
     <ng-template #versionUpdated>
-        {{ 'platformUploadCollection.messageUpdateVersionSuccess' | fdTranslate: { folderName: payload.item.name } }}
+        {{ 'platformUploadCollection.messageUpdateVersionSuccess' | fdTranslate : { folderName: payload.item.name } }}
     </ng-template>
 </ng-template>
 
@@ -534,13 +534,13 @@
     <ng-container *ngIf="messageStripType === 'error'; else fileRenamed">
         {{
             'platformUploadCollection.messageFileRenameFailed'
-                | fdTranslate: { from: payload.item.name, to: payload.fileName }
+                | fdTranslate : { from: payload.item.name, to: payload.fileName }
         }}
     </ng-container>
     <ng-template #fileRenamed>
         {{
             'platformUploadCollection.messageFileRenameSuccess'
-                | fdTranslate: { from: payload.item.name, to: payload.fileName }
+                | fdTranslate : { from: payload.item.name, to: payload.fileName }
         }}
     </ng-template>
 </ng-template>
@@ -550,32 +550,32 @@
         <ng-container *ngIf="messageStripType === 'error'; else foldersAndFilesRemoved">
             {{
                 'platformUploadCollection.messageRemoveFoldersAndFilesFailed'
-                    | fdTranslate: { foldersCount: count.folder, filesCount: count.file }
+                    | fdTranslate : { foldersCount: count.folder, filesCount: count.file }
             }}
         </ng-container>
         <ng-template #foldersAndFilesRemoved>
             {{
                 'platformUploadCollection.messageRemoveFoldersAndFilesSuccess'
-                    | fdTranslate: { foldersCount: count.folder, filesCount: count.file }
+                    | fdTranslate : { foldersCount: count.folder, filesCount: count.file }
             }}
         </ng-template>
     </ng-container>
 
     <ng-container *ngIf="payload.items.length > 1 && count.folder && !count.file">
         <ng-container *ngIf="messageStripType === 'error'; else foldersRemoved">
-            {{ 'platformUploadCollection.messageRemoveFoldersFailed' | fdTranslate: { foldersCount: count.folder } }}
+            {{ 'platformUploadCollection.messageRemoveFoldersFailed' | fdTranslate : { foldersCount: count.folder } }}
         </ng-container>
         <ng-template #foldersRemoved>
-            {{ 'platformUploadCollection.messageRemoveFoldersSuccess' | fdTranslate: { foldersCount: count.folder } }}
+            {{ 'platformUploadCollection.messageRemoveFoldersSuccess' | fdTranslate : { foldersCount: count.folder } }}
         </ng-template>
     </ng-container>
 
     <ng-container *ngIf="payload.items.length > 1 && count.file && !count.folder">
         <ng-container *ngIf="messageStripType === 'error'; else filesRemoved">
-            {{ 'platformUploadCollection.messageRemoveFilesFailed' | fdTranslate: { filesCount: count.file } }}
+            {{ 'platformUploadCollection.messageRemoveFilesFailed' | fdTranslate : { filesCount: count.file } }}
         </ng-container>
         <ng-template #filesRemoved>
-            {{ 'platformUploadCollection.messageRemoveFilesSuccess' | fdTranslate: { filesCount: count.file } }}
+            {{ 'platformUploadCollection.messageRemoveFilesSuccess' | fdTranslate : { filesCount: count.file } }}
         </ng-template>
     </ng-container>
 
@@ -583,13 +583,13 @@
         <ng-container *ngIf="messageStripType === 'error'; else oneItemRemoved">
             {{
                 'platformUploadCollection.messageRemoveFileOrFolderFailed'
-                    | fdTranslate: { name: payload.items[0].name }
+                    | fdTranslate : { name: payload.items[0].name }
             }}
         </ng-container>
         <ng-template #oneItemRemoved>
             {{
                 'platformUploadCollection.messageRemoveFileOrFolderSuccess'
-                    | fdTranslate: { name: payload.items[0].name }
+                    | fdTranslate : { name: payload.items[0].name }
             }}
         </ng-template>
     </ng-container>
@@ -602,7 +602,7 @@
                 (payload.to
                     ? 'platformUploadCollection.messageMoveFoldersAndFilesFailed'
                     : 'platformUploadCollection.messageMoveRootFoldersAndFilesFailed'
-                ) | fdTranslate: { foldersCount: count.folder, filesCount: count.file, to: payload.to?.name }
+                ) | fdTranslate : { foldersCount: count.folder, filesCount: count.file, to: payload.to?.name }
             }}
         </ng-container>
         <ng-template #filesAndFoldersMovedTo>
@@ -610,7 +610,7 @@
                 (payload.to
                     ? 'platformUploadCollection.messageMoveFoldersAndFilesSuccess'
                     : 'platformUploadCollection.messageMoveRootFoldersAndFilesSuccess'
-                ) | fdTranslate: { foldersCount: count.folder, filesCount: count.file, to: payload.to?.name }
+                ) | fdTranslate : { foldersCount: count.folder, filesCount: count.file, to: payload.to?.name }
             }}
         </ng-template>
     </ng-container>
@@ -621,7 +621,7 @@
                 (payload.to
                     ? 'platformUploadCollection.messageMoveFoldersFailed'
                     : 'platformUploadCollection.messageMoveRootFoldersFailed'
-                ) | fdTranslate: { foldersCount: count.folder, to: payload.to?.name }
+                ) | fdTranslate : { foldersCount: count.folder, to: payload.to?.name }
             }}
         </ng-container>
         <ng-template #foldersMovedTo>
@@ -629,7 +629,7 @@
                 (payload.to
                     ? 'platformUploadCollection.messageMoveFoldersSuccess'
                     : 'platformUploadCollection.messageMoveRootFoldersSuccess'
-                ) | fdTranslate: { foldersCount: count.folder, to: payload.to?.name }
+                ) | fdTranslate : { foldersCount: count.folder, to: payload.to?.name }
             }}
         </ng-template>
     </ng-container>
@@ -640,7 +640,7 @@
                 (payload.to
                     ? 'platformUploadCollection.messageMoveFilesFailed'
                     : 'platformUploadCollection.messageMoveRootFilesFailed'
-                ) | fdTranslate: { filesCount: count.file, to: payload.to?.name }
+                ) | fdTranslate : { filesCount: count.file, to: payload.to?.name }
             }}
         </ng-container>
         <ng-template #filesMovedTo>
@@ -648,7 +648,7 @@
                 (payload.to
                     ? 'platformUploadCollection.messageMoveFilesSuccess'
                     : 'platformUploadCollection.messageMoveRootFilesSuccess'
-                ) | fdTranslate: { filesCount: count.file, to: payload.to?.name }
+                ) | fdTranslate : { filesCount: count.file, to: payload.to?.name }
             }}
         </ng-template>
     </ng-container>
@@ -659,7 +659,7 @@
                 (payload.to
                     ? 'platformUploadCollection.messageMoveFileOrFolderFailed'
                     : 'platformUploadCollection.messageMoveRootFileOrFolderFailed'
-                ) | fdTranslate: { name: payload.items[0].name, to: payload.to?.name }
+                ) | fdTranslate : { name: payload.items[0].name, to: payload.to?.name }
             }}
         </ng-container>
         <ng-template #oneItemMovedTo>
@@ -667,7 +667,7 @@
                 (payload.to
                     ? 'platformUploadCollection.messageMoveFileOrFolderSuccess'
                     : 'platformUploadCollection.messageMoveRootFileOrFolderSuccess'
-                ) | fdTranslate: { name: payload.items[0].name, to: payload.to?.name }
+                ) | fdTranslate : { name: payload.items[0].name, to: payload.to?.name }
             }}
         </ng-template>
     </ng-container>
@@ -677,14 +677,14 @@
     <ng-container *ngIf="payload.items.length > 1">
         {{
             'platformUploadCollection.messageFileTypeMismatchPlural'
-                | fdTranslate: { filesCount: payload.items.length, allowedTypes: _getAllowedTypes() }
+                | fdTranslate : { filesCount: payload.items.length, allowedTypes: _getAllowedTypes() }
         }}
     </ng-container>
 
     <ng-container *ngIf="payload.items.length === 1">
         {{
             'platformUploadCollection.messageFileTypeMismatchSingular'
-                | fdTranslate: { fileName: payload.items[0].name, allowedTypes: _getAllowedTypes() }
+                | fdTranslate : { fileName: payload.items[0].name, allowedTypes: _getAllowedTypes() }
         }}
     </ng-container>
 </ng-template>
@@ -693,14 +693,14 @@
     <ng-container *ngIf="payload.items.length > 1">
         {{
             'platformUploadCollection.messageFileSizeExceededPlural'
-                | fdTranslate: { filesCount: payload.items.length, maxFileSize: maxFileSize || 0 }
+                | fdTranslate : { filesCount: payload.items.length, maxFileSize: maxFileSize || 0 }
         }}
     </ng-container>
 
     <ng-container *ngIf="payload.items.length === 1">
         {{
             'platformUploadCollection.messageFileSizeExceededSingular'
-                | fdTranslate: { fileName: payload.items[0].name, maxFileSize: maxFileSize || 0 }
+                | fdTranslate : { fileName: payload.items[0].name, maxFileSize: maxFileSize || 0 }
         }}
     </ng-container>
 </ng-template>
@@ -709,14 +709,14 @@
     <ng-container *ngIf="payload.items.length > 1">
         {{
             'platformUploadCollection.messageFileNameLengthExceededPlural'
-                | fdTranslate: { filesCount: payload.items.length, maxFilenameLength: maxFilenameLength || 0 }
+                | fdTranslate : { filesCount: payload.items.length, maxFilenameLength: maxFilenameLength || 0 }
         }}
     </ng-container>
 
     <ng-container *ngIf="payload.items.length === 1">
         {{
             'platformUploadCollection.messageFileNameLengthExceededSingular'
-                | fdTranslate: { fileName: payload.items[0].name, maxFilenameLength: maxFilenameLength || 0 }
+                | fdTranslate : { fileName: payload.items[0].name, maxFilenameLength: maxFilenameLength || 0 }
         }}
     </ng-container>
 </ng-template>

--- a/libs/platform/src/lib/value-help-dialog/components/define-tab/define-tab.component.html
+++ b/libs/platform/src/lib/value-help-dialog/components/define-tab/define-tab.component.html
@@ -11,7 +11,7 @@
                 <label [id]="selectedId" fd-form-label class="fdp-value-help-dialog__hidden_label">
                     {{
                         'platformVHD.defineConditionSelectedValueHiddenA11yLabel'
-                            | fdTranslate: { value: item.strategy }
+                            | fdTranslate : { value: item.strategy }
                     }}</label
                 >
                 <fd-select
@@ -215,7 +215,7 @@
 
 <ng-template #countError let-count>
     <fd-form-message type="error" *ngIf="count && count > 7">
-        {{ 'platformVHD.defineConditionMaxCountError' | fdTranslate: { count: 7 } }}
+        {{ 'platformVHD.defineConditionMaxCountError' | fdTranslate : { count: 7 } }}
     </fd-form-message>
 </ng-template>
 

--- a/libs/platform/src/lib/value-help-dialog/project.json
+++ b/libs/platform/src/lib/value-help-dialog/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/value-help-dialog"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/value-help-dialog/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/value-help-dialog/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/value-help-dialog/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/platform/src/lib/variant-management/project.json
+++ b/libs/platform/src/lib/variant-management/project.json
@@ -5,20 +5,10 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:package",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/variant-management"],
+            "executor": "nx:run-commands",
             "options": {
-                "project": "libs/platform/src/lib/variant-management/ng-package.json"
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/variant-management/tsconfig.lib.prod.json"
-                },
-                "development": {
-                    "tsConfig": "libs/platform/src/lib/variant-management/tsconfig.lib.json"
-                }
-            },
-            "defaultConfiguration": "production"
+                "command": "echo This should not be called && exit 1"
+            }
         },
         "test": {
             "executor": "@angular-devkit/build-angular:karma",

--- a/libs/platform/src/lib/wizard-generator/project.json
+++ b/libs/platform/src/lib/wizard-generator/project.json
@@ -5,17 +5,9 @@
     "prefix": "fdp",
     "targets": {
         "build": {
-            "executor": "@nrwl/angular:ng-packagr-lite",
-            "outputs": ["{workspaceRoot}/dist/libs/platform/wizard-generator"],
+            "executor": "nx:run-commands",
             "options": {
-                "tsConfig": "libs/platform/src/lib/wizard-generator/tsconfig.lib.json",
-                "project": "libs/platform/src/lib/wizard-generator/ng-package.json",
-                "updateBuildableProjectDepsInPackageJson": false
-            },
-            "configurations": {
-                "production": {
-                    "tsConfig": "libs/platform/src/lib/wizard-generator/tsconfig.lib.prod.json"
-                }
+                "command": "echo This should not be called && exit 1"
             }
         },
         "test": {

--- a/libs/plugins/wdio/project.json
+++ b/libs/plugins/wdio/project.json
@@ -5,35 +5,9 @@
     "projectType": "library",
     "targets": {
         "build": {
-            "executor": "@nrwl/js:tsc",
-            "outputs": ["{options.outputPath}"],
+            "executor": "nx:run-commands",
             "options": {
-                "outputPath": "dist/libs/plugins/wdio",
-                "main": "libs/plugins/wdio/src/index.ts",
-                "tsConfig": "libs/plugins/wdio/tsconfig.lib.json",
-                "assets": [
-                    "libs/plugins/wdio/*.md",
-                    {
-                        "input": "./libs/plugins/wdio/src",
-                        "glob": "**/!(*.ts)",
-                        "output": "./src"
-                    },
-                    {
-                        "input": "./libs/plugins/wdio/src",
-                        "glob": "**/*.d.ts",
-                        "output": "./src"
-                    },
-                    {
-                        "input": "./libs/plugins/wdio",
-                        "glob": "generators.json",
-                        "output": "."
-                    },
-                    {
-                        "input": "./libs/plugins/wdio",
-                        "glob": "executors.json",
-                        "output": "."
-                    }
-                ]
+                "command": "echo This should not be called && exit 1"
             }
         },
         "lint": {

--- a/nx.json
+++ b/nx.json
@@ -8,7 +8,15 @@
             "runner": "@nrwl/nx-cloud",
             "options": {
                 "accessToken": "MzFiYWRhMTItYTAxYi00MGZjLWJmNDEtOTllMzEwZjI5ODNkfHJlYWQ=",
-                "cacheableOperations": ["generate-typedoc", "compile-typedoc", "build-umbrella", "lint", "test", "e2e"],
+                "cacheableOperations": [
+                    "generate-typedoc",
+                    "compile-typedoc",
+                    "build",
+                    "build-umbrella",
+                    "lint",
+                    "test",
+                    "e2e"
+                ],
                 "canTrackAnalytics": false,
                 "showUsageWarnings": true
             }

--- a/nx.json
+++ b/nx.json
@@ -8,15 +8,7 @@
             "runner": "@nrwl/nx-cloud",
             "options": {
                 "accessToken": "MzFiYWRhMTItYTAxYi00MGZjLWJmNDEtOTllMzEwZjI5ODNkfHJlYWQ=",
-                "cacheableOperations": [
-                    "generate-typedoc",
-                    "compile-typedoc",
-                    "build",
-                    "build-umbrella",
-                    "lint",
-                    "test",
-                    "e2e"
-                ],
+                "cacheableOperations": ["generate-typedoc", "compile-typedoc", "build-umbrella", "lint", "test", "e2e"],
                 "canTrackAnalytics": false,
                 "showUsageWarnings": true
             }
@@ -57,12 +49,9 @@
     },
     "$schema": "./node_modules/nx/schemas/nx-schema.json",
     "targetDefaults": {
-        "build": {
-            "dependsOn": ["^build"],
-            "inputs": ["production", "^production"]
-        },
         "build-umbrella": {
-            "dependsOn": ["^build-umbrella"]
+            "dependsOn": ["^build-umbrella"],
+            "inputs": ["production", "^production"]
         },
         "prepare": {
             "dependsOn": ["build-umbrella"]

--- a/tools/executors/compile-typedoc/index.ts
+++ b/tools/executors/compile-typedoc/index.ts
@@ -12,7 +12,7 @@ export default async function compileTypedocs(_options: any, context: ExecutorCo
         },
         context
     );
-    const { buildTarget = 'build' } = context.workspace.projects[context.projectName as string] as any;
+    const { buildTarget = 'build-umbrella' } = context.workspace.projects[context.projectName as string] as any;
     const { tsConfig } = readTargetOptions({ project: context.projectName as string, target: buildTarget }, context);
     execSync(
         `npx typedoc --out ${outputPath} ${projectPath} --tsconfig ${tsConfig} --hideGenerator --theme apps/docs/src/fd-typedoc`,

--- a/versions.json
+++ b/versions.json
@@ -1,114 +1,114 @@
 [
-  {
-    "id": "0.38.2",
-    "url": "https://63acb39391241d000875beb0--fundamental-ngx.netlify.app"
-  },
-  {
-    "id": "0.37.1",
-    "url": "https://639481c052f12500083fa373--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.36.2",
-    "url": "https://635720a7e34ffc00087a288e--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.35.4",
-    "url": "https://62e4858ae62a5c0009e9e7c5--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.34.2",
-    "url": "https://624793d2f1d02d000925c339--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.33.5",
-    "url": "https://6230a5e98514e70008daf4ca--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.32.1",
-    "url": "https://6148d47b4c8c3d0008ecc1cf--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.31.0",
-    "url": "https://6116c4d420b1d40007ce5fd9--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.30.0",
-    "url": "https://6099b79d6eba2400084bb441--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.29.0",
-    "url": "https://6040dbed0b78130008f102b5--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.28.0",
-    "url": "https://60386a93e4a7010007247f23--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.27.0",
-    "url": "https://602a61e08b3cf200074fa0b5--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.26.0",
-    "url": "https://600860290fee570007d7f660--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.25.1",
-    "url": "https://5fdb2c4892110a00080b0895--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.24.1",
-    "url": "https://5fbd1c1239f44a000736c439--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.23.0",
-    "url": "https://5f96ff4047c5f300070eb8a1--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.22.0",
-    "url": "https://5f776fb812cfa300086de86a--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.21.0",
-    "url": "https://5f355f63718e9200075585e1--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.20.0",
-    "url": "https://5f0630964a7a370007f93dc4--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.19.0",
-    "url": "https://5ef288ca158ebd0008946f4d--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.18.0",
-    "url": "https://5ec04b7f46b9bd000648f8ec--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.17.0",
-    "url": "https://5e9a135cc7c8e90006047bdf--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.16.0",
-    "url": "https://5e97032838070600063141e4--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.15.0",
-    "url": "https://5e5fe7518009de0008f41fff--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.14.0",
-    "url": "https://5e4f1d0714bc4c000ae3282d--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.13.0",
-    "url": "https://5e25d4d1837fae0009b5c4fa--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.12.0",
-    "url": "https://5db1dc978d2a340009a82d64--fundamental-ngx.netlify.app/"
-  },
-  {
-    "id": "0.11.0",
-    "url": "https://5d8a3409acaf8d00070ccd64--fundamental-ngx.netlify.app/"
-  }
+    {
+        "id": "0.38.2",
+        "url": "https://63acb39391241d000875beb0--fundamental-ngx.netlify.app"
+    },
+    {
+        "id": "0.37.1",
+        "url": "https://639481c052f12500083fa373--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.36.2",
+        "url": "https://635720a7e34ffc00087a288e--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.35.4",
+        "url": "https://62e4858ae62a5c0009e9e7c5--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.34.2",
+        "url": "https://624793d2f1d02d000925c339--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.33.5",
+        "url": "https://6230a5e98514e70008daf4ca--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.32.1",
+        "url": "https://6148d47b4c8c3d0008ecc1cf--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.31.0",
+        "url": "https://6116c4d420b1d40007ce5fd9--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.30.0",
+        "url": "https://6099b79d6eba2400084bb441--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.29.0",
+        "url": "https://6040dbed0b78130008f102b5--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.28.0",
+        "url": "https://60386a93e4a7010007247f23--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.27.0",
+        "url": "https://602a61e08b3cf200074fa0b5--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.26.0",
+        "url": "https://600860290fee570007d7f660--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.25.1",
+        "url": "https://5fdb2c4892110a00080b0895--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.24.1",
+        "url": "https://5fbd1c1239f44a000736c439--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.23.0",
+        "url": "https://5f96ff4047c5f300070eb8a1--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.22.0",
+        "url": "https://5f776fb812cfa300086de86a--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.21.0",
+        "url": "https://5f355f63718e9200075585e1--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.20.0",
+        "url": "https://5f0630964a7a370007f93dc4--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.19.0",
+        "url": "https://5ef288ca158ebd0008946f4d--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.18.0",
+        "url": "https://5ec04b7f46b9bd000648f8ec--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.17.0",
+        "url": "https://5e9a135cc7c8e90006047bdf--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.16.0",
+        "url": "https://5e97032838070600063141e4--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.15.0",
+        "url": "https://5e5fe7518009de0008f41fff--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.14.0",
+        "url": "https://5e4f1d0714bc4c000ae3282d--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.13.0",
+        "url": "https://5e25d4d1837fae0009b5c4fa--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.12.0",
+        "url": "https://5db1dc978d2a340009a82d64--fundamental-ngx.netlify.app/"
+    },
+    {
+        "id": "0.11.0",
+        "url": "https://5d8a3409acaf8d00070ccd64--fundamental-ngx.netlify.app/"
+    }
 ]


### PR DESCRIPTION
## Description
These changes are trying to replace `build` with `build-umbrella`, having `build` is crucial for eslint. So let's try to replace it and leave it to be just a placeholder