### PR TITLE
fix(platform): special characters escape

### DIFF
--- a/libs/platform/src/lib/shared/domain/data-source.ts
+++ b/libs/platform/src/lib/shared/domain/data-source.ts
@@ -95,7 +95,8 @@ export interface MatchingBy {
 
 /** Matching Strategy: StartsWithPerTerm - Reqexp */
 export function getMatchingStrategyStartsWithPerTermReqexp(value: string): RegExp {
-    return new RegExp(`(\\s|^)(${value})`, 'gi');
+    // We need to escape all special characters in order not to break the regular expression.
+    return new RegExp(`(\\s|^)(${value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
 }
 
 /** @hidden */


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10661

## Description
- INitial issue caused by `getMatchingStrategyStartsWithPerTermReqexp` which is used only with `MatchingStrategy.STARTS_WITH_PER_TERM`. It uses regular expression, but does not escape the special characters that may affect the regex itself (`()`, `$`, `^`, etc.).
