### PR TITLE
fix(core): bug where token would not be removed from mobile mode

### DIFF
--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.html
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.html
@@ -171,7 +171,7 @@
         <ng-container *ngIf="isGroup">
             <ng-container *ngFor="let group of _suggestions">
                 <ng-container *ngIf="!groupItemTemplate">
-                    <label fd-list-item fd-list-group-header role="group">
+                    <label fd-list-group-header role="group">
                         <span fd-list-title>{{ group.label }}</span>
                     </label>
                 </ng-container>

--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
@@ -366,7 +366,7 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     }
 
     /** @hidden */
-    _toggleSelection(item: SelectableOptionItem): void {
+    _toggleSelection(item: SelectableOptionItem, fromTokenCloseClick = false): void {
         const idx = getTokenIndexByIdlOrValue(item, this._selectedSuggestions);
         if (idx === -1) {
             this._selectedSuggestions.push(item);
@@ -376,7 +376,7 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
 
         item.selected = !item.selected;
 
-        this._propagateChange();
+        this._propagateChange(fromTokenCloseClick);
 
         if (!this._selectedSuggestions.length) {
             this._focusToSearchField();
@@ -435,7 +435,7 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
         }
         const optionItem = this._suggestions.find((s) => s.value === token.value);
         if (optionItem) {
-            this._toggleSelection(optionItem);
+            this._toggleSelection(optionItem, true);
             this._rangeSelector.reset();
         }
     }

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -582,11 +582,11 @@ export class MultiInputComponent
     /** @hidden */
     _onTokenClick(value: any, resetSearch: boolean, event?: MouseEvent): void {
         event?.preventDefault(); // prevent this function from being called twice when checkbox updates
-        this._handleSelect(false, value, resetSearch);
+        this._handleSelect(false, value, resetSearch, true);
     }
 
     /** @hidden */
-    _handleSelect(checked: any, value: any, resetSearch = true): void {
+    _handleSelect(checked: any, value: any, resetSearch = true, fromTokenCloseClick = false): void {
         const previousLength = this._selectionModel.selected.length;
         if (checked) {
             this._selectionModel.select(value);
@@ -609,7 +609,7 @@ export class MultiInputComponent
         }
 
         // On Mobile mode changes are propagated only on approve.
-        this._propagateChange();
+        this._propagateChange(fromTokenCloseClick);
     }
 
     /** @hidden */

--- a/libs/docs/core/multi-input/examples/multi-input-mobile-example/multi-input-mobile-example.component.html
+++ b/libs/docs/core/multi-input/examples/multi-input-mobile-example/multi-input-mobile-example.component.html
@@ -7,3 +7,5 @@
     [mobileConfig]="secondConfig"
     [(ngModel)]="selectedValues"
 ></fd-multi-input>
+
+Selected: {{ selectedValues | json }}


### PR DESCRIPTION
part of #9236 

multi-combobox and multi-input mobile mode - removing tokens from the tokenizer is not reflected in the selection list when the popover is opened, nor the selected model

also removes fd-list-item from headers