### PR TITLE
feat(core): allowing close the overflowed tab menu under More when clicked

### DIFF
--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -145,6 +145,10 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
     @ViewChild(OverflowLayoutComponent)
     private _overflowLayout: OverflowLayoutComponent;
 
+    /** @hidden */
+    @ViewChild('menu', { read: MenuComponent })
+    menu: MenuComponent;
+
     /** @hidden Collection of tabs in original order */
     _tabArray: TabInfo[];
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #9385 

## Description

<!-- Enter short description of the change -->
When clicking on the menu item under  "More" - collapsed Overflow tab(click icon under tab 3 menu item, screenshot below), this menu stays open. Should provide a way(like calling tab.menu.close) to close it if needed.
![image](https://user-images.githubusercontent.com/48496287/218880040-865fe6b4-631e-4962-91ea-5b84e48a3d95.png)

## Screenshots
No any UI change. Just expose the overflow menu so that menu.close() can be called to close the menu in event handler code.
<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

### After:

#### Please check whether the PR fulfills the following requirements

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [na] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [na] Run npm run build-pack-library and test in external application
-   [na] update `README.md`
-   [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
