### PR TITLE
fix(platform): bug where checkbox would be checked when there are no selectable rows

### DIFF
--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -2475,7 +2475,7 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
     private _calculateCheckedAll(): void {
         const selectableRows = this._getSelectableRows();
         const totalSelected = selectableRows.filter((r) => r.checked);
-        this._checkedAll = totalSelected.length === selectableRows.length;
+        this._checkedAll = totalSelected.length === selectableRows.length && selectableRows.length !== 0;
         this._checkedAny = totalSelected.length > 0;
     }
 


### PR DESCRIPTION
#9453 

Fixes a bug where the select all checkbox would display as checked when there are no selectable rows
![image](https://user-images.githubusercontent.com/2471874/225763007-6211c1e5-b8e2-4431-a835-436b8b3a056b.png)
