### PR TITLE
fix(core): added spacing to the icons in fd-link

### DIFF
--- a/libs/core/src/lib/link/link.component.scss
+++ b/libs/core/src/lib/link/link.component.scss
@@ -3,3 +3,9 @@
 .fd-link__content--icon-line-height {
     line-height: var(--sapContent_LineHeight);
 }
+[fdLink],
+[fd-link],
+[fd-breadcrumb-link] {
+    --fdLink_Display: inline-flex;
+    --fdLink_Icon_Spacing: 0.125rem;
+}


### PR DESCRIPTION
## Related Issue(s)

closes #10135

## Description
This change adds spacing to the fd-link
