### PR TITLE
fix(core): fd-text does not show/hide 'MORE/LESS' button correctly when text length changes

### DIFF
--- a/libs/cdk/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
@@ -179,8 +179,6 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
     refreshTarget(event: LineClampTargetDirective): void {
         this._lineClampTarget = event.targetElement;
         this._originalText = event.fdLineClampTargetText;
-        this.reset();
-        this.refreshClamp();
         this._checkLineCount();
     }
 

--- a/libs/cdk/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/line-clamp/line-clamp.directive.ts
@@ -181,6 +181,7 @@ export class LineClampDirective implements OnChanges, AfterViewInit, OnDestroy {
         this._originalText = event.fdLineClampTargetText;
         this.reset();
         this.refreshClamp();
+        this._checkLineCount();
     }
 
     /** @hidden */


### PR DESCRIPTION
## Description

When `fd-text` is expandable, and the text length changes from exceeded long to short (for example, `maxLines` is set to 3 and the text changed from 4 lines to 1 line), the `MORE/LESS` button won't disappear. Vice versa, the `MORE/LESS` button won't show when the text changes from short to long.

stackblitz to reproduce: https://stackblitz.com/edit/angular-2miaxw?file=src/app/text-expandable.component.html

This fix makes it to check the line count every time when the text changes, this makes the `MORE/LESS` button to show/disappear properly.