### PR TITLE
chore: fixed build dependencies

### DIFF
--- a/libs/cdk/src/lib/data-source/ng-package.json
+++ b/libs/cdk/src/lib/data-source/ng-package.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "dest": "../../../../../dist/libs/cdk/data-source",
     "lib": {
         "entryFile": "./index.ts"
     }

--- a/libs/cdk/src/lib/data-source/ng-package.json
+++ b/libs/cdk/src/lib/data-source/ng-package.json
@@ -1,17 +1,6 @@
 {
     "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
-    "dest": "../../../../../dist/libs/cdk/data-source",
-    "deleteDestPath": true,
     "lib": {
         "entryFile": "./index.ts"
-    },
-    "allowedNonPeerDependencies": [
-        "@sap-theming/theming-base-content",
-        "focus-trap",
-        "fundamental-styles",
-        "lodash-es",
-        "compare-versions",
-        "@fundamental-ngx/i18n",
-        "fast-deep-equal"
-    ]
+    }
 }

--- a/libs/cdk/src/lib/forms/ng-package.json
+++ b/libs/cdk/src/lib/forms/ng-package.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "dest": "../../../../../dist/libs/cdk/forms",
     "lib": {
         "entryFile": "./index.ts"
     }

--- a/libs/cdk/src/lib/forms/ng-package.json
+++ b/libs/cdk/src/lib/forms/ng-package.json
@@ -1,17 +1,6 @@
 {
     "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
-    "dest": "../../../../../dist/libs/cdk/forms",
-    "deleteDestPath": true,
     "lib": {
         "entryFile": "./index.ts"
-    },
-    "allowedNonPeerDependencies": [
-        "@sap-theming/theming-base-content",
-        "focus-trap",
-        "fundamental-styles",
-        "lodash-es",
-        "compare-versions",
-        "@fundamental-ngx/i18n",
-        "fast-deep-equal"
-    ]
+    }
 }

--- a/libs/cdk/src/lib/ng-package.json
+++ b/libs/cdk/src/lib/ng-package.json
@@ -1,7 +1,6 @@
 {
     "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
     "dest": "../../../../dist/libs/cdk",
-    "deleteDestPath": true,
     "lib": {
         "entryFile": "./index.ts"
     },
@@ -11,7 +10,6 @@
         "fundamental-styles",
         "lodash-es",
         "compare-versions",
-        "@fundamental-ngx/i18n",
         "fast-deep-equal"
     ]
 }

--- a/libs/cdk/src/lib/package.json
+++ b/libs/cdk/src/lib/package.json
@@ -23,7 +23,6 @@
     "rxjs": "RXJS_VER_PLACEHOLDER"
   },
   "dependencies": {
-    "@fundamental-ngx/i18n": "VERSION_PLACEHOLDER",
     "@fundamental-styles/cx": "FDCXSTYLES_VER_PLACEHOLDER",
     "@sap-theming/theming-base-content": "THEMING_VER_PLACEHOLDER",
     "compare-versions": "COMPARE_VERSIONS_VER_PLACEHOLDER",

--- a/libs/cdk/src/lib/utils/ng-package.json
+++ b/libs/cdk/src/lib/utils/ng-package.json
@@ -1,5 +1,6 @@
 {
     "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "dest": "../../../../../dist/libs/cdk/utils",
     "lib": {
         "entryFile": "./index.ts"
     }

--- a/libs/cdk/src/lib/utils/ng-package.json
+++ b/libs/cdk/src/lib/utils/ng-package.json
@@ -1,17 +1,6 @@
 {
     "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
-    "dest": "../../../../../dist/libs/cdk/utils",
-    "deleteDestPath": true,
     "lib": {
         "entryFile": "./index.ts"
-    },
-    "allowedNonPeerDependencies": [
-        "@sap-theming/theming-base-content",
-        "focus-trap",
-        "fundamental-styles",
-        "lodash-es",
-        "compare-versions",
-        "@fundamental-ngx/i18n",
-        "fast-deep-equal"
-    ]
+    }
 }

--- a/libs/i18n/project.json
+++ b/libs/i18n/project.json
@@ -73,5 +73,6 @@
             }
         }
     },
-    "tags": ["type:lib", "scope:i18n"]
+    "tags": ["type:lib", "scope:i18n"],
+    "implicitDependencies": ["cdk"]
 }


### PR DESCRIPTION
## Related Issue(s)

Fixed https://github.com/SAP/fundamental-ngx/actions/runs/6313731280/job/17142547649

## Description

i18n package lacked the dependency on `cdk` itself, it only had dep on `cdk-utils`
