### PR TITLE
feat: vite builder support

### DIFF
--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -33,7 +33,7 @@
             "defaultConfiguration": "affected-local"
         },
         "compile": {
-            "executor": "@nx/angular:webpack-browser",
+            "executor": "@angular-devkit/build-angular:browser-esbuild",
             "options": {
                 "outputPath": "dist/apps/docs",
                 "index": "apps/docs/src/index.html",
@@ -174,6 +174,9 @@
                         "bundleName": "sap_horizon_fonts"
                     }
                 ],
+                "stylePreprocessorOptions": {
+                    "includePaths": ["node_modules"]
+                },
                 "scripts": ["node_modules/marked/marked.min.js"],
                 "allowedCommonJsDependencies": ["moment", "highlight.js", "fast-deep-equal", "focus-trap", "dayjs"],
                 "vendorChunk": true,
@@ -185,7 +188,8 @@
             },
             "configurations": {
                 "development": {
-                    "tsConfig": "apps/docs/tsconfig.app.json"
+                    "tsConfig": "apps/docs/tsconfig.app.json",
+                    "outputHashing": "all"
                 },
                 "production": {
                     "optimization": true,
@@ -211,6 +215,7 @@
                 },
                 "production-unoptimized": {
                     "tsConfig": "apps/docs/tsconfig.netlify.json",
+                    "outputHashing": "all",
                     "sourceMap": false,
                     "namedChunks": false,
                     "vendorChunk": false,
@@ -223,6 +228,7 @@
                     ]
                 },
                 "core": {
+                    "outputHashing": "all",
                     "fileReplacements": [
                         {
                             "replace": "apps/docs/src/environments/app.routes.ts",
@@ -231,6 +237,7 @@
                     ]
                 },
                 "cdk": {
+                    "outputHashing": "all",
                     "fileReplacements": [
                         {
                             "replace": "apps/docs/src/environments/app.routes.ts",
@@ -239,6 +246,7 @@
                     ]
                 },
                 "btp": {
+                    "outputHashing": "all",
                     "fileReplacements": [
                         {
                             "replace": "apps/docs/src/environments/app.routes.ts",
@@ -247,6 +255,7 @@
                     ]
                 },
                 "platform": {
+                    "outputHashing": "all",
                     "fileReplacements": [
                         {
                             "replace": "apps/docs/src/environments/app.routes.ts",
@@ -255,6 +264,7 @@
                     ]
                 },
                 "cx": {
+                    "outputHashing": "all",
                     "fileReplacements": [
                         {
                             "replace": "apps/docs/src/environments/app.routes.ts",
@@ -263,6 +273,7 @@
                     ]
                 },
                 "i18n": {
+                    "outputHashing": "all",
                     "fileReplacements": [
                         {
                             "replace": "apps/docs/src/environments/app.routes.ts",
@@ -276,7 +287,7 @@
             "dependsOn": ["^compile-typedoc", "^transform-translations"]
         },
         "serve": {
-            "executor": "@nx/angular:webpack-dev-server",
+            "executor": "@angular-devkit/build-angular:dev-server",
             "options": {
                 "browserTarget": "docs:compile"
             },

--- a/apps/docs/src/fd-typedoc/assets/css/main.scss
+++ b/apps/docs/src/fd-typedoc/assets/css/main.scss
@@ -52,8 +52,6 @@
     canvas,
     video {
         display: inline-block;
-        *display: inline;
-        *zoom: 1;
     }
 
     /** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
@@ -287,7 +285,6 @@
         border: 0; /* 1 */
         padding: 0;
         white-space: normal; /* 2 */
-        *margin-left: -7px;
     }
 
     /* 3 */
@@ -299,7 +296,6 @@
         font-size: 100%; /* 1 */
         margin: 0; /* 2 */
         vertical-align: baseline; /* 3 */
-        *vertical-align: middle;
     }
 
     /* 3 */
@@ -320,7 +316,6 @@
     html input[type='button'] {
         -webkit-appearance: button; /* 2 */
         cursor: pointer; /* 3 */
-        *overflow: visible;
     }
 
     /* 4 */
@@ -328,7 +323,6 @@
     input[type='submit'] {
         -webkit-appearance: button; /* 2 */
         cursor: pointer; /* 3 */
-        *overflow: visible;
     }
 
     /* 4 */
@@ -347,8 +341,6 @@
     input[type='radio'] {
         box-sizing: border-box; /* 1 */
         padding: 0; /* 2 */
-        *height: 13px; /* 3 */
-        *width: 13px;
     }
 
     input[type='search'] {

--- a/apps/docs/src/styles.scss
+++ b/apps/docs/src/styles.scss
@@ -8,7 +8,7 @@ $gutter-size: 15px;
 
 @font-face {
     font-family: '72';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Regular-full.woff')
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Regular-full.woff')
         format('woff');
     font-weight: normal;
     font-style: normal;
@@ -16,21 +16,21 @@ $gutter-size: 15px;
 
 @font-face {
     font-family: '72-Light';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Light.woff') format('woff');
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Light.woff') format('woff');
     font-weight: 300;
     font-style: normal;
 }
 
 @font-face {
     font-family: '72';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Light.woff') format('woff');
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Light.woff') format('woff');
     font-weight: 300;
     font-style: normal;
 }
 
 @font-face {
     font-family: '72';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff')
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff')
         format('woff');
     font-weight: 500;
     font-style: normal;
@@ -38,21 +38,21 @@ $gutter-size: 15px;
 
 @font-face {
     font-family: '72';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
     font-weight: 700;
     font-style: normal;
 }
 
 @font-face {
     font-family: '72-Bold';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-Bold.woff') format('woff');
     font-weight: 700;
     font-style: normal;
 }
 
 @font-face {
     font-family: '72-SemiboldDuplex';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff')
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/72-SemiboldDuplex.woff')
         format('woff');
     font-weight: bold;
     font-style: normal;

--- a/apps/docs/src/theming/sap_fiori_3_fonts.css
+++ b/apps/docs/src/theming/sap_fiori_3_fonts.css
@@ -1,21 +1,20 @@
 @font-face {
     font-family: 'SAP-icons';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/SAP-icons.woff') format('woff');
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/SAP-icons.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'SAP-icons-TNT';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/SAP-icons-TNT.woff')
-        format('woff');
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/SAP-icons-TNT.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'BusinessSuiteInAppSymbols';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/BusinessSuiteInAppSymbols.woff')
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/BusinessSuiteInAppSymbols.woff')
         format('woff');
     font-weight: normal;
     font-style: normal;

--- a/apps/docs/src/theming/sap_horizon_fonts.css
+++ b/apps/docs/src/theming/sap_horizon_fonts.css
@@ -1,13 +1,13 @@
 @font-face {
     font-family: 'SAP-icons';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/SAP-icons.woff') format('woff');
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/SAP-icons.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'SAP-icons-TNT';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/SAP-icons-TNT.woff')
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/SAP-icons-TNT.woff')
         format('woff');
     font-weight: normal;
     font-style: normal;
@@ -15,7 +15,7 @@
 
 @font-face {
     font-family: 'BusinessSuiteInAppSymbols';
-    src: url('~@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/BusinessSuiteInAppSymbols.woff')
+    src: url('@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/BusinessSuiteInAppSymbols.woff')
         format('woff');
     font-weight: normal;
     font-style: normal;

--- a/e2e/wdio/core-base-component.po.ts
+++ b/e2e/wdio/core-base-component.po.ts
@@ -1,12 +1,17 @@
 import {
     checkElementScreenshot,
+    checkSelectorExists,
+    checkSelectorSupported,
     click,
+    defaultWaitTime,
     elementArray,
     getImageTagBrowserPlatform,
     open,
+    pause,
     saveElementScreenshot,
     scrollIntoView,
-    waitForElDisplayed
+    waitForElDisplayed,
+    waitForPresent
 } from './driver/wdio';
 import { checkLtrOrientation, checkRtlOrientation } from './helper/assertion-helper';
 
@@ -29,6 +34,35 @@ export class CoreBaseComponentPo {
             await scrollIntoView(switchers, i);
             await click(switchers, i);
             await checkLtrOrientation(areas, i);
+        }
+    }
+
+    async waitForRoot(): Promise<void> {
+        try {
+            await browser.dismissAlert();
+        } catch {}
+        await browser.waitUntil(
+            async () => {
+                const state = await browser.execute(() => document.readyState);
+                return state === 'complete';
+            },
+            {
+                timeout: defaultWaitTime(),
+                timeoutMsg: 'Oops! Check your internet connection'
+            }
+        );
+
+        await this.checkPageLoaded();
+
+        await waitForPresent(this.root);
+    }
+
+    async checkPageLoaded(iteration = 0): Promise<void> {
+        if (!(await checkSelectorSupported(this.root)) && iteration < 2) {
+            await pause(500);
+            this.checkPageLoaded(iteration++);
+        } else if (iteration > 2) {
+            await checkSelectorExists(this.root);
         }
     }
 

--- a/e2e/wdio/driver/wdio.ts
+++ b/e2e/wdio/driver/wdio.ts
@@ -79,6 +79,7 @@ export async function refreshPage(isFullRefresh = true): Promise<void> {
         }
     } else {
         await browser.refresh();
+        await pause(500);
         if (browserIsSafari()) {
             await pause();
         }

--- a/e2e/wdio/driver/wdio.ts
+++ b/e2e/wdio/driver/wdio.ts
@@ -587,9 +587,13 @@ export async function checkElementScreenshot(
 }
 
 export async function checkSelectorExists(selector: string, index: number = 0): Promise<void> {
-    if ((await $$(selector))[index] === undefined) {
+    if (!(await checkSelectorSupported(selector, index))) {
         throw new Error(`Element with index: ${index} for selector: '${selector}' not found.`);
     }
+}
+
+export async function checkSelectorSupported(selector: string, index: number = 0): Promise<boolean> {
+    return (await $$(selector))[index] !== undefined;
 }
 
 export async function applyState(

--- a/libs/docs/core/action-bar/e2e/action-bar.po.ts
+++ b/libs/docs/core/action-bar/e2e/action-bar.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ActionBarPo extends CoreBaseComponentPo {
     url = '/action-bar';
@@ -29,7 +29,7 @@ export class ActionBarPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/action-sheet/e2e/action-sheet.e2e-spec.ts
+++ b/libs/docs/core/action-sheet/e2e/action-sheet.e2e-spec.ts
@@ -13,8 +13,7 @@ import {
     saveElementScreenshot,
     scrollIntoView,
     waitForElDisplayed,
-    waitForNotDisplayed,
-    waitForPresent
+    waitForNotDisplayed
 } from '../../../../../e2e';
 
 describe('Action sheet test suite', () => {
@@ -34,7 +33,7 @@ describe('Action sheet test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(actionSheetPage.root);
+        await actionSheetPage.waitForRoot();
         await waitForElDisplayed(actionSheetPage.title);
     }, 1);
 

--- a/libs/docs/core/action-sheet/e2e/action-sheet.po.ts
+++ b/libs/docs/core/action-sheet/e2e/action-sheet.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ActionSheetPo extends CoreBaseComponentPo {
     url = '/action-sheet';
@@ -14,7 +14,7 @@ export class ActionSheetPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/avatar-group-legacy/e2e/avatar-group-legacy.e2e-spec.ts
+++ b/libs/docs/core/avatar-group-legacy/e2e/avatar-group-legacy.e2e-spec.ts
@@ -31,7 +31,7 @@ describe('Avatar test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(avatarGroupPage.root);
+        await avatarGroupPage.waitForRoot();
         await waitForElDisplayed(avatarGroupPage.title);
     }, 1);
 

--- a/libs/docs/core/avatar-group-legacy/e2e/avatar-group-legacy.po.ts
+++ b/libs/docs/core/avatar-group-legacy/e2e/avatar-group-legacy.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class AvatarGroupLegacyPo extends CoreBaseComponentPo {
     private url = '/avatar-group-legacy';
@@ -14,7 +14,7 @@ export class AvatarGroupLegacyPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/avatar/e2e/avatar.po.ts
+++ b/libs/docs/core/avatar/e2e/avatar.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class AvatarPo extends CoreBaseComponentPo {
     private url = '/avatar';
@@ -17,7 +17,7 @@ export class AvatarPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/bar/e2e/bar.e2e-spec.ts
+++ b/libs/docs/core/bar/e2e/bar.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     refreshPage,
     saveElementScreenshot,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { BarPo } from './bar.po';
 
@@ -23,7 +22,7 @@ describe('Bar test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(barPage.root);
+        await barPage.waitForRoot();
         await waitForElDisplayed(barPage.title);
     }, 1);
 

--- a/libs/docs/core/bar/e2e/bar.po.ts
+++ b/libs/docs/core/bar/e2e/bar.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class BarPo extends CoreBaseComponentPo {
     private url = '/bar';
@@ -18,7 +18,7 @@ export class BarPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/breadcrumb/e2e/breadcrumb.e2e-spec.ts
+++ b/libs/docs/core/breadcrumb/e2e/breadcrumb.e2e-spec.ts
@@ -3,8 +3,7 @@ import {
     isElementClickable,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { BreadcrumbPo } from './breadcrumb.po';
 
@@ -18,7 +17,7 @@ describe('Breadcrumb test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(breadcrumbPage.root);
+        await breadcrumbPage.waitForRoot();
         await waitForElDisplayed(breadcrumbPage.title);
     }, 1);
 

--- a/libs/docs/core/breadcrumb/e2e/breadcrumb.po.ts
+++ b/libs/docs/core/breadcrumb/e2e/breadcrumb.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class BreadcrumbPo extends CoreBaseComponentPo {
     private url = '/breadcrumb';
@@ -20,7 +20,7 @@ export class BreadcrumbPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/busy-indicator/e2e/busy-indicator.e2e-spec.ts
+++ b/libs/docs/core/busy-indicator/e2e/busy-indicator.e2e-spec.ts
@@ -9,8 +9,7 @@ import {
     isElementDisplayed,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { sizeL, sizeM, sizeS } from './busy-indicator-contents';
 import { BusyIndicatorPo } from './busy-indicator.po';
@@ -44,7 +43,7 @@ describe('Busy Indicator test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(busyIndicatorPage.root);
+        await busyIndicatorPage.waitForRoot();
         await waitForElDisplayed(busyIndicatorPage.title);
     }, 1);
 

--- a/libs/docs/core/busy-indicator/e2e/busy-indicator.po.ts
+++ b/libs/docs/core/busy-indicator/e2e/busy-indicator.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class BusyIndicatorPo extends CoreBaseComponentPo {
     private url = '/busy-indicator';
@@ -39,7 +39,7 @@ export class BusyIndicatorPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/button/e2e/button.e2e-spec.ts
+++ b/libs/docs/core/button/e2e/button.e2e-spec.ts
@@ -13,8 +13,7 @@ import {
     saveElementScreenshot,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { fdTypeOptions, iconOptions, testText } from './button-contents';
 import { buttonPlaygroundTag } from './button-tags';
@@ -45,7 +44,7 @@ describe('Button test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(buttonPage.root);
+        await buttonPage.waitForRoot();
         await waitForElDisplayed(buttonPage.title);
     }, 1);
 

--- a/libs/docs/core/button/e2e/button.po.ts
+++ b/libs/docs/core/button/e2e/button.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ButtonPo extends CoreBaseComponentPo {
     private url = '/button';
@@ -21,7 +21,7 @@ export class ButtonPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/calendar/e2e/calendar.e2e-spec.ts
+++ b/libs/docs/core/calendar/e2e/calendar.e2e-spec.ts
@@ -13,8 +13,7 @@ import {
     pause,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import {
     activeClass,
@@ -85,7 +84,7 @@ describe('calendar test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(calendarPage.root);
+        await calendarPage.waitForRoot();
         await waitForElDisplayed(calendarPage.title);
     }, 1);
 

--- a/libs/docs/core/calendar/e2e/calendar.po.ts
+++ b/libs/docs/core/calendar/e2e/calendar.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { click, CoreBaseComponentPo, scrollIntoView, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { click, CoreBaseComponentPo, scrollIntoView, waitForElDisplayed } from '../../../../../e2e';
 
 export class CalendarPo extends CoreBaseComponentPo {
     url = '/calendar';
@@ -51,7 +51,7 @@ export class CalendarPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/card/e2e/card.po.ts
+++ b/libs/docs/core/card/e2e/card.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class CardPo extends CoreBaseComponentPo {
     private url = '/card';
@@ -68,7 +68,7 @@ export class CardPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/carousel/e2e/carousel.po.ts
+++ b/libs/docs/core/carousel/e2e/carousel.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class CarouselPo extends CoreBaseComponentPo {
     private url = '/carousel';
@@ -24,7 +24,7 @@ export class CarouselPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/checkbox/e2e/checkbox.po.ts
+++ b/libs/docs/core/checkbox/e2e/checkbox.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class CheckboxPo extends CoreBaseComponentPo {
     private url = '/checkbox';
@@ -20,7 +20,7 @@ export class CheckboxPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/combobox/e2e/combobox.e2e-spec.ts
+++ b/libs/docs/core/combobox/e2e/combobox.e2e-spec.ts
@@ -17,8 +17,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 
 import {
@@ -60,7 +59,7 @@ describe('Combobox component test suit', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(comboboxPage.root);
+        await comboboxPage.waitForRoot();
         await waitForElDisplayed(comboboxPage.title);
     }, 2);
 

--- a/libs/docs/core/combobox/e2e/combobox.po.ts
+++ b/libs/docs/core/combobox/e2e/combobox.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ComboboxPo extends CoreBaseComponentPo {
     url = '/combobox';
@@ -19,7 +19,7 @@ export class ComboboxPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/date-picker/e2e/date-picker.e2e-spec.ts
+++ b/libs/docs/core/date-picker/e2e/date-picker.e2e-spec.ts
@@ -16,8 +16,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { blockExamples } from './date-picker-contents';
 import { currentYear, getCurrentItemIndex, getCurrentMonth, getNextDay, invalidDate } from './date-picker-tags';
@@ -67,7 +66,7 @@ xdescribe('Date picker suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(datePickerPage.root);
+        await datePickerPage.waitForRoot();
         await waitForElDisplayed(datePickerPage.title);
     }, 1);
 
@@ -97,7 +96,7 @@ xdescribe('Date picker suite', () => {
             ) {
                 await checkChoosingDate(blockExamples[i]);
                 await refreshPage();
-                await waitForPresent(datePickerPage.root);
+                await datePickerPage.waitForRoot();
                 await waitForElDisplayed(datePickerPage.title);
             }
         }

--- a/libs/docs/core/date-picker/e2e/date-picker.po.ts
+++ b/libs/docs/core/date-picker/e2e/date-picker.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, getElementClass, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, getElementClass, waitForElDisplayed } from '../../../../../e2e';
 
 export class DatePickerPo extends CoreBaseComponentPo {
     private url = '/date-picker';
@@ -45,7 +45,7 @@ export class DatePickerPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/datetime-picker/e2e/date-time-picker.e2e-spec.ts
+++ b/libs/docs/core/datetime-picker/e2e/date-time-picker.e2e-spec.ts
@@ -15,8 +15,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { currentDay, date, date2, date3, date4, dates, i18n, testText, year2030 } from './date-time-picker-contents';
 import { DateTimePicker } from './date-time-picker.po';
@@ -60,7 +59,7 @@ describe('Datetime picker suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(dateTimePickerPage.root);
+        await dateTimePickerPage.waitForRoot();
         await waitForElDisplayed(dateTimePickerPage.title);
     }, 1);
 

--- a/libs/docs/core/datetime-picker/e2e/date-time-picker.po.ts
+++ b/libs/docs/core/datetime-picker/e2e/date-time-picker.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { click, CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { click, CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class DateTimePicker extends CoreBaseComponentPo {
     url = '/datetime-picker';
@@ -57,7 +57,7 @@ export class DateTimePicker extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/dialog/e2e/dialog.e2e-spec.ts
+++ b/libs/docs/core/dialog/e2e/dialog.e2e-spec.ts
@@ -26,8 +26,7 @@ import {
     waitForElDisappear,
     waitForElDisplayed,
     waitForNotDisplayed,
-    waitForNotPresent,
-    waitForPresent
+    waitForNotPresent
 } from '../../../../../e2e';
 import { papayaFruit } from './dialog';
 import {
@@ -84,7 +83,7 @@ describe('dialog test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(dialogPage.root);
+        await dialogPage.waitForRoot();
         await waitForElDisplayed(dialogPage.title);
     }, 1);
 
@@ -224,7 +223,7 @@ describe('dialog test suite', () => {
     describe('complex dialog example', () => {
         it('should check dialog selections', async () => {
             await refreshPage();
-            await waitForPresent(dialogPage.root);
+            await dialogPage.waitForRoot();
             await waitForElDisplayed(dialogPage.title);
             await openDialog(complexDialog);
             await pause(5000);

--- a/libs/docs/core/dialog/e2e/dialog.po.ts
+++ b/libs/docs/core/dialog/e2e/dialog.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class DialogPo extends CoreBaseComponentPo {
     url = '/dialog';
@@ -40,7 +40,7 @@ export class DialogPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/dynamic-page/e2e/dynamic-page.e2e-spec.ts
+++ b/libs/docs/core/dynamic-page/e2e/dynamic-page.e2e-spec.ts
@@ -11,8 +11,7 @@ import {
     pause,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { DynamicPagePo } from './dynamic-page.po';
 
@@ -50,7 +49,7 @@ describe('dynamic side content test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(dynamicPagePage.root);
+        await dynamicPagePage.waitForRoot();
         await waitForElDisplayed(dynamicPagePage.title);
     }, 1);
 

--- a/libs/docs/core/dynamic-page/e2e/dynamic-page.po.ts
+++ b/libs/docs/core/dynamic-page/e2e/dynamic-page.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class DynamicPagePo extends CoreBaseComponentPo {
     private url = '/dynamic-page';
@@ -33,7 +33,7 @@ export class DynamicPagePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/dynamic-side-content/e2e/dynamic-side-content.e2e-spec.ts
+++ b/libs/docs/core/dynamic-side-content/e2e/dynamic-side-content.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { refreshPage, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { refreshPage, waitForElDisplayed } from '../../../../../e2e';
 import { DynamicSideContentPo } from './dynamic-side-content.po';
 
 describe('dynamic side content test suite', () => {
@@ -10,7 +10,7 @@ describe('dynamic side content test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(dynamicSideContentPage.root);
+        await dynamicSideContentPage.waitForRoot();
         await waitForElDisplayed(dynamicSideContentPage.title);
     }, 1);
 

--- a/libs/docs/core/dynamic-side-content/e2e/dynamic-side-content.po.ts
+++ b/libs/docs/core/dynamic-side-content/e2e/dynamic-side-content.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class DynamicSideContentPo extends CoreBaseComponentPo {
     private url = '/dynamic-side-content';
@@ -7,7 +7,7 @@ export class DynamicSideContentPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/facets/e2e/facets.e2e-spec.ts
+++ b/libs/docs/core/facets/e2e/facets.e2e-spec.ts
@@ -4,8 +4,7 @@ import {
     getText,
     isElementClickable,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { FacetsPo } from './facets.po';
 
@@ -20,7 +19,7 @@ describe('dynamic side content test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(facetsPage.root);
+        await facetsPage.waitForRoot();
         await waitForElDisplayed(facetsPage.title);
     }, 1);
 

--- a/libs/docs/core/facets/e2e/facets.po.ts
+++ b/libs/docs/core/facets/e2e/facets.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FacetsPo extends CoreBaseComponentPo {
     url = '/facets';
@@ -13,7 +13,7 @@ export class FacetsPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/feed-input/e2e/feed-input.e2e-spec.ts
+++ b/libs/docs/core/feed-input/e2e/feed-input.e2e-spec.ts
@@ -26,7 +26,7 @@ describe('Verify Feed Input component', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(feedInputPage.root);
+        await feedInputPage.waitForRoot();
         await waitForElDisplayed(feedInputPage.title);
     }, 1);
 

--- a/libs/docs/core/feed-input/e2e/feed-input.po.ts
+++ b/libs/docs/core/feed-input/e2e/feed-input.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FeedInputPo extends CoreBaseComponentPo {
     private url = '/feed-input';
@@ -14,7 +14,7 @@ export class FeedInputPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/feed-list-item/e2e/feed-list-item.e2e-spec.ts
+++ b/libs/docs/core/feed-list-item/e2e/feed-list-item.e2e-spec.ts
@@ -10,8 +10,7 @@ import {
     isElementDisplayed,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { alertText, testTextLess, testTextMore } from './feed-list-item-contents';
 import { FeedListItemPo } from './feed-list-item.po';
@@ -44,7 +43,7 @@ describe('Feed list item test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(feedListItemPage.root);
+        await feedListItemPage.waitForRoot();
         await waitForElDisplayed(feedListItemPage.title);
     }, 1);
 

--- a/libs/docs/core/feed-list-item/e2e/feed-list-item.po.ts
+++ b/libs/docs/core/feed-list-item/e2e/feed-list-item.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FeedListItemPo extends CoreBaseComponentPo {
     private url = '/feed-list-item';
@@ -36,7 +36,7 @@ export class FeedListItemPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/file-uploader/e2e/file-uploader.e2e-spec.ts
+++ b/libs/docs/core/file-uploader/e2e/file-uploader.e2e-spec.ts
@@ -8,8 +8,7 @@ import {
     refreshPage,
     scrollIntoView,
     uploadFile,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { FileUploaderPo } from './file-uploader.po';
 
@@ -33,7 +32,7 @@ describe('File uploader component test', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(fileUploaderPage.root);
+        await fileUploaderPage.waitForRoot();
         await waitForElDisplayed(fileUploaderPage.title);
     }, 2);
 

--- a/libs/docs/core/file-uploader/e2e/file-uploader.po.ts
+++ b/libs/docs/core/file-uploader/e2e/file-uploader.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FileUploaderPo extends CoreBaseComponentPo {
     url = '/file-uploader';
@@ -14,7 +14,7 @@ export class FileUploaderPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/fixed-card-layout/e2e/fixed-card-layout.e2e-spec.ts
+++ b/libs/docs/core/fixed-card-layout/e2e/fixed-card-layout.e2e-spec.ts
@@ -8,8 +8,7 @@ import {
     refreshPage,
     scrollIntoView,
     waitForElDisplayed,
-    waitForInvisibilityOf,
-    waitForPresent
+    waitForInvisibilityOf
 } from '../../../../../e2e';
 import { FixedCardLayoutPo } from './fixed-card-layout.po';
 
@@ -35,7 +34,7 @@ describe('Fixed card layout test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(fxdCardLayoutPage.root);
+        await fxdCardLayoutPage.waitForRoot();
         await waitForElDisplayed(fxdCardLayoutPage.title);
     }, 1);
 

--- a/libs/docs/core/fixed-card-layout/e2e/fixed-card-layout.po.ts
+++ b/libs/docs/core/fixed-card-layout/e2e/fixed-card-layout.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FixedCardLayoutPo extends CoreBaseComponentPo {
     private url = '/fixed-card-layout';
@@ -19,7 +19,7 @@ export class FixedCardLayoutPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/flexible-column-layout/e2e/flexible-column-layout.e2e-spec.ts
+++ b/libs/docs/core/flexible-column-layout/e2e/flexible-column-layout.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     pause,
     refreshPage,
     waitForElDisplayed,
-    waitForNotDisplayed,
-    waitForPresent
+    waitForNotDisplayed
 } from '../../../../../e2e';
 import { FlexibleColumnLayoutPo } from './flexible-column-layout.po';
 
@@ -35,7 +34,7 @@ describe('Flexible column layout component test', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(flexibleColumnLayoutPage.root);
+        await flexibleColumnLayoutPage.waitForRoot();
         await waitForElDisplayed(flexibleColumnLayoutPage.title);
     }, 2);
 

--- a/libs/docs/core/flexible-column-layout/e2e/flexible-column-layout.po.ts
+++ b/libs/docs/core/flexible-column-layout/e2e/flexible-column-layout.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FlexibleColumnLayoutPo extends CoreBaseComponentPo {
     private url = '/flexible-column-layout';
@@ -21,7 +21,7 @@ export class FlexibleColumnLayoutPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/form-message/e2e/form-message.e2e-spec.ts
+++ b/libs/docs/core/form-message/e2e/form-message.e2e-spec.ts
@@ -10,8 +10,7 @@ import {
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { FormMessagePo } from './form-message.po';
 
@@ -36,7 +35,7 @@ describe('Form Message test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(formMessagePage.root);
+        await formMessagePage.waitForRoot();
         await waitForElDisplayed(formMessagePage.title);
     }, 1);
 

--- a/libs/docs/core/form-message/e2e/form-message.po.ts
+++ b/libs/docs/core/form-message/e2e/form-message.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FormMessagePo extends CoreBaseComponentPo {
     url = '/form-message';
@@ -13,7 +13,7 @@ export class FormMessagePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/formatted-text/e2e/formatted-text.e2e-spec.ts
+++ b/libs/docs/core/formatted-text/e2e/formatted-text.e2e-spec.ts
@@ -1,11 +1,4 @@
-import {
-    browserIsFirefox,
-    browserIsSafari,
-    getAlertText,
-    refreshPage,
-    waitForElDisplayed,
-    waitForPresent
-} from '../../../../../e2e';
+import { browserIsFirefox, browserIsSafari, getAlertText, refreshPage, waitForElDisplayed } from '../../../../../e2e';
 import { FormattedTextPo } from './formatted-text.po';
 
 describe('Formatted text component', () => {
@@ -17,7 +10,7 @@ describe('Formatted text component', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(formattedTextPage.root);
+        await formattedTextPage.waitForRoot();
         await waitForElDisplayed(formattedTextPage.title);
     }, 2);
 

--- a/libs/docs/core/formatted-text/e2e/formatted-text.po.ts
+++ b/libs/docs/core/formatted-text/e2e/formatted-text.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FormattedTextPo extends CoreBaseComponentPo {
     private url = '/formatted-text';
@@ -10,7 +10,7 @@ export class FormattedTextPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/grid-list/e2e/grid-list.e2e-spec.ts
+++ b/libs/docs/core/grid-list/e2e/grid-list.e2e-spec.ts
@@ -10,8 +10,7 @@ import {
     refreshPage,
     scrollIntoView,
     waitForClickable,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { isSelected, productTitle, text, textLocked } from './grid-list-content';
 import { GridListPo } from './grid-list.po';
@@ -43,7 +42,7 @@ describe('Grid-list test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(gridListPage.root);
+        await gridListPage.waitForRoot();
         await waitForElDisplayed(gridListPage.title);
     }, 1);
 
@@ -101,6 +100,10 @@ describe('Grid-list test suite', () => {
         for (let i = 0; i < arrayLength; i++) {
             await scrollIntoView(multiSelectModeCheckboxes, i);
             await click(multiSelectModeCheckboxes, i);
+            try {
+                // alerts block any interactions with the page
+                await browser.dismissAlert();
+            } catch {}
         }
         selectedArrayLength = await getElementArrayLength(multiSelectModeSelectedItems);
         await expect(selectedArrayLength).toEqual(arrayLength - 1);

--- a/libs/docs/core/grid-list/e2e/grid-list.po.ts
+++ b/libs/docs/core/grid-list/e2e/grid-list.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class GridListPo extends CoreBaseComponentPo {
     private url = '/grid-list';
@@ -45,7 +45,7 @@ export class GridListPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/icon/e2e/icon.po.ts
+++ b/libs/docs/core/icon/e2e/icon.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class IconPo extends CoreBaseComponentPo {
     private url = '/icon';
@@ -6,7 +6,7 @@ export class IconPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/illustrated-message/e2e/illustrated-message.po.ts
+++ b/libs/docs/core/illustrated-message/e2e/illustrated-message.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class IllustratedMessagePo extends CoreBaseComponentPo {
     url = '/illustrated-message';
@@ -12,7 +12,7 @@ export class IllustratedMessagePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/info-label/e2e/info-label.po.ts
+++ b/libs/docs/core/info-label/e2e/info-label.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class InfoLabelPo extends CoreBaseComponentPo {
     url = '/info-label';
@@ -13,7 +13,7 @@ export class InfoLabelPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/inline-help/e2e/inline-help.e2e-spec.ts
+++ b/libs/docs/core/inline-help/e2e/inline-help.e2e-spec.ts
@@ -33,7 +33,7 @@ describe('Inline help test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(inlineHelpPage.root);
+        await inlineHelpPage.waitForRoot();
         await waitForElDisplayed(inlineHelpPage.title);
     }, 1);
 

--- a/libs/docs/core/inline-help/e2e/inline-help.po.ts
+++ b/libs/docs/core/inline-help/e2e/inline-help.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class InlineHelpPo extends CoreBaseComponentPo {
     private url = '/inline-help';
@@ -15,7 +15,7 @@ export class InlineHelpPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/input-group/e2e/input-group.e2e-spec.ts
+++ b/libs/docs/core/input-group/e2e/input-group.e2e-spec.ts
@@ -13,8 +13,7 @@ import {
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { smallTestText, testText } from './input-group-contents';
 import { InputGroupPo } from './input-group.po';
@@ -40,7 +39,7 @@ describe('Input group component test', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(inputGroupPage.root);
+        await inputGroupPage.waitForRoot();
         await waitForElDisplayed(inputGroupPage.title);
     }, 2);
 

--- a/libs/docs/core/input-group/e2e/input-group.po.ts
+++ b/libs/docs/core/input-group/e2e/input-group.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class InputGroupPo extends CoreBaseComponentPo {
     url = '/input-group';
@@ -16,7 +16,7 @@ export class InputGroupPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/input/e2e/input.e2e-spec.ts
+++ b/libs/docs/core/input/e2e/input.e2e-spec.ts
@@ -16,8 +16,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { longLine, number, special_characters, text } from './input';
 import {
@@ -86,7 +85,7 @@ describe('Input should ', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(inputPage.root);
+        await inputPage.waitForRoot();
         await waitForElDisplayed(inputPage.title);
     }, 1);
 

--- a/libs/docs/core/input/e2e/input.po.ts
+++ b/libs/docs/core/input/e2e/input.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class InputPo extends CoreBaseComponentPo {
     readonly url = '/input';
@@ -44,7 +44,7 @@ export class InputPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/link/e2e/link.e2e-spec.ts
+++ b/libs/docs/core/link/e2e/link.e2e-spec.ts
@@ -4,8 +4,7 @@ import {
     isElementClickable,
     isElementDisplayed,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { LinkPo } from './link.po';
 
@@ -19,7 +18,7 @@ describe('Link test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(linkPage.root);
+        await linkPage.waitForRoot();
         await waitForElDisplayed(linkPage.title);
     }, 1);
 

--- a/libs/docs/core/link/e2e/link.po.ts
+++ b/libs/docs/core/link/e2e/link.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class LinkPo extends CoreBaseComponentPo {
     private url = '/link';
@@ -9,7 +9,7 @@ export class LinkPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/list-byline/e2e/list-byline.e2e-spec.ts
+++ b/libs/docs/core/list-byline/e2e/list-byline.e2e-spec.ts
@@ -5,8 +5,7 @@ import {
     isElementClickable,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { ListBylinePo } from './list-byline.po';
 
@@ -21,7 +20,7 @@ describe('List byline test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(listBylinePage.root);
+        await listBylinePage.waitForRoot();
         await waitForElDisplayed(listBylinePage.title);
     }, 1);
 

--- a/libs/docs/core/list-byline/e2e/list-byline.po.ts
+++ b/libs/docs/core/list-byline/e2e/list-byline.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ListBylinePo extends CoreBaseComponentPo {
     url = '/list-byline';
@@ -14,7 +14,7 @@ export class ListBylinePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/list/e2e/standard-list.po.ts
+++ b/libs/docs/core/list/e2e/standard-list.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class StandardListPo extends CoreBaseComponentPo {
     url = '/list';
@@ -26,7 +26,7 @@ export class StandardListPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/menu/e2e/menu.e2e-spec.ts
+++ b/libs/docs/core/menu/e2e/menu.e2e-spec.ts
@@ -10,8 +10,7 @@ import {
     mouseHoverElement,
     refreshPage,
     waitForElDisplayed,
-    waitForNotPresent,
-    waitForPresent
+    waitForNotPresent
 } from '../../../../../e2e';
 import { MenuPo } from './menu.po';
 
@@ -43,7 +42,7 @@ describe('Menu test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(menuPage.root);
+        await menuPage.waitForRoot();
         await waitForElDisplayed(menuPage.title);
     }, 1);
 

--- a/libs/docs/core/menu/e2e/menu.po.ts
+++ b/libs/docs/core/menu/e2e/menu.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MenuPo extends CoreBaseComponentPo {
     url = '/menu';
@@ -21,7 +21,7 @@ export class MenuPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/message-box/e2e/message-box.po.ts
+++ b/libs/docs/core/message-box/e2e/message-box.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MessageBoxPo extends CoreBaseComponentPo {
     private url = '/message-box';
@@ -22,7 +22,7 @@ export class MessageBoxPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/message-page/e2e/message-page.po.ts
+++ b/libs/docs/core/message-page/e2e/message-page.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MessagePagePo extends CoreBaseComponentPo {
     private url = '/message-page';
@@ -14,7 +14,7 @@ export class MessagePagePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/message-strip/e2e/message-strip.e2e-spec.ts
+++ b/libs/docs/core/message-strip/e2e/message-strip.e2e-spec.ts
@@ -8,8 +8,7 @@ import {
     isElementDisplayed,
     refreshPage,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 
 import { customMessage, customWidth } from './message-strip';
@@ -41,7 +40,7 @@ describe('Message-strip test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(messageStripPage.root);
+        await messageStripPage.waitForRoot();
         await waitForElDisplayed(messageStripPage.title);
     }, 1);
 

--- a/libs/docs/core/message-strip/e2e/message-strip.po.ts
+++ b/libs/docs/core/message-strip/e2e/message-strip.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MessageStripPo extends CoreBaseComponentPo {
     private url = '/message-strip';
@@ -22,7 +22,7 @@ export class MessageStripPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/message-toast/e2e/message-toast.e2e-spec.ts
+++ b/libs/docs/core/message-toast/e2e/message-toast.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     refreshPage,
     scrollIntoView,
     waitForElDisplayed,
-    waitForNotDisplayed,
-    waitForPresent
+    waitForNotDisplayed
 } from '../../../../../e2e';
 import { MessageToastPo } from './message-toast.po';
 
@@ -22,7 +21,7 @@ describe('Textarea component test', () => {
 
     beforeEach(async () => {
         await refreshPage(true);
-        await waitForPresent(messageToastPage.root);
+        await messageToastPage.waitForRoot();
         await waitForElDisplayed(messageToastPage.title);
     }, 2);
 

--- a/libs/docs/core/message-toast/e2e/message-toast.po.ts
+++ b/libs/docs/core/message-toast/e2e/message-toast.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MessageToastPo extends CoreBaseComponentPo {
     private url = '/message-toast';
@@ -11,7 +11,7 @@ export class MessageToastPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/multi-combobox/e2e/multi-combobox.e2e-spec.ts
+++ b/libs/docs/core/multi-combobox/e2e/multi-combobox.e2e-spec.ts
@@ -9,8 +9,7 @@ import {
     scrollIntoView,
     sendKeys,
     waitForElDisplayed,
-    waitForNotPresent,
-    waitForPresent
+    waitForNotPresent
 } from '../../../../../e2e';
 import { MultiComboboxPo } from './multi-combobox.po';
 
@@ -47,7 +46,7 @@ describe('multi-combobox test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(multiComboboxPage.root);
+        await multiComboboxPage.waitForRoot();
         await waitForElDisplayed(multiComboboxPage.title);
     }, 1);
 

--- a/libs/docs/core/multi-combobox/e2e/multi-combobox.po.ts
+++ b/libs/docs/core/multi-combobox/e2e/multi-combobox.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MultiComboboxPo extends CoreBaseComponentPo {
     private url = '/multi-combobox';
@@ -25,7 +25,7 @@ export class MultiComboboxPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/multi-input/e2e/multi-input.e2e-spec.ts
+++ b/libs/docs/core/multi-input/e2e/multi-input.e2e-spec.ts
@@ -67,7 +67,7 @@ describe('Multi input test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(multiInputPage.root);
+        await multiInputPage.waitForRoot();
         await waitForElDisplayed(multiInputPage.title);
     }, 1);
 

--- a/libs/docs/core/multi-input/e2e/multi-input.po.ts
+++ b/libs/docs/core/multi-input/e2e/multi-input.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MultiInputPo extends CoreBaseComponentPo {
     private url = '/multi-input';
@@ -34,7 +34,7 @@ export class MultiInputPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/notification/e2e/notification.e2e-spec.ts
+++ b/libs/docs/core/notification/e2e/notification.e2e-spec.ts
@@ -45,7 +45,7 @@ describe('Notification component test', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(notificationPage.root);
+        await notificationPage.waitForRoot();
         await waitForElDisplayed(notificationPage.title);
     }, 2);
 

--- a/libs/docs/core/notification/e2e/notification.po.ts
+++ b/libs/docs/core/notification/e2e/notification.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class NotificationPo extends CoreBaseComponentPo {
     private url = '/notification';
@@ -36,7 +36,7 @@ export class NotificationPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/object-identifier/e2e/object-identifier.e2e-spec.ts
+++ b/libs/docs/core/object-identifier/e2e/object-identifier.e2e-spec.ts
@@ -3,8 +3,7 @@ import {
     isElementClickable,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { ObjectIdentifierPo } from './object-identifier.po';
 
@@ -18,7 +17,7 @@ describe('Object identifier test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(objectIdentifierPage.root);
+        await objectIdentifierPage.waitForRoot();
         await waitForElDisplayed(objectIdentifierPage.title);
     }, 1);
 

--- a/libs/docs/core/object-identifier/e2e/object-identifier.po.ts
+++ b/libs/docs/core/object-identifier/e2e/object-identifier.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ObjectIdentifierPo extends CoreBaseComponentPo {
     private url = '/object-identifier';
@@ -8,7 +8,7 @@ export class ObjectIdentifierPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/object-marker/e2e/object-marker.e2e-spec.ts
+++ b/libs/docs/core/object-marker/e2e/object-marker.e2e-spec.ts
@@ -6,8 +6,7 @@ import {
     getElementTitle,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { iconStatusesList } from './object-marker-content';
 import { ObjectMarkerPo } from './object-marker.po';
@@ -22,7 +21,7 @@ describe('Object marker test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(objectMarkerPage.root);
+        await objectMarkerPage.waitForRoot();
         await waitForElDisplayed(objectMarkerPage.title);
     }, 1);
 

--- a/libs/docs/core/object-marker/e2e/object-marker.po.ts
+++ b/libs/docs/core/object-marker/e2e/object-marker.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ObjectMarkerPo extends CoreBaseComponentPo {
     private url = '/object-marker';
@@ -12,7 +12,7 @@ export class ObjectMarkerPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/object-number/e2e/object-number.po.ts
+++ b/libs/docs/core/object-number/e2e/object-number.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ObjectNumberPo extends CoreBaseComponentPo {
     private url = '/object-number';
@@ -25,7 +25,7 @@ export class ObjectNumberPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/object-status/e2e/object-status.po.ts
+++ b/libs/docs/core/object-status/e2e/object-status.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ObjectStatusPo extends CoreBaseComponentPo {
     private url = '/object-status';
@@ -20,7 +20,7 @@ export class ObjectStatusPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/pagination/e2e/pagination.e2e-spec.ts
+++ b/libs/docs/core/pagination/e2e/pagination.e2e-spec.ts
@@ -9,8 +9,7 @@ import {
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import {
     ResultsArr2,
@@ -54,7 +53,7 @@ describe('Pagination test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(paginationPage.root);
+        await paginationPage.waitForRoot();
         await waitForElDisplayed(paginationPage.title);
     }, 1);
 

--- a/libs/docs/core/pagination/e2e/pagination.po.ts
+++ b/libs/docs/core/pagination/e2e/pagination.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class PaginationPo extends CoreBaseComponentPo {
     private url = '/pagination';
@@ -45,7 +45,7 @@ export class PaginationPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/panel/e2e/panel.e2e-spec.ts
+++ b/libs/docs/core/panel/e2e/panel.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     isElementDisplayed,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { PanelPo } from './panel.po';
 
@@ -23,7 +22,7 @@ describe('Panel test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(panelPage.root);
+        await panelPage.waitForRoot();
         await waitForElDisplayed(panelPage.title);
     }, 1);
 

--- a/libs/docs/core/panel/e2e/panel.po.ts
+++ b/libs/docs/core/panel/e2e/panel.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class PanelPo extends CoreBaseComponentPo {
     private url = '/panel';
@@ -13,7 +13,7 @@ export class PanelPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/popover/e2e/popover.e2e-spec.ts
+++ b/libs/docs/core/popover/e2e/popover.e2e-spec.ts
@@ -14,8 +14,7 @@ import {
     mouseHoverElement,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { PopoverPo } from './popover.po';
 
@@ -93,7 +92,7 @@ describe('Popover test suite', () => {
 
     afterEach(async () => {
         await refreshPage(true);
-        await waitForPresent(popoverPage.root);
+        await popoverPage.waitForRoot();
         await waitForElDisplayed(popoverPage.title);
     }, 1);
 

--- a/libs/docs/core/popover/e2e/popover.po.ts
+++ b/libs/docs/core/popover/e2e/popover.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class PopoverPo extends CoreBaseComponentPo {
     private url = '/popover';
@@ -55,7 +55,7 @@ export class PopoverPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/product-switch/e2e/product-switch.e2e-spec.ts
+++ b/libs/docs/core/product-switch/e2e/product-switch.e2e-spec.ts
@@ -5,8 +5,7 @@ import {
     getText,
     isElementDisplayed,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { ProductSwitchPo } from './product-switch.po';
 
@@ -20,7 +19,7 @@ describe('product switch test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(productSwitchPage.root);
+        await productSwitchPage.waitForRoot();
         await waitForElDisplayed(productSwitchPage.title);
     }, 1);
 

--- a/libs/docs/core/product-switch/e2e/product-switch.po.ts
+++ b/libs/docs/core/product-switch/e2e/product-switch.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ProductSwitchPo extends CoreBaseComponentPo {
     url = '/product-switch';
@@ -9,7 +9,7 @@ export class ProductSwitchPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/quick-view/e2e/quick-view.e2e-spec.ts
+++ b/libs/docs/core/quick-view/e2e/quick-view.e2e-spec.ts
@@ -1,12 +1,4 @@
-import {
-    click,
-    getText,
-    refreshPage,
-    scrollIntoView,
-    waitForClickable,
-    waitForElDisplayed,
-    waitForPresent
-} from '../../../../../e2e';
+import { click, getText, refreshPage, scrollIntoView, waitForClickable, waitForElDisplayed } from '../../../../../e2e';
 import { address, companyName, email, mobile, phone, popoverHeaderValue } from './quick-view-content';
 import { QuickViewPo } from './quick-view.po';
 
@@ -39,7 +31,7 @@ describe('Quick view  test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(quickViewPage.root);
+        await quickViewPage.waitForRoot();
         await waitForElDisplayed(quickViewPage.title);
     }, 1);
 

--- a/libs/docs/core/quick-view/e2e/quick-view.po.ts
+++ b/libs/docs/core/quick-view/e2e/quick-view.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class QuickViewPo extends CoreBaseComponentPo {
     private url = '/quick-view';
@@ -26,7 +26,7 @@ export class QuickViewPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/radio/e2e/radio-button.e2e-spec.ts
+++ b/libs/docs/core/radio/e2e/radio-button.e2e-spec.ts
@@ -4,8 +4,7 @@ import {
     getElementArrayLength,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { RadioButtonPo } from './radio-button.po';
 
@@ -19,7 +18,7 @@ describe('Radio button component test', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(radioButtonPage.root);
+        await radioButtonPage.waitForRoot();
         await waitForElDisplayed(radioButtonPage.title);
     }, 2);
 

--- a/libs/docs/core/radio/e2e/radio-button.po.ts
+++ b/libs/docs/core/radio/e2e/radio-button.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class RadioButtonPo extends CoreBaseComponentPo {
     url = '/radio';
@@ -11,7 +11,7 @@ export class RadioButtonPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/rating-indicator/e2e/rating-indicator.e2e-spec.ts
+++ b/libs/docs/core/rating-indicator/e2e/rating-indicator.e2e-spec.ts
@@ -11,8 +11,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { RatingIndicatorPo } from './rating-indicator.po';
 
@@ -117,7 +116,7 @@ describe('Rating indicator test suite', () => {
                 return;
             }
             await refreshPage();
-            await waitForPresent(ratingIndicatorPage.root);
+            await ratingIndicatorPage.waitForRoot();
             await waitForElDisplayed(ratingIndicatorPage.title);
             await click(inputsDynamicChanges);
             // eslint-disable-next-line radix

--- a/libs/docs/core/rating-indicator/e2e/rating-indicator.po.ts
+++ b/libs/docs/core/rating-indicator/e2e/rating-indicator.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class RatingIndicatorPo extends CoreBaseComponentPo {
     url = '/rating-indicator';
@@ -18,7 +18,7 @@ export class RatingIndicatorPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/resizable-card-layout/e2e/resizable-card-layout.e2e-spec.ts
+++ b/libs/docs/core/resizable-card-layout/e2e/resizable-card-layout.e2e-spec.ts
@@ -9,8 +9,7 @@ import {
     pause,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { ResizableCardLayoutPo } from './resizable-card-layout.po';
 
@@ -45,7 +44,7 @@ describe('Resizable card layout component:', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(resizableCardLayoutPage.root);
+        await resizableCardLayoutPage.waitForRoot();
         await waitForElDisplayed(resizableCardLayoutPage.title);
     }, 2);
 

--- a/libs/docs/core/resizable-card-layout/e2e/resizable-card-layout.po.ts
+++ b/libs/docs/core/resizable-card-layout/e2e/resizable-card-layout.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ResizableCardLayoutPo extends CoreBaseComponentPo {
     url = '/resizable-card-layout';
@@ -31,7 +31,7 @@ export class ResizableCardLayoutPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/segmented-button/e2e/segmented-button.e2e-spec.ts
+++ b/libs/docs/core/segmented-button/e2e/segmented-button.e2e-spec.ts
@@ -5,8 +5,7 @@ import {
     getElementClass,
     getText,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { SegmentedButtonPo } from './segmented-button.po';
 
@@ -33,7 +32,7 @@ describe('Select component:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(segmentedButtonPage.root);
+        await segmentedButtonPage.waitForRoot();
         await waitForElDisplayed(segmentedButtonPage.title);
     }, 2);
 

--- a/libs/docs/core/segmented-button/e2e/segmented-button.po.ts
+++ b/libs/docs/core/segmented-button/e2e/segmented-button.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SegmentedButtonPo extends CoreBaseComponentPo {
     url = '/segmented-button';
@@ -20,7 +20,7 @@ export class SegmentedButtonPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/select/e2e/select.e2e-spec.ts
+++ b/libs/docs/core/select/e2e/select.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     refreshPage,
     scrollIntoView,
     waitForElDisplayed,
-    waitForInvisibilityOf,
-    waitForPresent
+    waitForInvisibilityOf
 } from '../../../../../e2e';
 import { SelectPo } from './select.po';
 
@@ -36,7 +35,7 @@ fdescribe('Select component:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(selectPage.root);
+        await selectPage.waitForRoot();
         await waitForElDisplayed(selectPage.title);
     }, 2);
 

--- a/libs/docs/core/select/e2e/select.po.ts
+++ b/libs/docs/core/select/e2e/select.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SelectPo extends CoreBaseComponentPo {
     url = '/select';
@@ -19,7 +19,7 @@ export class SelectPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/shellbar/e2e/shellbar.e2e-spec.ts
+++ b/libs/docs/core/shellbar/e2e/shellbar.e2e-spec.ts
@@ -15,8 +15,7 @@ import {
     refreshPage,
     scrollIntoView,
     sendKeys,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { ShellbarPo } from './shellbar.po';
 
@@ -52,7 +51,7 @@ describe('shellbar test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(shellbarPage.root);
+        await shellbarPage.waitForRoot();
         await waitForElDisplayed(shellbarPage.title);
     }, 1);
 

--- a/libs/docs/core/shellbar/e2e/shellbar.po.ts
+++ b/libs/docs/core/shellbar/e2e/shellbar.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ShellbarPo extends CoreBaseComponentPo {
     private url = '/shellbar';
@@ -34,7 +34,7 @@ export class ShellbarPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/side-navigation/e2e/side-navigation.e2e-spec.ts
+++ b/libs/docs/core/side-navigation/e2e/side-navigation.e2e-spec.ts
@@ -5,8 +5,7 @@ import {
     isElementDisplayed,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { blockExamples } from './side-navigation-content';
 import { SideNavigationPo } from './side-navigation.po';
@@ -40,7 +39,7 @@ describe('Side-navigation test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(sideNavigationPage.root);
+        await sideNavigationPage.waitForRoot();
         await waitForElDisplayed(sideNavigationPage.title);
     }, 1);
 

--- a/libs/docs/core/side-navigation/e2e/side-navigation.po.ts
+++ b/libs/docs/core/side-navigation/e2e/side-navigation.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SideNavigationPo extends CoreBaseComponentPo {
     private url = '/side-navigation';
@@ -30,7 +30,7 @@ export class SideNavigationPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/slider/e2e/slider.e2e-spec.ts
+++ b/libs/docs/core/slider/e2e/slider.e2e-spec.ts
@@ -14,8 +14,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { cozySliderClass, disabledAttribute } from './slider-contents';
 import { SliderPo } from './slider.po';
@@ -57,7 +56,7 @@ describe('slider test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(sliderPage.root);
+        await sliderPage.waitForRoot();
         await waitForElDisplayed(sliderPage.title);
     }, 1);
 

--- a/libs/docs/core/slider/e2e/slider.po.ts
+++ b/libs/docs/core/slider/e2e/slider.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SliderPo extends CoreBaseComponentPo {
     private url = '/slider';
@@ -42,7 +42,7 @@ export class SliderPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/split-button/e2e/split-button.e2e-spec.ts
+++ b/libs/docs/core/split-button/e2e/split-button.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     isElementDisplayed,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { SplitButtonPo } from './split-button.po';
 
@@ -32,7 +31,7 @@ describe('Split-button test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(splitButtonPage.root);
+        await splitButtonPage.waitForRoot();
         await waitForElDisplayed(splitButtonPage.title);
     }, 1);
 

--- a/libs/docs/core/split-button/e2e/split-button.po.ts
+++ b/libs/docs/core/split-button/e2e/split-button.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SplitButtonPo extends CoreBaseComponentPo {
     private url = '/split-button';
@@ -17,7 +17,7 @@ export class SplitButtonPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/splitter/e2e/splitter.e2e-spec.ts
+++ b/libs/docs/core/splitter/e2e/splitter.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     getElementSize,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { SplitterPo } from './spltiller.po';
 
@@ -23,7 +22,7 @@ describe('Standard List test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(splitterPage.root);
+        await splitterPage.waitForRoot();
         await waitForElDisplayed(splitterPage.title);
     }, 1);
 

--- a/libs/docs/core/splitter/e2e/spltiller.po.ts
+++ b/libs/docs/core/splitter/e2e/spltiller.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SplitterPo extends CoreBaseComponentPo {
     private url = '/splitter';
@@ -14,7 +14,7 @@ export class SplitterPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/status-indicator/e2e/status-indicator.po.ts
+++ b/libs/docs/core/status-indicator/e2e/status-indicator.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class StatusIndicatorPo extends CoreBaseComponentPo {
     url = '/status-indicator';
@@ -8,7 +8,7 @@ export class StatusIndicatorPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/step-input/e2e/step-input.e2e-spec.ts
+++ b/libs/docs/core/step-input/e2e/step-input.e2e-spec.ts
@@ -13,8 +13,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { sections } from './step-input-content';
 import { StepInputPo } from './step-input.po';
@@ -41,7 +40,7 @@ describe('Step input component test suit', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(stepInputPage.root);
+        await stepInputPage.waitForRoot();
         await waitForElDisplayed(stepInputPage.title);
     }, 2);
 

--- a/libs/docs/core/step-input/e2e/step-input.po.ts
+++ b/libs/docs/core/step-input/e2e/step-input.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class StepInputPo extends CoreBaseComponentPo {
     private url = '/step-input';
@@ -22,7 +22,7 @@ export class StepInputPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/switch/e2e/switch.e2e-spec.ts
+++ b/libs/docs/core/switch/e2e/switch.e2e-spec.ts
@@ -6,8 +6,7 @@ import {
     getElementClass,
     pause,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { SwitchPo } from './switch.po';
 
@@ -35,7 +34,7 @@ describe('Switch test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(switchPage.root);
+        await switchPage.waitForRoot();
         await waitForElDisplayed(switchPage.title);
     }, 1);
 

--- a/libs/docs/core/switch/e2e/switch.po.ts
+++ b/libs/docs/core/switch/e2e/switch.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SwitchPo extends CoreBaseComponentPo {
     private url = '/switch';
@@ -28,7 +28,7 @@ export class SwitchPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/table/e2e/table.e2e-spec.ts
+++ b/libs/docs/core/table/e2e/table.e2e-spec.ts
@@ -16,11 +16,11 @@ import {
     isElementClickable,
     isElementDisplayed,
     isEnabled,
+    pause,
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { alertText, componentExampleArr, dateTestText, tableCellArr, tableCellArr2, testText } from './table-content';
 import { TablePo } from './table.po';
@@ -71,7 +71,7 @@ describe('Table test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(tablePage.root);
+        await tablePage.waitForRoot();
         await waitForElDisplayed(tablePage.title);
     }, 1);
 
@@ -142,14 +142,18 @@ describe('Table test suite', () => {
         it('should check that table sort work correctly', async () => {
             await scrollIntoView(tableCustomColumnsExample);
             await click(tableCustomColumnsExample + button);
+            await pause(500);
             await click(dialogContent + button, 1);
             await click(dialogContent + button, 2);
+            await pause(500);
             const rowsDesc: string[] = await getTextArr(tableCustomColumnsExample + ' thead .fd-table__cell');
             await expect(await checkSortDirection(rowsDesc, 'desc')).toBe(true);
 
             await click(tableCustomColumnsExample + button);
+            await pause(500);
             await click(dialogContent + button);
             await click(dialogContent + button, 2);
+            await pause(500);
             const rowsAsc: string[] = await getTextArr(tableCustomColumnsExample + ' thead .fd-table__cell');
             await expect(await checkSortDirection(rowsAsc, 'asc')).toBe(true);
         });

--- a/libs/docs/core/table/e2e/table.po.ts
+++ b/libs/docs/core/table/e2e/table.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TablePo extends CoreBaseComponentPo {
     url = '/table';
@@ -47,7 +47,7 @@ export class TablePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/tabs/e2e/tabs.e2e-spec.ts
+++ b/libs/docs/core/tabs/e2e/tabs.e2e-spec.ts
@@ -12,8 +12,7 @@ import {
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { TabsPo } from './tabs.po';
 
@@ -60,7 +59,7 @@ describe('Tabs test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(tabsPage.root);
+        await tabsPage.waitForRoot();
         await waitForElDisplayed(tabsPage.title);
     }, 1);
 

--- a/libs/docs/core/tabs/e2e/tabs.po.ts
+++ b/libs/docs/core/tabs/e2e/tabs.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TabsPo extends CoreBaseComponentPo {
     private url = '/tabs';
@@ -43,7 +43,7 @@ export class TabsPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/text/e2e/text.e2e-spec.ts
+++ b/libs/docs/core/text/e2e/text.e2e-spec.ts
@@ -8,8 +8,7 @@ import {
     refreshPage,
     saveElementScreenshot,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { TextPo } from './text.po';
 
@@ -25,7 +24,7 @@ describe('Text component test', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(textPage.root);
+        await textPage.waitForRoot();
         await waitForElDisplayed(textPage.title);
     }, 2);
 

--- a/libs/docs/core/text/e2e/text.po.ts
+++ b/libs/docs/core/text/e2e/text.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TextPo extends CoreBaseComponentPo {
     url = '/text';
@@ -10,7 +10,7 @@ export class TextPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/textarea/e2e/textarea.e2e-spec.ts
+++ b/libs/docs/core/textarea/e2e/textarea.e2e-spec.ts
@@ -15,8 +15,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { TextareaPo } from './textarea.po';
 
@@ -43,7 +42,7 @@ describe('Textarea component test', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(textareaPage.root);
+        await textareaPage.waitForRoot();
         await waitForElDisplayed(textareaPage.title);
     }, 1);
 

--- a/libs/docs/core/textarea/e2e/textarea.po.ts
+++ b/libs/docs/core/textarea/e2e/textarea.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TextareaPo extends CoreBaseComponentPo {
     private url = '/textarea';
@@ -19,7 +19,7 @@ export class TextareaPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/tile/e2e/tile.e2e-spec.ts
+++ b/libs/docs/core/tile/e2e/tile.e2e-spec.ts
@@ -5,8 +5,7 @@ import {
     isElementClickable,
     isElementDisplayed,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { TilePo } from './tile.po';
 
@@ -36,7 +35,7 @@ describe('Tile component test', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(tilePage.root);
+        await tilePage.waitForRoot();
         await waitForElDisplayed(tilePage.title);
     }, 1);
 

--- a/libs/docs/core/tile/e2e/tile.po.ts
+++ b/libs/docs/core/tile/e2e/tile.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TilePo extends CoreBaseComponentPo {
     private url = '/tile';
@@ -24,7 +24,7 @@ export class TilePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/time-picker/e2e/time-picker.e2e-spec.ts
+++ b/libs/docs/core/time-picker/e2e/time-picker.e2e-spec.ts
@@ -14,8 +14,7 @@ import {
     refreshPage,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { TimePickerPo } from './time-picker.po';
 
@@ -59,7 +58,7 @@ describe('Time-picker component test', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(timePickerPage.root);
+        await timePickerPage.waitForRoot();
         await waitForElDisplayed(timePickerPage.title);
     }, 2);
 

--- a/libs/docs/core/time-picker/e2e/time-picker.po.ts
+++ b/libs/docs/core/time-picker/e2e/time-picker.po.ts
@@ -1,4 +1,4 @@
-import { click, CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { click, CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TimePickerPo extends CoreBaseComponentPo {
     url = '/time-picker';
@@ -51,7 +51,7 @@ export class TimePickerPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/time/e2e/time.e2e-spec.ts
+++ b/libs/docs/core/time/e2e/time.e2e-spec.ts
@@ -15,8 +15,7 @@ import {
     refreshPage,
     saveElementScreenshot,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { sections } from './time-contents';
 import { TimePo } from './time.po';
@@ -58,7 +57,7 @@ describe('Time component test', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(timePage.root);
+        await timePage.waitForRoot();
         await waitForElDisplayed(timePage.title);
     }, 2);
 

--- a/libs/docs/core/time/e2e/time.po.ts
+++ b/libs/docs/core/time/e2e/time.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TimePo extends CoreBaseComponentPo {
     private url = '/time';
@@ -45,7 +45,7 @@ export class TimePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/timeline/e2e/timeline.po.ts
+++ b/libs/docs/core/timeline/e2e/timeline.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TimelinePo extends CoreBaseComponentPo {
     private url = '/timeline';
@@ -10,7 +10,7 @@ export class TimelinePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/title/e2e/title.e2e-spec.ts
+++ b/libs/docs/core/title/e2e/title.e2e-spec.ts
@@ -1,10 +1,4 @@
-import {
-    getAttributeByName,
-    getElementClass,
-    refreshPage,
-    waitForElDisplayed,
-    waitForPresent
-} from '../../../../../e2e';
+import { getAttributeByName, getElementClass, refreshPage, waitForElDisplayed } from '../../../../../e2e';
 import { titleLevels, titleLevelsReversed } from './title-contents';
 import { TitlePo } from './title.po';
 
@@ -18,7 +12,7 @@ describe('Wizard component test', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(titlePage.root);
+        await titlePage.waitForRoot();
         await waitForElDisplayed(titlePage.title);
     }, 2);
 

--- a/libs/docs/core/title/e2e/title.po.ts
+++ b/libs/docs/core/title/e2e/title.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TitlePo extends CoreBaseComponentPo {
     private url = '/title';
@@ -13,7 +13,7 @@ export class TitlePo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/token/e2e/token.e2e-spec.ts
+++ b/libs/docs/core/token/e2e/token.e2e-spec.ts
@@ -9,8 +9,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { TokenPo } from './token.po';
 
@@ -34,7 +33,7 @@ describe('Token component test', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(tokenPage.root);
+        await tokenPage.waitForRoot();
         await waitForElDisplayed(tokenPage.title);
     }, 2);
 

--- a/libs/docs/core/token/e2e/token.po.ts
+++ b/libs/docs/core/token/e2e/token.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TokenPo extends CoreBaseComponentPo {
     url = '/token';
@@ -16,7 +16,7 @@ export class TokenPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/toolbar/e2e/toolbar.e2e-spec.ts
+++ b/libs/docs/core/toolbar/e2e/toolbar.e2e-spec.ts
@@ -61,7 +61,7 @@ describe('Toolbar test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(toolbarPage.root);
+        await toolbarPage.waitForRoot();
         await waitForElDisplayed(toolbarPage.title);
     }, 2);
 

--- a/libs/docs/core/toolbar/e2e/toolbar.po.ts
+++ b/libs/docs/core/toolbar/e2e/toolbar.po.ts
@@ -1,4 +1,4 @@
-import { click, CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { click, CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ToolbarPo extends CoreBaseComponentPo {
     url = '/toolbar';
@@ -40,7 +40,7 @@ export class ToolbarPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/upload-collection/e2e/upload-collection.e2e-spec.ts
+++ b/libs/docs/core/upload-collection/e2e/upload-collection.e2e-spec.ts
@@ -13,8 +13,7 @@ import {
     scrollIntoView,
     setValue,
     uploadFile,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import {
     acceptAlertText,
@@ -51,7 +50,7 @@ describe('File uploader component test', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(uploadCollectionPage.root);
+        await uploadCollectionPage.waitForRoot();
         await waitForElDisplayed(uploadCollectionPage.title);
     }, 2);
 

--- a/libs/docs/core/upload-collection/e2e/upload-collection.po.ts
+++ b/libs/docs/core/upload-collection/e2e/upload-collection.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class UploadCollectionPo extends CoreBaseComponentPo {
     url = '/upload-collection';
@@ -21,7 +21,7 @@ export class UploadCollectionPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/core/vertical-navigation/e2e/vertical-navigation.e2e-spec.ts
+++ b/libs/docs/core/vertical-navigation/e2e/vertical-navigation.e2e-spec.ts
@@ -6,8 +6,7 @@ import {
     isElementDisplayed,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { VerticalNavigationPo } from './vertical-navigation.po';
 
@@ -34,7 +33,7 @@ describe('Vertical navigation component tests', function () {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(verticalNavigationPage.root);
+        await verticalNavigationPage.waitForRoot();
         await waitForElDisplayed(verticalNavigationPage.title);
     }, 2);
 

--- a/libs/docs/core/vertical-navigation/e2e/vertical-navigation.po.ts
+++ b/libs/docs/core/vertical-navigation/e2e/vertical-navigation.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class VerticalNavigationPo extends CoreBaseComponentPo {
     private url = '/vertical-navigation';
@@ -19,7 +19,7 @@ export class VerticalNavigationPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/core/wizard/e2e/wizard.e2e-spec.ts
+++ b/libs/docs/core/wizard/e2e/wizard.e2e-spec.ts
@@ -14,8 +14,7 @@ import {
     sendKeys,
     setValue,
     waitForElDisappear,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { WizardPo } from './wizard.po';
 import { firstAdress, firstAdressLength, fullName, secAdress, update } from './wizard.tags';
@@ -58,7 +57,7 @@ describe('Wizard component test', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(wizardPage.root);
+        await wizardPage.waitForRoot();
         await waitForElDisplayed(wizardPage.title);
     }, 2);
 

--- a/libs/docs/core/wizard/e2e/wizard.po.ts
+++ b/libs/docs/core/wizard/e2e/wizard.po.ts
@@ -1,4 +1,4 @@
-import { CoreBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { CoreBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class WizardPo extends CoreBaseComponentPo {
     private url = '/wizard';
@@ -43,7 +43,7 @@ export class WizardPo extends CoreBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/action-bar/e2e/action-bar.po.ts
+++ b/libs/docs/platform/action-bar/e2e/action-bar.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ActionBarPo extends PlatformBaseComponentPo {
     url = '/action-bar';
@@ -13,7 +13,7 @@ export class ActionBarPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/action-list-item/e2e/action-list-item.e2e-spec.ts
+++ b/libs/docs/platform/action-list-item/e2e/action-list-item.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     getElementClass,
     getElementSize,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { alertTextArr, btnText } from './action-list-item-contents';
 import { ActionListItemPo } from './action-list-item.po';
@@ -23,7 +22,7 @@ describe('Action List Item Test Suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(actionListPage.root);
+        await actionListPage.waitForRoot();
         await waitForElDisplayed(actionListPage.title);
     }, 1);
 

--- a/libs/docs/platform/action-list-item/e2e/action-list-item.po.ts
+++ b/libs/docs/platform/action-list-item/e2e/action-list-item.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ActionListItemPo extends PlatformBaseComponentPo {
     url = '/action-list-item';
@@ -10,7 +10,7 @@ export class ActionListItemPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/approval-flow/e2e/approval-flow.e2e-spec.ts
+++ b/libs/docs/platform/approval-flow/e2e/approval-flow.e2e-spec.ts
@@ -110,7 +110,7 @@ describe('Approval flow', () => {
 
     afterEach(async () => {
         await refreshPage(true);
-        await waitForPresent(approvalFlowPage.root);
+        await approvalFlowPage.waitForRoot();
         await waitForElDisplayed(approvalFlowPage.title);
     }, 1);
 

--- a/libs/docs/platform/approval-flow/e2e/approval-flow.po.ts
+++ b/libs/docs/platform/approval-flow/e2e/approval-flow.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ApprovalFlowPo extends PlatformBaseComponentPo {
     url = '/approval-flow';
@@ -74,7 +74,7 @@ export class ApprovalFlowPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/button/e2e/button.e2e-spec.ts
+++ b/libs/docs/platform/button/e2e/button.e2e-spec.ts
@@ -6,8 +6,7 @@ import {
     isElementClickable,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { ButtonPo } from './button.po';
 
@@ -21,7 +20,7 @@ describe('Button test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(buttonPage.root);
+        await buttonPage.waitForRoot();
         await waitForElDisplayed(buttonPage.title);
     }, 1);
 

--- a/libs/docs/platform/button/e2e/button.po.ts
+++ b/libs/docs/platform/button/e2e/button.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ButtonPo extends PlatformBaseComponentPo {
     private url = '/button';
@@ -11,7 +11,7 @@ export class ButtonPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/checkbox-group/e2e/checkbox-group.e2e-spec.ts
+++ b/libs/docs/platform/checkbox-group/e2e/checkbox-group.e2e-spec.ts
@@ -12,8 +12,7 @@ import {
     mouseHoverElement,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import {
     countriesArr,
@@ -60,13 +59,13 @@ describe('Checkbox group test suite', () => {
 
     beforeAll(async () => {
         await checkboxGroupPage.open();
-        await waitForPresent(checkboxGroupPage.root);
+        await checkboxGroupPage.waitForRoot();
         await waitForElDisplayed(checkboxGroupPage.title);
     }, 2);
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(checkboxGroupPage.root);
+        await checkboxGroupPage.waitForRoot();
         await waitForElDisplayed(checkboxGroupPage.title);
     }, 2);
 

--- a/libs/docs/platform/checkbox-group/e2e/checkbox-group.po.ts
+++ b/libs/docs/platform/checkbox-group/e2e/checkbox-group.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class CheckboxGroupPO extends PlatformBaseComponentPo {
     url = '/checkbox-group';
@@ -23,7 +23,7 @@ export class CheckboxGroupPO extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/checkbox/e2e/checkbox.e2e-spec.ts
+++ b/libs/docs/platform/checkbox/e2e/checkbox.e2e-spec.ts
@@ -42,13 +42,13 @@ describe('Checkbox test suite', () => {
 
     beforeAll(async () => {
         await checkboxPage.open();
-        await waitForPresent(checkboxPage.root);
+        await checkboxPage.waitForRoot();
         await waitForElDisplayed(checkboxPage.title);
     }, 1);
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(checkboxPage.root);
+        await checkboxPage.waitForRoot();
         await waitForElDisplayed(checkboxPage.title);
     }, 1);
 

--- a/libs/docs/platform/checkbox/e2e/checkbox.po.ts
+++ b/libs/docs/platform/checkbox/e2e/checkbox.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class CheckboxPO extends PlatformBaseComponentPo {
     url = '/checkbox';
@@ -20,7 +20,7 @@ export class CheckboxPO extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/combobox/e2e/combobox.e2e-spec.ts
+++ b/libs/docs/platform/combobox/e2e/combobox.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Combobox test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(comboBoxPage.root);
+        await comboBoxPage.waitForRoot();
         await waitForElDisplayed(comboBoxPage.title);
     }, 1);
 

--- a/libs/docs/platform/combobox/e2e/combobox.po.ts
+++ b/libs/docs/platform/combobox/e2e/combobox.po.ts
@@ -62,7 +62,7 @@ export class ComboBoxPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.pageTitle);
     }
 

--- a/libs/docs/platform/date-picker/e2e/date-picker.e2e-spec.ts
+++ b/libs/docs/platform/date-picker/e2e/date-picker.e2e-spec.ts
@@ -9,8 +9,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { date, date1, date10, date11, date12, date2, date3, date5, date8, date9, text, year2025 } from './date-picker';
 import { DatePicker } from './date-picker.po';
@@ -39,13 +38,13 @@ describe('Date picker suite', () => {
 
     beforeAll(async () => {
         await datePickerPage.open();
-        await waitForPresent(datePickerPage.root);
+        await datePickerPage.waitForRoot();
         await waitForElDisplayed(datePickerPage.title);
     }, 1);
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(datePickerPage.root);
+        await datePickerPage.waitForRoot();
         await waitForElDisplayed(datePickerPage.title);
     }, 2);
 

--- a/libs/docs/platform/date-picker/e2e/date-picker.po.ts
+++ b/libs/docs/platform/date-picker/e2e/date-picker.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class DatePicker extends PlatformBaseComponentPo {
     url = '/date-picker';
@@ -32,7 +32,7 @@ export class DatePicker extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/datetime-picker/e2e/datetime-picker.e2e-spec.ts
+++ b/libs/docs/platform/datetime-picker/e2e/datetime-picker.e2e-spec.ts
@@ -12,7 +12,6 @@ import {
     sendKeys,
     setValue,
     waitForElDisplayed,
-    waitForPresent,
     waitForUnclickable
 } from '../../../../../e2e';
 import { compactDate, currentDate, date, text, year2030 } from './datetime-picker';
@@ -61,7 +60,7 @@ describe('Datetime picker suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(dateTimePickerPage.root);
+        await dateTimePickerPage.waitForRoot();
         await waitForElDisplayed(dateTimePickerPage.title);
     }, 2);
 

--- a/libs/docs/platform/datetime-picker/e2e/datetime-picker.po.ts
+++ b/libs/docs/platform/datetime-picker/e2e/datetime-picker.po.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { getElementClass, PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { getElementClass, PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class DateTimePicker extends PlatformBaseComponentPo {
     url = '/datetime-picker';
@@ -67,7 +67,7 @@ export class DateTimePicker extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/display-list-item/e2e/display-list-item.e2e-spec.ts
+++ b/libs/docs/platform/display-list-item/e2e/display-list-item.e2e-spec.ts
@@ -6,8 +6,7 @@ import {
     getCurrentUrl,
     getElementClass,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { navTitlesArr, navUrl } from './display-list-item-contents';
 import { DisplayListItemPo } from './display-list-item.po';
@@ -30,7 +29,7 @@ describe('Display List Item test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(displayListPage.root);
+        await displayListPage.waitForRoot();
         await waitForElDisplayed(displayListPage.title);
     }, 1);
 

--- a/libs/docs/platform/display-list-item/e2e/display-list-item.po.ts
+++ b/libs/docs/platform/display-list-item/e2e/display-list-item.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class DisplayListItemPo extends PlatformBaseComponentPo {
     private url = '/display-list-item';
@@ -16,7 +16,7 @@ export class DisplayListItemPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/dynamic-page/e2e/dynamic-page.e2e-spec.ts
+++ b/libs/docs/platform/dynamic-page/e2e/dynamic-page.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Dynamic Page Layout test suite:', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(dynamicPageLayoutPage.root);
+        await dynamicPageLayoutPage.waitForRoot();
         await waitForElDisplayed(dynamicPageLayoutPage.title);
     }, 1);
 

--- a/libs/docs/platform/dynamic-page/e2e/dynamic-page.po.ts
+++ b/libs/docs/platform/dynamic-page/e2e/dynamic-page.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class DynamicPagePo extends PlatformBaseComponentPo {
     private url = '/dynamic-page';
@@ -27,7 +27,7 @@ export class DynamicPagePo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/feed-input/e2e/feed-input.e2e-spec.ts
+++ b/libs/docs/platform/feed-input/e2e/feed-input.e2e-spec.ts
@@ -45,7 +45,7 @@ describe('Verify Feed Input component', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(feedInputPage.root);
+        await feedInputPage.waitForRoot();
         await waitForElDisplayed(feedInputPage.title);
     }, 1);
 

--- a/libs/docs/platform/file-uploader/e2e/file-uploader.e2e-spec.ts
+++ b/libs/docs/platform/file-uploader/e2e/file-uploader.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     getText,
     refreshPage,
     uploadFile,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { imagePath, placeholderValue, titleValue } from './file-uploader.page-content';
 import { FileUploaderPo } from './file-uploader.po';
@@ -23,7 +22,7 @@ describe('File uploader test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(fileUploaderPage.root);
+        await fileUploaderPage.waitForRoot();
         await waitForElDisplayed(fileUploaderPage.title);
     }, 1);
 

--- a/libs/docs/platform/file-uploader/e2e/file-uploader.po.ts
+++ b/libs/docs/platform/file-uploader/e2e/file-uploader.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FileUploaderPo extends PlatformBaseComponentPo {
     private url = '/file-uploader';
@@ -12,7 +12,7 @@ export class FileUploaderPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/form-container/e2e/form-container.po.ts
+++ b/libs/docs/platform/form-container/e2e/form-container.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FormContainerPo extends PlatformBaseComponentPo {
     private url = '/form-container';
@@ -70,7 +70,7 @@ export class FormContainerPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/platform/form-generator/e2e/form-generator.e2e-spec.ts
+++ b/libs/docs/platform/form-generator/e2e/form-generator.e2e-spec.ts
@@ -12,8 +12,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { correctPassword, invalidBirthday, simplePassword, validBirthday } from './form-generator';
 import {
@@ -57,7 +56,7 @@ describe('Form generator test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(formGeneratorPage.root);
+        await formGeneratorPage.waitForRoot();
         await waitForElDisplayed(formGeneratorPage.title);
         await pause(300);
         if ((await doesItExist(busyIndicator)) === true) {

--- a/libs/docs/platform/form-generator/e2e/form-generator.po.ts
+++ b/libs/docs/platform/form-generator/e2e/form-generator.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class FormGeneratorPo extends PlatformBaseComponentPo {
     private url = '/form-generator';
@@ -29,7 +29,7 @@ export class FormGeneratorPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/platform/icon-tab-bar/e2e/icon-tab-bar.e2e-spec.ts
+++ b/libs/docs/platform/icon-tab-bar/e2e/icon-tab-bar.e2e-spec.ts
@@ -10,8 +10,7 @@ import {
     isElementDisplayed,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { IconTabBarPO } from './icon-tab-bar.po';
 
@@ -50,7 +49,7 @@ describe('Icon Tab Bar component test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(iconTabBarPage.root);
+        await iconTabBarPage.waitForRoot();
         await waitForElDisplayed(iconTabBarPage.title);
     }, 2);
 

--- a/libs/docs/platform/icon-tab-bar/e2e/icon-tab-bar.po.ts
+++ b/libs/docs/platform/icon-tab-bar/e2e/icon-tab-bar.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class IconTabBarPO extends PlatformBaseComponentPo {
     url = '/icon-tab-bar';
@@ -29,7 +29,7 @@ export class IconTabBarPO extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/platform/info-label/e2e/info-label.e2e-spec.ts
+++ b/libs/docs/platform/info-label/e2e/info-label.e2e-spec.ts
@@ -39,7 +39,7 @@ xdescribe('Info Label component test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(infoLabelPage.root);
+        await infoLabelPage.waitForRoot();
         await waitForPresent(infoLabelPage.title);
     }, 1);
 

--- a/libs/docs/platform/info-label/e2e/info-label.po.ts
+++ b/libs/docs/platform/info-label/e2e/info-label.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class InfoLabelPO extends PlatformBaseComponentPo {
     url = '/info-label';
@@ -17,7 +17,7 @@ export class InfoLabelPO extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/input-group/e2e/input-group.e2e-spec.ts
+++ b/libs/docs/platform/input-group/e2e/input-group.e2e-spec.ts
@@ -65,7 +65,7 @@ describe('Input Group should', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(inputGroupPage.root);
+        await inputGroupPage.waitForRoot();
         await waitForElDisplayed(inputGroupPage.title);
     }, 1);
 

--- a/libs/docs/platform/input-group/e2e/input-group.po.ts
+++ b/libs/docs/platform/input-group/e2e/input-group.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class InputGroupPo extends PlatformBaseComponentPo {
     readonly url = '/input-group';
@@ -47,7 +47,7 @@ export class InputGroupPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.root);
     }
 

--- a/libs/docs/platform/input/e2e/input.po.ts
+++ b/libs/docs/platform/input/e2e/input.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class InputPo extends PlatformBaseComponentPo {
     readonly url = '/input';
@@ -27,7 +27,7 @@ export class InputPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/link/e2e/link.po.ts
+++ b/libs/docs/platform/link/e2e/link.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class LinkPo extends PlatformBaseComponentPo {
     readonly url = '/link';
@@ -13,7 +13,7 @@ export class LinkPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/list/e2e/list.e2e-spec.ts
+++ b/libs/docs/platform/list/e2e/list.e2e-spec.ts
@@ -20,8 +20,7 @@ import {
     sendKeys,
     waitForElDisplayed,
     waitForInvisibilityOf,
-    waitForNotPresent,
-    waitForPresent
+    waitForNotPresent
 } from '../../../../../e2e';
 import {
     compactClass,
@@ -88,7 +87,7 @@ describe('List test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(listPage.root);
+        await listPage.waitForRoot();
         await waitForElDisplayed(listPage.title);
     }, 1);
 

--- a/libs/docs/platform/list/e2e/list.po.ts
+++ b/libs/docs/platform/list/e2e/list.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ListPo extends PlatformBaseComponentPo {
     private url = '/list';
@@ -66,7 +66,7 @@ export class ListPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/menu-button/e2e/menu-button.e2e-spec.ts
+++ b/libs/docs/platform/menu-button/e2e/menu-button.e2e-spec.ts
@@ -39,13 +39,13 @@ describe('Menu button test suite', () => {
 
     beforeAll(async () => {
         await menuBtnPage.open();
-        await waitForPresent(menuBtnPage.root);
+        await menuBtnPage.waitForRoot();
         await waitForElDisplayed(menuBtnPage.title);
     }, 1);
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(menuBtnPage.root);
+        await menuBtnPage.waitForRoot();
         await waitForElDisplayed(menuBtnPage.title);
     }, 1);
 

--- a/libs/docs/platform/menu-button/e2e/menu-button.po.ts
+++ b/libs/docs/platform/menu-button/e2e/menu-button.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MenuButtonPo extends PlatformBaseComponentPo {
     private url = '/menu-button';
@@ -19,7 +19,7 @@ export class MenuButtonPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/menu/e2e/menu.e2e-spec.ts
+++ b/libs/docs/platform/menu/e2e/menu.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     isElementDisplayed,
     mouseHoverElement,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { MenuPo } from './menu.po';
 
@@ -38,7 +37,7 @@ describe('Menu component test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(menuPage.root);
+        await menuPage.waitForRoot();
         await waitForElDisplayed(menuPage.title);
     }, 1);
 

--- a/libs/docs/platform/menu/e2e/menu.po.ts
+++ b/libs/docs/platform/menu/e2e/menu.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MenuPo extends PlatformBaseComponentPo {
     url = '/menu';
@@ -27,7 +27,7 @@ export class MenuPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/multi-combobox/e2e/multi-combobox.e2e-spec.ts
+++ b/libs/docs/platform/multi-combobox/e2e/multi-combobox.e2e-spec.ts
@@ -10,8 +10,7 @@ import {
     scrollIntoView,
     sendKeys,
     waitForElDisplayed,
-    waitForNotPresent,
-    waitForPresent
+    waitForNotPresent
 } from '../../../../../e2e';
 import { MultiComboboxPo } from './multi-combobox.po';
 
@@ -47,7 +46,7 @@ describe('multi-combobox test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(multiComboboxPage.root);
+        await multiComboboxPage.waitForRoot();
         await waitForElDisplayed(multiComboboxPage.title);
     }, 1);
 

--- a/libs/docs/platform/multi-combobox/e2e/multi-combobox.po.ts
+++ b/libs/docs/platform/multi-combobox/e2e/multi-combobox.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class MultiComboboxPo extends PlatformBaseComponentPo {
     private url = '/multi-combobox';
@@ -25,7 +25,7 @@ export class MultiComboboxPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/multi-input/e2e/multi-input.e2e-spec.ts
+++ b/libs/docs/platform/multi-input/e2e/multi-input.e2e-spec.ts
@@ -6,6 +6,7 @@ import {
     getElementPlaceholder,
     getText,
     isElementDisplayed,
+    pause,
     refreshPage,
     scrollIntoView,
     sendKeys,
@@ -48,7 +49,7 @@ describe('Multi input test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(multiInputPage.root);
+        await multiInputPage.waitForRoot();
         await waitForElDisplayed(multiInputPage.title);
     }, 1);
 
@@ -63,11 +64,11 @@ describe('Multi input test suite', () => {
                 continue;
             }
             if (i !== mobileExample) {
-                await multiInputPage.expandDropdown(activeDropdownButtons, i, i === loadingExample);
+                await multiInputPage.expandDropdown(activeDropdownButtons, i);
                 const optionsArr = await getAttributeByNameArr(options, 'title');
                 await scrollIntoView(header, i);
                 await multiInputPage.selectOption(optionsArr[1]);
-                await multiInputPage.expandDropdown(activeDropdownButtons, i, i === loadingExample);
+                await multiInputPage.expandDropdown(activeDropdownButtons, i);
                 await scrollIntoView(header, i);
                 await multiInputPage.selectOption(optionsArr[2]);
                 await expect(await getText(filledInput, i)).toContain(optionsArr[1]);
@@ -141,6 +142,7 @@ describe('Multi input test suite', () => {
                 await scrollIntoView(header, i);
                 await multiInputPage.selectOption(optionsArr[1]);
                 await click(approveButton);
+                await pause(500);
                 await expect(await getText(filledInput, i)).toContain(optionsArr[1]);
                 await scrollIntoView('fd-tokenizer', i);
                 await (await $$('fd-tokenizer')[i]!.$('.fd-token__close')).click();
@@ -211,6 +213,7 @@ describe('Multi input test suite', () => {
                 await scrollIntoView(header, i);
                 await multiInputPage.selectOption(optionsArr[1]);
                 await click(approveButton);
+                await pause(500);
                 await expect(await getText(filledInput, i)).toContain(optionsArr[1]);
                 await expect((await getText(filledInput, i)).split('\n')[0]).toBe(optionsArr[1]);
                 await click(selectedToken);

--- a/libs/docs/platform/multi-input/e2e/multi-input.po.ts
+++ b/libs/docs/platform/multi-input/e2e/multi-input.po.ts
@@ -5,8 +5,7 @@ import {
     PlatformBaseComponentPo,
     scrollIntoView,
     sendKeys,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 
 export class MultiInputPo extends PlatformBaseComponentPo {
@@ -42,9 +41,9 @@ export class MultiInputPo extends PlatformBaseComponentPo {
             ? `//div[@title="${name}"]/../..`
             : `//span[@title="${name}"]/..`;
 
-    async expandDropdown(dropDownSelector: string, index: number = 0, usePause = false): Promise<void> {
+    async expandDropdown(dropDownSelector: string, index: number = 0): Promise<void> {
         await sendKeys(['Escape']);
-        usePause && (await pause(300));
+        await pause(300);
         await scrollIntoView(dropDownSelector, index);
         await click(dropDownSelector, index);
         await waitForElDisplayed(this.expandedDropdown);
@@ -58,7 +57,7 @@ export class MultiInputPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/object-attribute/e2e/object-attribute.po.ts
+++ b/libs/docs/platform/object-attribute/e2e/object-attribute.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ObjectAttributePo extends PlatformBaseComponentPo {
     url = '/object-attribute';
@@ -10,7 +10,7 @@ export class ObjectAttributePo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/object-list-item/e2e/object-list-item.e2e-spec.ts
+++ b/libs/docs/platform/object-list-item/e2e/object-list-item.e2e-spec.ts
@@ -9,8 +9,7 @@ import {
     getElementArrayLength,
     getText,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { navUrl } from './object-list-item-contents';
 import { ObjectListItemPo } from './object-list-item.po';
@@ -52,7 +51,7 @@ describe('Object list item suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(objListPage.root);
+        await objListPage.waitForRoot();
         await waitForElDisplayed(objListPage.title);
     }, 1);
 

--- a/libs/docs/platform/object-list-item/e2e/object-list-item.po.ts
+++ b/libs/docs/platform/object-list-item/e2e/object-list-item.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ObjectListItemPo extends PlatformBaseComponentPo {
     private url = '/object-list-item';
@@ -44,7 +44,7 @@ export class ObjectListItemPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/object-marker/e2e/object-marker.po.ts
+++ b/libs/docs/platform/object-marker/e2e/object-marker.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ObjectMarkerPo extends PlatformBaseComponentPo {
     private url = '/object-marker';
@@ -10,7 +10,7 @@ export class ObjectMarkerPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/object-status/e2e/object-status.po.ts
+++ b/libs/docs/platform/object-status/e2e/object-status.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ObjectStatusPo extends PlatformBaseComponentPo {
     private url = '/object-status';
@@ -20,7 +20,7 @@ export class ObjectStatusPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/page-footer/e2e/page-footer.po.ts
+++ b/libs/docs/platform/page-footer/e2e/page-footer.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class PageFooterPo extends PlatformBaseComponentPo {
     private url = '/page-footer';
@@ -7,7 +7,7 @@ export class PageFooterPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/panel/e2e/panel.po.ts
+++ b/libs/docs/platform/panel/e2e/panel.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class PanelPo extends PlatformBaseComponentPo {
     url = '/panel';
@@ -24,7 +24,7 @@ export class PanelPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/radio-group/e2e/radio-group.e2e-spec.ts
+++ b/libs/docs/platform/radio-group/e2e/radio-group.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     getText,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { RadioButtonGroupPage } from './radio-group.po';
 
@@ -86,7 +85,7 @@ describe('Radio button group  Test Suite', () => {
 
     afterEach(async () => {
         await refreshPage(true);
-        await waitForPresent(radioButtonGroupPage.root);
+        await radioButtonGroupPage.waitForRoot();
         await waitForElDisplayed(radioButtonGroupPage.title);
     }, 2);
 

--- a/libs/docs/platform/radio-group/e2e/radio-group.po.ts
+++ b/libs/docs/platform/radio-group/e2e/radio-group.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class RadioButtonGroupPage extends PlatformBaseComponentPo {
     url = '/radio-group';
@@ -19,7 +19,7 @@ export class RadioButtonGroupPage extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/search-field/e2e/search-field.e2e-spec.ts
+++ b/libs/docs/platform/search-field/e2e/search-field.e2e-spec.ts
@@ -10,8 +10,7 @@ import {
     isEnabled,
     refreshPage,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { expected_category, search_placeholder } from './search-field-content';
 import { SearchFieldPo } from './search-field.po';
@@ -41,7 +40,7 @@ describe('Search field', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(searchPage.root);
+        await searchPage.waitForRoot();
         await waitForElDisplayed(searchPage.title);
     });
 
@@ -129,7 +128,7 @@ describe('Search field', () => {
         await expect(await getText(cozyWithDataSourceSearch, 3)).not.toContain('test');
     });
 
-    fit('should have autosuggestion after one letter', async () => {
+    it('should have autosuggestion after one letter', async () => {
         const arrLength = await getElementArrayLength(searchFields);
         for (let i = 0; arrLength > i; i++) {
             if (i === 0 || i === 1) {

--- a/libs/docs/platform/search-field/e2e/search-field.po.ts
+++ b/libs/docs/platform/search-field/e2e/search-field.po.ts
@@ -1,11 +1,11 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SearchFieldPo extends PlatformBaseComponentPo {
     url = '/search-field';
     root = '#page-content';
 
     searchFields = '[type="search"]';
-    searchIcons = '[title="Search"]';
+    searchIcons = '.fdp-search-field__submit';
     clearSearchIcon = '.fdp-search-field__clear';
     searchCategoryBtn = '.fdp-search-field__category-button';
     autosuggestionItems = 'ul.fd-menu__list';
@@ -21,7 +21,7 @@ export class SearchFieldPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/select/e2e/select.e2e-spec.ts
+++ b/libs/docs/platform/select/e2e/select.e2e-spec.ts
@@ -8,8 +8,7 @@ import {
     isElementClickable,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import {
     disableSelectModeValueTestText,
@@ -53,7 +52,7 @@ describe('Select test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(selectPage.root);
+        await selectPage.waitForRoot();
         await waitForElDisplayed(selectPage.title);
     }, 2);
 

--- a/libs/docs/platform/select/e2e/select.po.ts
+++ b/libs/docs/platform/select/e2e/select.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SelectPo extends PlatformBaseComponentPo {
     url = '/select';
@@ -24,7 +24,7 @@ export class SelectPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/slider/e2e/slider.po.ts
+++ b/libs/docs/platform/slider/e2e/slider.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SliderPo extends PlatformBaseComponentPo {
     private url = '/slider';
@@ -41,7 +41,7 @@ export class SliderPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/split-menu-button/e2e/split-menu-button.e2e-spec.ts
+++ b/libs/docs/platform/split-menu-button/e2e/split-menu-button.e2e-spec.ts
@@ -9,8 +9,7 @@ import {
     getElementTitle,
     refreshPage,
     waitForElDisplayed,
-    waitForNotDisplayed,
-    waitForPresent
+    waitForNotDisplayed
 } from '../../../../../e2e';
 import {
     behaviorBtnTextArr,
@@ -49,7 +48,7 @@ describe('Split menu button test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(spMenuBtnPage.root);
+        await spMenuBtnPage.waitForRoot();
         await waitForElDisplayed(spMenuBtnPage.title);
     }, 1);
 

--- a/libs/docs/platform/split-menu-button/e2e/split-menu-button.po.ts
+++ b/libs/docs/platform/split-menu-button/e2e/split-menu-button.po.ts
@@ -1,4 +1,4 @@
-import { getText, PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { getText, PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 import { outputLabel } from './split-menu-button-page-contents';
 
 export class SplitMenuButtonPo extends PlatformBaseComponentPo {
@@ -33,7 +33,7 @@ export class SplitMenuButtonPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/standard-list-item/e2e/standard-list-item.e2e-spec.ts
+++ b/libs/docs/platform/standard-list-item/e2e/standard-list-item.e2e-spec.ts
@@ -8,8 +8,7 @@ import {
     getElementArrayLength,
     getText,
     refreshPage,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { linkAttr, secondaryAttr, secondaryTypes, toolbarTextValue } from './standard-list-item-contents';
 import { StandardListItemPo } from './standard-list-item.po';
@@ -50,7 +49,7 @@ describe('Standard List Item test suite:', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(standardListPage.root);
+        await standardListPage.waitForRoot();
         await waitForElDisplayed(standardListPage.title);
     }, 1);
 

--- a/libs/docs/platform/standard-list-item/e2e/standard-list-item.po.ts
+++ b/libs/docs/platform/standard-list-item/e2e/standard-list-item.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class StandardListItemPo extends PlatformBaseComponentPo {
     private url = '/standard-list-item';
@@ -48,7 +48,7 @@ export class StandardListItemPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/step-input/e2e/step-input.e2e-spec.ts
+++ b/libs/docs/platform/step-input/e2e/step-input.e2e-spec.ts
@@ -15,8 +15,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { StepInputPo } from './step-input.po';
 
@@ -45,7 +44,7 @@ describe('Step input test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(stepInputPage.root);
+        await stepInputPage.waitForRoot();
         await waitForElDisplayed(stepInputPage.title);
     }, 2);
 

--- a/libs/docs/platform/step-input/e2e/step-input.po.ts
+++ b/libs/docs/platform/step-input/e2e/step-input.po.ts
@@ -1,11 +1,4 @@
-import {
-    clearValue,
-    PlatformBaseComponentPo,
-    sendKeys,
-    setValue,
-    waitForElDisplayed,
-    waitForPresent
-} from '../../../../../e2e';
+import { clearValue, PlatformBaseComponentPo, sendKeys, setValue, waitForElDisplayed } from '../../../../../e2e';
 
 export class StepInputPo extends PlatformBaseComponentPo {
     private url = '/step-input';
@@ -41,7 +34,7 @@ export class StepInputPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/switch/e2e/switch.e2e-spec.ts
+++ b/libs/docs/platform/switch/e2e/switch.e2e-spec.ts
@@ -57,7 +57,7 @@ describe('Verify Switch component', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(switchPage.root);
+        await switchPage.waitForRoot();
         await waitForElDisplayed(switchPage.title);
     }, 1);
 

--- a/libs/docs/platform/switch/e2e/switch.po.ts
+++ b/libs/docs/platform/switch/e2e/switch.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class SwitchPo extends PlatformBaseComponentPo {
     private url = '/switch';
@@ -36,7 +36,7 @@ export class SwitchPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/table/e2e/table-clickable-rows.e2e-spec.ts
+++ b/libs/docs/platform/table/e2e/table-clickable-rows.e2e-spec.ts
@@ -5,8 +5,7 @@ import {
     getElementClass,
     refreshPage,
     scrollIntoView,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { runCommonTests } from './table-common-tests';
 import { tableCellArr } from './table-contents';
@@ -22,7 +21,7 @@ describe('Table component test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(tablePage.root);
+        await tablePage.waitForRoot();
         await waitForElDisplayed(tablePage.title);
     }, 1);
 

--- a/libs/docs/platform/table/e2e/table-p13-dialog.e2e-spec.ts
+++ b/libs/docs/platform/table/e2e/table-p13-dialog.e2e-spec.ts
@@ -7,8 +7,7 @@ import {
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { runCommonTests } from './table-common-tests';
 import {
@@ -60,7 +59,7 @@ describe('Table component test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(tablePage.root);
+        await tablePage.waitForRoot();
         await waitForElDisplayed(tablePage.title);
     }, 1);
 

--- a/libs/docs/platform/table/e2e/table-row-selection.e2e-spec.ts
+++ b/libs/docs/platform/table/e2e/table-row-selection.e2e-spec.ts
@@ -5,8 +5,7 @@ import {
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { runCommonTests } from './table-common-tests';
 import { tableCellArr } from './table-contents';
@@ -30,7 +29,7 @@ describe('Table component test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(tablePage.root);
+        await tablePage.waitForRoot();
         await waitForElDisplayed(tablePage.title);
     }, 1);
 

--- a/libs/docs/platform/table/e2e/table-scrolling.e2e-spec.ts
+++ b/libs/docs/platform/table/e2e/table-scrolling.e2e-spec.ts
@@ -8,8 +8,7 @@ import {
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { runCommonTests } from './table-common-tests';
 import { tableCellArr2, testText2 } from './table-contents';
@@ -35,7 +34,7 @@ describe('Table component test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(tablePage.root);
+        await tablePage.waitForRoot();
         await waitForElDisplayed(tablePage.title);
     }, 1);
 

--- a/libs/docs/platform/table/e2e/table-settings-dialog.e2e-spec.ts
+++ b/libs/docs/platform/table/e2e/table-settings-dialog.e2e-spec.ts
@@ -9,8 +9,7 @@ import {
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { runCommonTests } from './table-common-tests';
 import {
@@ -61,7 +60,7 @@ describe('Table component test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(tablePage.root);
+        await tablePage.waitForRoot();
         await waitForElDisplayed(tablePage.title);
     }, 1);
 

--- a/libs/docs/platform/table/e2e/table.e2e-spec.ts
+++ b/libs/docs/platform/table/e2e/table.e2e-spec.ts
@@ -15,8 +15,7 @@ import {
     refreshPage,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { runCommonTests } from './table-common-tests';
 import {
@@ -79,7 +78,7 @@ describe('Table component test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(tablePage.root);
+        await tablePage.waitForRoot();
         await waitForElDisplayed(tablePage.title);
     }, 1);
 

--- a/libs/docs/platform/table/e2e/table.po.ts
+++ b/libs/docs/platform/table/e2e/table.po.ts
@@ -9,8 +9,7 @@ import {
     PlatformBaseComponentPo,
     scrollIntoView,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import { alertTestText1, alertTestText2, testText, testTextName, testTextSearch } from './table-contents';
 
@@ -109,7 +108,7 @@ export class TablePo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/textarea/e2e/textarea.e2e-spec.ts
+++ b/libs/docs/platform/textarea/e2e/textarea.e2e-spec.ts
@@ -20,7 +20,6 @@ import {
     sendKeys,
     setValue,
     waitForElDisplayed,
-    waitForPresent,
     waitTextToBePresentInValue
 } from '../../../../../e2e';
 import {
@@ -79,7 +78,7 @@ describe('Verify Textarea component', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(textareaPage.root);
+        await textareaPage.waitForRoot();
         await waitForElDisplayed(textareaPage.title);
     }, 1);
 

--- a/libs/docs/platform/textarea/e2e/textarea.po.ts
+++ b/libs/docs/platform/textarea/e2e/textarea.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TextareaPo extends PlatformBaseComponentPo {
     url = '/textarea';
@@ -37,7 +37,7 @@ export class TextareaPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/thumbnail/e2e/thumbnail.e2e-spec.ts
+++ b/libs/docs/platform/thumbnail/e2e/thumbnail.e2e-spec.ts
@@ -33,7 +33,7 @@ describe('Thumbnail field', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(thumbnailPage.root);
+        await thumbnailPage.waitForRoot();
         await waitForElDisplayed(thumbnailPage.title);
     }, 1);
 

--- a/libs/docs/platform/thumbnail/e2e/thumbnail.po.ts
+++ b/libs/docs/platform/thumbnail/e2e/thumbnail.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class ThumbnailPo extends PlatformBaseComponentPo {
     url = '/thumbnail';
@@ -18,7 +18,7 @@ export class ThumbnailPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 

--- a/libs/docs/platform/time-picker/e2e/time-picker.e2e-spec.ts
+++ b/libs/docs/platform/time-picker/e2e/time-picker.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Time picker suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(timePickerPage.root);
+        await timePickerPage.waitForRoot();
         await waitForElDisplayed(timePickerPage.title);
     }, 1);
 

--- a/libs/docs/platform/time-picker/e2e/time-picker.po.ts
+++ b/libs/docs/platform/time-picker/e2e/time-picker.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class TimePickerPO extends PlatformBaseComponentPo {
     url = '/time-picker';
@@ -36,7 +36,7 @@ export class TimePickerPO extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/platform/upload-collection/e2e/upload-collection.e2e-spec.ts
+++ b/libs/docs/platform/upload-collection/e2e/upload-collection.e2e-spec.ts
@@ -14,8 +14,7 @@ import {
     sendKeys,
     setValue,
     waitForElDisplayed,
-    waitForNotDisplayed,
-    waitForPresent
+    waitForNotDisplayed
 } from '../../../../../e2e';
 import { columnHeaderTestArr, paginationTestArr, testFolder1, testFolderArr } from './upload-collection-content';
 
@@ -58,7 +57,7 @@ describe('Upload collection test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(uploadCollectionPage.root);
+        await uploadCollectionPage.waitForRoot();
         await waitForElDisplayed(uploadCollectionPage.title);
     }, 1);
 

--- a/libs/docs/platform/upload-collection/e2e/upload-collection.po.ts
+++ b/libs/docs/platform/upload-collection/e2e/upload-collection.po.ts
@@ -1,4 +1,4 @@
-import { PlatformBaseComponentPo, waitForElDisplayed, waitForPresent } from '../../../../../e2e';
+import { PlatformBaseComponentPo, waitForElDisplayed } from '../../../../../e2e';
 
 export class UploadCollectionPo extends PlatformBaseComponentPo {
     private url = '/upload-collection';
@@ -35,7 +35,7 @@ export class UploadCollectionPo extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForPresent(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/platform/vhd/e2e/vhd.e2e-spec.ts
+++ b/libs/docs/platform/vhd/e2e/vhd.e2e-spec.ts
@@ -79,7 +79,7 @@ describe('Value help dialog test suite', () => {
 
     afterEach(async () => {
         await refreshPage();
-        await waitForPresent(valueHelpDialogPage.root);
+        await valueHelpDialogPage.waitForRoot();
         await waitForElDisplayed(valueHelpDialogPage.title);
     }, 1);
 

--- a/libs/docs/platform/wizard-generator/e2e/wizard-generator.e2e-spec.ts
+++ b/libs/docs/platform/wizard-generator/e2e/wizard-generator.e2e-spec.ts
@@ -15,8 +15,7 @@ import {
     scrollIntoView,
     sendKeys,
     setValue,
-    waitForElDisplayed,
-    waitForPresent
+    waitForElDisplayed
 } from '../../../../../e2e';
 import {
     cardDetails,
@@ -75,7 +74,7 @@ describe('Wizard generator test suite', () => {
 
     beforeEach(async () => {
         await refreshPage();
-        await waitForPresent(wizardGeneratorPage.root);
+        await wizardGeneratorPage.waitForRoot();
         await waitForElDisplayed(wizardGeneratorPage.title);
     }, 1);
 
@@ -866,6 +865,7 @@ describe('Wizard generator test suite', () => {
         describe('Other cases', () => {
             it('should check validation first required field', async () => {
                 await click(responsiveDialogExample + button);
+                await pause(500);
                 await checkFirstRequiredFieldValidation(dialog);
             });
 

--- a/libs/docs/platform/wizard-generator/e2e/wizard-generator.po.ts
+++ b/libs/docs/platform/wizard-generator/e2e/wizard-generator.po.ts
@@ -36,7 +36,7 @@ export class WizardGeneratorPO extends PlatformBaseComponentPo {
 
     async open(): Promise<void> {
         await super.open(this.url);
-        await waitForElDisplayed(this.root);
+        await this.waitForRoot();
         await waitForElDisplayed(this.title);
     }
 }

--- a/libs/docs/shared/src/lib/getAsset.ts
+++ b/libs/docs/shared/src/lib/getAsset.ts
@@ -16,7 +16,13 @@ const fileExtensionToLanguage = {
 
 export const getAsset = (path: string): Observable<string> =>
     inject(HttpClient)
-        .get(path, { responseType: 'text' })
+        .get(path, {
+            responseType: 'text',
+            headers: {
+                // This one is needed for vite to ignore transforming TypeScript source files.
+                accept: 'text/html'
+            }
+        })
         .pipe(map((r) => r.trim()));
 
 export const getAssetFromModuleAssets = (

--- a/libs/docs/shared/src/lib/services/docs.service.ts
+++ b/libs/docs/shared/src/lib/services/docs.service.ts
@@ -14,8 +14,4 @@ export class DocsService {
     getLernaJson(): Record<string, any> {
         return this._lernaJson;
     }
-
-    rawFileContents(path: string): Promise<string> {
-        return import(`!${path}?raw`);
-    }
 }


### PR DESCRIPTION
Part of #10910
- Migrated build and serve tasks from Webpack-based builders to Vite-based builders;
- Updated project imports according to Vite's specifics;

Noticeable improvements:
- Documentation website build time and final bundle size is much smaller:
**BEFORE:**
Done in 140.00s.
**AFTER:**
Done in 50.53s.
- Serve RAM usage is much smaller
**BEFORE:**
RAM: 5.4GB
AFTER:
**RAM: 2.8GB**
- Rebuild time is faster