### PR TITLE
fix(platform): move initial focus to search input on p13

### DIFF
--- a/libs/platform/src/lib/table/components/table-p13-dialog/columns/columns.component.html
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/columns/columns.component.html
@@ -23,6 +23,7 @@
                 [inputText]="(_searchQuerySubject | async) || ''"
                 [suggestions]="[]"
                 (inputChange)="_searchInputChange($event)"
+                fdkInitialFocus
             ></fdp-search-field>
 
             <fd-toolbar-spacer></fd-toolbar-spacer>
@@ -132,7 +133,6 @@
                 fd-button
                 fdType="transparent"
                 fd-dialog-decisive-button
-                fdkInitialFocus
                 [label]="'platformTable.P13ColumnsDialogCancelBtnLabel' | fdTranslate"
                 (click)="cancel()"
             ></button>


### PR DESCRIPTION
fixes #10871 