### PR TITLE
fix(core): dialog bar cozy issue

### DIFF
--- a/libs/core/src/lib/bar/bar.component.ts
+++ b/libs/core/src/lib/bar/bar.component.ts
@@ -94,7 +94,7 @@ export class BarComponent implements OnChanges, OnInit, CssClassBuilder, OnDestr
     buildComponentCssClass(): string[] {
         return [
             'fd-bar',
-            this._contentDensityObserver.isCozy ? 'fd-bar--cozy' : '', // TODO: fix in styles
+            this._contentDensityObserver.isCompact || this._contentDensityObserver.isCondensed ? '' : 'fd-bar--cozy', // TODO: fix in styles
             this.barDesign ? `fd-bar--${this.barDesign}` : '',
             this.inPage && !this.size ? 'fd-bar--page' : '',
             this.inPage && this.size ? `fd-bar--page-${this.size}` : '',


### PR DESCRIPTION
fixes #10217 

Was also wondering if the `_isCozy$` BehaviorSubject in the content density observer service should default to true, i.e.

`private readonly _isCozy$ = new BehaviorSubject<boolean>(true);`