### PR TITLE
fix(core): tab list tabindex fix

### DIFF
--- a/libs/core/src/lib/tabs/tab-list.component.html
+++ b/libs/core/src/lib/tabs/tab-list.component.html
@@ -104,6 +104,7 @@
     [style.max-height]="maxContentHeight"
     fdScrollSpy
     fd-scrollbar
+    [overrideTabindex]="false"
     [trackedTags]="['fd-tab']"
     [scrollSpyDisabled]="_disableScrollSpy"
     (spyChange)="_highlightActiveTab($event)"


### PR DESCRIPTION
part of https://github.com/SAP/fundamental-ngx/pull/10576

## Description

- Only interactive elements should have a tab index. Tab content is not guaranteed to be an interactive element, so the forced default tabindex is the wrong a11y, causing us to fail the audit.
- No guide on how to get started, so it's easy to miss things, like the project uses yarn, getting version conflicts on `npm i`
- Top level package version is redundant for monorepos such as this (it being outdated for months proves that point, but also recommended to be removed [here](https://github.com/lerna/lerna/issues/2879#issuecomment-1471606448))

## Screenshots

### Before:
![tabs_before](https://github.com/SAP/fundamental-ngx/assets/115458873/4d338b73-4537-411d-9523-0e3ea264df1d)


### After:
![tabs_after](https://github.com/SAP/fundamental-ngx/assets/115458873/291f035b-d2b2-4091-a330-71d999c4bf9e)

