### PR TITLE
fix(core): multi input close dropdown when item selected

### DIFF
--- a/apps/docs/src/styles.scss
+++ b/apps/docs/src/styles.scss
@@ -29,6 +29,21 @@ $gutter-size: 15px;
 }
 
 @font-face {
+    font-family: '72';
+    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff')
+        format('woff');
+    font-weight: 500;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: '72';
+    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
+    font-weight: 700;
+    font-style: normal;
+}
+
+@font-face {
     font-family: '72-Bold';
     src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
     font-weight: 700;
@@ -40,22 +55,6 @@ $gutter-size: 15px;
     src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff')
         format('woff');
     font-weight: bold;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'BusinessSuiteInAppSymbols';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/BusinessSuiteInAppSymbols.woff')
-        format('woff');
-    font-weight: normal;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'SAP-icons-TNT';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/SAP-icons-TNT.woff')
-        format('woff');
-    font-weight: normal;
     font-style: normal;
 }
 

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -122,7 +122,7 @@
                 fd-list-item
                 [attr.aria-label]="option.label"
                 (click)="_onCheckboxClick(option, $event, idx, true)"
-                (keyup)="_onCheckboxKeyup(option, $event, idx)"
+                (keyup)="_onCheckboxKeyup(option, $event, idx, true)"
                 [selected]="!!option.isSelected"
             >
                 <fd-checkbox (click)="_onCheckboxClick(option, $event, idx)" [value]="option.isSelected">

--- a/libs/core/src/lib/multi-input/multi-input.component.ts
+++ b/libs/core/src/lib/multi-input/multi-input.component.ts
@@ -633,9 +633,14 @@ export class MultiInputComponent<ItemType = any, ValueType = any>
     }
 
     /** @hidden */
-    _onCheckboxKeyup(option: _OptionItem<ItemType, ValueType>, event: KeyboardEvent, index: number): void {
+    _onCheckboxKeyup(
+        option: _OptionItem<ItemType, ValueType>,
+        event: KeyboardEvent,
+        index: number,
+        isListItem = false
+    ): void {
         if (KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
-            this._onCheckboxClick(option, event, index);
+            this._onCheckboxClick(option, event, index, isListItem);
         }
     }
 

--- a/libs/docs/shared/src/lib/core-helpers/stackblitz/code-example-stack/styles.scss
+++ b/libs/docs/shared/src/lib/core-helpers/stackblitz/code-example-stack/styles.scss
@@ -16,16 +16,16 @@
 }
 
 @font-face {
-    font-family: '72-Bold';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
-    font-weight: 700;
+    font-family: '72';
+    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Light.woff') format('woff');
+    font-weight: 300;
     font-style: normal;
 }
 
 @font-face {
-    font-family: '72';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Light.woff') format('woff');
-    font-weight: 300;
+    font-family: '72-Bold';
+    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
+    font-weight: 700;
     font-style: normal;
 }
 
@@ -34,29 +34,6 @@
     src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff')
         format('woff');
     font-weight: bold;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'SAP-icons';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/SAP-icons.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'BusinessSuiteInAppSymbols';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/BusinessSuiteInAppSymbols.woff')
-        format('woff');
-    font-weight: normal;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'SAP-icons-TNT';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/SAP-icons-TNT.woff')
-        format('woff');
-    font-weight: normal;
     font-style: normal;
 }
 


### PR DESCRIPTION
closes #10814

- When user selects item from the dropdown via keyboard ENTER or SPACE, close the dropdown manu, clear input field and focus the input field;
- Updated fonts so it would work for fiori and horizon