### PR TITLE
fix(platform): missing tooltip - aria label for table toolbar actions

### DIFF
--- a/libs/i18n/src/lib/languages/albanian.ts
+++ b/libs/i18n/src/lib/languages/albanian.ts
@@ -431,6 +431,8 @@ export const FD_LANGUAGE_ALBANIAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filtro',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filtro sipas: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filtro',

--- a/libs/i18n/src/lib/languages/arabic.ts
+++ b/libs/i18n/src/lib/languages/arabic.ts
@@ -422,6 +422,8 @@ export const FD_LANGUAGE_ARABIC: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filter',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filter by: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filter',

--- a/libs/i18n/src/lib/languages/belarusian.ts
+++ b/libs/i18n/src/lib/languages/belarusian.ts
@@ -422,6 +422,8 @@ export const FD_LANGUAGE_BELARUSIAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filter',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filter by: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filter',

--- a/libs/i18n/src/lib/languages/bulgarian.ts
+++ b/libs/i18n/src/lib/languages/bulgarian.ts
@@ -492,6 +492,8 @@ export const FD_LANGUAGE_BULGARIAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Филтрирай',
         toolbarActionGroupButtonTitle: 'Групирай',
         toolbarActionColumnsButtonTitle: 'Колони',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Нефилтрирано)',
         filterDialogFilterByLabel: 'Филтрирано по: {{ filterLabel }}',
         filterDialogFilterTitle: 'Филтър',

--- a/libs/i18n/src/lib/languages/chinese.ts
+++ b/libs/i18n/src/lib/languages/chinese.ts
@@ -421,6 +421,8 @@ export const FD_LANGUAGE_CHINESE: FdLanguage = {
         toolbarActionFilterButtonTitle: '筛选',
         toolbarActionGroupButtonTitle: '分组',
         toolbarActionColumnsButtonTitle: '列',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '（未筛选）',
         filterDialogFilterByLabel: '筛选方式：{{ filterLabel }}',
         filterDialogFilterTitle: '筛选',

--- a/libs/i18n/src/lib/languages/croatian.ts
+++ b/libs/i18n/src/lib/languages/croatian.ts
@@ -422,6 +422,8 @@ export const FD_LANGUAGE_CROATIAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filter',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filter by: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filter',

--- a/libs/i18n/src/lib/languages/czech.ts
+++ b/libs/i18n/src/lib/languages/czech.ts
@@ -426,6 +426,8 @@ export const FD_LANGUAGE_CZECH: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filtr',
         toolbarActionGroupButtonTitle: 'Skupina',
         toolbarActionColumnsButtonTitle: 'Sloupce',
+        toolbarActionExpandAllButtonTitle: 'Rozbalit vše',
+        toolbarActionCollapseAllButtonTitle: 'Sbalit vše',
         filterDialogNotFilteredLabel: '(Nefiltrováno)',
         filterDialogFilterByLabel: 'Filtrovat podle: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filtr',

--- a/libs/i18n/src/lib/languages/english.ts
+++ b/libs/i18n/src/lib/languages/english.ts
@@ -422,6 +422,8 @@ export const FD_LANGUAGE_ENGLISH: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filter',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filter by: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filter',

--- a/libs/i18n/src/lib/languages/french.ts
+++ b/libs/i18n/src/lib/languages/french.ts
@@ -426,6 +426,8 @@ export const FD_LANGUAGE_FRENCH: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filtre',
         toolbarActionGroupButtonTitle: 'Grouper',
         toolbarActionColumnsButtonTitle: 'Colonnes',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Non filtré)',
         filterDialogFilterByLabel: 'Filtrer par: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filtre',

--- a/libs/i18n/src/lib/languages/georgian.ts
+++ b/libs/i18n/src/lib/languages/georgian.ts
@@ -424,6 +424,8 @@ export const FD_LANGUAGE_GEORGIAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'ფილტრაცია',
         toolbarActionGroupButtonTitle: 'დაჯგუფება',
         toolbarActionColumnsButtonTitle: 'სვეტები',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(გაუფილტრავი)',
         filterDialogFilterByLabel: 'გაფილტრე: {{ filterLabel }}',
         filterDialogFilterTitle: 'ფილტრი',

--- a/libs/i18n/src/lib/languages/german.ts
+++ b/libs/i18n/src/lib/languages/german.ts
@@ -422,6 +422,8 @@ export const FD_LANGUAGE_GERMAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filter',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Alles expandieren',
+        toolbarActionCollapseAllButtonTitle: 'Alles komprimieren',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filter by: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filter',

--- a/libs/i18n/src/lib/languages/hebrew.ts
+++ b/libs/i18n/src/lib/languages/hebrew.ts
@@ -422,6 +422,8 @@ export const FD_LANGUAGE_HEBREW: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filter',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filter by: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filter',

--- a/libs/i18n/src/lib/languages/hindi.ts
+++ b/libs/i18n/src/lib/languages/hindi.ts
@@ -423,6 +423,8 @@ export const FD_LANGUAGE_HINDI: FdLanguage = {
         toolbarActionFilterButtonTitle: 'फ़िल्टर',
         toolbarActionGroupButtonTitle: 'समूह',
         toolbarActionColumnsButtonTitle: 'कॉलम',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(फ़िल्टर नहीं किया गया)',
         filterDialogFilterByLabel: 'के द्वारा छनित: {{ filterLabel }}',
         filterDialogFilterTitle: 'फ़िल्टर',

--- a/libs/i18n/src/lib/languages/italian.ts
+++ b/libs/i18n/src/lib/languages/italian.ts
@@ -434,6 +434,8 @@ export const FD_LANGUAGE_ITALIAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filtro',
         toolbarActionGroupButtonTitle: 'Gruppo',
         toolbarActionColumnsButtonTitle: 'Colonne',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Non filtrato)',
         filterDialogFilterByLabel: 'Filtra per: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filtro',

--- a/libs/i18n/src/lib/languages/polish.ts
+++ b/libs/i18n/src/lib/languages/polish.ts
@@ -423,6 +423,8 @@ export const FD_LANGUAGE_POLISH: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filtr',
         toolbarActionGroupButtonTitle: 'Grupa',
         toolbarActionColumnsButtonTitle: 'Kolumny',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Nie zastosowano żadnego filtra)',
         filterDialogFilterByLabel: 'Użyto filtr: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filtr',

--- a/libs/i18n/src/lib/languages/portuguese.ts
+++ b/libs/i18n/src/lib/languages/portuguese.ts
@@ -422,6 +422,8 @@ export const FD_LANGUAGE_PORTUGUESE: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filter',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filter by: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filter',

--- a/libs/i18n/src/lib/languages/romanian.ts
+++ b/libs/i18n/src/lib/languages/romanian.ts
@@ -422,6 +422,8 @@ export const FD_LANGUAGE_ROMANIAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filter',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filter by: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filter',

--- a/libs/i18n/src/lib/languages/russian.ts
+++ b/libs/i18n/src/lib/languages/russian.ts
@@ -577,6 +577,8 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Фильтр',
         toolbarActionGroupButtonTitle: 'Группировка',
         toolbarActionColumnsButtonTitle: 'Столбцы',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Не отфильтровано)',
         filterDialogFilterByLabel: 'Фильтр: {{ filterLabel }}',
         filterDialogFilterTitle: 'Фильтр',

--- a/libs/i18n/src/lib/languages/sinhala.ts
+++ b/libs/i18n/src/lib/languages/sinhala.ts
@@ -422,6 +422,8 @@ export const FD_LANGUAGE_SINHALA: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filter',
         toolbarActionGroupButtonTitle: 'Group',
         toolbarActionColumnsButtonTitle: 'Columns',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Not Filtered)',
         filterDialogFilterByLabel: 'Filter by: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filter',

--- a/libs/i18n/src/lib/languages/spanish.ts
+++ b/libs/i18n/src/lib/languages/spanish.ts
@@ -426,6 +426,8 @@ export const FD_LANGUAGE_SPANISH: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filtro',
         toolbarActionGroupButtonTitle: 'Grupo',
         toolbarActionColumnsButtonTitle: 'Columnas',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(No filtrado)',
         filterDialogFilterByLabel: 'Filtrar por: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filtro',

--- a/libs/i18n/src/lib/languages/turkish.ts
+++ b/libs/i18n/src/lib/languages/turkish.ts
@@ -423,6 +423,8 @@ export const FD_LANGUAGE_TURKISH: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Filtre',
         toolbarActionGroupButtonTitle: 'Grup',
         toolbarActionColumnsButtonTitle: 'Kolonlar',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Filtrelenmemiş)',
         filterDialogFilterByLabel: 'Filtreleme ölçütü: {{ filterLabel }}',
         filterDialogFilterTitle: 'Filtre',

--- a/libs/i18n/src/lib/languages/ukrainian.ts
+++ b/libs/i18n/src/lib/languages/ukrainian.ts
@@ -575,6 +575,8 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         toolbarActionFilterButtonTitle: 'Фільтр',
         toolbarActionGroupButtonTitle: 'Сгрупувати',
         toolbarActionColumnsButtonTitle: 'Стовпці',
+        toolbarActionExpandAllButtonTitle: 'Expand all',
+        toolbarActionCollapseAllButtonTitle: 'Collapse all',
         filterDialogNotFilteredLabel: '(Не відфільтровано)',
         filterDialogFilterByLabel: 'Фільтрувати за: {{ filterLabel }}',
         filterDialogFilterTitle: 'Фільтр',

--- a/libs/i18n/src/lib/models/lang.ts
+++ b/libs/i18n/src/lib/models/lang.ts
@@ -519,6 +519,8 @@ export interface FdLanguage {
         toolbarActionFilterButtonTitle: FdLanguageKey;
         toolbarActionGroupButtonTitle: FdLanguageKey;
         toolbarActionColumnsButtonTitle: FdLanguageKey;
+        toolbarActionExpandAllButtonTitle: FdLanguageKey;
+        toolbarActionCollapseAllButtonTitle: FdLanguageKey;
         filterDialogNotFilteredLabel: FdLanguageKey;
         /** @param filterLabel */
         filterDialogFilterByLabel: FdLanguageKey;

--- a/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.html
+++ b/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.html
@@ -65,7 +65,6 @@
                     [title]="'platformTable.toolbarActionExpandAllButtonTitle' | fdTranslate"
                     [ariaLabel]="'platformTable.toolbarActionExpandAllButtonTitle' | fdTranslate"
                     buttonType="transparent"
-                    aria-haspopup="modal"
                 ></fdp-button>
 
                 <fdp-button
@@ -74,7 +73,6 @@
                     [title]="'platformTable.toolbarActionCollapseAllButtonTitle' | fdTranslate"
                     [ariaLabel]="'platformTable.toolbarActionCollapseAllButtonTitle' | fdTranslate"
                     buttonType="transparent"
-                    aria-haspopup="modal"
                 ></fdp-button>
             </ng-container>
 

--- a/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.html
+++ b/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.html
@@ -59,14 +59,30 @@
             <fd-toolbar-separator fd-toolbar-item *ngIf="tableToolbarActionsComponent"></fd-toolbar-separator>
 
             <ng-container *ngIf="showExpandCollapseButtons">
-                <fdp-button glyph="expand-all" (click)="_expandAll()" aria-haspopup="modal"></fdp-button>
-                <fdp-button glyph="collapse-all" (click)="_collapseAll()" aria-haspopup="modal"></fdp-button>
+                <fdp-button
+                    glyph="expand-all"
+                    (click)="_expandAll()"
+                    [title]="'platformTable.toolbarActionExpandAllButtonTitle' | fdTranslate"
+                    [ariaLabel]="'platformTable.toolbarActionExpandAllButtonTitle' | fdTranslate"
+                    buttonType="transparent"
+                    aria-haspopup="modal"
+                ></fdp-button>
+
+                <fdp-button
+                    glyph="collapse-all"
+                    (click)="_collapseAll()"
+                    [title]="'platformTable.toolbarActionCollapseAllButtonTitle' | fdTranslate"
+                    [ariaLabel]="'platformTable.toolbarActionCollapseAllButtonTitle' | fdTranslate"
+                    buttonType="transparent"
+                    aria-haspopup="modal"
+                ></fdp-button>
             </ng-container>
 
             <fdp-button
                 *ngIf="sortable"
                 glyph="sort"
                 [title]="'platformTable.toolbarActionSortButtonTitle' | fdTranslate"
+                [ariaLabel]="'platformTable.toolbarActionSortButtonTitle' | fdTranslate"
                 buttonType="transparent"
                 aria-haspopup="modal"
                 (click)="openSorting()"
@@ -75,6 +91,7 @@
                 *ngIf="filterable"
                 glyph="filter"
                 [title]="'platformTable.toolbarActionFilterButtonTitle' | fdTranslate"
+                [ariaLabel]="'platformTable.toolbarActionFilterButtonTitle' | fdTranslate"
                 buttonType="transparent"
                 aria-haspopup="modal"
                 (click)="openFiltering()"
@@ -83,6 +100,7 @@
                 *ngIf="groupable"
                 glyph="group-2"
                 [title]="'platformTable.toolbarActionGroupButtonTitle' | fdTranslate"
+                [ariaLabel]="'platformTable.toolbarActionGroupButtonTitle' | fdTranslate"
                 buttonType="transparent"
                 aria-haspopup="modal"
                 (click)="openGrouping()"
@@ -91,6 +109,7 @@
                 *ngIf="columns"
                 glyph="action-settings"
                 [title]="'platformTable.toolbarActionColumnsButtonTitle' | fdTranslate"
+                [ariaLabel]="'platformTable.toolbarActionColumnsButtonTitle' | fdTranslate"
                 buttonType="transparent"
                 aria-haspopup="modal"
                 (click)="openColumns()"

--- a/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.spec.ts
+++ b/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.spec.ts
@@ -21,6 +21,8 @@ class TableComponentMock
             | 'save'
             | 'cancel'
             | 'presetChanged'
+            | 'expandAll'
+            | 'collapseAll'
         >
 {
     openTableSortSettings = new EventEmitter();
@@ -33,6 +35,8 @@ class TableComponentMock
     presetChanged = new EventEmitter();
 
     search(): void {}
+    expandAll(): void {}
+    collapseAll(): void {}
 }
 
 describe('TableToolbarComponent', () => {
@@ -121,6 +125,22 @@ describe('TableToolbarComponent', () => {
             expect(tableHandlerSpy).not.toHaveBeenCalled();
 
             component.openColumns();
+
+            expect(tableHandlerSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('Should call table.expandAll by "_expandAll" action ', () => {
+            const tableHandlerSpy = spyOn(table, 'expandAll').and.stub();
+
+            component._expandAll();
+
+            expect(tableHandlerSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('Should call table.collapseAll by "_collapseAll" action ', () => {
+            const tableHandlerSpy = spyOn(table, 'collapseAll').and.stub();
+
+            component._collapseAll();
 
             expect(tableHandlerSpy).toHaveBeenCalledTimes(1);
         });


### PR DESCRIPTION
As part of this changed other actions were updated to match this requirement

## Related Issue(s)

closes #9551

## Description

Introduced additional attributes: `title` and `aria-label`. 3 other actions updated as well to match this requirement. 
As part of this change i18n files updated as well. languages are defaulted to English and some of them are already translated (en, de, cz)

