### PR TITLE
fix(platform): correct list markup

### DIFF
--- a/libs/docs/platform/action-list-item/e2e/action-list-item.po.ts
+++ b/libs/docs/platform/action-list-item/e2e/action-list-item.po.ts
@@ -4,7 +4,7 @@ export class ActionListItemPo extends PlatformBaseComponentPo {
     url = '/action-list-item';
 
     actionBtns = 'fdp-action-list-item button';
-    actionSections = 'fdp-platform-action-list-item-border-less-example ul';
+    actionSections = 'fdp-platform-action-list-item-border-less-example .fd-list';
     cozyItem = 'fdp-platform-action-list-item-border-less-example fdp-list#cozy-list .fd-list__item';
     compactItem = 'fdp-platform-action-list-item-border-less-example fdp-list#compact-list .fd-list__item';
 

--- a/libs/docs/platform/approval-flow/e2e/approval-flow.po.ts
+++ b/libs/docs/platform/approval-flow/e2e/approval-flow.po.ts
@@ -13,7 +13,7 @@ export class ApprovalFlowPo extends PlatformBaseComponentPo {
 
     detailsDialog = 'fd-dialog-container .fd-dialog--active';
     detailsDialogSearchInput = this.detailsDialog + ' input';
-    detailsDialogTeamMember = this.detailsDialog + ' li';
+    detailsDialogTeamMember = this.detailsDialog + ' .fd-list__item';
     detailsDialogTeamMemberName = this.detailsDialog + ' .fd-list__title';
     detailsDialogTeamMemberCheckBox = this.detailsDialogTeamMember + ' fd-checkbox ';
     detailsDialogBackIcon = this.detailsDialog + ' fd-icon';
@@ -39,7 +39,7 @@ export class ApprovalFlowPo extends PlatformBaseComponentPo {
     approvalFlowNodeActionMenuItem = '[role="menuitem"]';
 
     remaindersSendToInput = 'fd-multi-input fd-tokenizer input';
-    selectItem = '.fd-popover-custom-list .fd-list li[role="option"]';
+    selectItem = '.fd-popover-custom-list .fd-list .fd-list__item[role="option"]';
     bottomMenuItems = '.fd-bar__element button';
 
     addNode = '.fdp-approval-flow-node__add';

--- a/libs/docs/platform/display-list-item/e2e/display-list-item.po.ts
+++ b/libs/docs/platform/display-list-item/e2e/display-list-item.po.ts
@@ -8,11 +8,11 @@ export class DisplayListItemPo extends PlatformBaseComponentPo {
     displayLinks = 'fdp-platform-display-list-item-border-less-example a';
     cozyDisplayTitles = 'fdp-platform-display-list-item-border-less-example fdp-list:first-of-type a span';
     comfyDisplayTitles = 'fdp-platform-display-list-item-border-less-example fdp-list:nth-of-type(2) a span';
-    sections = 'fdp-platform-display-list-item-border-less-example ul';
+    sections = 'fdp-platform-display-list-item-border-less-example .fd-list';
 
     declarativeDisplayLinks = 'fdp-platform-display-list-item-with-navigation-example a';
     declarativeDisplayTitles = 'fdp-platform-display-list-item-with-navigation-example a span:first-of-type';
-    declarativeSection = 'fdp-platform-display-list-item-with-navigation-example ul';
+    declarativeSection = 'fdp-platform-display-list-item-with-navigation-example .fd-list';
 
     async open(): Promise<void> {
         await super.open(this.url);

--- a/libs/docs/platform/list/e2e/list.po.ts
+++ b/libs/docs/platform/list/e2e/list.po.ts
@@ -4,63 +4,63 @@ export class ListPo extends PlatformBaseComponentPo {
     private url = '/list';
 
     // borderless examples
-    noBorderListItems = 'fdp-platform-list-border-less-example li';
+    noBorderListItems = 'fdp-platform-list-border-less-example .fd-list__item';
     noBorderCompactList = 'fdp-platform-list-border-less-example #compact-list';
     // footer examples
-    footerListItems = 'fdp-platform-list-with-footer-example fdp-standard-list-item li';
+    footerListItems = 'fdp-platform-list-with-footer-example fdp-standard-list-item .fd-list__item';
     footerCompactList = 'fdp-platform-list-with-footer-example fdp-list[fdCompact]';
-    footer = 'fdp-platform-list-with-footer-example fdp-list-footer li';
+    footer = 'fdp-platform-list-with-footer-example fdp-list-footer .fd-list__item';
     // group header examples
-    groupHeaderListItems = 'fdp-platform-list-with-group-header-example fdp-list-item li';
-    groupHeader = 'fdp-platform-list-with-group-header-example fdp-list-group-header li';
+    groupHeaderListItems = 'fdp-platform-list-with-group-header-example fdp-list-item .fd-list__item';
+    groupHeader = 'fdp-platform-list-with-group-header-example fdp-list-group-header .fd-list__item';
     groupCompactList = 'fdp-platform-list-with-group-header-example fdp-list[fdCompact]';
     // interactive examples
-    interactiveListItems = 'fdp-platform-list-with-group-header fdp-standard-list-item li';
+    interactiveListItems = 'fdp-platform-list-with-group-header fdp-standard-list-item .fd-list__item';
     // counter examples
-    counterListItems = 'fdp-platform-list-with-item-counter-example li';
+    counterListItems = 'fdp-platform-list-with-item-counter-example .fd-list__item';
     counterCompactList = 'fdp-platform-list-with-item-counter-example fdp-list[fdCompact]';
-    counterTitleItems = 'fdp-platform-list-with-item-counter-example li span:first-of-type';
-    counterCounterItem = 'fdp-platform-list-with-item-counter-example li span:nth-of-type(2)';
+    counterTitleItems = 'fdp-platform-list-with-item-counter-example .fd-list__item span:first-of-type';
+    counterCounterItem = 'fdp-platform-list-with-item-counter-example .fd-list__item span:nth-of-type(2)';
     // deletion examples
-    deletionListItems = 'fdp-platform-list-with-delete-button-example li';
+    deletionListItems = 'fdp-platform-list-with-delete-button-example .fd-list__item';
     deletionBtn = 'fdp-platform-list-with-delete-button-example button';
     deletionIcon = 'fdp-platform-list-with-delete-button-example fd-icon';
     // multi selection examples
     multiList = 'fdp-platform-list-with-selection-example fdp-list';
-    multiListItems = 'fdp-platform-list-with-selection-example li';
+    multiListItems = 'fdp-platform-list-with-selection-example .fd-list__item';
     multiToolbar = 'fdp-platform-list-with-selection-example fd-toolbar';
     multiCheckbox = 'fdp-platform-list-with-selection-example fd-checkbox';
-    multiCheckBoxMark = 'fdp-platform-list-with-selection-example fdp-standard-list-item li';
+    multiCheckBoxMark = 'fdp-platform-list-with-selection-example fdp-standard-list-item .fd-list__item';
     // single selection examples
-    singleList = 'fdp-platform-list-with-single-selection-example fdp-list ul';
-    singleListItems = 'fdp-platform-list-with-single-selection-example li';
+    singleList = 'fdp-platform-list-with-single-selection-example fdp-list .fd-list';
+    singleListItems = 'fdp-platform-list-with-single-selection-example .fd-list__item';
     singleToolbar = 'fdp-platform-list-with-single-selection-example fd-toolbar';
     singleRadioBtn = 'fdp-platform-list-with-single-selection-example fd-radio-button';
     singleRadioBtnInput = 'fdp-platform-list-with-single-selection-example input';
     // navigation indicator examples
     navList = 'fdp-platform-list-with-navigation-example fdp-list';
-    navListItems = 'fdp-platform-list-with-navigation-example li';
+    navListItems = 'fdp-platform-list-with-navigation-example .fd-list__item';
     navListLink = 'fdp-platform-list-with-navigation-example a';
     // virtual scroll examples:
-    vScrollListItems = 'fdp-platform-list-with-infinite-scroll-example fdp-standard-list-item li';
+    vScrollListItems = 'fdp-platform-list-with-infinite-scroll-example fdp-standard-list-item .fd-list__item';
     vScrollLoadIcon = 'fd-busy-indicator .fd-busy-indicator';
     busyIndicator = '.fd-busy-indicator';
     // load on btn click examples
     loadList = 'fdp-platform-list-with-more-button-example fdp-list';
-    loadListItems = 'fdp-platform-list-with-more-button-example li';
+    loadListItems = 'fdp-platform-list-with-more-button-example .fd-list__item';
     loadShowMoreBtn = 'fdp-platform-list-with-more-button-example button';
     loadIcon = 'fd-busy-indicator .fd-busy-indicator';
     // button examples
     btnList = 'fdp-platform-list-with-buttons-example fdp-list';
-    btnListItems = 'fdp-platform-list-with-buttons-example li';
+    btnListItems = 'fdp-platform-list-with-buttons-example .fd-list__item';
     btnDeleteBtn = 'fdp-platform-list-with-buttons-example button[id^=delete]';
     btnEditBtn = 'fdp-platform-list-with-buttons-example button[id^=detail]';
     // no data examples
-    noDataListItems = 'fdp-platform-list-with-nodata-example li';
-    noDataCompactList = 'fdp-platform-list-with-nodata-example fdp-list:nth-of-type(2) ul';
+    noDataListItems = 'fdp-platform-list-with-nodata-example .fd-list__item';
+    noDataCompactList = 'fdp-platform-list-with-nodata-example fdp-list:nth-of-type(2) .fd-list';
     // unread data examples
-    unreadListItems = 'fdp-platform-list-with-unread-example li';
-    unreadListItemText = 'fdp-platform-list-with-unread-example li span';
+    unreadListItems = 'fdp-platform-list-with-unread-example .fd-list__item';
+    unreadListItemText = 'fdp-platform-list-with-unread-example .fd-list__item span';
     cozyItem = 'fdp-platform-list-border-less-example fdp-list#cozy-list .fd-list__item';
     compactItem = 'fdp-platform-list-border-less-example fdp-list#compact-list .fd-list__item';
 

--- a/libs/docs/platform/object-list-item/e2e/object-list-item.po.ts
+++ b/libs/docs/platform/object-list-item/e2e/object-list-item.po.ts
@@ -5,7 +5,7 @@ export class ObjectListItemPo extends PlatformBaseComponentPo {
     root = '#page-content';
 
     // selectors for all items on the page
-    allObjsList = 'fdp-object-list-item li';
+    allObjsList = 'fdp-object-list-item .fd-list__item';
     allObjAvatars = 'fdp-object-list-item fd-avatar';
     allObjNumbers = 'fdp-object-list-item fd-object-number';
     allObjIcons = 'fdp-object-list-item i';
@@ -13,26 +13,26 @@ export class ObjectListItemPo extends PlatformBaseComponentPo {
     allObjAttrStatusRows = 'fdp-object-list-item fdp-object-list-item-row';
     // object list item examples
     objListAttr = 'fdp-platform-object-list-item-border-less-example fdp-list';
-    objListItem = 'fdp-platform-object-list-item-border-less-example li';
+    objListItem = 'fdp-platform-object-list-item-border-less-example .fd-list__item';
     obJListIntro = 'fdp-platform-object-list-item-border-less-example .fd-object-list__intro';
     objListAttributes =
         'fdp-platform-object-list-item-border-less-example fdp-object-list-item:first-of-type fd-object-attribute';
     objListStatuses =
         'fdp-platform-object-list-item-border-less-example fdp-object-list-item:first-of-type .fd-object-status';
     // obj list item with row selection examples
-    objListSelItem = 'fdp-platform-object-list-item-with-row-selection-example li';
+    objListSelItem = 'fdp-platform-object-list-item-with-row-selection-example .fd-list__item';
     obJListSelIntro = 'fdp-platform-object-list-item-with-row-selection-example .fd-object-list__intro';
     objListSelAttributes = 'fdp-platform-object-list-item-with-row-selection-example fd-object-attribute';
     objListSelStatuses = 'fdp-platform-object-list-item-with-row-selection-example .fd-object-status';
     objSelToolbar = 'fdp-platform-object-list-item-with-row-selection-example fd-toolbar';
     // obj navigation examples
     objNavLink = 'fdp-platform-object-list-item-with-row-navigation-example a';
-    objNavList = 'fdp-platform-object-list-item-with-row-navigation-example li';
+    objNavList = 'fdp-platform-object-list-item-with-row-navigation-example .fd-list__item';
     objNavAttributes = 'fdp-platform-object-list-item-with-row-navigation-example fd-object-attribute';
     objNavStatuses = 'fdp-platform-object-list-item-with-row-navigation-example .fd-object-status';
     // row selection and navigation examples
     objRowNavLink = 'fdp-platform-object-list-item-with-row-selection-and-navigation-example a';
-    objRowNavList = 'fdp-platform-object-list-item-with-row-selection-and-navigation-example li';
+    objRowNavList = 'fdp-platform-object-list-item-with-row-selection-and-navigation-example .fd-list__item';
     objRowNavAttributes = 'fdp-platform-object-list-item-with-row-selection-and-navigation-example fd-object-attribute';
     objRowNavStatuses = 'fdp-platform-object-list-item-with-row-selection-and-navigation-example .fd-object-status';
     objRowNavToolbar = 'fdp-platform-object-list-item-with-row-selection-and-navigation-example fd-toolbar';

--- a/libs/platform/list/action-list-item/action-list-item.component.html
+++ b/libs/platform/list/action-list-item/action-list-item.component.html
@@ -1,4 +1,4 @@
-<li
+<div
     #listItem
     fd-list-item
     class="fd-list__item--action"
@@ -16,4 +16,4 @@
     <button #action class="fd-list__title" [attr.aria-label]="title" [attr.title]="title" (click)="_onActionClick()">
         {{ title }}
     </button>
-</li>
+</div>

--- a/libs/platform/list/action-list-item/action-list-item.component.spec.ts
+++ b/libs/platform/list/action-list-item/action-list-item.component.spec.ts
@@ -69,13 +69,13 @@ describe('ActionListItemComponent', () => {
     });
 
     it('Should display list container with role as list', () => {
-        const listContainer = fixture.debugElement.query(By.css('ul'));
+        const listContainer = fixture.debugElement.query(By.css('.fd-list'));
         fixture.detectChanges();
         expect(listContainer.nativeElement.getAttribute('role')).toEqual('list');
     });
 
     it('Should contain fd-list in list container', () => {
-        const listContainer = fixture.debugElement.query(By.css('ul'));
+        const listContainer = fixture.debugElement.query(By.css('.fd-list'));
         fixture.detectChanges();
         expect(listContainer.nativeElement.classList).toContain('fd-list');
     });
@@ -87,7 +87,7 @@ describe('ActionListItemComponent', () => {
     });
 
     it('Actionable items should has class list item actions', () => {
-        const actionItems = fixture.debugElement.queryAll(By.css('li'));
+        const actionItems = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         fixture.detectChanges();
         expect(actionItems[0].nativeElement.classList).toContain('fd-list__item--action');
     });
@@ -133,7 +133,7 @@ describe('ActionListItemComponent', () => {
     });
 
     it('Should has unique identification for list item', () => {
-        const actionItems = fixture.debugElement.queryAll(By.css('li'));
+        const actionItems = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         fixture.detectChanges();
         expect(actionItems[0].nativeElement.getAttribute('id')).toContain('fdp-list-item');
     });
@@ -192,13 +192,13 @@ describe('ActionListItemComponent Imperative', () => {
     });
 
     it('should create action list items with given values', () => {
-        const actionListElems = fixture.debugElement.queryAll(By.css('li'));
+        const actionListElems = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         expect(actionListElems.length).toEqual(4);
         actionListElems.forEach((listElem) => {
             expect(listElem.nativeElement.getAttribute('id')).toBeTruthy();
         });
 
-        const liElems = fixture.debugElement.queryAll(By.css('li'));
+        const liElems = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         expect(liElems.length).toEqual(4);
         liElems.forEach((liElem) => {
             expect(liElem.nativeElement.getAttribute('tabindex')).toBeTruthy();

--- a/libs/platform/list/base-list-item.ts
+++ b/libs/platform/list/base-list-item.ts
@@ -511,7 +511,8 @@ export class BaseListItem extends BaseComponent implements OnInit, AfterViewInit
      * will be deducted in list item
      */
     ngAfterViewChecked(): void {
-        const currentItem: Nullable<HTMLLIElement> = this.itemEl.nativeElement.querySelector('li');
+        const currentItem: Nullable<HTMLElement> =
+            this.itemEl.nativeElement.querySelector<HTMLElement>('.fd-list__item');
         if (!currentItem) {
             return;
         }

--- a/libs/platform/list/display-list-item/display-list-item.component.html
+++ b/libs/platform/list/display-list-item/display-list-item.component.html
@@ -1,6 +1,6 @@
 <!--  list item navigation with Arrow-->
 @if (navigationIndicator || (navigated && !(noDataText !== null && noDataText !== undefined))) {
-    <li
+    <div
         #listItem
         fd-list-item
         [attr.id]="id"
@@ -26,11 +26,11 @@
         >
             <ng-template [ngTemplateOutlet]="commonTemplate"></ng-template>
         </a>
-    </li>
+    </div>
 }
 <!--  list item without navigation and used for simple list display-->
 @if (!navigationIndicator && !navigated && !(noDataText !== null && noDataText !== undefined)) {
-    <li
+    <div
         #listItem
         fd-list-item
         [attr.id]="id"
@@ -47,7 +47,7 @@
         [attr.aria-selected]="_selectedAttr"
     >
         <ng-template [ngTemplateOutlet]="commonTemplate"></ng-template>
-    </li>
+    </div>
 }
 <ng-template #commonTemplate>
     @if (title) {

--- a/libs/platform/list/display-list-item/display-list-item.component.spec.ts
+++ b/libs/platform/list/display-list-item/display-list-item.component.spec.ts
@@ -54,13 +54,13 @@ describe('DisplayListItemComponent', () => {
     });
 
     it('Should display list container with role as list', () => {
-        const listContainer = fixture.debugElement.query(By.css('ul'));
+        const listContainer = fixture.debugElement.query(By.css('.fd-list'));
         fixture.detectChanges();
         expect(listContainer.nativeElement.getAttribute('role')).toEqual('list');
     });
 
     it('Should contain fd-list in list container', () => {
-        const listContainer = fixture.debugElement.query(By.css('ul'));
+        const listContainer = fixture.debugElement.query(By.css('.fd-list'));
         fixture.detectChanges();
         expect(listContainer.nativeElement.classList).toContain('fd-list');
     });
@@ -92,7 +92,7 @@ describe('DisplayListItemComponent', () => {
     });
 
     it('Should has unique identification for list item', () => {
-        const displayItems = fixture.debugElement.queryAll(By.css('li'));
+        const displayItems = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         fixture.detectChanges();
         expect(displayItems[0].nativeElement.getAttribute('id')).toContain('fdp-list-item');
     });
@@ -110,7 +110,7 @@ describe('DisplayListItemComponent', () => {
     });
 
     it('Should has partial Navigation on 2 list item', () => {
-        const naviationItems = fixture.debugElement.queryAll(By.css('li'));
+        const naviationItems = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         expect(naviationItems.length).toEqual(4);
         fixture.detectChanges();
         naviationItems.forEach((navElem) => {
@@ -168,13 +168,13 @@ describe('DisplayListItemComponent Imperative', () => {
     });
 
     it('should create display list items with given values', () => {
-        const displayListElems = fixture.debugElement.queryAll(By.css('li'));
+        const displayListElems = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         expect(displayListElems.length).toEqual(4);
         displayListElems.forEach((listElem) => {
             expect(listElem.nativeElement.getAttribute('id')).toBeTruthy();
         });
 
-        const liElems = fixture.debugElement.queryAll(By.css('li'));
+        const liElems = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         expect(liElems.length).toEqual(4);
         liElems.forEach((liElem) => {
             expect(liElem.nativeElement.getAttribute('tabindex')).toBeTruthy();
@@ -182,29 +182,29 @@ describe('DisplayListItemComponent Imperative', () => {
     });
 
     it('Title and secondary should to present for all Items', () => {
-        const li0 = fixture.debugElement.queryAll(By.css('li'))[0];
+        const li0 = fixture.debugElement.queryAll(By.css('.fd-list__item'))[0];
         const displayElems0 = li0.queryAll(By.css('span'));
         expect(displayElems0[0].nativeElement.getAttribute('title')).toEqual('title 1');
         expect(displayElems0[1].nativeElement.getAttribute('title')).toEqual('secondary 1');
 
-        const li1 = fixture.debugElement.queryAll(By.css('li'))[1];
+        const li1 = fixture.debugElement.queryAll(By.css('.fd-list__item'))[1];
         const displayElems1 = li1.queryAll(By.css('span'));
         expect(displayElems1[0].nativeElement.getAttribute('title')).toEqual('title 2');
         expect(displayElems1[1].nativeElement.getAttribute('title')).toEqual('secondary 2');
 
-        const li2 = fixture.debugElement.queryAll(By.css('li'))[2];
+        const li2 = fixture.debugElement.queryAll(By.css('.fd-list__item'))[2];
         const displayElems2 = li2.queryAll(By.css('span'));
         expect(displayElems2[0].nativeElement.getAttribute('title')).toEqual('title 3');
         expect(displayElems2[1].nativeElement.getAttribute('title')).toEqual('secondary 3');
 
-        const li3 = fixture.debugElement.queryAll(By.css('li'))[3];
+        const li3 = fixture.debugElement.queryAll(By.css('.fd-list__item'))[3];
         const displayElems3 = li3.queryAll(By.css('span'));
         expect(displayElems3[0].nativeElement.getAttribute('title')).toEqual('title 4');
         expect(displayElems3[1].nativeElement.getAttribute('title')).toEqual('secondary 4');
     });
 
     it('Should have partial Navigation enabled 4 list item', () => {
-        const naviationItemsImp = fixture.debugElement.queryAll(By.css('li'));
+        const naviationItemsImp = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         expect(naviationItemsImp.length).toEqual(4);
         fixture.detectChanges();
         expect(naviationItemsImp[0].nativeElement.classList).toContain('fd-list__item--link');

--- a/libs/platform/list/free-content-list-item/free-content-list-item.component.html
+++ b/libs/platform/list/free-content-list-item/free-content-list-item.component.html
@@ -1,4 +1,4 @@
-<li
+<div
     #listItem
     [class.fd-list__item--unread]="unRead"
     fd-list-item
@@ -19,4 +19,4 @@
     [attr.aria-selected]="_selectedAttr"
 >
     <ng-content></ng-content>
-</li>
+</div>

--- a/libs/platform/list/free-content-list-item/free-content-list-item.component.spec.ts
+++ b/libs/platform/list/free-content-list-item/free-content-list-item.component.spec.ts
@@ -39,19 +39,19 @@ describe('FreeContentListItemComponent', () => {
 
     it('should render a list item', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('li');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list__item');
         expect(listElement.classList).toContain('fd-list__item');
     });
 
     it('list item should have tabindex', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('li');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list__item');
         expect(listElement.getAttribute('tabindex')).toEqual('0');
     });
 
     it('list item should have id', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('li');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list__item');
         expect(listElement.getAttribute('id')).toContain('fdp-list-item-');
     });
 

--- a/libs/platform/list/list-group-footer.component.ts
+++ b/libs/platform/list/list-group-footer.component.ts
@@ -4,7 +4,7 @@ import { LIST_ITEM_TYPE } from './base-list-item';
 
 @Component({
     selector: 'fdp-list-footer',
-    template: `<li #listFooter class="fd-list__footer" [attr.id]="id" role="option"><ng-content></ng-content></li>`,
+    template: `<div #listFooter class="fd-list__footer" [attr.id]="id" role="option"><ng-content></ng-content></div>`,
     standalone: true,
     host: {
         role: 'none'

--- a/libs/platform/list/list-group-header.component.ts
+++ b/libs/platform/list/list-group-header.component.ts
@@ -6,7 +6,7 @@ let nextListGrpHeaderId = 0;
 
 @Component({
     selector: 'fdp-list-group-header',
-    template: ` <li
+    template: ` <div
         #listItem
         fd-list-group-header
         [attr.aria-labelledby]="ariaLabelledBy"
@@ -17,7 +17,7 @@ let nextListGrpHeaderId = 0;
     >
         <span fd-list-title>{{ groupHeaderTitle }}</span>
         <ng-content></ng-content>
-    </li>`,
+    </div>`,
     providers: [{ provide: BaseListItem, useExisting: forwardRef(() => ListGroupHeaderComponent) }],
     standalone: true,
     host: {

--- a/libs/platform/list/list.component.html
+++ b/libs/platform/list/list.component.html
@@ -1,5 +1,5 @@
 <ng-content select="fd-toolbar"></ng-content>
-<ul
+<div
     fd-list
     [attr.id]="id"
     [noBorder]="noBorder"
@@ -137,4 +137,4 @@
             </button>
         }
     </ng-template>
-</ul>
+</div>

--- a/libs/platform/list/list.component.spec.ts
+++ b/libs/platform/list/list.component.spec.ts
@@ -74,38 +74,38 @@ describe('ListComponent', () => {
     });
 
     it('should display list container with role as list', () => {
-        const listContainer = fixture.debugElement.nativeElement.querySelector('ul');
+        const listContainer = fixture.debugElement.nativeElement.querySelector('.fd-list');
         fixture.detectChanges();
         expect(listContainer.getAttribute('role')).toEqual('list');
     });
 
     it('should contain fd-list in list container', () => {
-        const listContainer = fixture.debugElement.nativeElement.querySelector('ul');
+        const listContainer = fixture.debugElement.nativeElement.querySelector('.fd-list');
         fixture.detectChanges();
         expect(listContainer.classList).toContain('fd-list');
     });
 
     it('should contain list--no-border class', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('ul');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list');
         expect(listElement.classList).toContain('fd-list--no-border');
     });
 
     it('should contain by Line class', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('ul');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list');
         expect(listElement.classList).toContain('fd-list--byline');
     });
 
     it('should contain show navigation arrow', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('ul');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list');
         expect(listElement.classList).toContain('fd-list--navigation-indication');
     });
 
     it('should contain navigation', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('ul');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list');
         expect(listElement.classList).toContain('fd-list--navigation-indication');
     });
 });

--- a/libs/platform/list/list.component.ts
+++ b/libs/platform/list/list.component.ts
@@ -311,7 +311,7 @@ export class ListComponent<T>
 
     /** @hidden */
     get _ulElement(): Nullable<HTMLUListElement> {
-        return this.elementRef.nativeElement.querySelector('ul');
+        return this.elementRef.nativeElement.querySelector('.fd-list');
     }
 
     /**
@@ -474,7 +474,7 @@ export class ListComponent<T>
         const linkElement = el.querySelector('a');
         if (el.tagName.toLowerCase() === 'a') {
             el.classList.add('is-navigated');
-        } else if (el.tagName.toLowerCase() === 'li' && !!linkElement) {
+        } else if (el.classList.contains('fd-list__item') && !!linkElement) {
             linkElement.classList.add('is-navigated');
         }
 

--- a/libs/platform/list/object-list-item/object-list-item.component.html
+++ b/libs/platform/list/object-list-item/object-list-item.component.html
@@ -1,6 +1,6 @@
 <!--  list item navigation with Arrow-->
 @if (navigationIndicator || (navigated && !(noDataText !== null && noDataText !== undefined))) {
-    <li
+    <div
         #listItem
         fd-list-item
         [attr.id]="id"
@@ -32,11 +32,11 @@
         >
             <ng-template [ngTemplateOutlet]="objectTemplate"></ng-template>
         </a>
-    </li>
+    </div>
 }
 <!--  list item without navigation and used for simple list display-->
 @if (!navigationIndicator && !navigated && !(noDataText !== null && noDataText !== undefined)) {
-    <li
+    <div
         #listItem
         fd-list-item
         [attr.id]="id"
@@ -56,10 +56,10 @@
     >
         <ng-template [ngTemplateOutlet]="selectionTemplate"></ng-template>
         <ng-template [ngTemplateOutlet]="objectTemplate"></ng-template>
-    </li>
+    </div>
 }
 @if (noDataText !== null && noDataText !== undefined) {
-    <li
+    <div
         #listItem
         fd-list-item
         [attr.id]="id"
@@ -71,7 +71,7 @@
         [attr.aria-setsize]="ariaSetSize | async"
     >
         <span fd-list-title [attr.aria-label]="noDataText" [attr.title]="noDataText">{{ noDataText }}</span>
-    </li>
+    </div>
 }
 <ng-template #objectTemplate>
     <div class="fd-object-list__container">

--- a/libs/platform/list/object-list-item/object-list-item.component.spec.ts
+++ b/libs/platform/list/object-list-item/object-list-item.component.spec.ts
@@ -56,13 +56,13 @@ describe('ObjectListItemComponent', () => {
     });
 
     it('Should contain fd-list in list container', () => {
-        const listContainer = fixture.debugElement.query(By.css('ul'));
+        const listContainer = fixture.debugElement.query(By.css('.fd-list'));
         fixture.detectChanges();
         expect(listContainer.nativeElement.classList).toContain('fd-list');
     });
 
     it('Should contain fd-list in list should have object list enabled', () => {
-        const listContainer = fixture.debugElement.query(By.css('ul'));
+        const listContainer = fixture.debugElement.query(By.css('.fd-list'));
         fixture.detectChanges();
         expect(listContainer.nativeElement.classList).toContain('fd-object-list');
     });
@@ -114,7 +114,7 @@ describe('ObjectListItemComponent', () => {
     });
 
     it('object list item should have id present', () => {
-        const listItems = fixture.debugElement.queryAll(By.css('li'));
+        const listItems = fixture.debugElement.queryAll(By.css('.fd-list__item'));
         fixture.detectChanges();
         listItems.forEach((listElem) => {
             expect(listElem.nativeElement.getAttribute('id')).toContain('fdp-list-item');
@@ -386,13 +386,13 @@ describe('Object  List Item Component with DataSource', () => {
     });
 
     it('Should Object list container with role as list', () => {
-        const listContainer = fixture.debugElement.query(By.css('ul'));
+        const listContainer = fixture.debugElement.query(By.css('.fd-list'));
         fixture.detectChanges();
         expect(listContainer.nativeElement.getAttribute('role')).toEqual('list');
     });
 
     it('Should contain fd-list and fd-object-list class in list', () => {
-        const listContainer = fixture.debugElement.query(By.css('ul'));
+        const listContainer = fixture.debugElement.query(By.css('.fd-list'));
         fixture.detectChanges();
         expect(listContainer.nativeElement.classList).toContain('fd-list');
         expect(listContainer.nativeElement.classList).toContain('fd-object-list');

--- a/libs/platform/list/standard-list-item/standard-list-item.component.html
+++ b/libs/platform/list/standard-list-item/standard-list-item.component.html
@@ -1,6 +1,6 @@
 <!--  list item navigation with Arrow-->
 @if (navigationIndicator || (navigated && !(noDataText !== null && noDataText !== undefined))) {
-    <li
+    <div
         #listItem
         [unread]="unRead"
         fd-list-item
@@ -29,11 +29,11 @@
         >
             <ng-template [ngTemplateOutlet]="_hasByLine ? byLineTemplate : commonTemplate"></ng-template>
         </a>
-    </li>
+    </div>
 }
 <!--  list item without navigation and used for simple list display-->
 @if (!navigationIndicator && !navigated && !(noDataText !== null && noDataText !== undefined)) {
-    <li
+    <div
         #listItem
         [unread]="unRead"
         fd-list-item
@@ -53,10 +53,10 @@
     >
         <ng-template [ngTemplateOutlet]="selectionTemplate"></ng-template>
         <ng-template [ngTemplateOutlet]="_hasByLine ? byLineTemplate : commonTemplate"></ng-template>
-    </li>
+    </div>
 }
 @if (noDataText !== null && noDataText !== undefined) {
-    <li
+    <div
         #listItem
         fd-list-item
         [attr.id]="id"
@@ -67,7 +67,7 @@
         [attr.aria-setsize]="ariaSetSize | async"
     >
         <span fd-list-title [attr.aria-label]="noDataText" [attr.title]="noDataText">{{ noDataText }}</span>
-    </li>
+    </div>
 }
 <ng-template #commonTemplate>
     @if (icon.glyph) {

--- a/libs/platform/list/standard-list-item/standard-list-item.component.spec.ts
+++ b/libs/platform/list/standard-list-item/standard-list-item.component.spec.ts
@@ -67,19 +67,19 @@ describe('StandardListItemComponent', () => {
 
     it('should render a list item', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('li');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list__item');
         expect(listElement.classList).toContain('fd-list__item');
     });
 
     it('list item should have tabindex', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('li');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list__item');
         expect(listElement.getAttribute('tabindex')).toEqual('0');
     });
 
     it('list item should have id', () => {
         fixture.detectChanges();
-        const listElement = fixture.debugElement.nativeElement.querySelector('li');
+        const listElement = fixture.debugElement.nativeElement.querySelector('.fd-list__item');
         expect(listElement.getAttribute('id')).toContain('fdp-list-item-');
     });
 });


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10993

## Description
Instead of having `fdp-list -> ul  -> fdp-list-item -> li` element tree, now we would have `fdp-list -> div.fd-list -> fdp-list-item -> div.fd-list__item`, which is more correct. It should not affect the accessibility tools since we already use roles for the list and list items.

BREAKING CHANGE:
Resulting markup will change:
Before:
```html
<fdp-list>
    <ul class="fd-list">
        <fdp-standard-list-item>
            <li class="fd-list__item">...</li>
        </fdp-standard-list-item>
    </ul>
</fdp-list>
```
After:
```html
<fdp-list>
    <div class="fd-list">
        <fdp-standard-list-item>
            <div class="fd-list__item">...</div>
        </fdp-standard-list-item>
    </div>
</fdp-list>
```