### PR TITLE
fix(core): redundant popover open/close/event things

### DIFF
--- a/libs/core/src/lib/popover/popover-mobile/popover-mobile.component.html
+++ b/libs/core/src/lib/popover/popover-mobile/popover-mobile.component.html
@@ -1,5 +1,5 @@
 <ng-template let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>
-    <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
+    <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog" data-mobile-popover>
         <fd-dialog-header>
             <h1 fd-title [id]="titleId">{{ title }}</h1>
             <button fd-dialog-close-button *ngIf="this.mobileConfig.hasCloseButton" (click)="close()"></button>

--- a/libs/core/src/lib/popover/popover-service/popover.service.ts
+++ b/libs/core/src/lib/popover/popover-service/popover.service.ts
@@ -39,6 +39,9 @@ export class PopoverService extends BasePopoverClass {
     _onLoad = new Subject<ElementRef>();
 
     /** @hidden */
+    _mobile = false;
+
+    /** @hidden */
     private _eventRef: (() => void)[] = [];
 
     /** @hidden */
@@ -388,7 +391,28 @@ export class PopoverService extends BasePopoverClass {
 
     /** @hidden */
     private _shouldClose(event: MouseEvent): boolean {
-        return this.isOpen && this.closeOnOutsideClick && !this._triggerContainsTarget(event);
+        return (
+            this.isOpen &&
+            this.closeOnOutsideClick &&
+            !this._triggerContainsTarget(event) &&
+            !this._targetIsPopoverMobileDialog(event)
+        );
+    }
+
+    /** @hidden */
+    private _targetIsPopoverMobileDialog(event: MouseEvent): boolean {
+        if (this._mobile) {
+            let el = (event.target as HTMLElement).parentElement;
+            while (el) {
+                if (el.hasAttribute('data-mobile-popover')) {
+                    return true;
+                } else {
+                    el = el.parentElement;
+                }
+            }
+        }
+
+        return false;
     }
 
     /** @hidden */

--- a/libs/core/src/lib/popover/popover.component.spec.ts
+++ b/libs/core/src/lib/popover/popover.component.spec.ts
@@ -64,26 +64,18 @@ describe('PopoverComponent', () => {
 
     it('should open popover', () => {
         jest.spyOn(popoverServiceStub, 'open');
-        jest.spyOn(component.isOpenChange, 'emit');
-        component.isOpen = false;
 
         component.open();
 
         expect(popoverServiceStub.open).toHaveBeenCalled();
-        expect(component.isOpenChange.emit).toHaveBeenCalled();
-        expect(component.isOpen).toBe(true);
     });
 
     it('should close popover', () => {
         jest.spyOn(popoverServiceStub, 'close');
-        jest.spyOn(component.isOpenChange, 'emit');
-        component.isOpen = true;
 
         component.close();
 
         expect(popoverServiceStub.close).toHaveBeenCalled();
-        expect(component.isOpenChange.emit).toHaveBeenCalled();
-        expect(component.isOpen).toBe(false);
     });
 
     it('should add ne wposition', () => {

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -161,23 +161,6 @@ export class PopoverComponent
 
     /** @hidden */
     ngAfterViewInit(): void {
-        if (!this.mobile) {
-            if (!this.popoverBody) {
-                this._popoverService.templateContent = this.templateRef;
-            }
-            this._popoverService.initialise(
-                this.trigger || this.triggerOrigin.elementRef,
-                this,
-                this.popoverBody
-                    ? {
-                          template: this.templateRef,
-                          container: this.container,
-                          popoverBody: this.popoverBody
-                      }
-                    : null
-            );
-        }
-
         this._setupView();
     }
 
@@ -271,7 +254,23 @@ export class PopoverComponent
 
     /** @hidden Select and instantiate popover view mode */
     private _setupView(): void {
-        if (this.mobile) {
+        if (!this.mobile) {
+            this._popoverService._mobile = false;
+            if (!this.popoverBody) {
+                this._popoverService.templateContent = this.templateRef;
+            }
+            this._popoverService.initialise(
+                this.trigger || this.triggerOrigin.elementRef,
+                this,
+                this.popoverBody
+                    ? {
+                          template: this.templateRef,
+                          container: this.container,
+                          popoverBody: this.popoverBody
+                      }
+                    : null
+            );
+        } else {
             this._setupMobileMode();
         }
 
@@ -284,6 +283,8 @@ export class PopoverComponent
             providers: [{ provide: POPOVER_COMPONENT, useValue: this }],
             parent: this._injector
         });
+
+        this._popoverService._mobile = true;
 
         this._mobileModeComponentRef = await this._dynamicComponentService.createDynamicModule(
             {

--- a/libs/core/src/lib/popover/popover.component.ts
+++ b/libs/core/src/lib/popover/popover.component.ts
@@ -230,17 +230,13 @@ export class PopoverComponent
 
     /** Opens the popover. */
     open(): void {
-        this.isOpen = true;
         this._popoverService.open();
-        this.isOpenChange.emit(this.isOpen);
         this._cdr.markForCheck();
     }
 
     /** Closes the popover. */
     close(focusActiveElement = true): void {
-        this.isOpen = false;
         this._popoverService.close(focusActiveElement);
-        this.isOpenChange.emit(this.isOpen);
         this._cdr.markForCheck();
     }
 

--- a/libs/docs/core/popover/e2e/popover.e2e-spec.ts
+++ b/libs/docs/core/popover/e2e/popover.e2e-spec.ts
@@ -495,7 +495,6 @@ describe('Popover test suite', () => {
             await expect(await getAlertText()).toBe(alertText1);
             await acceptAlert();
 
-            await scrollIntoView(popoverMobileExample + button);
             await click(popoverMobileExample + button);
             await click(mobileFooterButton, 1);
             await expect(await getAlertText()).toBe(alertText2);

--- a/libs/docs/core/popover/e2e/popover.e2e-spec.ts
+++ b/libs/docs/core/popover/e2e/popover.e2e-spec.ts
@@ -488,14 +488,19 @@ describe('Popover test suite', () => {
             await expect(await getValue(mobileInput)).toBe('0');
         });
 
-        it('should check alert messages appears', async () => {
+        it('should check alert message appears', async () => {
             await scrollIntoView(popoverMobileExample + button);
             await click(popoverMobileExample + button);
+            await waitForElDisplayed(mobileFooterButton);
             await click(mobileFooterButton);
             await expect(await getAlertText()).toBe(alertText1);
             await acceptAlert();
+        });
 
+        it('should check alert message 2 appears', async () => {
+            await scrollIntoView(popoverMobileExample + button);
             await click(popoverMobileExample + button);
+            await waitForElDisplayed(mobileFooterButton);
             await click(mobileFooterButton, 1);
             await expect(await getAlertText()).toBe(alertText2);
             await acceptAlert();

--- a/libs/docs/core/popover/e2e/popover.e2e-spec.ts
+++ b/libs/docs/core/popover/e2e/popover.e2e-spec.ts
@@ -495,6 +495,8 @@ describe('Popover test suite', () => {
             await expect(await getAlertText()).toBe(alertText1);
             await acceptAlert();
 
+            await scrollIntoView(popoverMobileExample + button);
+            await click(popoverMobileExample + button);
             await click(mobileFooterButton, 1);
             await expect(await getAlertText()).toBe(alertText2);
             await acceptAlert();

--- a/libs/docs/core/popover/e2e/popover.po.ts
+++ b/libs/docs/core/popover/e2e/popover.po.ts
@@ -51,7 +51,7 @@ export class PopoverPo extends CoreBaseComponentPo {
     mobilePopoverButton = 'fd-dialog-body button';
     popoverMobileExample = 'fd-popover-mobile-example ';
     mobileInput = 'fd-dialog-body input';
-    mobileFooterButton = 'fd-dialog-footer button';
+    mobileFooterButton = '.fd-dialog__footer .fd-button';
 
     async open(): Promise<void> {
         await super.open(this.url);

--- a/libs/docs/core/popover/examples/popover-mobile/popover-mobile-example.component.html
+++ b/libs/docs/core/popover/examples/popover-mobile/popover-mobile-example.component.html
@@ -26,7 +26,7 @@
     </ng-template>
 
     <ng-template #popoverFooterContent>
-        <fd-button-bar label="Accept" fdType="positive" (click)="accept()"> </fd-button-bar>
-        <fd-button-bar label="Decline" fdType="negative" (click)="decline()"> </fd-button-bar>
+        <fd-button-bar label="Accept" fdType="positive" (click)="accept(); popoverMobile.close()"> </fd-button-bar>
+        <fd-button-bar label="Decline" fdType="negative" (click)="decline(); popoverMobile.close()"> </fd-button-bar>
     </ng-template>
 </fd-popover>


### PR DESCRIPTION
part of #9236 

Both `PopoverComponent` and `PopoverService` extend `BasePopoverClass`. Both were emitting the `isOpenChange` event, causing mobile popovers to be opened twice. This is an immediate fix for that problem but I think we need to restructure these components, in my opinion it is not great to have the component and service extending the same base class

This solution of ascending the element parent node tree feels a bit code smelly but I think it is the best option for two reasons

1. We can solve the problem of ascending the parent tree by requiring the application developer to add `fd-popover-body` wrapper around the contents of the dialog. I'd like to avoid this since it is a breaking change
2. I thought why not just add `fd-popover-body` to the `popover-mobile.component.html` but to do this we need to import the popover module, which introduces a circular dependency between popover mobile module and popover module, because popover component uses `createDynamicModule`

So I think this is the best option, barring a more significant refactor