### PR TITLE
fix(cdk): ensure stable zone before applying autocomplete

### DIFF
--- a/libs/cdk/utils/directives/auto-complete/auto-complete.directive.spec.ts
+++ b/libs/cdk/utils/directives/auto-complete/auto-complete.directive.spec.ts
@@ -40,11 +40,11 @@ describe('AutoCompleteDirective', () => {
 
         directive.inputText = 'ap';
 
-        directive.handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'p' });
+        directive._handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'p' });
 
         expect((<any>directive)._elementRef.nativeElement.value).toBe('Apple');
 
-        directive.handleKeyboardEvent(<any>{ stopPropagation: () => {}, preventDefault: () => {}, key: 'Enter' });
+        directive._handleKeyboardEvent(<any>{ stopPropagation: () => {}, preventDefault: () => {}, key: 'Enter' });
 
         expect(spy).toHaveBeenCalledWith({
             term: 'Apple',
@@ -57,11 +57,11 @@ describe('AutoCompleteDirective', () => {
 
         directive.inputText = 'ap';
 
-        directive.handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'p' });
+        directive._handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'p' });
 
         expect((<any>directive)._elementRef.nativeElement.value).toBe('Apple');
 
-        directive.handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'ArrowLeft' });
+        directive._handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'ArrowLeft' });
 
         expect(spy).toHaveBeenCalledWith({
             term: 'Apple',
@@ -72,11 +72,11 @@ describe('AutoCompleteDirective', () => {
     it('should stop completing word', () => {
         directive.inputText = 'ap';
 
-        directive.handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'p' });
+        directive._handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'p' });
 
         expect((<any>directive)._elementRef.nativeElement.value).toBe('Apple');
 
-        directive.handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'Backspace' });
+        directive._handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'Backspace' });
 
         expect((<any>directive)._elementRef.nativeElement.value).toBe('ap');
     });
@@ -84,8 +84,8 @@ describe('AutoCompleteDirective', () => {
     it('should not complete, when other word is written', () => {
         directive.inputText = 'SomeOtherWord';
 
-        directive.handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'p' });
-        directive.handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'Escape' });
+        directive._handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'p' });
+        directive._handleKeyboardEvent(<any>{ preventDefault: () => {}, key: 'Escape' });
 
         expect((<any>directive)._elementRef.nativeElement.value).toBe('SomeOtherWord');
     });


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10710

## Description
Removing chinese symbols resulted in triggering keyup event before ngModel was stable with updated value.
This fix ensures that the zone is stable and all changes are applied.
