### PR TITLE
fix(docs): sidebar container css bug

### DIFF
--- a/libs/docs/shared/src/lib/core-helpers/sections-toolbar/sections-toolbar.component.scss
+++ b/libs/docs/shared/src/lib/core-helpers/sections-toolbar/sections-toolbar.component.scss
@@ -128,8 +128,6 @@
 }
 
 .fd-sidebar-container {
-    position: relative;
-    flex-grow: 1;
     overflow: hidden;
 }
 

--- a/libs/docs/shared/src/lib/documentation-base.component.scss
+++ b/libs/docs/shared/src/lib/documentation-base.component.scss
@@ -52,8 +52,6 @@ fd-base-documentation {
 }
 
 .fd-sidebar-container {
-    position: relative;
-    flex-grow: 1;
     overflow: hidden;
 }
 


### PR DESCRIPTION
fixes none

A user stumbled across this issue when using the JAWS screenreader: "whenever focus goes to the tooltip in linear reading mode, the screen goes blank."

Which I think is actually caused by these styles in the documentation somehow. So I'm removing those as they don't seem to really do anything, unless anyone objects