### PR TITLE
fix(platform): search field input value updated when used in form tag

### DIFF
--- a/libs/platform/src/lib/search-field/search-field.component.html
+++ b/libs/platform/src/lib/search-field/search-field.component.html
@@ -66,6 +66,7 @@
                 [attr.aria-controls]="_menuId"
                 [attr.aria-expanded]="_showDropdown ? 'true' : 'false'"
                 aria-haspopup="true"
+                autocomplete="off"
                 (keydown)="onKeydown($event)"
                 (keydown.enter)="onSearchSubmit($event)"
                 [(ngModel)]="inputText"
@@ -148,7 +149,7 @@
                     fdpSearchFieldSuggestion
                     class="fdp-search-field__suggestion-item fd-menu__item fd-menu__link"
                     *ngFor="let value of _dropdownValues$ | async | suggestionMatches : inputText : mobile"
-                    (keydown.enter)="onItemClick(value)"
+                    (keydown.enter)="onItemClick(value); $event.preventDefault()"
                     (keydown.tab)="onItemClick(value)"
                     (keyup.space)="onItemClick(value); $event.stopPropagation()"
                     (click)="onItemClick(value)"


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #9559 

## Description

The inputText value of ```fdp-search-field``` is now being populated when selecting an item via the Enter key in the suggestion dropdown, even when wrapped by a ```form``` tag. This is done by preventing the default behaviour of the browser when handling the event:
```(keydown.enter)="onItemClick(value); $event.preventDefault()"```

Additionally, the browser's default autocomplete function is silenced for the ```<input>``` element, as ```fdp-search-field``` has its own autocomplete function.