### PR TITLE
feat(core): add index emit to tab selection

### DIFF
--- a/libs/core/src/lib/tabs/tab-list.component.spec.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.spec.ts
@@ -1,10 +1,10 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Component, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { TabPanelComponent } from './tab-panel/tab-panel.component';
-import { TabListComponent } from './tab-list.component';
-import { TabsModule } from './tabs.module';
 import { whenStable } from '@fundamental-ngx/core/tests';
+import { TabListComponent } from './tab-list.component';
+import { TabPanelComponent } from './tab-panel/tab-panel.component';
+import { TabsModule } from './tabs.module';
 
 @Component({
     template: ` <fd-tab-list>
@@ -57,6 +57,7 @@ describe('TabListComponent', () => {
     it('should select tab', async () => {
         await whenStable(fixture);
         const tabChangeSpy = jest.spyOn(component.selectedTabChange, 'emit');
+        const tabIndexChangeSpy = jest.spyOn(component.selectedTabIndexChange, 'emit');
         const firstActiveTab = testComponent.tabs.first;
         const secondActiveTab = testComponent.tabs.last;
 
@@ -65,6 +66,7 @@ describe('TabListComponent', () => {
         await whenStable(fixture);
 
         expect(tabChangeSpy).toHaveBeenCalled();
+        expect(tabIndexChangeSpy).toHaveBeenCalledWith(3);
         expect(firstActiveTab.expanded).toBe(false);
         expect(secondActiveTab.expanded).toBe(true);
     });
@@ -87,11 +89,13 @@ describe('TabListComponent', () => {
         await whenStable(fixture);
 
         const tabChangeSpy = jest.spyOn(component.selectedTabChange, 'emit');
+        const tabIndexChangeSpy = jest.spyOn(component.selectedTabIndexChange, 'emit');
         fixture.componentInstance.showDisabled = false;
 
         await whenStable(fixture);
 
         expect(tabChangeSpy).toHaveBeenCalled();
+        expect(tabIndexChangeSpy).toHaveBeenCalledWith(0);
     });
 });
 
@@ -104,7 +108,7 @@ const NUMBER_OF_TABS = 10;
             [collapsibleTabs]="true"
             [collapseOverflow]="true"
             [maxVisibleTabs]="maxVisibleTabs"
-        >
+            >
             <fd-tab *ngFor="let title of _tabs" [title]="title">{{ title }} content</fd-tab>
         </fd-tab-list>
     `

--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -167,6 +167,10 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
     @Output()
     selectedTabChange = new EventEmitter<TabPanelComponent>();
 
+    /** Event emitted when the selected panel index changes. */
+    @Output()
+    selectedTabIndexChange = new EventEmitter<number>();
+
     /** Event emitted when visible items count has been changed. */
     @Output()
     visibleItemsCount = new EventEmitter<number>();
@@ -291,7 +295,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
             const _tabWasActive = tab.active;
             this._activateStackedTab(tab.panel, false);
             if (!_tabWasActive) {
-                this.selectedTabChange.emit(tab.panel);
+                this._selectedTabChange(tab.panel);
             }
         }
     }
@@ -428,7 +432,7 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
             this._detectChanges();
         }
 
-        this.selectedTabChange.emit(tabPanel);
+        this._selectedTabChange(tabPanel);
     }
 
     /** @hidden */
@@ -455,5 +459,13 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
     /** @hidden Whether tab can be expanded/collapsed */
     private _canChangeExpandState(tabPanel: TabPanelComponent, expand: boolean): boolean {
         return !tabPanel.disabled && expand !== tabPanel.expanded && expand === false ? this.collapsibleTabs : true;
+    }
+
+    /** @hidden */
+    private _selectedTabChange(tabPanel: TabPanelComponent): void {
+        this.selectedTabChange.emit(tabPanel);
+
+        const index = this._tabArray.findIndex((tabInfo) => tabInfo.panel === tabPanel);
+        this.selectedTabIndexChange.emit(index);
     }
 }


### PR DESCRIPTION
covering https://github.com/SAP/fundamental-ngx/pull/10596

## Description

Related to issue, but imo it is not an actual bug: #9994 
PR #4120 replaced the index emit with TabPanel. The index in itself also holds information that's not easily accessible by only the emitted Tab. Right now consumers need to get the index by searching the DOM for the emitted value by various means, while we have index readily available inside fundamental. \
Index can come handy in many situations from querying fresh data, update the queryparams in the browser to create deeplinking and so on, all of which are possible without the index as well, but way simpler with it.

