### PR TITLE
fix(core): escape key when using focusable grid closes dialog

### DIFF
--- a/libs/core/src/lib/dialog/base/dialog-base.class.ts
+++ b/libs/core/src/lib/dialog/base/dialog-base.class.ts
@@ -57,7 +57,7 @@ export abstract class DialogBase implements OnInit, AfterViewInit, OnDestroy {
     });
 
     /** @hidden Listen and close dialog on Escape key */
-    @HostListener('keyup', ['$event'])
+    @HostListener('keydown', ['$event'])
     closeDialogEsc(event: KeyboardEvent): void {
         if (this._config.escKeyCloseable && KeyUtil.isKeyCode(event, ESCAPE)) {
             this._ref.dismiss('escape');

--- a/libs/core/src/lib/dialog/dialog.component.spec.ts
+++ b/libs/core/src/lib/dialog/dialog.component.spec.ts
@@ -95,7 +95,7 @@ describe('DialogComponent', () => {
 
         const dismissSpy = spyOn(dialogRef, 'dismiss');
 
-        dialogComponent['_elementRef'].nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
+        dialogComponent['_elementRef'].nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
         fixture.detectChanges();
 
         expect(dismissSpy).toHaveBeenCalled();

--- a/libs/core/src/lib/message-box/message-box.component.spec.ts
+++ b/libs/core/src/lib/message-box/message-box.component.spec.ts
@@ -86,7 +86,7 @@ describe('MessageBoxComponent', () => {
 
         const dismissSpy = jest.spyOn(messageBoxRef, 'dismiss');
 
-        messageBoxComponent['_elementRef'].nativeElement.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
+        messageBoxComponent['_elementRef'].nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
         fixture.detectChanges();
 
         expect(dismissSpy).toHaveBeenCalled();


### PR DESCRIPTION
fixes #9794 

Dialog was previously using `keyup` which cannot be prevented coming from focusable item's `keydown`. Need to use `keydown` for dialog escape