### PR TITLE
fix(platform): cell height instead of tbody

### DIFF
--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -170,10 +170,11 @@
             <tbody *ngIf="pageScrolling" class="fd-table__body__focus-mock"></tbody>
 
             <!-- the tbody element below is so the scrollbar renders correctly -->
-            <tbody
-                *ngIf="_virtualScrollDirective?.virtualScroll"
-                [style.height.px]="_virtualScrollDirective?.virtualScrollTotalHeight"
-            ></tbody>
+            <tbody *ngIf="_virtualScrollDirective?.virtualScroll">
+                <tr>
+                    <td colspan="100%" [style.height.px]="_virtualScrollDirective?.virtualScrollTotalHeight"></td>
+                </tr>
+            </tbody>
         </table>
     </div>
 </ng-template>


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10367 

## Description
Previously we had tbody helper for virtual scroll table where we set total height of the table contents. This approach didn't work with safari and firefox well.
Now we have inner table cell with height applied to it which works fine in chrome, safari and ff
