### PR TITLE
fix(platform): when a frozen column is made wider than the table, unfreeze all columns

### DIFF
--- a/libs/platform/src/lib/table-helpers/services/table-column-resize.service.ts
+++ b/libs/platform/src/lib/table-helpers/services/table-column-resize.service.ts
@@ -310,14 +310,25 @@ export class TableColumnResizeService implements OnDestroy {
             }
         }
 
-        if (diffX > 0 && this._tableRef._freezableColumns.has(this._resizedColumn)) {
-            const freezeToNextColumnName = this._visibleColumnNames[this._tableRef._freezableColumns.size];
-            const actualWidth = this.getPrevColumnsWidth(freezeToNextColumnName);
+        /**
+         * In case "_resizedColumn" is freezable, make sure the overall width of freezable columns does not exceed the width of the table.
+         * If it does, columns will be made unfrozen.
+         */
+        if (
+            diffX > 0 &&
+            (this._tableRef._freezableColumns.has(this._resizedColumn) ||
+                this._tableRef._freezableEndColumns.has(this._resizedColumn))
+        ) {
+            let actualWidth = this.getPrevColumnsWidth(this._resizedColumn) + columnWidth;
+            if (this._tableRef._freezableEndColumns.has(this._resizedColumn)) {
+                actualWidth = this.getNextColumnsWidth(this._resizedColumn) + columnWidth;
+            }
             const newWidth = actualWidth + diffX;
             const maxWidth = this._tableRef.getMaxAllowedFreezableColumnsWidth();
-            // in case "_resizedColumn" is freezable, make sure the overall width of freezable columns does not exceed the width of the table
             if (newWidth >= maxWidth) {
-                diffX = maxWidth - actualWidth;
+                this._tableRef._freezableColumns.forEach((column) => {
+                    this._tableRef.unfreeze(column.toString());
+                });
             }
         }
 

--- a/libs/platform/src/lib/table-helpers/table.ts
+++ b/libs/platform/src/lib/table-helpers/table.ts
@@ -40,6 +40,9 @@ export abstract class Table<T = any> implements PresetManagedComponent<PlatformT
     /** Freezable column names and their respective indexes */
     abstract get _freezableColumns(): ReadonlyMap<string, number>;
 
+    /** Freezable column names and their respective indexes */
+    abstract get _freezableEndColumns(): ReadonlyMap<string, number>;
+
     /** Width of the table element in px */
     abstract get _tableWidthPx(): number;
 


### PR DESCRIPTION
fixes #10552 

Adjusts the functionality when resizing frozen columns to match that of sapui5. When the user resizes a frozen column such that it will be wider than the table, the column becomes unfrozen.