### PR TITLE
fix(core): multi input addon aria hidden

### DIFF
--- a/libs/core/src/lib/input-group/input-group.component.html
+++ b/libs/core/src/lib/input-group/input-group.component.html
@@ -26,6 +26,7 @@
                 fd-button
                 fdInputGroupAddonButton
                 type="button"
+                [attr.aria-hidden]="addonButtonAriaHidden"
                 [fdType]="inShellbar ? 'standard' : 'transparent'"
                 [id]="_addOnButtonId"
                 [attr.tabindex]="buttonFocusable ? 0 : -1"

--- a/libs/core/src/lib/input-group/input-group.component.ts
+++ b/libs/core/src/lib/input-group/input-group.component.ts
@@ -148,6 +148,14 @@ export class InputGroupComponent implements ControlValueAccessor, AfterViewInit,
     @Input()
     glyphAriaLabel: Nullable<string>;
 
+    /**
+     * Whether the input group addon button should be aria-hidden
+     * Useful in cases when the title is already applied on the
+     * input group parent component
+     **/
+    @Input()
+    addonButtonAriaHidden: Nullable<boolean>;
+
     /** The tooltip for the input group icon. */
     @Input()
     iconTitle: Nullable<string>;

--- a/libs/core/src/lib/multi-input/multi-input.component.html
+++ b/libs/core/src/lib/multi-input/multi-input.component.html
@@ -49,7 +49,7 @@
             [isExpanded]="open && !mobile && viewModel.displayedOptions.length > 0"
             [isControl]="true"
             [glyph]="showAddonButton ? glyph : ''"
-            [iconTitle]="title"
+            [addonButtonAriaHidden]="!!title"
             (addOnButtonClicked)="_addOnButtonClicked($event)"
         >
             <span [attr.id]="tokenHiddenId" aria-hidden="true" class="fd-multi-input__invisible-text">{{


### PR DESCRIPTION
## Related Issue(s)

part of #10627

## Description

- feat(core): added addonButtonAriaHidden input to the input group
- fix(core): added aria hidden to the input group addon button when the title is passed to the multi-input
