### PR TITLE
fix(core,platform): busy indicator should not have aria-live polite by default, search input count issue

### DIFF
--- a/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
+++ b/libs/core/src/lib/busy-indicator/busy-indicator.component.ts
@@ -67,7 +67,7 @@ export class BusyIndicatorComponent {
 
     /** Aria live attribute value. */
     @Input()
-    ariaLive: Nullable<'assertive' | 'polite' | 'off'> = 'polite';
+    ariaLive: Nullable<'assertive' | 'polite' | 'off'> = null;
 
     /** @hidden */
     @ViewChild('fakeFocusElement')

--- a/libs/platform/src/lib/search-field/search-field.component.ts
+++ b/libs/platform/src/lib/search-field/search-field.component.ts
@@ -253,6 +253,10 @@ export class SearchFieldComponent
     @Input()
     forceSearchButton = false;
 
+    /** Whether to disable the "suggestions found" live announcer. */
+    @Input()
+    disableSuggestionsFoundAnnouncer = false;
+
     /** Input change event. */
     @Output()
     inputChange: EventEmitter<SearchInput> = new EventEmitter();

--- a/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.html
+++ b/libs/platform/src/lib/table/components/table-toolbar/table-toolbar.component.html
@@ -31,6 +31,7 @@
             [ariaLabelledBy]="tableToolbarTitleId"
             (searchSubmit)="submitSearch($event)"
             (cancelSearch)="submitSearch($event)"
+            [disableSuggestionsFoundAnnouncer]="true"
         ></fdp-search-field>
 
         <ng-container *ngIf="editMode !== 'none'">


### PR DESCRIPTION
fixes #10381

- Fixes an issue where each element in the table was being read aloud due to the wrapping busy indicator having aria-live="polite". busy indicator should not have an aria-live attribute by default
- Fixes an issue with the fdp-search-field inside of the table where the screenreader would incorrectly say there are 0 items