### PR TITLE
fix(core): fixed switch default off icon

### DIFF
--- a/libs/core/src/lib/switch/switch.component.html
+++ b/libs/core/src/lib/switch/switch.component.html
@@ -36,7 +36,12 @@
                     {{ inactiveText }}
                 </span>
                 <ng-template #withIconOff>
-                    <i role="presentation" class="fd-switch__icon--off fd-switch__icon sap-icon--decline"></i>
+                    <i
+                        role="presentation"
+                        class="fd-switch__icon--off fd-switch__icon"
+                        [class.sap-icon--decline]="semantic"
+                        [class.sap-icon--less]="!semantic"
+                    ></i>
                 </ng-template>
             </div>
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes

## Description

Fixed default "off" icon for the switch