### PR TITLE
chore(core,platform): deprecate unmaintained Ariba specific components

### DIFF
--- a/libs/core/src/lib/action-bar/action-bar.component.ts
+++ b/libs/core/src/lib/action-bar/action-bar.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 /**
- * The parent action bar directive.
+ * @deprecated
+ * Action Bar component is depricated since version 0.40.0
  *
  * Children usage:
  * ```html

--- a/libs/docs/core/action-bar/action-bar-header/action-bar-header.component.html
+++ b/libs/docs/core/action-bar/action-bar-header/action-bar-header.component.html
@@ -1,5 +1,8 @@
 <fd-doc-page>
     <header>Action Bar</header>
+    <fd-message-strip type="warning" [dismissible]="false">
+        DEPRECATED. The component is not a standard SAP Design System component.
+    </fd-message-strip>
     <description>
         The Action Bar is located at the top of the page and is used for Page title and Main Actions for the page.
     </description>

--- a/libs/docs/platform/action-bar/platform-action-bar-header/platform-action-bar-header.component.html
+++ b/libs/docs/platform/action-bar/platform-action-bar-header/platform-action-bar-header.component.html
@@ -1,5 +1,8 @@
 <fd-doc-page>
     <header>Action Bar</header>
+    <fd-message-strip type="warning" [dismissible]="false">
+        DEPRECATED. The component is not a standard SAP Design System component.
+    </fd-message-strip>
     <fd-info-label label="SAP Ariba Component" title="SAP Ariba Component" color="8"></fd-info-label>
     <description>
         <p>

--- a/libs/docs/platform/approval-flow/platform-approval-flow-header/platform-approval-flow-header.component.html
+++ b/libs/docs/platform/approval-flow/platform-approval-flow-header/platform-approval-flow-header.component.html
@@ -1,5 +1,8 @@
 <fd-doc-page>
     <header>Approval Flow</header>
+    <fd-message-strip type="warning" [dismissible]="false">
+        DEPRECATED. The component is not a standard SAP Design System component.
+    </fd-message-strip>
     <fd-info-label label="SAP Ariba Component" title="SAP Ariba Component" color="8"></fd-info-label>
     <description>
         The Approval Flow component is a complex component which tracks and manages the approval process for a business

--- a/libs/docs/platform/page-footer/platform-page-footer-header/platform-page-footer-header.component.html
+++ b/libs/docs/platform/page-footer/platform-page-footer-header/platform-page-footer-header.component.html
@@ -1,5 +1,8 @@
 <fd-doc-page>
     <header>Page Footer Component</header>
+    <fd-message-strip type="warning" [dismissible]="false">
+        DEPRECATED. The component is not a standard SAP Design System component.
+    </fd-message-strip>
     <fd-info-label label="SAP Ariba Component" title="SAP Ariba Component" color="8"></fd-info-label>
     <description>
         <p>

--- a/libs/docs/platform/thumbnail/platform-thumbnail-header/platform-thumbnail-header.component.html
+++ b/libs/docs/platform/thumbnail/platform-thumbnail-header/platform-thumbnail-header.component.html
@@ -1,5 +1,8 @@
 <fd-doc-page>
     <header>Thumbnail</header>
+    <fd-message-strip type="warning" [dismissible]="false">
+        DEPRECATED. The component is not a standard SAP Design System component.
+    </fd-message-strip>
     <fd-info-label label="SAP Ariba Component" title="SAP Ariba Component" color="8"></fd-info-label>
     <description>
         Thumbnail is an image with a reduced file size that is used as a placeholder for full sized multimedia content.

--- a/libs/docs/platform/upload-collection/platform-upload-collection-header/platform-upload-collection-header.component.html
+++ b/libs/docs/platform/upload-collection/platform-upload-collection-header/platform-upload-collection-header.component.html
@@ -1,5 +1,8 @@
 <fd-doc-page>
     <header>Upload Collection</header>
+    <fd-message-strip type="warning" [dismissible]="false">
+        DEPRECATED. The component is not a standard SAP Design System component.
+    </fd-message-strip>
     <fd-info-label label="SAP Ariba Component" title="SAP Ariba Component" color="8"></fd-info-label>
     <description>
         <p>The upload collection allows users to upload one or more files from different devices.</p>

--- a/libs/platform/src/lib/action-bar/action-bar.component.ts
+++ b/libs/platform/src/lib/action-bar/action-bar.component.ts
@@ -4,7 +4,10 @@ import { map } from 'rxjs/operators';
 
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
-
+/**
+ * @deprecated
+ * Action Bar component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-action-bar',
     templateUrl: './action-bar.component.html'

--- a/libs/platform/src/lib/approval-flow/approval-flow-add-node/approval-flow-add-node.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-add-node/approval-flow-add-node.component.ts
@@ -51,6 +51,10 @@ export enum APPROVAL_FLOW_APPROVER_TYPES {
     EVERYONE = 'EVERYONE'
 }
 
+/**
+ * @deprecated
+ * ApprovalFlowAddNode component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow-add-node',
     templateUrl: './approval-flow-add-node.component.html',

--- a/libs/platform/src/lib/approval-flow/approval-flow-approver-details/approval-flow-approver-details.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-approver-details/approval-flow-approver-details.component.ts
@@ -23,6 +23,10 @@ export interface ApprovalFlowApproverDetailsDialogRefData {
     rtl?: boolean;
 }
 
+/**
+ * @deprecated
+ * ApprovalFlowApproverDetails component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow-approver-details',
     templateUrl: './approval-flow-approver-details.component.html',

--- a/libs/platform/src/lib/approval-flow/approval-flow-messages/approval-flow-messages.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-messages/approval-flow-messages.component.ts
@@ -16,6 +16,10 @@ export interface ApprovalFlowMessage {
     type: ApprovalFlowMessageType;
 }
 
+/**
+ * @deprecated
+ * ApprovalFlowMessages component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow-messages',
     templateUrl: './approval-flow-messages.component.html',

--- a/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-node/approval-flow-node.component.ts
@@ -42,6 +42,10 @@ const DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 
 let defaultId = 0;
 
+/**
+ * @deprecated
+ * ApprovalFlowNode component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow-node',
     templateUrl: './approval-flow-node.component.html',

--- a/libs/platform/src/lib/approval-flow/approval-flow-select-type/approval-flow-select-type.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-select-type/approval-flow-select-type.component.ts
@@ -9,6 +9,10 @@ export interface SelectTypeDialogFormData {
     toNextSerial: boolean;
 }
 
+/**
+ * @deprecated
+ * ApprovalFlowSelectType component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow-select-type',
     templateUrl: './approval-flow-select-type.component.html',

--- a/libs/platform/src/lib/approval-flow/approval-flow-team-list/approval-flow-team-list.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-team-list/approval-flow-team-list.component.ts
@@ -4,6 +4,10 @@ import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { ApprovalTeam } from '../interfaces';
 import { trackByFn } from '../helpers';
 
+/**
+ * @deprecated
+ * ApprovalFlowTeamList component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow-team-list',
     templateUrl: './approval-flow-team-list.component.html',

--- a/libs/platform/src/lib/approval-flow/approval-flow-toolbar-actions/approval-flow-toolbar-actions.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-toolbar-actions/approval-flow-toolbar-actions.component.ts
@@ -5,6 +5,10 @@ import { ApprovalFlowGraph, ApprovalGraphMetadata } from '../approval-flow-graph
 import { ApprovalGraphNode } from '../interfaces/approval-node';
 import { isNodeApproved } from '../helpers';
 
+/**
+ * @deprecated
+ * ApprovalFlowToolbarActions component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow-toolbar-actions',
     templateUrl: './approval-flow-toolbar-actions.component.html',

--- a/libs/platform/src/lib/approval-flow/approval-flow-user-details/approval-flow-user-details.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-user-details/approval-flow-user-details.component.ts
@@ -4,6 +4,10 @@ import { Observable } from 'rxjs';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { ApprovalUser } from '../interfaces';
 
+/**
+ * @deprecated
+ * ApprovalFlowUserDetails component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow-user-details',
     templateUrl: './approval-flow-user-details.component.html',

--- a/libs/platform/src/lib/approval-flow/approval-flow-user-list/approval-flow-user-list.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow-user-list/approval-flow-user-list.component.ts
@@ -27,6 +27,10 @@ import { trackByFn } from '../helpers';
 const ITEMS_RENDERED_AT_ONCE = 100;
 const INTERVAL_IN_MS = 10;
 
+/**
+ * @deprecated
+ * ApprovalFlowUserList component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow-user-list',
     templateUrl: './approval-flow-user-list.component.html',

--- a/libs/platform/src/lib/approval-flow/approval-flow.component.ts
+++ b/libs/platform/src/lib/approval-flow/approval-flow.component.ts
@@ -81,7 +81,10 @@ import {
 import { cloneDeep, uniqBy } from 'lodash-es';
 
 let defaultId = 0;
-
+/**
+ * @deprecated
+ * Approval Flow component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-approval-flow',
     templateUrl: './approval-flow.component.html',

--- a/libs/platform/src/lib/page-footer/page-footer.component.ts
+++ b/libs/platform/src/lib/page-footer/page-footer.component.ts
@@ -10,6 +10,10 @@ import {
 
 export type footerSize = 'sm' | 'md' | 'lg' | 'xl';
 
+/**
+ * @deprecated
+ * PlatformFooter component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-page-footer',
     templateUrl: './page-footer.component.html',

--- a/libs/platform/src/lib/thumbnail/thumbnail-details/thumbnail-details.component.ts
+++ b/libs/platform/src/lib/thumbnail/thumbnail-details/thumbnail-details.component.ts
@@ -19,6 +19,10 @@ interface DialogRefData {
     thumbnailId: string;
 }
 
+/**
+ * @deprecated
+ * ThumbnailDetails component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-thumbnail-details',
     templateUrl: './thumbnail-details.component.html',

--- a/libs/platform/src/lib/thumbnail/thumbnail-image/thumbnail-image.component.ts
+++ b/libs/platform/src/lib/thumbnail/thumbnail-image/thumbnail-image.component.ts
@@ -18,6 +18,10 @@ import { DialogService } from '@fundamental-ngx/core/dialog';
 import { Media } from '../thumbnail.interfaces';
 import { SPACE } from '@angular/cdk/keycodes';
 
+/**
+ * @deprecated
+ * ThumbnailImage component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-thumbnail-image',
     templateUrl: './thumbnail-image.component.html',

--- a/libs/platform/src/lib/thumbnail/thumbnail.component.ts
+++ b/libs/platform/src/lib/thumbnail/thumbnail.component.ts
@@ -35,6 +35,10 @@ export class ThumbnailClickedEvent<T extends ThumbnailComponent = ThumbnailCompo
     ) {}
 }
 
+/**
+ * @deprecated
+ * Thumbnail component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-thumbnail',
     templateUrl: './thumbnail.component.html',

--- a/libs/platform/src/lib/upload-collection/upload-collection/upload-collection.component.ts
+++ b/libs/platform/src/lib/upload-collection/upload-collection/upload-collection.component.ts
@@ -47,6 +47,10 @@ import { UploadCollectionDataSource } from '../domain/upload-collection-data-sou
 export type FdpUploadCollectionDataSource = UploadCollectionDataSource;
 let randomId = 0;
 
+/**
+ * @deprecated
+ * UploadCollection component is depricated since version 0.40.0
+ */
 @Component({
     selector: 'fdp-upload-collection',
     templateUrl: './upload-collection.component.html',


### PR DESCRIPTION
deprecate unmaintained Ariba specific components(updated documentation too)
- ActionMenu (core and platform)
- ApprovalFlow (platform)
- Page Footer (platform)
- Thumbnail (platform)
- UploadCollection (platform)