### PR TITLE
fix(platform): dynamic form item should support select controlTemplate to improve two-column rendering

### DIFF
--- a/libs/core/src/lib/select/select.component.ts
+++ b/libs/core/src/lib/select/select.component.ts
@@ -172,7 +172,7 @@ export class SelectComponent<T = any>
 
     /** Custom template used to build control body. */
     @Input()
-    controlTemplate: TemplateRef<any>;
+    controlTemplate?: TemplateRef<any>;
 
     /** The element to which the popover should be appended. */
     @Input()

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-select/dynamic-form-generator-select.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-select/dynamic-form-generator-select.component.html
@@ -10,6 +10,7 @@
             [secondaryKey]="formItem.secondaryKey"
             [showSecondaryText]="formItem.showSecondaryText ? formItem.showSecondaryText : false"
             [secondaryTextAlignment]="formItem.secondaryTextAlignment ? formItem.secondaryTextAlignment : 'right'"
+            [controlTemplate]="formItem.controlTemplate"
         ></fdp-select>
     </ng-container>
 </ng-container>

--- a/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
+++ b/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
@@ -1,6 +1,7 @@
 import { AsyncValidatorFn, ValidatorFn } from '@angular/forms';
 import { FormStates } from '@fundamental-ngx/cdk/forms';
 import { Observable } from 'rxjs';
+import { TemplateRef } from '@angular/core';
 
 import { ContentDensity } from '@fundamental-ngx/cdk/utils';
 import {
@@ -251,7 +252,7 @@ export interface DynamicFormFieldItem {
     secondaryTextAlignment?: TextAlignment;
 
     /** Custom template used to build control body. */
-    controlTemplate: TemplateRef<any>;
+    controlTemplate?: TemplateRef<any>;
 }
 
 type PreparedDynamicFormFieldItemFields = {

--- a/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
+++ b/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
@@ -249,6 +249,9 @@ export interface DynamicFormFieldItem {
 
     /** Horizontally align text inside the second column (Applicable for two columns layout) */
     secondaryTextAlignment?: TextAlignment;
+
+    /** Custom template used to build control body. */
+    controlTemplate: TemplateRef<any>;
 }
 
 type PreparedDynamicFormFieldItemFields = {

--- a/libs/platform/src/lib/form/select/commons/base-select.ts
+++ b/libs/platform/src/lib/form/select/commons/base-select.ts
@@ -129,7 +129,7 @@ export abstract class BaseSelect extends CollectionBaseInput implements AfterVie
 
     /** Custom template used to build control body. */
     @Input()
-    controlTemplate: TemplateRef<any>;
+    controlTemplate?: TemplateRef<any>;
 
     /** Binds to control aria-labelledBy attribute */
     @Input()


### PR DESCRIPTION
fixes https://github.com/SAP/fundamental-ngx/issues/9178

Adds some properties from select to dynamic form item, allowing further customization of select in form generator/wizard generator