### PR TITLE
fix(core): checkbox label container gap issue

### DIFF
--- a/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/src/lib/checkbox/checkbox/checkbox.component.html
@@ -35,8 +35,8 @@
     (click)="_onLabelClick($event)"
 >
     <span class="fd-checkbox__checkmark" aria-hidden="true"></span>
-    <div class="fd-checkbox__label-container">
-        <ng-container *ngIf="label">
+    <div class="fd-checkbox__label-container" *ngIf="label">
+        <ng-container>
             <span class="fd-checkbox__text">
                 {{ label }}
             </span>


### PR DESCRIPTION
fixes none

before:
<img width="154" alt="Screenshot 2023-08-29 at 11 45 39 AM" src="https://github.com/SAP/fundamental-ngx/assets/2471874/18400ed1-893f-477f-b4c8-5ed2ed004c38">

after:
<img width="128" alt="Screenshot 2023-08-29 at 11 45 32 AM" src="https://github.com/SAP/fundamental-ngx/assets/2471874/f0d25f08-acb3-4509-aa54-50076b4e7a39">
