### PR TITLE
fix(platform): add cellFocused event and focusCell method to platform table

### DIFF
--- a/libs/docs/platform/table/examples/preserved-state/platform-table-preserved-state-example.component.html
+++ b/libs/docs/platform/table/examples/preserved-state/platform-table-preserved-state-example.component.html
@@ -24,6 +24,7 @@
         (pageChange)="pageChangeCallback($event)"
         (tableScrolled)="setTableOffset($event)"
         (rowsRearrange)="onRowsRearrange($event)"
+        (cellFocused)="onCellFocused($event)"
     >
         <fdp-table-toolbar title="Order Items"></fdp-table-toolbar>
 

--- a/libs/docs/platform/table/examples/preserved-state/platform-table-preserved-state-example.component.ts
+++ b/libs/docs/platform/table/examples/preserved-state/platform-table-preserved-state-example.component.ts
@@ -6,7 +6,7 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { DestroyedService, FocusableCellPosition } from '@fundamental-ngx/cdk/utils';
 import { DatetimeAdapter, FdDate, FdDatetimeAdapter } from '@fundamental-ngx/core/datetime';
 import {
     CollectionBooleanFilter,
@@ -67,6 +67,8 @@ export class PlatformTablePreservedStateExampleComponent {
 
     tableOffset = 0;
 
+    focusedCell: FocusableCellPosition;
+
     applyScroll = false;
 
     private readonly _destroy$ = inject(DestroyedService);
@@ -111,6 +113,10 @@ export class PlatformTablePreservedStateExampleComponent {
                 }
                 this.applyScroll = false;
                 this.table.tableScrollable.setScrollTop(this.tableOffset, false);
+
+                if (this.focusedCell) {
+                    this.table.focusCell(this.focusedCell);
+                }
             });
     }
 
@@ -153,6 +159,10 @@ export class PlatformTablePreservedStateExampleComponent {
 
     setTableOffset(offset: number): void {
         this.tableOffset = offset;
+    }
+
+    onCellFocused(event: any): void {
+        this.focusedCell = event;
     }
 }
 

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -31,6 +31,7 @@ import {
 import {
     DndListDirective,
     FDK_FOCUSABLE_GRID_DIRECTIVE,
+    FocusableCellPosition,
     FocusableGridDirective,
     KeyUtil,
     Nullable,
@@ -453,6 +454,9 @@ export class TableComponent<T = any>
     /** Event emitted when all rows being collapsed. */
     @Output()
     allRowsCollapsed = new EventEmitter<void>();
+    /** Event emitted when a cell is focused. */
+    @Output()
+    readonly cellFocused = new EventEmitter<any>();
     /** @hidden */
     @ViewChild('tableScrollable')
     readonly tableScrollable: TableScrollable;
@@ -730,6 +734,12 @@ export class TableComponent<T = any>
                 })
             );
         }
+
+        this._subscriptions.add(
+            this._tableRowService.cellFocused$.subscribe((event) => {
+                this.cellFocused.emit(event);
+            })
+        );
     }
 
     /**
@@ -1270,6 +1280,14 @@ export class TableComponent<T = any>
 
             this._toggleGroupRow(tableRow);
         }
+    }
+
+    /**
+     * Function used to focus a cell in the table utilizing a FocusableCellPosition interface.
+     */
+    focusCell(position: FocusableCellPosition): void {
+        const tableEl = this.table.nativeElement as HTMLTableElement;
+        tableEl.rows[position.rowIndex].cells[position.colIndex].focus();
     }
 
     // Private API


### PR DESCRIPTION
fixes https://github.com/SAP/fundamental-ngx/issues/10900

Exposes a cellFocused event on the platform table as well as a focusCell function. This can be utilized to re-focus a cell after refreshing the datasource or navigating away from a page. I've added this functionality to the preserved state example