### PR TITLE
fix(core): no initial aria-pressed value for buttons

### DIFF
--- a/libs/core/src/lib/button/base-button.ts
+++ b/libs/core/src/lib/button/base-button.ts
@@ -100,5 +100,5 @@ export class BaseButton {
     /** @hidden */
     @HostBinding('class.fd-button--toggled')
     @HostBinding('attr.aria-pressed')
-    _toggled = false;
+    _toggled: boolean;
 }

--- a/libs/core/src/lib/button/base-button.ts
+++ b/libs/core/src/lib/button/base-button.ts
@@ -19,6 +19,17 @@ export type ButtonType =
 
 @Directive()
 export class BaseButton {
+    /** @hidden */
+    @HostBinding('class.fd-button--toggled')
+    @HostBinding('attr.aria-pressed')
+    _toggled: boolean;
+
+    /** @hidden */
+    _disabled = false;
+
+    /** @hidden */
+    _ariaDisabled: boolean;
+
     /**
      * Native type of button element
      */
@@ -90,15 +101,4 @@ export class BaseButton {
     get ariaDisabled(): boolean {
         return this._ariaDisabled;
     }
-
-    /** @hidden */
-    _disabled = false;
-
-    /** @hidden */
-    _ariaDisabled: boolean;
-
-    /** @hidden */
-    @HostBinding('class.fd-button--toggled')
-    @HostBinding('attr.aria-pressed')
-    _toggled: boolean;
 }


### PR DESCRIPTION
fixes #10222 

downported to ng15 with version 0.43.4