### PR TITLE
test(core): fix special calendar e2e

### DIFF
--- a/libs/docs/core/calendar/e2e/calendar.e2e-spec.ts
+++ b/libs/docs/core/calendar/e2e/calendar.e2e-spec.ts
@@ -263,7 +263,7 @@ describe('calendar test suite', () => {
 
             expect(
                 await (await $(specialDaysCalendar).$('.fd-calendar__item*=' + endDate.getDate())).getAttribute('class')
-            ).not.toContain('special-day');
+            ).toContain('special-day');
 
             expect(
                 await (


### PR DESCRIPTION
fix special calendar e2e - when we check the special days the first check should validate whether the 7th day after today is special, and that the day after that should not be special