### PR TITLE
fix(platform): do not set aria-expanded for table cells that do not expand

### DIFF
--- a/libs/docs/platform/table/platform-table-docs.component.html
+++ b/libs/docs/platform/table/platform-table-docs.component.html
@@ -288,7 +288,7 @@
 <separator></separator>
 
 <fd-docs-section-title id="responsive-columns" componentName="table">
-    Hidding columns depending on the table size
+    Hiding columns depending on the table size
 </fd-docs-section-title>
 <description>
     <p>it is not recommended to use large amount of columns in a table which has small size.</p>

--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -321,7 +321,7 @@
                                         : _tableColumnResizeService.getColumnWidthStyle(column.name)
                                         : _tableColumnResizeService.getNextColumnsWidth(column.name)
                             "
-                            [attr.aria-expanded]="_isTreeRow(row) ? row.expanded : null"
+                            [attr.aria-expanded]="_isTreeRowFirstCell(colIdx, row) ? row.expanded : null"
                             [attr.data-nesting-level]="colIdx === 0 ? row.level + 1 : null"
                             [cellFocusedEventAnnouncer]="null"
                             (cellFocused)="_onCellFocused($event)"


### PR DESCRIPTION
fixes #9964 

Fixes an accessibility issue where cells that can't be clicked to expand the row still had aria-expanded attribute. Also a doc typo