### PR TITLE
fix(platform): enforce css specificity in Value Help Dialog label

### DIFF
--- a/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.scss
+++ b/libs/platform/src/lib/value-help-dialog/value-help-dialog/value-help-dialog.component.scss
@@ -169,7 +169,7 @@ $block: fdp-value-help-dialog;
         }
     }
 
-    &__hidden_label {
+    &__hidden_label.fd-form-label__wrapper {
         display: none;
     }
 


### PR DESCRIPTION

## Description
enforce the specificity so that the css coming from the Platform is not dependant on the css files orger