### PR TITLE
fix(docs): core dialog examples initial focus targets

### DIFF
--- a/libs/docs/core/dialog/examples/auto-label/auto-label-dialog-example.component.html
+++ b/libs/docs/core/dialog/examples/auto-label/auto-label-dialog-example.component.html
@@ -16,12 +16,7 @@
                 ariaLabel="Interested Emphasized"
             ></fd-button-bar>
 
-            <fd-button-bar
-                fdInitialFocus
-                label="Cancel"
-                (click)="dialog.dismiss('Cancel')"
-                ariaLabel="Cancel"
-            ></fd-button-bar>
+            <fd-button-bar label="Cancel" (click)="dialog.dismiss('Cancel')" ariaLabel="Cancel"></fd-button-bar>
         </fd-dialog-footer>
     </fd-dialog>
 </ng-template>

--- a/libs/docs/core/dialog/examples/component-based/dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/component-based/dialog-example.component.ts
@@ -29,7 +29,6 @@ import { DialogRef } from '@fundamental-ngx/core/dialog';
                 </fd-button-bar>
                 <fd-button-bar
                     label="Cancel"
-                    fdInitialFocus
                     fdType="transparent"
                     (click)="dialogRef.dismiss('Cancel')"
                     ariaLabel="Cancel"

--- a/libs/docs/core/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.html
@@ -18,13 +18,7 @@
         </fd-dialog-body>
 
         <fd-dialog-footer>
-            <fd-button-bar
-                fd-initial-focus
-                fdType="emphasized"
-                label="Close"
-                (click)="dialog.close()"
-                ariaLabel="Close Emphasized"
-            >
+            <fd-button-bar fdType="emphasized" label="Close" (click)="dialog.close()" ariaLabel="Close Emphasized">
             </fd-button-bar>
         </fd-dialog-footer>
     </fd-dialog>

--- a/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.html
@@ -16,7 +16,7 @@
                 <div fd-bar-middle>
                     <fd-bar-element [fullWidth]="true">
                         <fd-input-group
-                            fd-initial-focus
+                            fdkInitialFocus
                             glyph="search"
                             placement="after"
                             placeholder="Search"

--- a/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.html
@@ -51,7 +51,6 @@
                 </div>
                 <div fd-bar-right>
                     <fd-button-bar
-                        fd-initial-focus
                         glyph="cart"
                         fdType="emphasized"
                         label="Checkout"

--- a/libs/docs/core/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
@@ -16,7 +16,6 @@
 
         <fd-dialog-footer>
             <fd-button-bar
-                fd-initial-focus
                 fdType="emphasized"
                 label="Interesting"
                 (click)="dialog.close()"

--- a/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.html
@@ -101,12 +101,7 @@
                 ariaLabel="Interested Emphasized"
             ></fd-button-bar>
 
-            <fd-button-bar
-                fdInitialFocus
-                label="Cancel"
-                (click)="dialog.dismiss('Cancel')"
-                ariaLabel="Cancel"
-            ></fd-button-bar>
+            <fd-button-bar label="Cancel" (click)="dialog.dismiss()" ariaLabel="Cancel"></fd-button-bar>
         </fd-dialog-footer>
     </fd-dialog>
 </ng-template>

--- a/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.html
@@ -101,7 +101,7 @@
                 ariaLabel="Interested Emphasized"
             ></fd-button-bar>
 
-            <fd-button-bar label="Cancel" (click)="dialog.dismiss()" ariaLabel="Cancel"></fd-button-bar>
+            <fd-button-bar label="Cancel" (click)="dialog.dismiss('Cancel')" ariaLabel="Cancel"></fd-button-bar>
         </fd-dialog-footer>
     </fd-dialog>
 </ng-template>

--- a/libs/docs/core/dialog/examples/dialog-inner-popover/dialog-inner-popover.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-inner-popover/dialog-inner-popover.component.ts
@@ -103,7 +103,6 @@ export class DialogInnerPopoverComponent {
                 </fd-button-bar>
                 <fd-button-bar
                     label="Cancel"
-                    fdInitialFocus
                     fdType="transparent"
                     (click)="dialogRef.dismiss('Cancel')"
                     ariaLabel="Cancel"

--- a/libs/docs/core/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
@@ -13,7 +13,6 @@
 
         <fd-dialog-footer>
             <fd-button-bar
-                fd-initial-focus
                 fdType="emphasized"
                 label="Interesting"
                 (click)="dialog.close()"

--- a/libs/docs/core/dialog/examples/dialog-object-example/dialog-object-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-object-example/dialog-object-example.component.html
@@ -7,7 +7,7 @@
 <ng-template #dialogSubHeader>
     <div fd-bar-middle>
         <fd-bar-element [fullWidth]="true">
-            <fd-input-group glyph="menu" glyphAriaLabel="Submit" [button]="true"> </fd-input-group>
+            <fd-input-group glyph="menu" fd-initial-focus glyphAriaLabel="Submit" [button]="true"> </fd-input-group>
         </fd-bar-element>
     </div>
 </ng-template>

--- a/libs/docs/core/dialog/examples/dialog-object-example/dialog-object-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-object-example/dialog-object-example.component.html
@@ -7,7 +7,7 @@
 <ng-template #dialogSubHeader>
     <div fd-bar-middle>
         <fd-bar-element [fullWidth]="true">
-            <fd-input-group glyph="menu" fd-initial-focus glyphAriaLabel="Submit" [button]="true"> </fd-input-group>
+            <fd-input-group glyph="menu" fdkInitialFocus glyphAriaLabel="Submit" [button]="true"> </fd-input-group>
         </fd-bar-element>
     </div>
 </ng-template>

--- a/libs/docs/core/dialog/examples/dialog-state/dialog-state-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-state/dialog-state-example.component.html
@@ -10,7 +10,7 @@
 
         <fd-dialog-footer>
             <fd-button-bar
-                fd-initial-focus
+                fdkInitialFocus
                 fdType="emphasized"
                 label="Ok"
                 (click)="dialog.close()"

--- a/libs/docs/core/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
@@ -19,7 +19,7 @@ import { SecondDialogExampleComponent } from './second-dialog-example.component'
 
             <fd-dialog-footer>
                 <fd-button-bar
-                    fd-initial-focus
+                    fdkInitialFocus
                     fdType="emphasized"
                     label="Open Second Dialog"
                     (click)="openDialog()"

--- a/libs/docs/core/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
@@ -18,7 +18,7 @@ import { DialogRef } from '@fundamental-ngx/core/dialog';
 
             <fd-dialog-footer>
                 <fd-button-bar
-                    fd-initial-focus
+                    fdkInitialFocus
                     fdType="emphasized"
                     label="Close"
                     (click)="dialogRef.close()"

--- a/libs/docs/core/dialog/examples/template-based/template-based-dialog-example.component.html
+++ b/libs/docs/core/dialog/examples/template-based/template-based-dialog-example.component.html
@@ -16,12 +16,7 @@
                 ariaLabel="Interested Emphasized"
             ></fd-button-bar>
 
-            <fd-button-bar
-                fdInitialFocus
-                label="Cancel"
-                (click)="dialog.dismiss('Cancel')"
-                ariaLabel="Cancel"
-            ></fd-button-bar>
+            <fd-button-bar label="Cancel" (click)="dialog.dismiss('Cancel')" ariaLabel="Cancel"></fd-button-bar>
         </fd-dialog-footer>
     </fd-dialog>
 </ng-template>


### PR DESCRIPTION
## Related Issue(s)

part of #9228

## Description

Dialog examples had incorrect initial focus targets, targeting close button
