### PR TITLE
fix(platform): do not display filterable=false columns in p13 filter dialog

### DIFF
--- a/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filtering.component.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filtering.component.ts
@@ -66,7 +66,7 @@ export class P13FilteringDialogComponent implements Resettable {
     constructor(public dialogRef: DialogRef<FilterDialogData>) {
         const { columns, collectionFilter } = this.dialogRef.data;
 
-        this.columns = columns || [];
+        this.columns = columns.filter((column) => column.filterable) || [];
 
         this._initiateRules(collectionFilter);
 

--- a/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filtering.model.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/filtering/filtering.model.ts
@@ -7,6 +7,7 @@ export interface FilterableColumn {
     label: string;
     key: string;
     dataType: FilterableColumnDataType;
+    filterable?: boolean;
 }
 
 export interface FilterDialogData extends TableDialogCommonData {

--- a/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -142,7 +142,7 @@ export class TableP13DialogComponent implements OnDestroy {
         const columns = this._getTableColumns();
         const filterBy = state?.filterBy;
         const dialogData: FilterDialogData = {
-            columns: columns.map(({ label, key, dataType }) => ({ label, key, dataType })),
+            columns: columns.map(({ label, key, dataType, filterable }) => ({ label, key, dataType, filterable })),
             collectionFilter: filterBy
         };
 


### PR DESCRIPTION
fixes #9417 

Fixes a bug where the p13 filter dialog was still displaying columns as filterable when the column has `[filterable]="false"`