### PR TITLE
fix(core): popover close strategy fix

### DIFF
--- a/libs/core/src/lib/popover/popover-service/popover.service.ts
+++ b/libs/core/src/lib/popover/popover-service/popover.service.ts
@@ -131,17 +131,17 @@ export class PopoverService extends BasePopoverClass {
 
     /** Closes the popover. */
     close(focusActiveElement = true): void {
-        if (this._overlayRef && this._overlayRef.hasAttached()) {
+        if (this._overlayRef) {
             this._overlayRef.dispose();
-
-            const prevState = this.isOpen;
-            this.isOpen = false;
-            if (prevState !== this.isOpen) {
-                this.isOpenChange.emit(this.isOpen);
-            }
-
-            this._focusLastActiveElementBeforeOpen(focusActiveElement);
         }
+
+        const prevState = this.isOpen;
+        this.isOpen = false;
+        if (prevState !== this.isOpen) {
+            this.isOpenChange.emit(this.isOpen);
+        }
+
+        this._focusLastActiveElementBeforeOpen(focusActiveElement);
     }
 
     /** Opens the popover. */


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes none

## Description
Previously we disposed overlayRef only when it had attached content. With Close scroll strategy, content is being disposed before the actual detachment happening, thus the condition did not match and the inner state of the popover service didn't update itself to mark the popover as closed.

This PR fixes this condition and disposes the overlay each time popover has being closed.