### PR TITLE
feat(platform): added id property to form generator items

### DIFF
--- a/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-custom-filter-example.component.ts
+++ b/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-custom-filter-example.component.ts
@@ -65,6 +65,7 @@ export class PlatformSmartFilterBarSliderComponent extends BaseDynamicFormGenera
         <ng-container [formGroup]="form">
             <ng-container [formGroupName]="formGroupName">
                 <fdp-date-picker
+                    [id]="id"
                     [placeholder]="formItem.placeholder || formItem.message"
                     [name]="name"
                     [formControlName]="name"

--- a/libs/platform/src/lib/form/form-generator/base-dynamic-form-generator-control.ts
+++ b/libs/platform/src/lib/form/form-generator/base-dynamic-form-generator-control.ts
@@ -8,6 +8,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from './provi
 export interface BaseDynamicFormGeneratorControlInterface {
     formItem: PreparedDynamicFormFieldItem;
     name: string;
+    id: string;
     form: FormGroup;
     formField: PlatformFormField;
 }
@@ -23,6 +24,11 @@ export abstract class BaseDynamicFormGeneratorControl implements BaseDynamicForm
      * @description @see DynamicFormItem.
      */
     @Input() formItem: PreparedDynamicFormFieldItem;
+
+    /**
+     * @description Id of the control.
+     */
+    @Input() id: string;
 
     /**
      * @description Represents form control name.

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
@@ -63,11 +63,6 @@ export class DynamicFormControlDirective implements OnInit {
     ) {}
 
     /** @hidden */
-    fieldId(): string {
-        return `fdp-form-control-${this.id || this.name}`;
-    }
-
-    /** @hidden */
     ngOnInit(): void {
         const foundComponent = this._formGeneratorService.getComponentDefinitionByType(this.formItem.type);
 
@@ -98,7 +93,7 @@ export class DynamicFormControlDirective implements OnInit {
         });
 
         componentRef.instance.formItem = this.formItem;
-        componentRef.instance.id = this.fieldId();
+        componentRef.instance.id = this.id;
         componentRef.instance.name = this.name;
         componentRef.instance.form = this.form;
         componentRef.instance.formField = this.formField;

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
@@ -26,6 +26,12 @@ export class DynamicFormControlDirective implements OnInit {
     @Input() formItem: PreparedDynamicFormFieldItem;
 
     /**
+     * @description Represents form control id.
+     */
+    @Input()
+    id: string;
+
+    /**
      * @description Represents form control name.
      */
     @Input() name: string;
@@ -55,6 +61,11 @@ export class DynamicFormControlDirective implements OnInit {
         private readonly _injector: Injector,
         @Optional() @Inject(CONTENT_DENSITY_DIRECTIVE) private contentDensityDirective: Observable<ContentDensityMode>
     ) {}
+
+    /** @hidden */
+    fieldId(): string {
+        return `fdp-form-control-${this.id || this.name}`;
+    }
 
     /** @hidden */
     ngOnInit(): void {
@@ -87,6 +98,7 @@ export class DynamicFormControlDirective implements OnInit {
         });
 
         componentRef.instance.formItem = this.formItem;
+        componentRef.instance.id = this.fieldId();
         componentRef.instance.name = this.name;
         componentRef.instance.form = this.form;
         componentRef.instance.formField = this.formField;

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
@@ -93,7 +93,7 @@ export class DynamicFormControlDirective implements OnInit {
         });
 
         componentRef.instance.formItem = this.formItem;
-        componentRef.instance.id = this.id;
+        componentRef.instance.id = this.id; // This is also done from fdp-form-field
         componentRef.instance.name = this.name;
         componentRef.instance.form = this.form;
         componentRef.instance.formField = this.formField;

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form">
     <ng-container [formGroupName]="formGroupName">
         <fdp-checkbox-group
+            [id]="id"
             [isInline]="formItem.guiOptions?.inline || false"
             [inlineLayout]="formItem.guiOptions?.inlineLayout"
             [name]="name"

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form">
     <ng-container [formGroupName]="formGroupName">
         <fdp-date-picker
+            [id]="id"
             [placeholder]="placeholder"
             [name]="name"
             [formControlName]="name"

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-editor/dynamic-form-generator-editor.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-editor/dynamic-form-generator-editor.component.html
@@ -1,5 +1,5 @@
 <ng-container [formGroup]="form">
     <ng-container [formGroupName]="formGroupName">
-        <fdp-textarea [placeholder]="placeholder" [name]="name" [formControlName]="name"></fdp-textarea>
+        <fdp-textarea [id]="id" [placeholder]="placeholder" [name]="name" [formControlName]="name"></fdp-textarea>
     </ng-container>
 </ng-container>

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-input/dynamic-form-generator-input.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-input/dynamic-form-generator-input.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form" *ngIf="formField">
     <ng-container [formGroupName]="formGroupName">
         <fdp-input
+            [id]="id"
             [placeholder]="placeholder"
             [name]="name"
             [type]="formItem.controlType || 'text'"

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-multi-input/dynamic-form-generator-multi-input.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-multi-input/dynamic-form-generator-multi-input.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form">
     <ng-container [formGroupName]="formGroupName">
         <fdp-multi-input
+            [id]="id"
             [formControlName]="name"
             [placeholder]="placeholder"
             type="text"

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-radio/dynamic-form-generator-radio.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-radio/dynamic-form-generator-radio.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form">
     <ng-container [formGroupName]="formGroupName">
         <fdp-radio-group
+            [id]="id"
             [isInline]="formItem.guiOptions?.inline || false"
             [inlineLayout]="formItem.guiOptions?.inlineLayout"
             [name]="name"

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-select/dynamic-form-generator-select.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-select/dynamic-form-generator-select.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form">
     <ng-container [formGroupName]="formGroupName">
         <fdp-select
+            [id]="id"
             [placeholder]="placeholder"
             [inline]="formItem.guiOptions?.inline !== false"
             [name]="name"

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-generator-switch/dynamic-form-generator-switch.component.html
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-generator-switch/dynamic-form-generator-switch.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form">
     <ng-container [formGroupName]="formGroupName">
         <fdp-switch
+            [id]="id"
             [name]="name"
             [semantic]="formItem.guiOptions?.additionalData?.semantic"
             [formControlName]="name"

--- a/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.html
+++ b/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.html
@@ -1,7 +1,7 @@
 <fdp-form-field
     [hint]="hintOptions"
     [placeholder]="_placeholder"
-    [id]="formFieldName"
+    [id]="field.formItem.id || formFieldName"
     [column]="field.formItem.guiOptions?.column || 1"
     [columnLayout]="field.formItem.guiOptions?.columnLayout"
     [colon]="field.formItem.guiOptions?.appendColon === true"
@@ -42,6 +42,7 @@
         [form]="form"
         [formGroupNamePath]="formGroupNamePath"
         fdpDynamicFormControl
+        [id]="field.formItem.id || formFieldName"
         [name]="formFieldName"
         [formItem]="field.formItem"
     >

--- a/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
+++ b/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
@@ -33,6 +33,12 @@ export type DynamicFormItem = DynamicFormFieldGroup | DynamicFormFieldItem;
 export interface DynamicFormFieldGroup {
     /**
      * @description
+     * ID of the form item, if not provided, name will be used instead
+     */
+    id?: string;
+
+    /**
+     * @description
      * Name of the form item in form.
      */
     name: string;
@@ -80,6 +86,12 @@ export interface DynamicFormFieldItem {
      * Additional set of options that can affect UI of the form item form control.
      */
     controlType?: InputType;
+
+    /**
+     * @description
+     * ID of the form item, if not provided, name will be used instead
+     */
+    id?: string;
 
     /**
      * @description

--- a/libs/platform/src/lib/form/form-group/form-group.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-group.component.ts
@@ -92,6 +92,8 @@ export const formGroupProvider: Provider = {
 
 type FormGroupField = (FormField | FormFieldGroup) & { hintOptions?: HintOptions };
 
+let formGroupUniqueId = 0;
+
 /**
  *
  * FormGroup represent high order container aggregating FormFields and ability to distribute these
@@ -179,7 +181,7 @@ export class FormGroupComponent
 {
     /** Id for the form group element */
     @Input()
-    id: string;
+    id: string = `fdp-form-group-${formGroupUniqueId++}`;
 
     /** Name property to be set on a form. Will be used if `useForm` is set to true */
     @Input()

--- a/libs/platform/src/lib/form/form-group/form-group.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-group.component.ts
@@ -181,7 +181,7 @@ export class FormGroupComponent
 {
     /** Id for the form group element */
     @Input()
-    id: string = `fdp-form-group-${formGroupUniqueId++}`;
+    id = `fdp-form-group-${formGroupUniqueId++}`;
 
     /** Name property to be set on a form. Will be used if `useForm` is set to true */
     @Input()

--- a/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-condition-field/smart-filter-bar-condition-field.component.html
+++ b/libs/platform/src/lib/smart-filter-bar/components/smart-filter-bar-condition-field/smart-filter-bar-condition-field.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form">
     <ng-container [formGroupName]="formGroupName">
         <fdp-multi-input
+            [id]="id"
             [addOnButtonClickFn]="openConditionsDialog"
             [autofocus]="true"
             [dataSource]="formItem.choices || []"


### PR DESCRIPTION
## Related Issue(s)

closes #8729 

## Description

Added `id` property to the `BaseDynamicFormGeneratorControlInterface` and made dynamic fields respect that. Previously `name` would have been used as an `id` for control fields, now users can use different id for their DOM elements.
As before, `fdp-form-label-${id || name}` is used for labels, `fdp-form-label-content-${id || name}` is used for label contents and additionally `id || name` is now used for the form controls themselves. Placement and usage of that passed id depend on the control itself, but provided controls are attaching those ids to the correct places.

Custom controls will have to implement that by themselves, examples that are given for custom controls are fixed
