### PR TITLE
fix(core): disable autocomplete if includes enabled

### DIFF
--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -86,7 +86,7 @@
                     [matcher]="typeAheadMatcher"
                     [inputText]="_searchTermCtrl.value || ''"
                     [options]="dropdownValues"
-                    [enable]="autoComplete && !mobile"
+                    [enable]="!includes && autoComplete && !mobile"
                     [placeholder]="placeholder"
                     [formControl]="_searchTermCtrl"
                     [attr.aria-required]="required"

--- a/libs/docs/platform/multi-input/platform-multi-input-docs.component.html
+++ b/libs/docs/platform/multi-input/platform-multi-input-docs.component.html
@@ -5,8 +5,7 @@
         To open suggestions dropdown with keyboard, use combination of <code>alt key + arrow down key</code> when
         focusing input field.
     </p>
-    ]</description
->
+</description>
 <component-example>
     <fdp-platform-multi-input-example></fdp-platform-multi-input-example>
 </component-example>


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10811

## Description
- Disable autocomplete functionality if `includes` input property is `true`.
