### PR TITLE
fix(platform): dont limit list items rendering if itemSize is empty

### DIFF
--- a/libs/docs/platform/list/examples/platform-list-border-less-example.component.ts
+++ b/libs/docs/platform/list/examples/platform-list-border-less-example.component.ts
@@ -11,7 +11,7 @@ const LIST_ELEMENTS: Address[] = new Array(6).fill(undefined).map((_, i) => ({ n
 })
 export class PlatformListBorderLessExampleComponent {
     _dataSource = new ListDataSource<Address>(new ListDataProvider());
-    _itemsArr: Address[] = LIST_ELEMENTS;
+    _itemsArr: Observable<Address[]> = of(LIST_ELEMENTS);
 }
 // it is from application point of to show as example,they refer internal structurs in general
 export interface Address {

--- a/libs/platform/src/lib/list/list.component.ts
+++ b/libs/platform/src/lib/list/list.component.ts
@@ -124,9 +124,9 @@ export class ListComponent<T>
     @Input()
     delayTime: number;
 
-    /** Items to be loaded at once. */
+    /** Items to be loaded at once. Intinity (no limit) by default. */
     @Input()
-    itemSize = 0;
+    itemSize = Infinity;
 
     /** Enables lazy loadMore of data. */
     @Input()
@@ -733,8 +733,13 @@ export class ListComponent<T>
             })
         );
 
+        const matchParams = new Map();
+
+        matchParams.set('query', '*');
+        matchParams.set('limit', this.itemSize);
+
         // initial data fetch
-        initDataSource.match('*');
+        initDataSource.match(matchParams);
 
         return initDataSource;
     }


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #9315 

## Description
- Changed default ItemSize to Infinity (no limit);
- Updated match params to reflect itemSize property;
