### PR TITLE
fix(core): pagination mobile displaying total items count instead of total pages

### DIFF
--- a/libs/core/src/lib/pagination/pagination.component.html
+++ b/libs/core/src/lib/pagination/pagination.component.html
@@ -92,8 +92,7 @@
             {{
                 labelBeforeInputMobile
                     ? labelBeforeInputMobile + ':'
-                    : ('corePagination.labelBeforeInputMobile'
-                      | fdTranslate : { pageNumber: currentPage, totalCount: totalItems })
+                    : ('corePagination.labelBeforeInputMobile' | fdTranslate)
             }}
         </label>
 
@@ -113,9 +112,9 @@
             [ngModel]="currentPage"
             [attr.aria-label]="
                 inputAriaLabel
-                    ? inputAriaLabel(currentPage, totalItems)
+                    ? inputAriaLabel(currentPage, _totalPages)
                     : ('corePagination.inputAriaLabel'
-                      | fdTranslate : { pageNumber: currentPage, totalCount: totalItems })
+                      | fdTranslate : { pageNumber: currentPage, totalCount: _totalPages })
             "
             (keydown.enter)="goToPage(currentPageModel.value)"
             (keydown.space)="goToPage(currentPageModel.value)"
@@ -127,7 +126,7 @@
                 labelAfterInputMobile
                     ? labelAfterInputMobile(_lastPage)
                     : ('corePagination.labelAfterInputMobile'
-                      | fdTranslate : { pageNumber: currentPage, totalCount: totalItems })
+                      | fdTranslate : { pageNumber: currentPage, totalCount: _totalPages })
             }}
         </label>
 

--- a/libs/core/src/lib/pagination/pagination.component.ts
+++ b/libs/core/src/lib/pagination/pagination.component.ts
@@ -249,6 +249,11 @@ export class PaginationComponent implements OnChanges, OnInit, OnDestroy {
     }
 
     /** @hidden */
+    get _totalPages(): number {
+        return this.paginationService.getTotalPages(this.paginationObject);
+    }
+
+    /** @hidden */
     get _totalPagesElementId(): string {
         return this.id + '__total';
     }


### PR DESCRIPTION
fixes none

Mobile pagination was showing the total number of items in a pagination component rather than total pages