### PR TITLE
feat(core,platform): ability to disable snap-on-scroll on dynamic page

### DIFF
--- a/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page.component.ts
@@ -44,6 +44,10 @@ import { debounceTime, map, observeOn, takeUntil } from 'rxjs/operators';
     providers: [DynamicPageService]
 })
 export class DynamicPageComponent implements AfterViewInit, OnDestroy {
+    /** Whether DynamicPage should snap on scroll */
+    @Input()
+    disableSnapOnScroll = false;
+
     /** Page role  */
     @Input()
     @HostBinding('attr.role')
@@ -151,7 +155,7 @@ export class DynamicPageComponent implements AfterViewInit, OnDestroy {
         this._propagatePropertiesToChildren();
         this._setContentFooterSpacer();
 
-        if (this._pageSubheaderComponent?.collapsible) {
+        if (!this.disableSnapOnScroll && this._pageSubheaderComponent?.collapsible) {
             this._addScrollListeners();
         }
 

--- a/libs/core/src/lib/scrollbar/scrollbar.directive.ts
+++ b/libs/core/src/lib/scrollbar/scrollbar.directive.ts
@@ -1,19 +1,20 @@
+import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
+import { CdkScrollable } from '@angular/cdk/overlay';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
     CSP_NONCE,
     Directive,
     ElementRef,
     HostBinding,
     HostListener,
-    inject,
     Input,
     OnDestroy,
     PLATFORM_ID,
-    Renderer2
+    Renderer2,
+    inject
 } from '@angular/core';
-import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
-import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { HasElementRef } from '@fundamental-ngx/cdk/utils';
 import scrollbarStyles from 'fundamental-styles/dist/js/scrollbar';
-import { CdkScrollable } from '@angular/cdk/overlay';
 
 export type ScrollbarOverflowOptions = 'auto' | 'scroll' | 'hidden';
 
@@ -40,7 +41,7 @@ let styleSheet: HTMLStyleElement | null = null;
     hostDirectives: [CdkScrollable],
     standalone: true
 })
-export class ScrollbarDirective implements OnDestroy {
+export class ScrollbarDirective implements OnDestroy, HasElementRef {
     /** Whether overflow horizontal content should be hidden. */
     @Input()
     set noHorizontalScroll(value: BooleanInput) {
@@ -105,6 +106,9 @@ export class ScrollbarDirective implements OnDestroy {
     _inPopover = false;
 
     /** @hidden */
+    elementRef: ElementRef<HTMLElement> = inject(ElementRef);
+
+    /** @hidden */
     private _document: Document = inject(DOCUMENT);
 
     /** @hidden */
@@ -124,7 +128,7 @@ export class ScrollbarDirective implements OnDestroy {
     /**
      * @hidden
      */
-    constructor(private _elementRef: ElementRef<HTMLElement>, renderer2: Renderer2) {
+    constructor(renderer2: Renderer2) {
         scrollbarElementsQuantity++;
         const platform = inject(PLATFORM_ID);
         if (!styleSheet && isPlatformBrowser(platform)) {
@@ -155,7 +159,7 @@ export class ScrollbarDirective implements OnDestroy {
 
     /** method to invoke scroll */
     scroll(options: ScrollToOptions): void {
-        this._elementRef.nativeElement.scroll(options);
+        this.elementRef.nativeElement.scroll(options);
     }
 
     /** @hidden */

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.component.html
@@ -77,14 +77,14 @@
     >
         <ng-container *ngFor="let tab of _tabs">
             <fd-tab [title]="tab.tabLabel" [id]="tab.id">
-                <fd-dynamic-page-content cdkScrollable>
+                <fd-dynamic-page-content>
                     <ng-container [ngTemplateOutlet]="tab.contentTemplateRef"></ng-container>
                 </fd-dynamic-page-content>
             </fd-tab>
         </ng-container>
     </fd-tab-list>
 
-    <fd-dynamic-page-content *ngIf="!_isTabbed && contentComponent" cdkScrollable>
+    <fd-dynamic-page-content *ngIf="!_isTabbed && contentComponent">
         <ng-container [ngTemplateOutlet]="contentComponent.contentTemplateRef"></ng-container>
     </fd-dynamic-page-content>
 

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.component.html
@@ -1,4 +1,5 @@
 <fd-dynamic-page
+    [disableSnapOnScroll]="disableSnapOnScroll"
     [autoResponsive]="autoResponsive"
     [background]="background"
     [size]="size"

--- a/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page.component.ts
@@ -20,8 +20,8 @@ import {
 } from '@angular/core';
 import { startWith } from 'rxjs/operators';
 
-import { TabListComponent, TabPanelComponent } from '@fundamental-ngx/core/tabs';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { TabListComponent, TabPanelComponent } from '@fundamental-ngx/core/tabs';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
 import { DynamicPageBackgroundType, DynamicPageResponsiveSize } from './constants';
 import { DynamicPageContentHostComponent } from './dynamic-page-content/dynamic-page-content-host.component';
@@ -50,6 +50,9 @@ export class DynamicPageTabChangeEvent {
     providers: [DynamicPageService]
 })
 export class DynamicPageComponent extends BaseComponent implements AfterContentInit, AfterViewInit, DoCheck, OnDestroy {
+    /** Whether DynamicPage should snap on scroll */
+    @Input()
+    disableSnapOnScroll = false;
     /** Page role  */
     @Input()
     @HostBinding('attr.role')


### PR DESCRIPTION
## Related Issue(s)

Part of #10375

## Description

This PR does two things:
1. fixes snap-on-scroll functionality when content is not tabbed
2. adds input to disable snap-on-scroll