### PR TITLE
chore: added `deprecated-decorator` as a dependency

### DIFF
--- a/libs/core/schematics/add-dependencies/index.ts
+++ b/libs/core/schematics/add-dependencies/index.ts
@@ -1,10 +1,10 @@
-import { Rule, Tree, SchematicContext, chain } from '@angular-devkit/schematics';
-import { NodeDependency, NodeDependencyType, addPackageJsonDependency } from '@schematics/angular/utility/dependencies';
+import { chain, Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { addPackageJsonDependency, NodeDependency, NodeDependencyType } from '@schematics/angular/utility/dependencies';
 import { Schema } from '../models/schema';
 import {
+    checkPackageVersion,
     getPackageVersionFromPackageJson,
     hasPackage,
-    checkPackageVersion,
     installDependencies
 } from '../utils/package-utils';
 
@@ -89,6 +89,19 @@ function addExternalLibraries(options: Schema): Rule {
                 // Will be replaced with the real version during sync-version script run
                 version: `VERSION_PLACEHOLDER`,
                 name: '@fundamental-ngx/cdk',
+                overwrite: true
+            });
+        }
+
+        if (
+            !hasPackage(tree, 'deprecated-decorator') ||
+            checkPackageVersion(tree, 'deprecated-decorator', '0.1.6', '<')
+        ) {
+            dependencies.push({
+                type: NodeDependencyType.Default,
+                // Will be replaced with the real version during sync-version script run
+                version: `0.1.6`,
+                name: 'deprecated-decorator',
                 overwrite: true
             });
         }

--- a/libs/core/src/lib/package.json
+++ b/libs/core/src/lib/package.json
@@ -34,7 +34,8 @@
     "fast-deep-equal": "FAST_DEEP_EQUAL_VER_PLACEHOLDER",
     "focus-trap": "FOCUSTRAP_VER_PLACEHOLDER",
     "lodash-es": "LODASH_ES_VER_PLACEHOLDER",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "deprecated-decorator": "0.1.6"
   },
   "exports": {
     "./styles/fundamental-ngx-core.css": {

--- a/libs/cx/src/lib/side-navigation/side-navigation.component.ts
+++ b/libs/cx/src/lib/side-navigation/side-navigation.component.ts
@@ -48,6 +48,7 @@ export class SideNavigationComponent
     @Input()
     @HostBinding('class.fdx-side-nav--condensed')
     set condensed(value: boolean) {
+        console.warn('The "condensed" input is not applicable to the CX side nav.');
         this._condensed = value;
     }
 

--- a/libs/moment-adapter/package-lock.json
+++ b/libs/moment-adapter/package-lock.json
@@ -1,5 +1,0 @@
-{
-  "name": "@fundamental-ngx/moment-adapter",
-  "version": "0.44.0-rc.4",
-  "lockfileVersion": 1
-}

--- a/libs/platform/schematics/ng-add/index.ts
+++ b/libs/platform/schematics/ng-add/index.ts
@@ -33,7 +33,7 @@ function callCoreSchematic(options: Schema): Rule {
 
         addPackageJsonDependency(tree, {
             type: NodeDependencyType.Default,
-            // Will be replaced with the real version during sync-version scipt run
+            // Will be replaced with the real version during sync-version script run
             version: `VERSION_PLACEHOLDER`,
             name: '@fundamental-ngx/core'
         });


### PR DESCRIPTION
## Description

This will fix runtime issue, dependency was missing from `ng-add` schematic
