### PR TITLE
fix(core): default element style breaking standalone tokens

### DIFF
--- a/libs/core/src/lib/token/token.component.scss
+++ b/libs/core/src/lib/token/token.component.scss
@@ -1,5 +1,9 @@
 @import 'fundamental-styles/dist/token';
 
+fd-token {
+    display: inline-flex;
+}
+
 //temporary fix until fundamental styles introduces a disabled token
 .fd-token__disabled::after {
     cursor: not-allowed;


### PR DESCRIPTION
fixes none

before:
<img width="1483" alt="Screenshot 2023-08-29 at 10 54 06 AM" src="https://github.com/SAP/fundamental-ngx/assets/2471874/5cda6313-2743-4ab2-8dec-2c82cf2f05f1">

after:
<img width="470" alt="Screenshot 2023-08-29 at 10 53 55 AM" src="https://github.com/SAP/fundamental-ngx/assets/2471874/372a740f-f0e8-444f-b136-a3da026c8850">
