### PR TITLE
feat(platform): change and apply smart filter bar events

### DIFF
--- a/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-basic-example.component.html
+++ b/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-basic-example.component.html
@@ -1,4 +1,13 @@
-<fdp-smart-filter-bar fdCompact [subject]="subject"></fdp-smart-filter-bar>
+<button fd-button (click)="logFilters(smartFilterBar)">Log current set of filters</button>
+<br />
+<br />
+<fdp-smart-filter-bar
+    #smartFilterBar
+    (smartFiltersApplied)="filtersChanged($event, 'applied')"
+    (smartFiltersChanged)="filtersChanged($event, 'changed')"
+    fdCompact
+    [subject]="subject"
+></fdp-smart-filter-bar>
 <br />
 <h4 fd-title>Line Items</h4>
 <br />

--- a/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-basic-example.component.ts
+++ b/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-basic-example.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { FdDate } from '@fundamental-ngx/core/datetime';
+import { SmartFilterBar, SmartFilterChangeObject } from '@fundamental-ngx/platform';
 import { FilterableColumnDataType, FilterType } from '@fundamental-ngx/platform/table';
 
 @Component({
@@ -16,6 +17,16 @@ export class PlatformSmartFilterBarBasicExampleComponent {
 
     trackBy(_: number, item: ExampleItem): number {
         return item.id;
+    }
+
+    filtersChanged(filters: SmartFilterChangeObject, type: string): void {
+        console.log(`Filters has been ${type}. Current value: `, filters);
+    }
+
+    async logFilters(filterBar: SmartFilterBar): Promise<void> {
+        const conditions = await filterBar.getFormattedConditions();
+        const search = filterBar.search;
+        console.log({ search, conditions });
     }
 }
 

--- a/libs/platform/src/lib/smart-filter-bar/smart-filter-bar.class.ts
+++ b/libs/platform/src/lib/smart-filter-bar/smart-filter-bar.class.ts
@@ -1,5 +1,6 @@
 import { Directive, EventEmitter, Input, Output } from '@angular/core';
 import { PresetManagedComponent } from '@fundamental-ngx/platform/shared';
+import { CollectionFilterGroup, SearchInput } from '@fundamental-ngx/platform/table';
 import { SmartFilterBarManagedPreset } from './interfaces/smart-filter-bar-change';
 import { SmartFilterBarCondition } from './interfaces/smart-filter-bar-condition';
 import { SmartFilterBarStrategyLabels } from './interfaces/strategy-labels.type';
@@ -17,6 +18,8 @@ export abstract class SmartFilterBar implements PresetManagedComponent<SmartFilt
     /** @hidden */
     defineStrategyLabels?: SmartFilterBarStrategyLabels;
 
+    abstract search: SearchInput | undefined;
+
     /** @hidden */
     abstract getDisplayValue(condition: SmartFilterBarCondition, filterType: string): Promise<string>;
 
@@ -25,4 +28,6 @@ export abstract class SmartFilterBar implements PresetManagedComponent<SmartFilt
 
     /** Returns current preset configuration. */
     abstract getCurrentPreset(): SmartFilterBarManagedPreset;
+
+    abstract getFormattedConditions(): Promise<CollectionFilterGroup[]>;
 }


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #9143 

## Description
Added new events: `smartFiltersApplied` and `searchInputChanged`.
`smartFiltersApplied` emitted when 'Go' button clicked.
`searchInputChanged` emitted when `inputChange` event of search field is emitted.
`smartFiltersChanged` is now triggered everytime when filters model has been updated without 'GO' button click.

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [x] update `README.md`
-   [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
