### PR TITLE
fix(platform): do not select parent row if tristate is disabled

### DIFF
--- a/libs/platform/src/lib/table-helpers/helpers.ts
+++ b/libs/platform/src/lib/table-helpers/helpers.ts
@@ -146,7 +146,8 @@ export function convertTreeObjectsToTableRows<T>(
     hasChildrenKey: string,
     selectedKey: string,
     expandedStateKey: string,
-    rowNavigatable: string | boolean
+    rowNavigatable: string | boolean,
+    enableTristateMode = false
 ): TableRow<T>[] {
     const rows: TableRow<T>[] = [];
     const selectedRowsMap = getSelectionStatusByRowValue(source, selectionMode, tableRows, rowComparator);
@@ -183,7 +184,8 @@ export function convertTreeObjectsToTableRows<T>(
                 hasChildrenKey,
                 selectedKey,
                 expandedStateKey,
-                rowNavigatable
+                rowNavigatable,
+                enableTristateMode
             );
 
             children.forEach((c) => {
@@ -212,6 +214,9 @@ export function convertTreeObjectsToTableRows<T>(
                 const selectedSome = selectedChildren.length > 0;
                 if (r.checked) {
                     applySelectionToChildren(rows, r, [], []);
+                    return;
+                }
+                if (!enableTristateMode) {
                     return;
                 }
                 if (selectedAll) {

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1827,7 +1827,8 @@ export class TableComponent<T = any>
                 this.hasChildrenKey,
                 this.selectedKey,
                 this.expandedStateKey,
-                this.rowNavigatable
+                this.rowNavigatable,
+                this.enableTristateMode
             );
         }
         return [];


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10847

## Description
Added check whether the table is in tristate mode. Same algorithm was applied on selection change callback but not on the initial row definition function.
