### PR TITLE
fix: dayjs adapter was enforcing double digits for month and day

### DIFF
--- a/libs/datetime-adapter/src/lib/dayjs-datetime-formats.ts
+++ b/libs/datetime-adapter/src/lib/dayjs-datetime-formats.ts
@@ -2,14 +2,14 @@ import { DateTimeFormats } from '@fundamental-ngx/core/datetime';
 
 export const DAYJS_DATETIME_FORMATS: DateTimeFormats = {
     parse: {
-        dateInput: 'L',
+        dateInput: 'l',
         timeInput: 'h:mm A',
-        dateTimeInput: 'L h:mm A'
+        dateTimeInput: 'l h:mm A'
     },
     display: {
-        dateInput: 'L',
+        dateInput: 'l',
         timeInput: 'h:mm A',
-        dateTimeInput: 'L h:mm A',
+        dateTimeInput: 'l h:mm A',
 
         dateA11yLabel: 'YYYY MMMM DD',
         monthA11yLabel: 'MMMM',


### PR DESCRIPTION
fixes none

Fixes an issue where the DayJS adapter would require leading zeros in front of the day or month, if less than 10, and if no leading zero was provided, would revert to US-style date formatting for any locale.