### PR TITLE
fix(platform): exclude columns from p13n dialog

### DIFF
--- a/libs/docs/platform/table/child-docs/p13-dialog/p13-dialog-docs.component.html
+++ b/libs/docs/platform/table/child-docs/p13-dialog/p13-dialog-docs.component.html
@@ -16,7 +16,8 @@
 <description>
     To make columns settings available connect
     <code>&lt;fdp-table-p13-dialog [table]="table"&gt;&lt;/fdp-table-p13-dialog&gt;</code> to a table. Once there is at
-    least one <code>fdp-column</code> definition the columns settings button will be available in the table toolbar.
+    least one <code>fdp-column</code> definition the columns settings button will be available in the table toolbar. You
+    can also exclude columns from the p13n dialog using the <code>disableP13n</code> input property.
 </description>
 <component-example>
     <fdp-platform-table-p13-columns-example></fdp-platform-table-p13-columns-example>

--- a/libs/docs/platform/table/e2e/table-contents.ts
+++ b/libs/docs/platform/table/e2e/table-contents.ts
@@ -37,7 +37,8 @@ export const tableCellArr4 = [
     'diam neque vestibulum eget vulputate',
     '66.04',
     'true',
-    'Stocked on demand'
+    'Stocked on demand',
+    'Action'
 ];
 export const tableCellArr5 = [
     '10 Portable DVD player',

--- a/libs/docs/platform/table/examples/platform-table-p13-columns-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-p13-columns-example.component.html
@@ -10,6 +10,12 @@
     <fdp-column name="verified" key="verified" label="Verified"> </fdp-column>
 
     <fdp-column name="status" key="status" label="Status"> </fdp-column>
+
+    <fdp-column name="action" key="" label="" [disableP13n]="true">
+        <fdp-table-cell *fdpCellDef="let item">
+            <fdp-button label="Action"></fdp-button>
+        </fdp-table-cell>
+    </fdp-column>
 </fdp-table>
 
 <!-- Connect P13 Dialog to the table -->

--- a/libs/platform/src/lib/table/components/table-column/table-column.component.ts
+++ b/libs/platform/src/lib/table/components/table-column/table-column.component.ts
@@ -114,6 +114,13 @@ export class TableColumnComponent extends TableColumn implements OnInit, OnChang
     @Input()
     applyText = true;
 
+    /**
+     * When TRUE, excludes this column from p13n functionality. No option to Sort, Filter, Group or
+     * show/hide columns
+     */
+    @Input()
+    disableP13n = false;
+
     /** Column cell template */
     columnCellTemplate: Nullable<TemplateRef<any>>;
 

--- a/libs/platform/src/lib/table/components/table-column/table-column.ts
+++ b/libs/platform/src/lib/table/components/table-column/table-column.ts
@@ -60,6 +60,12 @@ export abstract class TableColumn {
     /** Whether to apply fd-table-text (text-shadow) to the cell content, if disabled noWrap has no effect. */
     abstract applyText: boolean;
 
+    /**
+     * When TRUE, excludes this column from p13n functionality. No option to Sort, Filter, Group or
+     * show/hide columns
+     */
+    abstract disableP13n: boolean;
+
     /** Stores information for the header cell if the ellipsis are visible after the column resize */
     abstract headerOverflows: boolean;
 

--- a/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.spec.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.spec.ts
@@ -1,26 +1,70 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { DialogModule } from '@fundamental-ngx/core/dialog';
+import { DialogModule, DialogService } from '@fundamental-ngx/core/dialog';
 import { TableP13DialogComponent } from './table-p13-dialog.component';
+import { PlatformTableModule } from '../../table.module';
+import { TableComponent } from '../../table.component';
+import { TableColumnResizeService } from '../../table-column-resize.service';
+import { TableColumnComponent } from '../table-column/table-column.component';
+import { TableColumnResizeServiceMock } from '../../mocks/table-column-resize-mock.service';
+
+const generateColumn = (label: string, disableP13n: boolean): TableColumnComponent => {
+    const columnFixture = TestBed.createComponent(TableColumnComponent);
+    const columnInstance = columnFixture.componentInstance;
+    columnInstance.name = label;
+    columnInstance.disableP13n = disableP13n;
+    return columnInstance;
+};
 
 describe('TableP13DialogComponent', () => {
+    let tableComponent: TableComponent;
+    let tableFixture: ComponentFixture<TableComponent>;
+
     let component: TableP13DialogComponent;
     let fixture: ComponentFixture<TableP13DialogComponent>;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [DialogModule],
-            declarations: [TableP13DialogComponent]
+            imports: [PlatformTableModule, DialogModule],
+            declarations: [TableP13DialogComponent],
+            providers: [DialogService, { provide: TableColumnResizeService, useClass: TableColumnResizeServiceMock }]
         }).compileComponents();
     }));
 
     beforeEach(() => {
         fixture = TestBed.createComponent(TableP13DialogComponent);
         component = fixture.componentInstance;
+
+        tableFixture = TestBed.createComponent(TableComponent);
+        tableComponent = tableFixture.componentInstance;
+        component.table = tableComponent;
+
         fixture.detectChanges();
     });
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    it('should exclude columns from the list when disableP13=true is used', () => {
+        spyOn(tableComponent, 'getTableColumns').and.returnValue([
+            generateColumn('Name', false),
+            generateColumn('Actions', true)
+        ]);
+        fixture.detectChanges();
+
+        const p13Columns = (component as any)._getTableColumns() || [];
+        expect(p13Columns.length).toBe(1);
+    });
+
+    it('should include all the table column by default', () => {
+        spyOn(tableComponent, 'getTableColumns').and.returnValue([
+            generateColumn('Name', false),
+            generateColumn('Actions', false)
+        ]);
+        fixture.detectChanges();
+
+        const p13Columns = (component as any)._getTableColumns() || [];
+        expect(p13Columns.length).toBe(2);
     });
 });

--- a/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -278,7 +278,8 @@ export class TableP13DialogComponent implements OnDestroy {
 
     /** @hidden */
     private _getTableColumns(): TableColumn[] {
-        return this._table?.getTableColumns() || [];
+        const cols = this._table?.getTableColumns() || [];
+        return cols.filter(({ disableP13n }) => !disableP13n);
     }
 
     /** @hidden */


### PR DESCRIPTION
Introducing new input property which removes column from the P13n list

## Related Issue(s)

closes #9520

## Description

Introduced new `disableP13n` property on the `TableColum` that excludes columns from P13n Dialog. By default all columns are included. 