### PR TITLE
fix(cdk): resize observer cleanup and breakpoint directive export absence

### DIFF
--- a/libs/cdk/src/lib/utils/services/resize-observer.service.ts
+++ b/libs/cdk/src/lib/utils/services/resize-observer.service.ts
@@ -74,7 +74,7 @@ export class ResizeObserverService implements OnDestroy {
             return;
         }
 
-        if (!--observedElement.count) {
+        if (--observedElement.count) {
             return;
         }
         this._cleanupObserver(element);

--- a/libs/cdk/src/lib/utils/utils.module.ts
+++ b/libs/cdk/src/lib/utils/utils.module.ts
@@ -18,7 +18,8 @@ import {
     ResizeModule,
     SelectableListModule,
     TemplateModule,
-    TruncateModule
+    TruncateModule,
+    BreakpointModule
 } from './directives';
 import { DragAndDropModule } from './drag-and-drop/drag-and-drop.module';
 
@@ -41,7 +42,8 @@ import { DragAndDropModule } from './drag-and-drop/drag-and-drop.module';
         SelectableListModule,
         ReadonlyBehaviorModule,
         ClickedBehaviorModule,
-        InitialFocusModule
+        InitialFocusModule,
+        BreakpointModule
     ],
     exports: [
         FocusableItemModule,
@@ -60,7 +62,8 @@ import { DragAndDropModule } from './drag-and-drop/drag-and-drop.module';
         SelectableListModule,
         ReadonlyBehaviorModule,
         ClickedBehaviorModule,
-        InitialFocusModule
+        InitialFocusModule,
+        BreakpointModule
     ],
     providers: [RtlService, ThemesService]
 })


### PR DESCRIPTION
## Related Issue(s)

related to https://github.com/SAP/fundamental-ngx/issues/9361#issuecomment-1508931202

## Description

- Resize observer was cleaned up prematurely
- Breakpoint directive was not exported and as a result the examples on stackblitz might not have worked in some cases

