### PR TITLE
feat(core): scrollbar uses cdk scrollable

### DIFF
--- a/libs/core/src/lib/scrollbar/scrollbar.directive.ts
+++ b/libs/core/src/lib/scrollbar/scrollbar.directive.ts
@@ -2,6 +2,7 @@ import { Directive, ElementRef, HostBinding, inject, Input, OnDestroy, PLATFORM_
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { isPlatformBrowser } from '@angular/common';
 import scrollbarStyles from 'fundamental-styles/dist/js/scrollbar';
+import { CdkScrollable } from '@angular/cdk/overlay';
 
 export type ScrollbarOverflowOptions = 'auto' | 'scroll' | 'hidden';
 
@@ -25,6 +26,7 @@ let styleSheet: CSSStyleSheet | undefined;
     host: {
         class: 'fd-scrollbar'
     },
+    hostDirectives: [CdkScrollable],
     standalone: true
 })
 export class ScrollbarDirective implements OnDestroy {

--- a/libs/docs/platform/menu/examples/platform-menu-scrolling-example.component.html
+++ b/libs/docs/platform/menu/examples/platform-menu-scrolling-example.component.html
@@ -1,5 +1,5 @@
 <div class="fdp-menu-example">
-    <div style="height: 25rem; overflow: scroll" cdkScrollable>
+    <div style="height: 15rem" fdScrollbar>
         <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed et odio eu tellus vehicula pharetra. Interdum
             et malesuada fames ac ante ipsum primis in faucibus. In mi sem, sollicitudin a porta a, tempus non nibh.

--- a/libs/docs/platform/menu/examples/platform-menu-scrolling-example.component.html
+++ b/libs/docs/platform/menu/examples/platform-menu-scrolling-example.component.html
@@ -12,7 +12,7 @@
             ut ipsum lobortis placerat. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
         </p>
 
-        <button fd-button [fdpMenuTriggerFor]="scrollableMenu" label="Button example"></button>
+        <button fd-button [fdpMenuTriggerFor]="scrollableMenu" label="Button example" style="margin: 0 1rem"></button>
         <fdp-menu #scrollableMenu id="scrollable-menu">
             <fdp-menu-item>First Item</fdp-menu-item>
             <fdp-menu-item>Second Item</fdp-menu-item>

--- a/libs/docs/platform/menu/platform-menu-docs.component.html
+++ b/libs/docs/platform/menu/platform-menu-docs.component.html
@@ -60,7 +60,8 @@
     </p>
     <p>
         For containers that are scrollable (e.g. via the CSS <code>overflow: scroll</code> property), the user needs to
-        add the <code>cdkScrollable</code> directive to that container, and import the CDK ScrollingModule.
+        add the <code>cdkScrollable</code> directive to that container, and import the CDK ScrollingModule, or use
+        <a fd-link routerLink="/core/scrollbar"><code>scrollbar</code></a> directive.
     </p>
 </description>
 <component-example>

--- a/libs/docs/platform/menu/platform-menu.module.ts
+++ b/libs/docs/platform/menu/platform-menu.module.ts
@@ -16,6 +16,7 @@ import { PlatformMenuScrollingExampleComponent } from './examples/platform-menu-
 import { PlatformMenuXPositionExampleComponent } from './examples/platform-menu-x-position-example.component';
 import { PlatformMenuWithIconsExampleComponent } from './examples/platform-menu-with-icons-example.component';
 import { platformContentDensityModuleDeprecationsProvider } from '@fundamental-ngx/platform/shared';
+import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 
 const routes: Routes = [
     {
@@ -35,7 +36,8 @@ const routes: Routes = [
         PlatformMenuModule,
         ButtonModule,
         AvatarModule,
-        ScrollingModule
+        ScrollingModule,
+        ScrollbarDirective
     ],
     exports: [RouterModule],
     declarations: [


### PR DESCRIPTION
## Related Issue(s)

part of #9228 

## Description

When you have a menu or something which needs repositioning inside the scrollable area, you need to specify cdkScrollable for the scrollable area. So why not include it in fdScrollbar and alongside styles, functionality will also be included

