### PR TITLE
feat(core,platform): lightweight tokens

### DIFF
--- a/libs/core/src/lib/avatar/avatar.component.ts
+++ b/libs/core/src/lib/avatar/avatar.component.ts
@@ -23,6 +23,7 @@ import {
     CssClassBuilder
 } from '@fundamental-ngx/cdk/utils';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { FD_AVATAR_COMPONENT } from './tokens';
 
 let avatarUniqueId = 0;
 
@@ -39,6 +40,12 @@ const ALTER_ICON_OPTIONS = {
     styleUrls: ['./avatar.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [
+        {
+            provide: FD_AVATAR_COMPONENT,
+            useExisting: AvatarComponent
+        }
+    ],
     host: {
         '[attr.tabindex]': '_tabindex'
     }

--- a/libs/core/src/lib/avatar/public_api.ts
+++ b/libs/core/src/lib/avatar/public_api.ts
@@ -1,2 +1,3 @@
 export * from './avatar.module';
 export * from './avatar.component';
+export * from './tokens';

--- a/libs/core/src/lib/avatar/tokens.ts
+++ b/libs/core/src/lib/avatar/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_AVATAR_COMPONENT = new InjectionToken('FdAvatarComponent');

--- a/libs/core/src/lib/bar/button-bar/button-bar.component.ts
+++ b/libs/core/src/lib/bar/button-bar/button-bar.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectorRef, Component, HostBinding, Input, OnDestroy, ViewChild 
 import { BaseButton, ButtonComponent, ButtonType } from '@fundamental-ngx/core/button';
 import { Subscription } from 'rxjs';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { FD_BUTTON_BAR_COMPONENT } from '../tokens';
 
 let randomButtonBarId = 0;
 
@@ -23,7 +24,13 @@ let randomButtonBarId = 0;
         >
             <ng-content></ng-content>
         </button>
-    `
+    `,
+    providers: [
+        {
+            provide: FD_BUTTON_BAR_COMPONENT,
+            useExisting: ButtonBarComponent
+        }
+    ]
 })
 export class ButtonBarComponent extends BaseButton implements OnDestroy {
     /** Whether the element should take the whole width of the container. */

--- a/libs/core/src/lib/bar/public_api.ts
+++ b/libs/core/src/lib/bar/public_api.ts
@@ -7,3 +7,4 @@ export * from './directives/bar-right.directive';
 export * from './button-bar/button-bar.component';
 export * from './deprecated-bar-content-density.directive';
 export * from './deprecated-bar-button-content-density.directive';
+export * from './tokens';

--- a/libs/core/src/lib/bar/tokens.ts
+++ b/libs/core/src/lib/bar/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_BUTTON_BAR_COMPONENT = new InjectionToken('FdButtonBarComponent');

--- a/libs/core/src/lib/breadcrumb/breadcrumb-item.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb-item.component.ts
@@ -5,10 +5,10 @@ import {
     Component,
     ContentChild,
     ElementRef,
-    forwardRef,
     ViewEncapsulation
 } from '@angular/core';
-import { LinkComponent } from '@fundamental-ngx/core/link';
+import { FD_LINK_COMPONENT, LinkComponent } from '@fundamental-ngx/core/link';
+import { FD_BREADCRUMB_ITEM_COMPONENT } from './tokens';
 
 /**
  * Breadcrumb item directive. Must have child breadcrumb link directives.
@@ -25,12 +25,18 @@ import { LinkComponent } from '@fundamental-ngx/core/link';
     host: {
         class: 'fd-breadcrumb__item'
     },
+    providers: [
+        {
+            provide: FD_BREADCRUMB_ITEM_COMPONENT,
+            useExisting: BreadcrumbItemComponent
+        }
+    ],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BreadcrumbItemComponent implements AfterViewInit {
     /** @hidden */
-    @ContentChild(forwardRef(() => LinkComponent))
+    @ContentChild(FD_LINK_COMPONENT)
     breadcrumbLink: LinkComponent;
 
     /** In case there is no link in Item and breadcrumb item is non-interactive, we move whole item content to menu item title */

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -6,7 +6,6 @@ import {
     ContentChildren,
     ElementRef,
     EventEmitter,
-    forwardRef,
     Input,
     isDevMode,
     OnInit,
@@ -22,6 +21,7 @@ import { BehaviorSubject, takeUntil } from 'rxjs';
 import { MenuComponent } from '@fundamental-ngx/core/menu';
 import { Placement } from '@fundamental-ngx/core/shared';
 import { BreadcrumbItemComponent } from './breadcrumb-item.component';
+import { FD_BREADCRUMB_COMPONENT, FD_BREADCRUMB_ITEM_COMPONENT } from './tokens';
 
 /**
  * Breadcrumb parent wrapper directive. Must have breadcrumb item child directives.
@@ -44,7 +44,13 @@ import { BreadcrumbItemComponent } from './breadcrumb-item.component';
     styleUrls: ['./breadcrumb.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [DestroyedService]
+    providers: [
+        DestroyedService,
+        {
+            provide: FD_BREADCRUMB_COMPONENT,
+            useExisting: BreadcrumbComponent
+        }
+    ]
 })
 export class BreadcrumbComponent implements OnInit, AfterViewInit {
     /**
@@ -84,12 +90,8 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     hiddenItemsCount = new EventEmitter<number>();
 
     /** @hidden */
-    @ContentChildren(BreadcrumbItemComponent)
+    @ContentChildren(FD_BREADCRUMB_ITEM_COMPONENT)
     private readonly _contentItems: QueryList<BreadcrumbItemComponent>;
-
-    /** @hidden */
-    @ContentChildren(forwardRef(() => BreadcrumbItemComponent))
-    breadcrumbItems: QueryList<BreadcrumbItemComponent>;
 
     /** @hidden */
     @ViewChild(MenuComponent)

--- a/libs/core/src/lib/breadcrumb/public_api.ts
+++ b/libs/core/src/lib/breadcrumb/public_api.ts
@@ -2,3 +2,4 @@ export * from './breadcrumb.module';
 export * from './breadcrumb-item.component';
 export * from './breadcrumb.component';
 export * from './deprecated-breadcrumbs-compact.directive';
+export * from './tokens';

--- a/libs/core/src/lib/breadcrumb/tokens.ts
+++ b/libs/core/src/lib/breadcrumb/tokens.ts
@@ -1,0 +1,4 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_BREADCRUMB_ITEM_COMPONENT = new InjectionToken('FdBreadcrumbItemComponent');
+export const FD_BREADCRUMB_COMPONENT = new InjectionToken('FdBreadcrumbComponent');

--- a/libs/core/src/lib/busy-indicator/busy-indicator-extended/busy-indicator-extended.directive.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator-extended/busy-indicator-extended.directive.ts
@@ -1,5 +1,6 @@
 import { AfterContentInit, ContentChild, Directive, ElementRef } from '@angular/core';
 import { BusyIndicatorComponent } from '../busy-indicator.component';
+import { FD_BUSY_INDICATOR_COMPONENT } from '../tokens';
 
 const messageToastClass = 'fd-message-toast';
 
@@ -9,7 +10,7 @@ const messageToastClass = 'fd-message-toast';
 })
 export class BusyIndicatorExtendedDirective implements AfterContentInit {
     /** @hidden */
-    @ContentChild(BusyIndicatorComponent)
+    @ContentChild(FD_BUSY_INDICATOR_COMPONENT)
     busyIndicator: BusyIndicatorComponent;
 
     /** @hidden */

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
@@ -10,6 +10,7 @@ import {
 import { KeyUtil } from '@fundamental-ngx/cdk/utils';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { TAB } from '@angular/cdk/keycodes';
+import { FD_BUSY_INDICATOR_COMPONENT } from './tokens';
 
 export type BusyIndicatorSize = 's' | 'm' | 'l';
 
@@ -19,6 +20,12 @@ export type BusyIndicatorSize = 's' | 'm' | 'l';
     styleUrls: ['./busy-indicator.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [
+        {
+            provide: FD_BUSY_INDICATOR_COMPONENT,
+            useExisting: BusyIndicatorComponent
+        }
+    ],
     host: {
         '[attr.role]': "loading ? 'progressbar' : 'presentation'",
         '[attr.tabindex]': 'loading ? 0 : -1',

--- a/libs/core/src/lib/busy-indicator/public_api.ts
+++ b/libs/core/src/lib/busy-indicator/public_api.ts
@@ -1,3 +1,4 @@
 export * from './busy-indicator.module';
 export * from './busy-indicator.component';
 export * from './busy-indicator-extended/busy-indicator-extended.directive';
+export * from './tokens';

--- a/libs/core/src/lib/busy-indicator/tokens.ts
+++ b/libs/core/src/lib/busy-indicator/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_BUSY_INDICATOR_COMPONENT = new InjectionToken('FdBusyIndicatorComponent');

--- a/libs/core/src/lib/card/card-header.component.ts
+++ b/libs/core/src/lib/card/card-header.component.ts
@@ -11,7 +11,7 @@ import {
     OnChanges
 } from '@angular/core';
 
-import { AvatarComponent } from '@fundamental-ngx/core/avatar';
+import { AvatarComponent, FD_AVATAR_COMPONENT } from '@fundamental-ngx/core/avatar';
 
 import { CLASS_NAME } from './constants';
 import { CardSubtitleDirective } from './card-subtitle.directive';
@@ -45,7 +45,7 @@ export class CardHeaderComponent implements OnInit, OnChanges, CssClassBuilder, 
     class: string;
 
     /** @hidden */
-    @ContentChild(AvatarComponent)
+    @ContentChild(FD_AVATAR_COMPONENT)
     _avatar: AvatarComponent;
 
     /** @hidden */

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -29,6 +29,7 @@ import {
     ContentDensityObserver,
     contentDensityObserverProviders
 } from '@fundamental-ngx/core/content-density';
+import { FD_CHECKBOX_COMPONENT } from '../tokens';
 
 let checkboxUniqueId = 0;
 
@@ -45,6 +46,10 @@ export type FdCheckboxTypes = 'checked' | 'unchecked' | 'indeterminate' | 'force
             provide: NG_VALUE_ACCESSOR,
             useExisting: forwardRef(() => CheckboxComponent),
             multi: true
+        },
+        {
+            provide: FD_CHECKBOX_COMPONENT,
+            useExisting: CheckboxComponent
         },
         registerFormItemControl(CheckboxComponent),
         contentDensityObserverProviders()

--- a/libs/core/src/lib/checkbox/public_api.ts
+++ b/libs/core/src/lib/checkbox/public_api.ts
@@ -2,3 +2,4 @@ export * from './checkbox.module';
 export * from './checkbox/checkbox.component';
 export * from './checkbox/fd-checkbox-values.interface';
 export * from './deprecated-checkbox-content-density.directive';
+export * from './tokens';

--- a/libs/core/src/lib/checkbox/tokens.ts
+++ b/libs/core/src/lib/checkbox/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_CHECKBOX_COMPONENT = new InjectionToken('FdCheckboxComponent');

--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -36,7 +36,7 @@ import {
 } from '@angular/cdk/keycodes';
 import { Subscription } from 'rxjs';
 
-import { ListComponent, ListMessageDirective } from '@fundamental-ngx/core/list';
+import { FD_LIST_MESSAGE_DIRECTIVE, ListComponent, ListMessageDirective } from '@fundamental-ngx/core/list';
 import {
     AutoCompleteEvent,
     DynamicComponentService,
@@ -312,7 +312,7 @@ export class ComboboxComponent
     inputGroup: InputGroupComponent;
 
     /** @hidden */
-    @ContentChildren(ListMessageDirective)
+    @ContentChildren(FD_LIST_MESSAGE_DIRECTIVE)
     listMessages: QueryList<ListMessageDirective>;
 
     /** @hidden */

--- a/libs/core/src/lib/dialog/base/dialog-footer-base.class.ts
+++ b/libs/core/src/lib/dialog/base/dialog-footer-base.class.ts
@@ -2,7 +2,7 @@ import { AfterContentInit, ContentChildren, Directive, QueryList, TemplateRef } 
 import { startWith } from 'rxjs/operators';
 
 import { TemplateDirective } from '@fundamental-ngx/cdk/utils';
-import { ButtonBarComponent } from '@fundamental-ngx/core/bar';
+import { ButtonBarComponent, FD_BUTTON_BAR_COMPONENT } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 
 @Directive()
@@ -15,7 +15,7 @@ export abstract class DialogFooterBase implements AfterContentInit {
     customTemplates: QueryList<TemplateDirective>;
 
     /** @hidden */
-    @ContentChildren(ButtonBarComponent)
+    @ContentChildren(FD_BUTTON_BAR_COMPONENT)
     buttons: QueryList<ButtonBarComponent>;
 
     /** @hidden */

--- a/libs/core/src/lib/dialog/base/dialog-header-base.class.ts
+++ b/libs/core/src/lib/dialog/base/dialog-header-base.class.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 
 import { TemplateDirective } from '@fundamental-ngx/cdk/utils';
-import { TitleComponent } from '@fundamental-ngx/core/title';
+import { TitleComponent, TitleToken } from '@fundamental-ngx/core/title';
 
 @Directive()
 export abstract class DialogHeaderBase implements AfterContentInit {
@@ -20,7 +20,7 @@ export abstract class DialogHeaderBase implements AfterContentInit {
     subHeaderTemplate: TemplateRef<any>;
 
     /** @hidden */
-    @ContentChild(TitleComponent)
+    @ContentChild(TitleToken)
     set defaultTitleSize(title: TitleComponent) {
         if (title && !title.headerSize) {
             title.headerSize = 5;

--- a/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
+++ b/libs/core/src/lib/dialog/dialog-body/dialog-body.component.ts
@@ -1,4 +1,5 @@
 import { Component, ElementRef, Optional } from '@angular/core';
+import { FD_DIALOG_BODY_COMPONENT } from '../tokens';
 
 import { DialogConfig } from '../utils/dialog-config.class';
 import { DialogRef } from '../utils/dialog-ref.class';
@@ -20,7 +21,13 @@ import { DialogRef } from '../utils/dialog-ref.class';
         '[class.fd-dialog__body--no-vertical-padding]': '!dialogConfig.verticalPadding',
         '[class.fd-dialog__body--no-horizontal-padding]': '!dialogConfig.horizontalPadding',
         '[style.min-height]': 'dialogConfig.bodyMinHeight'
-    }
+    },
+    providers: [
+        {
+            provide: FD_DIALOG_BODY_COMPONENT,
+            useExisting: DialogBodyComponent
+        }
+    ]
 })
 export class DialogBodyComponent {
     /** @hidden */

--- a/libs/core/src/lib/dialog/public_api.ts
+++ b/libs/core/src/lib/dialog/public_api.ts
@@ -28,3 +28,4 @@ export * from './utils/dialog.animations';
 
 export * from './dialog.types';
 export * from './utils/dialog-overlay.container';
+export * from './tokens';

--- a/libs/core/src/lib/dialog/tokens.ts
+++ b/libs/core/src/lib/dialog/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_DIALOG_BODY_COMPONENT = new InjectionToken('FdDialogBodyComponent');

--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
@@ -17,7 +17,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { DYNAMIC_PAGE_HEADER_TOKEN, DynamicPageHeader } from '@fundamental-ngx/core/shared';
-import { BreadcrumbComponent } from '@fundamental-ngx/core/breadcrumb';
+import { BreadcrumbComponent, FD_BREADCRUMB_COMPONENT } from '@fundamental-ngx/core/breadcrumb';
 
 import { DYNAMIC_PAGE_CLASS_NAME, DynamicPageResponsiveSize } from '../../constants';
 import { DynamicPageService } from '../../dynamic-page.service';
@@ -65,7 +65,7 @@ export class DynamicPageHeaderComponent implements OnInit, AfterViewInit, OnDest
     subtitleWrap = false;
 
     /** @hidden */
-    @ContentChild(BreadcrumbComponent)
+    @ContentChild(FD_BREADCRUMB_COMPONENT)
     _breadcrumbComponent: BreadcrumbComponent;
 
     /** @hidden */

--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
@@ -7,6 +7,7 @@ import {
     ContentChildren,
     ElementRef,
     HostBinding,
+    Inject,
     Input,
     OnDestroy,
     Optional,
@@ -26,7 +27,10 @@ import { DynamicPageService } from './dynamic-page.service';
 import { addClassNameToElement, dynamicPageWidthToSize } from './utils';
 import { TabListComponent } from '@fundamental-ngx/core/tabs';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
-import { FlexibleColumnLayoutComponent } from '@fundamental-ngx/core/flexible-column-layout';
+import {
+    FD_FLEXIBLE_COLUMN_LAYOUT_COMPONENT,
+    FlexibleColumnLayoutComponent
+} from '@fundamental-ngx/core/flexible-column-layout';
 
 import { asyncScheduler, fromEvent, Observable, startWith, Subject } from 'rxjs';
 import { debounceTime, map, observeOn, takeUntil } from 'rxjs/operators';
@@ -130,7 +134,7 @@ export class DynamicPageComponent implements AfterViewInit, OnDestroy {
         private _elementRef: ElementRef<HTMLElement>,
         private _renderer: Renderer2,
         private _dynamicPageService: DynamicPageService,
-        @Optional() private _columnLayout: FlexibleColumnLayoutComponent,
+        @Optional() @Inject(FD_FLEXIBLE_COLUMN_LAYOUT_COMPONENT) private _columnLayout: FlexibleColumnLayoutComponent,
         @Optional() private _dynamicPageWrapper: DynamicPageWrapperDirective
     ) {}
 

--- a/libs/core/src/lib/flexible-column-layout/flexible-column-layout.component.ts
+++ b/libs/core/src/lib/flexible-column-layout/flexible-column-layout.component.ts
@@ -37,13 +37,20 @@ import {
     TWO_COLUMNS_MID_EXPANDED,
     TWO_COLUMNS_START_EXPANDED
 } from './constants';
+import { FD_FLEXIBLE_COLUMN_LAYOUT_COMPONENT } from './tokens';
 
 @Component({
     selector: 'fd-flexible-column-layout',
     templateUrl: './flexible-column-layout.component.html',
     styleUrls: ['./flexible-column-layout.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    providers: [
+        {
+            provide: FD_FLEXIBLE_COLUMN_LAYOUT_COMPONENT,
+            useExisting: FlexibleColumnLayoutComponent
+        }
+    ]
 })
 export class FlexibleColumnLayoutComponent implements AfterViewInit, OnChanges, OnDestroy, OnInit {
     /**

--- a/libs/core/src/lib/flexible-column-layout/public_api.ts
+++ b/libs/core/src/lib/flexible-column-layout/public_api.ts
@@ -1,3 +1,4 @@
 export * from './flexible-column-layout.component';
 export * from './flexible-column-layout.module';
 export * from './constants';
+export * from './tokens';

--- a/libs/core/src/lib/flexible-column-layout/tokens.ts
+++ b/libs/core/src/lib/flexible-column-layout/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_FLEXIBLE_COLUMN_LAYOUT_COMPONENT = new InjectionToken('FdFlexibleColumnLayoutComponent');

--- a/libs/core/src/lib/icon/icon.component.ts
+++ b/libs/core/src/lib/icon/icon.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { applyCssClass, CssClassBuilder } from '@fundamental-ngx/cdk/utils';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { FD_ICON_COMPONENT } from './tokens';
 
 export type IconFont = 'SAP-icons' | 'BusinessSuiteInAppSymbols' | 'SAP-icons-TNT';
 
@@ -31,6 +32,12 @@ const BusinessSuiteInAppSymbol_PREFIX = 'businessSuiteInAppSymbols';
     host: {
         role: 'presentation'
     },
+    providers: [
+        {
+            provide: FD_ICON_COMPONENT,
+            useExisting: IconComponent
+        }
+    ],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/libs/core/src/lib/icon/public_api.ts
+++ b/libs/core/src/lib/icon/public_api.ts
@@ -1,2 +1,3 @@
 export * from './icon.module';
 export * from './icon.component';
+export * from './tokens';

--- a/libs/core/src/lib/icon/tokens.ts
+++ b/libs/core/src/lib/icon/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_ICON_COMPONENT = new InjectionToken('FdIconComponent');

--- a/libs/core/src/lib/inline-help/inline-help.directive.ts
+++ b/libs/core/src/lib/inline-help/inline-help.directive.ts
@@ -1,6 +1,7 @@
 import {
     Directive,
     ElementRef,
+    Inject,
     Input,
     OnChanges,
     OnDestroy,
@@ -8,11 +9,12 @@ import {
     Optional,
     Self,
     SimpleChanges,
-    TemplateRef
+    TemplateRef,
+    Type
 } from '@angular/core';
 import { PopoverService, TriggerConfig } from '@fundamental-ngx/core/popover';
 import { BasePopoverClass } from '@fundamental-ngx/core/popover';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_ICON_COMPONENT } from '@fundamental-ngx/core/icon';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 
 const INLINE_HELP_CLASS = 'fd-popover__body--inline-help fd-inline-help__content';
@@ -65,7 +67,7 @@ export class InlineHelpDirective extends BasePopoverClass implements OnInit, OnC
     constructor(
         private _popoverService: PopoverService,
         private _elementRef: ElementRef,
-        @Optional() @Self() private _icon: IconComponent
+        @Optional() @Self() @Inject(FD_ICON_COMPONENT) private _icon: Type<any>
     ) {
         super();
     }

--- a/libs/core/src/lib/link/link.component.ts
+++ b/libs/core/src/lib/link/link.component.ts
@@ -21,7 +21,8 @@ import { RouterLink } from '@angular/router';
 import { applyCssClass, CssClassBuilder } from '@fundamental-ngx/cdk/utils';
 import { map, startWith, Subject, takeUntil, tap } from 'rxjs';
 import { DomPortal, Portal } from '@angular/cdk/portal';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_ICON_COMPONENT, IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_LINK_COMPONENT } from './tokens';
 
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
@@ -31,6 +32,10 @@ import { IconComponent } from '@fundamental-ngx/core/icon';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
+        {
+            provide: FD_LINK_COMPONENT,
+            useExisting: LinkComponent
+        },
         {
             provide: 'linkRouterTarget',
             useFactory: (withHref?: RouterLink, routerLink?: RouterLink): RouterLink | undefined =>
@@ -44,7 +49,7 @@ import { IconComponent } from '@fundamental-ngx/core/icon';
 })
 export class LinkComponent implements OnChanges, OnInit, CssClassBuilder, AfterViewInit, OnDestroy {
     /** @hidden */
-    @ContentChildren(IconComponent)
+    @ContentChildren(FD_ICON_COMPONENT)
     iconComponents: QueryList<IconComponent>;
 
     /** @hidden */

--- a/libs/core/src/lib/link/public_api.ts
+++ b/libs/core/src/lib/link/public_api.ts
@@ -1,3 +1,4 @@
 export * from './link.module';
 export * from './link.component';
 export * from './constants';
+export * from './tokens';

--- a/libs/core/src/lib/link/tokens.ts
+++ b/libs/core/src/lib/link/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_LINK_COMPONENT = new InjectionToken('FdLinkComponent');

--- a/libs/core/src/lib/list/directives/list-link.directive.ts
+++ b/libs/core/src/lib/list/directives/list-link.directive.ts
@@ -1,11 +1,18 @@
 import { Directive, ElementRef, HostBinding, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Subject } from 'rxjs';
+import { FD_LIST_LINK_DIRECTIVE } from '../tokens';
 
 @Directive({
     selector: '[fd-list-link], [fdListLink]',
     host: {
         '[attr.tabindex]': '-1'
-    }
+    },
+    providers: [
+        {
+            provide: FD_LIST_LINK_DIRECTIVE,
+            useExisting: ListLinkDirective
+        }
+    ]
 })
 export class ListLinkDirective implements OnChanges {
     /** Defines if navigation indicator arrow should be included inside list item */

--- a/libs/core/src/lib/list/list-item/list-item.component.ts
+++ b/libs/core/src/lib/list/list-item/list-item.component.ts
@@ -21,8 +21,8 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
-import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
-import { RadioButtonComponent } from '@fundamental-ngx/core/radio';
+import { CheckboxComponent, FD_CHECKBOX_COMPONENT } from '@fundamental-ngx/core/checkbox';
+import { FD_RADIO_BUTTON_COMPONENT, RadioButtonComponent } from '@fundamental-ngx/core/radio';
 import { ListLinkDirective } from '../directives/list-link.directive';
 import { merge, Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
@@ -31,9 +31,10 @@ import { LIST_ITEM_COMPONENT, ListItemInterface } from '@fundamental-ngx/cdk/uti
 import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { FD_LIST_UNREAD_INDICATOR } from '../list-component.token';
 import { ListFocusItem } from '../list-focus-item.model';
-import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { ButtonComponent, FD_BUTTON_COMPONENT } from '@fundamental-ngx/core/button';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { ListUnreadIndicator } from '../list-unread-indicator.interface';
+import { FD_LIST_LINK_DIRECTIVE } from '../tokens';
 
 let listItemUniqueId = 0;
 
@@ -129,7 +130,7 @@ export class ListItemComponent
     link = false;
 
     /** @hidden */
-    @ContentChild(RadioButtonComponent)
+    @ContentChild(FD_RADIO_BUTTON_COMPONENT)
     set radio(value: RadioButtonComponent) {
         this._radio = value;
         if (this._radio && this._radio.tabIndex == null) {
@@ -141,7 +142,7 @@ export class ListItemComponent
     }
 
     /** @hidden */
-    @ContentChild(CheckboxComponent)
+    @ContentChild(FD_CHECKBOX_COMPONENT)
     set checkbox(value: CheckboxComponent) {
         this._checkbox = value;
         if (this._checkbox && this._checkbox.tabIndexValue == null) {
@@ -153,11 +154,11 @@ export class ListItemComponent
     }
 
     /** @hidden */
-    @ContentChildren(ListLinkDirective)
+    @ContentChildren(FD_LIST_LINK_DIRECTIVE)
     linkDirectives: QueryList<ListLinkDirective>;
 
     /** @hidden */
-    @ContentChildren(ButtonComponent, { descendants: true })
+    @ContentChildren(FD_BUTTON_COMPONENT, { descendants: true })
     buttons: QueryList<ButtonComponent>;
 
     /** @hidden An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */

--- a/libs/core/src/lib/list/list-message.directive.ts
+++ b/libs/core/src/lib/list/list-message.directive.ts
@@ -2,9 +2,16 @@ import { Directive, ElementRef, Input, OnChanges, OnInit } from '@angular/core';
 import { MessageStates } from '@fundamental-ngx/core/form';
 import { applyCssClass } from '@fundamental-ngx/cdk/utils';
 import { CssClassBuilder } from '@fundamental-ngx/cdk/utils';
+import { FD_LIST_MESSAGE_DIRECTIVE } from './tokens';
 
 @Directive({
-    selector: '[fd-list-message], [fdListMessage]'
+    selector: '[fd-list-message], [fdListMessage]',
+    providers: [
+        {
+            provide: FD_LIST_MESSAGE_DIRECTIVE,
+            useExisting: ListMessageDirective
+        }
+    ]
 })
 export class ListMessageDirective implements OnChanges, OnInit, CssClassBuilder {
     /** Type of the message. Can be 'success' | 'error' | 'warning' | 'information' */

--- a/libs/core/src/lib/list/list-navigation-item/list-navigation-item.component.ts
+++ b/libs/core/src/lib/list/list-navigation-item/list-navigation-item.component.ts
@@ -9,7 +9,7 @@ import {
     Input,
     Optional
 } from '@angular/core';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_ICON_COMPONENT, IconComponent } from '@fundamental-ngx/core/icon';
 import { KeyUtil, RtlService } from '@fundamental-ngx/cdk/utils';
 import { ENTER, LEFT_ARROW, RIGHT_ARROW, SPACE } from '@angular/cdk/keycodes';
 import { FocusableOption } from '@angular/cdk/a11y';
@@ -61,7 +61,7 @@ export class ListNavigationItemComponent implements AfterContentInit, AfterViewI
     _listNavigationItemArrow: ListNavigationItemArrowDirective;
 
     /** @hidden */
-    @ContentChild(IconComponent)
+    @ContentChild(FD_ICON_COMPONENT)
     _iconComponent: IconComponent;
 
     /** @hidden */

--- a/libs/core/src/lib/list/public_api.ts
+++ b/libs/core/src/lib/list/public_api.ts
@@ -20,5 +20,5 @@ export * from './list.component';
 export * from './list-focus-item.model';
 export * from './deprecated-list-content-density,directive';
 export * from './list-unread-indicator.interface';
-export * from './list-component.token';
 export * from './list-component.interface';
+export * from './tokens';

--- a/libs/core/src/lib/list/tokens.ts
+++ b/libs/core/src/lib/list/tokens.ts
@@ -1,0 +1,8 @@
+import { InjectionToken } from '@angular/core';
+import { ListComponentInterface } from './list-component.interface';
+
+export const FD_LIST_MESSAGE_DIRECTIVE = new InjectionToken('FdListMessageDirective');
+export const FD_LIST_LINK_DIRECTIVE = new InjectionToken('FdListLinkDirective');
+export const FD_LIST_COMPONENT = new InjectionToken<ListComponentInterface>('ListComponent');
+
+export const FD_LIST_UNREAD_INDICATOR = new InjectionToken('ListUnreadIndicator');

--- a/libs/core/src/lib/notification/notification-actions/notification-actions.component.ts
+++ b/libs/core/src/lib/notification/notification-actions/notification-actions.component.ts
@@ -6,7 +6,7 @@ import {
     QueryList,
     ViewEncapsulation
 } from '@angular/core';
-import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { ButtonComponent, FD_BUTTON_COMPONENT } from '@fundamental-ngx/core/button';
 
 @Component({
     selector: 'fd-notification-actions',
@@ -20,6 +20,6 @@ export class NotificationActionsComponent {
     fdNotificationActionsClass = true;
 
     /** @hidden */
-    @ContentChildren(ButtonComponent)
+    @ContentChildren(FD_BUTTON_COMPONENT)
     buttons: QueryList<ButtonComponent>;
 }

--- a/libs/core/src/lib/notification/notification-group/notification-group.component.ts
+++ b/libs/core/src/lib/notification/notification-group/notification-group.component.ts
@@ -7,11 +7,12 @@ import {
     ViewEncapsulation,
     OnChanges,
     OnInit,
-    Optional
+    Optional,
+    Inject
 } from '@angular/core';
 import { applyCssClass } from '@fundamental-ngx/cdk/utils';
 import { CssClassBuilder } from '@fundamental-ngx/cdk/utils';
-import { PopoverComponent } from '@fundamental-ngx/core/popover';
+import { BasePopoverClass, FD_POPOVER_COMPONENT } from '@fundamental-ngx/core/popover';
 
 @Component({
     selector: 'fd-notification-group',
@@ -33,7 +34,10 @@ export class NotificationGroupComponent implements OnChanges, OnInit, CssClassBu
     width: string;
 
     /** @hidden */
-    constructor(private _elementRef: ElementRef, @Optional() private _popover: PopoverComponent) {
+    constructor(
+        private _elementRef: ElementRef,
+        @Optional() @Inject(FD_POPOVER_COMPONENT) private _popover: BasePopoverClass
+    ) {
         if (this._popover) {
             this._popover.focusTrapped = true;
             this._popover.focusAutoCapture = true;

--- a/libs/core/src/lib/notification/notification/notification.component.ts
+++ b/libs/core/src/lib/notification/notification/notification.component.ts
@@ -17,14 +17,15 @@ import {
     Type,
     ViewChild,
     ViewContainerRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    Inject
 } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
 import { NotificationRef } from '../notification-utils/notification-ref';
 import { AbstractFdNgxClass, RtlService, KeyUtil } from '@fundamental-ngx/cdk/utils';
 import { NotificationConfig } from '../notification-utils/notification-config';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
-import { PopoverComponent } from '@fundamental-ngx/core/popover';
+import { FD_POPOVER_COMPONENT, PopoverComponent } from '@fundamental-ngx/core/popover';
 import { ESCAPE } from '@angular/cdk/keycodes';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { filter, take, takeUntil } from 'rxjs/operators';
@@ -114,7 +115,7 @@ export class NotificationComponent extends AbstractFdNgxClass implements OnInit,
         @Optional() private _notificationConfig: NotificationConfig,
         @Optional() private _notificationRef: NotificationRef,
         @Optional() private _rtlService: RtlService,
-        @Optional() private _popover: PopoverComponent
+        @Optional() @Inject(FD_POPOVER_COMPONENT) private _popover: PopoverComponent
     ) {
         super(_elRef);
 

--- a/libs/core/src/lib/object-identifier/object-identifier.component.ts
+++ b/libs/core/src/lib/object-identifier/object-identifier.component.ts
@@ -10,7 +10,7 @@ import {
     OnDestroy,
     ElementRef
 } from '@angular/core';
-import { LinkComponent } from '@fundamental-ngx/core/link';
+import { FD_LINK_COMPONENT } from '@fundamental-ngx/core/link';
 import { startWith, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
@@ -48,7 +48,7 @@ export class ObjectIdentifierComponent implements AfterContentInit, OnDestroy {
     objectIdentifierClass = true;
 
     /** @hidden */
-    @ContentChildren(LinkComponent, { read: ElementRef })
+    @ContentChildren(FD_LINK_COMPONENT, { read: ElementRef })
     linkComponents: QueryList<ElementRef>;
 
     /** An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */

--- a/libs/core/src/lib/object-status/object-status.component.ts
+++ b/libs/core/src/lib/object-status/object-status.component.ts
@@ -8,6 +8,7 @@ import {
     OnInit
 } from '@angular/core';
 import { applyCssClass, CssClassBuilder, NullableObject, Nullable } from '@fundamental-ngx/cdk/utils';
+import { FD_OBJECT_STATUS_COMPONENT } from './tokens';
 
 export type ObjectStatus = 'negative' | 'critical' | 'positive' | 'informative' | 'neutral';
 
@@ -32,6 +33,12 @@ export type ObjectStatus = 'negative' | 'critical' | 'positive' | 'informative' 
     styleUrls: ['./object-status.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [
+        {
+            provide: FD_OBJECT_STATUS_COMPONENT,
+            useExisting: ObjectStatusComponent
+        }
+    ],
     host: {
         '[attr.tabindex]': 'clickable ? 0 : -1'
     }

--- a/libs/core/src/lib/object-status/public_api.ts
+++ b/libs/core/src/lib/object-status/public_api.ts
@@ -1,2 +1,3 @@
 export * from './object-status.component';
 export * from './object-status.module';
+export * from './tokens';

--- a/libs/core/src/lib/object-status/tokens.ts
+++ b/libs/core/src/lib/object-status/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_OBJECT_STATUS_COMPONENT = new InjectionToken('FdObjectStatusComponent');

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -33,6 +33,7 @@ import { POPOVER_COMPONENT } from './popover.interface';
 import { PopoverMobileComponent } from './popover-mobile/popover-mobile.component';
 import { PopoverMobileModule } from './popover-mobile/popover-mobile.module';
 import { PopoverChildContent } from './popover-child-content.interface';
+import { FD_POPOVER_COMPONENT } from './tokens';
 
 export const SELECT_CLASS_NAMES = {
     selectControl: 'fd-select__control'
@@ -50,7 +51,13 @@ let cdkPopoverUniqueId = 0;
     templateUrl: './popover.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [PopoverService],
+    providers: [
+        PopoverService,
+        {
+            provide: FD_POPOVER_COMPONENT,
+            useExisting: PopoverComponent
+        }
+    ],
     host: {
         class: 'fd-popover-custom',
         '[class.fd-popover-custom--mobile]': 'mobile',

--- a/libs/core/src/lib/popover/public_api.ts
+++ b/libs/core/src/lib/popover/public_api.ts
@@ -13,3 +13,4 @@ export * from './popover-service/popover.service';
 export * from './base/base-popover.class';
 export * from './popover-child-content.interface';
 export * from './popover-container/popover-container.directive';
+export * from './tokens';

--- a/libs/core/src/lib/popover/tokens.ts
+++ b/libs/core/src/lib/popover/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_POPOVER_COMPONENT = new InjectionToken('FdPopoverComponent');

--- a/libs/core/src/lib/radio/public_api.ts
+++ b/libs/core/src/lib/radio/public_api.ts
@@ -1,3 +1,4 @@
 export * from './radio.module';
 export * from './deprecated-radio-button-compact.directive';
 export * from './radio-button/radio-button.component';
+export * from './tokens';

--- a/libs/core/src/lib/radio/radio-button/radio-button.component.ts
+++ b/libs/core/src/lib/radio/radio-button/radio-button.component.ts
@@ -17,6 +17,7 @@ import { applyCssClass, CssClassBuilder } from '@fundamental-ngx/cdk/utils';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { registerFormItemControl, FormItemControl } from '@fundamental-ngx/core/form';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
+import { FD_RADIO_BUTTON_COMPONENT } from '../tokens';
 
 export type stateType = 'success' | 'error' | 'warning' | 'default' | 'information';
 let uniqueId = 0;
@@ -32,6 +33,10 @@ let uniqueId = 0;
             provide: NG_VALUE_ACCESSOR,
             useExisting: forwardRef(() => RadioButtonComponent),
             multi: true
+        },
+        {
+            provide: FD_RADIO_BUTTON_COMPONENT,
+            useExisting: RadioButtonComponent
         },
         registerFormItemControl(RadioButtonComponent),
         contentDensityObserverProviders()

--- a/libs/core/src/lib/radio/tokens.ts
+++ b/libs/core/src/lib/radio/tokens.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_RADIO_BUTTON_COMPONENT = new InjectionToken('FdRadioButtonComponent');

--- a/libs/core/src/lib/segmented-button/segmented-button.component.ts
+++ b/libs/core/src/lib/segmented-button/segmented-button.component.ts
@@ -11,7 +11,7 @@ import {
     QueryList,
     ViewEncapsulation
 } from '@angular/core';
-import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { ButtonComponent, FD_BUTTON_COMPONENT } from '@fundamental-ngx/core/button';
 import { filter, startWith, takeUntil, tap } from 'rxjs/operators';
 import { Subject, merge, fromEvent } from 'rxjs';
 import { DestroyedService, KeyUtil } from '@fundamental-ngx/cdk/utils';
@@ -63,7 +63,7 @@ export class SegmentedButtonComponent implements AfterContentInit, ControlValueA
     _fdSegmentedButtonClass = true;
 
     /** @hidden */
-    @ContentChildren(ButtonComponent)
+    @ContentChildren(FD_BUTTON_COMPONENT)
     _buttons: QueryList<ButtonComponent>;
 
     /**

--- a/libs/core/src/lib/table/directives/table-cell.directive.ts
+++ b/libs/core/src/lib/table/directives/table-cell.directive.ts
@@ -6,10 +6,9 @@ import {
     Input,
     QueryList,
     ContentChildren,
-    forwardRef,
     inject
 } from '@angular/core';
-import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
+import { CheckboxComponent, FD_CHECKBOX_COMPONENT } from '@fundamental-ngx/core/checkbox';
 import { CellFocusedEventAnnouncer, FocusableItemDirective } from '@fundamental-ngx/cdk/utils';
 import { BooleanInput } from '@angular/cdk/coercion';
 
@@ -80,7 +79,7 @@ export class TableCellDirective implements AfterContentInit {
     }
 
     /** @hidden */
-    @ContentChildren(forwardRef(() => CheckboxComponent))
+    @ContentChildren(FD_CHECKBOX_COMPONENT)
     _checkboxes: QueryList<CheckboxComponent>;
 
     /** @hidden */

--- a/libs/core/src/lib/upload-collection/upload-collection-simple.directives.ts
+++ b/libs/core/src/lib/upload-collection/upload-collection-simple.directives.ts
@@ -9,7 +9,7 @@ import {
     QueryList
 } from '@angular/core';
 import { ObjectMarkerComponent } from '@fundamental-ngx/core/object-marker';
-import { ObjectStatusComponent } from '@fundamental-ngx/core/object-status';
+import { FD_OBJECT_STATUS_COMPONENT, ObjectStatusComponent } from '@fundamental-ngx/core/object-status';
 
 @Directive({
     // eslint-disable-next-line @angular-eslint/directive-selector
@@ -56,7 +56,7 @@ export class UploadCollectionStatusGroupDirective {}
 })
 export class UploadCollectionStatusItemDirective implements OnInit {
     /** @hidden */
-    constructor(@Optional() @Inject(ObjectStatusComponent) private _objectStatus: ObjectStatusComponent) {}
+    constructor(@Optional() @Inject(FD_OBJECT_STATUS_COMPONENT) private _objectStatus: ObjectStatusComponent) {}
 
     /** @hidden */
     ngOnInit(): void {

--- a/libs/core/src/lib/vertical-navigation/vertical-navigation-main-navigation.component.ts
+++ b/libs/core/src/lib/vertical-navigation/vertical-navigation-main-navigation.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, ContentChild, ViewEncapsulation } from '@angular/core';
-import { ListComponent } from '@fundamental-ngx/core/list';
+import { ListComponent, FD_LIST_COMPONENT } from '@fundamental-ngx/core/list';
 
 @Component({
     selector: 'fd-vertical-navigation-main-navigation',
@@ -10,6 +10,6 @@ import { ListComponent } from '@fundamental-ngx/core/list';
 })
 export class VerticalNavigationMainNavigationComponent {
     /** @hidden */
-    @ContentChild(ListComponent)
+    @ContentChild(FD_LIST_COMPONENT)
     _list: ListComponent;
 }

--- a/libs/core/src/lib/wizard/wizard.component.ts
+++ b/libs/core/src/lib/wizard/wizard.component.ts
@@ -18,7 +18,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
-import { DialogBodyComponent } from '@fundamental-ngx/core/dialog';
+import { DialogBodyComponent, FD_DIALOG_BODY_COMPONENT } from '@fundamental-ngx/core/dialog';
 import { scrollTop } from '@fundamental-ngx/cdk/utils';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { WizardStepComponent } from './wizard-step/wizard-step.component';
@@ -149,7 +149,7 @@ export class WizardComponent implements AfterViewInit, OnDestroy {
         private _elRef: ElementRef,
         private readonly _cdRef: ChangeDetectorRef,
         @Inject(FD_LANGUAGE) _language$: Observable<FdLanguage>,
-        @Optional() private _dialogBodyComponent: DialogBodyComponent
+        @Optional() @Inject(FD_DIALOG_BODY_COMPONENT) private _dialogBodyComponent: DialogBodyComponent
     ) {
         const sub = _language$.subscribe((lang) => {
             // set ariaLabel only if it's not applied manually

--- a/libs/platform/src/lib/link/link.component.ts
+++ b/libs/platform/src/lib/link/link.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_ICON_COMPONENT, IconComponent } from '@fundamental-ngx/core/icon';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
 
@@ -110,7 +110,7 @@ export class LinkComponent extends BaseComponent implements OnInit, AfterViewIni
     click: EventEmitter<MouseEvent | KeyboardEvent | TouchEvent> = new EventEmitter();
 
     /** @hidden */
-    @ContentChild(IconComponent)
+    @ContentChild(FD_ICON_COMPONENT)
     icon: IconComponent;
 
     /** Access child element, for checking link content*/


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #9209

## Description
Changed majority of ContentChild/ContentChildren and `@Optional` injectors to use lightweight injection tokens.
This is not applied to ViewChild/ViewChildren since they won't be tree-shaken anyway, and also it does not applied to the same components from the same sub-package (for example, popoverBody injected as is for PopoverComponent) 'cause it doesn't make much of a sense to do so.