### PR TITLE
feat(core): horizon carousel update

### DIFF
--- a/libs/core/src/lib/carousel/carousel-item.directive.ts
+++ b/libs/core/src/lib/carousel/carousel-item.directive.ts
@@ -4,7 +4,8 @@ let carouselItemCounter = 0;
 
 @Directive({
     selector: '[fd-carousel-item], [fdCarouselItem]',
-    exportAs: 'fdCarouselItem'
+    exportAs: 'fdCarouselItem',
+    standalone: true
 })
 export class CarouselItemDirective {
     /** Value of the item , to keep some information inside */

--- a/libs/core/src/lib/carousel/carousel-item/carousel-item.component.ts
+++ b/libs/core/src/lib/carousel/carousel-item/carousel-item.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, ViewEncapsulation } from '@angular/core';
 import { CarouselItemInterface } from '../carousel.service';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { BusyIndicatorComponent } from '@fundamental-ngx/core/busy-indicator';
 
 export type Visibility = 'visible' | 'hidden';
 
@@ -10,7 +11,9 @@ let carouselItemCounter = 0;
     selector: 'fd-carousel-item',
     templateUrl: './carousel-item.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    standalone: true,
+    imports: [BusyIndicatorComponent]
 })
 export class CarouselItemComponent implements CarouselItemInterface {
     /** Id of the Carousel items. */

--- a/libs/core/src/lib/carousel/carousel.component.html
+++ b/libs/core/src/lib/carousel/carousel.component.html
@@ -17,6 +17,7 @@
     <div
         class="fd-carousel__content"
         [class.fd-carousel__content--horizontal]="!vertical"
+        [ngClass]="'fd-carousel__content--' + contentBackground"
         [style.width]="_contentSizePx"
     >
         <ng-container *ngIf="_showNavigationButtonInContent">
@@ -42,7 +43,11 @@
 </div>
 
 <ng-template #pageIndicatorContainer>
-    <div class="fd-carousel__page-indicator-container">
+    <div
+        class="fd-carousel__page-indicator-container"
+        [class.fd-carousel__page-indicator-container--no-border]="noPaginationContainerBorder"
+        [ngClass]="'fd-carousel__page-indicator-container--' + pageIndicatorBackground"
+    >
         <ng-container *ngIf="_showNavigationButtonInPageIndicatorContainer">
             <ng-container *ngTemplateOutlet="buttonLeft"></ng-container>
         </ng-container>
@@ -83,27 +88,31 @@
 <ng-template #buttonLeft>
     <button
         fd-button
-        class="fd-carousel__button fd-carousel__button--left"
+        class="fd-carousel__button"
+        [class.fd-carousel__button--left]="!vertical"
+        [class.fd-carousel__button--up]="vertical"
         [style.z-index]="1"
         data-slide="previous"
         [attr.aria-label]="leftNavigationBtnLabel || ('coreCarousel.leftNavigationBtnLabel' | fdTranslate)"
         (click)="previous(); $event.stopPropagation()"
         [disabled]="leftButtonDisabled"
         [attr.title]="leftNavigationBtnLabel || ('coreCarousel.leftNavigationBtnLabel' | fdTranslate)"
-        glyph="slim-arrow-left"
+        [glyph]="vertical ? 'slim-arrow-up' : 'slim-arrow-left'"
     ></button>
 </ng-template>
 
 <ng-template #buttonRight>
     <button
         fd-button
-        class="fd-carousel__button fd-carousel__button--right"
+        class="fd-carousel__button"
+        [class.fd-carousel__button--right]="!vertical"
+        [class.fd-carousel__button--down]="vertical"
         [style.z-index]="1"
         data-slide="next"
         [attr.aria-label]="rightNavigationBtnLabel || ('coreCarousel.rightNavigationBtnLabel' | fdTranslate)"
         (click)="next(); $event.stopPropagation()"
         [disabled]="rightButtonDisabled"
         [attr.title]="rightNavigationBtnLabel || ('coreCarousel.rightNavigationBtnLabel' | fdTranslate)"
-        glyph="slim-arrow-right"
+        [glyph]="vertical ? 'slim-arrow-down' : 'slim-arrow-right'"
     ></button>
 </ng-template>

--- a/libs/core/src/lib/carousel/carousel.component.spec.ts
+++ b/libs/core/src/lib/carousel/carousel.component.spec.ts
@@ -18,6 +18,8 @@ const carouselItems = `<fd-carousel-item>
 
 @Component({
     selector: 'fd-test-carousel',
+    standalone: true,
+    imports: [CarouselModule],
     template: `
         <fd-carousel
             [vertical]="vertical"
@@ -58,8 +60,7 @@ describe('CarouselComponent', () => {
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            declarations: [TestCarouselComponent],
-            imports: [CarouselModule]
+            imports: [TestCarouselComponent]
         }).compileComponents();
     }));
 
@@ -178,6 +179,8 @@ describe('CarouselComponent', () => {
 
 @Component({
     selector: 'fd-test-multiple-active-item-carousel',
+    standalone: true,
+    imports: [CarouselModule],
     template: `
         <fd-carousel
             [visibleSlidesCount]="visibleItemsCount"
@@ -210,8 +213,7 @@ describe('CarouselComponent Multiple Active Item', () => {
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            declarations: [TestCarouselMultipleActiveItemComponent],
-            imports: [CarouselModule]
+            imports: [TestCarouselMultipleActiveItemComponent]
         }).compileComponents();
     }));
 
@@ -303,6 +305,8 @@ describe('CarouselComponent Multiple Active Item', () => {
 
 @Component({
     selector: 'fd-test-looping-navigation-carousel',
+    imports: [CarouselModule],
+    standalone: true,
     template: `
         <fd-carousel
             [visibleSlidesCount]="visibleItemsCount"
@@ -335,8 +339,7 @@ describe('CarouselComponent looping navigation', () => {
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            declarations: [TestCarouselLoopingNavigationComponent],
-            imports: [CarouselModule]
+            imports: [TestCarouselLoopingNavigationComponent]
         }).compileComponents();
     }));
 

--- a/libs/core/src/lib/carousel/carousel.component.spec.ts
+++ b/libs/core/src/lib/carousel/carousel.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { whenStable } from '@fundamental-ngx/core/tests';
-import { CarouselComponent, PageIndicatorsOrientation } from './carousel.component';
+import { CarouselBackgroundOptions, CarouselComponent, PageIndicatorsOrientation } from './carousel.component';
 import { CarouselModule } from './carousel.module';
 
 const carouselItems = `<fd-carousel-item>
@@ -20,6 +20,7 @@ const carouselItems = `<fd-carousel-item>
     selector: 'fd-test-carousel',
     template: `
         <fd-carousel
+            [vertical]="vertical"
             [visibleSlidesCount]="visibleItemsCount"
             [pageIndicatorContainer]="showPageIndicatorContainer"
             [pageIndicator]="showPageIndicator"
@@ -27,6 +28,9 @@ const carouselItems = `<fd-carousel-item>
             [navigatorInPageIndicator]="navigatorInPageIndicator"
             [pageIndicatorsOrientation]="pageIndicatorContainerPlacement"
             [loop]="isCircular"
+            [noPaginationContainerBorder]="noPaginationContainerBorder"
+            [contentBackground]="contentBackground"
+            [pageIndicatorBackground]="pageIndicatorBackground"
             >${carouselItems}</fd-carousel
         >
     `
@@ -35,6 +39,7 @@ class TestCarouselComponent {
     @ViewChild(CarouselComponent)
     carousel: CarouselComponent;
 
+    vertical = false;
     visibleItemsCount = 1;
     showPageIndicatorContainer = true;
     showPageIndicator = true;
@@ -42,6 +47,9 @@ class TestCarouselComponent {
     navigatorInPageIndicator = true;
     pageIndicatorContainerPlacement: PageIndicatorsOrientation = 'top';
     isCircular = false;
+    noPaginationContainerBorder = false;
+    contentBackground: CarouselBackgroundOptions;
+    pageIndicatorBackground: CarouselBackgroundOptions;
 }
 
 describe('CarouselComponent', () => {
@@ -63,6 +71,69 @@ describe('CarouselComponent', () => {
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    it('should apply background config', async () => {
+        const backgroundOptions: CarouselBackgroundOptions[] = ['solid', 'translucent', 'transparent'];
+
+        // Apply properties in a separate loop to exclude possibility of incorrect property binding.
+        backgroundOptions.forEach((option) => {
+            component.contentBackground = option;
+            fixture.detectChanges();
+            expect(fixture.nativeElement.querySelector('.fd-carousel__content').classList).toContain(
+                `fd-carousel__content--${option}`
+            );
+        });
+
+        backgroundOptions.forEach((option) => {
+            component.pageIndicatorBackground = option;
+            fixture.detectChanges();
+            expect(fixture.nativeElement.querySelector('.fd-carousel__page-indicator-container').classList).toContain(
+                `fd-carousel__page-indicator-container--${option}`
+            );
+        });
+    });
+
+    it('should change icons for vertical carousel', async () => {
+        component.vertical = false;
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('.fd-carousel__content').classList).toContain(
+            'fd-carousel__content--horizontal'
+        );
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--left')).toBeTruthy();
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--up')).toBeFalsy();
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--right')).toBeTruthy();
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--down')).toBeFalsy();
+        expect(
+            fixture.nativeElement.querySelector('.fd-carousel__button--left .sap-icon--slim-arrow-left')
+        ).toBeTruthy();
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--left .sap-icon--slim-arrow-up')).toBeFalsy();
+        expect(
+            fixture.nativeElement.querySelector('.fd-carousel__button--right .sap-icon--slim-arrow-right')
+        ).toBeTruthy();
+        expect(
+            fixture.nativeElement.querySelector('.fd-carousel__button--right .sap-icon--slim-arrow-down')
+        ).toBeFalsy();
+
+        component.vertical = true;
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('.fd-carousel__content').classList).not.toContain(
+            'fd-carousel__content--horizontal'
+        );
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--left')).toBeFalsy();
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--up')).toBeTruthy();
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--right')).toBeFalsy();
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--down')).toBeTruthy();
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--up .sap-icon--slim-arrow-left')).toBeFalsy();
+        expect(fixture.nativeElement.querySelector('.fd-carousel__button--up .sap-icon--slim-arrow-up')).toBeTruthy();
+        expect(
+            fixture.nativeElement.querySelector('.fd-carousel__button--down .sap-icon--slim-arrow-right')
+        ).toBeFalsy();
+        expect(
+            fixture.nativeElement.querySelector('.fd-carousel__button--down .sap-icon--slim-arrow-down')
+        ).toBeTruthy();
     });
 
     it('should have 8 carousel items', async () => {

--- a/libs/core/src/lib/carousel/carousel.component.ts
+++ b/libs/core/src/lib/carousel/carousel.component.ts
@@ -32,6 +32,9 @@ import { resizeObservable, RtlService } from '@fundamental-ngx/cdk/utils';
 import { CarouselItemComponent } from './carousel-item/carousel-item.component';
 import { CarouselResourceStringsEN, FdCarouselResourceStrings } from './i18n/carousel-resources';
 import { CarouselConfig, CarouselItemInterface, CarouselService, PanEndOutput } from './carousel.service';
+import { FdTranslatePipe } from '@fundamental-ngx/i18n';
+import { ButtonModule } from '@fundamental-ngx/core/button';
+import { NgIf, NgTemplateOutlet, NgClass, NgFor } from '@angular/common';
 
 /** Page limit to switch to numerical indicator */
 const ICON_PAGE_INDICATOR_LIMIT = 8;
@@ -66,7 +69,9 @@ class CarouselActiveSlides {
     providers: [CarouselService],
     host: {
         '[style.width]': 'width'
-    }
+    },
+    standalone: true,
+    imports: [NgIf, NgTemplateOutlet, NgClass, NgFor, ButtonModule, FdTranslatePipe]
 })
 export class CarouselComponent
     implements OnInit, AfterContentInit, AfterViewInit, AfterViewChecked, OnChanges, OnDestroy

--- a/libs/core/src/lib/carousel/carousel.component.ts
+++ b/libs/core/src/lib/carousel/carousel.component.ts
@@ -38,6 +38,8 @@ const ICON_PAGE_INDICATOR_LIMIT = 8;
 
 export type PageIndicatorsOrientation = 'bottom' | 'top';
 
+export type CarouselBackgroundOptions = 'translucent' | 'transparent' | 'solid';
+
 export enum SlideDirection {
     None,
     NEXT,
@@ -163,6 +165,18 @@ export class CarouselComponent
     /** Is carousel is vertical. Default value is false. */
     @Input()
     vertical = false;
+
+    /** Whether to hide top border of the Pagination Container. */
+    @Input()
+    noPaginationContainerBorder = false;
+
+    /** Background configuration for the Content container. */
+    @Input()
+    contentBackground: CarouselBackgroundOptions = 'translucent';
+
+    /** Background configuration for the Pagination container */
+    @Input()
+    pageIndicatorBackground: CarouselBackgroundOptions = 'solid';
 
     /** Number of items to be visible at a time */
     @Input()

--- a/libs/core/src/lib/carousel/carousel.directive.spec.ts
+++ b/libs/core/src/lib/carousel/carousel.directive.spec.ts
@@ -55,13 +55,8 @@ describe('CarouselDirective', () => {
     beforeEach(() => {
         TestBed.resetTestingModule();
         TestBed.configureTestingModule({
-            imports: [CommonModule],
-            declarations: [
-                HorizontalCarouselComponent,
-                VerticalCarouselComponent,
-                CarouselItemDirective,
-                CarouselDirective
-            ],
+            imports: [CommonModule, CarouselItemDirective, CarouselDirective],
+            declarations: [HorizontalCarouselComponent, VerticalCarouselComponent],
             providers: [CarouselService]
         }).compileComponents();
     });

--- a/libs/core/src/lib/carousel/carousel.directive.ts
+++ b/libs/core/src/lib/carousel/carousel.directive.ts
@@ -17,7 +17,8 @@ import { CarouselItemDirective } from './carousel-item.directive';
     host: {
         class: 'fd-carousel_'
     },
-    providers: [CarouselService]
+    providers: [CarouselService],
+    standalone: true
 })
 export class CarouselDirective implements AfterContentInit {
     /** Configuration for carousel */

--- a/libs/core/src/lib/carousel/carousel.module.ts
+++ b/libs/core/src/lib/carousel/carousel.module.ts
@@ -1,18 +1,13 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { CarouselItemDirective } from './carousel-item.directive';
 import { CarouselDirective } from './carousel.directive';
 import { CarouselComponent } from './carousel.component';
 import { CarouselItemComponent } from './carousel-item/carousel-item.component';
-import { BusyIndicatorModule } from '@fundamental-ngx/core/busy-indicator';
-import { I18nModule } from '@fundamental-ngx/i18n';
-import { ButtonModule } from '@fundamental-ngx/core/button';
 import { CarouselService } from './carousel.service';
 
 @NgModule({
-    imports: [CommonModule, BusyIndicatorModule, ButtonModule, I18nModule],
+    imports: [CarouselItemDirective, CarouselDirective, CarouselComponent, CarouselItemComponent],
     exports: [CarouselItemDirective, CarouselDirective, CarouselComponent, CarouselItemComponent],
-    declarations: [CarouselItemDirective, CarouselDirective, CarouselComponent, CarouselItemComponent],
     providers: [CarouselService]
 })
 export class CarouselModule {}

--- a/libs/docs/core/carousel/carousel-docs.component.html
+++ b/libs/docs/core/carousel/carousel-docs.component.html
@@ -151,3 +151,28 @@
     <fd-carousel-auto-slides-example></fd-carousel-auto-slides-example>
 </component-example>
 <code-example [exampleFiles]="carouselAutoSlides"></code-example>
+<separator></separator>
+
+<fd-docs-section-title id="background-options" componentName="carousel">Background modifiers</fd-docs-section-title>
+<description>
+    <p>
+        The background of the Carousel Content and Page Indicator Container can be changed by providing
+        <code>[contentBackground]</code> and <code>[pageIndicatorBackground]</code> input properties.
+    </p>
+    <p>Background options can be following:</p>
+    <ul>
+        <li><code>translucent</code></li>
+        <li><code>transparent</code></li>
+        <li><code>solid</code></li>
+    </ul>
+    <p>The <b>default</b> background for the Carousel Content is <code>translucent</code>.</p>
+    <p>The <b>default</b> background for the Page Indicator Container is <code>solid</code>.</p>
+    <p>
+        Additionally, developers can pass <code>[noPaginationContainerBorder]="true"</code> to remove the border top or
+        bottom of the Pagination container.
+    </p>
+</description>
+<component-example>
+    <fd-carousel-background-example></fd-carousel-background-example>
+</component-example>
+<code-example [exampleFiles]="carouselAutoSlides"></code-example>

--- a/libs/docs/core/carousel/carousel-docs.module.ts
+++ b/libs/docs/core/carousel/carousel-docs.module.ts
@@ -22,6 +22,7 @@ import { CarouselLoopedNavigationExampleComponent } from './examples/carousel-lo
 import { CarouselErrorMessageExampleComponent } from './examples/carousel-error-message-example.component';
 import { CarouselLoadingContentExampleComponent } from './examples/carousel-loading-content-example.component';
 import { CarouselAutoSlidesExampleComponent } from './examples/carousel-auto-slides-example.component';
+import { CarouselBackgroundExampleComponent } from './examples/carousel-background-example.component';
 
 const routes: Routes = [
     {
@@ -60,7 +61,8 @@ const routes: Routes = [
         CarouselLoopedNavigationExampleComponent,
         CarouselErrorMessageExampleComponent,
         CarouselLoadingContentExampleComponent,
-        CarouselAutoSlidesExampleComponent
+        CarouselAutoSlidesExampleComponent,
+        CarouselBackgroundExampleComponent
     ],
     providers: [currentComponentProvider('carousel')]
 })

--- a/libs/docs/core/carousel/e2e/carousel.e2e-spec.ts
+++ b/libs/docs/core/carousel/e2e/carousel.e2e-spec.ts
@@ -215,17 +215,17 @@ describe('Carousel test suite', () => {
 
     describe('carousel with looped navigation example', () => {
         it('should check loop navigation', async () => {
-            const firstImg = await getAttributeByName(displayedImg, imgSource, 5);
+            const firstImg = await getAttributeByName(displayedImg, imgSource, 6);
 
-            await click(navBtns, 14);
+            await click(navBtns, 16);
             // pause for animation to complete
             await pause(1500);
-            await expect(await getAttributeByName(displayedImg, imgSource, 5)).not.toBe(firstImg);
+            await expect(await getAttributeByName(displayedImg, imgSource, 6)).not.toBe(firstImg);
 
-            await click(navBtns, 15);
+            await click(navBtns, 17);
             // pause for animation to complete
             await pause(1500);
-            await expect(await getAttributeByName(displayedImg, imgSource, 5)).toBe(firstImg);
+            await expect(await getAttributeByName(displayedImg, imgSource, 6)).toBe(firstImg);
         });
     });
 

--- a/libs/docs/core/carousel/examples/carousel-background-example.component.html
+++ b/libs/docs/core/carousel/examples/carousel-background-example.component.html
@@ -1,0 +1,62 @@
+<p>Transparent Carousel Content:</p>
+<ng-container
+    *ngTemplateOutlet="
+        renderer;
+        context: { contentBackground: 'transparent', paginationBackground: 'solid', noPaginationBorder: false }
+    "
+></ng-container>
+<p>Solid Carousel Content:</p>
+<ng-container
+    *ngTemplateOutlet="
+        renderer;
+        context: { contentBackground: 'solid', paginationBackground: 'solid', noPaginationBorder: false }
+    "
+></ng-container>
+<p>Transparent Page Indicator Container:</p>
+<ng-container
+    *ngTemplateOutlet="
+        renderer;
+        context: { contentBackground: 'solid', paginationBackground: 'transparent', noPaginationBorder: false }
+    "
+></ng-container>
+<p>Translucent Page Indicator Container:</p>
+<ng-container
+    *ngTemplateOutlet="
+        renderer;
+        context: { contentBackground: 'solid', paginationBackground: 'translucent', noPaginationBorder: false }
+    "
+></ng-container>
+<p>Page Indicator Container with no border:</p>
+<ng-container
+    *ngTemplateOutlet="
+        renderer;
+        context: { contentBackground: 'solid', paginationBackground: 'solid', noPaginationBorder: true }
+    "
+></ng-container>
+
+<ng-template
+    #renderer
+    let-contentBackground="contentBackground"
+    let-paginationBackground="paginationBackground"
+    let-noPaginationBorder="noPaginationBorder"
+>
+    <div style="display: flex; justify-content: center">
+        <fd-carousel
+            width="500px"
+            [contentBackground]="contentBackground"
+            [pageIndicatorBackground]="paginationBackground"
+            [noPaginationContainerBorder]="noPaginationBorder"
+        >
+            <fd-carousel-item>
+                <img
+                    src="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22500%22%20height%3D%22400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20500%20400%22%20preserveAspectRatio%3D%22none%22%3E%0A%20%20%20%20%20%20%3Cdefs%3E%0A%20%20%20%20%20%20%20%20%3Cstyle%20type%3D%22text%2Fcss%22%3E%0A%20%20%20%20%20%20%20%20%20%20%23holder%20text%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20fill%3A%20%23ccc%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20font-family%3A%20sans-serif%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20font-size%3A%2040px%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20font-weight%3A%20400%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%3C%2Fstyle%3E%0A%20%20%20%20%20%20%3C%2Fdefs%3E%0A%20%20%20%20%20%20%3Cg%20id%3D%22holder%22%3E%0A%20%20%20%20%20%20%20%20%3Crect%20width%3D%22100%25%22%20height%3D%22100%25%22%20fill%3D%22transparent%22%3E%3C%2Frect%3E%0A%20%20%20%20%20%20%20%20%3Cg%3E%0A%20%20%20%20%20%20%20%20%20%20%3Ctext%20text-anchor%3D%22middle%22%20x%3D%2250%25%22%20y%3D%2250%25%22%20dy%3D%22.3em%22%3E500%20x%20400%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3C%2Fg%3E%0A%20%20%20%20%20%20%3C%2Fg%3E%0A%20%20%20%20%3C%2Fsvg%3E"
+                />
+            </fd-carousel-item>
+            <fd-carousel-item>
+                <img
+                    src="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22500%22%20height%3D%22400%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20500%20400%22%20preserveAspectRatio%3D%22none%22%3E%0A%20%20%20%20%20%20%3Cdefs%3E%0A%20%20%20%20%20%20%20%20%3Cstyle%20type%3D%22text%2Fcss%22%3E%0A%20%20%20%20%20%20%20%20%20%20%23holder%20text%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20fill%3A%20%23ccc%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20font-family%3A%20sans-serif%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20font-size%3A%2040px%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20font-weight%3A%20400%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%3C%2Fstyle%3E%0A%20%20%20%20%20%20%3C%2Fdefs%3E%0A%20%20%20%20%20%20%3Cg%20id%3D%22holder%22%3E%0A%20%20%20%20%20%20%20%20%3Crect%20width%3D%22100%25%22%20height%3D%22100%25%22%20fill%3D%22transparent%22%3E%3C%2Frect%3E%0A%20%20%20%20%20%20%20%20%3Cg%3E%0A%20%20%20%20%20%20%20%20%20%20%3Ctext%20text-anchor%3D%22middle%22%20x%3D%2250%25%22%20y%3D%2250%25%22%20dy%3D%22.3em%22%3E500%20x%20400%3C%2Ftext%3E%0A%20%20%20%20%20%20%20%20%3C%2Fg%3E%0A%20%20%20%20%20%20%3C%2Fg%3E%0A%20%20%20%20%3C%2Fsvg%3E"
+                />
+            </fd-carousel-item>
+        </fd-carousel>
+    </div>
+</ng-template>

--- a/libs/docs/core/carousel/examples/carousel-background-example.component.ts
+++ b/libs/docs/core/carousel/examples/carousel-background-example.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+    selector: 'fd-carousel-background-example',
+    templateUrl: './carousel-background-example.component.html',
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CarouselBackgroundExampleComponent {}

--- a/libs/docs/core/carousel/examples/carousel-content-navigation-example.component.html
+++ b/libs/docs/core/carousel/examples/carousel-content-navigation-example.component.html
@@ -1,39 +1,52 @@
-<div style="display: flex; justify-content: center">
-    <fd-carousel [navigatorInPageIndicator]="false" carouselIndicatorsOrientation="top" width="500px">
-        <fd-carousel-item>
-            <img src="https://picsum.photos/500/500?nature/1" alt="first image" />
-        </fd-carousel-item>
+<p>Horizontal navigation:</p>
+<ng-container *ngTemplateOutlet="renderer; context: { $implicit: false }"></ng-container>
+<p>Vertical navigation:</p>
+<ng-container *ngTemplateOutlet="renderer; context: { $implicit: true }"></ng-container>
 
-        <fd-carousel-item>
-            <img src="https://picsum.photos/500/500?nature/2" alt="second image" />
-        </fd-carousel-item>
+<ng-template #renderer let-direction>
+    <div style="display: flex; justify-content: center">
+        <fd-carousel
+            [navigatorInPageIndicator]="false"
+            carouselIndicatorsOrientation="top"
+            width="500px"
+            height="550px"
+            [vertical]="direction"
+        >
+            <fd-carousel-item>
+                <img src="https://picsum.photos/500/500?nature/1" alt="first image" />
+            </fd-carousel-item>
 
-        <fd-carousel-item>
-            <img src="https://picsum.photos/500/500?nature/3" alt="third image" />
-        </fd-carousel-item>
+            <fd-carousel-item>
+                <img src="https://picsum.photos/500/500?nature/2" alt="second image" />
+            </fd-carousel-item>
 
-        <fd-carousel-item>
-            <img src="https://picsum.photos/500/500?nature/4" alt="forth image" />
-        </fd-carousel-item>
+            <fd-carousel-item>
+                <img src="https://picsum.photos/500/500?nature/3" alt="third image" />
+            </fd-carousel-item>
 
-        <fd-carousel-item>
-            <img src="https://picsum.photos/500/500?nature/5" alt="fifth image" />
-        </fd-carousel-item>
+            <fd-carousel-item>
+                <img src="https://picsum.photos/500/500?nature/4" alt="forth image" />
+            </fd-carousel-item>
 
-        <fd-carousel-item>
-            <img src="https://picsum.photos/500/500?nature/6" alt="sixth image" />
-        </fd-carousel-item>
+            <fd-carousel-item>
+                <img src="https://picsum.photos/500/500?nature/5" alt="fifth image" />
+            </fd-carousel-item>
 
-        <fd-carousel-item>
-            <img src="https://picsum.photos/500/500?nature/7" alt="seventh image" />
-        </fd-carousel-item>
+            <fd-carousel-item>
+                <img src="https://picsum.photos/500/500?nature/6" alt="sixth image" />
+            </fd-carousel-item>
 
-        <fd-carousel-item>
-            <img src="https://picsum.photos/500/500?nature/8" alt="eight image" />
-        </fd-carousel-item>
+            <fd-carousel-item>
+                <img src="https://picsum.photos/500/500?nature/7" alt="seventh image" />
+            </fd-carousel-item>
 
-        <fd-carousel-item>
-            <img src="https://picsum.photos/500/500?sports/1" alt="ninth image" />
-        </fd-carousel-item>
-    </fd-carousel>
-</div>
+            <fd-carousel-item>
+                <img src="https://picsum.photos/500/500?nature/8" alt="eight image" />
+            </fd-carousel-item>
+
+            <fd-carousel-item>
+                <img src="https://picsum.photos/500/500?sports/1" alt="ninth image" />
+            </fd-carousel-item>
+        </fd-carousel>
+    </div>
+</ng-template>

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@fundamental-styles/cx": "0.30.0-rc.35",
     "@fundamental-styles/fn": "0.25.1-rc.16",
     "@nx/angular": "16.5.5",
-    "@sap-theming/theming-base-content": "11.6.1",
+    "@sap-theming/theming-base-content": "11.6.4",
     "@stackblitz/sdk": "1.8.2",
     "@swc/helpers": "0.5.1",
     "compare-versions": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3237,10 +3237,10 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@sap-theming/theming-base-content@11.6.1":
-  version "11.6.1"
-  resolved "https://registry.yarnpkg.com/@sap-theming/theming-base-content/-/theming-base-content-11.6.1.tgz#1368380b196d5445c7698c7a1a2725366cc1f9e3"
-  integrity sha512-07e1P2sOEl/CadBP3iejy/IpcHBWzojCNfly6WURM3HZeZLVvfGmLXVv0HQeJYfE8t+wRhDMJhnJvX5fjVH3Nw==
+"@sap-theming/theming-base-content@11.6.4":
+  version "11.6.4"
+  resolved "https://registry.yarnpkg.com/@sap-theming/theming-base-content/-/theming-base-content-11.6.4.tgz#828b314c5036b054d4bae20243b382e1eb57c7cf"
+  integrity sha512-ub3W9qRO4Kt1nrXJBvTqUbQjpAhcQNGcIh1CTopVStpGGhEP1a2VPeXxJQPL37FCzIFeN898OBiQgCgQNpVqYQ==
 
 "@sap-theming/theming-base-content@^11.4.0":
   version "11.6.3"


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #9821
## Description
- Added vertical carousel buttons changes;
- Added background configuration;

BREAKING CHANGE:
Vertical carousel markup change:
Previously navigation buttons had icons `sap-icon--slim-arrow-left` and `sap-icon--slim-arrow-left` ignoring the direction. Now if vertical navigation is applied, buttons will have icons `sap-icon--slim-arrow-up` and `sap-icon--slim-arrow-down` respectively.
<!-- Enter short description of the change -->
