### PR TITLE
fix(core): selecting only date and not time and pressing OK does not set date

### DIFF
--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.html
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.html
@@ -110,6 +110,7 @@
                                 <button
                                     fd-button
                                     fdType="emphasized"
+                                    [disabled]="!_tempDate"
                                     [label]="okLabel || ('coreDatetimePicker.datetimeOkLabel' | fdTranslate)"
                                     [ariaLabel]="okLabel || ('coreDatetimePicker.datetimeOkLabel' | fdTranslate)"
                                     (click)="submit()"

--- a/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/src/lib/datetime-picker/datetime-picker.component.ts
@@ -610,7 +610,11 @@ export class DatetimePickerComponent<D>
     submit(): void {
         // marking date & time as not null, errors will be caught below
         const currentDate = this._tempDate!;
-        const currentTime = this._tempTime!;
+        let currentTime = this._tempTime;
+
+        if (!currentTime) {
+            currentTime = this._dateTimeAdapter.today();
+        }
 
         try {
             this.date = this._dateTimeAdapter.setTime(


### PR DESCRIPTION
fixes #10050 

Also, disables the submit button if no date is selected. Maybe preferred UX would be to leave it enabled, and select today's date if user sets a time but no date?