### PR TITLE
fix(platform): custom row height

### DIFF
--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1750,6 +1750,7 @@ export class TableComponent<T = any>
                     tap(() => {
                         this._setSelectionColumnWidth();
                     }),
+                    filter(() => Array.from(ROW_HEIGHT.values()).includes(this.rowHeight)),
                     filter(() => !this._rowHeightManuallySet)
                 )
                 .subscribe((contentDensity) => {


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10321

## Description
Previously, `rowHeight` input property would be overriden by changes in content density. Now it checks whether previous rowHeight is content-density related. If not, ignore content density changes.
