### PR TITLE
fix(core): remove incorrect aria attribute

### DIFF
--- a/libs/core/src/lib/token/token.component.html
+++ b/libs/core/src/lib/token/token.component.html
@@ -11,7 +11,6 @@
     [class.fd-token--selected]="selected"
     [class.fd-token--readonly]="readOnly"
     [attr.aria-selected]="selected"
-    [attr.aria-readonly]="readOnly"
 >
     <span class="fd-token__text no-text-select">
         <ng-container #viewContainer></ng-container>


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10382

## Description
- Removed `aria-readonly` from the element with the role that is not associated with that aria attribute.
