### PR TITLE
fix(platform): table with freezing columns hidden cell issues

### DIFF
--- a/libs/docs/platform/table/e2e/table-contents.ts
+++ b/libs/docs/platform/table/e2e/table-contents.ts
@@ -7,6 +7,14 @@ export const tableCellArr = [
     '66.04',
     'Stocked on demand'
 ];
+export const freezeTableCellArr = [
+    '10 Portable DVD player',
+    'diam neque vestibulum eget vulputate',
+    '66.04',
+    'Stocked on demand',
+    '2020',
+    'true'
+];
 export const groupTableCellArr = [
     '10 Portable DVD player',
     'diam neque vestibulum eget vulputate',

--- a/libs/docs/platform/table/e2e/table.e2e-spec.ts
+++ b/libs/docs/platform/table/e2e/table.e2e-spec.ts
@@ -55,7 +55,8 @@ import {
     testText7,
     testTextName,
     testTextSearch,
-    groupTableCellArr
+    groupTableCellArr,
+    freezeTableCellArr
 } from './table-contents';
 
 describe('Table component test suite', () => {
@@ -425,7 +426,7 @@ describe('Table component test suite', () => {
             const cellLength = await getElementArrayLength(tableFreezableExample + tableRow + tableCellText);
             for (let i = 0; i < cellLength; i++) {
                 await expect((await getText(tableFreezableExample + tableRow + tableCellText, i)).trim()).toBe(
-                    tableCellArr[i]
+                    freezeTableCellArr[i]
                 );
             }
         });

--- a/libs/docs/platform/table/examples/platform-table-freezable-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-freezable-example.component.html
@@ -13,6 +13,10 @@
 
         <fdp-column name="price" key="price.value" label="Price" align="end" width="100px"> </fdp-column>
 
+        <fdp-column name="date" key="date.year" label="Date" align="end" width="100px"> </fdp-column>
+
+        <fdp-column name="verified" key="verified" label="Verified" align="end" width="100px"> </fdp-column>
+
         <fdp-column name="status" key="status" label="Status" align="center" width="200px"> </fdp-column>
     </fdp-table>
 </div>

--- a/libs/docs/platform/table/examples/platform-table-freezable-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-freezable-example.component.html
@@ -13,10 +13,10 @@
 
         <fdp-column name="price" key="price.value" label="Price" align="end" width="100px"> </fdp-column>
 
+        <fdp-column name="status" key="status" label="Status" align="center" width="200px"> </fdp-column>
+
         <fdp-column name="date" key="date.year" label="Date" align="end" width="100px"> </fdp-column>
 
         <fdp-column name="verified" key="verified" label="Verified" align="end" width="100px"> </fdp-column>
-
-        <fdp-column name="status" key="status" label="Status" align="center" width="200px"> </fdp-column>
     </fdp-table>
 </div>

--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -21,7 +21,7 @@
         class="fdp-table__body fd-scrollbar"
         [class.fdp-table__body--virtual-scroll]="!!virtualScroll"
         fdpTableScrollable
-        #verticalScrollable="tableScrollable"
+        #tableScrollable="tableScrollable"
         [style.height]="bodyHeight"
         [class.fixed-height]="!!bodyHeight"
         [attr.role]="pageScrolling ? 'feed' : null"

--- a/libs/platform/src/lib/table/table.component.scss
+++ b/libs/platform/src/lib/table/table.component.scss
@@ -273,6 +273,8 @@ $fd-table-scrollbar-width-with-border: calc(#{$fd-table-scrollbar-width} + var(-
     }
 
     .fd-table__cell {
+        z-index: 0; // need so fixed cells are above not-fixed cells
+
         &--checkbox {
             border-left: none;
             border-right: $fd-table-border;

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -533,8 +533,8 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
     onDataReceived = new EventEmitter<void>();
 
     /** @hidden */
-    @ViewChild('verticalScrollable')
-    readonly verticalScrollable: TableScrollable;
+    @ViewChild('tableScrollable')
+    readonly tableScrollable: TableScrollable;
 
     /** @hidden */
     @ViewChildren('columnHeaderPopover')
@@ -1682,6 +1682,14 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
         nestingLevel: number | null
     ): Promise<void> {
         this._focusedCellPosition = { rowIndex: position.rowIndex, colIndex: position.colIndex };
+        const tableScrollableEl = this.tableScrollable.getElementRef().nativeElement;
+
+        if (this._freezableColumns.size && tableScrollableEl.scrollWidth > tableScrollableEl.clientWidth) {
+            const activeEl = document.activeElement;
+            if (activeEl) {
+                activeEl.scrollIntoView({ block: 'nearest', inline: 'end' });
+            }
+        }
 
         if (this.cellFocusedEventAnnouncer) {
             this._liveAnnouncer.clear();
@@ -2034,7 +2042,7 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
 
         const totalNodeCount = this._tableRowsVisible.length;
 
-        let startNodeIndex = Math.floor(this.verticalScrollable.getScrollTop() / this.rowHeight) - this.renderAhead;
+        let startNodeIndex = Math.floor(this.tableScrollable.getScrollTop() / this.rowHeight) - this.renderAhead;
         startNodeIndex = Math.max(0, startNodeIndex);
 
         let visibleNodeCount =
@@ -2578,7 +2586,7 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
                 .pipe(
                     filter(() => this.pageScrolling),
                     debounceTime(50),
-                    filter((scrollable) => scrollable === this.verticalScrollable),
+                    filter((scrollable) => scrollable === this.tableScrollable),
                     map((scrollable) => scrollable.getElementRef().nativeElement),
                     filter((element) => !!element),
                     filter(


### PR DESCRIPTION
fixes #9492 

Previously if a non-frozen table cell was partially obstructed by a frozen one, the focus for the entire non-frozen cell was still visible. Also, if a non-frozen cell was entirely obstructed by a frozen one and was navigated via keyboard, the cell would not be scrolled to, and it would appear as though focus was lost (when it was simply on the hidden element). This fixes both issues

https://user-images.githubusercontent.com/2471874/224383490-f335beac-be47-4394-a032-203b12b0d898.mov


