### PR TITLE
fix(core): dialog service dismiss all

### DIFF
--- a/libs/core/src/lib/dialog/base/dialog-base.service.ts
+++ b/libs/core/src/lib/dialog/base/dialog-base.service.ts
@@ -2,12 +2,14 @@ import { ComponentRef, Injectable, OnDestroy } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { DialogConfig } from '../utils/dialog-config.class';
+import { DialogContainer } from '../utils/dialog-container.model';
 import { DialogConfigBase } from './dialog-config-base.class';
 import { DialogRefBase } from './dialog-ref-base.class';
 
 /** Service used to dynamically generate a dialog. */
 @Injectable()
-export abstract class DialogBaseService<T> implements OnDestroy {
+export abstract class DialogBaseService<T extends DialogContainer<any>> implements OnDestroy {
+    abstract open<D>(content: unknown, config: DialogConfigBase<D>): DialogRefBase<D>;
     /** @hidden Collection of existing dialog references */
     protected _dialogs: ComponentRef<T>[] = [];
 
@@ -23,8 +25,12 @@ export abstract class DialogBaseService<T> implements OnDestroy {
     }
 
     /** Dismisses all currently open dialogs. */
-    dismissAll(): void {
-        this._dialogs.forEach((item) => this._destroyDialog(item));
+    dismissAll(reason?: any): void {
+        this._dialogs.forEach((item) => {
+            item.instance.ref.dismiss(reason);
+            item.destroy();
+        });
+        this._dialogs = [];
     }
 
     /** @hidden */
@@ -32,8 +38,6 @@ export abstract class DialogBaseService<T> implements OnDestroy {
         this._destroy$.next();
         this._destroy$.complete();
     }
-
-    abstract open<D>(content: unknown, config: DialogConfigBase<D>): DialogRefBase<D>;
 
     /** @hidden Extends configuration using default values*/
     protected _applyDefaultConfig(config: DialogConfig, defaultConfig: DialogConfig): DialogConfig {

--- a/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
+++ b/libs/core/src/lib/dialog/dialog-container/dialog-container.component.ts
@@ -1,3 +1,4 @@
+import { AnimationEvent } from '@angular/animations';
 import {
     AfterContentChecked,
     AfterViewInit,
@@ -17,18 +18,18 @@ import {
     ViewChild,
     ViewRef
 } from '@angular/core';
-import { AnimationEvent } from '@angular/animations';
 
 import { applyCssClass, CssClassBuilder, DynamicComponentContainer, Nullable } from '@fundamental-ngx/cdk/utils';
 
-import { DialogRef } from '../utils/dialog-ref.class';
-import { DialogConfig } from '../utils/dialog-config.class';
-import { DialogDefaultComponent } from '../dialog-default/dialog-default.component';
-import { DialogDefaultContent } from '../utils/dialog-default-content.class';
-import { DialogContentType } from '../dialog.types';
-import { dialogFade } from '../utils/dialog.animations';
 import { CdkPortalOutlet, CdkPortalOutletAttachedRef } from '@angular/cdk/portal';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DialogDefaultComponent } from '../dialog-default/dialog-default.component';
+import { DialogContentType } from '../dialog.types';
+import { DialogConfig } from '../utils/dialog-config.class';
+import { DialogContainer } from '../utils/dialog-container.model';
+import { DialogDefaultContent } from '../utils/dialog-default-content.class';
+import { DialogRef } from '../utils/dialog-ref.class';
+import { dialogFade } from '../utils/dialog.animations';
 
 /** Dialog container where the dialog content is embedded. */
 @Component({
@@ -40,7 +41,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 })
 export class DialogContainerComponent
     extends DynamicComponentContainer<DialogContentType>
-    implements AfterViewInit, AfterContentChecked, CssClassBuilder
+    implements DialogContainer<any>, AfterViewInit, AfterContentChecked, CssClassBuilder
 {
     /** Custom classes */
     @Input()
@@ -63,7 +64,7 @@ export class DialogContainerComponent
     /** @hidden */
     constructor(
         public dialogConfig: DialogConfig,
-        private _dialogRef: DialogRef,
+        public ref: DialogRef,
         private _destroyRef: DestroyRef,
         elementRef: ElementRef,
         changeDetectorRef: ChangeDetectorRef,
@@ -84,8 +85,8 @@ export class DialogContainerComponent
         const { toState } = event;
 
         if (toState === 'hidden') {
-            this._dialogRef._endClose$.next();
-            this._dialogRef._endClose$.complete();
+            this.ref._endClose$.next();
+            this.ref._endClose$.complete();
         }
     }
 
@@ -131,7 +132,7 @@ export class DialogContainerComponent
 
     /** @hidden Returns context for embedded template*/
     private _templateContext(): { $implicit: DialogRef; dialogConfig: DialogConfig } {
-        return { $implicit: this._dialogRef, dialogConfig: this.dialogConfig };
+        return { $implicit: this.ref, dialogConfig: this.dialogConfig };
     }
 
     /** @hidden Load Dialog component from passed object */
@@ -151,7 +152,7 @@ export class DialogContainerComponent
             this._animationState = 'hidden';
             this._cdr.detectChanges();
         };
-        this._dialogRef.afterClosed.pipe(takeUntilDestroyed(this._destroyRef)).subscribe({
+        this.ref.afterClosed.pipe(takeUntilDestroyed(this._destroyRef)).subscribe({
             next: () => callback(),
             error: () => callback()
         });

--- a/libs/core/src/lib/dialog/index.ts
+++ b/libs/core/src/lib/dialog/index.ts
@@ -1,19 +1,19 @@
-export * from './dialog.module';
-export * from './dialog.component';
-export * from './dialog-service/dialog.service';
 export * from './dialog-body/dialog-body.component';
-export * from './dialog-header/dialog-header.component';
-export * from './dialog-footer/dialog-footer.component';
 export * from './dialog-close-button/dialog-close-button.component';
+export * from './dialog-footer/dialog-footer.component';
+export * from './dialog-header/dialog-header.component';
+export * from './dialog-service/dialog.service';
+export * from './dialog.component';
+export * from './dialog.module';
 
 export * from './directives/dialog-title.directive';
 
-export * from './utils/dialog-ref.class';
-export * from './utils/dialog-config.class';
-export * from './utils/dialog-position.class';
-export * from './utils/dialog-default-content.class';
-export * from './dialog-default/dialog-default.component';
 export * from './dialog-container/dialog-container.component';
+export * from './dialog-default/dialog-default.component';
+export * from './utils/dialog-config.class';
+export * from './utils/dialog-default-content.class';
+export * from './utils/dialog-position.class';
+export * from './utils/dialog-ref.class';
 
 export * from './base/dialog-base.class';
 export * from './base/dialog-base.service';
@@ -22,8 +22,9 @@ export * from './base/dialog-content-base.class';
 export * from './base/dialog-footer-base.class';
 export * from './base/dialog-header-base.class';
 export * from './base/dialog-ref-base.class';
+export * from './utils/dialog-container.model';
 export * from './utils/dialog.animations';
 
 export * from './dialog.types';
-export * from './utils/dialog-overlay.container';
 export * from './tokens';
+export * from './utils/dialog-overlay.container';

--- a/libs/core/src/lib/dialog/utils/dialog-container.model.ts
+++ b/libs/core/src/lib/dialog/utils/dialog-container.model.ts
@@ -1,0 +1,5 @@
+import { DialogRefBase } from '../base/dialog-ref-base.class';
+
+export interface DialogContainer<T> {
+    ref: DialogRefBase<T>;
+}

--- a/libs/core/src/lib/message-box/message-box-container/message-box-container.component.ts
+++ b/libs/core/src/lib/message-box/message-box-container/message-box-container.component.ts
@@ -1,3 +1,5 @@
+import { AnimationEvent } from '@angular/animations';
+import { CdkPortalOutlet, CdkPortalOutletAttachedRef } from '@angular/cdk/portal';
 import {
     AfterViewInit,
     ChangeDetectorRef,
@@ -14,16 +16,14 @@ import {
     Type,
     ViewChild
 } from '@angular/core';
-import { AnimationEvent } from '@angular/animations';
-import { applyCssClass, CssClassBuilder, DynamicComponentContainer } from '@fundamental-ngx/cdk/utils';
-import { MessageBoxConfig } from '../utils/message-box-config.class';
-import { MessageBoxRef } from '../utils/message-box-ref.class';
-import { MessageBoxContent } from '../utils/message-box-content.class';
-import { MessageBoxDefaultComponent } from '../message-box-default/message-box-default.component';
-import { MessageBoxContentType } from '../message-box-content.type';
-import { CdkPortalOutlet, CdkPortalOutletAttachedRef } from '@angular/cdk/portal';
-import { dialogFade } from '@fundamental-ngx/core/dialog';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CssClassBuilder, DynamicComponentContainer, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { DialogContainer, dialogFade } from '@fundamental-ngx/core/dialog';
+import { MessageBoxContentType } from '../message-box-content.type';
+import { MessageBoxDefaultComponent } from '../message-box-default/message-box-default.component';
+import { MessageBoxConfig } from '../utils/message-box-config.class';
+import { MessageBoxContent } from '../utils/message-box-content.class';
+import { MessageBoxRef } from '../utils/message-box-ref.class';
 
 /** Message box container where the message box content is embedded. */
 @Component({
@@ -33,7 +33,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 })
 export class MessageBoxContainerComponent
     extends DynamicComponentContainer<MessageBoxContentType>
-    implements AfterViewInit, CssClassBuilder
+    implements DialogContainer<any>, AfterViewInit, CssClassBuilder
 {
     /** Custom classes */
     @Input()
@@ -56,7 +56,7 @@ export class MessageBoxContainerComponent
     /** @hidden */
     constructor(
         public messageBoxConfig: MessageBoxConfig,
-        private _messageBoxRef: MessageBoxRef,
+        public ref: MessageBoxRef,
         private _destroyRef: DestroyRef,
         elementRef: ElementRef,
         changeDetectorRef: ChangeDetectorRef,
@@ -77,8 +77,8 @@ export class MessageBoxContainerComponent
         const { toState } = event;
 
         if (toState === 'hidden') {
-            this._messageBoxRef._endClose$.next();
-            this._messageBoxRef._endClose$.complete();
+            this.ref._endClose$.next();
+            this.ref._endClose$.complete();
         }
     }
 
@@ -114,7 +114,7 @@ export class MessageBoxContainerComponent
 
     /** @hidden Returns context for embedded template*/
     private _templateContext(): { $implicit: MessageBoxRef; messageBoxConfig: MessageBoxConfig } {
-        return { $implicit: this._messageBoxRef, messageBoxConfig: this.messageBoxConfig };
+        return { $implicit: this.ref, messageBoxConfig: this.messageBoxConfig };
     }
 
     /** @hidden Load Dialog component from passed object */
@@ -133,7 +133,7 @@ export class MessageBoxContainerComponent
             this._animationState = 'hidden';
             this._cdr.detectChanges();
         };
-        this._messageBoxRef.afterClosed.pipe(takeUntilDestroyed(this._destroyRef)).subscribe({
+        this.ref.afterClosed.pipe(takeUntilDestroyed(this._destroyRef)).subscribe({
             next: () => callback(),
             error: () => callback()
         });


### PR DESCRIPTION
closes none;

Previously we had `dismissAll` method in `DialogService` which just removed dialog instance from the array of opened dialogs.

Now this method actually dismisses all dialog instance with optional reason and destroys dialog components.