### PR TITLE
fix: aria-label not being properly applied to fdp-input

### DIFF
--- a/libs/core/src/lib/form/form-control/form-control.component.ts
+++ b/libs/core/src/lib/form/form-control/form-control.component.ts
@@ -47,25 +47,25 @@ export class FormControlComponent implements CssClassBuilder, OnInit, OnChanges,
     @Input()
     class: string;
 
+    /** aria-label for form-control. */
+    @Input()
+    ariaLabel: Nullable<string>;
+
+    /** aria-label for form-control. */
+    @Input()
+    ariaLabelledBy: Nullable<string>;
+
     /** @hidden */
     @HostBinding('attr.aria-label')
     private get ariaLabelBinding(): string {
         return this.ariaLabelAttr || this.ariaLabel || '';
     }
 
-    /** aria-label for form-control. */
-    @Input()
-    ariaLabel: Nullable<string>;
-
     /** @hidden */
     @HostBinding('attr.aria-labelledby')
     private get ariaLabelledByBinding(): string {
         return this.ariaLabelledByAttr || this.ariaLabelledBy || '';
     }
-
-    /** aria-label for form-control. */
-    @Input()
-    ariaLabelledBy: Nullable<string>;
 
     /** @hidden */
     private _subscriptions = new Subscription();

--- a/libs/core/src/lib/form/form-control/form-control.component.ts
+++ b/libs/core/src/lib/form/form-control/form-control.component.ts
@@ -54,6 +54,7 @@ export class FormControlComponent implements CssClassBuilder, OnInit, OnChanges,
     }
 
     /** aria-label for form-control. */
+    @Input()
     ariaLabel: Nullable<string>;
 
     /** @hidden */
@@ -63,6 +64,7 @@ export class FormControlComponent implements CssClassBuilder, OnInit, OnChanges,
     }
 
     /** aria-label for form-control. */
+    @Input()
     ariaLabelledBy: Nullable<string>;
 
     /** @hidden */

--- a/libs/platform/src/lib/form/input/input.component.html
+++ b/libs/platform/src/lib/form/input/input.component.html
@@ -15,7 +15,7 @@
     [readOnly]="readonly"
     (blur)="_onBlur()"
     (focus)="_onFocus()"
-    [attr.aria-label]="ariaLabel"
-    [attr.aria-labelledby]="ariaLabelledBy"
+    [ariaLabel]="ariaLabel"
+    [ariaLabelledBy]="ariaLabelledBy"
     [attr.aria-required]="required"
 />


### PR DESCRIPTION
fixes #9358 

Fixes a bug where aria-label was not being applied to fdp-input

<img width="641" alt="Screenshot 2023-02-24 at 12 49 33 PM" src="https://user-images.githubusercontent.com/2471874/221277142-3edad3dc-d2d9-4812-ac0c-722c3e372fbb.png">
