### PR TITLE
fix(platform): extend TableRowsRearrangeEvent with new data

### DIFF
--- a/libs/platform/src/lib/table/models/table-rows-rearrange-event.model.ts
+++ b/libs/platform/src/lib/table/models/table-rows-rearrange-event.model.ts
@@ -1,3 +1,5 @@
+import { FdDndDropEventMode } from '@fundamental-ngx/cdk/utils';
+
 export class TableRowsRearrangeEvent<T> {
     /**
      * Table rows rearrange event
@@ -6,5 +8,13 @@ export class TableRowsRearrangeEvent<T> {
      * @param newIndex New index of the row
      * @param rows All rows of the table
      */
-    constructor(public row: T, public previousIndex: number, public newIndex: number, public rows: T[]) {}
+    constructor(
+        public row: T,
+        public dropRow: T,
+        public previousIndex: number,
+        public newIndex: number,
+        public insertAt: 'before' | 'after' | null,
+        public mode: FdDndDropEventMode,
+        public rows: T[]
+    ) {}
 }

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1568,10 +1568,20 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
      * @hidden
      * Create table rows rearrange event
      */
-    _emitRowsRearrangeEvent(row: TableRow, previousIndex: number, newIndex: number): void {
+    _emitRowsRearrangeEvent(row: TableRow, dropRow: TableRow, event: FdDropEvent<TableRow>): void {
         const rows = this._tableRows.map(({ value }) => value);
 
-        this.rowsRearrange.emit(new TableRowsRearrangeEvent(row.value, previousIndex, newIndex, rows));
+        this.rowsRearrange.emit(
+            new TableRowsRearrangeEvent(
+                row.value,
+                dropRow.value,
+                event.draggedItemIndex,
+                event.replacedItemIndex,
+                event.insertAt,
+                event.mode,
+                rows
+            )
+        );
     }
 
     /**
@@ -1713,7 +1723,7 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
             }
 
             this._cdr.markForCheck();
-            this._emitRowsRearrangeEvent(dragRow, event.draggedItemIndex, event.replacedItemIndex);
+            this._emitRowsRearrangeEvent(dragRow, dropRow, event);
         }
     }
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #9665

## Description
Added additional information regarding drop row event such as:
insertAt: before or after;
mode: shift or group;
dropRow: row that dragged row was dropped on

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![image](https://user-images.githubusercontent.com/6586561/231478684-1e5f1e5e-ba9c-4c90-b965-2dc10c95ad06.png)

### After:
![image](https://user-images.githubusercontent.com/6586561/231478805-841147a2-edd2-4c44-bebf-95e2b688ad9c.png)
