### PR TITLE
fix: add focusAutoCapture to table popover

### DIFF
--- a/libs/docs/core/table/examples/table-column-sorting-example.component.html
+++ b/libs/docs/core/table/examples/table-column-sorting-example.component.html
@@ -65,7 +65,7 @@
     <thead fd-table-header>
         <tr fd-table-row>
             <th fd-table-cell>
-                <fd-popover fd-table-popover [(isOpen)]="open">
+                <fd-popover [focusAutoCapture]="true" [focusTrapped]="true" fd-table-popover [(isOpen)]="open">
                     <fd-popover-control>
                         <div fd-table-inner>
                             Column 1


### PR DESCRIPTION
fixes #10194 