### PR TITLE
fix(core): no tooltip for breadcrumb when overflow dots are shown

### DIFF
--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -59,12 +59,18 @@
         <span class="fd-breadcrumb__item" *ngIf="breadcrumbs.length > 0" [fdMenuTrigger]="menu">
             <a
                 fd-link
+                [attr.aria-label]="'coreBreadcrumb.overflowTitleMore' | fdTranslate"
+                aria-haspopup="listbox"
                 tabindex="0"
                 class="fd-breadcrumb__collapsed"
                 (keydown.enter)="_keyDownHandle($event)"
                 (keydown.space)="_keyDownHandle($event)"
             >
-                <fd-icon glyph="overflow"></fd-icon>
+                <fd-icon
+                    glyph="overflow"
+                    [title]="'coreBreadcrumb.overflowTitleMore' | fdTranslate"
+                    [ariaLabel]="'coreBreadcrumb.overflowTitleMore' | fdTranslate"
+                ></fd-icon>
                 <fd-icon glyph="slim-arrow-down"></fd-icon>
             </a>
         </span>

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -13,6 +13,7 @@ import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { BreadcrumbItemComponent } from './breadcrumb-item.component';
 import { BreadcrumbComponent } from './breadcrumb.component';
 import { whenStable } from '@fundamental-ngx/core/tests';
+import { I18nModule } from '@fundamental-ngx/i18n';
 
 @Component({
     selector: 'fd-breadcrumb-test-component',
@@ -49,7 +50,8 @@ describe('BreadcrumbComponent', () => {
                 RouterModule,
                 RouterTestingModule,
                 OverflowLayoutModule,
-                PortalModule
+                PortalModule,
+                I18nModule
             ],
             providers: [RtlService],
             schemas: [NO_ERRORS_SCHEMA]

--- a/libs/core/src/lib/breadcrumb/breadcrumb.module.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.module.ts
@@ -13,6 +13,7 @@ import { PortalModule } from '@angular/cdk/portal';
 import { PipeModule } from '@fundamental-ngx/cdk/utils';
 import { DeprecatedBreadcrumbsCompactDirective } from './deprecated-breadcrumbs-compact.directive';
 import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
+import { I18nModule } from '@fundamental-ngx/i18n';
 
 @NgModule({
     imports: [
@@ -25,7 +26,8 @@ import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
         PipeModule,
         ContentDensityModule,
         OverflowLayoutModule,
-        ButtonModule
+        ButtonModule,
+        I18nModule
     ],
     exports: [
         BreadcrumbComponent,

--- a/libs/i18n/src/lib/languages/albanian.ts
+++ b/libs/i18n/src/lib/languages/albanian.ts
@@ -154,6 +154,9 @@ export const FD_LANGUAGE_ALBANIAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Magjistar'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'Më shumë'
+    },
     platformActionBar: {
         backButtonLabel: 'Kthehu mbrapa'
     },

--- a/libs/i18n/src/lib/languages/arabic.ts
+++ b/libs/i18n/src/lib/languages/arabic.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_ARABIC: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'Më shumë'
+    },
     platformActionBar: {
         backButtonLabel: 'Go Back'
     },

--- a/libs/i18n/src/lib/languages/belarusian.ts
+++ b/libs/i18n/src/lib/languages/belarusian.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_BELARUSIAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'More'
+    },
     platformActionBar: {
         backButtonLabel: 'Go Back'
     },

--- a/libs/i18n/src/lib/languages/bulgarian.ts
+++ b/libs/i18n/src/lib/languages/bulgarian.ts
@@ -171,6 +171,9 @@ export const FD_LANGUAGE_BULGARIAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Помощник'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'Повече'
+    },
     platformActionBar: {
         backButtonLabel: 'Върни Се Обратно'
     },

--- a/libs/i18n/src/lib/languages/chinese.ts
+++ b/libs/i18n/src/lib/languages/chinese.ts
@@ -146,6 +146,9 @@ export const FD_LANGUAGE_CHINESE: FdLanguage = {
     coreWizard: {
         ariaLabel: '向导'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: '更多'
+    },
     platformActionBar: {
         backButtonLabel: '返回'
     },

--- a/libs/i18n/src/lib/languages/croatian.ts
+++ b/libs/i18n/src/lib/languages/croatian.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_CROATIAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'More'
+    },
     platformActionBar: {
         backButtonLabel: 'Go Back'
     },

--- a/libs/i18n/src/lib/languages/czech.ts
+++ b/libs/i18n/src/lib/languages/czech.ts
@@ -150,6 +150,9 @@ export const FD_LANGUAGE_CZECH: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'Více'
+    },
     platformActionBar: {
         backButtonLabel: 'Vraťit se zpět'
     },

--- a/libs/i18n/src/lib/languages/english.ts
+++ b/libs/i18n/src/lib/languages/english.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_ENGLISH: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'More'
+    },
     platformActionBar: {
         backButtonLabel: 'Go Back'
     },

--- a/libs/i18n/src/lib/languages/french.ts
+++ b/libs/i18n/src/lib/languages/french.ts
@@ -149,6 +149,9 @@ export const FD_LANGUAGE_FRENCH: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Assistant'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: "Plus d'infos"
+    },
     platformActionBar: {
         backButtonLabel: 'Revenir en arrière'
     },

--- a/libs/i18n/src/lib/languages/georgian.ts
+++ b/libs/i18n/src/lib/languages/georgian.ts
@@ -148,6 +148,9 @@ export const FD_LANGUAGE_GEORGIAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'ოსტატი'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'მეტი'
+    },
     platformActionBar: {
         backButtonLabel: 'უკან დაბრუნება'
     },

--- a/libs/i18n/src/lib/languages/german.ts
+++ b/libs/i18n/src/lib/languages/german.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_GERMAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'More'
+    },
     platformActionBar: {
         backButtonLabel: 'Go Back'
     },

--- a/libs/i18n/src/lib/languages/hebrew.ts
+++ b/libs/i18n/src/lib/languages/hebrew.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_HEBREW: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'More'
+    },
     platformActionBar: {
         backButtonLabel: 'Go Back'
     },

--- a/libs/i18n/src/lib/languages/hindi.ts
+++ b/libs/i18n/src/lib/languages/hindi.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_HINDI: FdLanguage = {
     coreWizard: {
         ariaLabel: 'विज़ार्ड'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'और'
+    },
     platformActionBar: {
         backButtonLabel: 'वापस जाएं'
     },

--- a/libs/i18n/src/lib/languages/italian.ts
+++ b/libs/i18n/src/lib/languages/italian.ts
@@ -157,6 +157,9 @@ export const FD_LANGUAGE_ITALIAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Procedura guidata'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'Altro'
+    },
     platformActionBar: {
         backButtonLabel: 'Torna indietro'
     },

--- a/libs/i18n/src/lib/languages/polish.ts
+++ b/libs/i18n/src/lib/languages/polish.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_POLISH: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Kreator'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'Więcej'
+    },
     platformActionBar: {
         backButtonLabel: 'Powrót'
     },

--- a/libs/i18n/src/lib/languages/portuguese.ts
+++ b/libs/i18n/src/lib/languages/portuguese.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_PORTUGUESE: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'More'
+    },
     platformActionBar: {
         backButtonLabel: 'Go Back'
     },

--- a/libs/i18n/src/lib/languages/romanian.ts
+++ b/libs/i18n/src/lib/languages/romanian.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_ROMANIAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'More'
+    },
     platformActionBar: {
         backButtonLabel: 'Go Back'
     },

--- a/libs/i18n/src/lib/languages/russian.ts
+++ b/libs/i18n/src/lib/languages/russian.ts
@@ -173,6 +173,9 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Мастер'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'Больше'
+    },
     platformActionBar: {
         backButtonLabel: 'Вернуться назад'
     },

--- a/libs/i18n/src/lib/languages/sinhala.ts
+++ b/libs/i18n/src/lib/languages/sinhala.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_SINHALA: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'More'
+    },
     platformActionBar: {
         backButtonLabel: 'Go Back'
     },

--- a/libs/i18n/src/lib/languages/spanish.ts
+++ b/libs/i18n/src/lib/languages/spanish.ts
@@ -149,6 +149,9 @@ export const FD_LANGUAGE_SPANISH: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Wizard'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'More'
+    },
     platformActionBar: {
         backButtonLabel: 'Regresar'
     },

--- a/libs/i18n/src/lib/languages/turkish.ts
+++ b/libs/i18n/src/lib/languages/turkish.ts
@@ -147,6 +147,9 @@ export const FD_LANGUAGE_TURKISH: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Sihirbaz'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'Daha'
+    },
     platformActionBar: {
         backButtonLabel: 'Geri dön'
     },

--- a/libs/i18n/src/lib/languages/ukrainian.ts
+++ b/libs/i18n/src/lib/languages/ukrainian.ts
@@ -172,6 +172,9 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
     coreWizard: {
         ariaLabel: 'Майстер'
     },
+    coreBreadcrumb: {
+        overflowTitleMore: 'Більше'
+    },
     platformActionBar: {
         backButtonLabel: 'Повернутися назад'
     },

--- a/libs/i18n/src/lib/models/lang.ts
+++ b/libs/i18n/src/lib/models/lang.ts
@@ -219,6 +219,9 @@ export interface FdLanguage {
     coreWizard: {
         ariaLabel: FdLanguageKey;
     };
+    coreBreadcrumb: {
+        overflowTitleMore: FdLanguageKey;
+    };
     platformActionBar: {
         backButtonLabel: FdLanguageKey;
     };


### PR DESCRIPTION
## Related Issue(s)


closes #9534

## Description

Updated wrapping link to have proper aria attribute and added title to the `more` icon so it shows some tooltip .  
The `"More"` also added to the i18n files. 

## Screenshots

<img width="274" alt="Screenshot 2023-03-31 at 9 22 56" src="https://user-images.githubusercontent.com/17149942/229051905-bec03222-c202-4f2c-afbd-7c49dad7b5c9.png">
<img width="806" alt="Screenshot 2023-03-31 at 9 23 31" src="https://user-images.githubusercontent.com/17149942/229052048-17ce3c13-63a5-4ff6-a02e-90e336aedbf4.png">


##### PR Quality

-   [X] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [X ] tests for the changes that have been done
-   [X ] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [x] update `README.md`
-   [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
