### PR TITLE
fix(core,platform): openDropdownOnAddOnClicked event for multi components 

### DIFF
--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.html
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.html
@@ -38,7 +38,7 @@
             [attr.aria-readonly]="this._cva.readonly"
             [glyphAriaLabel]="this._cva.ariaLabel || ('platformMultiCombobox.inputGlyphAriaLabel' | fdTranslate)"
             [iconTitle]="addonIconTitle || ('platformMultiCombobox.inputGlyphAriaLabel' | fdTranslate)"
-            (addOnButtonClicked)="addOnButtonClicked.emit($event); !mobile && _onPrimaryButtonClick(isOpen)"
+            (addOnButtonClicked)="_addOnClicked($event)"
             (click)="mobile && !isOpen && _onPrimaryButtonClick(false)"
             (keydown)="_navigateByTokens($event)"
         >

--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.spec.ts
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.spec.ts
@@ -149,6 +149,15 @@ describe('MultiComboBox component', () => {
 
         expect(component._selectedSuggestions.length).toEqual(0);
     });
+
+    it('should not open dropdown when openDropdownOnAddOnClicked is false', () => {
+        spyOn(component.addOnButtonClicked, 'emit');
+        spyOn(component, '_showList');
+        component.openDropdownOnAddOnClicked = false;
+        component._addOnClicked(new MouseEvent('click'));
+        expect(component.addOnButtonClicked.emit).toHaveBeenCalled();
+        expect(component._showList).not.toHaveBeenCalled();
+    });
 });
 
 describe('MultiComboBox component CVA', () => {

--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
@@ -156,6 +156,10 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     @Input()
     autoResize = true;
 
+    /** Whether to open the dropdown when the addon button is clicked. */
+    @Input()
+    openDropdownOnAddOnClicked = true;
+
     /** Value of the multi combobox */
     @Input()
     set value(value: T[]) {
@@ -600,7 +604,9 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
             this._searchTermChanged('');
         }
 
-        this._showList(!isOpen);
+        if (this.openDropdownOnAddOnClicked) {
+            this._showList(!isOpen);
+        }
 
         if (this.isOpen && this.listComponent) {
             this.listComponent.setItemActive(0);
@@ -654,6 +660,16 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     _handleListFocusEscape(direction: FocusEscapeDirection): void {
         if (direction === 'up') {
             this.searchInputElement?.elmRef?.nativeElement.focus();
+        }
+    }
+
+    /**
+     * @hidden
+     */
+    _addOnClicked($event: Event): void {
+        this.addOnButtonClicked.emit($event);
+        if (!this.mobile) {
+            this._onPrimaryButtonClick(this.isOpen);
         }
     }
 

--- a/libs/core/src/lib/multi-input/multi-input.component.spec.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.spec.ts
@@ -259,4 +259,13 @@ describe('MultiInputComponent', () => {
 
         expect(component.selected).toEqual([]);
     });
+
+    it('should not open dropdown when openDropdownOnAddOnClicked is false', () => {
+        spyOn(component.addOnButtonClicked, 'emit');
+        spyOn(component, 'openChangeHandle');
+        component.openDropdownOnAddOnClicked = false;
+        component._addOnButtonClicked(new MouseEvent('click'));
+        expect(component.addOnButtonClicked.emit).toHaveBeenCalled();
+        expect(component.openChangeHandle).not.toHaveBeenCalled();
+    });
 });

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -114,6 +114,10 @@ export class MultiInputComponent
     @Input()
     dropdownValues: any[] = [];
 
+    /** Whether to open the dropdown when the addon button is clicked. */
+    @Input()
+    openDropdownOnAddOnClicked = true;
+
     /** Search term, or more specifically the value of the inner input field. */
     @Input()
     set searchTerm(value: string) {
@@ -688,7 +692,9 @@ export class MultiInputComponent
     /** @hidden */
     _addOnButtonClicked(event: Event): void {
         this.addOnButtonClicked.emit(event);
-        this.openChangeHandle(!this.open);
+        if (this.openDropdownOnAddOnClicked) {
+            this.openChangeHandle(!this.open);
+        }
     }
 
     /** @hidden */

--- a/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.html
+++ b/libs/docs/core/multi-input/examples/multi-input-addon-clicked-example/multi-input-addon-clicked-example.component.html
@@ -2,5 +2,6 @@
     [dropdownValues]="['Banana', 'Pineapple', 'Tomato', 'Kiwi', 'Strawberry', 'Blueberry', 'Orange']"
     placeholder="Search here..."
     style="width: 200px"
+    [openDropdownOnAddOnClicked]="false"
     (addOnButtonClicked)="addOnClicked($event)"
 ></fd-multi-input>

--- a/libs/docs/core/multi-input/multi-input-docs.component.html
+++ b/libs/docs/core/multi-input/multi-input-docs.component.html
@@ -163,7 +163,10 @@
 <description>
     <p>
         The <code>addOnButtonClicked</code> event is emitted when the user clicks the addon button. This event can be
-        captured to further configure custom behavior.
+        captured to further configure custom behavior, in this example opening a window alert.
+        <br />
+        Use the <code>[openDropdownOnAddOnClicked]</code> to configure whether the multi-input dropdown list should be
+        opened when the addon button is clicked. Default is true.
     </p>
 </description>
 <component-example>

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -183,6 +183,10 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
     @Input()
     limitless: boolean;
 
+    /** Whether to open the dropdown when the addon button is clicked. */
+    @Input()
+    openDropdownOnAddOnClicked = true;
+
     /** Event emitted when item is selected. */
     @Output()
     selectionChange = new EventEmitter<MultiComboboxSelectionChangeEvent>();
@@ -514,7 +518,9 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
             this.searchTermChanged('');
         }
 
-        this.showList(!isOpen);
+        if (this.openDropdownOnAddOnClicked) {
+            this.showList(!isOpen);
+        }
 
         if (this.isOpen && this.listComponent) {
             this.listComponent.setItemActive(0);

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.html
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.html
@@ -38,7 +38,7 @@
             [attr.aria-readonly]="readonly"
             [glyphAriaLabel]="ariaLabel || ('platformMultiCombobox.inputGlyphAriaLabel' | fdTranslate)"
             [iconTitle]="addonIconTitle || ('platformMultiCombobox.inputGlyphAriaLabel' | fdTranslate)"
-            (addOnButtonClicked)="addOnButtonClicked.emit($event); !mobile && onPrimaryButtonClick(isOpen)"
+            (addOnButtonClicked)="_addOnClicked($event)"
             (click)="mobile && !isOpen && onPrimaryButtonClick(false)"
             (keydown)="navigateByTokens($event)"
         >

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.spec.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.spec.ts
@@ -206,4 +206,13 @@ describe('MultiComboboxComponent default values', () => {
 
         expect(multiCombobox._selectedSuggestions.length).toEqual(0);
     });
+
+    it('should not open dropdown when openDropdownOnAddOnClicked is false', () => {
+        spyOn(multiCombobox.addOnButtonClicked, 'emit');
+        spyOn(multiCombobox, 'showList');
+        multiCombobox.openDropdownOnAddOnClicked = false;
+        multiCombobox._addOnClicked(new MouseEvent('click'));
+        expect(multiCombobox.addOnButtonClicked.emit).toHaveBeenCalled();
+        expect(multiCombobox.showList).not.toHaveBeenCalled();
+    });
 });

--- a/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
+++ b/libs/platform/src/lib/form/multi-combobox/multi-combobox/multi-combobox.component.ts
@@ -299,6 +299,14 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
         this.close();
     }
 
+    /** @hidden */
+    _addOnClicked(event: Event): void {
+        this.addOnButtonClicked.emit(event);
+        if (!this.mobile) {
+            this.onPrimaryButtonClick(this.isOpen);
+        }
+    }
+
     /**
      * @hidden
      * applying range selection. Note, that this function will be invoked after combobox item's value has been changed

--- a/libs/platform/src/lib/form/multi-input/base-multi-input.ts
+++ b/libs/platform/src/lib/form/multi-input/base-multi-input.ts
@@ -146,6 +146,10 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
     @Input()
     autoResize = false;
 
+    /** Whether to open the dropdown when the addon button is clicked. */
+    @Input()
+    openDropdownOnAddOnClicked = true;
+
     /** Value of the multi input */
     @Input()
     set value(value: any) {

--- a/libs/platform/src/lib/form/multi-input/multi-input.component.spec.ts
+++ b/libs/platform/src/lib/form/multi-input/multi-input.component.spec.ts
@@ -86,6 +86,15 @@ describe('PlatformMultiInputComponent', () => {
         const toggleButton = fixture.nativeElement.querySelectorAll('.fd-token');
         expect(toggleButton.length).toBe(1);
     });
+
+    it('should not open dropdown when openDropdownOnAddOnClicked is false', () => {
+        spyOn(component.platformMultiInputComponent.addOnButtonClicked, 'emit');
+        spyOn(component.platformMultiInputComponent, 'showList');
+        component.platformMultiInputComponent.openDropdownOnAddOnClicked = false;
+        component.platformMultiInputComponent.addOnButtonClick(new MouseEvent('click'));
+        expect(component.platformMultiInputComponent.addOnButtonClicked.emit).toHaveBeenCalled();
+        expect(component.platformMultiInputComponent.showList).not.toHaveBeenCalled();
+    });
 });
 
 const MULTI_INPUT_IDENTIFIER = 'platform-multi-input-unit-test';

--- a/libs/platform/src/lib/form/multi-input/multi-input.component.ts
+++ b/libs/platform/src/lib/form/multi-input/multi-input.component.ts
@@ -285,7 +285,9 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
             return;
         }
 
-        this.showList(!this.isOpen);
+        if (this.openDropdownOnAddOnClicked) {
+            this.showList(!this.isOpen);
+        }
     }
 
     /** @hidden */


### PR DESCRIPTION
fixes none

Adds an input `openDropdownOnAddOnClicked` which allows the developer to specify whether the dropdown list should open for multi-input and multi-combobox components when the addon button is clicked. Default is true. Should be useful when developer is handling `addOnButtonClicked` events