### PR TITLE
fix(core): file uploader buttonAriaLabel is not working

### DIFF
--- a/libs/core/src/lib/file-uploader/file-uploader.component.html
+++ b/libs/core/src/lib/file-uploader/file-uploader.component.html
@@ -36,7 +36,7 @@
     <button
         fd-button
         class="file-uploader__button"
-        [attr.aria-label]="buttonAriaLabel"
+        [ariaLabel]="buttonAriaLabel"
         [label]="buttonLabel"
         [disabled]="disabled"
         (click)="open()"


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #11027 

## Description

File Uploader buttonAriaLabel is not working

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->
With code
```
<fd-file-uploader
    #fileUploaderComponentRef
    ariaLabel="Choose file"
    ariaLabelledBy="Choose file"
    placeholder="Select the file "
    buttonLabel="Browse"
    buttonAriaLabel="browse file"
    accept=".png,.jpg"
    [required]="true"
    [(ngModel)]="files"
    [multiple]="true"
    (selectedFilesChanged)="handleFileSelection($event)"
>
</fd-file-uploader>
```
### Before:
```
<button fd-button="" class="fd-button fd-button--standard file-uploader__button" type="button"><!----><span class="fd-button__text ng-star-inserted"> Browse
</span><!----><!----><!----></button>
```
### After:
```
<button fd-button="" class="fd-button fd-button--standard file-uploader__button" ng-reflect-aria-label="browse file" ng-reflect-label="Browse" ng-reflect-disabled="false" type="button" aria-label="browse file"><!--bindings={}--><span class="fd-button__text ng-star-inserted"> Browse
</span><!--bindings={
  "ng-reflect-ng-if": "Browse"
}--><!--bindings={}--><!--bindings={
  "ng-reflect-ng-if": "false"
}--></button>
```
