### PR TITLE
fix(platform): if entire table row is not focusable, focus first cell

### DIFF
--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -798,6 +798,8 @@ export class TableComponent<T = any>
                 })
             );
         }
+
+        this._focusableGrid.shortRowFocus = 'first';
     }
 
     /** @hidden */


### PR DESCRIPTION
fixes #9791 