### PR TITLE
feat(cdk): focusable item interface

### DIFF
--- a/libs/cdk/src/lib/utils/directives/focusable-grid/focusable-grid.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-grid/focusable-grid.directive.ts
@@ -6,6 +6,7 @@ import {
     DestroyRef,
     Directive,
     EventEmitter,
+    inject,
     Input,
     Output,
     QueryList
@@ -13,13 +14,8 @@ import {
 import { merge, startWith, switchMap } from 'rxjs';
 import { KeyUtil } from '../../functions';
 import { Nullable } from '../../models/nullable';
-import { FocusableItemPosition } from '../focusable-item';
-import {
-    FDK_FOCUSABLE_LIST_DIRECTIVE,
-    FocusableListDirective,
-    FocusableListPosition,
-    ScrollPosition
-} from '../focusable-list';
+import { FocusableItemPosition, FocusableListPosition } from '../focusable-item';
+import { FDK_FOCUSABLE_LIST_DIRECTIVE, FocusableListDirective, ScrollPosition } from '../focusable-list';
 import { findLastIndex } from 'lodash-es';
 import { FDK_FOCUSABLE_GRID_DIRECTIVE } from './focusable-grid.tokens';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -68,14 +64,14 @@ export class FocusableGridDirective implements AfterViewInit {
     readonly rowFocused = new EventEmitter<FocusableListPosition>();
 
     /** @hidden */
-    private _wrapHorizontally = false;
-
-    /** @hidden */
     @ContentChildren(FDK_FOCUSABLE_LIST_DIRECTIVE, { descendants: true })
     private readonly _focusableLists: QueryList<FocusableListDirective>;
 
     /** @hidden */
-    constructor(private readonly _destroyRef: DestroyRef) {}
+    private _wrapHorizontally = false;
+
+    /** @hidden */
+    private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     ngAfterViewInit(): void {

--- a/libs/cdk/src/lib/utils/directives/focusable-item/focusable-list.position.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-item/focusable-list.position.ts
@@ -1,0 +1,4 @@
+export interface FocusableListPosition {
+    rowIndex: number;
+    totalRows: number;
+}

--- a/libs/cdk/src/lib/utils/directives/focusable-item/focusable.item.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-item/focusable.item.ts
@@ -1,0 +1,11 @@
+import { FocusableOption } from '@angular/cdk/a11y';
+import { Observable } from 'rxjs';
+import { FocusableItemPosition } from './focusable-item.directive';
+
+export interface FocusableItem extends FocusableOption {
+    _position?: FocusableItemPosition;
+    isFocusable: (() => boolean) | boolean;
+    keydown: Observable<KeyboardEvent>;
+    setTabbable: (tabbable: boolean) => void;
+    element: (() => HTMLElement) | HTMLElement;
+}

--- a/libs/cdk/src/lib/utils/directives/focusable-item/get-item-element.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-item/get-item-element.ts
@@ -1,0 +1,16 @@
+import { FocusableItem } from './focusable.item';
+
+/**
+ * Returns the element of the item.
+ * @param item
+ */
+export function getItemElement(item?: FocusableItem): HTMLElement | null {
+    if (!item) {
+        return null;
+    }
+    if (typeof item.element === 'function') {
+        return item.element();
+    }
+
+    return item.element;
+}

--- a/libs/cdk/src/lib/utils/directives/focusable-item/index.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-item/index.ts
@@ -2,3 +2,6 @@ export * from './focusable-item.module';
 export * from './focusable-item.directive';
 export * from './focusable-item.tokens';
 export * from './focusable.observer';
+export * from './focusable.item';
+export * from './is-item-focusable';
+export * from './focusable-list.position';

--- a/libs/cdk/src/lib/utils/directives/focusable-item/is-item-focusable.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-item/is-item-focusable.ts
@@ -1,0 +1,9 @@
+import { FocusableItem } from './focusable.item';
+
+/**
+ * Returns true if the item configured to be focusable.
+ * @param item
+ */
+export function isItemFocusable(item: FocusableItem): boolean {
+    return Boolean(typeof item.isFocusable === 'function' ? item.isFocusable() : item.isFocusable);
+}

--- a/libs/cdk/src/lib/utils/directives/focusable-list/focusable-list.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-list/focusable-list.directive.ts
@@ -183,12 +183,12 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
     /** @hidden */
     constructor() {
         intersectionObservable(this._elementRef.nativeElement, { threshold: 0.25 })
-            .pipe(takeUntilDestroyed(this._destroyRef))
+            .pipe(takeUntilDestroyed())
             .subscribe((isVisible) => (this._isVisible = isVisible[0]?.isIntersecting));
 
         this._focusableObserver
             .observe(this._elementRef, false)
-            .pipe(takeUntilDestroyed(this._destroyRef))
+            .pipe(takeUntilDestroyed())
             .subscribe((isFocusable) => {
                 if (!isFocusable && isFocusable !== this.focusable) {
                     this.focusable = isFocusable;

--- a/libs/cdk/src/lib/utils/directives/focusable-list/focusable-list.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-list/focusable-list.directive.ts
@@ -18,29 +18,30 @@ import {
     SimpleChanges
 } from '@angular/core';
 import { finalize, map, startWith, takeUntil, tap } from 'rxjs/operators';
-import { FocusableItemDirective, FocusableItemPosition } from '../focusable-item/focusable-item.directive';
+import { FocusableItemPosition } from '../focusable-item/focusable-item.directive';
 import {
     DeprecatedSelector,
     FD_DEPRECATED_DIRECTIVE_SELECTOR,
     getDeprecatedModel
 } from '../../deprecated-selector.class';
-import { FDK_FOCUSABLE_ITEM_DIRECTIVE, FocusableObserver } from '../focusable-item';
+import {
+    FDK_FOCUSABLE_ITEM_DIRECTIVE,
+    FocusableItem,
+    FocusableListPosition,
+    FocusableObserver,
+    isItemFocusable
+} from '../focusable-item';
 import { FDK_FOCUSABLE_LIST_DIRECTIVE } from './focusable-list.tokens';
 import { merge, Subject } from 'rxjs';
 import { Nullable } from '../../models/nullable';
-import { FocusableOption, FocusKeyManager, LiveAnnouncer } from '@angular/cdk/a11y';
-import { destroyObservable, getNativeElement } from '../../helpers';
-import { HasElementRef } from '../../interfaces';
+import { FocusKeyManager, LiveAnnouncer } from '@angular/cdk/a11y';
 import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { intersectionObservable, KeyUtil } from '../../functions';
 import { ENTER, ESCAPE, F2, MAC_ENTER } from '@angular/cdk/keycodes';
 import { scrollIntoView, ScrollPosition } from './scroll';
+import { getItemElement } from '../focusable-item/get-item-element';
+import { destroyObservable } from '../../helpers';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
-export interface FocusableListPosition {
-    rowIndex: number;
-    totalRows: number;
-}
 
 export interface FocusableListItemFocusedEvent {
     index: number;
@@ -58,9 +59,6 @@ interface FocusableListConfig {
     direction?: 'vertical' | 'horizontal';
     contentDirection?: 'ltr' | 'rtl' | null;
 }
-
-export type FocusableItem = FocusableOption &
-    HasElementRef & { index: number; focusable: (() => boolean) | boolean; keydown: Subject<KeyboardEvent> };
 
 @Directive({
     // eslint-disable-next-line @angular-eslint/directive-selector
@@ -94,6 +92,7 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
 
         this.setTabbable(this._focusable);
     }
+
     get focusable(): boolean {
         return this._focusable;
     }
@@ -122,15 +121,15 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
 
     /** @hidden */
     @ContentChildren(FDK_FOCUSABLE_ITEM_DIRECTIVE, { descendants: true })
-    readonly _projectedFocusableItems: QueryList<FocusableItemDirective>;
+    readonly _projectedFocusableItems: QueryList<FocusableItem>;
 
     /** @hidden */
-    get _focusableItems(): QueryList<FocusableItemDirective> {
+    get _focusableItems(): QueryList<FocusableItem> {
         return this._items ? this._items : this._projectedFocusableItems;
     }
 
     /** @hidden */
-    _items: QueryList<FocusableItemDirective> | undefined;
+    _items: QueryList<FocusableItem> | undefined;
 
     /** @hidden */
     readonly _gridItemFocused$ = new Subject<FocusableItemPosition>();
@@ -140,14 +139,15 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
 
     /** @hidden */
     readonly _keydown$ = new Subject<FocusableListKeydownEvent>();
+
     /** @hidden */
     _isVisible = false;
 
     /** @hidden */
-    protected _focusable = false;
+    protected readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
-    protected readonly _destroyRef = inject(DestroyRef);
+    protected _focusable = false;
 
     /** @hidden */
     private _gridPosition: { rowIndex: number; totalRows: number };
@@ -183,12 +183,12 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
     /** @hidden */
     constructor() {
         intersectionObservable(this._elementRef.nativeElement, { threshold: 0.25 })
-            .pipe(takeUntilDestroyed())
+            .pipe(takeUntilDestroyed(this._destroyRef))
             .subscribe((isVisible) => (this._isVisible = isVisible[0]?.isIntersecting));
 
         this._focusableObserver
             .observe(this._elementRef, false)
-            .pipe(takeUntilDestroyed())
+            .pipe(takeUntilDestroyed(this._destroyRef))
             .subscribe((isFocusable) => {
                 if (!isFocusable && isFocusable !== this.focusable) {
                     this.focusable = isFocusable;
@@ -260,7 +260,7 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
     }
 
     /** Set items programmatically. */
-    setItems(items: QueryList<FocusableItemDirective>): void {
+    setItems(items: QueryList<FocusableItem>): void {
         this._items = items;
         this._listenOnItems();
     }
@@ -275,7 +275,7 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
         let availableIndex;
 
         this._focusableItems.find((item, itemIndex) => {
-            if (itemIndex >= index && item.fdkFocusableItem) {
+            if (itemIndex >= index && isItemFocusable(item)) {
                 availableIndex = itemIndex;
                 return true;
             }
@@ -284,7 +284,7 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
         });
 
         if (availableIndex != null) {
-            scrollIntoView(this._focusableItems.get(availableIndex)?.elementRef.nativeElement, scrollPosition);
+            scrollIntoView(getItemElement(this._focusableItems.get(availableIndex)), scrollPosition);
             this._keyManager?.setActiveItem(availableIndex);
         }
     }
@@ -357,24 +357,25 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
             keyManager = keyManager.withVerticalOrientation(false);
         }
 
-        keyManager.skipPredicate((item) => !(typeof item.focusable === 'boolean' ? item.focusable : item.focusable()));
+        keyManager.skipPredicate((i) => !isItemFocusable(i));
 
         this._keyManager = keyManager;
 
         const focusListenerDestroyers = items.map((item, index) =>
-            this._renderer.listen(getNativeElement(item), 'focus', () => {
+            this._renderer.listen(getItemElement(item), 'focus', () => {
                 const directiveItem = this._focusableItems.get(index);
                 if (!directiveItem) {
                     return;
                 }
 
                 if (this._gridPosition) {
-                    this._gridItemFocused$.next(directiveItem._position);
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    this._gridItemFocused$.next(directiveItem._position!);
                 }
 
-                this.itemFocused.next({ index: item.index, total: items.length });
+                this.itemFocused.next({ index, total: items.length });
                 this._focusableItems.forEach((i) => i.setTabbable(i === directiveItem));
-                this._keyManager?.setActiveItem(item.index);
+                this._keyManager?.setActiveItem(index);
             })
         );
 
@@ -395,6 +396,11 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
     }
 
     /** @hidden */
+    private _defaultListFocusedEventAnnouncer(position: FocusableListPosition): string {
+        return `Row: ${position.rowIndex + 1} of ${position.totalRows}, use F2 button to dive in and focus list's item`;
+    }
+
+    /** @hidden */
     private _listenOnItems(): void {
         const refresh$ = merge(this._refresh$, destroyObservable(this._destroyRef));
         this._refresh$.next();
@@ -402,18 +408,10 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
             .pipe(
                 startWith(null),
                 map(() => this._focusableItems.toArray()),
-                tap((items: FocusableItemDirective[]): void => {
-                    const focusableItems: FocusableItem[] = items.map((item, index) => ({
-                        index,
-                        focusable: () => item.fdkFocusableItem,
-                        elementRef: item.elementRef,
-                        focus: () => item.elementRef.nativeElement.focus(),
-                        keydown: item._keydown$
-                    }));
-
+                tap((items: FocusableItem[]): void => {
                     const direction = this.navigationDirection === 'grid' ? 'horizontal' : this.navigationDirection;
 
-                    this._initializeFocusManager(focusableItems, {
+                    this._initializeFocusManager(items, {
                         direction,
                         contentDirection: this.contentDirection,
                         wrap: this.wrap
@@ -422,10 +420,5 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
                 takeUntil(refresh$)
             )
             .subscribe();
-    }
-
-    /** @hidden */
-    private _defaultListFocusedEventAnnouncer(position: FocusableListPosition): string {
-        return `Row: ${position.rowIndex + 1} of ${position.totalRows}, use F2 button to dive in and focus list's item`;
     }
 }

--- a/libs/core/src/lib/table/directives/table-cell.directive.ts
+++ b/libs/core/src/lib/table/directives/table-cell.directive.ts
@@ -7,10 +7,6 @@ import { BooleanInput } from '@angular/cdk/coercion';
     selector: '[fdTableCell], [fd-table-cell]',
     providers: [
         {
-            provide: FocusableItemDirective,
-            useExisting: TableCellDirective
-        },
-        {
             provide: FDK_FOCUSABLE_ITEM_DIRECTIVE,
             useExisting: TableCellDirective
         }


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

Previously items should have extended FocusableItemDirective, although that is not a big deal in many cases, there are cases when that behavior is limiting and in general, depending on interface and not on inheritance better dev practice, so this PR does that, introduces the interface and alters behavior
