### PR TITLE
feat(platform): form generator dynamic controls

### DIFF
--- a/libs/docs/platform/form-generator/examples/advanced/platform-form-generator-advanced-example.component.html
+++ b/libs/docs/platform/form-generator/examples/advanced/platform-form-generator-advanced-example.component.html
@@ -1,0 +1,22 @@
+<fdp-form-generator
+    columnLayout="XL2-L2-M2-S1"
+    mainTitle="Default Form Generator example"
+    [formItems]="questions"
+    (formSubmitted)="onFormSubmitted($event)"
+    (formCreated)="onFormCreated()"
+>
+</fdp-form-generator>
+
+<p>Form created: {{ formCreated }}</p>
+
+<p *ngIf="formValue">Form value: {{ formValue | json }}</p>
+
+<div *ngIf="formCreated" fd-bar barDesign="footer">
+    <div fd-bar-left>
+        <fdp-button (click)="submitForm()" type="submit" label="Submit form"></fdp-button>
+    </div>
+    <div fd-bar-right>
+        <fd-button-bar (click)="addControl()" label="Add new control"></fd-button-bar>
+        <fd-button-bar *ngIf="newControlIndex > 0" (click)="removeControl()" label="Remove control"></fd-button-bar>
+    </div>
+</div>

--- a/libs/docs/platform/form-generator/examples/advanced/platform-form-generator-advanced-example.component.ts
+++ b/libs/docs/platform/form-generator/examples/advanced/platform-form-generator-advanced-example.component.ts
@@ -1,0 +1,302 @@
+import { ChangeDetectionStrategy, Component, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Validators } from '@angular/forms';
+import {
+    DATE_TIME_FORMATS,
+    DatetimeAdapter,
+    FD_DATETIME_FORMATS,
+    FdDate,
+    FdDatetimeAdapter
+} from '@fundamental-ngx/core/datetime';
+import { DynamicFormItem, DynamicFormValue, FormGeneratorComponent } from '@fundamental-ngx/platform/form';
+import { BehaviorSubject } from 'rxjs';
+
+export const dummyAwaitablePromise = (timeout = 200): Promise<boolean> =>
+    new Promise<boolean>((resolve) => {
+        setTimeout(() => {
+            resolve(true);
+        }, timeout);
+    });
+
+@Component({
+    selector: 'fdp-platform-form-generator-advanced-example',
+    templateUrl: './platform-form-generator-advanced-example.component.html',
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [
+        // Note that this is usually provided in the root of your application.
+        // Due to the limit of this example we must provide it on this level.
+        {
+            provide: DatetimeAdapter,
+            useClass: FdDatetimeAdapter
+        },
+        {
+            provide: DATE_TIME_FORMATS,
+            useValue: FD_DATETIME_FORMATS
+        }
+    ]
+})
+export class PlatformFormGeneratorAdvancedExampleComponent {
+    @ViewChild(FormGeneratorComponent) formGenerator: FormGeneratorComponent;
+
+    newControlIndex = 0;
+
+    loading = false;
+
+    formCreated = false;
+    formValue: DynamicFormValue;
+
+    questions = new BehaviorSubject(INITIAL_QUESTIONS);
+
+    addControl(): void {
+        this.newControlIndex++;
+
+        const index = this.newControlIndex;
+
+        this.formGenerator.addControl(
+            {
+                type: 'input',
+                name: `nameInGroup${index}`,
+                message: `New input (group) ${index}`,
+                default: `John${index}`,
+                placeholder: 'Please provide your name',
+                guiOptions: {
+                    hint: {
+                        content: 'Some contextual hint',
+                        glyph: 'accidental-leave'
+                    },
+                    appendColon: true,
+                    column: 1
+                },
+                validate: async (value) => {
+                    await dummyAwaitablePromise();
+
+                    return value === `John${index}` ? null : `Your name should be John${index}`;
+                },
+                transformer: async (value: any) => {
+                    await dummyAwaitablePromise();
+                    return `${value}777`;
+                },
+                validators: [Validators.required]
+            },
+            ['some']
+        );
+    }
+
+    removeControl(): void {
+        if (this.newControlIndex === 0) {
+            return;
+        }
+
+        this.formGenerator.removeControl(`nameInGroup${this.newControlIndex}`, ['some']);
+
+        this.newControlIndex--;
+    }
+
+    onFormCreated(): void {
+        this.formCreated = true;
+    }
+
+    async onFormSubmitted(value: DynamicFormValue): Promise<void> {
+        console.log(value);
+
+        this.formValue = value;
+
+        this.loading = true;
+
+        // Simulate API request
+        await dummyAwaitablePromise(5000);
+
+        this.loading = false;
+    }
+
+    submitForm(): void {
+        this.formGenerator.submit();
+    }
+}
+
+const INITIAL_QUESTIONS: DynamicFormItem[] = [
+    {
+        name: 'some',
+        message: 'Some Group Name',
+        guiOptions: {
+            hint: 'Some contextual hint on group header'
+        },
+        items: [
+            {
+                type: 'input',
+                name: 'nameInGroup',
+                message: 'Your Name (Group)',
+                default: 'John',
+                placeholder: 'Please provide your name',
+                guiOptions: {
+                    hint: {
+                        content: 'Some contextual hint',
+                        glyph: 'accidental-leave'
+                    },
+                    appendColon: true,
+                    column: 1
+                },
+                validate: async (value) => {
+                    await dummyAwaitablePromise();
+
+                    return value === 'John' ? null : 'Your name should be John';
+                },
+                transformer: async (value: any) => {
+                    await dummyAwaitablePromise();
+                    return `${value}777`;
+                },
+                validators: [Validators.required]
+            }
+        ]
+    },
+    {
+        type: 'input',
+        name: 'name',
+        message: 'Your Name',
+        default: 'John',
+        placeholder: 'Please provide your name',
+        guiOptions: {
+            hint: 'Some contextual hint',
+            column: 1
+        },
+        validate: async (value) => {
+            await dummyAwaitablePromise();
+
+            return value === 'John' ? null : 'Your name should be John';
+        },
+        transformer: async (value: any) => {
+            await dummyAwaitablePromise();
+            return `${value}777`;
+        },
+        validators: [Validators.required]
+    },
+    {
+        type: 'password',
+        controlType: 'password',
+        name: 'password',
+        message: 'Password',
+        validators: [Validators.required],
+        validate: (value: string) => {
+            const passwordPattern = new RegExp('^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[^\\w\\s]).{8,}$');
+            return passwordPattern.test(value)
+                ? null
+                : 'Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character';
+        },
+        guiOptions: {
+            column: 1
+        }
+    },
+    {
+        type: 'number',
+        name: 'age',
+        controlType: 'number',
+        message: () => 'Your Age',
+        default: '18',
+        validators: [Validators.required],
+        guiOptions: {
+            column: 1
+        }
+    },
+    {
+        type: 'editor',
+        name: 'bio',
+        message: 'Your Biography',
+        guiOptions: {
+            column: 1
+        }
+    },
+    {
+        type: 'checkbox',
+        name: 'citizenship',
+        message: 'Your Citizenship',
+        guiOptions: {
+            inline: true,
+            column: 2
+        },
+        choices: () => [
+            'USA',
+            'Germany',
+            {
+                label: 'Ukraine',
+                value: 'Ukraine'
+            }
+        ],
+        validators: [Validators.required],
+        validate: (input) => (input?.length > 0 ? null : 'You need to select some country')
+    },
+    {
+        type: 'list',
+        name: 'department',
+        message: 'Department You Work In',
+        validators: [Validators.required],
+        default: 'IT',
+        choices: ['IT', 'Accounting', 'Management'],
+        guiOptions: {
+            column: 2
+        }
+    },
+    {
+        type: 'list',
+        name: 'main_speciality',
+        message: 'Main Speciality',
+        validators: [Validators.required],
+        choices: async () => {
+            await dummyAwaitablePromise();
+            return ['Front-end', 'Back-end'];
+        },
+        when: async (formValue: any) => {
+            await dummyAwaitablePromise();
+            return formValue.department === 'IT';
+        },
+        guiOptions: {
+            column: 2
+        }
+    },
+    {
+        type: 'confirm',
+        name: 'agree',
+        message: 'Do You Agree With Terms And Conditions?',
+        choices: ['Yes', 'No'],
+        validators: [Validators.required],
+        validate: async (value) => {
+            await dummyAwaitablePromise();
+            return value === 'Yes' ? null : 'You must agree';
+        },
+        guiOptions: {
+            column: 2
+        }
+    },
+    {
+        type: 'radio',
+        name: 'choose_best_option',
+        message: 'Primary Front-end Framework You Use',
+        choices: ['Angular', 'React', 'VueJS'],
+        guiOptions: {
+            column: 2
+        },
+        validators: [Validators.required],
+        validate: (result: string) => (result === 'Angular' ? null : 'You should pick Angular')
+    },
+    {
+        type: 'datepicker',
+        name: 'birthday',
+        message: 'Your Birthday',
+        guiOptions: {
+            column: 1
+        },
+        validators: [Validators.required],
+        validate: (value: FdDate) => (value !== null && value.year < 2020 ? null : 'You need to be born before 2020'),
+        transformer: (value: FdDate) => value?.toDateString()
+    },
+    {
+        type: 'switch',
+        name: 'enable_feature',
+        message: 'Enable Some Analytics',
+        default: false,
+        guiOptions: {
+            additionalData: {
+                semantic: true
+            }
+        }
+    }
+];

--- a/libs/docs/platform/form-generator/platform-form-generator-docs.component.html
+++ b/libs/docs/platform/form-generator/platform-form-generator-docs.component.html
@@ -192,3 +192,35 @@
 <code-example [exampleFiles]="loadingFormGenerator"></code-example>
 
 <separator></separator>
+
+<fd-docs-section-title id="advanced" componentName="form-generator">
+    Advanced control management
+</fd-docs-section-title>
+<description>
+    <p>There are several options on how to manage the control visibility in Form Generator:</p>
+    <ul>
+        <li>
+            With <code>when</code> function. This function reacts on form value changes and calculates whether the
+            particular control should be visible or not;
+        </li>
+        <li>
+            With <code>addControl</code> and <code>removeControl</code> methods. The logic of calling these methods
+            should be implemented by the developers;
+        </li>
+        <li>
+            With custom control that has inner form. This method allows developers to create groups of controls that can
+            be added or removed on the fly;
+        </li>
+    </ul>
+    <p>
+        The difference between <code>addControl/removeControl</code> and control with inner form is that with first
+        case, control can be placed into any group of Form Generator, where second option will be bound to the control
+        itself.
+    </p>
+</description>
+<component-example>
+    <fdp-platform-form-generator-advanced-example></fdp-platform-form-generator-advanced-example>
+</component-example>
+<code-example [exampleFiles]="loadingFormGenerator"></code-example>
+
+<separator></separator>

--- a/libs/docs/platform/form-generator/platform-form-generator-docs.module.ts
+++ b/libs/docs/platform/form-generator/platform-form-generator-docs.module.ts
@@ -29,6 +29,8 @@ import { PlatformFormGeneratorGroupingExampleComponent } from './examples/platfo
 import { PlatformFormGeneratorInlineHelpExampleComponent } from './examples/platform-form-generator-inline-help-example.component';
 import { TableModule } from '@fundamental-ngx/core/table';
 import { PlatformFormGeneratorLoadingExampleComponent } from './examples/loading/platform-form-generator-loading-example.component';
+import { PlatformFormGeneratorAdvancedExampleComponent } from './examples/advanced/platform-form-generator-advanced-example.component';
+import { BarModule } from '@fundamental-ngx/core/bar';
 
 const routes: Routes = [
     {
@@ -51,7 +53,8 @@ const routes: Routes = [
         PlatformButtonModule,
         PlatformSliderModule,
         BusyIndicatorModule,
-        TableModule
+        TableModule,
+        BarModule
     ],
     exports: [RouterModule],
     declarations: [
@@ -68,7 +71,8 @@ const routes: Routes = [
         PlatformFormGeneratorCustomFieldLayoutExampleComponent,
         PlatformFormGeneratorGroupingExampleComponent,
         PlatformFormGeneratorInlineHelpExampleComponent,
-        PlatformFormGeneratorLoadingExampleComponent
+        PlatformFormGeneratorLoadingExampleComponent,
+        PlatformFormGeneratorAdvancedExampleComponent
     ],
     providers: [currentComponentProvider('form-generator')]
 })

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
@@ -7,6 +7,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../p
     selector: 'fdp-dynamic-form-generator-checkbox',
     templateUrl: './dynamic-form-generator-checkbox.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorCheckboxComponent extends BaseDynamicFormGeneratorControl {

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component.ts
@@ -2,13 +2,17 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
+import { PlatformCheckboxGroupModule } from '../../../checkbox-group/checkbox-group.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
     selector: 'fdp-dynamic-form-generator-checkbox',
     templateUrl: './dynamic-form-generator-checkbox.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
+    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider],
+    standalone: true,
+    imports: [FormsModule, ReactiveFormsModule, PlatformCheckboxGroupModule]
 })
 export class DynamicFormGeneratorCheckboxComponent extends BaseDynamicFormGeneratorControl {
     /** @hidden */

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
@@ -7,6 +7,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../p
     selector: 'fdp-dynamic-form-generator-datepicker',
     templateUrl: './dynamic-form-generator-datepicker.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorDatepickerComponent extends BaseDynamicFormGeneratorControl {

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-datepicker/dynamic-form-generator-datepicker.component.ts
@@ -2,13 +2,17 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
+import { PlatformDatePickerModule } from '../../../date-picker/date-picker.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
     selector: 'fdp-dynamic-form-generator-datepicker',
     templateUrl: './dynamic-form-generator-datepicker.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
+    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider],
+    standalone: true,
+    imports: [FormsModule, ReactiveFormsModule, PlatformDatePickerModule]
 })
 export class DynamicFormGeneratorDatepickerComponent extends BaseDynamicFormGeneratorControl {
     /** @hidden */

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-editor/dynamic-form-generator-editor.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-editor/dynamic-form-generator-editor.component.ts
@@ -2,13 +2,17 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
+import { PlatformTextAreaModule } from '../../../text-area/text-area.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
     selector: 'fdp-dynamic-form-generator-editor',
     templateUrl: './dynamic-form-generator-editor.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
+    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider],
+    standalone: true,
+    imports: [FormsModule, ReactiveFormsModule, PlatformTextAreaModule]
 })
 export class DynamicFormGeneratorEditorComponent extends BaseDynamicFormGeneratorControl {
     /** @hidden */

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-editor/dynamic-form-generator-editor.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-editor/dynamic-form-generator-editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
@@ -7,6 +7,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../p
     selector: 'fdp-dynamic-form-generator-editor',
     templateUrl: './dynamic-form-generator-editor.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorEditorComponent extends BaseDynamicFormGeneratorControl {

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-input/dynamic-form-generator-input.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-input/dynamic-form-generator-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
@@ -8,6 +8,7 @@ import { InputDynamicFormFieldItem } from '../../interfaces/dynamic-form-item';
     selector: 'fdp-dynamic-form-generator-input',
     templateUrl: './dynamic-form-generator-input.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorInputComponent extends BaseDynamicFormGeneratorControl<InputDynamicFormFieldItem> {

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-input/dynamic-form-generator-input.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-input/dynamic-form-generator-input.component.ts
@@ -3,13 +3,18 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
 import { InputDynamicFormFieldItem } from '../../interfaces/dynamic-form-item';
+import { PlatformInputModule } from '../../../input/fdp-input.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NgIf } from '@angular/common';
 
 @Component({
     selector: 'fdp-dynamic-form-generator-input',
     templateUrl: './dynamic-form-generator-input.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
+    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider],
+    standalone: true,
+    imports: [NgIf, FormsModule, ReactiveFormsModule, PlatformInputModule]
 })
 export class DynamicFormGeneratorInputComponent extends BaseDynamicFormGeneratorControl<InputDynamicFormFieldItem> {
     /** @hidden */

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-multi-input/dynamic-form-generator-multi-input.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-multi-input/dynamic-form-generator-multi-input.component.ts
@@ -2,13 +2,17 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
+import { PlatformMultiInputModule } from '../../../multi-input/multi-input.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
     selector: 'fdp-dynamic-form-generator-multi-input',
     templateUrl: './dynamic-form-generator-multi-input.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
+    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider],
+    standalone: true,
+    imports: [FormsModule, ReactiveFormsModule, PlatformMultiInputModule]
 })
 export class DynamicFormGeneratorMultiInputComponent extends BaseDynamicFormGeneratorControl {
     /** @hidden */

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-multi-input/dynamic-form-generator-multi-input.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-multi-input/dynamic-form-generator-multi-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
@@ -7,6 +7,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../p
     selector: 'fdp-dynamic-form-generator-multi-input',
     templateUrl: './dynamic-form-generator-multi-input.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorMultiInputComponent extends BaseDynamicFormGeneratorControl {

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-object-status/dynamic-form-generator-object-status.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-object-status/dynamic-form-generator-object-status.component.ts
@@ -2,12 +2,16 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
 import { ObjectStatusDynamicFormFieldItem } from '../../interfaces/dynamic-form-item';
+import { PlatformObjectStatusModule } from '@fundamental-ngx/platform/object-status';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
     selector: 'fdp-dynamic-form-generator-object-status',
     templateUrl: './dynamic-form-generator-object-status.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
+    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider],
+    standalone: true,
+    imports: [FormsModule, ReactiveFormsModule, PlatformObjectStatusModule]
 })
 export class DynamicFormGeneratorObjectStatusComponent extends BaseDynamicFormGeneratorControl<ObjectStatusDynamicFormFieldItem> {}

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-radio/dynamic-form-generator-radio.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-radio/dynamic-form-generator-radio.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
@@ -7,6 +7,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../p
     selector: 'fdp-dynamic-form-generator-radio',
     templateUrl: './dynamic-form-generator-radio.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorRadioComponent extends BaseDynamicFormGeneratorControl {

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-radio/dynamic-form-generator-radio.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-radio/dynamic-form-generator-radio.component.ts
@@ -2,13 +2,17 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
+import { PlatformRadioGroupModule } from '../../../radio-group/radio-group.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
     selector: 'fdp-dynamic-form-generator-radio',
     templateUrl: './dynamic-form-generator-radio.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
+    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider],
+    standalone: true,
+    imports: [FormsModule, ReactiveFormsModule, PlatformRadioGroupModule]
 })
 export class DynamicFormGeneratorRadioComponent extends BaseDynamicFormGeneratorControl {
     /** @hidden */

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-select/dynamic-form-generator-select.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-select/dynamic-form-generator-select.component.ts
@@ -3,13 +3,17 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
 import { SelectDynamicFormFieldItem } from '../../interfaces/dynamic-form-item';
+import { PlatformSelectModule } from '../../../select/select.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
     selector: 'fdp-dynamic-form-generator-select',
     templateUrl: './dynamic-form-generator-select.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
+    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider],
+    standalone: true,
+    imports: [FormsModule, ReactiveFormsModule, PlatformSelectModule]
 })
 export class DynamicFormGeneratorSelectComponent extends BaseDynamicFormGeneratorControl<SelectDynamicFormFieldItem> {
     /** @hidden */

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-select/dynamic-form-generator-select.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-select/dynamic-form-generator-select.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
@@ -8,6 +8,7 @@ import { SelectDynamicFormFieldItem } from '../../interfaces/dynamic-form-item';
     selector: 'fdp-dynamic-form-generator-select',
     templateUrl: './dynamic-form-generator-select.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorSelectComponent extends BaseDynamicFormGeneratorControl<SelectDynamicFormFieldItem> {

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-switch/dynamic-form-generator-switch.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-switch/dynamic-form-generator-switch.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
@@ -7,6 +7,7 @@ import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../p
     selector: 'fdp-dynamic-form-generator-switch',
     templateUrl: './dynamic-form-generator-switch.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class DynamicFormGeneratorSwitchComponent extends BaseDynamicFormGeneratorControl {

--- a/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-switch/dynamic-form-generator-switch.component.ts
+++ b/libs/platform/src/lib/form/form-generator/controls/dynamic-form-generator-switch/dynamic-form-generator-switch.component.ts
@@ -2,13 +2,17 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 
 import { BaseDynamicFormGeneratorControl } from '../../base-dynamic-form-generator-control';
 import { dynamicFormFieldProvider, dynamicFormGroupChildProvider } from '../../providers/providers';
+import { PlatformSwitchModule } from '../../../switch/switch.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
     selector: 'fdp-dynamic-form-generator-switch',
     templateUrl: './dynamic-form-generator-switch.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
+    viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider],
+    standalone: true,
+    imports: [FormsModule, ReactiveFormsModule, PlatformSwitchModule]
 })
 export class DynamicFormGeneratorSwitchComponent extends BaseDynamicFormGeneratorControl {
     /** @hidden */

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control-field.directive.spec.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control-field.directive.spec.ts
@@ -15,7 +15,9 @@ import { DynamicFormControl } from './dynamic-form-control';
         <div class="should-hide" *fdpDynamicFormControlField="control; show: !shouldShow">
             <p>This is hidden</p>
         </div>
-    `
+    `,
+    standalone: true,
+    imports: [DynamicFormControlFieldDirective]
 })
 class HostComponent {
     control = new DynamicFormControl('default value', {
@@ -30,7 +32,7 @@ describe('DynamicFormControlFieldDirective', () => {
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            declarations: [DynamicFormControlFieldDirective, HostComponent]
+            imports: [HostComponent]
         }).compileComponents();
     }));
 

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control-field.directive.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control-field.directive.ts
@@ -9,7 +9,8 @@ import { DynamicFormControl } from './dynamic-form-control';
  * Structural directive, which hides current form item and toggles validation rules for it.
  */
 @Directive({
-    selector: '[fdpDynamicFormControlField]'
+    selector: '[fdpDynamicFormControlField]',
+    standalone: true
 })
 export class DynamicFormControlFieldDirective implements OnInit {
     /**

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control.directive.ts
@@ -17,7 +17,8 @@ import { Observable, of } from 'rxjs';
  * based on the information provided in `formItem` input
  */
 @Directive({
-    selector: '[fdpDynamicFormControl]'
+    selector: '[fdpDynamicFormControl]',
+    standalone: true
 })
 export class DynamicFormControlDirective implements OnInit {
     /**

--- a/libs/platform/src/lib/form/form-generator/dynamic-form-control.ts
+++ b/libs/platform/src/lib/form/form-generator/dynamic-form-control.ts
@@ -1,7 +1,7 @@
 import { AbstractControlOptions, AsyncValidatorFn, FormControl, FormGroup, ValidatorFn } from '@angular/forms';
 
 import { DynamicAbstractControlOptions } from './interfaces/dynamic-abstract-control';
-import { DynamicFormFieldGroup, PreparedDynamicFormFieldItem } from './interfaces/dynamic-form-item';
+import { DynamicFormFieldGroupMap, PreparedDynamicFormFieldItem } from './interfaces/dynamic-form-item';
 
 export type DynamicFormGroupControl = DynamicFormControl | DynamicFormControlGroup;
 
@@ -11,7 +11,7 @@ export interface DynamicFormGroupControls {
 
 export class DynamicFormControlGroup extends FormGroup {
     /** @hidden */
-    public formItem: DynamicFormFieldGroup;
+    public formItem: DynamicFormFieldGroupMap;
     /** @hidden */
     public type = 'group';
     /** @hidden */
@@ -19,7 +19,7 @@ export class DynamicFormControlGroup extends FormGroup {
 
     /** @hidden */
     constructor(
-        formItem: DynamicFormFieldGroup,
+        formItem: DynamicFormFieldGroupMap,
         controls: DynamicFormGroupControls,
         validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null,
         asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null

--- a/libs/platform/src/lib/form/form-generator/fdp-form-generator.module.ts
+++ b/libs/platform/src/lib/form/form-generator/fdp-form-generator.module.ts
@@ -1,22 +1,7 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-
-import { FormMessageModule } from '@fundamental-ngx/core/form';
-import { BusyIndicatorModule } from '@fundamental-ngx/core/busy-indicator';
-import { PlatformButtonModule } from '@fundamental-ngx/platform/button';
-import { SkeletonModule } from '@fundamental-ngx/core/skeleton';
 import { FormGeneratorComponentsAccessorService } from './form-generator-components-accessor.service';
 import { FormGeneratorComponent } from './form-generator/form-generator.component';
 import { DynamicFormControlFieldDirective } from './dynamic-form-control-field.directive';
-import { PlatformInputModule } from '../input/fdp-input.module';
-import { FdpFormGroupModule } from '../form-group/fdp-form.module';
-import { PlatformCheckboxGroupModule } from '../checkbox-group/checkbox-group.module';
-import { PlatformSelectModule } from '../select/select.module';
-import { PlatformRadioGroupModule } from '../radio-group/radio-group.module';
-import { PlatformTextAreaModule } from '../text-area/text-area.module';
-import { PlatformDatePickerModule } from '../date-picker/date-picker.module';
-import { PlatformSwitchModule } from '../switch/switch.module';
 import { DynamicFormControlDirective } from './dynamic-form-control.directive';
 import { DynamicFormGeneratorCheckboxComponent } from './controls/dynamic-form-generator-checkbox/dynamic-form-generator-checkbox.component';
 import { DynamicFormGeneratorInputComponent } from './controls/dynamic-form-generator-input/dynamic-form-generator-input.component';
@@ -30,8 +15,6 @@ import { FormGeneratorFieldComponent } from './form-generator-field/form-generat
 import { DynamicFormGeneratorMultiInputComponent } from './controls/dynamic-form-generator-multi-input/dynamic-form-generator-multi-input.component';
 import { FormGeneratorModuleConfig } from './interfaces/form-generator-module-config';
 import { GetOrderedFieldControlsPipe } from './pipes/get-ordered-form-controls.pipe';
-import { PlatformMultiComboboxModule } from '../multi-combobox/multi-combobox.module';
-import { PlatformMultiInputModule } from '../multi-input/multi-input.module';
 import {
     defaultFormGeneratorConfigProvider,
     defaultFormGeneratorItemConfigProvider,
@@ -39,9 +22,8 @@ import {
     FORM_GENERATOR_ITEM_CONFIG
 } from './providers/providers';
 import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
-import { ListModule } from '@fundamental-ngx/core/list';
 import { DynamicFormGeneratorObjectStatusComponent } from './controls/dynamic-form-generator-object-status/dynamic-form-generator-object-status.component';
-import { PlatformObjectStatusModule } from '@fundamental-ngx/platform/object-status';
+import { GetHintOptionsPipe } from './pipes/get-hint-options.pipe';
 
 /**
  * Adds Form Generator functionality to your application.
@@ -51,7 +33,7 @@ import { PlatformObjectStatusModule } from '@fundamental-ngx/platform/object-sta
  * * With `withConfig()` method which allows passing custom default configuration.
  */
 @NgModule({
-    declarations: [
+    imports: [
         FormGeneratorComponent,
         DynamicFormControlFieldDirective,
         DynamicFormControlDirective,
@@ -65,30 +47,8 @@ import { PlatformObjectStatusModule } from '@fundamental-ngx/platform/object-sta
         FormGeneratorFieldComponent,
         DynamicFormGeneratorMultiInputComponent,
         GetOrderedFieldControlsPipe,
-        DynamicFormGeneratorObjectStatusComponent
-    ],
-    imports: [
-        CommonModule,
-        FdpFormGroupModule,
-        PlatformInputModule,
-        FormsModule,
-        ReactiveFormsModule,
-        PlatformButtonModule,
-        PlatformCheckboxGroupModule,
-        PlatformSelectModule,
-        PlatformRadioGroupModule,
-        PlatformTextAreaModule,
-        PlatformInputModule,
-        PlatformDatePickerModule,
-        PlatformSwitchModule,
-        FormMessageModule,
-        BusyIndicatorModule,
-        PlatformMultiComboboxModule,
-        PlatformMultiInputModule,
-        ContentDensityModule,
-        SkeletonModule,
-        ListModule,
-        PlatformObjectStatusModule
+        DynamicFormGeneratorObjectStatusComponent,
+        GetHintOptionsPipe
     ],
     providers: [
         FormGeneratorService,
@@ -109,7 +69,8 @@ import { PlatformObjectStatusModule } from '@fundamental-ngx/platform/object-sta
         DynamicFormGeneratorSwitchComponent,
         FormGeneratorFieldComponent,
         ContentDensityModule,
-        DynamicFormGeneratorObjectStatusComponent
+        DynamicFormGeneratorObjectStatusComponent,
+        GetHintOptionsPipe
     ]
 })
 export class PlatformFormGeneratorModule {

--- a/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.html
+++ b/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.html
@@ -18,7 +18,7 @@
 >
     <ng-container *ngFor="let error of _errorModels; trackBy: _errorsTrackBy">
         <span *fdpFormFieldError="error.type; let directiveError">
-            <ng-container *ngIf="_isAdvancedError(directiveError)">
+            <ng-container *ngIf="_isAdvancedError(directiveError); else simpleErrorTemplate">
                 <ng-container *ngIf="directiveError.heading">
                     <span *fdpFormFieldErrorHeading="let validationError; type: directiveError.type">
                         {{ validationError.heading }}
@@ -30,11 +30,11 @@
                     </span>
                 </ng-container>
             </ng-container>
-            <ng-container *ngIf="!_isAdvancedError(directiveError)">
+            <ng-template #simpleErrorTemplate>
                 <span *fdpFormFieldErrorHeading="let validationError">
                     {{ error.value ? error.value : validationError }}
                 </span>
-            </ng-container>
+            </ng-template>
         </span>
     </ng-container>
     <ng-container

--- a/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.html
+++ b/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.html
@@ -16,7 +16,7 @@
     [formGroup]="form"
     #formField
 >
-    <ng-container *ngFor="let error of _errorModels">
+    <ng-container *ngFor="let error of _errorModels; trackBy: _errorsTrackBy">
         <span *fdpFormFieldError="error.type; let directiveError">
             <ng-container *ngIf="_isAdvancedError(directiveError)">
                 <ng-container *ngIf="directiveError.heading">

--- a/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.ts
@@ -17,6 +17,10 @@ import { DynamicFormControl } from '../dynamic-form-control';
 import { FormGeneratorService } from '../form-generator.service';
 import { DynamicFormGroup } from '../interfaces/dynamic-form-group';
 import { DynamicFormItemValidationObject } from '../interfaces/dynamic-form-item';
+import { DynamicFormControlDirective } from '../dynamic-form-control.directive';
+import { NgFor, NgIf } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FdpFormGroupModule } from '../../form-group/fdp-form.module';
 
 const formFieldProvider: Provider = {
     provide: FD_FORM_FIELD,
@@ -32,7 +36,9 @@ const formGroupChildProvider: Provider = {
     selector: 'fdp-form-generator-field',
     templateUrl: './form-generator-field.component.html',
     providers: [formFieldProvider, formGroupChildProvider],
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    standalone: true,
+    imports: [FdpFormGroupModule, FormsModule, ReactiveFormsModule, NgFor, NgIf, DynamicFormControlDirective]
 })
 export class FormGeneratorFieldComponent implements OnInit {
     /**
@@ -113,6 +119,11 @@ export class FormGeneratorFieldComponent implements OnInit {
     }
 
     /** @hidden */
+    _isAdvancedError(error: any): error is DynamicFormItemValidationObject {
+        return error.heading && error.description && error.type;
+    }
+
+    /** @hidden */
     private _getErrors(): { type: string; value: any }[] {
         const registeredErrors = this._fgService.validationErrorHints;
 
@@ -133,10 +144,5 @@ export class FormGeneratorFieldComponent implements OnInit {
         });
 
         return returnErrors;
-    }
-
-    /** @hidden */
-    _isAdvancedError(error: any): error is DynamicFormItemValidationObject {
-        return error.heading && error.description && error.type;
     }
 }

--- a/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator-field/form-generator-field.component.ts
@@ -108,6 +108,11 @@ export class FormGeneratorFieldComponent implements OnInit {
     }
 
     /** @hidden */
+    _errorsTrackBy(_: number, error: { type: string; value: any }): string {
+        return error.type;
+    }
+
+    /** @hidden */
     private _getErrors(): { type: string; value: any }[] {
         const registeredErrors = this._fgService.validationErrorHints;
 

--- a/libs/platform/src/lib/form/form-generator/form-generator.service.spec.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.spec.ts
@@ -13,6 +13,8 @@ import {
 } from './providers/providers';
 import { BaseDynamicFormGeneratorControl } from './base-dynamic-form-generator-control';
 import { mapFormItems } from './helpers';
+import { PlatformFormGeneratorModule } from './fdp-form-generator.module';
+import { ContentDensityModule } from '@fundamental-ngx/core/content-density';
 
 export const dummyFormItemsWithWhenCondition: Map<string, DynamicFormItemMap> = mapFormItems([
     {
@@ -58,8 +60,8 @@ export const brokenFormItems: Map<string, DynamicFormItemMap> = mapFormItems([
     template: `
         <ng-container [formGroup]="form">
             <fdp-slider
-                [fdContentDensity]="formItem.guiOptions?.contentDensity"
-                [customValues]="formItem.choices"
+                [fdContentDensity]="$any(formItem.guiOptions?.contentDensity)"
+                [customValues]="$any(formItem.choices)"
                 [showTicks]="formItem.guiOptions?.additionalData?.showTicks"
                 [showTicksLabels]="formItem.guiOptions?.additionalData?.showTicksLabels"
                 [name]="name"
@@ -67,6 +69,8 @@ export const brokenFormItems: Map<string, DynamicFormItemMap> = mapFormItems([
             ></fdp-slider>
         </ng-container>
     `,
+    standalone: true,
+    imports: [PlatformFormGeneratorModule, PlatformSliderModule, ReactiveFormsModule, ContentDensityModule],
     viewProviders: [dynamicFormFieldProvider, dynamicFormGroupChildProvider]
 })
 export class TestCustomComponent extends BaseDynamicFormGeneratorControl {
@@ -80,8 +84,7 @@ describe('FormGeneratorService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            declarations: [TestCustomComponent],
-            imports: [FormsModule, ReactiveFormsModule, PlatformSliderModule],
+            imports: [FormsModule, ReactiveFormsModule, TestCustomComponent],
             providers: [
                 defaultFormGeneratorItemConfigProvider,
                 FormGeneratorService,

--- a/libs/platform/src/lib/form/form-generator/form-generator.service.spec.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator.service.spec.ts
@@ -5,15 +5,16 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { PlatformSliderModule } from '@fundamental-ngx/platform/slider';
 import { FormGeneratorComponentsAccessorService } from './form-generator-components-accessor.service';
 import { FormGeneratorService } from './form-generator.service';
-import { DynamicFormFieldItem } from './interfaces/dynamic-form-item';
+import { DynamicFormItemMap } from './interfaces/dynamic-form-item';
 import {
     defaultFormGeneratorItemConfigProvider,
     dynamicFormFieldProvider,
     dynamicFormGroupChildProvider
 } from './providers/providers';
 import { BaseDynamicFormGeneratorControl } from './base-dynamic-form-generator-control';
+import { mapFormItems } from './helpers';
 
-export const dummyFormItemsWithWhenCondition: DynamicFormFieldItem[] = [
+export const dummyFormItemsWithWhenCondition: Map<string, DynamicFormItemMap> = mapFormItems([
     {
         type: 'input',
         name: 'shouldBeVisible',
@@ -26,9 +27,9 @@ export const dummyFormItemsWithWhenCondition: DynamicFormFieldItem[] = [
         message: 'Should be hidden',
         when: (answers) => answers.shouldBeVisible === true
     }
-];
+]);
 
-export const dummyFormItems: DynamicFormFieldItem[] = [
+export const dummyFormItems: Map<string, DynamicFormItemMap> = mapFormItems([
     {
         type: 'input',
         name: 'something',
@@ -36,9 +37,9 @@ export const dummyFormItems: DynamicFormFieldItem[] = [
         default: 'test',
         transformer: (value: string) => `${value}!!!`
     }
-];
+]);
 
-export const brokenFormItems: DynamicFormFieldItem[] = [
+export const brokenFormItems: Map<string, DynamicFormItemMap> = mapFormItems([
     {
         type: 'notExistingControlType',
         name: 'shouldNotBeInForm',
@@ -51,7 +52,7 @@ export const brokenFormItems: DynamicFormFieldItem[] = [
         message: 'wow',
         default: 'test'
     }
-];
+]);
 
 @Component({
     template: `
@@ -95,7 +96,7 @@ describe('FormGeneratorService', () => {
     });
 
     it('should create empty form', async () => {
-        const form = await service.generateForm('dummyForm', []);
+        const form = await service.generateForm('dummyForm', new Map());
         // There's always a default group called 'ungrouped'.
         expect(Object.keys(form.controls).length).toBe(1);
     });

--- a/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.html
+++ b/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.html
@@ -15,7 +15,7 @@
     >
         <ng-container *ngFor="let error of _errorModels; trackBy: _errorsTrackBy">
             <span *fdpFormFieldError="error.type; let directiveError">
-                <ng-container *ngIf="_isAdvancedError(directiveError)">
+                <ng-container *ngIf="_isAdvancedError(directiveError); else simpleErrorTemplate">
                     <ng-container *ngIf="directiveError.heading">
                         <span *fdpFormFieldErrorHeading="let validationError; type: directiveError.type">
                             {{ validationError.heading }}
@@ -27,11 +27,11 @@
                         </span>
                     </ng-container>
                 </ng-container>
-                <ng-container *ngIf="!_isAdvancedError(directiveError)">
+                <ng-template #simpleErrorTemplate>
                     <span *fdpFormFieldErrorHeading="let validationError">
                         {{ error.value ? error.value : validationError }}
                     </span>
-                </ng-container>
+                </ng-template>
             </span>
         </ng-container>
         <ng-container *ngFor="let field of formControlItems; trackBy: _trackFn">
@@ -52,7 +52,7 @@
                     *fdpDynamicFormControlField="field; show: shouldShowFields[field.formItem.name] !== false"
                 >
                     <fdp-form-generator-field
-                        [hintOptions]="getHintOptions(field.formItem.guiOptions)"
+                        [hintOptions]="field.formItem.guiOptions | getHintOptions"
                         [form]="form"
                         [shouldShow]="shouldShowFields[field.formItem.name] !== false"
                         [field]="field"
@@ -64,7 +64,7 @@
             </ng-template>
             <ng-template #groupRenderer>
                 <fdp-form-field-group
-                    [hintOptions]="getHintOptions(field.formItem.guiOptions)"
+                    [hintOptions]="field.formItem.guiOptions | getHintOptions"
                     [label]="field.formItem.message || ''"
                     [labelColumnLayout]="field.formItem.guiOptions?.labelColumnLayout"
                     [fieldColumnLayout]="field.formItem.guiOptions?.fieldColumnLayout"
@@ -79,7 +79,7 @@
                             "
                         >
                             <fdp-form-generator-field
-                                [hintOptions]="getHintOptions(groupField.formItem.guiOptions)"
+                                [hintOptions]="groupField.formItem.guiOptions | getHintOptions"
                                 [form]="form"
                                 [field]="groupField"
                                 [shouldShow]="shouldShowFields[groupField.formItem.name!] !== false"

--- a/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.html
+++ b/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.html
@@ -13,7 +13,7 @@
         [inlineColumnLayout]="inlineColumnLayout"
         [useForm]="true"
     >
-        <ng-container *ngFor="let error of _errorModels">
+        <ng-container *ngFor="let error of _errorModels; trackBy: _errorsTrackBy">
             <span *fdpFormFieldError="error.type; let directiveError">
                 <ng-container *ngIf="_isAdvancedError(directiveError)">
                     <ng-container *ngIf="directiveError.heading">
@@ -71,7 +71,7 @@
                     [gapColumnLayout]="field.formItem.guiOptions?.gapColumnLayout"
                     [formName]="field.formItem.name"
                 >
-                    <ng-container *ngFor="let groupField of field | getOrderedFieldControls">
+                    <ng-container *ngFor="let groupField of field | getOrderedFieldControls; trackBy: _groupTrackFn">
                         <ng-container
                             *fdpDynamicFormControlField="
                                 groupField;

--- a/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.spec.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.spec.ts
@@ -18,7 +18,9 @@ import { DynamicFormGroup } from '../interfaces/dynamic-form-group';
             (formSubmitted)="onFormSubmitted($event)"
             (formCreated)="onFormCreated($event)"
         ></fdp-form-generator>
-    `
+    `,
+    standalone: true,
+    imports: [PlatformFormGeneratorModule]
 })
 export class HostComponent {
     @ViewChild(FormGeneratorComponent) formGenerator: FormGeneratorComponent;
@@ -68,9 +70,7 @@ describe('FormGeneratorComponent', () => {
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [PlatformFormGeneratorModule],
-            declarations: [HostComponent]
-            // providers: [FormGeneratorService, FormGeneratorComponentsAccessorService]
+            imports: [HostComponent]
         }).compileComponents();
     }));
 

--- a/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.ts
+++ b/libs/platform/src/lib/form/form-generator/form-generator/form-generator.component.ts
@@ -15,7 +15,7 @@ import {
     ViewChildren,
     ViewEncapsulation
 } from '@angular/core';
-import { FormControlStatus, FormGroupDirective, NgForm } from '@angular/forms';
+import { FormControlStatus, FormGroupDirective, NgForm, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { debounceTime, filter, startWith, switchMap, take, takeUntil } from 'rxjs/operators';
 import { BehaviorSubject, Observable, Subject, Subscription, isObservable, merge, of } from 'rxjs';
 import {
@@ -31,9 +31,7 @@ import { FormGeneratorFieldComponent } from '../form-generator-field/form-genera
 
 import { FormGeneratorService } from '../form-generator.service';
 import {
-    BaseDynamicFormItemGuiOptions,
     DynamicFormItem,
-    DynamicFormItemGuiOptions,
     DynamicFormItemMap,
     DynamicFormItemValidationObject,
     DynamicFormValue
@@ -49,6 +47,13 @@ import { DefaultGapLayout, DefaultVerticalFieldLayout, DefaultVerticalLabelLayou
 import { FDP_FORM_GENERATOR_DEFAULT_HINT_OPTIONS } from '../form-generator.tokens';
 import { defaultFormGeneratorHintOptions } from '../config/default-form-generator-hint-options';
 import { getParentItem, isFormFieldItem, mapFormItems, transformFormItem } from '../helpers';
+import { GetOrderedFieldControlsPipe } from '../pipes/get-ordered-form-controls.pipe';
+import { SkeletonModule } from '@fundamental-ngx/core/skeleton';
+import { DynamicFormControlFieldDirective } from '../dynamic-form-control-field.directive';
+import { FdpFormGroupModule } from '../../form-group/fdp-form.module';
+import { BusyIndicatorModule } from '@fundamental-ngx/core/busy-indicator';
+import { NgIf, NgFor, NgTemplateOutlet } from '@angular/common';
+import { GetHintOptionsPipe } from '../pipes/get-hint-options.pipe';
 
 let formUniqueId = 0;
 
@@ -82,6 +87,21 @@ export interface SubmitFormEventResult {
             useFactory: (formGenerator: FormGeneratorComponent) => formGenerator.doCheck$,
             deps: [FormGeneratorComponent]
         }
+    ],
+    standalone: true,
+    imports: [
+        NgIf,
+        BusyIndicatorModule,
+        FdpFormGroupModule,
+        FormsModule,
+        ReactiveFormsModule,
+        NgFor,
+        NgTemplateOutlet,
+        DynamicFormControlFieldDirective,
+        FormGeneratorFieldComponent,
+        SkeletonModule,
+        GetOrderedFieldControlsPipe,
+        GetHintOptionsPipe
     ]
 })
 export class FormGeneratorComponent implements OnDestroy, OnChanges {
@@ -407,31 +427,6 @@ export class FormGeneratorComponent implements OnDestroy, OnChanges {
      */
     submit(): void {
         this.formGroup.onSubmit(new Event('submit'));
-    }
-
-    /**
-     * @description
-     * Used for extracting hintOptions from GuiOptions. This will coerce string | HintOptions to FieldHintOptions,
-     * will combine default value of hints for form generator with provided options.
-     * @param guiOptions
-     */
-    getHintOptions(
-        guiOptions?: BaseDynamicFormItemGuiOptions | DynamicFormItemGuiOptions
-    ): FieldHintOptions | undefined {
-        if (!guiOptions?.hint) {
-            return;
-        }
-        const formItemHintOptions = guiOptions.hint;
-        if (typeof formItemHintOptions === 'string' || formItemHintOptions instanceof TemplateRef) {
-            return {
-                ...this._defaultHintOptions,
-                content: formItemHintOptions
-            };
-        }
-        return {
-            ...this._defaultHintOptions,
-            ...formItemHintOptions
-        };
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/form/form-generator/helpers.ts
+++ b/libs/platform/src/lib/form/form-generator/helpers.ts
@@ -1,6 +1,72 @@
 import { HintOptions } from '@fundamental-ngx/platform/shared';
+import {
+    DynamicFormFieldGroup,
+    DynamicFormFieldGroupMap,
+    DynamicFormFieldItem,
+    DynamicFormItem,
+    DynamicFormItemMap
+} from './interfaces/dynamic-form-item';
 
 /** @hidden */
 export function isHintOptions(opts: string | HintOptions): opts is HintOptions {
     return !!opts && typeof opts !== 'string';
+}
+
+/** @hidden */
+export function mapFormItems(formItems?: DynamicFormItem[]): Map<string, DynamicFormItemMap> {
+    const mappedItems: Map<string, DynamicFormItemMap> = new Map();
+
+    if (!formItems) {
+        return mappedItems;
+    }
+
+    formItems.forEach((item, index) => {
+        const mappedItem = transformFormItem(item, index);
+
+        mappedItems.set(mappedItem.name, mappedItem);
+    });
+
+    return mappedItems;
+}
+
+/** @hidden */
+export function transformFormItem(
+    item: DynamicFormItem,
+    index: number
+): DynamicFormFieldGroupMap | DynamicFormFieldItem {
+    if (isFormGroupItem(item)) {
+        const mappedItem = Object.assign({}, item, { items: mapFormItems(item.items) });
+        mappedItem.rank = mappedItem.rank || index;
+        return mappedItem;
+    } else {
+        item.rank = item.rank || index;
+    }
+    return item;
+}
+
+/**
+ * Is current form item is a field item.
+ * @param item form item.
+ * @returns is current form item is a field.
+ */
+export function isFormFieldItem(item: any): item is DynamicFormFieldItem {
+    return !!(item as DynamicFormFieldItem).type;
+}
+
+/**
+ * Is current form item is a group item.
+ * @param item form item.
+ * @returns is current form item is a group.
+ */
+/** @hidden */
+export function isFormGroupItem(item: any): item is DynamicFormFieldGroup {
+    return !!(item as DynamicFormFieldGroup).items;
+}
+
+/** @hidden */
+export function getParentItem(path: string[], rootItems: Map<string, DynamicFormItemMap>): DynamicFormItemMap | null {
+    return path.reduce((acc: DynamicFormItemMap | null, chunk) => {
+        const parent = acc === null ? rootItems : acc.items;
+        return parent.get(chunk) || null;
+    }, null);
 }

--- a/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
+++ b/libs/platform/src/lib/form/form-generator/interfaces/dynamic-form-item.ts
@@ -40,7 +40,12 @@ export type DynamicFormItem<
     U extends BaseDynamicFormFieldItem = AnyDynamicFormFieldItem
 > = DynamicFormFieldGroup | DynamicFormFieldItem<T, U>;
 
-export interface DynamicFormFieldGroup {
+export type DynamicFormItemMap<
+    T extends Record<string, any> = Record<string, any>,
+    U extends BaseDynamicFormFieldItem = AnyDynamicFormFieldItem
+> = DynamicFormFieldGroupMap | DynamicFormFieldItem<T, U>;
+
+export interface BaseDynamicFormFieldGroup {
     /**
      * @description
      * ID of the form item, if not provided, name will be used instead
@@ -62,13 +67,6 @@ export interface DynamicFormFieldGroup {
 
     /**
      * @description
-     * List of @see DynamicFormItem representing the list of items
-     * to be rendered in the form.
-     */
-    items?: DynamicFormFieldItem[];
-
-    /**
-     * @description
      * Rank is used for ordering.
      * Than lower number then higher priority.
      */
@@ -79,6 +77,24 @@ export interface DynamicFormFieldGroup {
      * Additional set of options that can affect UI of the form field group.
      */
     guiOptions?: BaseDynamicFormItemGuiOptions;
+}
+
+export interface DynamicFormFieldGroup extends BaseDynamicFormFieldGroup {
+    /**
+     * @description
+     * List of @see DynamicFormItem representing the list of items
+     * to be rendered in the form.
+     */
+    items?: DynamicFormFieldItem[];
+}
+
+export interface DynamicFormFieldGroupMap extends BaseDynamicFormFieldGroup {
+    /**
+     * @description
+     * Map of @see DynamicFormItem representing the list of items
+     * to be rendered in the form.
+     */
+    items?: Map<string, DynamicFormItemMap>;
 }
 
 export type FdpFormGeneratorAsyncProperty<T = string> = T | Promise<T> | Observable<T>;

--- a/libs/platform/src/lib/form/form-generator/pipes/get-hint-options.pipe.ts
+++ b/libs/platform/src/lib/form/form-generator/pipes/get-hint-options.pipe.ts
@@ -1,0 +1,45 @@
+import { Inject, Pipe, PipeTransform, TemplateRef } from '@angular/core';
+import { FieldHintOptions } from '@fundamental-ngx/platform/shared';
+import { BaseDynamicFormItemGuiOptions, DynamicFormItemGuiOptions } from '../interfaces/dynamic-form-item';
+import { FDP_FORM_GENERATOR_DEFAULT_HINT_OPTIONS } from '../form-generator.tokens';
+import { defaultFormGeneratorHintOptions } from '../config/default-form-generator-hint-options';
+
+@Pipe({
+    name: 'getHintOptions',
+    standalone: true
+})
+export class GetHintOptionsPipe implements PipeTransform {
+    /** @hidden */
+    private readonly _defaultHintOptions: FieldHintOptions;
+
+    /** @hidden */
+    constructor(@Inject(FDP_FORM_GENERATOR_DEFAULT_HINT_OPTIONS) _providedHintOptions: FieldHintOptions) {
+        this._defaultHintOptions = {
+            ...defaultFormGeneratorHintOptions,
+            ..._providedHintOptions
+        };
+    }
+
+    /**
+     * Used for extracting hintOptions from GuiOptions. This will coerce string | HintOptions to FieldHintOptions,
+     * will combine default value of hints for form generator with provided options.
+     */
+    transform(
+        hintOptions: BaseDynamicFormItemGuiOptions | DynamicFormItemGuiOptions | undefined
+    ): FieldHintOptions | undefined {
+        if (!hintOptions?.hint) {
+            return;
+        }
+        const formItemHintOptions = hintOptions.hint;
+        if (typeof formItemHintOptions === 'string' || formItemHintOptions instanceof TemplateRef) {
+            return {
+                ...this._defaultHintOptions,
+                content: formItemHintOptions
+            };
+        }
+        return {
+            ...this._defaultHintOptions,
+            ...formItemHintOptions
+        };
+    }
+}

--- a/libs/platform/src/lib/form/form-generator/pipes/get-ordered-form-controls.pipe.ts
+++ b/libs/platform/src/lib/form/form-generator/pipes/get-ordered-form-controls.pipe.ts
@@ -1,7 +1,11 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { DynamicFormControl, DynamicFormControlGroup, DynamicFormGroupControl } from '../dynamic-form-control';
 
-@Pipe({ name: 'getOrderedFieldControls', pure: false })
+@Pipe({
+    name: 'getOrderedFieldControls',
+    pure: false,
+    standalone: true
+})
 export class GetOrderedFieldControlsPipe implements PipeTransform {
     /** @hidden */
     transform(field: DynamicFormGroupControl): DynamicFormControl[] {

--- a/libs/platform/src/lib/form/form-generator/pipes/get-ordered-form-controls.pipe.ts
+++ b/libs/platform/src/lib/form/form-generator/pipes/get-ordered-form-controls.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { DynamicFormControl, DynamicFormControlGroup, DynamicFormGroupControl } from '../dynamic-form-control';
 
-@Pipe({ name: 'getOrderedFieldControls' })
+@Pipe({ name: 'getOrderedFieldControls', pure: false })
 export class GetOrderedFieldControlsPipe implements PipeTransform {
     /** @hidden */
     transform(field: DynamicFormGroupControl): DynamicFormControl[] {

--- a/libs/platform/src/lib/form/form-generator/providers/providers.ts
+++ b/libs/platform/src/lib/form/form-generator/providers/providers.ts
@@ -1,4 +1,4 @@
-import { forwardRef, InjectionToken, Provider } from '@angular/core';
+import { forwardRef, InjectionToken, Provider, StaticProvider } from '@angular/core';
 import { Validators } from '@angular/forms';
 import { FD_FORM_FIELD } from '@fundamental-ngx/cdk/forms';
 
@@ -7,12 +7,12 @@ import { FormFieldComponent } from '../../form-group/form-field/form-field.compo
 import { DynamicFormFieldItem } from '../interfaces/dynamic-form-item';
 import { FormGeneratorConfig } from '../interfaces/form-generator-module-config';
 
-export const dynamicFormFieldProvider: Provider = {
+export const dynamicFormFieldProvider: StaticProvider = {
     provide: FD_FORM_FIELD,
     useExisting: forwardRef(() => FormFieldComponent)
 };
 
-export const dynamicFormGroupChildProvider: Provider = {
+export const dynamicFormGroupChildProvider: StaticProvider = {
     provide: FORM_GROUP_CHILD_FIELD_TOKEN,
     useExisting: forwardRef(() => FormFieldComponent)
 };

--- a/libs/platform/src/lib/form/form-group/form-group-header/form-group-header.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-group-header/form-group-header.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
-import { FieldGroup } from '../../form-helpers';
 import { HintOptions } from '@fundamental-ngx/platform/shared';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { FieldGroup } from '../../models/field.model';
 
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector

--- a/libs/platform/src/lib/form/form-group/form-group.component.ts
+++ b/libs/platform/src/lib/form/form-group/form-group.component.ts
@@ -57,16 +57,7 @@ import {
     PlatformFormField
 } from '@fundamental-ngx/platform/shared';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
-import {
-    Field,
-    FieldColumn,
-    FieldGroup,
-    getField,
-    getFormField,
-    isFieldChild,
-    isFieldGroupChild,
-    isFieldGroupWrapperChild
-} from '../form-helpers';
+import { getField, getFormField, isFieldChild, isFieldGroupChild, isFieldGroupWrapperChild } from '../form-helpers';
 import { FormFieldErrorDirective } from './form-field-error/form-field-error.directive';
 import { FormFieldComponent } from './form-field/form-field.component';
 import {
@@ -81,6 +72,7 @@ import { FormFieldLayoutService } from './services/form-field-layout.service';
 import { FDP_FORM_FIELD_HINT_OPTIONS_DEFAULT } from './fdp-form.tokens';
 import { contentDensityObserverProviders, ContentDensityObserver } from '@fundamental-ngx/core/content-density';
 import { FormField } from '@fundamental-ngx/cdk/forms';
+import { Field, FieldColumn, FieldGroup } from '../models/field.model';
 
 export const formGroupProvider: Provider = {
     provide: FormGroupContainer,

--- a/libs/platform/src/lib/form/form-group/pipes/field-group-row-value.pipe.ts
+++ b/libs/platform/src/lib/form/form-group/pipes/field-group-row-value.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { KeyValue } from '@angular/common';
-import { FieldColumn, FieldGroup } from '../../form-helpers';
+import { FieldColumn, FieldGroup } from '../../models/field.model';
 
 @Pipe({ name: 'fieldGroupRowValue' })
 export class FieldGroupRowValuePipe implements PipeTransform {

--- a/libs/platform/src/lib/form/form-helpers.ts
+++ b/libs/platform/src/lib/form/form-helpers.ts
@@ -1,13 +1,8 @@
-import { TemplateRef } from '@angular/core';
-
-import { PlatformFormField, HintOptions } from '@fundamental-ngx/platform/shared';
+import { PlatformFormField } from '@fundamental-ngx/platform/shared';
 import { FormFieldComponent } from './form-group/form-field/form-field.component';
 import { FormFieldGroupComponent } from './form-group/form-field-group/form-field-group.component';
 import { FormGeneratorFieldComponent } from './form-generator/form-generator-field/form-generator-field.component';
-
-export interface FieldColumn {
-    [key: number]: Array<Field>;
-}
+import { Field } from './models/field.model';
 
 /** @hidden */
 export function isFieldChild(child: unknown): child is PlatformFormField {
@@ -34,19 +29,4 @@ export function getField(field: PlatformFormField): Field {
     field = isFieldGroupWrapperChild(field) ? field.fieldRenderer : field;
 
     return new Field(field.id, field.rank, field.renderer, field.column);
-}
-
-export class Field {
-    /** @hidden */
-    constructor(
-        public name?: string,
-        public rank?: number,
-        public renderer?: TemplateRef<any>,
-        public column?: number
-    ) {}
-}
-
-export class FieldGroup {
-    /** @hidden */
-    constructor(public label: string, public fields: FieldColumn, public hintOptions?: HintOptions) {}
 }

--- a/libs/platform/src/lib/form/index.ts
+++ b/libs/platform/src/lib/form/index.ts
@@ -1,5 +1,6 @@
 export * from './form-helpers';
 export * from './helpers';
+export * from './models/field.model';
 
 export * from './auto-complete/auto-complete.directive';
 export * from './auto-complete/auto-complete.module';

--- a/libs/platform/src/lib/form/index.ts
+++ b/libs/platform/src/lib/form/index.ts
@@ -51,6 +51,7 @@ export * from './form-generator/interfaces/form-generator-module-config';
 export * from './form-generator/providers/providers';
 export * from './form-generator/form-generator-field/form-generator-field.component';
 export * from './form-generator/form-generator-components-accessor.service';
+export * from './form-generator/pipes/get-hint-options.pipe';
 
 export * from './form-group/constants';
 export * from './form-group/config/default-form-field-hint-options';

--- a/libs/platform/src/lib/form/input-message-group-with-template/input-message-group-with-template.component.html
+++ b/libs/platform/src/lib/form/input-message-group-with-template/input-message-group-with-template.component.html
@@ -6,7 +6,7 @@
     [fillControlMode]="fillControlMode"
     [isOpen]="isOpen"
     [placement]="placement"
-    [triggers]="['focusin', 'focusout']"
+    [triggers]="triggers"
     class="fd-form-input-message-group fd-popover--input-message-group"
 >
     <fd-popover-control>

--- a/libs/platform/src/lib/form/input-message-group-with-template/input-message-group-with-template.component.ts
+++ b/libs/platform/src/lib/form/input-message-group-with-template/input-message-group-with-template.component.ts
@@ -1,6 +1,7 @@
-import { ChangeDetectionStrategy, Component, ContentChild, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
 
 import { FormInputMessageGroupComponent } from '@fundamental-ngx/core/form';
+import { TriggerConfig } from '@fundamental-ngx/core/popover';
 
 /**
  * This extends core implementation  to support richer extensibility and instead of relying
@@ -17,6 +18,23 @@ import { FormInputMessageGroupComponent } from '@fundamental-ngx/core/form';
 })
 // eslint-disable-next-line @angular-eslint/component-class-suffix
 export class InputMessageGroupWithTemplate extends FormInputMessageGroupComponent {
+    /**
+     * To allow user to determine what event he wants to trigger the messages to show
+     * Accepts any [HTML DOM Events](https://www.w3schools.com/jsref/dom_obj_event.asp).
+     */
+    @Input()
+    triggers: (string | TriggerConfig)[] = [
+        {
+            trigger: 'focusin',
+            openAction: true,
+            closeAction: false
+        },
+        {
+            trigger: 'focusout',
+            openAction: false,
+            closeAction: true
+        }
+    ];
     /**
      * Custom trigger element.
      */

--- a/libs/platform/src/lib/form/models/field.model.ts
+++ b/libs/platform/src/lib/form/models/field.model.ts
@@ -1,0 +1,21 @@
+import { TemplateRef } from '@angular/core';
+import { HintOptions } from '@fundamental-ngx/platform/shared';
+
+export interface FieldColumn {
+    [key: number]: Array<Field>;
+}
+
+export class Field {
+    /** @hidden */
+    constructor(
+        public name?: string,
+        public rank?: number,
+        public renderer?: TemplateRef<any>,
+        public column?: number
+    ) {}
+}
+
+export class FieldGroup {
+    /** @hidden */
+    constructor(public label: string, public fields: FieldColumn, public hintOptions?: HintOptions) {}
+}


### PR DESCRIPTION
closes none

Improvements:
- Added `addControl` and `removeControl` to dynamically manipulate of the Form Generator controls.
- Improved change detection performance;
- Improved overall performance;
- Standalone migration