### PR TITLE
fix(ci): fixed agents timeout when running e2e tests on local

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -112,6 +112,11 @@ jobs:
               if: ${{ steps.firebase_hosting_preview.outputs.details_url }}
               run: |
                   npx nx affected --target=e2e --base=origin/main --head=HEAD --parallel=2 --baseUrl=${{ steps.firebase_hosting_preview.outputs.details_url }} --devServerTarget=""
+
+            - name: Stopping agents # They're no longer needed, so we can stop them to avoid them going on timeout
+              if: ${{ !steps.firebase_hosting_preview.outputs.details_url }}
+              run: npx nx-cloud stop-all-agents
+
             - name: Test affected on local
               if: ${{ !steps.firebase_hosting_preview.outputs.details_url }}
               run: |


### PR DESCRIPTION
## Description
If firebase deploy fails for some reason, agents should be stopped, otherwise they will go on timeout, because local e2e tests do not require DTE
