### PR TITLE
fix: temp fix for popover scrolling issues

### DIFF
--- a/libs/core/src/lib/popover/popover-body/popover-body.component.html
+++ b/libs/core/src/lib/popover/popover-body/popover-body.component.html
@@ -8,12 +8,7 @@
     [style.min-width.px]="_popoverBodyMinWidth"
     [style.width.px]="_popoverBodyWidth"
 >
-    <div
-        fd-scrollbar
-        class="fd-popover__wrapper"
-        [overrideTabindex]="_tabbableScrollbar"
-        *ngIf="!_disableScrollbar; else renderer"
-    >
+    <div class="fd-popover__wrapper" *ngIf="!_disableScrollbar; else renderer">
         <ng-container *ngTemplateOutlet="renderer"></ng-container>
     </div>
 </div>


### PR DESCRIPTION
temporary fix for #9637 

fd-scrollbar seems to be conflicting with the scroll position strategy logic from angular cdk, often making popovers unscrollable. This is a temporary workaround