### PR TITLE
fix(core): some improvements to using labels with block busy indicator

### DIFF
--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.html
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.html
@@ -7,7 +7,6 @@
         [class.fd-busy-indicator--l]="size === 'l'"
         [class.fd-busy-indicator--m]="size === 'm'"
         [class.fd-busy-indicator--s]="size === 's'"
-        [class.fd-busy-indicator--absolute]="busyIndicator?.previousElementSibling"
     >
         <div class="fd-busy-indicator__circle"></div>
         <div class="fd-busy-indicator__circle"></div>
@@ -16,10 +15,7 @@
 
     <span *ngIf="label" class="fd-busy-indicator-extended__label">{{ label }}</span>
 
-    <div
-        class="fd-busy-indicator__overlay"
-        [class.fd-busy-indicator__overlay--transparent]="!busyIndicator?.previousElementSibling"
-    ></div>
+    <div class="fd-busy-indicator__overlay"></div>
 
     <div #fakeFocusElement tabindex="0" aria-hidden="true" (focusin)="fakeElementFocusHandler($event)"></div>
 </ng-container>

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.scss
@@ -1,15 +1,28 @@
 @import 'fundamental-styles/dist/busy-indicator';
 
+$siblingBusyIndicator: '* + .fd-busy-indicator';
+$onlyChildBusyIndicator: '.fd-busy-indicator:first-child';
+
+#{$siblingBusyIndicator},
+#{$siblingBusyIndicator} + .fd-busy-indicator-extended__label {
+    white-space: nowrap;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+#{$siblingBusyIndicator} + .fd-busy-indicator-extended__label {
+    z-index: 2;
+    transform: translate(-50%, 50%) !important;
+}
+
+#{$onlyChildBusyIndicator} ~ .fd-busy-indicator__overlay {
+    background-color: transparent;
+}
+
 .fd-busy-indicator {
     z-index: 2;
-
-    &--absolute {
-        white-space: nowrap;
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-    }
 
     &__container {
         display: block;
@@ -39,9 +52,5 @@
         z-index: 1;
         background-color: var(--sapBaseColor);
         opacity: 0.72;
-
-        &--transparent {
-            background-color: transparent;
-        }
     }
 }

--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.spec.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.spec.ts
@@ -64,22 +64,6 @@ describe('BusyIndicatorComponent', () => {
         expect(fixture.nativeElement.querySelector('.fd-busy-indicator--l')).toBeTruthy();
     });
 
-    it('should display properly with content projection', () => {
-        component.hasContent = true;
-        fixture.detectChanges();
-
-        expect(fixture.nativeElement.querySelector('.fd-busy-indicator--absolute')).toBeTruthy();
-        expect(fixture.nativeElement.querySelector('.fd-busy-indicator__overlay--transparent')).toBeFalsy();
-    });
-
-    it('should display properly with no projection', () => {
-        component.hasContent = false;
-        fixture.detectChanges();
-
-        expect(fixture.nativeElement.querySelector('.fd-busy-indicator--absolute')).toBeFalsy();
-        expect(fixture.nativeElement.querySelector('.fd-busy-indicator__overlay--transparent')).toBeTruthy();
-    });
-
     it('should display as block', () => {
         component.block = true;
         fixture.detectChanges();


### PR DESCRIPTION
fixes #10412 

before:
<img width="1214" alt="Screenshot 2023-09-29 at 12 23 19 PM" src="https://github.com/SAP/fundamental-ngx/assets/2471874/d95adac7-ea1d-48b4-9aef-adc8f2fe5fbf">

after:
<img width="1221" alt="Screenshot 2023-09-29 at 12 22 50 PM" src="https://github.com/SAP/fundamental-ngx/assets/2471874/ae96f129-71b5-4fe2-8320-f3f621f5ad1c">
