### PR TITLE
fix(core): simplify change detection for segmented button

### DIFF
--- a/libs/core/src/lib/button/base-button.ts
+++ b/libs/core/src/lib/button/base-button.ts
@@ -92,7 +92,7 @@ export class BaseButton {
     }
 
     /** @hidden */
-    _disabled: boolean;
+    _disabled = false;
 
     /** @hidden */
     _ariaDisabled: boolean;
@@ -100,5 +100,5 @@ export class BaseButton {
     /** @hidden */
     @HostBinding('class.fd-button--toggled')
     @HostBinding('attr.aria-pressed')
-    _toggled: boolean;
+    _toggled = false;
 }

--- a/libs/core/src/lib/segmented-button/segmented-button.component.spec.ts
+++ b/libs/core/src/lib/segmented-button/segmented-button.component.spec.ts
@@ -45,11 +45,12 @@ describe('SegmentedButtonComponent', () => {
         }).compileComponents();
     }));
 
-    beforeEach(() => {
+    beforeEach(waitForAsync(() => {
         fixture = TestBed.createComponent(HostComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
-    });
+        fixture.whenStable();
+    }));
 
     it('should create', () => {
         expect(component).toBeTruthy();


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #9633

## Description
- Simplified change detection;
- Use `asyncScheduler` for triggering the callback function when buttons being changed;

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [x] update `README.md`
-   [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
