### PR TITLE
fix(e2e): core calendar fix

### DIFF
--- a/libs/docs/core/calendar/e2e/calendar.e2e-spec.ts
+++ b/libs/docs/core/calendar/e2e/calendar.e2e-spec.ts
@@ -261,6 +261,8 @@ describe('calendar test suite', () => {
             const today = new Date();
             const endDate = new Date(today);
             endDate.setDate(today.getDate() + 7);
+            const nextDayAfterEndDate = new Date();
+            nextDayAfterEndDate.setDate(endDate.getDate() + 1);
 
             if (endDate.getDate() < today.getDate()) {
                 await click(nextMonthButton);
@@ -276,9 +278,7 @@ describe('calendar test suite', () => {
             expect(
                 await (
                     await $(
-                        `fd-calendar-special-day-example .fd-calendar__item[data-fd-calendar-date-day="${
-                            endDate.getDate() + 1
-                        }"]:not(.fd-calendar__item--other)`
+                        `fd-calendar-special-day-example .fd-calendar__item[data-fd-calendar-date-day="${nextDayAfterEndDate.getDay()}"]:not(.fd-calendar__item--other)`
                     )
                 ).getAttribute('class')
             ).not.toContain('-legend-');


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes none

## Description
This PR fixes the issue with core calendar e2e bug that happening on the specific date, which is [end-of-month-day] - 7 days. Originally, e2e script incorrectly added new day by simply adding +1 to days number, which could result in 32.
