### PR TITLE
fix(core): add the correct styling for Select placeholder

### DIFF
--- a/libs/core/src/lib/select/select.component.html
+++ b/libs/core/src/lib/select/select.component.html
@@ -40,7 +40,7 @@
         [attr.id]="controlId"
         [attr.aria-active]="_isOpen"
         aria-live="polite"
-        [attr.aria-selected]="selected ? selected.selected : null"
+        [attr.aria-selected]="selected ? selected.selected : false"
         [attr.aria-expanded]="_isOpen"
         [attr.aria-disabled]="disabled"
         [attr.aria-controls]="controlId + '-list-box'"

--- a/libs/core/src/lib/select/select.component.scss
+++ b/libs/core/src/lib/select/select.component.scss
@@ -22,4 +22,19 @@ $block: fd-select;
             position: static;
         }
     }
+
+    .#{$block}__control[aria-selected='false'] {
+        .#{$block}__text-content {
+            font-style: italic;
+            font-weight: normal;
+            padding: 0 0.625rem;
+            color: var(--sapField_PlaceholderTextColor);
+
+            [class*='sap-icon'] {
+                font-style: italic;
+                font-weight: normal;
+                color: var(--sapField_PlaceholderTextColor);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/10088

## Description
The placeholder in Select component should be italic with color `var(--sapField_PlaceholderTextColor)`. 
The fix is done here, not in Fundamental-ngx as we can't control the value of aria-selected without JavaScript.

## Screenshots

### Before:
<img width="222" alt="Screenshot 2023-06-27 at 10 09 13 AM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/fcd5c4c6-8412-47c5-a765-b7dc04edd9dd">
<img width="423" alt="Screenshot 2023-06-27 at 10 09 09 AM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/345ce66d-fb95-45ca-9358-6216cf8d1c6a">
<img width="229" alt="Screenshot 2023-06-27 at 10 09 04 AM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/6887122f-223e-444a-a3ff-3c08dd6014ff">



### After:
<img width="209" alt="Screenshot 2023-06-27 at 10 08 27 AM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/09ac09f5-b1ce-4bfb-959a-07569434575d">
<img width="429" alt="Screenshot 2023-06-27 at 10 08 21 AM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/1867bd4f-a7bf-46da-aff2-64f9c5cfa130">
<img width="248" alt="Screenshot 2023-06-27 at 10 08 13 AM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/7fd16f85-973b-4ea2-9ed8-38199f814135">

