### PR TITLE
fix(core,cx,fn,platform): textContent instead of innerText for matter of performance

### DIFF
--- a/libs/core/src/lib/avatar/avatar.component.ts
+++ b/libs/core/src/lib/avatar/avatar.component.ts
@@ -336,7 +336,7 @@ export class AvatarComponent implements OnChanges, OnInit, CssClassBuilder, OnCh
             const option = options[i];
 
             if (option === ALTER_ICON_OPTIONS.CONTENT) {
-                const contentValue = this._content?.nativeElement.innerText;
+                const contentValue = this._content?.nativeElement.textContent;
                 if (contentValue) {
                     this.abbreviate = this._generateAbbreviation(contentValue);
                     break;

--- a/libs/core/src/lib/list/list-navigation-item/list-navigation-item.component.ts
+++ b/libs/core/src/lib/list/list-navigation-item/list-navigation-item.component.ts
@@ -98,7 +98,7 @@ export class ListNavigationItemComponent implements AfterContentInit, AfterViewI
         if (this._iconComponent) {
             this._iconComponent._navigationItemIcon = true;
         }
-        this._innerText = this._text.elementRef.nativeElement.innerText;
+        this._innerText = this._text.elementRef.nativeElement.textContent ?? '';
     }
 
     /** @hidden */

--- a/libs/core/src/lib/nested-list/nested-list-directives.ts
+++ b/libs/core/src/lib/nested-list/nested-list-directives.ts
@@ -69,7 +69,7 @@ export class NestedListTitleDirective {
 
     /** Returns element's InnerText */
     getInnerText(): string {
-        return this.elementRef && this.elementRef.nativeElement.innerText;
+        return this.elementRef && this.elementRef.nativeElement.textContent;
     }
 }
 

--- a/libs/cx/src/lib/nested-list/nested-list-directives.ts
+++ b/libs/cx/src/lib/nested-list/nested-list-directives.ts
@@ -71,7 +71,7 @@ export class NestedListTitleDirective {
 
     /** Returns element's InnerText */
     getInnerText(): string {
-        return this.elementRef && this.elementRef.nativeElement.innerText;
+        return this.elementRef && this.elementRef.nativeElement.textContent;
     }
 }
 

--- a/libs/fn/src/lib/avatar/avatar.component.ts
+++ b/libs/fn/src/lib/avatar/avatar.component.ts
@@ -250,9 +250,9 @@ export class AvatarComponent implements OnInit, OnChanges {
 
                 if (option === ALTER_ICON_OPTIONS.CONTENT) {
                     const contentEl = this._content.nativeElement;
-                    const contentValue = contentEl.innerText.trim()[0];
+                    const contentValue = contentEl.textContent.trim()[0];
                     if (contentValue && contentValue !== '') {
-                        this._abbreviate = this._getAbbreviate(contentEl.innerText.trim());
+                        this._abbreviate = this._getAbbreviate(contentEl.textContent.trim());
                         break;
                     }
 

--- a/libs/platform/src/lib/form/multi-input/multi-input.component.ts
+++ b/libs/platform/src/lib/form/multi-input/multi-input.component.ts
@@ -300,7 +300,7 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
     deleteToken(selectedValue: MultiInputOption): void {
         if (this.tokenizer.tokenList.length > 0) {
             this.tokenizer.tokenList.forEach((token) => {
-                if (token.tokenWrapperElement.nativeElement.innerText === selectedValue.label) {
+                if (token.tokenWrapperElement.nativeElement.textContent === selectedValue.label) {
                     this.selected.splice(this.selected.indexOf(selectedValue), 1);
                 }
             });

--- a/libs/platform/src/lib/table/utils.ts
+++ b/libs/platform/src/lib/table/utils.ts
@@ -113,7 +113,7 @@ export const getUniqueListValuesByKey = <T, K extends keyof T>(list: T[], key: K
 
 export const getScrollBarWidth = (document: Document): number => {
     const div = document.createElement('div');
-    div.innerText = 'W';
+    div.textContent = 'W';
     div.style.position = 'absolute';
     div.style.visibility = 'hidden';
     div.style.overflowY = 'scroll';


### PR DESCRIPTION
## Related Issue(s)

Closes none.

## Description

`textContent` causes reflow and its performance a way worse than `textContent`s. In our cases, usage of `textContent` should not cause breaking changes or unpredicted behavior.

## Screenshots

*Platform Table doc page loading*

### Before:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/20265336/218503932-ffd5a4f3-ed5e-40e3-9eb4-c87965635bca.png">


### After:
<img width="725" alt="SCR-20230213-kc1" src="https://user-images.githubusercontent.com/20265336/218474947-d5b10a87-7f31-444b-aa97-7d57b557d2ce.png">
