### PR TITLE
fix(core): time picker hour/minute/seconds being read twice on JAWS

### DIFF
--- a/libs/core/src/lib/time/time-column/time-column.component.html
+++ b/libs/core/src/lib/time/time-column/time-column.component.html
@@ -63,7 +63,6 @@
     >
         <span
             class="fd-time-column-custom-hidden"
-            aria-live="assertive"
             aria-atomic="true"
             [attr.aria-hidden]="!active"
             [attr.id]="currentIndicatorValueId"


### PR DESCRIPTION
fixes #10437 