### PR TITLE
fix(core): date-picker respects closeOnDateChoose input now

### DIFF
--- a/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
+++ b/libs/core/src/lib/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
@@ -51,9 +51,11 @@ export class CalendarDayViewComponent<D> implements OnInit, OnChanges, OnDestroy
             this._buildDayViewGrid();
         }
     }
+
     get currentlyDisplayed(): CalendarCurrent {
         return this._currentlyDisplayed;
     }
+
     /** @hidden */
     private _currentlyDisplayed: CalendarCurrent;
 
@@ -66,9 +68,11 @@ export class CalendarDayViewComponent<D> implements OnInit, OnChanges, OnDestroy
             this._changeSelectedSingleDay(dayFromDate, this._calendarDayList);
         }
     }
+
     get selectedDate(): Nullable<D> {
         return this._selectedDate;
     }
+
     /** @hidden */
     private _selectedDate: Nullable<D>;
 
@@ -88,9 +92,11 @@ export class CalendarDayViewComponent<D> implements OnInit, OnChanges, OnDestroy
             this._changeSelectedRangeDays(dateRange, this._calendarDayList);
         }
     }
+
     get selectedRangeDate(): DateRange<D> {
         return this._selectedRangeDate;
     }
+
     /** @hidden */
     private _selectedRangeDate: DateRange<D>;
 

--- a/libs/core/src/lib/calendar/calendar.component.spec.ts
+++ b/libs/core/src/lib/calendar/calendar.component.spec.ts
@@ -55,8 +55,8 @@ describe('CalendarComponent', () => {
         spyOn(component.closeCalendar, 'emit');
         spyOn(component, 'onChange');
         component.selectedRangeDateChanged({ start: date1, end: null });
-        expect(component.onChange).toHaveBeenCalledWith({ start: date1, end: date1 });
-        expect(component.selectedRangeDateChange.emit).toHaveBeenCalledWith({ start: date1, end: date1 });
+        expect(component.onChange).toHaveBeenCalledWith({ start: date1, end: null });
+        expect(component.selectedRangeDateChange.emit).toHaveBeenCalledWith({ start: date1, end: null });
         expect(component.closeCalendar.emit).toHaveBeenCalled();
     });
 

--- a/libs/core/src/lib/calendar/calendar.component.ts
+++ b/libs/core/src/lib/calendar/calendar.component.ts
@@ -439,7 +439,7 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
      */
     selectedRangeDateChanged(dates: DateRange<D>): void {
         if (dates) {
-            this.selectedRangeDate = { start: dates.start, end: dates.end ? dates.end : dates.start };
+            this.selectedRangeDate = { start: dates.start, end: dates.end };
             this.selectedRangeDateChange.emit(this.selectedRangeDate);
             this.onChange(this.selectedRangeDate);
             this.closeCalendar.emit();

--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -526,6 +526,9 @@ export class DatePickerComponent<D>
             this.onChange(date);
             this.formatInputDate(date);
             this._isInvalidDateInput = !this.isModelValid();
+            if (this.closeOnDateChoose && this.type === 'single') {
+                this.closeCalendar();
+            }
         }
     }
 
@@ -544,16 +547,18 @@ export class DatePickerComponent<D>
      * Method that is triggered by events from calendar component, when there is selected range date changed
      */
     public handleRangeDateChange(dates: DateRange<D>): void {
-        if (
-            dates &&
-            (!this._dateTimeAdapter.datesEqual(this.selectedRangeDate.start, dates.start) ||
-                !this._dateTimeAdapter.datesEqual(this.selectedRangeDate.end, dates.end))
-        ) {
+        const startChanged = !this._dateTimeAdapter.datesEqual(dates.start, this.selectedRangeDate.start);
+        const endChanged = !this._dateTimeAdapter.datesEqual(dates.end, this.selectedRangeDate.end);
+        if (dates && (startChanged || endChanged)) {
+            const shouldClose = this.closeOnDateChoose && dates.end !== null;
             this._inputFieldDate = this._formatDateRange(dates);
             this.selectedRangeDate = { start: dates.start, end: dates.end };
             this.selectedRangeDateChange.emit(this.selectedRangeDate);
             this.onChange(this.selectedRangeDate);
             this._isInvalidDateInput = !this.isModelValid();
+            if (shouldClose) {
+                this.closeCalendar();
+            }
         }
     }
 


### PR DESCRIPTION
## Related Issue(s)

closes #9060 

## Description

The calendar would alter date-range values, as a result, there was no way of knowing whether or not the user had finished selecting dates, and also date-picker was not respecting `closeOnDateChoose` input.
