### PR TITLE
fix(core): combobox groupFn nullable type

### DIFF
--- a/libs/core/src/lib/combobox/combobox.component.ts
+++ b/libs/core/src/lib/combobox/combobox.component.ts
@@ -227,7 +227,7 @@ export class ComboboxComponent<T = any>
      * Function used to handle grouping of items.
      */
     @Input()
-    groupFn: GroupFunction;
+    groupFn: Nullable<GroupFunction>;
 
     /** Max height of the popover. Any overflowing elements will be accessible through scrolling. */
     @Input()


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10829

- Marked groupFn as an optional input property.