### PR TITLE
fix(core,platform): table toolbar title updates

### DIFF
--- a/libs/docs/core/table/examples/table-column-sorting-example.component.html
+++ b/libs/docs/core/table/examples/table-column-sorting-example.component.html
@@ -1,7 +1,6 @@
 <p>Sorting and filtering with toolbar elements:</p>
 
-<fd-toolbar>
-    <label fd-toolbar-label> Filter and sort for table elements </label>
+<fd-toolbar title="Filter and sort for table elements">
     <fd-toolbar-spacer></fd-toolbar-spacer>
     <ng-container fdCompact>
         <fd-input-group
@@ -43,7 +42,10 @@
         </tr>
     </thead>
     <tbody fd-table-body>
-        <tr *ngFor="let row of displayedRows | filter: filterVal:'column1' | sortBy: ascending:'column1'" fd-table-row>
+        <tr
+            *ngFor="let row of displayedRows | filter : filterVal : 'column1' | sortBy : ascending : 'column1'"
+            fd-table-row
+        >
             <td fd-table-cell class="fd-has-font-weight-semi">
                 <a fd-link href="#">{{ row.column1 }}</a>
             </td>
@@ -109,7 +111,7 @@
     </thead>
     <tbody fd-table-body>
         <tr
-            *ngFor="let row of displayedRows2 | filter: filterVal2:'column1' | sortBy: ascending2:'column1'"
+            *ngFor="let row of displayedRows2 | filter : filterVal2 : 'column1' | sortBy : ascending2 : 'column1'"
             fd-table-row
         >
             <td fd-table-cell class="fd-has-font-weight-semi">

--- a/libs/docs/core/table/examples/table-toolbar-example.component.html
+++ b/libs/docs/core/table/examples/table-toolbar-example.component.html
@@ -1,5 +1,5 @@
-<fd-toolbar aria-label="With Toolbar">
-    <label fd-toolbar-label> Table Toolbar Label ({{ tableRows.length }} rows) </label>
+<fd-toolbar aria-label="With Toolbar" fdType="transparent" [clearBorder]="true" [hasTitle]="true">
+    <h4 fd-title>Table Toolbar Label ({{ tableRows.length }} rows)</h4>
     <fd-toolbar-spacer></fd-toolbar-spacer>
     <fd-input-group
         glyph="decline"

--- a/libs/docs/core/table/table-docs.module.ts
+++ b/libs/docs/core/table/table-docs.module.ts
@@ -49,6 +49,7 @@ import { moduleDeprecationsProvider, RepeatModule } from '@fundamental-ngx/cdk/u
 import { SkeletonModule } from '../../../core/src/lib/skeleton';
 import { TableLoadingExampleComponent } from './examples/loading/table-loading-example.component';
 import { TableFixedExampleComponent } from './examples/table-fixed-example.component';
+import { TitleModule } from '@fundamental-ngx/core/title';
 
 const routes: Routes = [
     {
@@ -82,7 +83,8 @@ const routes: Routes = [
         StepInputModule,
         PopoverModule,
         SkeletonModule,
-        RepeatModule
+        RepeatModule,
+        TitleModule
     ],
     exports: [RouterModule],
     declarations: [

--- a/libs/docs/platform/table/e2e/table.po.ts
+++ b/libs/docs/platform/table/e2e/table.po.ts
@@ -73,7 +73,7 @@ export class TablePo extends PlatformBaseComponentPo {
     optionMultiple = this.playgroundSelectionModeDropdown + ' option[value="multiple"]';
     tableCellFixed = '.fd-table__cell';
     playgroundSchemaInput = '.form-control.fd-input';
-    toolbarText = '.fd-label.fd-toolbar__overflow-label';
+    toolbarText = '.fd-toolbar__title';
     dropdownList = '.fd-select-options';
     dropdownOption = 'li[fd-option].fd-list__item ';
     dialogButton = 'fd-dialog-body .sort-row__actions .fd-button';

--- a/libs/docs/platform/table/examples/platform-table-default-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-default-example.component.html
@@ -1,10 +1,5 @@
 <fdp-table [dataSource]="source" [trackBy]="trackBy" emptyTableMessage="No data found">
-    <fdp-table-toolbar [hideItemCount]="true">
-        <fdp-table-toolbar-left-actions>
-            <label fd-toolbar-label class="fd-toolbar__title"> Custom table title </label>
-            <fd-toolbar-separator></fd-toolbar-separator>
-            <fdp-button label="I'm a button"></fdp-button>
-        </fdp-table-toolbar-left-actions>
+    <fdp-table-toolbar title="Order Line Items">
         <fdp-table-toolbar-actions>
             <fdp-button label="Action One" (click)="alert('Action One')"></fdp-button>
             <fdp-button label="Action Two" (click)="alert('Action Two')"></fdp-button>

--- a/libs/docs/platform/table/platform-table-docs.component.html
+++ b/libs/docs/platform/table/platform-table-docs.component.html
@@ -62,6 +62,15 @@
 
 <separator></separator>
 
+<fd-docs-section-title id="custom-titles" componentName="table"> Custom Toolbar Title </fd-docs-section-title>
+<description>This example shows how to customize the title of the table</description>
+<component-example>
+    <fdp-platform-table-custom-title-example></fdp-platform-table-custom-title-example>
+</component-example>
+<code-example [exampleFiles]="customTitleTableFiles"></code-example>
+
+<separator></separator>
+
 <fd-docs-section-title id="single-row-selection" componentName="table"> Single Row Selection</fd-docs-section-title>
 <description>
     <p>This example shows single row selection</p>

--- a/libs/docs/platform/table/platform-table-docs.component.ts
+++ b/libs/docs/platform/table/platform-table-docs.component.ts
@@ -18,6 +18,8 @@ const platformTableDefaultSrc = 'platform-table-default-example.component.html';
 const platformTableDefaultTsSrc = 'platform-table-default-example.component.ts';
 const platformTableCustomColumnSrc = 'platform-table-custom-column-example.component.html';
 const platformTableCustomColumnTsSrc = 'platform-table-custom-column-example.component.ts';
+const platformTableCustomTitleSrc = 'platform-table-custom-title-example.component.html';
+const platformTableCustomTitleTsSrc = 'platform-table-custom-title-example.component.ts';
 const platformTableCustomWidthSrc = 'platform-table-custom-width-example.component.html';
 const platformTableCustomWidthTsSrc = 'platform-table-custom-width-example.component.ts';
 const platformTableSingleRowSelectionSrc = 'platform-table-single-row-selection-example.component.html';
@@ -141,6 +143,22 @@ export class PlatformTableDocsComponent {
             code: getAssetFromModuleAssets(platformTableCustomColumnTsSrc),
             fileName: 'platform-table-custom-column-example',
             component: 'PlatformTableCustomColumnExampleComponent',
+            name: 'platform-table-example.component.ts'
+        }
+    ];
+
+    customTitleTableFiles: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(platformTableCustomTitleSrc),
+            fileName: 'platform-table-custom-title-example',
+            name: 'platform-table-example.component.html'
+        },
+        {
+            language: 'typescript',
+            code: getAssetFromModuleAssets(platformTableCustomTitleTsSrc),
+            fileName: 'platform-table-custom-title-example',
+            component: 'PlatformTableCustomTitleExampleComponent',
             name: 'platform-table-example.component.ts'
         }
     ];

--- a/libs/docs/platform/table/platform-table.module.ts
+++ b/libs/docs/platform/table/platform-table.module.ts
@@ -29,6 +29,7 @@ import { PlatformTableHeaderComponent } from './platform-table-header/platform-t
 import { PlatformTableDocsComponent } from './platform-table-docs.component';
 import { PlatformTableDefaultExampleComponent } from './examples/platform-table-default-example.component';
 import { PlatformTableCustomColumnExampleComponent } from './examples/platform-table-custom-column-example.component';
+import { PlatformTableCustomTitleExampleComponent } from './examples/platform-table-custom-title-example.component';
 import { PlatformTableMultipleRowSelectionExampleComponent } from './examples/platform-table-multiple-row-selection-example.component';
 import { PlatformTableSingleRowSelectionExampleComponent } from './examples/platform-table-single-row-selection-example.component';
 import { PlatformTableSortableExampleComponent } from './examples/platform-table-sortable-example.component';
@@ -96,6 +97,7 @@ const routes: Routes = [
         PlatformTableHeaderComponent,
         PlatformTableDefaultExampleComponent,
         PlatformTableCustomColumnExampleComponent,
+        PlatformTableCustomTitleExampleComponent,
         PlatformTableSingleRowSelectionExampleComponent,
         PlatformTableMultipleRowSelectionExampleComponent,
         PlatformTableSortableExampleComponent,

--- a/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.html
+++ b/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.html
@@ -6,9 +6,9 @@
     let-columns="columns"
 >
     <fd-toolbar fdType="transparent" [clearBorder]="true" [hasTitle]="!!title">
-        <label fd-toolbar-label [id]="tableToolbarTitleId" [class.fd-toolbar__title]="!!title">
+        <h4 class="fd-title fd-title--h4 fd-toolbar__title" [id]="tableToolbarTitleId">
             {{ title }} <span *ngIf="!hideItemCount">({{ counter }})</span>
-        </label>
+        </h4>
         <ng-container *ngIf="_tableToolbarLeftActionsComponent">
             <fd-toolbar-separator *ngIf="!!title || !hideItemCount"></fd-toolbar-separator>
             <ng-container *ngTemplateOutlet="_tableToolbarLeftActionsComponent._contentTemplateRef"></ng-container>


### PR DESCRIPTION
fixes #9065 

before:
<img width="480" alt="Screenshot 2023-03-03 at 1 52 04 PM" src="https://user-images.githubusercontent.com/2471874/222826991-6d0f901a-2766-4820-a597-a448eefac62e.png">


after:
<img width="377" alt="Screenshot 2023-03-03 at 1 51 34 PM" src="https://user-images.githubusercontent.com/2471874/222826899-30ec5596-8c83-4153-a13a-9c267cdd5643.png">
