### PR TITLE
fix(platform): reset pagination when ds changed

### DIFF
--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -1347,6 +1347,8 @@ export class TableComponent<T = any>
         this._tableRowsInViewPortPlaceholder = [];
         this._newTableRows = [];
         this._dataSourceTableRows = [];
+        this._setTableRows([]);
+        this._tableService.setCurrentPage(1);
     }
 
     // Private API


### PR DESCRIPTION
Addition to #11057

Previous fix did not account for set page with previous dataSource. This one resets the page to first.