### PR TITLE
fix(core): dynamic page facets stackblitz

### DIFF
--- a/libs/docs/core/dynamic-page/dynamic-page-docs.component.ts
+++ b/libs/docs/core/dynamic-page/dynamic-page-docs.component.ts
@@ -110,7 +110,7 @@ export class DynamicPageDocsComponent {
         {
             language: 'html',
             code: getAssetFromModuleAssets(dynamicPageFacetsExampleHtmlCode),
-            fileName: 'dynamic-page-responsive-example'
+            fileName: 'dynamic-page-facets-example'
         },
         {
             language: 'typescript',

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1855,7 +1855,6 @@ export class TableComponent<T = any>
     /** @hidden */
     private _calculateVisibleTableRows(): void {
         this._tableRowsVisible = this._tableRows.filter((row) => !row.hidden);
-        console.log({ visible: this._tableRowsVisible, total: this._tableRows });
         if (this._virtualScrollDirective?.virtualScroll) {
             this._virtualScrollDirective.calculateVirtualScrollRows();
         } else {


### PR DESCRIPTION
fixes none

dynamic page had the wrong template for the facets example for stackblitz. also a platform table console log i noticed.