### PR TITLE
feat(core): added wrapping to the checkbox label

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -26,6 +26,8 @@
     [class]="labelClass"
     [attr.title]="title"
     [class.fd-checkbox__label--required]="required"
+    [class.fd-checkbox__label--wrap]="wrapLabel && valignLabel === 'middle'"
+    [class.fd-checkbox__label--wrap-top-aligned]="wrapLabel && valignLabel === 'top'"
     (click)="_onLabelClick($event)"
 >
     <span class="fd-checkbox__checkmark" aria-hidden="true"></span>

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -61,10 +61,10 @@ export class CheckboxComponent implements ControlValueAccessor, AfterViewInit, O
     @ViewChild('labelElement')
     labelElement: ElementRef;
 
-    /** @hidden Whether input label should be wrapped */
+    /** Whether input label should be wrapped */
     @Input() wrapLabel: boolean;
 
-    /** @hidden Whether input label should be wrapped */
+    /** Vertical position of the label compared to the checkbox box */
     @Input() valignLabel: 'top' | 'middle' = 'middle';
 
     /** Sets the `aria-label` attribute to the element. */

--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.ts
@@ -61,6 +61,12 @@ export class CheckboxComponent implements ControlValueAccessor, AfterViewInit, O
     @ViewChild('labelElement')
     labelElement: ElementRef;
 
+    /** @hidden Whether input label should be wrapped */
+    @Input() wrapLabel: boolean;
+
+    /** @hidden Whether input label should be wrapped */
+    @Input() valignLabel: 'top' | 'middle' = 'middle';
+
     /** Sets the `aria-label` attribute to the element. */
     @Input()
     ariaLabel: Nullable<string>;
@@ -131,6 +137,7 @@ export class CheckboxComponent implements ControlValueAccessor, AfterViewInit, O
     set values(checkboxValues: FdCheckboxValues) {
         this._values = { ...FD_CHECKBOX_VALUES_DEFAULT, ...(checkboxValues ?? {}) };
     }
+
     get values(): FdCheckboxValues {
         return this._values;
     }

--- a/libs/docs/core/checkbox/checkbox-docs.component.html
+++ b/libs/docs/core/checkbox/checkbox-docs.component.html
@@ -70,6 +70,21 @@
 
 <separator></separator>
 
+<fd-docs-section-title id="label-wrapping" componentName="checkbox">
+    Checkbox with label wrapping
+</fd-docs-section-title>
+<description>
+    Checkbox labels by default do not wrap. If you want to wrap the labels, then you should use
+    <code>fd-checkbox[wrapLabel]</code>
+    input
+</description>
+<component-example>
+    <fd-checkbox-label-wrapping-example></fd-checkbox-label-wrapping-example>
+</component-example>
+<code-example [exampleFiles]="checkboxLabelWrapping"></code-example>
+
+<separator></separator>
+
 <fd-docs-section-title id="states" componentName="checkbox"> Checkbox styling properties </fd-docs-section-title>
 <description>
     Checkbox can be but in various states by modifying following properties:

--- a/libs/docs/core/checkbox/checkbox-docs.component.ts
+++ b/libs/docs/core/checkbox/checkbox-docs.component.ts
@@ -67,4 +67,13 @@ export class CheckboxDocsComponent {
             code: getAssetFromModuleAssets(checkboxCustomLabelTsCode)
         }
     ];
+
+    checkboxLabelWrapping: ExampleFile[] = [
+        {
+            language: 'typescript',
+            fileName: 'checkbox-label-wrapping-example',
+            component: 'CheckboxLabelWrappingExampleComponent',
+            code: getAssetFromModuleAssets('checkbox-label-wrapping-example.component.ts')
+        }
+    ];
 }

--- a/libs/docs/core/checkbox/examples/checkbox-label-wrapping-example.component.ts
+++ b/libs/docs/core/checkbox/examples/checkbox-label-wrapping-example.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'fd-checkbox-label-wrapping-example',
+    template: `
+        <div>
+            <fd-checkbox [wrapLabel]="true">
+                LABEL WILL BE POSITIONED IN THE MIDDLE. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+                Corporis ea eos in porro quae ullam. Aliquid corporis doloribus exercitationem facilis hic illo labore
+                laudantium quam reprehenderit sapiente, tempore voluptatibus voluptatum?
+            </fd-checkbox>
+        </div>
+        <div>
+            <fd-checkbox [wrapLabel]="true" valignLabel="top">
+                LABEL WILL BE POSITIONED ON THE TOP. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corporis
+                ea eos in porro quae ullam. Aliquid corporis doloribus exercitationem facilis hic illo labore laudantium
+                quam reprehenderit sapiente, tempore voluptatibus voluptatum?
+            </fd-checkbox>
+        </div>
+    `,
+    styles: [
+        `
+            :host {
+                display: flex;
+                flex-direction: column;
+                gap: 1rem;
+            }
+            div {
+                max-width: 300px;
+            }
+        `
+    ]
+})
+export class CheckboxLabelWrappingExampleComponent {}

--- a/libs/docs/core/checkbox/examples/index.ts
+++ b/libs/docs/core/checkbox/examples/index.ts
@@ -4,6 +4,7 @@ import { CheckboxDefaultExampleComponent } from './checkbox-default-example.comp
 import { CheckboxReactiveFormsExampleComponent } from './checkbox-reactive-forms-example.component';
 import { CheckboxStatesExampleComponent } from './checkbox-states-example.component';
 import { CheckboxTristateExampleComponent } from './checkbox-tristate-example.component';
+import { CheckboxLabelWrappingExampleComponent } from './checkbox-label-wrapping-example.component';
 
 export * from './checkbox-custom-label-example.component';
 export * from './checkbox-custom-values-example.component';
@@ -18,5 +19,6 @@ export const examples = [
     CheckboxTristateExampleComponent,
     CheckboxCustomLabelExampleComponent,
     CheckboxCustomValuesExampleComponent,
-    CheckboxReactiveFormsExampleComponent
+    CheckboxReactiveFormsExampleComponent,
+    CheckboxLabelWrappingExampleComponent
 ];


### PR DESCRIPTION
## Related Issue(s)

closes #9832
part of #9823 

## Description

Not much has changed, but I noticed that label wrapping was missing from the API
