### PR TITLE
fix(docs): dayjs datetime adapter docs

### DIFF
--- a/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.ts
+++ b/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.ts
@@ -82,8 +82,9 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
         if (dayjs.locale() !== locale) {
             throw new Error(
                 `Failed to load locale ${locale}. ` +
-                    'Make sure it exists and is preloaded. You may use "loadLocale" function from this package to load the locale you need. ' +
-                    'List of supported locales can be found here: https://day.js.org/docs/en/i18n/i18n.'
+                    'Make sure it exists and is preloaded. See the imports at the top of the example file at ' +
+                    'https://sap.github.io/fundamental-ngx/#/core/dayjs-datetime-adapter' +
+                    'List of supported locales can be found here: https://github.com/iamkun/dayjs/tree/dev/src/locale.'
             );
         }
 

--- a/libs/docs/core/dayjs-datetime-adapter/examples/date-picker-dayjs-adapter-example.component.ts
+++ b/libs/docs/core/dayjs-datetime-adapter/examples/date-picker-dayjs-adapter-example.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, LOCALE_ID, ViewChild } from '@angular/core';
 import { DatePickerComponent } from '@fundamental-ngx/core/date-picker';
-import { DatetimeAdapter } from '@fundamental-ngx/core/datetime';
+import { DATE_TIME_FORMATS, DatetimeAdapter } from '@fundamental-ngx/core/datetime';
 import dayjs, { Dayjs } from 'dayjs';
 
 import 'dayjs/locale/en';
@@ -8,11 +8,24 @@ import 'dayjs/locale/fr';
 import 'dayjs/locale/de';
 import 'dayjs/locale/bg';
 import 'dayjs/locale/ar';
+import { DAYJS_DATETIME_FORMATS, DayjsDatetimeAdapter } from '@fundamental-ngx/datetime-adapter';
 
 @Component({
     selector: 'fd-date-picker-dayjs-adapter-example',
     templateUrl: './date-picker-dayjs-adapter-example.component.html',
-    providers: [{ provide: LOCALE_ID, useValue: 'fr' }]
+    providers: [
+        // Note that this is usually provided in the root of your application.
+        // Due to the limit of this example we must provide it on this level.
+        { provide: LOCALE_ID, useValue: 'fr' },
+        {
+            provide: DATE_TIME_FORMATS,
+            useValue: DAYJS_DATETIME_FORMATS
+        },
+        {
+            provide: DatetimeAdapter,
+            useClass: DayjsDatetimeAdapter
+        }
+    ]
 })
 export class DatePickerDayjsAdapterExampleComponent {
     @ViewChild(DatePickerComponent) datePicker: DatePickerComponent<Dayjs>;

--- a/libs/docs/core/dayjs-datetime-adapter/examples/dayjs-adapter-options-example.component.ts
+++ b/libs/docs/core/dayjs-datetime-adapter/examples/dayjs-adapter-options-example.component.ts
@@ -1,11 +1,18 @@
-import { Component } from '@angular/core';
-import { DatetimeAdapter } from '@fundamental-ngx/core/datetime';
-import { DAYJS_DATE_TIME_ADAPTER_OPTIONS, DayjsDatetimeAdapter } from '@fundamental-ngx/datetime-adapter';
+import { Component, LOCALE_ID } from '@angular/core';
+import { DATE_TIME_FORMATS, DatetimeAdapter } from '@fundamental-ngx/core/datetime';
+import {
+    DAYJS_DATE_TIME_ADAPTER_OPTIONS,
+    DAYJS_DATETIME_FORMATS,
+    DayjsDatetimeAdapter
+} from '@fundamental-ngx/datetime-adapter';
 
 @Component({
     selector: 'fd-dayjs-adapter-options-example',
     templateUrl: './dayjs-adapter-options-example.component.html',
     providers: [
+        // Note that this is usually provided in the root of your application.
+        // Due to the limit of this example we must provide it on this level.
+        { provide: DATE_TIME_FORMATS, useValue: DAYJS_DATETIME_FORMATS },
         { provide: DatetimeAdapter, useClass: DayjsDatetimeAdapter },
         { provide: DAYJS_DATE_TIME_ADAPTER_OPTIONS, useValue: { useUtc: true, strict: true } }
     ]


### PR DESCRIPTION
fixes none

Our doc application was working fine due to providing the adapter at a higher level and having that bleed in to all the examples, but the example code wasn't working in isolation on stackblitz or in a test project. This fixes that