### PR TITLE
fix(core): dynamic footer z-index must be higher than that of fd-scrollbar

### DIFF
--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.scss
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.scss
@@ -27,7 +27,7 @@
     height: 100%;
 
     .fd-bar--floating-footer {
-        z-index: 2;
+        z-index: 6;
     }
 
     .fd-tabs-custom {


### PR DESCRIPTION
fixes #9152 

Note that the original issue isn't apparent until clicking on the dynamic page content.