### PR TITLE
fix(docs): background color on the search input in side nav

### DIFF
--- a/libs/docs/shared/src/lib/core-helpers/sections-toolbar/sections-toolbar.component.scss
+++ b/libs/docs/shared/src/lib/core-helpers/sections-toolbar/sections-toolbar.component.scss
@@ -84,11 +84,12 @@
 
 .fd-docs-search {
     flex: 0 0 auto;
-    padding: 15px 15px;
-    margin: 0 15px;
+    padding: 15px 15px 15px 30px;
+    margin: 0 15px 0 0;
 
     border-right: var(--sapList_BorderWidth) solid;
     border-right-color: var(--sapGroup_ContentBorderColor);
+    background-color: var(--sapList_Background);
 }
 
 .nav-item-container {


### PR DESCRIPTION
fixes none. quick docs thing that's been bothering me

before:
<img width="363" alt="Screenshot 2023-04-25 at 2 23 20 PM" src="https://user-images.githubusercontent.com/2471874/234396710-5dee4cb8-b419-4322-9d38-ea5465e347ab.png">

after:
<img width="330" alt="Screenshot 2023-04-25 at 2 31 51 PM" src="https://user-images.githubusercontent.com/2471874/234396773-5ffb0f6d-084c-4ee4-a35e-56fe5d89d4a9.png">
