### PR TITLE
fix(core,cx): nested list icon should extend fd-icon

### DIFF
--- a/libs/core/src/lib/nested-list/nested-list-directives.spec.ts
+++ b/libs/core/src/lib/nested-list/nested-list-directives.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NestedItemService } from './nested-item/nested-item.service';
 import {
     NestedListExpandIconComponent,
-    NestedListIconDirective,
+    NestedListIconComponent,
     NestedListTitleDirective
 } from './nested-list-directives';
 import { NestedListModule } from './nested-list.module';
@@ -22,14 +22,14 @@ class TestNestedContainerComponent {
     @ViewChild(NestedListExpandIconComponent)
     expandIconElement: NestedListExpandIconComponent;
 
-    @ViewChild(NestedListIconDirective)
-    iconElement: NestedListIconDirective;
+    @ViewChild(NestedListIconComponent)
+    iconElement: NestedListIconComponent;
 }
 
 describe('NestedListDirectives', () => {
     let component: TestNestedContainerComponent;
     let expandIconElement: NestedListExpandIconComponent;
-    let iconElement: NestedListIconDirective;
+    let iconElement: NestedListIconComponent;
     let titleElement: NestedListTitleDirective;
     let fixture: ComponentFixture<TestNestedContainerComponent>;
 

--- a/libs/core/src/lib/nested-list/nested-list-directives.ts
+++ b/libs/core/src/lib/nested-list/nested-list-directives.ts
@@ -7,17 +7,14 @@ import {
     HostBinding,
     HostListener,
     Input,
-    OnChanges,
-    OnInit,
     Optional,
     ViewEncapsulation
 } from '@angular/core';
 import { NestedItemService } from './nested-item/nested-item.service';
-import { applyCssClass } from '@fundamental-ngx/cdk/utils';
-import { CssClassBuilder } from '@fundamental-ngx/cdk/utils';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { map } from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 
 let uniqueId = 0;
 
@@ -43,20 +40,12 @@ export class NestedListHeaderDirective {
     }
 }
 
-@Directive({
-    selector: '[fdNestedDirectivesIcon], [fd-nested-list-icon]'
+@Component({
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: '[fdNestedDirectivesIcon], [fd-nested-list-icon]',
+    template: `<ng-content></ng-content>`
 })
-export class NestedListIconDirective implements CssClassBuilder, OnChanges, OnInit {
-    /** The property allows user to pass additional css classes */
-    @Input()
-    class = '';
-
-    /**
-     * The icon name to display. See the icon page for the list of icons
-     * here: https://sap.github.io/fundamental-ngx/icon
-     */
-    @Input() glyph: string;
-
+export class NestedListIconComponent extends IconComponent {
     /** Role attribute */
     @Input()
     @HostBinding('attr.role')
@@ -65,30 +54,6 @@ export class NestedListIconDirective implements CssClassBuilder, OnChanges, OnIn
     /** @hidden */
     @HostBinding('class.fd-nested-list__icon')
     fdNestedListIconClass = true;
-
-    /** @hidden */
-    constructor(private _elementRef: ElementRef) {}
-
-    /** @hidden */
-    ngOnChanges(): void {
-        this.buildComponentCssClass();
-    }
-
-    /** @hidden */
-    ngOnInit(): void {
-        this.buildComponentCssClass();
-    }
-
-    /** @hidden CssClassBuilder interface implementation */
-    @applyCssClass
-    buildComponentCssClass(): string[] {
-        return ['fd-nested-list__icon', this.glyph ? `sap-icon--${this.glyph}` : '', this.class];
-    }
-
-    /** HasElementRef interface implementation */
-    elementRef(): ElementRef<any> {
-        return this._elementRef;
-    }
 }
 
 @Directive({

--- a/libs/core/src/lib/nested-list/nested-list.module.ts
+++ b/libs/core/src/lib/nested-list/nested-list.module.ts
@@ -5,7 +5,7 @@ import { NestedItemDirective } from './nested-item/nested-item.directive';
 import {
     NestedListExpandIconComponent,
     NestedListHeaderDirective,
-    NestedListIconDirective,
+    NestedListIconComponent,
     NestedListTitleDirective
 } from './nested-list-directives';
 import { MenuKeyboardService } from '@fundamental-ngx/core/menu';
@@ -27,7 +27,7 @@ import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
         NestedListDirective,
         NestedLinkDirective,
         NestedItemDirective,
-        NestedListIconDirective,
+        NestedListIconComponent,
         NestedListTitleDirective,
         NestedListHeaderDirective,
         NestedListPopoverComponent,
@@ -40,7 +40,7 @@ import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
         NestedListDirective,
         NestedLinkDirective,
         NestedItemDirective,
-        NestedListIconDirective,
+        NestedListIconComponent,
         NestedListTitleDirective,
         NestedListHeaderDirective,
         NestedListPopoverComponent,

--- a/libs/cx/src/lib/nested-list/nested-list-directives.spec.ts
+++ b/libs/cx/src/lib/nested-list/nested-list-directives.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { NestedItemService } from './nested-item/nested-item.service';
 import {
-    NestedListIconDirective,
+    NestedListIconComponent,
     NestedListTitleDirective,
     NestedListExpandIconComponent
 } from './nested-list-directives';
@@ -23,14 +23,14 @@ class TestNestedContainerComponent {
     @ViewChild(NestedListExpandIconComponent)
     expandIconElement: NestedListExpandIconComponent;
 
-    @ViewChild(NestedListIconDirective)
-    iconElement: NestedListIconDirective;
+    @ViewChild(NestedListIconComponent)
+    iconElement: NestedListIconComponent;
 }
 
 describe('NestedListDirectives', () => {
     let component: TestNestedContainerComponent;
     let expandIconElement: NestedListExpandIconComponent;
-    let iconElement: NestedListIconDirective;
+    let iconElement: NestedListIconComponent;
     let titleElement: NestedListTitleDirective;
     let fixture: ComponentFixture<TestNestedContainerComponent>;
 

--- a/libs/cx/src/lib/nested-list/nested-list-directives.ts
+++ b/libs/cx/src/lib/nested-list/nested-list-directives.ts
@@ -9,17 +9,14 @@ import {
     HostBinding,
     HostListener,
     Input,
-    OnChanges,
-    OnInit,
     Optional,
     ViewEncapsulation
 } from '@angular/core';
 import { NestedItemService } from './nested-item/nested-item.service';
-import { applyCssClass } from '@fundamental-ngx/core/utils';
-import { CssClassBuilder } from '@fundamental-ngx/core/utils';
 import { RtlService } from '@fundamental-ngx/core/utils';
 import { map } from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 
 let uniqueId = 0;
 
@@ -45,20 +42,12 @@ export class NestedListHeaderDirective {
     }
 }
 
-@Directive({
-    selector: '[cxNestedDirectivesIcon], [fdx-nested-list-icon]'
+@Component({
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: '[cxNestedDirectivesIcon], [fdx-nested-list-icon]',
+    template: `<ng-content></ng-content>`
 })
-export class NestedListIconDirective implements CssClassBuilder, OnChanges, OnInit {
-    /** The property allows user to pass additional css classes */
-    @Input()
-    class = '';
-
-    /**
-     * The icon name to display. See the icon page for the list of icons
-     * here: https://sap.github.io/fundamental-ngx/icon
-     */
-    @Input() glyph: string;
-
+export class NestedListIconComponent extends IconComponent {
     /** Role attribute */
     @Input()
     @HostBinding('attr.role')
@@ -66,31 +55,7 @@ export class NestedListIconDirective implements CssClassBuilder, OnChanges, OnIn
 
     /** @hidden */
     @HostBinding('class.fdx-nested-list__icon')
-    cxNestedListIconClass = true;
-
-    /** @hidden */
-    constructor(private _elementRef: ElementRef) {}
-
-    /** @hidden */
-    ngOnChanges(): void {
-        this.buildComponentCssClass();
-    }
-
-    /** @hidden */
-    ngOnInit(): void {
-        this.buildComponentCssClass();
-    }
-
-    /** @hidden CssClassBuilder interface implementation */
-    @applyCssClass
-    buildComponentCssClass(): string[] {
-        return ['fdx-nested-list__icon', this.glyph ? `sap-icon--${this.glyph}` : '', this.class];
-    }
-
-    /** HasElementRef interface implementation */
-    elementRef(): ElementRef<any> {
-        return this._elementRef;
-    }
+    fdNestedListIconClass = true;
 }
 
 @Directive({

--- a/libs/cx/src/lib/nested-list/nested-list.module.ts
+++ b/libs/cx/src/lib/nested-list/nested-list.module.ts
@@ -6,7 +6,7 @@ import {
     NestedListButtonDirective,
     NestedListExpandIconComponent,
     NestedListHeaderDirective,
-    NestedListIconDirective,
+    NestedListIconComponent,
     NestedListTitleDirective
 } from './nested-list-directives';
 import { MenuKeyboardService } from '@fundamental-ngx/core/menu';
@@ -27,7 +27,7 @@ import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
         NestedListComponent,
         NestedLinkComponent,
         NestedItemComponent,
-        NestedListIconDirective,
+        NestedListIconComponent,
         NestedListTitleDirective,
         NestedListHeaderDirective,
         NestedListPopoverComponent,
@@ -40,7 +40,7 @@ import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
         NestedListComponent,
         NestedLinkComponent,
         NestedItemComponent,
-        NestedListIconDirective,
+        NestedListIconComponent,
         NestedListTitleDirective,
         NestedListHeaderDirective,
         NestedListPopoverComponent,

--- a/libs/docs/core/shared/src/lib/api-files.ts
+++ b/libs/docs/core/shared/src/lib/api-files.ts
@@ -265,7 +265,7 @@ export const API_FILES = {
         'NestedListDirective',
         'NestedListPopoverComponent',
         'NestedListHeaderDirective',
-        'NestedListIconDirective',
+        'NestedListIconComponent',
         'NestedListItem',
         'NestedListModel',
         'NestedListLink',


### PR DESCRIPTION
fixes #8902 

<code>NestedListIconDirective</code> becomes <code>NestedListIconComponent</code> and extends <code>IconComponent</code>, allowing devs to pass a <code>[font]</code> input to change the icon set. No breaking changes to existing templates