### PR TITLE
feat(core): toolbar horizon update

### DIFF
--- a/libs/cdk/src/lib/utils/components/dynamic-portal/dynamic-portal.component.ts
+++ b/libs/cdk/src/lib/utils/components/dynamic-portal/dynamic-portal.component.ts
@@ -2,6 +2,7 @@ import {
     AfterViewInit,
     Component,
     ComponentRef,
+    DestroyRef,
     ElementRef,
     EmbeddedViewRef,
     EventEmitter,
@@ -22,8 +23,8 @@ import {
     TemplatePortal
 } from '@angular/cdk/portal';
 import { coerceElement } from '@angular/cdk/coercion';
-import { BehaviorSubject, filter, map, takeUntil, tap } from 'rxjs';
-import { DestroyedService } from '../../services';
+import { BehaviorSubject, filter, map, tap } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /**
  * A component that can be used to attach a portal to a DOM element, without explicitly creating portal instances on place.
@@ -34,8 +35,7 @@ import { DestroyedService } from '../../services';
     selector: 'fdk-dynamic-portal',
     standalone: true,
     imports: [PortalModule],
-    template: ` <ng-template cdkPortalOutlet></ng-template>`,
-    providers: [DestroyedService]
+    template: ` <ng-template cdkPortalOutlet></ng-template>`
 })
 export class DynamicPortalComponent implements AfterViewInit {
     /** The DOM element to attach */
@@ -76,7 +76,7 @@ export class DynamicPortalComponent implements AfterViewInit {
     >(undefined);
 
     /** @hidden */
-    private destroy$ = inject(DestroyedService);
+    private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     private viewContainerRef = inject(ViewContainerRef);
@@ -107,7 +107,7 @@ export class DynamicPortalComponent implements AfterViewInit {
                     return new ComponentPortal(content);
                 }),
                 filter(Boolean),
-                takeUntil(this.destroy$)
+                takeUntilDestroyed(this._destroyRef)
             )
             .subscribe((portal) => {
                 const ref = portalOutlet.attach(portal);

--- a/libs/core/src/lib/toolbar/deprecated-toolbar-size.directive.ts
+++ b/libs/core/src/lib/toolbar/deprecated-toolbar-size.directive.ts
@@ -17,7 +17,8 @@ type ToolbarSize = 'cozy' | 'compact' | 'condensed' | null;
             provide: CONTENT_DENSITY_DIRECTIVE,
             useExisting: forwardRef(() => DeprecatedToolbarSizeDirective)
         }
-    ]
+    ],
+    standalone: true
 })
 export class DeprecatedToolbarSizeDirective
     extends BehaviorSubject<LocalContentDensityMode>

--- a/libs/core/src/lib/toolbar/toolbar-form-label.directive.ts
+++ b/libs/core/src/lib/toolbar/toolbar-form-label.directive.ts
@@ -6,6 +6,7 @@ import { ToolbarItemDirective } from './toolbar-item.directive';
     selector: '[fd-toolbar-form-label]',
     host: {
         class: 'fd-form-label fd-toolbar__overflow-form-label fd-toolbar__overflow-form-label--text'
-    }
+    },
+    standalone: true
 })
 export class ToolbarFormLabelDirective extends ToolbarItemDirective {}

--- a/libs/core/src/lib/toolbar/toolbar-item.directive.ts
+++ b/libs/core/src/lib/toolbar/toolbar-item.directive.ts
@@ -5,7 +5,8 @@ import { OverflowPriorityEnum } from './toolbar.component';
 
 @Directive({
     selector: '[fd-toolbar-item], [fdOverflowGroup], [fdOverflowPriority]',
-    providers: [{ provide: ToolbarItem, useExisting: forwardRef(() => ToolbarItemDirective) }]
+    providers: [{ provide: ToolbarItem, useExisting: forwardRef(() => ToolbarItemDirective) }],
+    standalone: true
 })
 export class ToolbarItemDirective implements ToolbarItem {
     /** @hidden */

--- a/libs/core/src/lib/toolbar/toolbar-label.directive.ts
+++ b/libs/core/src/lib/toolbar/toolbar-label.directive.ts
@@ -7,6 +7,7 @@ import { ToolbarItemDirective } from './toolbar-item.directive';
     selector: '[fd-toolbar-label]',
     host: {
         class: 'fd-label fd-toolbar__overflow-label'
-    }
+    },
+    standalone: true
 })
 export class ToolbarLabelDirective extends ToolbarItemDirective {}

--- a/libs/core/src/lib/toolbar/toolbar-overflow-button-menu.directive.ts
+++ b/libs/core/src/lib/toolbar/toolbar-overflow-button-menu.directive.ts
@@ -5,6 +5,7 @@ import { ToolbarItemDirective } from './toolbar-item.directive';
     selector: '[fdToolbarOverflowButtonMenu], [fd-toolbar-overflow-button-menu]',
     host: {
         class: 'fd-toolbar__overflow-button--menu'
-    }
+    },
+    standalone: true
 })
 export class ToolbarOverflowButtonMenuDirective extends ToolbarItemDirective {}

--- a/libs/core/src/lib/toolbar/toolbar-overflow-button.directive.ts
+++ b/libs/core/src/lib/toolbar/toolbar-overflow-button.directive.ts
@@ -5,6 +5,7 @@ import { ToolbarItemDirective } from './toolbar-item.directive';
     selector: '[fdToolbarOverflowButton], [fd-toolbar-overflow-button]',
     host: {
         class: 'fd-toolbar__overflow-button'
-    }
+    },
+    standalone: true
 })
 export class ToolbarOverflowButtonDirective extends ToolbarItemDirective {}

--- a/libs/core/src/lib/toolbar/toolbar-separator.component.ts
+++ b/libs/core/src/lib/toolbar/toolbar-separator.component.ts
@@ -7,6 +7,7 @@ import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         class: 'fd-toolbar__separator'
-    }
+    },
+    standalone: true
 })
 export class ToolbarSeparatorComponent {}

--- a/libs/core/src/lib/toolbar/toolbar-spacer.directive.ts
+++ b/libs/core/src/lib/toolbar/toolbar-spacer.directive.ts
@@ -2,7 +2,8 @@ import { Directive, HostBinding, Input } from '@angular/core';
 
 @Directive({
     // eslint-disable-next-line @angular-eslint/directive-selector
-    selector: 'fd-toolbar-spacer'
+    selector: 'fd-toolbar-spacer',
+    standalone: true
 })
 export class ToolbarSpacerDirective {
     /** Determines the width of spacer when fixed property is set to true

--- a/libs/core/src/lib/toolbar/toolbar.component.html
+++ b/libs/core/src/lib/toolbar/toolbar.component.html
@@ -1,35 +1,33 @@
-<div #toolbar [tabindex]="tabindex" [class.fd-toolbar--cozy]="_contentDensityObserver.isCozy$ | async">
-    <h4 *ngIf="title" class="fd-title fd-title--h4 fd-toolbar__title" [id]="titleId" #titleElement>{{ title }}</h4>
+<h4 *ngIf="title" class="fd-title fd-title--h4 fd-toolbar__title" [id]="titleId" #titleElement>{{ title }}</h4>
 
-    <ng-content></ng-content>
+<ng-content></ng-content>
 
-    <ng-container *ngIf="overflownItems.length > 0">
-        <fd-toolbar-spacer></fd-toolbar-spacer>
-        <fd-toolbar-separator></fd-toolbar-separator>
-        <fd-popover placement="bottom-end" [noArrow]="true" class="fd-popover">
-            <fd-popover-control>
-                <button
-                    fd-button
-                    title="More"
-                    aria-label="More"
-                    aria-haspopup="true"
-                    fdType="transparent"
-                    glyph="overflow"
-                ></button>
-            </fd-popover-control>
+<ng-container *ngIf="overflownItems.length > 0">
+    <fd-toolbar-spacer></fd-toolbar-spacer>
+    <fd-toolbar-separator></fd-toolbar-separator>
+    <fd-popover placement="bottom-end" [noArrow]="true" class="fd-popover">
+        <fd-popover-control>
+            <button
+                fd-button
+                title="More"
+                aria-label="More"
+                aria-haspopup="true"
+                fdType="transparent"
+                glyph="overflow"
+            ></button>
+        </fd-popover-control>
 
-            <fd-popover-body>
-                <div class="fd-toolbar__overflow">
-                    <ng-container *ngFor="let overflowedItem of overflownItems">
-                        <fdk-dynamic-portal
-                            [domElement]="overflowedItem.element"
-                            [style.display]="overflowedItem.priority === 'disappear' ? 'none' : 'flex'"
-                            [style.flex-direction]="overflowedItem.priority === 'disappear' ? undefined : 'column'"
-                        >
-                        </fdk-dynamic-portal>
-                    </ng-container>
-                </div>
-            </fd-popover-body>
-        </fd-popover>
-    </ng-container>
-</div>
+        <fd-popover-body>
+            <div class="fd-toolbar__overflow">
+                <ng-container *ngFor="let overflowedItem of overflownItems">
+                    <fdk-dynamic-portal
+                        [domElement]="overflowedItem.element"
+                        [style.display]="overflowedItem.priority === 'disappear' ? 'none' : 'flex'"
+                        [style.flex-direction]="overflowedItem.priority === 'disappear' ? undefined : 'column'"
+                    >
+                    </fdk-dynamic-portal>
+                </ng-container>
+            </div>
+        </fd-popover-body>
+    </fd-popover>
+</ng-container>

--- a/libs/core/src/lib/toolbar/toolbar.component.spec.ts
+++ b/libs/core/src/lib/toolbar/toolbar.component.spec.ts
@@ -63,7 +63,7 @@ describe('ToolbarComponent', () => {
                 expect(actualOverflowItems.length).toBeGreaterThan(0);
                 doneFn();
             });
-            resizeService.trigger(toolbar.toolbar.nativeElement, []);
+            resizeService.trigger(toolbar.elementRef.nativeElement, []);
         });
     });
 });
@@ -111,7 +111,7 @@ describe('ToolbarComponent - Prioritization', () => {
                 expect(actualOverflownItems.map((el) => el.priority)).toEqual(overflownItems);
                 doneFn();
             });
-            resizeService.trigger(toolbar.toolbar.nativeElement, []);
+            resizeService.trigger(toolbar.elementRef.nativeElement, []);
         });
     });
 });
@@ -166,7 +166,7 @@ describe('ToolbarComponent - Prioritization and Grouping', () => {
                 );
                 doneFn();
             });
-            resizeService.trigger(toolbar.toolbar.nativeElement, []);
+            resizeService.trigger(toolbar.elementRef.nativeElement, []);
         });
     });
 });

--- a/libs/core/src/lib/toolbar/toolbar.component.ts
+++ b/libs/core/src/lib/toolbar/toolbar.component.ts
@@ -10,9 +10,10 @@ import {
     DestroyRef,
     ElementRef,
     forwardRef,
+    HostBinding,
+    inject,
     Inject,
     Input,
-    NgZone,
     Optional,
     QueryList,
     SkipSelf,
@@ -132,6 +133,16 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
     @Input()
     tabindex = -1;
 
+    /** Toolbar Aria-label attribute. */
+    @Input()
+    @HostBinding('attr.aria-label')
+    ariaLabel: string;
+
+    /** Toolbar Aria-labelledby attribute. */
+    @Input()
+    @HostBinding('attr.aria-labelledby')
+    ariaLabelledBy: string;
+
     /** @hidden */
     @ViewChild('toolbar')
     toolbar: ElementRef;
@@ -160,6 +171,13 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
     /** @hidden */
     overflownItems: ToolbarItem[] = [];
 
+    /** HTML Element Reference. */
+    readonly elementRef = inject(ElementRef);
+
+    /** @hidden */
+    @HostBinding('attr.role')
+    private readonly _role = 'toolbar';
+
     /** @hidden */
     private _hasTitle = false;
 
@@ -171,14 +189,11 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
 
     /** @hidden */
     private get _toolbarWidth(): number {
-        return (this.toolbar.nativeElement as HTMLElement).clientWidth - OVERFLOW_SPACE;
+        return (this.elementRef.nativeElement as HTMLElement).clientWidth - OVERFLOW_SPACE;
     }
 
     /** @hidden */
     private _shouldOverflow = false;
-
-    /** @hidden */
-    private _initialised = false;
 
     /** @hidden */
     private shouldOverflow$ = new BehaviorSubject<boolean>(false);
@@ -189,7 +204,6 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
         readonly _contentDensityObserver: ContentDensityObserver,
         private readonly _destroyRef: DestroyRef,
         private resizeObserverService: ResizeObserverService,
-        private ngZone: NgZone,
         @Optional() @SkipSelf() @Inject(DYNAMIC_PAGE_HEADER_TOKEN) private _dynamicPageHeader?: DynamicPageHeader
     ) {
         _contentDensityObserver.subscribe();
@@ -211,7 +225,7 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
     /** @hidden */
     ngAfterViewInit(): void {
         this.overflowItems$ = combineLatest([
-            this.resizeObserverService.observe(this.toolbar.nativeElement).pipe(map(() => this._toolbarWidth)),
+            this.resizeObserverService.observe(this.elementRef.nativeElement).pipe(map(() => this._toolbarWidth)),
             this.toolbarItems.changes.pipe(
                 startWith(this.toolbarItems),
                 map((toolbarItems) => toolbarItems.toArray())
@@ -275,7 +289,6 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
             this.overflownItems = items;
             this._cd.detectChanges();
         });
-        this._initialised = true;
         this.buildComponentCssClass();
     }
 
@@ -298,9 +311,9 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
     }
 
     /** @hidden */
-    get elementRef(): ElementRef {
-        return this.toolbar;
-    }
+    // get elementRef(): ElementRef {
+    //     return this.toolbar;
+    // }
 
     /** Method triggering collapsible toolbar  */
     updateCollapsibleItems(): void {

--- a/libs/core/src/lib/toolbar/toolbar.component.ts
+++ b/libs/core/src/lib/toolbar/toolbar.component.ts
@@ -322,11 +322,6 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
         this._cd.detectChanges();
     }
 
-    /** @hidden */
-    // get elementRef(): ElementRef {
-    //     return this.toolbar;
-    // }
-
     /** Method triggering collapsible toolbar  */
     updateCollapsibleItems(): void {
         this._refreshOverflow$.next();

--- a/libs/core/src/lib/toolbar/toolbar.component.ts
+++ b/libs/core/src/lib/toolbar/toolbar.component.ts
@@ -39,6 +39,12 @@ import {
 } from '@fundamental-ngx/core/content-density';
 import { ToolbarItem } from './abstract-toolbar-item.class';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DynamicPortalComponent } from '@fundamental-ngx/cdk/utils';
+import { ButtonModule } from '@fundamental-ngx/core/button';
+import { PopoverModule } from '@fundamental-ngx/core/popover';
+import { ToolbarSeparatorComponent } from './toolbar-separator.component';
+import { ToolbarSpacerDirective } from './toolbar-spacer.directive';
+import { NgIf, NgFor } from '@angular/common';
 
 const ELEMENT_MARGIN = 8;
 const OVERFLOW_SPACE = 50 + 2 * ELEMENT_MARGIN;
@@ -64,6 +70,16 @@ export const enum OverflowPriorityEnum {
         contentDensityObserverProviders({
             defaultContentDensity: ContentDensityMode.COMPACT
         })
+    ],
+    standalone: true,
+    imports: [
+        NgIf,
+        ToolbarSpacerDirective,
+        ToolbarSeparatorComponent,
+        PopoverModule,
+        ButtonModule,
+        NgFor,
+        DynamicPortalComponent
     ]
 })
 export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssClassBuilder, AfterContentInit {
@@ -142,10 +158,6 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
     @Input()
     @HostBinding('attr.aria-labelledby')
     ariaLabelledBy: string;
-
-    /** @hidden */
-    @ViewChild('toolbar')
-    toolbar: ElementRef;
 
     /** @hidden */
     @ViewChild('titleElement')

--- a/libs/core/src/lib/toolbar/toolbar.module.ts
+++ b/libs/core/src/lib/toolbar/toolbar.module.ts
@@ -1,8 +1,4 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-
-import { ButtonModule } from '@fundamental-ngx/core/button';
-import { PopoverModule } from '@fundamental-ngx/core/popover';
 import { ToolbarComponent } from './toolbar.component';
 import { ToolbarItemDirective } from './toolbar-item.directive';
 import { ToolbarSeparatorComponent } from './toolbar-separator.component';
@@ -13,7 +9,6 @@ import { ToolbarOverflowButtonMenuDirective } from './toolbar-overflow-button-me
 import { ToolbarFormLabelDirective } from './toolbar-form-label.directive';
 import { DeprecatedToolbarSizeDirective } from './deprecated-toolbar-size.directive';
 import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
-import { DynamicPortalComponent } from '@fundamental-ngx/cdk/utils';
 
 const components = [
     ToolbarComponent,
@@ -28,8 +23,7 @@ const components = [
 ];
 
 @NgModule({
-    declarations: [...components],
-    imports: [CommonModule, ButtonModule, PopoverModule, ContentDensityModule, DynamicPortalComponent],
+    imports: [ContentDensityModule, ...components],
     exports: [...components, ContentDensityModule]
 })
 export class ToolbarModule {}

--- a/libs/docs/core/toolbar/examples/toolbar-overflow-grouping-example.component.html
+++ b/libs/docs/core/toolbar/examples/toolbar-overflow-grouping-example.component.html
@@ -1,4 +1,4 @@
-<fd-toolbar [shouldOverflow]="true">
+<fd-toolbar [shouldOverflow]="true" ariaLabel="Toolbar grouping example">
     <button fd-toolbar-item fd-button label="Button"></button>
     <button fd-toolbar-item fd-button fdOverflowPriority="always" label="Always"></button>
     <button fd-toolbar-item fd-button fdOverflowPriority="never" label="Never"></button>

--- a/libs/docs/core/toolbar/examples/toolbar-overflow-priority-example.component.html
+++ b/libs/docs/core/toolbar/examples/toolbar-overflow-priority-example.component.html
@@ -1,4 +1,4 @@
-<fd-toolbar [shouldOverflow]="true">
+<fd-toolbar [shouldOverflow]="true" ariaLabel="Toolbar overflow priority">
     <button fd-toolbar-item fd-button label="Button First"></button>
     <button fd-toolbar-item fd-button label="Always" fdOverflowPriority="always"></button>
     <button fd-toolbar-item fd-button label="Never" fdOverflowPriority="never"></button>

--- a/libs/docs/core/toolbar/examples/toolbar-separator-example.component.html
+++ b/libs/docs/core/toolbar/examples/toolbar-separator-example.component.html
@@ -1,4 +1,4 @@
-<fd-toolbar>
+<fd-toolbar ariaLabel="Toolbar separator example">
     <label fd-toolbar-label>text</label>
     <fd-toolbar-separator></fd-toolbar-separator>
     <label fd-toolbar-label>text</label>

--- a/libs/docs/core/toolbar/examples/toolbar-size-example.component.html
+++ b/libs/docs/core/toolbar/examples/toolbar-size-example.component.html
@@ -1,9 +1,9 @@
-<fd-toolbar fdCompact>
+<fd-toolbar fdCompact ariaLabel="Compact toolbar example">
     <label fd-toolbar-label>Text</label>
 </fd-toolbar>
 
 <br />
 
-<fd-toolbar fdCozy>
+<fd-toolbar fdCozy ariaLabel="Cozy toolbar example">
     <label fd-toolbar-label>Text</label>
 </fd-toolbar>

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "fast-deep-equal": "3.1.3",
     "focus-trap": "7.1.0",
     "focus-visible": "5.2.0",
-    "fundamental-styles": "0.30.0-rc.35",
+    "fundamental-styles": "0.30.2-rc.6",
     "highlight.js": "11.7.0",
     "intl": "1.2.5",
     "karma-viewport": "1.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9524,10 +9524,10 @@ fundamental-styles@0.25.1-rc.16:
   resolved "https://registry.yarnpkg.com/fundamental-styles/-/fundamental-styles-0.25.1-rc.16.tgz#8560a5e1411ac3dfbf6d593ba4cd7b1f3124f3d5"
   integrity sha512-/ETPbzv98pMtqT5nNODkamxDBJsDPJ4KG/f5XEAvExvdx0+IvESuZQES6n1F3He1o1zMGLJj4HVqp4UJFiRGsQ==
 
-fundamental-styles@0.30.0-rc.35:
-  version "0.30.0-rc.35"
-  resolved "https://registry.yarnpkg.com/fundamental-styles/-/fundamental-styles-0.30.0-rc.35.tgz#0827fa49ced8990cf75f17ce917e4a46c52cd117"
-  integrity sha512-x+Dd/G5gxVv9wpPbV3CZzWM6gYfMoImojaOCG2cX8dvBUbyYF8ANERXOyWzcRBceA1yNDksLU5b8O1VRjknWgA==
+fundamental-styles@0.30.2-rc.6:
+  version "0.30.2-rc.6"
+  resolved "https://registry.yarnpkg.com/fundamental-styles/-/fundamental-styles-0.30.2-rc.6.tgz#43b5e314eff0c16a0721cf0122ba6fbdb8746dc1"
+  integrity sha512-vKWZFlijWNNvju5v5Y93sVWGxe3uGicBptbfD+4r0lwInKEU0tQnQx87NfjtfdkPkqzDhmewMWTHI5ujNWXmOw==
 
 gauge@^4.0.3:
   version "4.0.4"


### PR DESCRIPTION
closes #9824
BREAKING CHANGE:
Removed inner `<div class="fd-toolbar">...</div>`.
Now classes and other attributes applied to the root `fd-toolbar` element.