### PR TITLE
fix(core): cannot clear file uploader

### DIFF
--- a/libs/core/src/lib/file-uploader/file-uploader.component.spec.ts
+++ b/libs/core/src/lib/file-uploader/file-uploader.component.spec.ts
@@ -104,10 +104,20 @@ describe('FileUploaderComponent', () => {
 
     it('should handle clear', () => {
         spyOn(component, 'onChange');
+        spyOn(component, 'setInputValue');
         component.clear();
         expect(component.inputRef.nativeElement.value).toEqual('');
+        expect(component.inputRef.nativeElement.placeholder).toEqual('');
+        expect(component.inputRef.nativeElement.title).toEqual('');
         expect(component.validFiles).toEqual([]);
         expect(component.invalidFiles).toEqual([]);
+        expect(component.setInputValue).toHaveBeenCalledWith([]);
+    });
+
+    it('should call clear when files array is set to empty', () => {
+        spyOn(component, 'clear');
+        component.writeValue([]);
+        expect(component.clear).toHaveBeenCalled();
     });
 
     it('should be manageable width', () => {

--- a/libs/core/src/lib/file-uploader/file-uploader.component.ts
+++ b/libs/core/src/lib/file-uploader/file-uploader.component.ts
@@ -191,13 +191,13 @@ export class FileUploaderComponent implements ControlValueAccessor, OnDestroy, F
 
     /** @hidden */
     writeValue(files: File[]): void {
-        if (this._isEmpty()) {
-            return;
-        }
-        if (!files) {
+        if (files && files.length === 0) {
             this.clear();
+        } else if (this._isEmpty()) {
+            return;
+        } else {
+            this._propagateFiles();
         }
-        this._propagateFiles();
     }
 
     /** @hidden */
@@ -231,7 +231,7 @@ export class FileUploaderComponent implements ControlValueAccessor, OnDestroy, F
     }
 
     /** @hidden */
-    setInputValue(selectedFiles: File[]): void {
+    setInputValue(selectedFiles: File[], fromClear = false): void {
         let fileName = '';
         selectedFiles.forEach((file) => (fileName = fileName.concat(' ' + file.name)));
         if (!this.inputRefText) {
@@ -245,7 +245,9 @@ export class FileUploaderComponent implements ControlValueAccessor, OnDestroy, F
             this.inputRefText.nativeElement.placeholder = this.placeholder;
             this.inputRefText.nativeElement.title = this.placeholder;
         }
-        this.inputRefText.nativeElement.focus();
+        if (!fromClear) {
+            this.inputRefText.nativeElement.focus();
+        }
     }
 
     /** @hidden */
@@ -269,14 +271,9 @@ export class FileUploaderComponent implements ControlValueAccessor, OnDestroy, F
      * Clears the files from the input.
      */
     public clear(): void {
-        if (this.inputRef) {
-            this.inputRef.nativeElement.value = '';
-        }
-        if (this.inputRefText) {
-            this.inputRefText.nativeElement.value = '';
-        }
         this.validFiles = [];
         this.invalidFiles = [];
+        this._propagateFiles();
     }
 
     /** @hidden */

--- a/libs/docs/core/file-uploader/examples/file-uploader-example/file-uploader-example.component.html
+++ b/libs/docs/core/file-uploader/examples/file-uploader-example/file-uploader-example.component.html
@@ -1,4 +1,5 @@
 <fd-file-uploader
+    #fileUploaderComponentRef
     ariaLabel="Choose file"
     ariaLabelledBy="Choose file"
     placeholder="Select the file "
@@ -19,3 +20,12 @@ Files Selected:
 <span *ngFor="let file of files">
     <span class="green">{{ file.name }} </span><br />
 </span>
+
+<button
+    fd-button
+    (click)="fileUploaderComponentRef.clear()"
+    label="Reset File Selection via clear() function"
+    style="margin-top: 0.5rem"
+></button>
+<br />
+<button fd-button (click)="resetFiles()" label="Reset File Selection via ngModel" style="margin-top: 0.5rem"></button>

--- a/libs/docs/core/file-uploader/examples/file-uploader-example/file-uploader-example.component.ts
+++ b/libs/docs/core/file-uploader/examples/file-uploader-example/file-uploader-example.component.ts
@@ -12,4 +12,8 @@ export class FileUploaderExampleComponent {
     handleFileSelection(files: File[]): void {
         alert(files.length + ' Files selected successfully!!!');
     }
+
+    resetFiles(): void {
+        this.files = [];
+    }
 }


### PR DESCRIPTION
fixes none

Public function `clear()` did not work and setting the ngModel to an empty array did not work. Bug was raised to me on teams, fixed while investigating. Added examples as well