### PR TITLE
fix: update nx/lint versions to fix commit error

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "karma-typescript": "5.5.3",
     "karma-typescript-angular2-transform": "5.5.3",
     "karma-webpack": "5.0.0",
-    "lint-staged": "13.1.0",
+    "lint-staged": "13.1.1",
     "nan": "2.17.0",
     "ng-packagr": "15.1.1",
     "ngx-cva-test-suite": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11627,10 +11627,10 @@ lines-and-columns@~2.0.3:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-2.0.3.tgz#b2f0badedb556b747020ab8ea7f0373e22efac1b"
   integrity sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==
 
-lint-staged@13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.1.0.tgz#d4c61aec939e789e489fa51987ec5207b50fd37e"
-  integrity sha512-pn/sR8IrcF/T0vpWLilih8jmVouMlxqXxKuAojmbiGX5n/gDnz+abdPptlj0vYnbfE0SQNl3CY/HwtM0+yfOVQ==
+lint-staged@13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-13.1.1.tgz#db61636850660e291a6885da65d8e79850bd8307"
+  integrity sha512-LLJLO0Kdbcv2a+CvSF4p1M7jBZOajKSMpBUvyR8+bXccsqPER0/NxTFQSpNHjqwV9kM3tkHczYerTB5wI+bksQ==
   dependencies:
     cli-truncate "^3.1.0"
     colorette "^2.0.19"


### PR DESCRIPTION
fixes none

Fixes the `Error: Nx no longer supports using positional arguments for base and head. Please use --base and --head instead.` we're all seeing