### PR TITLE
fix(platform): clear table rows on data source changes

### DIFF
--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1598,6 +1598,15 @@ export class TableComponent<T = any>
     /** @hidden */
     private _listenToTableRowsPipe(): void {
         this._subscriptions.add(
+            /*
+             * Reset table when the data source is changed,
+             * because new data source can have different set of data
+             */
+            this._dataSourceDirective.dataSourceChanged.subscribe(() => {
+                this._setTableRows([]);
+            })
+        );
+        this._subscriptions.add(
             this._dataSourceDirective.items$
                 .pipe(
                     // map source items to table rows
@@ -1851,7 +1860,7 @@ export class TableComponent<T = any>
     /** @hidden */
     private _calculateVisibleTableRows(): void {
         this._tableRowsVisible = this._tableRows.filter((row) => !row.hidden);
-
+        console.log({ visible: this._tableRowsVisible, total: this._tableRows });
         if (this._virtualScrollDirective?.virtualScroll) {
             this._virtualScrollDirective.calculateVirtualScrollRows();
         } else {


### PR DESCRIPTION
## Related Issue(s)

part of the #11002 needs downporting

## Description

State needs to be reset, when data source instance is swapped, otherwise data from old data source gets leaked into the new list of the items