### PR TITLE
fix(core): [Accessibility] fd-shellbar action button missing title and aria-label

### DIFF
--- a/libs/core/src/lib/shellbar/shellbar-action/shellbar-action.component.html
+++ b/libs/core/src/lib/shellbar/shellbar-action/shellbar-action.component.html
@@ -4,6 +4,8 @@
         fdType="transparent"
         class="fd-shellbar__button"
         fdCozy
+        [attr.title]="title"
+        [ariaLabel]="ariaLabel"
         [glyph]="glyph"
         (click)="callback ? callback($event) : ''"
     >

--- a/libs/core/src/lib/shellbar/shellbar-action/shellbar-action.component.ts
+++ b/libs/core/src/lib/shellbar/shellbar-action/shellbar-action.component.ts
@@ -45,4 +45,12 @@ export class ShellbarActionComponent {
     /** Represents the number of notifications. */
     @Input()
     notificationCount: number;
+
+    /** title of the action button. */
+    @Input()
+    title: string;
+
+    /** aria-label of the action button */
+    @Input()
+    ariaLabel: string;
 }

--- a/libs/core/src/lib/shellbar/shellbar-action/shellbar-action.component.ts
+++ b/libs/core/src/lib/shellbar/shellbar-action/shellbar-action.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { FD_SHELLBAR_ACTION_COMPONENT } from '../tokens';
+import { Nullable } from '@fundamental-ngx/cdk/utils';
 
 /**
  * The component that represents a shellbar action.
@@ -48,9 +49,9 @@ export class ShellbarActionComponent {
 
     /** title of the action button. */
     @Input()
-    title: string;
+    title: Nullable<string>;
 
     /** aria-label of the action button */
     @Input()
-    ariaLabel: string;
+    ariaLabel: Nullable<string>;
 }

--- a/libs/docs/core/shellbar/examples/shellbar-collapsible-example.component.html
+++ b/libs/docs/core/shellbar/examples/shellbar-collapsible-example.component.html
@@ -33,6 +33,8 @@
                 [label]="action.label"
                 [notificationCount]="action.notificationCount"
                 [notificationLabel]="action.notificationLabel"
+                [title]="action.title"
+                [ariaLabel]="!action.notificationCount ? action.ariaLabel : ''"
             ></fd-shellbar-action>
 
             <fd-product-switch>

--- a/libs/docs/core/shellbar/examples/shellbar-collapsible-example.component.ts
+++ b/libs/docs/core/shellbar/examples/shellbar-collapsible-example.component.ts
@@ -135,6 +135,8 @@ export class ShellbarCollapsibleExampleComponent {
             glyph: 'pool',
             callback: this.actionPoolCallback,
             label: 'Pool',
+            title: 'Pool',
+            ariaLabel: 'Pool',
             notificationCount: 3,
             notificationLabel: 'Pool Count'
         },
@@ -142,6 +144,8 @@ export class ShellbarCollapsibleExampleComponent {
             glyph: 'bell',
             callback: this.actionNotificationCallback,
             label: 'Notifications',
+            title: 'Notifications',
+            ariaLabel: 'Notifications',
             notificationCount: 12,
             notificationLabel: 'Unread Notifications'
         }

--- a/libs/docs/core/shellbar/examples/shellbar-collapsible-example.component.ts
+++ b/libs/docs/core/shellbar/examples/shellbar-collapsible-example.component.ts
@@ -137,7 +137,7 @@ export class ShellbarCollapsibleExampleComponent {
             label: 'Pool',
             title: 'Pool',
             ariaLabel: 'Pool',
-            notificationCount: 3,
+            notificationCount: 0,
             notificationLabel: 'Pool Count'
         },
         {


### PR DESCRIPTION
## Related Issue(s)
close #10956 
<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes

## Description

<!-- Enter short description of the change -->
Adding title and aria-label for fd-shellbar action button

Before change
<img width="1792" alt="Screenshot 2023-11-17 at 3 33 16 PM" src="https://github.com/SAP/fundamental-ngx/assets/48496287/ad5beb71-e167-4297-9bed-965e757823d7">

Afeter change
<img width="1288" alt="Screenshot 2023-11-17 at 3 36 02 PM" src="https://github.com/SAP/fundamental-ngx/assets/48496287/561d750a-2a0f-40d7-b091-a3434d8c978e">
