### PR TITLE
chore(core,platform,cdk): replaced DestroyService usages with DestroyRef

### DIFF
--- a/libs/cdk/src/lib/data-source/data-source.directive.ts
+++ b/libs/cdk/src/lib/data-source/data-source.directive.ts
@@ -1,48 +1,17 @@
-import { Directive, EventEmitter, inject, Input, OnDestroy, Output } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { DestroyRef, Directive, EventEmitter, inject, Input, OnDestroy, Output } from '@angular/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { isDataSource } from './helpers/is-datasource';
 import { DataSource, DataSourceParser, DataSourceProvider } from './models';
 import { FD_DATA_SOURCE_TRANSFORMER } from './tokens';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Directive({
     selector: '[fdkDataSource]',
-    standalone: true,
-    providers: [DestroyedService]
+    standalone: true
 })
 export class DataSourceDirective<T = any, P extends DataSourceProvider<T> = DataSourceProvider<T>>
     implements OnDestroy
 {
-    /**
-     * Data source.
-     * @param source
-     */
-    @Input()
-    set dataSource(source: DataSource<T, P> | null) {
-        this._dataSource = source;
-        this._initializeDataSource();
-        this.dataSourceChanged.next();
-    }
-
-    get dataSource(): DataSource<T, P> | null {
-        return this._dataSource;
-    }
-
-    /** @hidden */
-    private _dataSource: DataSource<T, P> | null;
-
-    /** @hidden */
-    dataSourceProvider: P | undefined;
-
-    /** @hidden */
-    private _dsSubscription = new Subscription();
-
-    /**
-     * Data stream. Emits when new data retrieved.
-     */
-    readonly dataChanged$ = new BehaviorSubject<T[]>([]);
-
     /**
      * Emits when the data source object has been changed.
      */
@@ -61,11 +30,55 @@ export class DataSourceDirective<T = any, P extends DataSourceProvider<T> = Data
     @Output()
     readonly isLoading = new EventEmitter<boolean>();
 
+    /**
+     * Data source.
+     * @param source
+     */
+    @Input()
+    set dataSource(source: DataSource<T, P> | null) {
+        this._dataSource = source;
+        this._initializeDataSource();
+        this.dataSourceChanged.next();
+    }
+
+    get dataSource(): DataSource<T, P> | null {
+        return this._dataSource;
+    }
+
     /** @hidden */
-    protected readonly _destroyed$ = inject(DestroyedService);
+    dataSourceProvider: P | undefined;
+
+    /**
+     * Data stream. Emits when new data retrieved.
+     */
+    readonly dataChanged$ = new BehaviorSubject<T[]>([]);
+
+    /** @hidden */
+    protected readonly _destroyRef = inject(DestroyRef);
+
+    /** @hidden */
+    private _dataSource: DataSource<T, P> | null;
+
+    /** @hidden */
+    private _dsSubscription = new Subscription();
 
     /** @hidden */
     private readonly _dataSourceTransformer = inject<DataSourceParser<T, P>>(FD_DATA_SOURCE_TRANSFORMER);
+
+    /** @hidden */
+    ngOnDestroy(): void {
+        this.dataSourceProvider?.unsubscribe();
+        this._dsSubscription?.unsubscribe();
+    }
+
+    /** @Hidden */
+    protected _toDataStream(source: DataSource<T> | null): P | undefined {
+        return !source
+            ? undefined
+            : this._dataSourceTransformer
+            ? this._dataSourceTransformer.parse(source)
+            : undefined;
+    }
 
     /** @hidden */
     private _initializeDataSource(): void {
@@ -85,30 +98,15 @@ export class DataSourceDirective<T = any, P extends DataSourceProvider<T> = Data
 
         this._dsSubscription.add(
             this.dataSourceProvider.dataLoading
-                .pipe(takeUntil(this._destroyed$))
+                .pipe(takeUntilDestroyed(this._destroyRef))
                 .subscribe((isLoading) => this.isLoading.emit(isLoading))
         );
 
         this._dsSubscription.add(
-            this.dataSourceProvider.dataChanges.pipe(takeUntil(this._destroyed$)).subscribe((data) => {
+            this.dataSourceProvider.dataChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((data) => {
                 this.dataChanged.emit(data);
                 this.dataChanged$.next(data);
             })
         );
-    }
-
-    /** @hidden */
-    ngOnDestroy(): void {
-        this.dataSourceProvider?.unsubscribe();
-        this._dsSubscription?.unsubscribe();
-    }
-
-    /** @Hidden */
-    protected _toDataStream(source: DataSource<T> | null): P | undefined {
-        return !source
-            ? undefined
-            : this._dataSourceTransformer
-            ? this._dataSourceTransformer.parse(source)
-            : undefined;
     }
 }

--- a/libs/cdk/src/lib/forms/cva/cva-control.class.ts
+++ b/libs/cdk/src/lib/forms/cva/cva-control.class.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectorRef, inject, Injectable } from '@angular/core';
-import { takeUntil } from 'rxjs';
+import { ChangeDetectorRef, DestroyRef, inject, Injectable } from '@angular/core';
 import { CvaDirective } from './cva.directive';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /**
  * Base ControlValueAccessor control class.
@@ -25,15 +24,15 @@ export class CvaControl<T> {
     protected _changeDetector = inject(ChangeDetectorRef);
 
     /** @Hidden */
-    protected _destroy$ = inject(DestroyedService);
+    protected _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     listenToChanges(): void {
-        this.cvaDirective?.markForCheck.pipe(takeUntil(this._destroy$)).subscribe(() => {
+        this.cvaDirective?.markForCheck.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
             this._changeDetector.detectChanges();
         });
 
-        this.cvaDirective?.detectChanges.pipe(takeUntil(this._destroy$)).subscribe(() => {
+        this.cvaDirective?.detectChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
             this._changeDetector.detectChanges();
         });
     }

--- a/libs/cdk/src/lib/utils/directives/focusable-grid/focusable-grid.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-grid/focusable-grid.directive.ts
@@ -1,15 +1,28 @@
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { DOWN_ARROW, LEFT_ARROW, PAGE_DOWN, PAGE_UP, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
-import { AfterViewInit, ContentChildren, Directive, EventEmitter, Input, Output, QueryList } from '@angular/core';
-import { merge, startWith, switchMap, takeUntil } from 'rxjs';
+import {
+    AfterViewInit,
+    ContentChildren,
+    DestroyRef,
+    Directive,
+    EventEmitter,
+    Input,
+    Output,
+    QueryList
+} from '@angular/core';
+import { merge, startWith, switchMap } from 'rxjs';
 import { KeyUtil } from '../../functions';
 import { Nullable } from '../../models/nullable';
-import { DestroyedService } from '../../services';
 import { FocusableItemPosition } from '../focusable-item';
-import { FDK_FOCUSABLE_LIST_DIRECTIVE, FocusableListDirective, FocusableListPosition } from '../focusable-list';
+import {
+    FDK_FOCUSABLE_LIST_DIRECTIVE,
+    FocusableListDirective,
+    FocusableListPosition,
+    ScrollPosition
+} from '../focusable-list';
 import { findLastIndex } from 'lodash-es';
-import { ScrollPosition } from '../focusable-list';
 import { FDK_FOCUSABLE_GRID_DIRECTIVE } from './focusable-grid.tokens';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export interface FocusableCellPosition {
     rowIndex: number;
@@ -24,8 +37,7 @@ export interface FocusableCellPosition {
         {
             provide: FDK_FOCUSABLE_GRID_DIRECTIVE,
             useExisting: FocusableGridDirective
-        },
-        DestroyedService
+        }
     ]
 })
 export class FocusableGridDirective implements AfterViewInit {
@@ -63,12 +75,12 @@ export class FocusableGridDirective implements AfterViewInit {
     private readonly _focusableLists: QueryList<FocusableListDirective>;
 
     /** @hidden */
-    constructor(private readonly _destroy$: DestroyedService) {}
+    constructor(private readonly _destroyRef: DestroyRef) {}
 
     /** @hidden */
     ngAfterViewInit(): void {
         this._focusableLists.changes
-            .pipe(startWith(this._focusableLists), takeUntil(this._destroy$))
+            .pipe(startWith(this._focusableLists), takeUntilDestroyed(this._destroyRef))
             .subscribe((lists) =>
                 lists.forEach((list, index) =>
                     list._setGridPosition({ rowIndex: index, totalRows: this._focusableLists.length })
@@ -81,7 +93,7 @@ export class FocusableGridDirective implements AfterViewInit {
                 switchMap((queryList: QueryList<FocusableListDirective>) =>
                     merge(...queryList.toArray().map((list) => list._gridListFocused$))
                 ),
-                takeUntil(this._destroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((focusedEvent) => {
                 this.rowFocused.emit(focusedEvent);
@@ -96,7 +108,7 @@ export class FocusableGridDirective implements AfterViewInit {
                 switchMap((queryList: QueryList<FocusableListDirective>) =>
                     merge(...queryList.toArray().map((list) => list._gridItemFocused$))
                 ),
-                takeUntil(this._destroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((focusedEvent) => {
                 this.itemFocused.emit(focusedEvent);
@@ -111,7 +123,7 @@ export class FocusableGridDirective implements AfterViewInit {
                 switchMap((queryList: QueryList<FocusableListDirective>) =>
                     merge(...queryList.toArray().map((list) => list._keydown$))
                 ),
-                takeUntil(this._destroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe(({ event, list, activeItemIndex }) => this._onKeydown(event, list, activeItemIndex));
     }

--- a/libs/cdk/src/lib/utils/directives/focusable-list/focusable-list.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-list/focusable-list.directive.ts
@@ -2,6 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import {
     AfterViewInit,
     ContentChildren,
+    DestroyRef,
     Directive,
     ElementRef,
     EventEmitter,
@@ -18,7 +19,6 @@ import {
 } from '@angular/core';
 import { finalize, map, startWith, takeUntil, tap } from 'rxjs/operators';
 import { FocusableItemDirective, FocusableItemPosition } from '../focusable-item/focusable-item.directive';
-import { DestroyedService } from '../../services/destroyed.service';
 import {
     DeprecatedSelector,
     FD_DEPRECATED_DIRECTIVE_SELECTOR,
@@ -29,12 +29,13 @@ import { FDK_FOCUSABLE_LIST_DIRECTIVE } from './focusable-list.tokens';
 import { merge, Subject } from 'rxjs';
 import { Nullable } from '../../models/nullable';
 import { FocusableOption, FocusKeyManager, LiveAnnouncer } from '@angular/cdk/a11y';
-import { getNativeElement } from '../../helpers';
+import { destroyObservable, getNativeElement } from '../../helpers';
 import { HasElementRef } from '../../interfaces';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { intersectionObservable, KeyUtil } from '../../functions';
 import { ENTER, ESCAPE, F2, MAC_ENTER } from '@angular/cdk/keycodes';
 import { scrollIntoView, ScrollPosition } from './scroll';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export interface FocusableListPosition {
     rowIndex: number;
@@ -82,8 +83,7 @@ export class DeprecatedFocusableListDirective extends DeprecatedSelector {}
         {
             provide: FDK_FOCUSABLE_LIST_DIRECTIVE,
             useExisting: FocusableListDirective
-        },
-        DestroyedService
+        }
     ]
 })
 export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestroy {
@@ -97,9 +97,6 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
     get focusable(): boolean {
         return this._focusable;
     }
-
-    /** @hidden */
-    protected _focusable = false;
 
     /** Direction of navigation. Should be set to 'grid' when list is a part of grid. */
     @Input()
@@ -125,7 +122,7 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
 
     /** @hidden */
     @ContentChildren(FDK_FOCUSABLE_ITEM_DIRECTIVE, { descendants: true })
-    public readonly _projectedFocusableItems: QueryList<FocusableItemDirective>;
+    readonly _projectedFocusableItems: QueryList<FocusableItemDirective>;
 
     /** @hidden */
     get _focusableItems(): QueryList<FocusableItemDirective> {
@@ -136,13 +133,21 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
     _items: QueryList<FocusableItemDirective> | undefined;
 
     /** @hidden */
-    public readonly _gridItemFocused$ = new Subject<FocusableItemPosition>();
+    readonly _gridItemFocused$ = new Subject<FocusableItemPosition>();
 
     /** @hidden */
-    public readonly _gridListFocused$ = new Subject<FocusableListPosition>();
+    readonly _gridListFocused$ = new Subject<FocusableListPosition>();
 
     /** @hidden */
-    public readonly _keydown$ = new Subject<FocusableListKeydownEvent>();
+    readonly _keydown$ = new Subject<FocusableListKeydownEvent>();
+    /** @hidden */
+    _isVisible = false;
+
+    /** @hidden */
+    protected _focusable = false;
+
+    /** @hidden */
+    protected readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     private _gridPosition: { rowIndex: number; totalRows: number };
@@ -155,20 +160,17 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
 
     /** @hidden */
     private readonly _refreshItems$ = new Subject<void>();
-
     /** @hidden */
     private readonly _refresh$ = new Subject<void>();
-
     /** @hidden */
     private readonly _renderer = inject(Renderer2);
-    /** @hidden */
-    protected readonly _destroy$ = inject(DestroyedService);
     /** @hidden */
     private readonly _elementRef: ElementRef<HTMLElement> = inject(ElementRef);
     /** @hidden */
     private readonly _liveAnnouncer = inject(LiveAnnouncer);
     /** @hidden */
     private readonly _focusableObserver = inject(FocusableObserver);
+
     /** @hidden */
     private readonly _document = inject(DOCUMENT);
 
@@ -179,83 +181,19 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
     }
 
     /** @hidden */
-    _isVisible = false;
-
-    /** @hidden */
     constructor() {
         intersectionObservable(this._elementRef.nativeElement, { threshold: 0.25 })
-            .pipe(takeUntil(this._destroy$))
+            .pipe(takeUntilDestroyed())
             .subscribe((isVisible) => (this._isVisible = isVisible[0]?.isIntersecting));
 
         this._focusableObserver
             .observe(this._elementRef, false)
-            .pipe(takeUntil(this._destroy$))
+            .pipe(takeUntilDestroyed())
             .subscribe((isFocusable) => {
                 if (!isFocusable && isFocusable !== this.focusable) {
                     this.focusable = isFocusable;
                 }
             });
-    }
-
-    /** @hidden */
-    ngOnChanges(changes: SimpleChanges): void {
-        if (!this._keyManager) {
-            return;
-        }
-
-        if (changes['wrap']) {
-            this._keyManager = this._keyManager.withWrap(changes['wrap'].currentValue);
-        }
-
-        if (changes['navigationDirection']) {
-            this._updateNavigationDirection();
-        }
-    }
-
-    /** @hidden */
-    ngAfterViewInit(): void {
-        this._listenOnItems();
-    }
-
-    /** Set items programmatically. */
-    setItems(items: QueryList<FocusableItemDirective>): void {
-        this._items = items;
-        this._listenOnItems();
-    }
-
-    /** @hidden */
-    private _listenOnItems(): void {
-        const refresh$ = merge(this._refresh$, this._destroy$);
-        this._refresh$.next();
-        this._focusableItems.changes
-            .pipe(
-                startWith(null),
-                map(() => this._focusableItems.toArray()),
-                tap((items: FocusableItemDirective[]): void => {
-                    const focusableItems: FocusableItem[] = items.map((item, index) => ({
-                        index,
-                        focusable: () => item.fdkFocusableItem,
-                        elementRef: item.elementRef,
-                        focus: () => item.elementRef.nativeElement.focus(),
-                        keydown: item._keydown$
-                    }));
-
-                    const direction = this.navigationDirection === 'grid' ? 'horizontal' : this.navigationDirection;
-
-                    this._initializeFocusManager(focusableItems, this, {
-                        direction,
-                        contentDirection: this.contentDirection,
-                        wrap: this.wrap
-                    });
-                }),
-                takeUntil(refresh$)
-            )
-            .subscribe();
-    }
-
-    /** @hidden */
-    ngOnDestroy(): void {
-        this._keyManager?.destroy();
     }
 
     /** @hidden */
@@ -286,6 +224,50 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
         }
 
         this._keydown$.next({ list: this, event, activeItemIndex: this._keyManager?.activeItemIndex ?? null });
+    }
+
+    /** @hidden */
+    @HostListener('focus')
+    async _onFocus(): Promise<void> {
+        if (this._gridPosition) {
+            this._gridListFocused$.next(this._gridPosition);
+
+            this._liveAnnouncer.clear();
+            await this._liveAnnouncer.announce(this.listFocusedEventAnnouncer(this._gridPosition));
+
+            this.setTabbable(true);
+        }
+    }
+
+    /** @hidden */
+    ngOnChanges(changes: SimpleChanges): void {
+        if (!this._keyManager) {
+            return;
+        }
+
+        if (changes['wrap']) {
+            this._keyManager = this._keyManager.withWrap(changes['wrap'].currentValue);
+        }
+
+        if (changes['navigationDirection']) {
+            this._updateNavigationDirection();
+        }
+    }
+
+    /** @hidden */
+    ngAfterViewInit(): void {
+        this._listenOnItems();
+    }
+
+    /** Set items programmatically. */
+    setItems(items: QueryList<FocusableItemDirective>): void {
+        this._items = items;
+        this._listenOnItems();
+    }
+
+    /** @hidden */
+    ngOnDestroy(): void {
+        this._keyManager?.destroy();
     }
 
     /** Set active item in list */
@@ -321,19 +303,6 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
     }
 
     /** @hidden */
-    @HostListener('focus')
-    async _onFocus(): Promise<void> {
-        if (this._gridPosition) {
-            this._gridListFocused$.next(this._gridPosition);
-
-            this._liveAnnouncer.clear();
-            await this._liveAnnouncer.announce(this.listFocusedEventAnnouncer(this._gridPosition));
-
-            this.setTabbable(true);
-        }
-    }
-
-    /** @hidden */
     _updateNavigationDirection(): void {
         if (!this._keyManager) {
             return;
@@ -358,7 +327,7 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
         this._gridPosition = position;
 
         this._focusableItems.changes
-            .pipe(startWith(this._focusableItems), takeUntil(this._destroy$))
+            .pipe(startWith(this._focusableItems), takeUntilDestroyed(this._destroyRef))
             .subscribe((items) =>
                 items.forEach(
                     (item, index) =>
@@ -372,11 +341,7 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
     }
 
     /** @hidden */
-    private _initializeFocusManager(
-        items: FocusableItem[],
-        list: FocusableListDirective,
-        config: FocusableListConfig = {}
-    ): void {
+    private _initializeFocusManager(items: FocusableItem[], config: FocusableListConfig = {}): void {
         this._refreshItems$.next();
 
         let keyManager = new FocusKeyManager<any>(items).withHomeAndEnd();
@@ -423,8 +388,38 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
 
                     this._keyManager?.onKeydown(event);
                 }),
-                takeUntil(merge(this._refreshItems$, this._destroy$)),
+                takeUntil(merge(this._refreshItems$, destroyObservable(this._destroyRef))),
                 finalize(() => focusListenerDestroyers.forEach((d) => d()))
+            )
+            .subscribe();
+    }
+
+    /** @hidden */
+    private _listenOnItems(): void {
+        const refresh$ = merge(this._refresh$, destroyObservable(this._destroyRef));
+        this._refresh$.next();
+        this._focusableItems.changes
+            .pipe(
+                startWith(null),
+                map(() => this._focusableItems.toArray()),
+                tap((items: FocusableItemDirective[]): void => {
+                    const focusableItems: FocusableItem[] = items.map((item, index) => ({
+                        index,
+                        focusable: () => item.fdkFocusableItem,
+                        elementRef: item.elementRef,
+                        focus: () => item.elementRef.nativeElement.focus(),
+                        keydown: item._keydown$
+                    }));
+
+                    const direction = this.navigationDirection === 'grid' ? 'horizontal' : this.navigationDirection;
+
+                    this._initializeFocusManager(focusableItems, {
+                        direction,
+                        contentDirection: this.contentDirection,
+                        wrap: this.wrap
+                    });
+                }),
+                takeUntil(refresh$)
             )
             .subscribe();
     }

--- a/libs/cdk/src/lib/utils/directives/intersection-spy/intersection-spy.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/intersection-spy/intersection-spy.directive.ts
@@ -1,14 +1,13 @@
-import { Directive, ElementRef, EventEmitter, inject, Input, Output } from '@angular/core';
-import { map, takeUntil } from 'rxjs';
+import { DestroyRef, Directive, ElementRef, EventEmitter, inject, Input, OnInit, Output } from '@angular/core';
+import { map } from 'rxjs';
 import { intersectionObservable } from '../../functions';
-import { DestroyedService } from '../../services';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Directive({
     selector: '[fdkIntersectionSpy]',
-    standalone: true,
-    providers: [DestroyedService]
+    standalone: true
 })
-export class IntersectionSpyDirective {
+export class IntersectionSpyDirective implements OnInit {
     /** Intersection offset in px. */
     @Input('fdkIntersectionSpy')
     offset = 20;
@@ -21,7 +20,7 @@ export class IntersectionSpyDirective {
     intersected = new EventEmitter<boolean>();
 
     /** @hidden */
-    private readonly _destroy$ = inject(DestroyedService);
+    private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     private readonly _elementRef = inject(ElementRef);
@@ -31,7 +30,7 @@ export class IntersectionSpyDirective {
         intersectionObservable(this._elementRef.nativeElement, this.viewportOptions)
             .pipe(
                 map((entries) => entries[0]),
-                takeUntil(this._destroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((entry) => {
                 this.intersected.emit(entry.isIntersecting);

--- a/libs/cdk/src/lib/utils/helpers/destroy-observable.ts
+++ b/libs/cdk/src/lib/utils/helpers/destroy-observable.ts
@@ -1,0 +1,12 @@
+import { DestroyRef, inject } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+
+/**
+ * Creates an observable that emits when the component is destroyed.
+ * @param destroyRef
+ */
+export const destroyObservable = (destroyRef = inject(DestroyRef)): Observable<void> => {
+    const destroy$ = new Subject<void>();
+    destroyRef.onDestroy(() => destroy$.next());
+    return destroy$.asObservable();
+};

--- a/libs/cdk/src/lib/utils/helpers/index.ts
+++ b/libs/cdk/src/lib/utils/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './range-selector';
 export * from './get-native-element';
+export * from './destroy-observable';

--- a/libs/cdk/src/lib/utils/services/destroyed.service.ts
+++ b/libs/cdk/src/lib/utils/services/destroyed.service.ts
@@ -1,11 +1,18 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { ReplaySubject } from 'rxjs';
 
+/**
+ * @deprecated Use Angular's built-in `DestroyRef` and `takeUntilDestroyed` instead.
+ * Will be removed in next release
+ */
 @Injectable()
 export class DestroyedService extends ReplaySubject<void> implements OnDestroy {
     /** @hidden */
     constructor() {
         super(1);
+        console.warn(
+            `DestroyedService is deprecated. Use Angular's built-in 'DestroyRef' and 'takeUntilDestroyed' instead.`
+        );
     }
 
     /** @hidden */

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -4,6 +4,7 @@ import {
     ChangeDetectorRef,
     Component,
     ContentChildren,
+    DestroyRef,
     ElementRef,
     EventEmitter,
     Input,
@@ -16,12 +17,13 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { OverflowLayoutComponent } from '@fundamental-ngx/core/overflow-layout';
-import { DestroyedService, RtlService } from '@fundamental-ngx/cdk/utils';
-import { BehaviorSubject, takeUntil } from 'rxjs';
+import { RtlService } from '@fundamental-ngx/cdk/utils';
+import { BehaviorSubject } from 'rxjs';
 import { MenuComponent } from '@fundamental-ngx/core/menu';
 import { Placement } from '@fundamental-ngx/core/shared';
 import { BreadcrumbItemComponent } from './breadcrumb-item.component';
 import { FD_BREADCRUMB_COMPONENT, FD_BREADCRUMB_ITEM_COMPONENT } from './tokens';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /**
  * Breadcrumb parent wrapper directive. Must have breadcrumb item child directives.
@@ -45,7 +47,6 @@ import { FD_BREADCRUMB_COMPONENT, FD_BREADCRUMB_ITEM_COMPONENT } from './tokens'
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
-        DestroyedService,
         {
             provide: FD_BREADCRUMB_COMPONENT,
             useExisting: BreadcrumbComponent
@@ -113,7 +114,7 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     /** @hidden */
     constructor(
         public elementRef: ElementRef<HTMLElement>,
-        private _onDestroy$: DestroyedService,
+        private _destroyRef: DestroyRef,
         @Optional() private _rtlService: RtlService | null,
         private _cdr: ChangeDetectorRef
     ) {}
@@ -121,7 +122,7 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     /** @hidden */
     ngOnInit(): void {
         this._rtlService?.rtl
-            .pipe(takeUntil(this._onDestroy$))
+            .pipe(takeUntilDestroyed(this._destroyRef))
             .subscribe((value) => this._placement$.next(value ? 'bottom-end' : 'bottom-start'));
     }
 

--- a/libs/core/src/lib/content-density/providers/content-density-observer-providers.ts
+++ b/libs/core/src/lib/content-density/providers/content-density-observer-providers.ts
@@ -1,11 +1,11 @@
 import { Provider } from '@angular/core';
-import { consumerProviderFactory, DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { consumerProviderFactory } from '@fundamental-ngx/cdk/utils';
 import { ContentDensityObserver } from '../services/content-density-observer.service';
 import { ContentDensityObserverSettings } from '../classes/content-density-observer.settings';
 
 /**
- * Creates provider for ContentDensityObserver and adds DestroyedService provider
+ * Creates provider for ContentDensityObserver
  */
 export function contentDensityObserverProviders(params?: ContentDensityObserverSettings): Provider[] {
-    return [DestroyedService, consumerProviderFactory(ContentDensityObserver, params)];
+    return [consumerProviderFactory(ContentDensityObserver, params)];
 }

--- a/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
+++ b/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
@@ -5,6 +5,7 @@ import {
     ChangeDetectorRef,
     Component,
     ComponentRef,
+    DestroyRef,
     ElementRef,
     EmbeddedViewRef,
     HostBinding,
@@ -18,13 +19,7 @@ import {
 } from '@angular/core';
 import { AnimationEvent } from '@angular/animations';
 
-import {
-    applyCssClass,
-    CssClassBuilder,
-    DestroyedService,
-    DynamicComponentContainer,
-    Nullable
-} from '@fundamental-ngx/cdk/utils';
+import { applyCssClass, CssClassBuilder, DynamicComponentContainer, Nullable } from '@fundamental-ngx/cdk/utils';
 
 import { DialogRef } from '../utils/dialog-ref.class';
 import { DialogConfig } from '../utils/dialog-config.class';
@@ -33,7 +28,7 @@ import { DialogDefaultContent } from '../utils/dialog-default-content.class';
 import { DialogContentType } from '../dialog.types';
 import { dialogFade } from '../utils/dialog.animations';
 import { CdkPortalOutlet, CdkPortalOutletAttachedRef } from '@angular/cdk/portal';
-import { takeUntil } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /** Dialog container where the dialog content is embedded. */
 @Component({
@@ -41,7 +36,6 @@ import { takeUntil } from 'rxjs';
     template: '<ng-template (attached)="_attached($event)" cdkPortalOutlet></ng-template>',
     styleUrls: ['./dialog-container.component.scss'],
     animations: [dialogFade],
-    providers: [DestroyedService],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DialogContainerComponent
@@ -70,7 +64,7 @@ export class DialogContainerComponent
     constructor(
         public dialogConfig: DialogConfig,
         private _dialogRef: DialogRef,
-        private _destroy$: DestroyedService,
+        private _destroyRef: DestroyRef,
         elementRef: ElementRef,
         changeDetectorRef: ChangeDetectorRef,
         injector: Injector
@@ -157,7 +151,7 @@ export class DialogContainerComponent
             this._animationState = 'hidden';
             this._cdr.detectChanges();
         };
-        this._dialogRef.afterClosed.pipe(takeUntil(this._destroy$)).subscribe({
+        this._dialogRef.afterClosed.pipe(takeUntilDestroyed(this._destroyRef)).subscribe({
             next: () => callback(),
             error: () => callback()
         });

--- a/libs/core/src/lib/message-box/message-box-container/message-box-container.component.ts
+++ b/libs/core/src/lib/message-box/message-box-container/message-box-container.component.ts
@@ -3,6 +3,7 @@ import {
     ChangeDetectorRef,
     Component,
     ComponentRef,
+    DestroyRef,
     ElementRef,
     EmbeddedViewRef,
     HostBinding,
@@ -14,10 +15,7 @@ import {
     ViewChild
 } from '@angular/core';
 import { AnimationEvent } from '@angular/animations';
-import { applyCssClass, DestroyedService } from '@fundamental-ngx/cdk/utils';
-import { CssClassBuilder } from '@fundamental-ngx/cdk/utils';
-import { DynamicComponentContainer } from '@fundamental-ngx/cdk/utils';
-import { takeUntil } from 'rxjs';
+import { applyCssClass, CssClassBuilder, DynamicComponentContainer } from '@fundamental-ngx/cdk/utils';
 import { MessageBoxConfig } from '../utils/message-box-config.class';
 import { MessageBoxRef } from '../utils/message-box-ref.class';
 import { MessageBoxContent } from '../utils/message-box-content.class';
@@ -25,13 +23,13 @@ import { MessageBoxDefaultComponent } from '../message-box-default/message-box-d
 import { MessageBoxContentType } from '../message-box-content.type';
 import { CdkPortalOutlet, CdkPortalOutletAttachedRef } from '@angular/cdk/portal';
 import { dialogFade } from '@fundamental-ngx/core/dialog';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /** Message box container where the message box content is embedded. */
 @Component({
     selector: 'fd-message-box-container',
     template: '<ng-template (attached)="_attached($event)" cdkPortalOutlet></ng-template>',
-    animations: [dialogFade],
-    providers: [DestroyedService]
+    animations: [dialogFade]
 })
 export class MessageBoxContainerComponent
     extends DynamicComponentContainer<MessageBoxContentType>
@@ -59,7 +57,7 @@ export class MessageBoxContainerComponent
     constructor(
         public messageBoxConfig: MessageBoxConfig,
         private _messageBoxRef: MessageBoxRef,
-        private _destroy$: DestroyedService,
+        private _destroyRef: DestroyRef,
         elementRef: ElementRef,
         changeDetectorRef: ChangeDetectorRef,
         injector: Injector
@@ -135,7 +133,7 @@ export class MessageBoxContainerComponent
             this._animationState = 'hidden';
             this._cdr.detectChanges();
         };
-        this._messageBoxRef.afterClosed.pipe(takeUntil(this._destroy$)).subscribe({
+        this._messageBoxRef.afterClosed.pipe(takeUntilDestroyed(this._destroyRef)).subscribe({
             next: () => callback(),
             error: () => callback()
         });

--- a/libs/core/src/lib/message-strip/alert/message-strip-alert-container-footer/message-strip-alert-container-footer.component.ts
+++ b/libs/core/src/lib/message-strip/alert/message-strip-alert-container-footer/message-strip-alert-container-footer.component.ts
@@ -1,11 +1,11 @@
-import { AfterViewInit, Component, inject, Injector, Input } from '@angular/core';
+import { AfterViewInit, Component, DestroyRef, inject, Injector, Input } from '@angular/core';
 import { MessageStripAlertService } from '../message-strip-alert.service';
-import { DestroyedService, Nullable } from '@fundamental-ngx/cdk/utils';
-import { takeUntil } from 'rxjs/operators';
+import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { BehaviorSubject, map, tap } from 'rxjs';
 import { ComponentPortal, PortalModule } from '@angular/cdk/portal';
 import { MessageStripAlertRef } from '../message-strip-alert.ref';
 import { MessageStripAlertContainerAlertRefs, MessageStripAlertContainerPosition } from '../tokens';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /**
  * The component that represents the footer of the message strip alert container.
@@ -25,8 +25,7 @@ import { MessageStripAlertContainerAlertRefs, MessageStripAlertContainerPosition
         `
     ],
     standalone: true,
-    imports: [PortalModule],
-    providers: [DestroyedService]
+    imports: [PortalModule]
 })
 export class MessageStripAlertContainerFooterComponent implements AfterViewInit {
     /** @hidden */
@@ -46,7 +45,7 @@ export class MessageStripAlertContainerFooterComponent implements AfterViewInit 
     private position = inject(MessageStripAlertContainerPosition);
 
     /** @hidden */
-    private destroyed = inject(DestroyedService);
+    private _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     private messageStripAlertService = inject(MessageStripAlertService);
@@ -70,7 +69,7 @@ export class MessageStripAlertContainerFooterComponent implements AfterViewInit 
                                 providers: [
                                     {
                                         provide: MessageStripAlertContainerAlertRefs,
-                                        useValue: this.alertRefs$.pipe(takeUntil(this.destroyed))
+                                        useValue: this.alertRefs$.pipe(takeUntilDestroyed(this._destroyRef))
                                     }
                                 ]
                             })
@@ -79,7 +78,7 @@ export class MessageStripAlertContainerFooterComponent implements AfterViewInit 
                         this.footerComponentPortal = undefined;
                     }
                 }),
-                takeUntil(this.destroyed)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe();
     }

--- a/libs/core/src/lib/multi-combobox/select-all-toggler/select-all-toggler.component.ts
+++ b/libs/core/src/lib/multi-combobox/select-all-toggler/select-all-toggler.component.ts
@@ -2,15 +2,16 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    DestroyRef,
     HostListener,
     inject,
     Input,
     OnInit,
     ViewEncapsulation
 } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
-import { Observable, takeUntil } from 'rxjs';
+import { Observable } from 'rxjs';
 import { ListFocusItem } from '@fundamental-ngx/core/list';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fd-multi-combobox-select-all-toggler',
@@ -31,8 +32,7 @@ import { ListFocusItem } from '@fundamental-ngx/core/list';
         {
             provide: ListFocusItem,
             useExisting: SelectAllTogglerComponent
-        },
-        DestroyedService
+        }
     ],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -78,7 +78,7 @@ export class SelectAllTogglerComponent extends ListFocusItem implements OnInit {
     }
 
     /** @hidden */
-    private destroy$ = inject(DestroyedService);
+    private _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     private changeDetector: ChangeDetectorRef = inject(ChangeDetectorRef);
@@ -101,7 +101,7 @@ export class SelectAllTogglerComponent extends ListFocusItem implements OnInit {
     /** @hidden */
     ngOnInit(): void {
         this.tabindex = 0;
-        this.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+        this.valueChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
             this.changeDetector.detectChanges();
         });
     }

--- a/libs/core/src/lib/overflow-layout/directives/overflow-layout-popover-content.directive.ts
+++ b/libs/core/src/lib/overflow-layout/directives/overflow-layout-popover-content.directive.ts
@@ -1,21 +1,20 @@
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, TAB, UP_ARROW } from '@angular/cdk/keycodes';
 import { Directive, HostBinding, HostListener, Inject, Input, OnDestroy, Optional } from '@angular/core';
-import { DestroyedService, KeyUtil, RtlService } from '@fundamental-ngx/cdk/utils';
-import { takeUntil } from 'rxjs';
+import { KeyUtil, RtlService } from '@fundamental-ngx/cdk/utils';
 import { OverflowContainer } from '../interfaces/overflow-container.interface';
 import { OverflowLayoutFocusableItem } from '../interfaces/overflow-focusable-item.interface';
 import { OverflowPopoverContent } from '../interfaces/overflow-popover-content.interface';
 import { OverflowItemRef } from '../interfaces/overflow-item-ref.interface';
 import { FD_OVERFLOW_CONTAINER } from '../tokens/overflow-container.token';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /**
  * Directive to wrap Overlay Layout "More" popover content.
  * Used to apply keyboard navigation through the items.
  */
 @Directive({
-    selector: '[fdOverflowLayoutPopoverContent]',
-    providers: [DestroyedService]
+    selector: '[fdOverflowLayoutPopoverContent]'
 })
 export class OverflowLayoutPopoverContentDirective implements OverflowPopoverContent, OnDestroy {
     /**
@@ -38,14 +37,14 @@ export class OverflowLayoutPopoverContentDirective implements OverflowPopoverCon
     }
 
     /** @hidden */
+    @HostBinding('class')
+    private readonly _initialClass = 'fd-overflow-layout__popover-container';
+
+    /** @hidden */
     private _keyboardEventsManager: FocusKeyManager<OverflowLayoutFocusableItem>;
 
     /** @hidden */
     private _items: OverflowItemRef[];
-
-    /** @hidden */
-    @HostBinding('class')
-    private readonly _initialClass = 'fd-overflow-layout__popover-container';
 
     /** @hidden */
     private _dir: 'ltr' | 'rtl' = 'ltr';
@@ -53,12 +52,11 @@ export class OverflowLayoutPopoverContentDirective implements OverflowPopoverCon
     /** @hidden */
     constructor(
         @Inject(FD_OVERFLOW_CONTAINER) private _overflowContainer: OverflowContainer,
-        @Optional() private _rtl: RtlService,
-        private readonly _onDestroy$: DestroyedService
+        @Optional() private _rtl: RtlService
     ) {
         this._overflowContainer?.registerPopoverContent(this);
 
-        this._rtl?.rtl.pipe(takeUntil(this._onDestroy$)).subscribe((rtl) => {
+        this._rtl?.rtl.pipe(takeUntilDestroyed()).subscribe((rtl) => {
             this._dir = rtl ? 'rtl' : 'ltr';
             if (this._keyboardEventsManager) {
                 this._keyboardEventsManager = this._keyboardEventsManager.withHorizontalOrientation(this._dir);

--- a/libs/core/src/lib/split-button/split-button.component.ts
+++ b/libs/core/src/lib/split-button/split-button.component.ts
@@ -5,6 +5,7 @@ import {
     ChangeDetectorRef,
     Component,
     ContentChild,
+    DestroyRef,
     ElementRef,
     EventEmitter,
     Input,
@@ -17,7 +18,7 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import { Subscription, takeUntil, tap } from 'rxjs';
+import { Subscription, tap } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { ButtonType } from '@fundamental-ngx/core/button';
 import { MenuComponent, MenuItemComponent } from '@fundamental-ngx/core/menu';
@@ -25,7 +26,7 @@ import { MenuComponent, MenuItemComponent } from '@fundamental-ngx/core/menu';
 import { SplitButtonActionTitle } from './split-button-utils/split-button.directives';
 import { MainAction } from './main-action';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export const splitButtonTextClass = 'fd-button-split__text';
 const splitButtonTextClasses = [splitButtonTextClass];
@@ -150,7 +151,7 @@ export class SplitButtonComponent implements AfterContentInit, OnChanges, OnDest
     /** @hidden */
     constructor(
         private _cdRef: ChangeDetectorRef,
-        private _destroy$: DestroyedService,
+        private _destroyRef: DestroyRef,
         private _contentDensityObserver: ContentDensityObserver,
         private _renderer: Renderer2
     ) {}
@@ -195,7 +196,7 @@ export class SplitButtonComponent implements AfterContentInit, OnChanges, OnDest
     /** @hidden */
     ngAfterViewInit(): void {
         this._contentDensityObserver.isCompact$
-            .pipe(tap(this._addButtonTextClass), takeUntil(this._destroy$))
+            .pipe(tap(this._addButtonTextClass), takeUntilDestroyed(this._destroyRef))
             .subscribe();
     }
 

--- a/libs/core/src/lib/table/directives/table-cell.directive.ts
+++ b/libs/core/src/lib/table/directives/table-cell.directive.ts
@@ -1,6 +1,6 @@
-import { AfterContentInit, Directive, HostBinding, Input, QueryList, ContentChildren } from '@angular/core';
+import { AfterContentInit, ContentChildren, Directive, HostBinding, Input, QueryList } from '@angular/core';
 import { CheckboxComponent, FD_CHECKBOX_COMPONENT } from '@fundamental-ngx/core/checkbox';
-import { DestroyedService, FDK_FOCUSABLE_ITEM_DIRECTIVE, FocusableItemDirective } from '@fundamental-ngx/cdk/utils';
+import { FDK_FOCUSABLE_ITEM_DIRECTIVE, FocusableItemDirective } from '@fundamental-ngx/cdk/utils';
 import { BooleanInput } from '@angular/cdk/coercion';
 
 @Directive({
@@ -13,8 +13,7 @@ import { BooleanInput } from '@angular/cdk/coercion';
         {
             provide: FDK_FOCUSABLE_ITEM_DIRECTIVE,
             useExisting: TableCellDirective
-        },
-        DestroyedService
+        }
     ]
 })
 export class TableCellDirective extends FocusableItemDirective implements AfterContentInit {

--- a/libs/core/src/lib/table/directives/table-row.directive.ts
+++ b/libs/core/src/lib/table/directives/table-row.directive.ts
@@ -17,7 +17,7 @@ import { startWith } from 'rxjs/operators';
 import { TableService } from '../table.service';
 import { TableCellDirective } from './table-cell.directive';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
-import { DestroyedService, FDK_FOCUSABLE_LIST_DIRECTIVE, FocusableListDirective } from '@fundamental-ngx/cdk/utils';
+import { FDK_FOCUSABLE_LIST_DIRECTIVE, FocusableListDirective } from '@fundamental-ngx/cdk/utils';
 
 export const HIDDEN_CLASS_NAME = 'fd-table--hidden';
 
@@ -27,8 +27,7 @@ export const HIDDEN_CLASS_NAME = 'fd-table--hidden';
         {
             provide: FDK_FOCUSABLE_LIST_DIRECTIVE,
             useExisting: TableRowDirective
-        },
-        DestroyedService
+        }
     ]
 })
 export class TableRowDirective extends FocusableListDirective implements AfterViewInit, OnDestroy, OnInit {
@@ -83,19 +82,14 @@ export class TableRowDirective extends FocusableListDirective implements AfterVi
     active = false;
 
     /** @hidden */
-    private _propagateKeysSubscription: Subscription;
+    elementRef: ElementRef<HTMLTableRowElement> = inject(ElementRef);
 
+    /** @hidden */
+    private _propagateKeysSubscription: Subscription;
     /** @hidden */
     private readonly _changeDetRef = inject(ChangeDetectorRef);
     /** @hidden */
     private _tableService = inject(TableService);
-    /** @hidden */
-    public elementRef: ElementRef<HTMLTableRowElement> = inject(ElementRef);
-
-    /** @hidden */
-    constructor() {
-        super();
-    }
 
     /** @hidden */
     ngOnInit(): void {

--- a/libs/core/src/lib/table/table.component.ts
+++ b/libs/core/src/lib/table/table.component.ts
@@ -4,6 +4,7 @@ import {
     ChangeDetectionStrategy,
     Component,
     ContentChildren,
+    DestroyRef,
     HostBinding,
     Input,
     NgZone,
@@ -16,10 +17,11 @@ import {
     ContentDensityObserver,
     contentDensityObserverProviders
 } from '@fundamental-ngx/core/content-density';
-import { DestroyedService, FocusableGridDirective } from '@fundamental-ngx/cdk/utils';
+import { FocusableGridDirective } from '@fundamental-ngx/cdk/utils';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
-import { first, startWith, takeUntil } from 'rxjs';
+import { first, startWith } from 'rxjs';
 import { TableCellDirective } from './directives/table-cell.directive';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export const FdTableContentDensityProviderParams = {
     supportedContentDensity: [ContentDensityMode.COMPACT, ContentDensityMode.CONDENSED, ContentDensityMode.COZY]
@@ -103,7 +105,7 @@ export class TableComponent implements AfterContentInit, AfterViewInit {
     constructor(
         private readonly _tableService: TableService,
         private readonly _contentDensityObserver: ContentDensityObserver,
-        private readonly _destroy$: DestroyedService,
+        private readonly _destroyRef: DestroyRef,
         private readonly _ngZone: NgZone
     ) {
         this._contentDensityObserver.subscribe();
@@ -112,7 +114,7 @@ export class TableComponent implements AfterContentInit, AfterViewInit {
     /** @hidden */
     ngAfterContentInit(): void {
         this._cells.changes
-            .pipe(startWith(this._cells), takeUntil(this._destroy$))
+            .pipe(startWith(this._cells), takeUntilDestroyed(this._destroyRef))
             .subscribe(() => this._updateCells());
     }
 

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -5,6 +5,7 @@ import {
     ChangeDetectorRef,
     Component,
     ContentChildren,
+    DestroyRef,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -18,8 +19,8 @@ import {
 } from '@angular/core';
 import { OverflowLayoutComponent } from '@fundamental-ngx/core/overflow-layout';
 import { fromEvent, merge, Observable, Subject, Subscription } from 'rxjs';
-import { debounceTime, delay, filter, first, map, startWith, switchMap, takeUntil } from 'rxjs/operators';
-import { DestroyedService, KeyUtil, scrollTop } from '@fundamental-ngx/cdk/utils';
+import { debounceTime, delay, filter, first, map, startWith, switchMap } from 'rxjs/operators';
+import { KeyUtil, Nullable, scrollTop } from '@fundamental-ngx/cdk/utils';
 import { TabItemExpandComponent } from './tab-item-expand/tab-item-expand.component';
 import { TabLinkDirective } from './tab-link/tab-link.directive';
 import { TabItemDirective } from './tab-item/tab-item.directive';
@@ -27,10 +28,10 @@ import { TabPanelComponent } from './tab-panel/tab-panel.component';
 import { TabInfo } from './tab-utils/tab-info.class';
 import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { MenuComponent } from '@fundamental-ngx/core/menu';
-import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { LIST_COMPONENT } from './tab-list.token';
 import { TabListComponentInterface } from './tab-list-component.interface';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export type TabModes = 'icon-only' | 'process' | 'filter';
 
@@ -50,7 +51,6 @@ export type TabSizes = 's' | 'm' | 'l' | 'xl' | 'xxl';
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
         contentDensityObserverProviders(),
-        DestroyedService,
         {
             provide: LIST_COMPONENT,
             useExisting: forwardRef(() => TabListComponent)
@@ -176,7 +176,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
         private readonly _changeDetectorRef: ChangeDetectorRef,
         private _elRef: ElementRef,
         readonly _contentDensityObserver: ContentDensityObserver,
-        private readonly _onDestroy$: DestroyedService
+        private readonly _destroyRef: DestroyRef
     ) {}
 
     /** @hidden */
@@ -247,7 +247,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
         return this.tabPanels.changes.pipe(
             startWith(this.tabPanels),
             map((tabPanels) => tabPanels.toArray()),
-            takeUntil(this._onDestroy$)
+            takeUntilDestroyed(this._destroyRef)
         );
     }
 
@@ -272,7 +272,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
             .pipe(
                 filter(() => this.stackContent),
                 delay(0),
-                takeUntil(this._onDestroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe(() =>
                 this._tabArray.filter((tab) => !tab.panel.disabled).forEach((tab) => tab.panel._expand(true))
@@ -284,7 +284,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
         this._tabPanelsChange$
             .pipe(
                 map((tabPanels) => tabPanels.map((el) => new TabInfo(el))),
-                takeUntil(this._onDestroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((tabs) => {
                 this._tabArray = tabs;
@@ -297,14 +297,14 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
             .pipe(
                 map((tabPanels) => tabPanels.map((tab) => tab._expandedStateChange.asObservable())),
                 switchMap((tabPanels) => merge(...tabPanels)),
-                takeUntil(this._onDestroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((event) => this._expandTab(event.target, event.state));
     }
 
     /** @hidden */
     private _listenOnTabPanelsAndInitiallyExpandTabPanel(): void {
-        this._tabPanelsChange$.pipe(takeUntil(this._onDestroy$)).subscribe(() => {
+        this._tabPanelsChange$.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
             const activeTab = this._tabArray.find((_tab) => _tab.active);
             let tab: Nullable<TabInfo>;
 
@@ -327,7 +327,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
     /** @hidden */
     private _listenOnPropertiesChange(): void {
         merge(this.tabPanelPropertyChanged, this.tabPanels.changes)
-            .pipe(takeUntil(this._onDestroy$))
+            .pipe(takeUntilDestroyed(this._destroyRef))
             .subscribe(() => this._detectChanges());
     }
 
@@ -383,7 +383,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
         if (!(currentScrollPosition === maximumScrollTop && distanceToScroll > maximumScrollTop)) {
             !this._init ? (this._disableScrollSpy = true) : (this._init = false);
             fromEvent(containerElement, 'scroll')
-                .pipe(debounceTime(100), first(), takeUntil(this._onDestroy$))
+                .pipe(debounceTime(100), first(), takeUntilDestroyed(this._destroyRef))
                 .subscribe(() => (this._disableScrollSpy = false));
             scrollTop(containerElement, distanceToScroll);
         }

--- a/libs/cx/src/lib/side-navigation/side-navigation.component.ts
+++ b/libs/cx/src/lib/side-navigation/side-navigation.component.ts
@@ -9,7 +9,6 @@ import {
     HostListener,
     Input,
     OnChanges,
-    OnDestroy,
     OnInit,
     QueryList,
     SimpleChanges,
@@ -17,16 +16,18 @@ import {
     ViewChildren,
     ViewEncapsulation
 } from '@angular/core';
-import { NestedListComponent } from '@fundamental-ngx/cx/nested-list';
-import { NestedListKeyboardService } from '@fundamental-ngx/cx/nested-list';
+import {
+    NestedListComponent,
+    NestedListKeyboardService,
+    NestedListStateService,
+    PreparedNestedListComponent
+} from '@fundamental-ngx/cx/nested-list';
 import { SideNavigationUtilityDirective } from './side-navigation-utility.directive';
 import { SideNavigationMainComponent } from './side-navigation-main.component';
 import { SideNavigationModel } from './side-navigation-model';
-import { PreparedNestedListComponent } from '@fundamental-ngx/cx/nested-list';
-import { NestedListStateService } from '@fundamental-ngx/cx/nested-list';
-import { Subscription } from 'rxjs';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { SideNavigationInterface } from '@fundamental-ngx/core/side-navigation';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /**
  * The side-navigation is a wrapping component representing
@@ -41,7 +42,7 @@ import { SideNavigationInterface } from '@fundamental-ngx/core/side-navigation';
     providers: [NestedListKeyboardService, NestedListStateService]
 })
 export class SideNavigationComponent
-    implements AfterContentInit, AfterViewInit, OnInit, OnChanges, OnDestroy, SideNavigationInterface
+    implements AfterContentInit, AfterViewInit, OnInit, OnChanges, SideNavigationInterface
 {
     /**
      * Side navigation configuration, to pass whole model object, instead of creating HTML from scratch
@@ -110,15 +111,12 @@ export class SideNavigationComponent
     additionalShellbarCssClass = 'fd-shellbar--cx-side-nav';
 
     /** @hidden */
-    private _keyboardSubscription = new Subscription();
-
-    /** @hidden */
     constructor(
         private keyboardService: NestedListKeyboardService,
         private nestedListState: NestedListStateService,
         private _cdRef: ChangeDetectorRef
     ) {
-        this._keyboardSubscription = this.keyboardService.refresh$.subscribe(() => {
+        this.keyboardService.refresh$.pipe(takeUntilDestroyed()).subscribe(() => {
             /** Refresh list of elements, that are being supported by keyboard */
             this.keyboardService.refreshItems(this.getLists());
         });
@@ -155,11 +153,6 @@ export class SideNavigationComponent
         if (this.sideNavigationConfiguration) {
             this.keyboardService.refreshItems(this.getLists());
         }
-    }
-
-    /** @hidden */
-    ngOnDestroy(): void {
-        this._keyboardSubscription?.unsubscribe();
     }
 
     /** @hidden */

--- a/libs/docs/cdk/data-source/examples/default/data-source-default-example.component.ts
+++ b/libs/docs/cdk/data-source/examples/default/data-source-default-example.component.ts
@@ -1,15 +1,15 @@
-import { Component, ChangeDetectionStrategy, OnInit, ChangeDetectorRef } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit } from '@angular/core';
 import {
+    AbstractDataProvider,
+    BaseDataSource,
+    DataProvider,
     DataSourceDirective,
     DataSourceParser,
-    BaseDataSource,
-    AbstractDataProvider,
-    DataProvider,
-    isDataSource,
-    FD_DATA_SOURCE_TRANSFORMER
+    FD_DATA_SOURCE_TRANSFORMER,
+    isDataSource
 } from '@fundamental-ngx/cdk/data-source';
-import { delay, isObservable, Observable, of, takeUntil } from 'rxjs';
+import { delay, isObservable, Observable, of } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export class ExampleDataSource<T> extends BaseDataSource<T> {
     constructor(public dataProvider: AbstractDataProvider<T>) {
@@ -68,7 +68,6 @@ export class ExampleDataSourceParser<T> implements DataSourceParser<T, ExampleDa
         }
     ],
     providers: [
-        DestroyedService,
         {
             provide: FD_DATA_SOURCE_TRANSFORMER,
             useClass: ExampleDataSourceParser<number>
@@ -88,7 +87,7 @@ export class DataSourceDefaultExampleComponent implements OnInit {
     isLoading = false;
 
     constructor(
-        private readonly _destroy$: DestroyedService,
+        private readonly _destroyRef: DestroyRef,
         private readonly _cd: ChangeDetectorRef,
         public readonly dataSourceDirective: DataSourceDirective<number>
     ) {}
@@ -96,12 +95,12 @@ export class DataSourceDefaultExampleComponent implements OnInit {
     ngOnInit(): void {
         this.dataSourceDirective.dataSource = this.arrayDataSource;
 
-        this.dataSourceDirective.dataChanged$.pipe(takeUntil(this._destroy$)).subscribe((data) => {
+        this.dataSourceDirective.dataChanged$.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((data) => {
             this.currentData = data;
             this._cd.detectChanges();
         });
 
-        this.dataSourceDirective.isLoading.pipe(takeUntil(this._destroy$)).subscribe((isLoading) => {
+        this.dataSourceDirective.isLoading.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((isLoading) => {
             this.isLoading = isLoading;
             this._cd.detectChanges;
         });

--- a/libs/docs/cdk/forms/examples/default/forms-default-example.component.ts
+++ b/libs/docs/cdk/forms/examples/default/forms-default-example.component.ts
@@ -1,9 +1,17 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, Input, ViewChild } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    DestroyRef,
+    inject,
+    Input,
+    ViewChild
+} from '@angular/core';
 import { FormBuilder, FormGroup, FormGroupDirective } from '@angular/forms';
-import { DestroyedService, FD_FORM_FIELD_CONTROL } from '@fundamental-ngx/cdk';
+import { FD_FORM_FIELD_CONTROL } from '@fundamental-ngx/cdk';
 import { CvaControl, CvaDirective } from '@fundamental-ngx/cdk/forms';
 import { cloneDeep } from 'lodash-es';
-import { takeUntil } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fundamental-ngx-forms-default-example',
@@ -44,7 +52,6 @@ export class FormsDefaultExampleComponent {
     ],
     providers: [
         CvaControl,
-        DestroyedService,
         { provide: FD_FORM_FIELD_CONTROL, useExisting: CustomCdkControlExampleComponent, multi: true }
     ]
 })
@@ -65,13 +72,13 @@ export class CustomCdkControlExampleComponent {
 
     form: FormGroup;
     cvaControl: CvaControl<string[]> = inject(CvaControl);
-    _destroy$ = inject(DestroyedService);
+    _destroyRef = inject(DestroyRef);
 
     constructor(private readonly _formBuilder: FormBuilder) {}
 
     ngOnInit(): void {
         this.cvaControl.listenToChanges();
-        this.form?.valueChanges.pipe(takeUntil(this._destroy$)).subscribe(() => {
+        this.form?.valueChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
             const formValue = Object.entries(cloneDeep(this.form.value)).reduce((acc, [currentKey, currentValue]) => {
                 if (currentValue) {
                     acc[currentKey] = currentValue;

--- a/libs/docs/core/alert/examples/alert-component-as-content-example.component.ts
+++ b/libs/docs/core/alert/examples/alert-component-as-content-example.component.ts
@@ -1,17 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, DestroyRef } from '@angular/core';
 import { AlertContentComponent } from './alert-content.component';
 import { AlertConfig, AlertService } from '@fundamental-ngx/core/alert';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
-import { takeUntil } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fd-alert-component-as-content-example',
     templateUrl: './alert-component-as-content-example.component.html',
-    styleUrls: ['alert-component-as-content-example.component.scss'],
-    providers: [DestroyedService]
+    styleUrls: ['alert-component-as-content-example.component.scss']
 })
 export class AlertComponentAsContentExampleComponent {
-    constructor(public alertService: AlertService, private readonly _destroy$: DestroyedService) {}
+    constructor(public alertService: AlertService, private readonly _destroyRef: DestroyRef) {}
 
     openFromComponent(): void {
         this.alertService.open(AlertContentComponent, {
@@ -44,7 +42,7 @@ export class AlertComponentAsContentExampleComponent {
             }
         } as AlertConfig);
 
-        alertRef.afterDismissed.pipe(takeUntil(this._destroy$)).subscribe(() => {
+        alertRef.afterDismissed.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
             // Do something after closing, receive data
             // You can also manually close this alert using alertRef.dismiss()
         });

--- a/libs/docs/core/card/examples/card-kpi-example.component.ts
+++ b/libs/docs/core/card/examples/card-kpi-example.component.ts
@@ -3,20 +3,20 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    DestroyRef,
     ElementRef,
     ViewChild
 } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
-import { delay, takeUntil, tap } from 'rxjs/operators';
+import { delay, tap } from 'rxjs/operators';
 
 import { GoogleChartService, Visualization } from './card-kpi-google-charts.service';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fd-card-kpi-example',
     templateUrl: './card-kpi-example.component.html',
     styleUrls: ['./card-kpi-example.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [DestroyedService]
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CardKpiExampleComponent implements AfterViewInit {
     isLoading = true;
@@ -27,7 +27,7 @@ export class CardKpiExampleComponent implements AfterViewInit {
     constructor(
         private googleChartService: GoogleChartService,
         private changeDetectorRef: ChangeDetectorRef,
-        private readonly _destroy$: DestroyedService
+        private readonly _destroyRef: DestroyRef
     ) {}
 
     ngAfterViewInit(): void {
@@ -42,7 +42,7 @@ export class CardKpiExampleComponent implements AfterViewInit {
                 }),
                 // postpone until the next tick to get view updated
                 delay(0),
-                takeUntil(this._destroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((visualization) => {
                 this.drawChart(visualization);

--- a/libs/docs/core/carousel/examples/carousel-dynamic-items-example.component.ts
+++ b/libs/docs/core/carousel/examples/carousel-dynamic-items-example.component.ts
@@ -3,20 +3,20 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    DestroyRef,
     ElementRef,
     OnInit,
     ViewChild
 } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
-import { fromEvent, Subject } from 'rxjs';
-import { debounceTime, takeUntil } from 'rxjs/operators';
+import { fromEvent } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fd-carousel-dynamic-items-example',
     templateUrl: './carousel-dynamic-items-example.component.html',
     styleUrls: ['./carousel-example.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [DestroyedService]
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CarouselDynamicItemsExampleComponent implements OnInit, AfterViewInit {
     @ViewChild('carousel')
@@ -26,11 +26,11 @@ export class CarouselDynamicItemsExampleComponent implements OnInit, AfterViewIn
     visibleSlidesCount = 3;
     cardsHidden = [];
 
-    constructor(private _changeDetectorRef: ChangeDetectorRef, private readonly _destroy$: DestroyedService) {}
+    constructor(private _changeDetectorRef: ChangeDetectorRef, private readonly _destroyRef: DestroyRef) {}
 
     ngOnInit(): void {
         fromEvent(window, 'resize')
-            .pipe(debounceTime(60), takeUntil(this._destroy$))
+            .pipe(debounceTime(60), takeUntilDestroyed(this._destroyRef))
             .subscribe(() => this.updateLayout());
     }
 

--- a/libs/docs/core/carousel/examples/carousel-multiple-active-item-example.component.ts
+++ b/libs/docs/core/carousel/examples/carousel-multiple-active-item-example.component.ts
@@ -3,20 +3,20 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    DestroyRef,
     ElementRef,
     OnInit,
     ViewChild
 } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
-import { fromEvent, Subject } from 'rxjs';
-import { debounceTime, takeUntil } from 'rxjs/operators';
+import { fromEvent } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fd-carousel-multiple-active-item-example',
     templateUrl: './carousel-multiple-active-item-example.component.html',
     styleUrls: ['./carousel-example.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [DestroyedService]
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CarouselMultipleActiveItemExampleComponent implements OnInit, AfterViewInit {
     @ViewChild('carousel')
@@ -25,17 +25,15 @@ export class CarouselMultipleActiveItemExampleComponent implements OnInit, After
     width = '900px';
     visibleSlidesCount = 3;
 
-    /** An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */
-    private readonly _onDestroy$: Subject<void> = new Subject<void>();
     card1Visibility = true;
     card2Visibility = true;
     card3Visibility = true;
 
-    constructor(private _changeDetectorRef: ChangeDetectorRef, private readonly _destroy$: DestroyedService) {}
+    constructor(private _changeDetectorRef: ChangeDetectorRef, private readonly _destroyRef: DestroyRef) {}
 
     ngOnInit(): void {
         fromEvent(window, 'resize')
-            .pipe(debounceTime(60), takeUntil(this._destroy$))
+            .pipe(debounceTime(60), takeUntilDestroyed(this._destroyRef))
             .subscribe(() => this.updateLayout());
     }
 

--- a/libs/docs/core/checkbox/examples/checkbox-reactive-forms-example.component.ts
+++ b/libs/docs/core/checkbox/examples/checkbox-reactive-forms-example.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
-import { map, takeUntil } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fd-checkbox-reactive-forms-example',
@@ -28,8 +28,7 @@ import { map, takeUntil } from 'rxjs/operators';
             Form Dirty: {{ registrationForm.dirty }}<br />
             Form Valid: {{ registrationForm.valid }}<br />
         </small>
-    `,
-    providers: [DestroyedService]
+    `
 })
 export class CheckboxReactiveFormsExampleComponent implements OnInit {
     public registrationForm = new FormGroup({
@@ -41,7 +40,7 @@ export class CheckboxReactiveFormsExampleComponent implements OnInit {
         })
     });
 
-    constructor(private readonly _destroy$: DestroyedService) {}
+    private readonly _destroyRef = inject(DestroyRef);
 
     ngOnInit(): void {
         this.setAgreementsOnAcceptAllChange();
@@ -59,7 +58,7 @@ export class CheckboxReactiveFormsExampleComponent implements OnInit {
     private setAgreementsOnAcceptAllChange(): void {
         this.registrationForm
             .get('acceptAll')
-            ?.valueChanges.pipe(takeUntil(this._destroy$))
+            ?.valueChanges.pipe(takeUntilDestroyed(this._destroyRef))
             .subscribe((value) => this.acceptAll(value));
     }
 
@@ -79,7 +78,7 @@ export class CheckboxReactiveFormsExampleComponent implements OnInit {
                         return null;
                     }
                 }),
-                takeUntil(this._destroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((acceptAllValue) =>
                 this.registrationForm.get('acceptAll')?.setValue(acceptAllValue, { emitEvent: false })

--- a/libs/docs/core/link/examples/link-example.component.ts
+++ b/libs/docs/core/link/examples/link-example.component.ts
@@ -1,24 +1,21 @@
-import { Component, OnInit } from '@angular/core';
-import { BehaviorSubject, takeUntil } from 'rxjs';
-import { DestroyedService, RtlService } from '@fundamental-ngx/cdk/utils';
+import { Component, inject } from '@angular/core';
+import { BehaviorSubject, of } from 'rxjs';
+import { RtlService } from '@fundamental-ngx/cdk/utils';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fd-link-example',
-    templateUrl: './link-example.component.html',
-    providers: [DestroyedService]
+    templateUrl: './link-example.component.html'
 })
-export class LinkExampleComponent implements OnInit {
+export class LinkExampleComponent {
     arrowRight$: BehaviorSubject<string> = new BehaviorSubject<string>('slim-arrow-right');
     arrowLeft$: BehaviorSubject<string> = new BehaviorSubject<string>('slim-arrow-left');
 
-    constructor(private rtlService: RtlService, private readonly _destroy$: DestroyedService) {}
-
-    ngOnInit(): void {
-        if (this.rtlService) {
-            this.rtlService.rtl.pipe(takeUntil(this._destroy$)).subscribe((value) => {
-                this.arrowRight$.next(value ? 'slim-arrow-left' : 'slim-arrow-right');
-                this.arrowLeft$.next(value ? 'slim-arrow-right' : 'slim-arrow-left');
-            });
-        }
+    constructor() {
+        const { rtl: rtl$ } = inject(RtlService, { optional: true }) || { rtl: of(false) };
+        rtl$.pipe(takeUntilDestroyed()).subscribe((value) => {
+            this.arrowRight$.next(value ? 'slim-arrow-left' : 'slim-arrow-right');
+            this.arrowLeft$.next(value ? 'slim-arrow-right' : 'slim-arrow-left');
+        });
     }
 }

--- a/libs/docs/core/list/examples/list-action-example/list-action-example.component.ts
+++ b/libs/docs/core/list/examples/list-action-example/list-action-example.component.ts
@@ -1,13 +1,12 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, inject } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject } from '@angular/core';
 import { of } from 'rxjs';
-import { delay, takeUntil } from 'rxjs/operators';
+import { delay } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fd-list-action-example',
     templateUrl: './list-action-example.component.html',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [DestroyedService]
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ListActionExampleComponent {
     readonly ITEMS_AMOUNT_ON_LOAD = 5;
@@ -16,14 +15,14 @@ export class ListActionExampleComponent {
 
     items = [1, 2, 3, 4, 5];
 
-    private readonly _destroy$ = inject(DestroyedService);
+    private readonly _destroyRef = inject(DestroyRef);
     private readonly _cdr = inject(ChangeDetectorRef);
 
     loadMore(): void {
         this.loading = true;
 
         of(this._getNewItems())
-            .pipe(delay(2000), takeUntil(this._destroy$))
+            .pipe(delay(2000), takeUntilDestroyed(this._destroyRef))
             .subscribe((result) => {
                 this.items = this.items.concat(result);
                 this.loading = false;

--- a/libs/docs/core/list/examples/list-infinite-scroll-example.component.ts
+++ b/libs/docs/core/list/examples/list-infinite-scroll-example.component.ts
@@ -1,16 +1,15 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef } from '@angular/core';
 import { of } from 'rxjs';
-import { delay, takeUntil } from 'rxjs/operators';
+import { delay } from 'rxjs/operators';
 import { LiveAnnouncer } from '@angular/cdk/a11y';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 const ITEMS_AMOUNT_ON_LOAD = 5;
 
 @Component({
     selector: 'fd-list-infinite-scroll-example',
     templateUrl: './list-infinite-scroll-example.component.html',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [DestroyedService]
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ListInfiniteScrollExampleComponent {
     // List that is displayed to the user
@@ -20,7 +19,7 @@ export class ListInfiniteScrollExampleComponent {
 
     constructor(
         private liveAnnouncer: LiveAnnouncer,
-        private readonly _destroy$: DestroyedService,
+        private readonly _destroyRef: DestroyRef,
         private readonly _cdr: ChangeDetectorRef
     ) {}
 
@@ -28,7 +27,7 @@ export class ListInfiniteScrollExampleComponent {
         this.loading = true;
         this.liveAnnouncer.announce('Loading', 'assertive');
         of(this._getNewItems())
-            .pipe(delay(2000), takeUntil(this._destroy$))
+            .pipe(delay(2000), takeUntilDestroyed(this._destroyRef))
             .subscribe((result) => {
                 this.items = this.items.concat(result);
                 this.loading = false;

--- a/libs/docs/platform/settings-generator/examples/custom-layout/settings-generator-custom-layout-example.component.ts
+++ b/libs/docs/platform/settings-generator/examples/custom-layout/settings-generator-custom-layout-example.component.ts
@@ -2,6 +2,7 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    DestroyRef,
     ElementRef,
     inject,
     QueryList,
@@ -11,15 +12,14 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { Validators } from '@angular/forms';
-import { DestroyedService } from '@fundamental-ngx/cdk';
 import { TabPanelComponent } from '@fundamental-ngx/core/tabs';
 import { AnyDynamicFormFieldItem } from '@fundamental-ngx/platform/form';
 import {
     BaseSettingsGeneratorLayout,
     BaseSettingsModel,
-    SettingsModel,
+    SettingsGeneratorComponent,
     SettingsGeneratorLayoutAccessorService,
-    SettingsGeneratorComponent
+    SettingsModel
 } from '@fundamental-ngx/platform/settings-generator';
 import { take } from 'rxjs/operators';
 
@@ -31,11 +31,10 @@ import { take } from 'rxjs/operators';
                 <fdp-settings-generator-content [settings]="tab"></fdp-settings-generator-content>
             </fd-tab>
         </fd-tab-list>
-    `,
-    providers: [DestroyedService]
+    `
 })
 export class SettingsGeneratorTabsLayoutComponent extends BaseSettingsGeneratorLayout {
-    protected _destroy$ = inject(DestroyedService);
+    protected _destroyRef = inject(DestroyRef);
 
     @ViewChildren(TabPanelComponent)
     tabPanels: QueryList<TabPanelComponent>;

--- a/libs/docs/platform/table/examples/platform-table-responsive-columns-example.component.ts
+++ b/libs/docs/platform/table/examples/platform-table-responsive-columns-example.component.ts
@@ -3,20 +3,20 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    DestroyRef,
     ElementRef,
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
 import { FdDate } from '@fundamental-ngx/core/datetime';
-import { DestroyedService, resizeObservable } from '@fundamental-ngx/cdk/utils';
+import { resizeObservable } from '@fundamental-ngx/cdk/utils';
 import { TableComponent, TableDataProvider, TableDataSource, TableState } from '@fundamental-ngx/platform/table';
 import { Observable, of } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fdp-platform-table-responsive-columns-example',
     templateUrl: './platform-table-responsive-columns-example.component.html',
-    providers: [DestroyedService],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
@@ -30,7 +30,7 @@ export class PlatformTableResponsiveColumnsExampleComponent implements AfterView
 
     currentTableWidth = 0;
 
-    constructor(private _onDestroy$: DestroyedService, private _cdr: ChangeDetectorRef) {
+    constructor(private _destroyRef: DestroyRef, private _cdr: ChangeDetectorRef) {
         this.source = new TableDataSource(new TableDataProviderExample());
     }
 
@@ -44,7 +44,7 @@ export class PlatformTableResponsiveColumnsExampleComponent implements AfterView
 
     ngAfterViewInit(): void {
         resizeObservable(this.table.nativeElement)
-            .pipe(takeUntil(this._onDestroy$))
+            .pipe(takeUntilDestroyed(this._destroyRef))
             .subscribe(() => {
                 this.currentTableWidth = Math.ceil(this.table.nativeElement.getBoundingClientRect().width);
                 this._cdr.detectChanges();

--- a/libs/docs/platform/table/examples/preserved-state/platform-table-preserved-state-example.component.ts
+++ b/libs/docs/platform/table/examples/preserved-state/platform-table-preserved-state-example.component.ts
@@ -2,11 +2,11 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    DestroyRef,
     inject,
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
 import { DatetimeAdapter, FdDate, FdDatetimeAdapter } from '@fundamental-ngx/core/datetime';
 import {
     CollectionBooleanFilter,
@@ -29,6 +29,7 @@ import {
     TableState
 } from '@fundamental-ngx/platform/table';
 import { delay, map, merge, Observable, of, Subject, switchMap, takeUntil } from 'rxjs';
+import { destroyObservable } from '@fundamental-ngx/cdk';
 
 @Component({
     selector: 'fdp-platform-table-preserved-state-example',
@@ -39,8 +40,7 @@ import { delay, map, merge, Observable, of, Subject, switchMap, takeUntil } from
         {
             provide: DatetimeAdapter,
             useClass: FdDatetimeAdapter
-        },
-        DestroyedService
+        }
     ]
 })
 export class PlatformTablePreservedStateExampleComponent {
@@ -69,7 +69,7 @@ export class PlatformTablePreservedStateExampleComponent {
 
     applyScroll = false;
 
-    private readonly _destroy$ = inject(DestroyedService);
+    private readonly _destroyRef = inject(DestroyRef);
 
     private _refresh$: Subject<void> = new Subject();
 
@@ -98,7 +98,7 @@ export class PlatformTablePreservedStateExampleComponent {
             return;
         }
 
-        const refresh = merge(this._destroy$, this._refresh$);
+        const refresh = merge(destroyObservable(this._destroyRef), this._refresh$);
 
         this.table._dataSourceDirective.onDataReceived
             .pipe(

--- a/libs/docs/shared/src/lib/core-helpers/docs-section-title/docs-section-title.component.ts
+++ b/libs/docs/shared/src/lib/core-helpers/docs-section-title/docs-section-title.component.ts
@@ -1,17 +1,17 @@
 import {
-    Component,
-    OnInit,
-    Input,
-    ElementRef,
-    ViewChild,
     AfterViewInit,
+    ChangeDetectionStrategy,
+    Component,
+    DestroyRef,
+    ElementRef,
     Inject,
-    ChangeDetectionStrategy
+    Input,
+    OnInit,
+    ViewChild
 } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { DestroyedService } from '@fundamental-ngx/cdk';
-import { takeUntil } from 'rxjs';
 import { CURRENT_LIB, Libraries } from '../../utilities/libraries';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fd-docs-section-title',
@@ -29,8 +29,7 @@ import { CURRENT_LIB, Libraries } from '../../utilities/libraries';
         </h2>
     `,
     styleUrls: ['./docs-section-title.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [DestroyedService]
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DocsSectionTitleComponent implements OnInit, AfterViewInit {
     @ViewChild('title', { read: ElementRef })
@@ -49,13 +48,13 @@ export class DocsSectionTitleComponent implements OnInit, AfterViewInit {
     constructor(
         private readonly activatedRoute: ActivatedRoute,
         @Inject(CURRENT_LIB) private readonly currentLib: Libraries,
-        private readonly _destroy$: DestroyedService
+        private readonly _destroyRef: DestroyRef
     ) {
         this.currentLibrary = this.currentLib;
     }
 
     ngOnInit(): void {
-        this.activatedRoute.fragment.pipe(takeUntil(this._destroy$)).subscribe((fragment) => {
+        this.activatedRoute.fragment.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((fragment) => {
             this.idFromUrl = fragment;
             this.handleUrlFragment();
         });

--- a/libs/fn/src/lib/list/list-item/list-item.component.ts
+++ b/libs/fn/src/lib/list/list-item/list-item.component.ts
@@ -32,7 +32,6 @@ import { CheckboxContext } from '../list-item-checkbox.directive';
 import { ListComponent } from '../list/list.component';
 import { distinctUntilChanged, map, Observable } from 'rxjs';
 import { BooleanInput, coerceArray } from '@angular/cdk/coercion';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
 
 @Component({
     selector: 'fn-list-item, [fn-list-item]',
@@ -42,7 +41,7 @@ import { DestroyedService } from '@fundamental-ngx/cdk/utils';
     host: {
         '[class.fn-list__item]': 'true'
     },
-    providers: [DestroyedService, FdkDisabledProvider, FdkReadonlyProvider],
+    providers: [FdkDisabledProvider, FdkReadonlyProvider],
     hostDirectives: [FocusableItemDirective]
 })
 export class ListItemComponent {
@@ -73,7 +72,6 @@ export class ListItemComponent {
 
     constructor(
         private _cd: ChangeDetectorRef,
-        private _destroy$: DestroyedService,
         @Optional() private _selectionService: SelectionService<HTMLElement>,
         @Optional() @Inject(SelectableItemToken) private _selectableItem: SelectableItemToken,
         @Optional() @Inject(ListComponent) private _listComponent: ListComponent | null,

--- a/libs/i18n/src/lib/directives/patch-language.directive.ts
+++ b/libs/i18n/src/lib/directives/patch-language.directive.ts
@@ -13,7 +13,8 @@ import { FD_LANGUAGE } from './../utils/tokens';
             provide: FD_LANGUAGE,
             useValue: new BehaviorSubject<FdLanguage>(FD_LANGUAGE_ENGLISH)
         }
-    ]
+    ],
+    standalone: true
 })
 export class FdPatchLanguageDirective implements OnDestroy {
     /** @hidden */

--- a/libs/i18n/src/lib/i18n.module.ts
+++ b/libs/i18n/src/lib/i18n.module.ts
@@ -1,11 +1,9 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { FdTranslatePipe } from './pipes';
 import { FdPatchLanguageDirective } from './directives';
 
 @NgModule({
-    imports: [CommonModule],
-    declarations: [FdTranslatePipe, FdPatchLanguageDirective],
+    imports: [FdTranslatePipe, FdPatchLanguageDirective],
     exports: [FdTranslatePipe, FdPatchLanguageDirective]
 })
 export class I18nModule {}

--- a/libs/i18n/src/lib/pipes/fd-translate.pipe.spec.ts
+++ b/libs/i18n/src/lib/pipes/fd-translate.pipe.spec.ts
@@ -1,25 +1,27 @@
-import { ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectorRef, DestroyRef } from '@angular/core';
 import { delay, of } from 'rxjs';
 import { FD_LANGUAGE_ENGLISH } from '../languages';
 import { FdLanguage } from '../models';
 import { FdTranslatePipe } from './fd-translate.pipe';
+import { TestBed } from '@angular/core/testing';
 
 describe('FdTranslate pipe', () => {
     let pipe: FdTranslatePipe;
     const changeDetectorRefMock = { markForCheck: () => {} } as ChangeDetectorRef;
-
+    let destroyRef: DestroyRef;
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        destroyRef = TestBed.inject(DestroyRef);
+    });
     describe('pipe functionality', () => {
-        beforeEach(() => {
-            pipe = new FdTranslatePipe(of(FD_LANGUAGE_ENGLISH), changeDetectorRefMock);
-        });
-
         it("should return value by key, if it's available", () => {
-            pipe = new FdTranslatePipe(of(FD_LANGUAGE_ENGLISH), changeDetectorRefMock);
+            pipe = new FdTranslatePipe(of(FD_LANGUAGE_ENGLISH), destroyRef, changeDetectorRefMock);
             expect(pipe.transform('platformApprovalFlow.defaultWatchersLabel')).toBe('Watchers');
             expect(pipe.transform('platformApprovalFlow.nodeMembersCount', { count: 10 })).toBe('10 members');
         });
 
         it('should return empty string if value is not found', () => {
+            pipe = new FdTranslatePipe(of(FD_LANGUAGE_ENGLISH), destroyRef, changeDetectorRefMock);
             expect(pipe.transform('wrong')).toBe('');
         });
 
@@ -32,7 +34,7 @@ describe('FdTranslate pipe', () => {
                 }
             } as FdLanguage;
             const spy = jest.spyOn<any, any>(customLang.platformApprovalFlow, 'nodeMembersCount');
-            pipe = new FdTranslatePipe(of(customLang), changeDetectorRefMock);
+            pipe = new FdTranslatePipe(of(customLang), destroyRef, changeDetectorRefMock);
             expect(pipe.transform('platformApprovalFlow.nodeMembersCount', { count: 15 })).toBe('15 function members');
             expect(spy).toHaveBeenCalledWith({ count: 15 });
             expect(spy).toHaveBeenCalledTimes(1);
@@ -48,7 +50,7 @@ describe('FdTranslate pipe', () => {
                 }
             } as FdLanguage;
             const spy = jest.spyOn<any, any>(customLang.platformApprovalFlow, 'nodeMembersCount' as any);
-            pipe = new FdTranslatePipe(of(customLang), changeDetectorRefMock);
+            pipe = new FdTranslatePipe(of(customLang), destroyRef, changeDetectorRefMock);
             expect(pipe.transform('platformApprovalFlow.nodeMembersCount', { count: 15 })).toBe('15 members');
             expect(spy).toHaveBeenCalled();
         });
@@ -57,7 +59,7 @@ describe('FdTranslate pipe', () => {
                 ...FD_LANGUAGE_ENGLISH
             } as FdLanguage;
             delete (<any>customLang).platformApprovalFlow;
-            pipe = new FdTranslatePipe(of(customLang), changeDetectorRefMock);
+            pipe = new FdTranslatePipe(of(customLang), destroyRef, changeDetectorRefMock);
             expect(pipe.transform('platformApprovalFlow.nodeMembersCount', { count: 15 })).toBe('15 members');
         });
     });
@@ -68,7 +70,7 @@ describe('FdTranslate pipe', () => {
         const DELAY = 5;
 
         beforeEach(() => {
-            pipe = new FdTranslatePipe(of(FD_LANGUAGE_ENGLISH).pipe(delay(DELAY)), changeDetectorRefMock);
+            pipe = new FdTranslatePipe(of(FD_LANGUAGE_ENGLISH).pipe(delay(DELAY)), destroyRef, changeDetectorRefMock);
         });
 
         it('without params', (done) => {

--- a/libs/i18n/src/lib/pipes/fd-translate.pipe.ts
+++ b/libs/i18n/src/lib/pipes/fd-translate.pipe.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, DestroyRef, inject, Inject, Pipe, PipeTransform } from '@angular/core';
+import { ChangeDetectorRef, DestroyRef, Inject, Pipe, PipeTransform } from '@angular/core';
 import { BehaviorSubject, combineLatest, distinctUntilChanged, filter, map, Observable, skip } from 'rxjs';
 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -8,7 +8,8 @@ import { TranslationResolver } from '../utils/translation-resolver';
 
 @Pipe({
     name: 'fdTranslate',
-    pure: false // required to update the value when the observable is resolved
+    pure: false, // required to update the value when the observable is resolved
+    standalone: true
 })
 export class FdTranslatePipe implements PipeTransform {
     /** @hidden */
@@ -24,10 +25,11 @@ export class FdTranslatePipe implements PipeTransform {
     private _value: string | undefined;
 
     /** @hidden */
-    private readonly _onDestroy$ = inject(DestroyRef);
-
-    /** @hidden */
-    constructor(@Inject(FD_LANGUAGE) private _language$: Observable<FdLanguage>, private _cdr: ChangeDetectorRef) {
+    constructor(
+        @Inject(FD_LANGUAGE) private _language$: Observable<FdLanguage>,
+        private readonly _destroyRef: DestroyRef,
+        private _cdr: ChangeDetectorRef
+    ) {
         this._instantiateSubscription();
     }
 
@@ -48,7 +50,7 @@ export class FdTranslatePipe implements PipeTransform {
         ])
             .pipe(
                 map(([lang, key, args]) => this._translationResolver.resolve(lang, key, args)),
-                takeUntilDestroyed(this._onDestroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((value) => {
                 this._value = value;

--- a/libs/i18n/src/lib/pipes/fd-translate.pipe.ts
+++ b/libs/i18n/src/lib/pipes/fd-translate.pipe.ts
@@ -1,16 +1,7 @@
-import { ChangeDetectorRef, Inject, OnDestroy, Pipe, PipeTransform } from '@angular/core';
-import {
-    BehaviorSubject,
-    combineLatest,
-    distinctUntilChanged,
-    filter,
-    map,
-    Observable,
-    skip,
-    Subject,
-    takeUntil
-} from 'rxjs';
+import { ChangeDetectorRef, DestroyRef, inject, Inject, Pipe, PipeTransform } from '@angular/core';
+import { BehaviorSubject, combineLatest, distinctUntilChanged, filter, map, Observable, skip } from 'rxjs';
 
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FdLanguage, FdLanguageKeyArgs } from '../models/lang';
 import { FD_LANGUAGE } from '../utils/tokens';
 import { TranslationResolver } from '../utils/translation-resolver';
@@ -19,7 +10,7 @@ import { TranslationResolver } from '../utils/translation-resolver';
     name: 'fdTranslate',
     pure: false // required to update the value when the observable is resolved
 })
-export class FdTranslatePipe implements PipeTransform, OnDestroy {
+export class FdTranslatePipe implements PipeTransform {
     /** @hidden */
     private readonly _translationResolver = new TranslationResolver();
 
@@ -33,16 +24,11 @@ export class FdTranslatePipe implements PipeTransform, OnDestroy {
     private _value: string | undefined;
 
     /** @hidden */
-    private readonly _onDestroy$ = new Subject<void>();
+    private readonly _onDestroy$ = inject(DestroyRef);
 
     /** @hidden */
     constructor(@Inject(FD_LANGUAGE) private _language$: Observable<FdLanguage>, private _cdr: ChangeDetectorRef) {
         this._instantiateSubscription();
-    }
-
-    /** @hidden */
-    ngOnDestroy(): void {
-        this._onDestroy$.next();
     }
 
     /** Translate a key with arguments and, optionally, default value */
@@ -62,7 +48,7 @@ export class FdTranslatePipe implements PipeTransform, OnDestroy {
         ])
             .pipe(
                 map(([lang, key, args]) => this._translationResolver.resolve(lang, key, args)),
-                takeUntil(this._onDestroy$)
+                takeUntilDestroyed(this._onDestroy$)
             )
             .subscribe((value) => {
                 this._value = value;

--- a/libs/platform/src/lib/message-popover/components/message-view/message-view.component.ts
+++ b/libs/platform/src/lib/message-popover/components/message-view/message-view.component.ts
@@ -4,6 +4,7 @@ import {
     AfterViewInit,
     ChangeDetectionStrategy,
     Component,
+    DestroyRef,
     ElementRef,
     EventEmitter,
     HostBinding,
@@ -13,17 +14,17 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import { Nullable } from '@fundamental-ngx/cdk/utils';
-import { DestroyedService, resizeObservable, TabbableElementService } from '@fundamental-ngx/cdk/utils';
-import { debounceTime, takeUntil } from 'rxjs';
+import { Nullable, resizeObservable, TabbableElementService } from '@fundamental-ngx/cdk/utils';
+import { debounceTime } from 'rxjs';
 import { MessagePopoverEntry, MessagePopoverErrorGroup } from '../../models/message-popover-entry.interface';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fdp-message-view',
     templateUrl: './message-view.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [DestroyedService, TabbableElementService],
+    providers: [TabbableElementService],
     animations: [
         trigger('openCloseList', [
             // ...
@@ -128,7 +129,7 @@ export class MessageViewComponent implements AfterViewInit {
 
     /** @hidden */
     constructor(
-        private readonly _destroy$: DestroyedService,
+        private readonly _destroyRef: DestroyRef,
         private readonly _tabbableService: TabbableElementService,
         @Inject(DOCUMENT) private readonly _document: Document
     ) {}
@@ -136,7 +137,7 @@ export class MessageViewComponent implements AfterViewInit {
     /** @hidden */
     ngAfterViewInit(): void {
         resizeObservable(this._detailsView.nativeElement)
-            .pipe(debounceTime(20), takeUntil(this._destroy$))
+            .pipe(debounceTime(20), takeUntilDestroyed(this._destroyRef))
             .subscribe(() => {
                 const { height } = this._detailsView.nativeElement.getBoundingClientRect();
                 this._listView.nativeElement.style.minHeight = `${height}px`;

--- a/libs/platform/src/lib/settings-generator/layouts/base-settings-generator-layout.ts
+++ b/libs/platform/src/lib/settings-generator/layouts/base-settings-generator-layout.ts
@@ -1,13 +1,30 @@
-import { ChangeDetectorRef, Directive, ElementRef, inject, OnInit } from '@angular/core';
-import { takeUntil } from 'rxjs/operators';
+import { ChangeDetectorRef, DestroyRef, Directive, ElementRef, inject, OnInit } from '@angular/core';
 import { SettingsGeneratorService } from '../settings-generator.service';
-import { Subject } from 'rxjs';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { SettingsModel } from '../models/settings.model';
 import { FDP_SETTINGS_GENERATOR } from '../tokens';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Directive()
 export abstract class BaseSettingsGeneratorLayout implements OnInit {
+    /**
+     * Subject to notify subscriptions to unsubscribe when component destroys.
+     */
+    protected abstract _destroyRef: DestroyRef;
+
+    /**
+     * Method for focusing inner form control.
+     * It is responsible for activating the section and placing focus on the element.
+     * @param path path of the control joined by dot(.). Usually represents section ID and inner group ID.
+     * @param element ElementRef of native element to focus.
+     */
+    abstract focusElementByPath(path: string, element: ElementRef<HTMLElement>): void;
+
+    /**
+     * Settings schema.
+     */
+    settings: Nullable<SettingsModel>;
+
     /**
      * Settings generator service.
      */
@@ -23,29 +40,11 @@ export abstract class BaseSettingsGeneratorLayout implements OnInit {
      */
     protected _settingsGenerator = inject(FDP_SETTINGS_GENERATOR);
 
-    /**
-     * Subject to notify subscriptions to unsubscribe when component destroys.
-     */
-    protected abstract _destroy$: Subject<void>;
-
-    /**
-     * Settings schema.
-     */
-    settings: Nullable<SettingsModel>;
-
     /** @hidden */
     ngOnInit(): void {
-        this._settingsGeneratorService.settings.pipe(takeUntil(this._destroy$)).subscribe((settings) => {
+        this._settingsGeneratorService.settings.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((settings) => {
             this.settings = settings;
             this._cdr.detectChanges();
         });
     }
-
-    /**
-     * Method for focusing inner form control.
-     * It is responsible for activating the section and placing focus on the element.
-     * @param path path of the control joined by dot(.). Usually represents section ID and inner group ID.
-     * @param element ElementRef of native element to focus.
-     */
-    abstract focusElementByPath(path: string, element: ElementRef<HTMLElement>): void;
 }

--- a/libs/platform/src/lib/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-icon/settings-generator-sidebar-icon.component.ts
+++ b/libs/platform/src/lib/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-icon/settings-generator-sidebar-icon.component.ts
@@ -1,16 +1,24 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, ViewEncapsulation, inject } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    DestroyRef,
+    inject,
+    Input,
+    ViewEncapsulation
+} from '@angular/core';
 import { ThumbnailSettingsItem } from '../../../models/settings.model';
 import { ListAvatarConfig, ListIconConfig } from '@fundamental-ngx/platform/list';
 import { merge } from 'lodash-es';
-import { Observable, takeUntil } from 'rxjs';
-import { DestroyedService, isSubscribable } from '@fundamental-ngx/cdk/utils';
+import { Observable } from 'rxjs';
+import { isSubscribable } from '@fundamental-ngx/cdk/utils';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'fdp-settings-generator-sidebar-icon',
     templateUrl: './settings-generator-sidebar-icon.component.html',
     encapsulation: ViewEncapsulation.None,
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [DestroyedService]
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SettingsGeneratorSidebarIconComponent {
     /** Thumbnail configuration. */
@@ -31,16 +39,16 @@ export class SettingsGeneratorSidebarIconComponent {
     }
 
     /** @hidden */
-    private _thumbnail: ThumbnailSettingsItem;
-
-    /** @hidden */
     _avatarConfig: ListAvatarConfig | undefined;
 
     /** @hidden */
     _iconConfig: ListIconConfig | undefined;
 
     /** @hidden */
-    private readonly _destroy$ = inject(DestroyedService);
+    private _thumbnail: ThumbnailSettingsItem;
+
+    /** @hidden */
+    private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     private readonly _cdr = inject(ChangeDetectorRef);
@@ -70,7 +78,7 @@ export class SettingsGeneratorSidebarIconComponent {
     /** @hidden */
     private _getConfigFromObservable<T>(config: T | Observable<T>, callback: (config: T) => void): void {
         if (isSubscribable(config)) {
-            config.pipe(takeUntil(this._destroy$)).subscribe((_config) => {
+            config.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((_config) => {
                 callback(_config);
             });
 

--- a/libs/platform/src/lib/table-helpers/directives/table-cell-resizable.directive.ts
+++ b/libs/platform/src/lib/table-helpers/directives/table-cell-resizable.directive.ts
@@ -5,7 +5,8 @@ import { TableCellDirective } from '@fundamental-ngx/core/table';
 import equal from 'fast-deep-equal';
 import { TableColumnResizeService } from '../services/table-column-resize.service';
 import { fromEvent } from 'rxjs';
-import { distinctUntilChanged, filter, map, takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 export type TableColumnResizableSide = 'start' | 'end' | 'both';
 
@@ -79,13 +80,13 @@ export class PlatformTableCellResizableDirective
                     filter(() => this._tableColumnResizeService?.resizeInProgress !== true),
                     map((event) => this._getResizer(event) || { resizerPosition: 0, resizedColumn: this.columnName }),
                     distinctUntilChanged((prev, curr) => equal(prev, curr)),
-                    takeUntil(this._destroy$)
+                    takeUntilDestroyed(this._destroyRef)
                 )
                 .subscribe((data) => {
                     this._tableColumnResizeService.setInitialResizerPosition(data.resizerPosition, data.resizedColumn);
                 });
             fromEvent<FocusEvent>(this.elementRef.nativeElement, 'focus')
-                .pipe(takeUntil(this._destroy$))
+                .pipe(takeUntilDestroyed(this._destroyRef))
                 .subscribe(() => {
                     this._tableColumnResizeService.setInitialResizerPosition(0, this.columnName);
                 });

--- a/libs/platform/src/lib/table-helpers/directives/table-scrollable.directive.ts
+++ b/libs/platform/src/lib/table-helpers/directives/table-scrollable.directive.ts
@@ -1,13 +1,13 @@
-import { Directive, ElementRef, NgZone, OnDestroy, OnInit, forwardRef, inject } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { DestroyRef, Directive, ElementRef, forwardRef, inject, NgZone, OnDestroy, OnInit } from '@angular/core';
 import {
     TABLE_SCROLLABLE,
     TableScrollable,
     TableScrollDispatcherService
 } from '../services/table-scroll-dispatcher.service';
-import { Observable, Observer, fromEvent } from 'rxjs';
-import { filter, share, takeUntil, tap } from 'rxjs/operators';
+import { fromEvent, Observable, Observer } from 'rxjs';
+import { filter, share, tap } from 'rxjs/operators';
 import { DOCUMENT } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /**
  * Table Scrollable.
@@ -21,10 +21,7 @@ import { DOCUMENT } from '@angular/common';
     selector: '[fdpTableScrollable]',
     exportAs: 'tableScrollable',
     standalone: true,
-    providers: [
-        { provide: TABLE_SCROLLABLE, useExisting: forwardRef(() => TableScrollableDirective) },
-        DestroyedService
-    ]
+    providers: [{ provide: TABLE_SCROLLABLE, useExisting: forwardRef(() => TableScrollableDirective) }]
 })
 export class TableScrollableDirective implements TableScrollable, OnInit, OnDestroy {
     /** @hidden */
@@ -37,7 +34,7 @@ export class TableScrollableDirective implements TableScrollable, OnInit, OnDest
     private _prevScrollLeft = 0;
 
     /** @hidden */
-    private readonly _destroyed$ = inject(DestroyedService);
+    private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     private readonly _document = inject(DOCUMENT);
@@ -56,7 +53,7 @@ export class TableScrollableDirective implements TableScrollable, OnInit, OnDest
             }
             return true;
         }),
-        takeUntil(this._destroyed$),
+        takeUntilDestroyed(this._destroyRef),
         share()
     );
 

--- a/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
+++ b/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
@@ -1,19 +1,17 @@
-import { Directive, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { DestroyRef, Directive, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { ContentDensityMode } from '@fundamental-ngx/core/content-density';
 import { BehaviorSubject, filter } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { FDP_TABLE_VIRTUAL_SCROLL_DIRECTIVE, ROW_HEIGHT } from '../constants';
 import { TableVirtualScroll } from '../models';
 import { TableScrollDispatcherService } from '../services/table-scroll-dispatcher.service';
 import { Table } from '../table';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Directive({
     // eslint-disable-next-line @angular-eslint/directive-selector
     selector: 'fdp-table[virtualScroll]',
     standalone: true,
     providers: [
-        DestroyedService,
         {
             provide: FDP_TABLE_VIRTUAL_SCROLL_DIRECTIVE,
             useExisting: TableVirtualScrollDirective
@@ -58,7 +56,7 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
     private readonly _tableScrollDispatcher = inject(TableScrollDispatcherService);
 
     /** @hidden */
-    private readonly _destroy$ = inject(DestroyedService);
+    private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
@@ -127,7 +125,7 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
             .verticallyScrolled()
             .pipe(
                 filter(() => this.virtualScroll && !!this.bodyHeight),
-                takeUntil(this._destroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((scrollable) => {
                 this.calculateVirtualScrollRows();

--- a/libs/platform/src/lib/table/components/table-header-row/table-header-row.component.ts
+++ b/libs/platform/src/lib/table/components/table-header-row/table-header-row.component.ts
@@ -10,7 +10,6 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import {
-    DestroyedService,
     FDK_FOCUSABLE_ITEM_DIRECTIVE,
     FDK_FOCUSABLE_LIST_DIRECTIVE,
     FocusableItemDirective,
@@ -26,7 +25,7 @@ import {
     TableRowService,
     TableService
 } from '@fundamental-ngx/platform/table-helpers';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
@@ -38,8 +37,7 @@ import { takeUntil } from 'rxjs/operators';
         {
             provide: FDK_FOCUSABLE_LIST_DIRECTIVE,
             useExisting: TableHeaderRowComponent
-        },
-        DestroyedService
+        }
     ]
 })
 export class TableHeaderRowComponent extends TableRowDirective implements OnInit {
@@ -126,7 +124,7 @@ export class TableHeaderRowComponent extends TableRowDirective implements OnInit
     /** @hidden */
     constructor() {
         super();
-        this._rtlService?.rtl.pipe(takeUntil(this._destroy$)).subscribe((isRtl) => {
+        this._rtlService?.rtl.pipe(takeUntilDestroyed()).subscribe((isRtl) => {
             this._rtl = isRtl;
         });
     }
@@ -134,7 +132,7 @@ export class TableHeaderRowComponent extends TableRowDirective implements OnInit
     /** @hidden */
     ngOnInit(): void {
         super.ngOnInit();
-        this._tableColumnResizeService.markForCheck.pipe(takeUntil(this._destroy$)).subscribe(() => {
+        this._tableColumnResizeService.markForCheck.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
             this._cdr.detectChanges();
         });
     }

--- a/libs/platform/src/lib/table/components/table-popping-row/table-popping-row.component.ts
+++ b/libs/platform/src/lib/table/components/table-popping-row/table-popping-row.component.ts
@@ -1,14 +1,14 @@
 import {
-    Component,
-    ViewEncapsulation,
     ChangeDetectionStrategy,
-    Input,
-    HostBinding,
+    Component,
     EventEmitter,
+    HostBinding,
+    inject,
+    Input,
     Output,
-    inject
+    ViewEncapsulation
 } from '@angular/core';
-import { DestroyedService, FDK_FOCUSABLE_LIST_DIRECTIVE } from '@fundamental-ngx/cdk/utils';
+import { FDK_FOCUSABLE_LIST_DIRECTIVE } from '@fundamental-ngx/cdk/utils';
 import { TableRowDirective } from '@fundamental-ngx/core/table';
 import {
     isTreeRow,
@@ -29,8 +29,7 @@ import {
         {
             provide: FDK_FOCUSABLE_LIST_DIRECTIVE,
             useExisting: TablePoppingRowComponent
-        },
-        DestroyedService
+        }
     ]
 })
 export class TablePoppingRowComponent<T> extends TableRowDirective {


### PR DESCRIPTION
## Related Issue(s)

closes None

## Description

As of Angular 16, there is no need for our DestroyService anymore, so this PR replaces that with built-in alternative, and deprecates existing service

