### PR TITLE
fix(platform): enables correct behavior for buttons when used as acti…

### DIFF
--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1689,7 +1689,9 @@ export class TableComponent<T = any> extends Table<T> implements AfterViewInit, 
             const eventTarget = event.target as HTMLInputElement;
             if (
                 eventTarget.type === 'checkbox' ||
-                (eventTarget.tagName !== 'INPUT' && eventTarget.tagName !== 'TEXTAREA')
+                (eventTarget.tagName !== 'INPUT' &&
+                    eventTarget.tagName !== 'BUTTON' &&
+                    eventTarget.tagName !== 'TEXTAREA')
             ) {
                 event.preventDefault(); // prevent page scroll but still allow space presses in inputs
             }


### PR DESCRIPTION
## Related Issue(s)
closes #9668

## Description
Additional fix for the 9668 to enable full buttons behavior when used as popover trigger. SPACE keyboard event was eaten up by `onRowClick` and it did not consider there could be a action buttons. 

So now the buttons works with enter and space. 


##### PR Quality

-   [X] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [na] tests for the changes that have been done
-   [X] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [na] Run npm run build-pack-library and test in external application
-   [na] update `README.md`
-   [na] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
