### PR TITLE
fix(platform): screenreader only span for empty platform table cells

### DIFF
--- a/libs/i18n/src/lib/languages/albanian.ts
+++ b/libs/i18n/src/lib/languages/albanian.ts
@@ -387,6 +387,7 @@ export const FD_LANGUAGE_ALBANIAN: FdLanguage = {
         headerMenuUnfreeze: 'Menuja "Shkrije"',
         headerMenuFilter: 'Filtro',
         defaultEmptyMessage: 'No data found',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Rivendos',

--- a/libs/i18n/src/lib/languages/albanian.ts
+++ b/libs/i18n/src/lib/languages/albanian.ts
@@ -387,7 +387,7 @@ export const FD_LANGUAGE_ALBANIAN: FdLanguage = {
         headerMenuUnfreeze: 'Menuja "Shkrije"',
         headerMenuFilter: 'Filtro',
         defaultEmptyMessage: 'No data found',
-        emptyCell: 'Empty',
+        emptyCell: 'Bosh',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Rivendos',

--- a/libs/i18n/src/lib/languages/bulgarian.ts
+++ b/libs/i18n/src/lib/languages/bulgarian.ts
@@ -451,6 +451,7 @@ export const FD_LANGUAGE_BULGARIAN: FdLanguage = {
         headerMenuUnfreeze: 'Размрази',
         headerMenuFilter: 'Филтър',
         defaultEmptyMessage: 'Няма намерени данни',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'В момента в таблицата няма видими колони. Моля, изберете нужните колони в настройките на таблицата.',
         resetChangesButtonLabel: 'Нулиране',

--- a/libs/i18n/src/lib/languages/bulgarian.ts
+++ b/libs/i18n/src/lib/languages/bulgarian.ts
@@ -451,7 +451,7 @@ export const FD_LANGUAGE_BULGARIAN: FdLanguage = {
         headerMenuUnfreeze: 'Размрази',
         headerMenuFilter: 'Филтър',
         defaultEmptyMessage: 'Няма намерени данни',
-        emptyCell: 'Empty',
+        emptyCell: 'Празна',
         noVisibleColumnsMessage:
             'В момента в таблицата няма видими колони. Моля, изберете нужните колони в настройките на таблицата.',
         resetChangesButtonLabel: 'Нулиране',

--- a/libs/i18n/src/lib/languages/chinese.ts
+++ b/libs/i18n/src/lib/languages/chinese.ts
@@ -371,6 +371,7 @@ export const FD_LANGUAGE_CHINESE: FdLanguage = {
         headerMenuUnfreeze: '解冻标题菜单',
         headerMenuFilter: '筛选',
         defaultEmptyMessage: '没有找到相关数据',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: '重置',

--- a/libs/i18n/src/lib/languages/chinese.ts
+++ b/libs/i18n/src/lib/languages/chinese.ts
@@ -371,7 +371,7 @@ export const FD_LANGUAGE_CHINESE: FdLanguage = {
         headerMenuUnfreeze: '解冻标题菜单',
         headerMenuFilter: '筛选',
         defaultEmptyMessage: '没有找到相关数据',
-        emptyCell: 'Empty',
+        emptyCell: '空',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: '重置',

--- a/libs/i18n/src/lib/languages/czech.ts
+++ b/libs/i18n/src/lib/languages/czech.ts
@@ -376,7 +376,7 @@ export const FD_LANGUAGE_CZECH: FdLanguage = {
         headerMenuUnfreeze: 'HeaderMenuUnfreeze',
         headerMenuFilter: 'Filtr',
         defaultEmptyMessage: 'Nenalezena žádná data',
-        emptyCell: 'Empty',
+        emptyCell: 'Prázdnýyoge',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Resetovat',

--- a/libs/i18n/src/lib/languages/czech.ts
+++ b/libs/i18n/src/lib/languages/czech.ts
@@ -376,6 +376,7 @@ export const FD_LANGUAGE_CZECH: FdLanguage = {
         headerMenuUnfreeze: 'HeaderMenuUnfreeze',
         headerMenuFilter: 'Filtr',
         defaultEmptyMessage: 'Nenalezena žádná data',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Resetovat',

--- a/libs/i18n/src/lib/languages/english.ts
+++ b/libs/i18n/src/lib/languages/english.ts
@@ -372,6 +372,7 @@ export const FD_LANGUAGE_ENGLISH: FdLanguage = {
         headerMenuUnfreeze: 'Unfreeze',
         headerMenuFilter: 'Filter',
         defaultEmptyMessage: 'No data found',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Reset',

--- a/libs/i18n/src/lib/languages/french.ts
+++ b/libs/i18n/src/lib/languages/french.ts
@@ -376,6 +376,7 @@ export const FD_LANGUAGE_FRENCH: FdLanguage = {
         headerMenuUnfreeze: "Déverrouillage du menu d'en-tête",
         headerMenuFilter: 'Filtrer',
         defaultEmptyMessage: 'Aucune donnée trouvée',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Réinitialiser',

--- a/libs/i18n/src/lib/languages/french.ts
+++ b/libs/i18n/src/lib/languages/french.ts
@@ -376,7 +376,7 @@ export const FD_LANGUAGE_FRENCH: FdLanguage = {
         headerMenuUnfreeze: "Déverrouillage du menu d'en-tête",
         headerMenuFilter: 'Filtrer',
         defaultEmptyMessage: 'Aucune donnée trouvée',
-        emptyCell: 'Empty',
+        emptyCell: 'Vide',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Réinitialiser',

--- a/libs/i18n/src/lib/languages/georgian.ts
+++ b/libs/i18n/src/lib/languages/georgian.ts
@@ -374,6 +374,7 @@ export const FD_LANGUAGE_GEORGIAN: FdLanguage = {
         headerMenuUnfreeze: 'მენიუს განბლოკვა',
         headerMenuFilter: 'ფილტრი',
         defaultEmptyMessage: 'მონაცემები ვერ მოიძებნა',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'ამჟამად, ცხრილში არ არის ხილული სვეტები. გთხოვთ, აირჩიოთ თქვენთვის საჭირო სვეტები ცხრილის პარამეტრებში.',
         resetChangesButtonLabel: 'გააუქმეთ ცვლილებები',

--- a/libs/i18n/src/lib/languages/georgian.ts
+++ b/libs/i18n/src/lib/languages/georgian.ts
@@ -374,7 +374,7 @@ export const FD_LANGUAGE_GEORGIAN: FdLanguage = {
         headerMenuUnfreeze: 'მენიუს განბლოკვა',
         headerMenuFilter: 'ფილტრი',
         defaultEmptyMessage: 'მონაცემები ვერ მოიძებნა',
-        emptyCell: 'Empty',
+        emptyCell: 'ცარიელი',
         noVisibleColumnsMessage:
             'ამჟამად, ცხრილში არ არის ხილული სვეტები. გთხოვთ, აირჩიოთ თქვენთვის საჭირო სვეტები ცხრილის პარამეტრებში.',
         resetChangesButtonLabel: 'გააუქმეთ ცვლილებები',

--- a/libs/i18n/src/lib/languages/hindi.ts
+++ b/libs/i18n/src/lib/languages/hindi.ts
@@ -373,6 +373,7 @@ export const FD_LANGUAGE_HINDI: FdLanguage = {
         headerMenuUnfreeze: 'हैडर मेनू अनफ्रीज',
         headerMenuFilter: 'फिल्टर',
         defaultEmptyMessage: 'डाटा प्राप्त नहीं हुआ',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'रीसेट करें',

--- a/libs/i18n/src/lib/languages/hindi.ts
+++ b/libs/i18n/src/lib/languages/hindi.ts
@@ -373,7 +373,7 @@ export const FD_LANGUAGE_HINDI: FdLanguage = {
         headerMenuUnfreeze: 'हैडर मेनू अनफ्रीज',
         headerMenuFilter: 'फिल्टर',
         defaultEmptyMessage: 'डाटा प्राप्त नहीं हुआ',
-        emptyCell: 'Empty',
+        emptyCell: 'खाली',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'रीसेट करें',

--- a/libs/i18n/src/lib/languages/italian.ts
+++ b/libs/i18n/src/lib/languages/italian.ts
@@ -390,6 +390,7 @@ export const FD_LANGUAGE_ITALIAN: FdLanguage = {
         headerMenuUnfreeze: 'Sblocca',
         headerMenuFilter: 'Filtro',
         defaultEmptyMessage: 'Nessun dato trovato',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Reset',

--- a/libs/i18n/src/lib/languages/italian.ts
+++ b/libs/i18n/src/lib/languages/italian.ts
@@ -390,7 +390,7 @@ export const FD_LANGUAGE_ITALIAN: FdLanguage = {
         headerMenuUnfreeze: 'Sblocca',
         headerMenuFilter: 'Filtro',
         defaultEmptyMessage: 'Nessun dato trovato',
-        emptyCell: 'Empty',
+        emptyCell: 'Vuoto',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Reset',

--- a/libs/i18n/src/lib/languages/polish.ts
+++ b/libs/i18n/src/lib/languages/polish.ts
@@ -373,6 +373,7 @@ export const FD_LANGUAGE_POLISH: FdLanguage = {
         headerMenuUnfreeze: 'HeaderMenuUnfreeze',
         headerMenuFilter: 'Filtr',
         defaultEmptyMessage: 'Brak wyników',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Reset',

--- a/libs/i18n/src/lib/languages/polish.ts
+++ b/libs/i18n/src/lib/languages/polish.ts
@@ -373,7 +373,7 @@ export const FD_LANGUAGE_POLISH: FdLanguage = {
         headerMenuUnfreeze: 'HeaderMenuUnfreeze',
         headerMenuFilter: 'Filtr',
         defaultEmptyMessage: 'Brak wyników',
-        emptyCell: 'Empty',
+        emptyCell: 'Pusty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Reset',

--- a/libs/i18n/src/lib/languages/russian.ts
+++ b/libs/i18n/src/lib/languages/russian.ts
@@ -538,7 +538,7 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         headerMenuUnfreeze: 'Разморозить',
         headerMenuFilter: 'Фильтр',
         defaultEmptyMessage: 'Ничего не найдено',
-        emptyCell: 'Empty',
+        emptyCell: 'Пусто',
         noVisibleColumnsMessage:
             'Сейчас в таблице нет видимых столбцов. Пожалуйста, выберите нужные столбцы в настройках таблицы.',
         resetChangesButtonLabel: 'Сбросить',

--- a/libs/i18n/src/lib/languages/russian.ts
+++ b/libs/i18n/src/lib/languages/russian.ts
@@ -538,6 +538,7 @@ export const FD_LANGUAGE_RUSSIAN: FdLanguage = {
         headerMenuUnfreeze: 'Разморозить',
         headerMenuFilter: 'Фильтр',
         defaultEmptyMessage: 'Ничего не найдено',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Сейчас в таблице нет видимых столбцов. Пожалуйста, выберите нужные столбцы в настройках таблицы.',
         resetChangesButtonLabel: 'Сбросить',

--- a/libs/i18n/src/lib/languages/turkish.ts
+++ b/libs/i18n/src/lib/languages/turkish.ts
@@ -373,6 +373,7 @@ export const FD_LANGUAGE_TURKISH: FdLanguage = {
         headerMenuUnfreeze: 'HeaderMenuUnfreeze',
         headerMenuFilter: 'Filtre',
         defaultEmptyMessage: 'Hiçbir veri bulunamadı',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Sıfırla',

--- a/libs/i18n/src/lib/languages/turkish.ts
+++ b/libs/i18n/src/lib/languages/turkish.ts
@@ -373,7 +373,7 @@ export const FD_LANGUAGE_TURKISH: FdLanguage = {
         headerMenuUnfreeze: 'HeaderMenuUnfreeze',
         headerMenuFilter: 'Filtre',
         defaultEmptyMessage: 'Hiçbir veri bulunamadı',
-        emptyCell: 'Empty',
+        emptyCell: 'Boş',
         noVisibleColumnsMessage:
             'Right now, there are no visible columns in the table. Please select the columns you need in the table settings.',
         resetChangesButtonLabel: 'Sıfırla',

--- a/libs/i18n/src/lib/languages/ukrainian.ts
+++ b/libs/i18n/src/lib/languages/ukrainian.ts
@@ -536,6 +536,7 @@ export const FD_LANGUAGE_UKRAINIAN: FdLanguage = {
         headerMenuUnfreeze: 'Розморозити',
         headerMenuFilter: 'Фільтр',
         defaultEmptyMessage: 'Нічого не знайдено',
+        emptyCell: 'Empty',
         noVisibleColumnsMessage:
             'На даний момент у таблиці немає видимих стовпців. Виберіть потрібні стовпці в налаштуваннях таблиці.',
         resetChangesButtonLabel: 'Скинути',

--- a/libs/i18n/src/lib/models/lang.ts
+++ b/libs/i18n/src/lib/models/lang.ts
@@ -468,6 +468,7 @@ export interface FdLanguage {
         headerMenuUnfreeze: FdLanguageKey;
         headerMenuFilter: FdLanguageKey;
         defaultEmptyMessage: FdLanguageKey;
+        emptyCell: FdLanguageKey;
         noVisibleColumnsMessage: FdLanguageKey;
         resetChangesButtonLabel: FdLanguageKey;
         editableCellNumberPlaceholder: FdLanguageKey;

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.html
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.html
@@ -156,6 +156,19 @@
         ></span>
 
         <ng-container *ngIf="row.state === 'readonly'; else editModeCell">
+            <span
+                *ngIf="(row.value | valueByPath : column.key) === '' || (row.value | valueByPath : column.key) === null"
+                style="
+                    position: absolute !important;
+                    height: 1px;
+                    width: 1px;
+                    overflow: hidden;
+                    opacity: 0;
+                    clip: rect(1px 1px 1px 1px);
+                    clip: rect(1px, 1px, 1px, 1px);
+                "
+                >{{ 'platformTable.emptyCell' | fdTranslate }}</span
+            >
             <ng-container *ngIf="column?.columnCellTemplate; else defaultTableCellTemplate">
                 <ng-container
                     *ngTemplateOutlet="

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.html
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.html
@@ -158,15 +158,15 @@
         <ng-container *ngIf="row.state === 'readonly'; else editModeCell">
             <span
                 *ngIf="(row.value | valueByPath : column.key) === '' || (row.value | valueByPath : column.key) === null"
-                style="
-                    position: absolute !important;
-                    height: 1px;
-                    width: 1px;
-                    overflow: hidden;
-                    opacity: 0;
-                    clip: rect(1px 1px 1px 1px);
-                    clip: rect(1px, 1px, 1px, 1px);
-                "
+                [ngStyle]="{
+                    position: 'absolute !important',
+                    height: '1px',
+                    width: '1px',
+                    overflow: 'hidden',
+                    clip: 'rect(1px, 1px, 1px, 1px)',
+                    color: 'transparent',
+                    display: 'block'
+                }"
                 >{{ 'platformTable.emptyCell' | fdTranslate }}</span
             >
             <ng-container *ngIf="column?.columnCellTemplate; else defaultTableCellTemplate">


### PR DESCRIPTION
fixes #10320 