### PR TITLE
fix(core): vertical navigation focus issue

### DIFF
--- a/libs/core/src/lib/list/directives/list-navigation-item-arrow.directive.ts
+++ b/libs/core/src/lib/list/directives/list-navigation-item-arrow.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, HostBinding } from '@angular/core';
+import { Directive, ElementRef, HostBinding } from '@angular/core';
 
 @Directive({
     selector: '[fd-list-navigation-item-arrow], [fdListNavigaitonItemArrow]'
@@ -21,11 +21,19 @@ export class ListNavigationItemArrowDirective {
     expanded = false;
 
     /** @hidden */
+    constructor(private _elRef: ElementRef) {}
+
+    /** @hidden */
     _setExpanded(expanded: boolean): void {
         if (this.expanded !== expanded) {
             this.rightArrowClass = !this.rightArrowClass;
             this.downArrowClass = !this.downArrowClass;
         }
         this.expanded = expanded;
+    }
+
+    /** @hidden */
+    _focus(): void {
+        this._elRef.nativeElement.focus();
     }
 }

--- a/libs/core/src/lib/list/list-navigation-item/list-navigation-item.component.ts
+++ b/libs/core/src/lib/list/list-navigation-item/list-navigation-item.component.ts
@@ -163,7 +163,11 @@ export class ListNavigationItemComponent implements AfterContentInit, AfterViewI
 
     /** support for FocusKeyManager for arrow key navigation */
     focus(): void {
-        this._elementRef.nativeElement.focus();
+        if (!this._isExpandable) {
+            this._elementRef.nativeElement.focus();
+        } else {
+            this._listNavigationItemArrow?._focus();
+        }
     }
 
     /** support for FocusKeyManager for arrow key navigation */


### PR DESCRIPTION
part of #9608 

Fixes a focus outline issue when an expandable vertical navigation item was focused.

before:
![Screenshot 2023-05-04 at 2 56 11 PM](https://user-images.githubusercontent.com/2471874/236327933-b7deef91-fc2e-4dfd-837e-1e1653f3e504.png)

after:
![Screenshot 2023-05-04 at 2 56 00 PM](https://user-images.githubusercontent.com/2471874/236327966-66e5e1bb-1529-457b-8bf4-17744611ba03.png)

