### PR TITLE
fix(core): datepicker outer focustrap

### DIFF
--- a/libs/core/src/lib/date-picker/date-picker.component.ts
+++ b/libs/core/src/lib/date-picker/date-picker.component.ts
@@ -41,7 +41,7 @@ import { FormItemControl, PopoverFormMessageService, registerFormItemControl } f
 import { PopoverService } from '@fundamental-ngx/core/popover';
 import { InputGroupInputDirective } from '@fundamental-ngx/core/input-group';
 import { createMissingDateImplementationError } from './errors';
-import { DynamicComponentService, Nullable } from '@fundamental-ngx/cdk/utils';
+import { DynamicComponentService, FocusTrapService, Nullable } from '@fundamental-ngx/cdk/utils';
 import { FormStates } from '@fundamental-ngx/cdk/forms';
 import { MobileModeConfig } from '@fundamental-ngx/core/mobile-mode';
 import { FD_DATE_PICKER_COMPONENT, FD_DATE_PICKER_MOBILE_CONFIG } from './tokens';
@@ -431,6 +431,11 @@ export class DatePickerComponent<D>
     private readonly _dynamicComponentService = inject(DynamicComponentService);
 
     /** @hidden */
+    private readonly _focusTrapService = inject(FocusTrapService, {
+        optional: true
+    });
+
+    /** @hidden */
     private _mobileComponentRef: Nullable<ComponentRef<DatePickerMobileComponent<D>>>;
 
     /** @hidden */
@@ -529,6 +534,11 @@ export class DatePickerComponent<D>
             const calendar = this._calendars.first;
             this._calendarComponent = calendar;
             setTimeout(() => {
+                if (this._calendarComponent) {
+                    this._focusTrapService?.pauseCurrentFocusTrap();
+                } else {
+                    this._focusTrapService?.unpauseCurrentFocusTrap();
+                }
                 calendar?.setCurrentlyDisplayed(this._calendarPendingDate);
                 calendar?.initialFocus();
             });


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10323

## Description
- Focus trap now temporary pauses when the date(time) picker being opened;
- Fixed issue with setting initial focus in datetime picker;

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [x] update `README.md`
-   [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
