### PR TITLE
fix(platform): fixed non-existent predefined selected value selection

### DIFF
--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -625,7 +625,12 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
             const idFromSuggestions = (this._suggestions || []).findIndex(finder);
             const itemIndex = Math.max(idFromFullFlatSuggestions, idFromSuggestions);
             const collection = idFromFullFlatSuggestions !== -1 ? this._fullFlatSuggestions : this._suggestions;
-            if (this._suggestions && collection === this._suggestions) {
+            if (idFromFullFlatSuggestions === -1 && idFromSuggestions === -1) {
+                this._convertToOptionItems([selectedItem]).forEach((optionItem: SelectableOptionItem) => {
+                    optionItem.selected = true;
+                    this._selectedSuggestions.push(optionItem);
+                });
+            } else if (this._suggestions && collection === this._suggestions) {
                 this._fullFlatSuggestions.push(collection[itemIndex]);
             }
             if (itemIndex > -1) {


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

When predefined selected value did not exist in the initial list of the items, it would throw an error because faulty logic would push `undefined` into the list of the suggestions. This fix patches that error and now it creates from the selection data items which should be rendered