### PR TITLE
fix(platform): do not select parent row if tristate is disabled

### DIFF
--- a/libs/platform/src/lib/table-helpers/helpers.ts
+++ b/libs/platform/src/lib/table-helpers/helpers.ts
@@ -148,7 +148,8 @@ export function convertTreeObjectsToTableRows<T>(
     hasChildrenKey: string,
     selectedKey: string,
     expandedStateKey: string,
-    rowNavigatable: string | boolean
+    rowNavigatable: string | boolean,
+    enableTristateMode = false
 ): TableRow<T>[] {
     const rows: TableRow<T>[] = [];
     const selectedRowsMap = getSelectionStatusByRowValue(source, selectionMode, tableRows, rowComparator);
@@ -185,7 +186,8 @@ export function convertTreeObjectsToTableRows<T>(
                 hasChildrenKey,
                 selectedKey,
                 expandedStateKey,
-                rowNavigatable
+                rowNavigatable,
+                enableTristateMode
             );
 
             children.forEach((c) => {
@@ -214,6 +216,9 @@ export function convertTreeObjectsToTableRows<T>(
                 const selectedSome = selectedChildren.length > 0;
                 if (r.checked) {
                     applySelectionToChildren(rows, r, [], []);
+                    return;
+                }
+                if (!enableTristateMode) {
                     return;
                 }
                 if (selectedAll) {

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1779,7 +1779,8 @@ export class TableComponent<T = any>
                 this.hasChildrenKey,
                 this.selectedKey,
                 this.expandedStateKey,
-                this.rowNavigatable
+                this.rowNavigatable,
+                this.enableTristateMode
             );
         }
         return [];


### PR DESCRIPTION
Downport of #11046