### PR TITLE
fix(platform): can not enter space characters in inputs inside table cells

### DIFF
--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1404,7 +1404,12 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
             return;
         }
 
-        event?.preventDefault();
+        if (event) {
+            const eventTarget = event.target as HTMLElement;
+            if (eventTarget.tagName !== 'INPUT' && eventTarget.tagName !== 'TEXTAREA') {
+                event.preventDefault();
+            }
+        }
 
         if (row.navigatable) {
             this._emitRowNavigate(row);

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -92,7 +92,7 @@ import {
     ContentDensityObserver,
     contentDensityObserverProviders
 } from '@fundamental-ngx/core/content-density';
-import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
+import { LEFT_ARROW, RIGHT_ARROW, SPACE } from '@angular/cdk/keycodes';
 
 export type FdpTableDataSource<T> = T[] | Observable<T[]> | TableDataSource<T>;
 
@@ -1404,13 +1404,13 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
             return;
         }
 
-        if (event) {
+        if (event && event instanceof KeyboardEvent && KeyUtil.isKeyCode(event, SPACE)) {
             const eventTarget = event.target as HTMLInputElement;
             if (
                 eventTarget.type === 'checkbox' ||
                 (eventTarget.tagName !== 'INPUT' && eventTarget.tagName !== 'TEXTAREA')
             ) {
-                event.preventDefault();
+                event.preventDefault(); // prevent page scroll but still allow space presses in inputs
             }
         }
 

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1405,8 +1405,11 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
         }
 
         if (event) {
-            const eventTarget = event.target as HTMLElement;
-            if (eventTarget.tagName !== 'INPUT' && eventTarget.tagName !== 'TEXTAREA') {
+            const eventTarget = event.target as HTMLInputElement;
+            if (
+                eventTarget.type === 'checkbox' ||
+                (eventTarget.tagName !== 'INPUT' && eventTarget.tagName !== 'TEXTAREA')
+            ) {
                 event.preventDefault();
             }
         }


### PR DESCRIPTION
part of #9248

On our current build, go to the platform table custom columns example, which has a column where the cells have input components. Note that you can not press space to enter a space character in the input