### PR TITLE
fix: documentation for multi-input addon button events

### DIFF
--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.html
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.html
@@ -38,7 +38,7 @@
             [attr.aria-readonly]="this._cva.readonly"
             [glyphAriaLabel]="this._cva.ariaLabel || ('platformMultiCombobox.inputGlyphAriaLabel' | fdTranslate)"
             [iconTitle]="addonIconTitle || ('platformMultiCombobox.inputGlyphAriaLabel' | fdTranslate)"
-            (addOnButtonClicked)="addOnButtonClicked.emit(); !mobile && _onPrimaryButtonClick(isOpen)"
+            (addOnButtonClicked)="addOnButtonClicked.emit($event); !mobile && _onPrimaryButtonClick(isOpen)"
             (click)="mobile && !isOpen && _onPrimaryButtonClick(false)"
             (keydown)="_navigateByTokens($event)"
         >

--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
@@ -224,7 +224,7 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
 
     /** Emits event when the addon button is clicked. */
     @Output()
-    addOnButtonClicked: EventEmitter<void> = new EventEmitter<void>();
+    addOnButtonClicked: EventEmitter<Event> = new EventEmitter<Event>();
 
     /** Event emitted when data loading is started. */
     @Output()

--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
@@ -222,7 +222,7 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     @Output()
     isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-    /** @hidden Emits event when the addon button is clicked. */
+    /** Emits event when the addon button is clicked. */
     @Output()
     addOnButtonClicked: EventEmitter<void> = new EventEmitter<void>();
 

--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.spec.ts
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.spec.ts
@@ -75,29 +75,21 @@ describe('MultiInputMobileComponent', () => {
 
     it('should open and close with approve', () => {
         component.ngOnInit();
-        component.ngAfterViewInit();
-        spyOn(anyComponent.dialogRef._onHide, 'next');
         spyOn(anyComponent._component, 'dialogApprove');
         fixture.detectChanges();
-        expect(anyComponent._dialogService.hasOpenDialogs()).toBe(true);
         anyComponent._component.openChange.emit(true);
         fixture.detectChanges();
-        expect(anyComponent.dialogRef._onHide.next).toHaveBeenCalledWith(false);
         component.handleApprove();
         expect(anyComponent._component.dialogApprove).toHaveBeenCalled();
     });
 
     it('should open and close with dismiss', () => {
         component.ngOnInit();
-        component.ngAfterViewInit();
-        spyOn(anyComponent.dialogRef._onHide, 'next');
         spyOn(anyComponent._component, 'dialogDismiss');
         fixture.detectChanges();
-        expect(anyComponent._dialogService.hasOpenDialogs()).toBe(true);
         anyComponent._component.selected = [];
         anyComponent._component.openChange.emit(true);
         fixture.detectChanges();
-        expect(anyComponent.dialogRef._onHide.next).toHaveBeenCalledWith(false);
         component.handleDismiss();
         expect(anyComponent._component.dialogDismiss).toHaveBeenCalledWith([]);
     });

--- a/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input-mobile/multi-input-mobile.component.ts
@@ -1,5 +1,4 @@
 import {
-    AfterViewInit,
     ChangeDetectionStrategy,
     Component,
     ElementRef,
@@ -20,6 +19,7 @@ import {
     MobileModeControl,
     MobileModeConfigToken
 } from '@fundamental-ngx/core/mobile-mode';
+import { Nullable } from '@fundamental-ngx/cdk/utils';
 
 @Component({
     selector: 'fd-multi-input-mobile',
@@ -28,10 +28,7 @@ import {
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class MultiInputMobileComponent
-    extends MobileModeBase<MultiInputInterface>
-    implements OnInit, AfterViewInit, OnDestroy
-{
+export class MultiInputMobileComponent extends MobileModeBase<MultiInputInterface> implements OnInit, OnDestroy {
     /** @hidden */
     allItemsSelected: boolean;
 
@@ -43,10 +40,10 @@ export class MultiInputMobileComponent
      * Control element, which will be rendered inside dialog.
      * List element, which will be rendered inside dialog.
      */
-    childContent: {
+    childContent: Nullable<{
         listTemplate: TemplateRef<any>;
         controlTemplate: TemplateRef<any>;
-    } | null = null;
+    }> = null;
 
     /** @hidden */
     private _selectedBackup: any[];
@@ -67,14 +64,7 @@ export class MultiInputMobileComponent
     }
 
     /** @hidden */
-    ngAfterViewInit(): void {
-        this._open();
-        this.dialogRef.hide(true);
-    }
-
-    /** @hidden */
     ngOnDestroy(): void {
-        this.dialogRef.close();
         super.onDestroy();
     }
 
@@ -85,25 +75,26 @@ export class MultiInputMobileComponent
 
     /** @hidden */
     handleDismiss(): void {
-        this.dialogRef.hide(true);
+        this.dialogRef.dismiss();
         this._component.dialogDismiss(this._selectedBackup);
     }
 
     /** @hidden */
     handleApprove(): void {
-        this.dialogRef.hide(true);
+        this.dialogRef.close();
         this._component.dialogApprove();
     }
 
     /** @hidden */
     private _toggleDialog(open: boolean): void {
-        if (open) {
-            this._selectedBackup = [...this._component.selected];
-            if (!this._dialogService.hasOpenDialogs()) {
-                this._open();
-            }
+        if (!open) {
+            return;
         }
-        this.dialogRef.hide(!open);
+
+        this._selectedBackup = this._component.selected?.length ? [...this._component.selected] : [];
+        if (!this._dialogService.hasOpenDialogs()) {
+            this._open();
+        }
     }
 
     /** @hidden */

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -11,7 +11,6 @@
                 (input)="!open && openChangeHandle(true)"
                 [triggers]="[]"
                 [maxWidth]="_popoverMaxWidth"
-                [focusTrapped]="true"
                 [disabled]="disabled"
                 [fillControlMode]="fillControlMode"
                 class="fd-multi-input-popover-custom"

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -45,7 +45,7 @@
             [isControl]="true"
             [glyph]="displayAddonButton ? glyph : ''"
             [iconTitle]="title"
-            (addOnButtonClicked)="_addOnButtonClicked()"
+            (addOnButtonClicked)="_addOnButtonClicked($event)"
         >
             <fd-tokenizer
                 [compactCollapse]="compactCollapse"

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -299,7 +299,7 @@ export class MultiInputComponent
     @Output()
     readonly openChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-    /** @hidden Emits event when the addon button is clicked. */
+    /** Emits event when the addon button is clicked. */
     @Output()
     readonly addOnButtonClicked: EventEmitter<void> = new EventEmitter<void>();
 

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -301,7 +301,7 @@ export class MultiInputComponent
 
     /** Emits event when the addon button is clicked. */
     @Output()
-    readonly addOnButtonClicked: EventEmitter<void> = new EventEmitter<void>();
+    readonly addOnButtonClicked: EventEmitter<Event> = new EventEmitter<Event>();
 
     /** Event emitted, when the multi input's all item checked or not */
     @Output()
@@ -686,8 +686,8 @@ export class MultiInputComponent
     }
 
     /** @hidden */
-    _addOnButtonClicked(): void {
-        this.addOnButtonClicked.emit();
+    _addOnButtonClicked(event: Event): void {
+        this.addOnButtonClicked.emit(event);
         this.openChangeHandle(!this.open);
     }
 

--- a/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.html
+++ b/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.html
@@ -2,5 +2,5 @@
     [dropdownValues]="['Banana', 'Pineapple', 'Tomato', 'Kiwi', 'Strawberry', 'Blueberry', 'Orange']"
     placeholder="Search here..."
     style="width: 200px"
-    (addOnButtonClicked)="addOnClicked()"
+    (addOnButtonClicked)="addOnClicked($event)"
 ></fd-multi-input>

--- a/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.html
+++ b/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.html
@@ -1,0 +1,6 @@
+<fd-multi-input
+    [dropdownValues]="['Banana', 'Pineapple', 'Tomato', 'Kiwi', 'Strawberry', 'Blueberry', 'Orange']"
+    placeholder="Search here..."
+    style="width: 200px"
+    (addOnButtonClicked)="addOnClicked()"
+></fd-multi-input>

--- a/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.ts
+++ b/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.ts
@@ -7,7 +7,8 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MultiInputAddonClickedExampleComponent {
-    addOnClicked(): void {
+    addOnClicked(event?: Event): void {
+        console.log(event);
         window.alert('Add On Button Clicked!');
     }
 }

--- a/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.ts
+++ b/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+    selector: 'fd-multi-input-addon-clicked-example',
+    templateUrl: './multi-input-addon-clicked-example.component.html',
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MultiInputAddonClickedExampleComponent {
+    addOnClicked(): void {
+        window.alert('Add On Button Clicked!');
+    }
+}

--- a/libs/docs/core/multi-input/multi-input-docs.component.html
+++ b/libs/docs/core/multi-input/multi-input-docs.component.html
@@ -156,3 +156,17 @@
     <fd-multi-input-dropdown-width-example></fd-multi-input-dropdown-width-example>
 </component-example>
 <code-example [exampleFiles]="customWidth"></code-example>
+
+<fd-docs-section-title id="addon-clicked" componentName="multi-input">
+    Addon Button Clicked Event
+</fd-docs-section-title>
+<description>
+    <p>
+        The <code>addOnButtonClicked</code> event is emitted when the user clicks the addon button. This event can be
+        captured to further configure custom behavior.
+    </p>
+</description>
+<component-example>
+    <fd-multi-input-addon-clicked-example></fd-multi-input-addon-clicked-example>
+</component-example>
+<code-example [exampleFiles]="addonClicked"></code-example>

--- a/libs/docs/core/multi-input/multi-input-docs.component.ts
+++ b/libs/docs/core/multi-input/multi-input-docs.component.ts
@@ -35,6 +35,9 @@ const customT = 'multi-input-custom-item-example/multi-input-custom-item-example
 const widthH = 'multi-input-dropdown-width-example/multi-input-dropdown-width-example.component.html';
 const widthT = 'multi-input-dropdown-width-example/multi-input-dropdown-width-example.component.ts';
 
+const addonH = 'multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.html';
+const addonT = 'multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.ts';
+
 @Component({
     selector: 'app-multi-input-docs',
     templateUrl: './multi-input-docs.component.html',
@@ -192,6 +195,20 @@ export class MultiInputDocsComponent {
             component: 'MultiInputDropdownWidthExampleComponent',
             code: getAssetFromModuleAssets(widthT),
             fileName: 'multi-input-dropdown-width-example'
+        }
+    ];
+
+    addonClicked: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(addonH),
+            fileName: 'multi-input-addon-clicked-example'
+        },
+        {
+            language: 'typescript',
+            component: 'MultiInputAddonClickedExampleComponent',
+            code: getAssetFromModuleAssets(addonT),
+            fileName: 'multi-input-addon-clicked-example'
         }
     ];
 }

--- a/libs/docs/core/multi-input/multi-input-docs.module.ts
+++ b/libs/docs/core/multi-input/multi-input-docs.module.ts
@@ -20,6 +20,7 @@ import { IconModule } from '@fundamental-ngx/core/icon';
 import { ListModule } from '@fundamental-ngx/core/list';
 import { moduleDeprecationsProvider } from '@fundamental-ngx/cdk/utils';
 import { MultiInputDropdownWidthExampleComponent } from './examples/multi-input-dropdown-width-example/multi-input-dropdown-width-example.component';
+import { MultiInputAddonClickedExampleComponent } from './examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component';
 
 const routes: Routes = [
     {
@@ -55,7 +56,8 @@ const routes: Routes = [
         MultiInputMobileExampleComponent,
         MultiInputIncludesExampleComponent,
         MultiInputCustomItemExampleComponent,
-        MultiInputDropdownWidthExampleComponent
+        MultiInputDropdownWidthExampleComponent,
+        MultiInputAddonClickedExampleComponent
     ],
     providers: [
         moduleDeprecationsProvider(DeprecatedMultiInputCompactDirective),

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -199,7 +199,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
     // eslint-disable-next-line @angular-eslint/no-output-on-prefix
     @Output() onDataReceived = new EventEmitter<void>();
 
-    /** @hidden Emits event when the addon button is clicked. */
+    /** Emits event when the addon button is clicked. */
     @Output()
     addOnButtonClicked: EventEmitter<void> = new EventEmitter<void>();
 

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -201,7 +201,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
 
     /** Emits event when the addon button is clicked. */
     @Output()
-    addOnButtonClicked: EventEmitter<void> = new EventEmitter<void>();
+    addOnButtonClicked: EventEmitter<Event> = new EventEmitter<Event>();
 
     /** @hidden */
     @ViewChild(ListComponent)

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.html
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.html
@@ -38,7 +38,7 @@
             [attr.aria-readonly]="readonly"
             [glyphAriaLabel]="ariaLabel || ('platformMultiCombobox.inputGlyphAriaLabel' | fdTranslate)"
             [iconTitle]="addonIconTitle || ('platformMultiCombobox.inputGlyphAriaLabel' | fdTranslate)"
-            (addOnButtonClicked)="addOnButtonClicked.emit(); !mobile && onPrimaryButtonClick(isOpen)"
+            (addOnButtonClicked)="addOnButtonClicked.emit($event); !mobile && onPrimaryButtonClick(isOpen)"
             (click)="mobile && !isOpen && onPrimaryButtonClick(false)"
             (keydown)="navigateByTokens($event)"
         >

--- a/libs/platform/src/lib/form/multi-input/base-multi-input.ts
+++ b/libs/platform/src/lib/form/multi-input/base-multi-input.ts
@@ -179,7 +179,7 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
     @Output()
     readonly searchTermChange: EventEmitter<string> = new EventEmitter<string>();
 
-    /** @hidden Emits event when the addon button is clicked. */
+    /** Emits event when the addon button is clicked. */
     @Output()
     readonly addOnButtonClicked: EventEmitter<void> = new EventEmitter<void>();
 

--- a/libs/platform/src/lib/form/multi-input/base-multi-input.ts
+++ b/libs/platform/src/lib/form/multi-input/base-multi-input.ts
@@ -181,7 +181,7 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
 
     /** Emits event when the addon button is clicked. */
     @Output()
-    readonly addOnButtonClicked: EventEmitter<void> = new EventEmitter<void>();
+    readonly addOnButtonClicked: EventEmitter<Event> = new EventEmitter<Event>();
 
     /** @hidden */
     @ViewChild(ListComponent)

--- a/libs/platform/src/lib/form/multi-input/multi-input.component.html
+++ b/libs/platform/src/lib/form/multi-input/multi-input.component.html
@@ -36,7 +36,7 @@
         [state]="state"
         [disabled]="disabled"
         (keydown)="removeSelectedTokens($event)"
-        (addOnButtonClicked)="addOnButtonClick()"
+        (addOnButtonClicked)="addOnButtonClick($event)"
         (click)="onInputGroupClicked()"
     >
         <span [attr.id]="tokenHiddenId" aria-hidden="true" class="fdp-multi-input__invisible-text"

--- a/libs/platform/src/lib/form/multi-input/multi-input.component.ts
+++ b/libs/platform/src/lib/form/multi-input/multi-input.component.ts
@@ -272,8 +272,8 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
     }
 
     /** @hidden */
-    addOnButtonClick(): void {
-        this.addOnButtonClicked.emit();
+    addOnButtonClick(event: Event): void {
+        this.addOnButtonClicked.emit(event);
         if (isFunction(this.addOnButtonClickFn)) {
             this.addOnButtonClickFn();
             return;


### PR DESCRIPTION
fixes none

Adds documentation for fd-multi-input addOnButtonClicked event. Also applies to fdp-multi-input, fd-multi-combobox, and fdp-multi-combobox

Also fixes a bug where multi-input mobile mode would automatically open its dialog during ngOnInit, then hide it, which would effectively create an invisible focus trap, so tab keys would not work on any page which creates a mobile fd-multi-input