### PR TITLE
fix(docs): api absence in prod builds

### DIFF
--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -43,7 +43,8 @@
                     "npx nx run cdk:compile-typedoc"
                 ],
                 "parallel": true
-            }
+            },
+            "outputs": ["libs/docs/typedoc"]
         },
         "build": {
             "executor": "@nrwl/angular:webpack-browser",


### PR DESCRIPTION
## Related Issue(s)

closes #9724 for good

## Description
Even though commands themselves were cached, the root command was not properly saved and after an RC, release is exactly the same contents, so it was not triggered as it should have been

