### PR TITLE
fix(core,platform): addon button should always close popover if it is open despite inputs

### DIFF
--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
@@ -606,6 +606,8 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
 
         if (this.openDropdownOnAddOnClicked) {
             this._showList(!isOpen);
+        } else if (this.isOpen) {
+            this._showList(false);
         }
 
         if (this.isOpen && this.listComponent) {

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -694,6 +694,8 @@ export class MultiInputComponent
         this.addOnButtonClicked.emit(event);
         if (this.openDropdownOnAddOnClicked) {
             this.openChangeHandle(!this.open);
+        } else if (this.open) {
+            this.openChangeHandle(false);
         }
     }
 

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -520,6 +520,8 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
 
         if (this.openDropdownOnAddOnClicked) {
             this.showList(!isOpen);
+        } else if (this.isOpen) {
+            this.showList(false);
         }
 
         if (this.isOpen && this.listComponent) {

--- a/libs/platform/src/lib/form/multi-input/base-multi-input.ts
+++ b/libs/platform/src/lib/form/multi-input/base-multi-input.ts
@@ -405,14 +405,14 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
     /** Closes the select popover body. */
     close(): void {
         this.isOpen = false;
+        this.inputText = '';
         this.searchTermChanged();
-        this.isOpenChange.emit(this.isOpen);
-        this.openChange.next(this.isOpen);
-        this._cd.markForCheck();
-
         if (!this.mobile) {
             this.searchInputElement.nativeElement.focus();
         }
+        this.isOpenChange.emit(false);
+        this.openChange.next(false);
+        this._cd.markForCheck();
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/form/multi-input/multi-input.component.ts
+++ b/libs/platform/src/lib/form/multi-input/multi-input.component.ts
@@ -279,14 +279,17 @@ export class PlatformMultiInputComponent extends BaseMultiInput implements OnIni
 
     /** @hidden */
     addOnButtonClick(event: Event): void {
+        if (!this.openDropdownOnAddOnClicked && this.isOpen) {
+            this.showList(false);
+        } else if (this.openDropdownOnAddOnClicked) {
+            this.showList(!this.isOpen);
+        }
+
         this.addOnButtonClicked.emit(event);
+
         if (isFunction(this.addOnButtonClickFn)) {
             this.addOnButtonClickFn();
             return;
-        }
-
-        if (this.openDropdownOnAddOnClicked) {
-            this.showList(!this.isOpen);
         }
     }
 


### PR DESCRIPTION
fixes none

When any multi-input/multi-combobox is open and the user has `[openDropdownOnAddOnClicked]="false"`, if the dropdown is open and they click the addon, we should still close the dropdown. Input specifies "open" not toggle
