### PR TITLE
feat(btp,core,platform): glyph font family support

### DIFF
--- a/libs/btp/navigation-menu/src/lib/navigation-menu-item.component.ts
+++ b/libs/btp/navigation-menu/src/lib/navigation-menu-item.component.ts
@@ -6,14 +6,20 @@ import {
     IndirectFocusableItemDirective,
     Nullable
 } from '@fundamental-ngx/cdk/utils';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { fromEvent, Observable } from 'rxjs';
 
 @Component({
     selector: 'fdb-navigation-menu-item, li[fdb-navigation-menu-item]',
     template: `
         @if (glyph) {
-            <fd-icon class="fd-navigation-menu__icon" [glyph]="glyph" role="presentation" aria-hidden="true"></fd-icon>
+            <fd-icon
+                class="fd-navigation-menu__icon"
+                [glyph]="glyph"
+                [font]="glyphFont"
+                role="presentation"
+                aria-hidden="true"
+            ></fd-icon>
         }
         @if (label) {
             <span class="fd-navigation-menu__text">
@@ -41,6 +47,10 @@ export class NavigationMenuItemComponent implements FocusableItem, HasElementRef
      */
     @Input()
     glyph: Nullable<string>;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /**
      * Text to be displayed.

--- a/libs/btp/navigation/components/navigation-link/navigation-link.component.html
+++ b/libs/btp/navigation/components/navigation-link/navigation-link.component.html
@@ -1,5 +1,11 @@
 @if (glyph) {
-    <fd-icon [glyph]="glyph" class="fd-navigation__icon" [attr.role]="'presentation'" [ariaHidden]="true"></fd-icon>
+    <fd-icon
+        [glyph]="glyph"
+        [font]="glyphFont"
+        class="fd-navigation__icon"
+        [attr.role]="'presentation'"
+        [ariaHidden]="true"
+    ></fd-icon>
 }
 <span class="fd-navigation__text">
     <ng-content></ng-content>

--- a/libs/btp/navigation/components/navigation-link/navigation-link.component.ts
+++ b/libs/btp/navigation/components/navigation-link/navigation-link.component.ts
@@ -18,7 +18,7 @@ import {
 import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { KeyUtil, Nullable, RtlService } from '@fundamental-ngx/cdk';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { of, startWith } from 'rxjs';
 import { FdbNavigationItemLink } from '../../models/navigation-item-link.class';
 import { FdbNavigationListItem } from '../../models/navigation-list-item.class';
@@ -58,9 +58,13 @@ export class NavigationLinkComponent extends FdbNavigationItemLink implements On
     @Input()
     class: Nullable<string>;
 
-    /** @hidden */
+    /** Link glyph */
     @Input()
     glyph: Nullable<string>;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Whether the link is for the external resource. */
     @Input()

--- a/libs/core/action-sheet/action-sheet-item/action-sheet-item.component.html
+++ b/libs/core/action-sheet/action-sheet-item/action-sheet-item.component.html
@@ -5,6 +5,7 @@
     class="fd-button--full-width"
     [label]="label"
     [glyph]="glyph"
+    [glyphFont]="glyphFont"
     [disabled]="disabled"
 >
     <ng-content></ng-content>

--- a/libs/core/action-sheet/action-sheet-item/action-sheet-item.component.ts
+++ b/libs/core/action-sheet/action-sheet-item/action-sheet-item.component.ts
@@ -11,6 +11,7 @@ import {
 } from '@angular/core';
 import { KeyboardSupportItemInterface } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 
 export interface ActionSheetClickEvent {
     shouldClose: boolean;
@@ -50,6 +51,10 @@ export class ActionSheetItemComponent implements KeyboardSupportItemInterface {
     /** Sets icon of action item. */
     @Input()
     glyph: string;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Indicate state of the button.*/
     @Input()

--- a/libs/core/avatar/avatar.component.ts
+++ b/libs/core/avatar/avatar.component.ts
@@ -24,7 +24,7 @@ import {
     applyCssClass,
     getRandomColorAccent
 } from '@fundamental-ngx/cdk/utils';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent } from '@fundamental-ngx/core/icon';
 import { AvatarIconPipe } from './avatar-icon.pipe';
 import { AvatarValueStates } from './avatar-value-states.type';
 import { FD_AVATAR_COMPONENT } from './tokens';
@@ -89,7 +89,7 @@ export class AvatarComponent implements OnChanges, OnInit, CssClassBuilder, OnCh
 
     /** Font family of the icon. */
     @Input()
-    font: IconComponent['font'] = 'SAP-icons';
+    font: IconComponent['font'] = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** The glyph name. */
     @Input() glyph: Nullable<string> = null;

--- a/libs/core/button/base-button.ts
+++ b/libs/core/button/base-button.ts
@@ -2,6 +2,7 @@ import { BooleanInput, coerceBooleanProperty } from '@angular/cdk/coercion';
 import { Directive, HostBinding, Input } from '@angular/core';
 
 import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 
 export type GlyphPosition = 'before' | 'after';
 
@@ -24,12 +25,6 @@ export class BaseButton {
     @HostBinding('attr.aria-pressed')
     _toggled: Nullable<boolean>;
 
-    /** @hidden */
-    _disabled = false;
-
-    /** @hidden */
-    _ariaDisabled: boolean;
-
     /**
      * Native type of button element
      */
@@ -46,6 +41,10 @@ export class BaseButton {
      */
     @Input()
     glyph: Nullable<string>;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** The type of the button. Types include:
      * 'standard' | 'positive' | 'negative' | 'attention' | 'half' | 'ghost' | 'transparent' | 'emphasized' | 'menu'.
@@ -107,4 +106,10 @@ export class BaseButton {
     get ariaDisabled(): boolean {
         return this._ariaDisabled;
     }
+
+    /** @hidden */
+    _disabled = false;
+
+    /** @hidden */
+    _ariaDisabled: boolean;
 }

--- a/libs/core/button/button.component.html
+++ b/libs/core/button/button.component.html
@@ -1,5 +1,5 @@
 @if (glyph && glyphPosition === 'before') {
-    <fd-icon [glyph]="glyph"></fd-icon>
+    <fd-icon [glyph]="glyph" [font]="glyphFont"></fd-icon>
 }
 @if (label) {
     <span class="fd-button__text">
@@ -9,7 +9,7 @@
 <ng-content></ng-content>
 <ng-content select="fd-button-badge"></ng-content>
 @if (glyph && glyphPosition === 'after') {
-    <fd-icon [glyph]="glyph"></fd-icon>
+    <fd-icon [glyph]="glyph" [font]="glyphFont"></fd-icon>
 }
 @if (fdMenu) {
     <fd-icon glyph="slim-arrow-down"></fd-icon>

--- a/libs/core/combobox/combobox.component.html
+++ b/libs/core/combobox/combobox.component.html
@@ -43,6 +43,7 @@
     <fd-input-group
         [button]="showDropdownButton"
         [glyph]="showDropdownButton ? glyphValue : null"
+        [glyphFont]="isSearch ? _defaultFontFamily : glyphFont"
         [state]="state"
         [buttonFocusable]="buttonFocusable"
         [disabled]="disabled"

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -62,7 +62,7 @@ import {
     ContentDensityObserver,
     contentDensityObserverProviders
 } from '@fundamental-ngx/core/content-density';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 import { ListModule } from '@fundamental-ngx/core/list';
 import { PopoverBodyComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
@@ -191,6 +191,10 @@ export class ComboboxComponent<T = any>
     /** Icon to display in the right-side button. */
     @Input()
     glyph = 'navigation-down-arrow';
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /**
      * Whether to show the clear search term button when the Combobox is a Search Field
@@ -401,6 +405,9 @@ export class ComboboxComponent<T = any>
 
     /** @hidden */
     readonly _repositionScrollStrategy: RepositionScrollStrategy;
+
+    /** @hidden */
+    readonly _defaultFontFamily = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Whether the combobox is opened. */
     open = false;

--- a/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
+++ b/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
@@ -23,7 +23,7 @@
                     [attr.aria-controls]="id"
                     (click)="toggleCollapse()"
                 >
-                    <i [class.sap-icon--slim-arrow-up]="!collapsed" [class.sap-icon--slim-arrow-down]="collapsed"></i>
+                    <fd-icon [glyph]="collapsed ? 'slim-arrow-down' : 'slim-arrow-up'"></fd-icon>
                 </button>
                 @if (pinnable && !collapsed) {
                     <button
@@ -34,7 +34,7 @@
                         [toggled]="_pinned"
                         (click)="togglePinned()"
                     >
-                        <i class="sap-icon--pushpin-off"></i>
+                        <fd-icon glyph="pushpin-off"></fd-icon>
                     </button>
                 }
             </div>

--- a/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.ts
+++ b/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.ts
@@ -16,6 +16,7 @@ import { distinctUntilChanged } from 'rxjs/operators';
 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 import { FD_LANGUAGE, FdTranslatePipe, resolveTranslationSignalFn } from '@fundamental-ngx/i18n';
 import { DynamicPageConfig } from '../../dynamic-page.config';
 import { DynamicPageService } from '../../dynamic-page.service';
@@ -28,7 +29,7 @@ let dynamicPageSubHeaderId = 0;
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [ButtonComponent, FdTranslatePipe],
+    imports: [ButtonComponent, FdTranslatePipe, IconComponent],
     providers: [
         {
             provide: FD_LANGUAGE,

--- a/libs/core/flexible-column-layout/flexible-column-layout.component.html
+++ b/libs/core/flexible-column-layout/flexible-column-layout.component.html
@@ -27,10 +27,10 @@
                 class="fd-flexible-column-layout__button"
                 [title]="_leftColumnSeparator === 'left' ? expandTitle : collapseTitle"
             >
-                <i
-                    [class]="_leftColumnSeparator ? 'sap-icon--slim-arrow-' + _leftColumnSeparator : ''"
+                <fd-icon
+                    [glyph]="_leftColumnSeparator ? 'slim-arrow-' + _leftColumnSeparator : ''"
                     role="presentation"
-                ></i>
+                ></fd-icon>
             </button>
         </div>
     }
@@ -58,10 +58,10 @@
                 class="fd-flexible-column-layout__button"
                 [title]="_rightColumnSeparator === 'left' ? expandTitle : collapseTitle"
             >
-                <i
-                    [class]="_rightColumnSeparator ? 'sap-icon--slim-arrow-' + _rightColumnSeparator : ''"
+                <fd-icon
+                    [glyph]="_rightColumnSeparator ? 'slim-arrow-' + _rightColumnSeparator : ''"
                     role="presentation"
-                ></i>
+                ></fd-icon>
             </button>
         </div>
     }

--- a/libs/core/flexible-column-layout/flexible-column-layout.component.ts
+++ b/libs/core/flexible-column-layout/flexible-column-layout.component.ts
@@ -17,6 +17,7 @@ import {
 } from '@angular/core';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityDirective } from '@fundamental-ngx/core/content-density';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 import { Subscription, fromEvent } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import {
@@ -55,7 +56,7 @@ import { FD_FLEXIBLE_COLUMN_LAYOUT_COMPONENT } from './tokens';
         }
     ],
     standalone: true,
-    imports: [NgTemplateOutlet, ButtonComponent, ContentDensityDirective]
+    imports: [NgTemplateOutlet, ButtonComponent, ContentDensityDirective, IconComponent]
 })
 export class FlexibleColumnLayoutComponent implements AfterViewInit, OnChanges, OnDestroy, OnInit {
     /**

--- a/libs/core/generic-tag/generic-tag.component.html
+++ b/libs/core/generic-tag/generic-tag.component.html
@@ -1,11 +1,10 @@
 @if (type) {
-    <span
+    <fd-icon
         class="fd-generic-tag__icon"
-        [class]="type ? 'sap-icon--message-' + type : ''"
+        [glyph]="type ? 'message-' + type : ''"
         role="presentation"
         aria-hidden="true"
-    >
-    </span>
+    ></fd-icon>
 }
 <span class="fd-generic-tag__name">{{ name }}</span>
 @if (value) {

--- a/libs/core/generic-tag/generic-tag.component.ts
+++ b/libs/core/generic-tag/generic-tag.component.ts
@@ -10,6 +10,7 @@ import {
     inject
 } from '@angular/core';
 import { CssClassBuilder, Nullable, NullableObject, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 import { FD_GENERIC_TAG_COMPONENT } from './tokens';
 
 export type GenericTagType = 'error' | 'success' | 'warning' | 'information';
@@ -33,7 +34,7 @@ export type GenericTagType = 'error' | 'success' | 'warning' | 'information';
         role: 'button'
     },
     standalone: true,
-    imports: [NgClass]
+    imports: [NgClass, IconComponent]
 })
 export class GenericTagComponent implements OnChanges, OnInit, CssClassBuilder {
     /** User's custom classes */

--- a/libs/core/icon/icon.component.ts
+++ b/libs/core/icon/icon.component.ts
@@ -14,6 +14,8 @@ import { FD_ICON_COMPONENT } from './tokens';
 
 export type IconFont = 'SAP-icons' | 'BusinessSuiteInAppSymbols' | 'SAP-icons-TNT';
 
+export const FD_DEFAULT_ICON_FONT_FAMILY = 'SAP-icons';
+
 export type IconColor =
     | 'default'
     | 'contrast'
@@ -33,6 +35,35 @@ export const FD_ICON_FONT_FAMILY: Record<IconFont, string> = {
     BusinessSuiteInAppSymbols: `${SAP_ICONS_PREFIX}-businessSuiteInAppSymbols`,
     'SAP-icons-TNT': `${SAP_ICONS_PREFIX}-TNT`
 };
+
+/**
+ * Helper function to build icon css class.
+ * @param font Font family
+ * @param glyph Icon
+ * @param color Icon color
+ * @param background Icon background color
+ * @returns Computed css class string.
+ */
+export function fdBuildIconClass(
+    font: IconFont,
+    glyph: any,
+    color?: IconColor | null,
+    background?: IconColor | null
+): string {
+    const fontFamily = FD_ICON_FONT_FAMILY[font];
+
+    const returnIconClass = [`${fontFamily}--${glyph}`];
+
+    if (color) {
+        returnIconClass.push(`${fontFamily}--color-${color}`);
+    }
+
+    if (background) {
+        returnIconClass.push(`${fontFamily}--background-${background}`);
+    }
+
+    return returnIconClass.join(' ');
+}
 
 /**
  * The component that represents an icon.
@@ -121,7 +152,7 @@ export class IconComponent implements CssClassBuilder {
     /** @hidden */
     private readonly _glyph = signal<any>('');
     /** @hidden */
-    private readonly _font = signal<IconFont>('SAP-icons');
+    private readonly _font = signal<IconFont>(FD_DEFAULT_ICON_FONT_FAMILY);
 
     /** @hidden */
     private readonly _color = signal<IconColor | null>(null);
@@ -130,21 +161,9 @@ export class IconComponent implements CssClassBuilder {
     private readonly _background = signal<IconColor | null>(null);
 
     /** @hidden */
-    private readonly _fontIconClass = computed(() => {
-        const fontFamily = FD_ICON_FONT_FAMILY[this._font()];
-
-        const returnIconClass = [`${fontFamily}--${this._glyph()}`];
-
-        if (this._color()) {
-            returnIconClass.push(`${fontFamily}--color-${this._color()}`);
-        }
-
-        if (this._background()) {
-            returnIconClass.push(`${fontFamily}--background-${this._background()}`);
-        }
-
-        return returnIconClass.join(' ');
-    });
+    private readonly _fontIconClass = computed(() =>
+        fdBuildIconClass(this._font(), this._glyph(), this._color(), this._background())
+    );
 
     /** @hidden */
     constructor(public readonly elementRef: ElementRef) {

--- a/libs/core/input-group/input-group.component.html
+++ b/libs/core/input-group/input-group.component.html
@@ -30,6 +30,7 @@
                     [attr.tabindex]="buttonFocusable ? 0 : -1"
                     [attr.title]="iconTitle || glyphAriaLabel || glyph"
                     [glyph]="glyph"
+                    [glyphFont]="glyphFont"
                     [class.fd-shellbar__button]="inShellbar"
                     [class.is-expanded]="isExpanded"
                     [attr.aria-haspopup]="isControl"
@@ -58,7 +59,7 @@
                 @if (!glyph) {
                     {{ addOnText }}
                 } @else {
-                    <span [className]="'sap-icon--' + glyph"></span>
+                    <fd-icon [glyph]="glyph" [font]="glyphFont"></fd-icon>
                 }
             </span>
         }

--- a/libs/core/input-group/input-group.component.ts
+++ b/libs/core/input-group/input-group.component.ts
@@ -23,6 +23,7 @@ import { FormItemControl, registerFormItemControl } from '@fundamental-ngx/core/
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { FormStates } from '@fundamental-ngx/cdk/forms';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import {
     InputGroupAddonButtonDirective,
     InputGroupAddOnDirective,
@@ -69,7 +70,8 @@ let addOnInputRandomId = 0;
         InputGroupAddonButtonDirective,
         FormsModule,
         InputGroupInputDirective,
-        AsyncPipe
+        AsyncPipe,
+        IconComponent
     ]
 })
 export class InputGroupComponent implements ControlValueAccessor, AfterViewInit, OnDestroy, FormItemControl {
@@ -107,6 +109,10 @@ export class InputGroupComponent implements ControlValueAccessor, AfterViewInit,
     /** The icon value for the add-on. */
     @Input()
     glyph: Nullable<string>;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Whether the icon add-on or the text add-on is a button. */
     @Input()

--- a/libs/core/list/directives/list-icon.directive.ts
+++ b/libs/core/list/directives/list-icon.directive.ts
@@ -1,5 +1,6 @@
-import { Directive, ElementRef, HostBinding, Input, OnChanges, OnInit } from '@angular/core';
+import { Directive, ElementRef, HostBinding, Input, OnChanges, OnInit, inject } from '@angular/core';
 import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont, fdBuildIconClass } from '@fundamental-ngx/core/icon';
 
 @Directive({
     selector: '[fdListIcon], [fd-list-icon]',
@@ -12,6 +13,10 @@ export class ListIconDirective implements OnChanges, OnInit, CssClassBuilder {
     @Input()
     glyph: string;
 
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
+
     /** Apply user custom styles */
     @Input()
     class: string;
@@ -22,7 +27,17 @@ export class ListIconDirective implements OnChanges, OnInit, CssClassBuilder {
     role = 'presentation';
 
     /** @hidden */
-    constructor(public readonly elementRef: ElementRef) {}
+    readonly elementRef = inject(ElementRef);
+
+    /** @hidden
+     * CssClassBuilder interface implementation
+     * function must return single string
+     * function is responsible for order which css classes are applied
+     */
+    @applyCssClass
+    buildComponentCssClass(): string[] {
+        return ['fd-list__icon', this.glyph ? fdBuildIconClass(this.glyphFont, this.glyph) : '', this.class];
+    }
 
     /** @hidden */
     ngOnChanges(): void {
@@ -32,15 +47,5 @@ export class ListIconDirective implements OnChanges, OnInit, CssClassBuilder {
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
-    }
-
-    /** @hidden
-     * CssClassBuilder interface implementation
-     * function must return single string
-     * function is responsible for order which css classes are applied
-     */
-    @applyCssClass
-    buildComponentCssClass(): string[] {
-        return ['fd-list__icon', this.glyph ? 'sap-icon--' + this.glyph : '', this.class];
     }
 }

--- a/libs/core/list/list-item/list-item.component.html
+++ b/libs/core/list/list-item/list-item.component.html
@@ -5,7 +5,7 @@
     </div>
 }
 @if (unread && (!_list || _list.byline)) {
-    <span class="sap-icon--circle-task-2 fd-list__notification"></span>
+    <fd-icon class="fd-list__notification" glyph="circle-task-2"></fd-icon>
 }
 <ng-content></ng-content>
 @if (counter || counter === 0) {

--- a/libs/core/list/list-item/list-item.component.ts
+++ b/libs/core/list/list-item/list-item.component.ts
@@ -27,6 +27,7 @@ import { KeyUtil, LIST_ITEM_COMPONENT, ListItemInterface, Nullable } from '@fund
 import { ButtonComponent, FD_BUTTON_COMPONENT } from '@fundamental-ngx/core/button';
 import { CheckboxComponent, FD_CHECKBOX_COMPONENT } from '@fundamental-ngx/core/checkbox';
 import { FormItemComponent } from '@fundamental-ngx/core/form';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 import { FD_RADIO_BUTTON_COMPONENT, RadioButtonComponent } from '@fundamental-ngx/core/radio';
 import { Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
@@ -61,7 +62,7 @@ let listItemUniqueId = 0;
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [FormItemComponent, DecimalPipe]
+    imports: [FormItemComponent, DecimalPipe, IconComponent]
 })
 export class ListItemComponent<T = any>
     extends ListFocusItem<T>

--- a/libs/core/message-box/message-box-semantic-icon/message-box-semantic-icon.component.ts
+++ b/libs/core/message-box/message-box-semantic-icon/message-box-semantic-icon.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, Optional } from '@angular/core';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { MessageBoxConfig, MessageBoxHost } from '../utils/message-box-config.class';
 
 /**
@@ -10,14 +11,19 @@ import { MessageBoxConfig, MessageBoxHost } from '../utils/message-box-config.cl
  */
 @Component({
     selector: 'fd-message-box-semantic-icon',
-    template: `<i [class]="'sap-icon--' + _getIcon" role="presentation"></i>`,
+    template: `<fd-icon [glyph]="_getIcon" [font]="glyphFont" role="presentation"></fd-icon>`,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [IconComponent],
     standalone: true
 })
 export class MessageBoxSemanticIconComponent {
     /** Custom semantic icon */
     @Input()
     glyph: string;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** @hidden */
     get messageBoxConfig(): MessageBoxConfig {

--- a/libs/core/message-page/message-page.component.html
+++ b/libs/core/message-page/message-page.component.html
@@ -1,7 +1,7 @@
 <div class="fd-message-page__container">
     @if (hasIcon) {
         <div class="fd-message-page__icon-container">
-            <i role="presentation" class="fd-message-page__icon" [class]="'sap-icon--' + glyph"></i>
+            <fd-icon role="presentation" class="fd-message-page__icon" [glyph]="glyph" [font]="glyphFont"></fd-icon>
         </div>
     }
     <div role="status" aria-live="polite" class="fd-message-page__content">

--- a/libs/core/message-page/message-page.component.ts
+++ b/libs/core/message-page/message-page.component.ts
@@ -8,6 +8,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 
 export type MessagePageType = '' | 'filter' | 'search' | 'no-items' | 'error';
 
@@ -18,7 +19,7 @@ export type MessagePageType = '' | 'filter' | 'search' | 'no-items' | 'error';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: []
+    imports: [IconComponent]
 })
 export class MessagePageComponent implements OnChanges, OnInit, CssClassBuilder {
     /** User's custom class */
@@ -40,6 +41,10 @@ export class MessagePageComponent implements OnChanges, OnInit, CssClassBuilder 
      */
     @Input()
     hasIcon = true;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /**
      * The icon of the Message Page.

--- a/libs/core/multi-input/multi-input.component.html
+++ b/libs/core/multi-input/multi-input.component.html
@@ -47,6 +47,7 @@
             [isExpanded]="open && !mobile && viewModel.displayedOptions.length > 0"
             [isControl]="true"
             [glyph]="showAddonButton ? glyph : ''"
+            [glyphFont]="glyphFont"
             [addonButtonAriaHidden]="!!title"
             (addOnButtonClicked)="_addOnButtonClicked($event)"
         >

--- a/libs/core/multi-input/multi-input.component.ts
+++ b/libs/core/multi-input/multi-input.component.ts
@@ -55,6 +55,7 @@ import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { FormStates } from '@fundamental-ngx/cdk/forms';
 import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 import { LinkComponent } from '@fundamental-ngx/core/link';
 import { MultiAnnouncerDirective } from '@fundamental-ngx/core/multi-combobox';
@@ -153,6 +154,10 @@ export class MultiInputComponent<ItemType = any, ValueType = any>
     /** Icon of the button on the right of the input field. */
     @Input()
     glyph = 'value-help';
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Values to be displayed in the unfiltered dropdown. */
     @Input()

--- a/libs/core/notification/notification-group-header/notification-group-header.component.spec.ts
+++ b/libs/core/notification/notification-group-header/notification-group-header.component.spec.ts
@@ -2,6 +2,7 @@ import { Component, ElementRef, ViewChild, EventEmitter } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NotificationModule } from '../notification.module';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 
 @Component({
     template: `
@@ -48,7 +49,7 @@ describe('NotificationGroupHeaderComponent', () => {
 
     it('should change the icon when the button is clicked', () => {
         button = fixture.debugElement.query(By.css('button'));
-        buttonIcon = fixture.debugElement.query(By.css('i'));
+        buttonIcon = fixture.debugElement.query(By.directive(IconComponent));
 
         expect(buttonIcon.nativeElement.classList).toContain('sap-icon--slim-arrow-right');
 

--- a/libs/core/notification/notification-group-header/notification-group-header.component.ts
+++ b/libs/core/notification/notification-group-header/notification-group-header.component.ts
@@ -19,6 +19,7 @@ import {
     ContentDensityMode,
     LocalContentDensityMode
 } from '@fundamental-ngx/core/content-density';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 import { Subscription } from 'rxjs';
 import { NotificationGroupBaseDirective } from '../notification-utils/notification-group-base';
 
@@ -36,7 +37,7 @@ import { NotificationGroupBaseDirective } from '../notification-utils/notificati
             [attr.aria-labelledby]="expandAriaLabelledBy"
             (click)="toggleExpand()"
         >
-            <i [class]="'sap-icon--' + _getButtonIcon()"></i>
+            <fd-icon [glyph]="_getButtonIcon()"></fd-icon>
         </button>
         <div class="fd-notification__content">
             <ng-content select="fd-notification-header"></ng-content>
@@ -47,7 +48,7 @@ import { NotificationGroupBaseDirective } from '../notification-utils/notificati
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [ButtonComponent, ContentDensityDirective]
+    imports: [ButtonComponent, ContentDensityDirective, IconComponent]
 })
 export class NotificationGroupHeaderComponent extends NotificationGroupBaseDirective implements OnInit, OnDestroy {
     /** @hidden */

--- a/libs/core/object-marker/object-marker.component.ts
+++ b/libs/core/object-marker/object-marker.component.ts
@@ -8,12 +8,13 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
     selector: '[fd-object-marker]',
     template: `@if (glyph) {
-            <i class="fd-object-marker__icon" [class]="' sap-icon--' + glyph"></i>
+            <fd-icon [glyph]="glyph" [font]="glyphFont" class="fd-object-marker__icon"></fd-icon>
         }
         @if (label) {
             <span class="fd-object-marker__text">{{ label }}</span>
@@ -27,7 +28,7 @@ import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
         '[attr.role]': 'clickable ? "link" :""'
     },
     standalone: true,
-    imports: []
+    imports: [IconComponent]
 })
 export class ObjectMarkerComponent implements OnChanges, OnInit, CssClassBuilder {
     /** User's custom classes */
@@ -37,6 +38,10 @@ export class ObjectMarkerComponent implements OnChanges, OnInit, CssClassBuilder
     /** Glyph (icon) of the Object Status.*/
     @Input()
     glyph: string;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Whether the Object Status is clickable. */
     @Input()

--- a/libs/core/object-status/object-status.component.ts
+++ b/libs/core/object-status/object-status.component.ts
@@ -10,7 +10,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { ColorAccent, CssClassBuilder, Nullable, NullableObject, applyCssClass } from '@fundamental-ngx/cdk/utils';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { FD_OBJECT_STATUS_COMPONENT } from './tokens';
 
 export type ObjectStatus = 'negative' | 'critical' | 'positive' | 'informative' | 'neutral';
@@ -23,6 +23,7 @@ export type ObjectStatus = 'negative' | 'critical' | 'positive' | 'informative' 
             <fd-icon
                 class="fd-object-status__icon"
                 [glyph]="glyph"
+                [font]="glyphFont"
                 [attr.role]="glyphAriaLabel ? 'presentation' : ''"
                 [ariaLabel]="glyphAriaLabel"
             >
@@ -70,6 +71,10 @@ export class ObjectStatusComponent implements OnChanges, OnInit, CssClassBuilder
      */
     @Input()
     glyph: Nullable<string>;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Define the text content of the Object Status */
     @Input()

--- a/libs/core/product-switch/product-switch-body/product-switch-body.component.html
+++ b/libs/core/product-switch/product-switch-body/product-switch-body.component.html
@@ -21,11 +21,7 @@
                 [draggable]="!product.disabledDragAndDrop && dragAndDropEnabled"
                 [stickInPlace]="!!product.stickToPosition"
             >
-                <i
-                    role="presentation"
-                    class="fd-product-switch__icon"
-                    [class]="product.icon ? 'sap-icon--' + product.icon : ''"
-                ></i>
+                <fd-icon role="presentation" class="fd-product-switch__icon" [glyph]="product.icon"></fd-icon>
                 <div class="fd-product-switch__text">
                     <div class="fd-product-switch__title">{{ product.title }}</div>
                     @if (product.subtitle) {

--- a/libs/core/product-switch/product-switch-body/product-switch-body.component.ts
+++ b/libs/core/product-switch/product-switch-body/product-switch-body.component.ts
@@ -17,6 +17,7 @@ import { Subscription } from 'rxjs';
 import { FdDropEvent, KeyUtil, RtlService } from '@fundamental-ngx/cdk/utils';
 
 import { DragAndDropModule } from '@fundamental-ngx/cdk/utils';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 import { ProductSwitchItem } from './product-switch.item';
 
 const containerWidthPxSmallMode = 588;
@@ -29,7 +30,7 @@ const containerWidthPx = 776;
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [DragAndDropModule]
+    imports: [DragAndDropModule, IconComponent]
 })
 export class ProductSwitchBodyComponent implements OnInit, OnDestroy {
     /** Defines if drag and drop functionality should be included in product switch*/

--- a/libs/core/progress-indicator/progress-indicator.component.html
+++ b/libs/core/progress-indicator/progress-indicator.component.html
@@ -34,7 +34,7 @@
                     <div class="fd-progress-indicator__overflow">
                         <span>{{ valueText }}</span>
                         <span class="fd-progress-indicator__overflow-close" (click)="popover.close()">
-                            <i class="sap-icon sap-icon--decline"></i>
+                            <fd-icon glyph="decline"></fd-icon>
                         </span>
                     </div>
                 </div>

--- a/libs/core/progress-indicator/progress-indicator.component.ts
+++ b/libs/core/progress-indicator/progress-indicator.component.ts
@@ -13,6 +13,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { resizeObservable } from '@fundamental-ngx/cdk/utils';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
@@ -26,7 +27,7 @@ export type ProgressIndicatorState = 'informative' | 'positive' | 'critical' | '
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgTemplateOutlet, PopoverComponent, PopoverControlComponent, PopoverBodyComponent]
+    imports: [NgTemplateOutlet, PopoverComponent, PopoverControlComponent, PopoverBodyComponent, IconComponent]
 })
 export class ProgressIndicatorComponent implements OnInit, OnDestroy, OnChanges, AfterViewInit {
     /** The text to display if you would like to override the default percentage text. */

--- a/libs/core/select/select.component.html
+++ b/libs/core/select/select.component.html
@@ -67,7 +67,7 @@
                 [ngClass]="selectDropdownButtonClass"
                 [class.is-disabled]="disabled"
             >
-                <fd-icon [ariaHidden]="true" [glyph]="glyph"></fd-icon>
+                <fd-icon [ariaHidden]="true" [glyph]="glyph" [font]="glyphFont"></fd-icon>
             </span>
         }
     </div>

--- a/libs/core/select/select.component.ts
+++ b/libs/core/select/select.component.ts
@@ -41,7 +41,7 @@ import { ENTER, ESCAPE, SPACE } from '@angular/cdk/keycodes';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { FormFieldAdvancedStateMessage, FormStates, SingleDropdownValueControl } from '@fundamental-ngx/cdk/forms';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { ListComponent, ListMessageDirective } from '@fundamental-ngx/core/list';
 import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
@@ -179,6 +179,10 @@ export class SelectComponent<T = any>
     /** Glyph to add icon in the select component. */
     @Input()
     glyph = 'slim-arrow-down';
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Whether close the popover on outside click. */
     @Input()

--- a/libs/core/shellbar/shellbar-action/shellbar-action.component.html
+++ b/libs/core/shellbar/shellbar-action/shellbar-action.component.html
@@ -5,6 +5,7 @@
         class="fd-shellbar__button"
         fdCozy
         [glyph]="glyph"
+        [glyphFont]="glyphFont"
         (click)="callback ? callback($event) : ''"
     >
         @if (notificationCount) {

--- a/libs/core/shellbar/shellbar-action/shellbar-action.component.ts
+++ b/libs/core/shellbar/shellbar-action/shellbar-action.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityDirective } from '@fundamental-ngx/core/content-density';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { FD_SHELLBAR_ACTION_COMPONENT } from '../tokens';
 
 /**
@@ -34,6 +35,10 @@ export class ShellbarActionComponent {
     /** The glyph (icon) name */
     @Input()
     glyph: string;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Callback that hanldles the response to clicks on any of the actions. */
     @Input()

--- a/libs/core/shellbar/shellbar-actions-mobile/shellbar-actions-mobile.component.html
+++ b/libs/core/shellbar/shellbar-actions-mobile/shellbar-actions-mobile.component.html
@@ -20,7 +20,7 @@
                 <li
                     fd-action-sheet-item
                     tabindex="-1"
-                    [glyph]="'search'"
+                    glyph="search"
                     [label]="'coreShellbar.search' | fdTranslate"
                     (click)="showSearch.emit(); actionSheet.close()"
                 ></li>

--- a/libs/core/split-button/split-button.component.html
+++ b/libs/core/split-button/split-button.component.html
@@ -23,6 +23,7 @@
         fd-button
         #menuActionButton
         [glyph]="glyph"
+        [glyphFont]="glyphFont"
         [fdType]="fdType"
         [disabled]="disabled"
         [ariaLabel]="'coreSplitButton.expandButtonAriaLabel' | fdTranslate"

--- a/libs/core/split-button/split-button.component.ts
+++ b/libs/core/split-button/split-button.component.ts
@@ -27,6 +27,7 @@ import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { MenuTriggerDirective } from '@fundamental-ngx/core/menu';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { MainAction } from './main-action';
@@ -70,6 +71,10 @@ export class SplitButtonComponent implements AfterContentInit, OnChanges, OnDest
     /** The icon to include in the button. See the icon page for the list of icons. */
     @Input()
     glyph = 'slim-arrow-down';
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** The icon to include in the button. See the icon page for the list of icons. */
     @Input()

--- a/libs/core/switch/switch.component.html
+++ b/libs/core/switch/switch.component.html
@@ -30,7 +30,7 @@
                         {{ activeText }}
                     </span>
                 } @else {
-                    <i role="presentation" class="fd-switch__icon fd-switch__icon--on sap-icon--accept"></i>
+                    <fd-icon role="presentation" class="fd-switch__icon fd-switch__icon--on" glyph="accept"></fd-icon>
                 }
                 <span class="fd-switch__handle" role="presentation"></span>
                 @if (inactiveText) {
@@ -38,12 +38,11 @@
                         {{ inactiveText }}
                     </span>
                 } @else {
-                    <i
+                    <fd-icon
                         role="presentation"
                         class="fd-switch__icon--off fd-switch__icon"
-                        [class.sap-icon--decline]="semantic"
-                        [class.sap-icon--less]="!semantic"
-                    ></i>
+                        [glyph]="semantic ? 'decline' : 'less'"
+                    ></fd-icon>
                 }
             </div>
             @if (semantic) {

--- a/libs/core/switch/switch.component.ts
+++ b/libs/core/switch/switch.component.ts
@@ -16,6 +16,7 @@ import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/f
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { FormItemControl, registerFormItemControl } from '@fundamental-ngx/core/form';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { Subscription } from 'rxjs';
 
@@ -46,7 +47,7 @@ let switchUniqueId = 0;
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [FormsModule, AsyncPipe, FdTranslatePipe]
+    imports: [FormsModule, AsyncPipe, FdTranslatePipe, IconComponent]
 })
 export class SwitchComponent implements ControlValueAccessor, OnDestroy, FormItemControl {
     /** @hidden */

--- a/libs/core/table/directives/table-icon.directive.ts
+++ b/libs/core/table/directives/table-icon.directive.ts
@@ -1,5 +1,6 @@
-import { Directive, ElementRef, HostBinding, Input, OnChanges, OnInit } from '@angular/core';
+import { Directive, ElementRef, HostBinding, Input, OnChanges, OnInit, inject } from '@angular/core';
 import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont, fdBuildIconClass } from '@fundamental-ngx/core/icon';
 
 @Directive({
     selector: '[fdTableIcon], [fd-table-icon]',
@@ -13,21 +14,41 @@ export class TableIconDirective implements OnChanges, CssClassBuilder, OnInit {
     /** The property allows user to pass additional css classes
      */
     @Input()
-    public class = '';
+    class = '';
 
     /** The icon to include in the button. See the icon page for the list of icons.
      * Setter is used to control when css class have to be rebuilded.
      * Default value is set to ''.
      */
     @Input()
-    public glyph = '';
+    glyph = '';
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Whether or no icon is used as navigation  */
     @Input()
     navigation = false;
 
     /** @hidden */
-    constructor(public readonly elementRef: ElementRef) {}
+    readonly elementRef = inject(ElementRef);
+
+    /**
+     * @hidden
+     * CssClassBuilder interface implementation
+     * function must return single string
+     * function is responsible for order which css classes are applied
+     */
+    @applyCssClass
+    buildComponentCssClass(): string[] {
+        return [
+            'fd-table__icon',
+            this.glyph ? fdBuildIconClass(this.glyphFont, this.glyph) : '',
+            this.navigation ? 'fd-table__icon--navigation' : '',
+            this.class
+        ];
+    }
 
     /** Function runs when component is initialized
      * function should build component css class
@@ -40,19 +61,5 @@ export class TableIconDirective implements OnChanges, CssClassBuilder, OnInit {
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
-    }
-
-    /** @hidden CssClassBuilder interface implementation
-     * function must return single string
-     * function is responsible for order which css classes are applied
-     */
-    @applyCssClass
-    buildComponentCssClass(): string[] {
-        return [
-            'fd-table__icon',
-            this.glyph ? `sap-icon--${this.glyph}` : '',
-            this.navigation ? 'fd-table__icon--navigation' : '',
-            this.class
-        ];
     }
 }

--- a/libs/core/tabs/tab-utils/tab-directives.ts
+++ b/libs/core/tabs/tab-utils/tab-directives.ts
@@ -9,7 +9,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 
 /**
  * Directive used to identify the template which will populate the tab header.
@@ -51,7 +51,7 @@ export class TabCountDirective {
     selector: '[fd-tab-icon]',
     template: `
         @if (icon) {
-            <fd-icon role="presentation" [glyph]="icon"></fd-icon>
+            <fd-icon role="presentation" [glyph]="icon" [font]="iconFont"></fd-icon>
         }
         <ng-content></ng-content>
     `,
@@ -71,6 +71,10 @@ export class TabIconComponent implements CssClassBuilder, OnChanges {
      */
     @Input()
     icon: string;
+
+    /** Icon font family */
+    @Input()
+    iconFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** @hidden */
     constructor(public readonly elementRef: ElementRef) {}

--- a/libs/core/tile/directives/numeric-content.directives.ts
+++ b/libs/core/tile/directives/numeric-content.directives.ts
@@ -1,5 +1,6 @@
-import { Directive, ElementRef, HostBinding, Input, OnChanges, OnInit } from '@angular/core';
+import { Directive, ElementRef, HostBinding, Input, OnChanges, OnInit, inject } from '@angular/core';
 import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont, fdBuildIconClass } from '@fundamental-ngx/core/icon';
 
 export type NumericContentState = 'negative' | 'critical' | 'positive' | 'informative' | 'neutral';
 export type NumericContentSize = 's' | 'm' | 'l';
@@ -25,17 +26,8 @@ export class NumericContentDirective implements OnInit, OnChanges, CssClassBuild
     /** @hidden */
     constructor(public readonly elementRef: ElementRef) {}
 
-    /** @hidden */
-    ngOnChanges(): void {
-        this.buildComponentCssClass();
-    }
-
-    /** @hidden */
-    ngOnInit(): void {
-        this.buildComponentCssClass();
-    }
-
-    /** @hidden
+    /**
+     * @hidden
      * CssClassBuilder interface implementation
      * function must return single string
      * function is responsible for order which css classes are applied
@@ -48,6 +40,16 @@ export class NumericContentDirective implements OnInit, OnChanges, CssClassBuild
             this.class,
             this._isSmallTile() ? 'fd-numeric-content--small-tile' : ''
         ];
+    }
+
+    /** @hidden */
+    ngOnChanges(): void {
+        this.buildComponentCssClass();
+    }
+
+    /** @hidden */
+    ngOnInit(): void {
+        this.buildComponentCssClass();
     }
 
     /** @hidden */
@@ -89,8 +91,27 @@ export class NumericContentLaunchIconDirective implements OnInit, OnChanges, Css
     @Input()
     glyph: string;
 
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
+
     /** @hidden */
-    constructor(public readonly elementRef: ElementRef) {}
+    readonly elementRef = inject(ElementRef);
+
+    /**
+     * @hidden
+     * CssClassBuilder interface implementation
+     * function must return single string
+     * function is responsible for order which css classes are applied
+     */
+    @applyCssClass
+    buildComponentCssClass(): string[] {
+        return [
+            'fd-numeric-content__launch-icon',
+            this.glyph ? fdBuildIconClass(this.glyphFont, this.glyph) : '',
+            this.class
+        ];
+    }
 
     /** @hidden */
     ngOnChanges(): void {
@@ -100,16 +121,6 @@ export class NumericContentLaunchIconDirective implements OnInit, OnChanges, Css
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
-    }
-
-    /** @hidden
-     * CssClassBuilder interface implementation
-     * function must return single string
-     * function is responsible for order which css classes are applied
-     */
-    @applyCssClass
-    buildComponentCssClass(): string[] {
-        return ['fd-numeric-content__launch-icon', this.glyph ? 'sap-icon--' + this.glyph : '', this.class];
     }
 }
 
@@ -143,7 +154,18 @@ export class NumericContentKpiDirective implements OnInit, OnChanges, CssClassBu
     glyph: string;
 
     /** @hidden */
-    constructor(public readonly elementRef: ElementRef) {}
+    readonly elementRef = inject(ElementRef);
+
+    /**
+     * @hidden
+     * CssClassBuilder interface implementation
+     * function must return single string
+     * function is responsible for order which css classes are applied
+     */
+    @applyCssClass
+    buildComponentCssClass(): string[] {
+        return ['fd-numeric-content__kpi', this.state ? 'fd-numeric-content__kpi--' + this.state : '', this.class];
+    }
 
     /** @hidden */
     ngOnChanges(): void {
@@ -153,16 +175,6 @@ export class NumericContentKpiDirective implements OnInit, OnChanges, CssClassBu
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
-    }
-
-    /** @hidden
-     * CssClassBuilder interface implementation
-     * function must return single string
-     * function is responsible for order which css classes are applied
-     */
-    @applyCssClass
-    buildComponentCssClass(): string[] {
-        return ['fd-numeric-content__kpi', this.state ? 'fd-numeric-content__kpi--' + this.state : '', this.class];
     }
 }
 
@@ -191,8 +203,26 @@ export class NumericContentScaleArrowDirective implements OnInit, OnChanges, Css
     @Input()
     glyph: string;
 
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
+
     /** @hidden */
-    constructor(public readonly elementRef: ElementRef) {}
+    readonly elementRef = inject(ElementRef);
+
+    /** @hidden
+     * CssClassBuilder interface implementation
+     * function must return single string
+     * function is responsible for order which css classes are applied
+     */
+    @applyCssClass
+    buildComponentCssClass(): string[] {
+        return [
+            'fd-numeric-content__scale-arrow',
+            this.glyph ? fdBuildIconClass(this.glyphFont, this.glyph) : '',
+            this.class
+        ];
+    }
 
     /** @hidden */
     ngOnChanges(): void {
@@ -202,16 +232,6 @@ export class NumericContentScaleArrowDirective implements OnInit, OnChanges, Css
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
-    }
-
-    /** @hidden
-     * CssClassBuilder interface implementation
-     * function must return single string
-     * function is responsible for order which css classes are applied
-     */
-    @applyCssClass
-    buildComponentCssClass(): string[] {
-        return ['fd-numeric-content__scale-arrow', this.glyph ? 'sap-icon--' + this.glyph : '', this.class];
     }
 }
 
@@ -230,7 +250,18 @@ export class NumericContentScaleDirective implements OnInit, OnChanges, CssClass
     class: string;
 
     /** @hidden */
-    constructor(public readonly elementRef: ElementRef) {}
+    readonly elementRef = inject(ElementRef);
+
+    /**
+     * @hidden
+     * CssClassBuilder interface implementation
+     * function must return single string
+     * function is responsible for order which css classes are applied
+     */
+    @applyCssClass
+    buildComponentCssClass(): string[] {
+        return ['fd-numeric-content__scale', this.state ? 'fd-numeric-content__scale--' + this.state : '', this.class];
+    }
 
     /** @hidden */
     ngOnChanges(): void {
@@ -240,16 +271,6 @@ export class NumericContentScaleDirective implements OnInit, OnChanges, CssClass
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
-    }
-
-    /** @hidden
-     * CssClassBuilder interface implementation
-     * function must return single string
-     * function is responsible for order which css classes are applied
-     */
-    @applyCssClass
-    buildComponentCssClass(): string[] {
-        return ['fd-numeric-content__scale', this.state ? 'fd-numeric-content__scale--' + this.state : '', this.class];
     }
 }
 

--- a/libs/core/tile/directives/tile.directives.ts
+++ b/libs/core/tile/directives/tile.directives.ts
@@ -1,5 +1,6 @@
 import { Directive, ElementRef, HostBinding, Input, OnChanges, OnInit } from '@angular/core';
 import { CssClassBuilder, Nullable, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont, fdBuildIconClass } from '@fundamental-ngx/core/icon';
 
 @Directive({
     selector: '[fdTileContent], [fd-tile-content]',
@@ -135,6 +136,10 @@ export class TileRefreshDirective implements OnInit, OnChanges, CssClassBuilder 
     @Input()
     glyph: string;
 
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
+
     /** Apply user custom styles */
     @Input()
     class: string;
@@ -164,7 +169,7 @@ export class TileRefreshDirective implements OnInit, OnChanges, CssClassBuilder 
      */
     @applyCssClass
     buildComponentCssClass(): string[] {
-        return ['fd-tile__refresh', this.glyph ? 'sap-icon--' + this.glyph : '', this.class];
+        return ['fd-tile__refresh', this.glyph ? fdBuildIconClass(this.glyphFont, this.glyph) : '', this.class];
     }
 }
 

--- a/libs/core/timeline/components/timeline-node/timeline-node.component.html
+++ b/libs/core/timeline/components/timeline-node/timeline-node.component.html
@@ -2,7 +2,7 @@
     <div class="fd-timeline__icon-wrapper">
         <div class="fd-timeline__node" [class.fd-timeline__node--icon]="!!glyph">
             @if (glyph) {
-                <fd-icon [glyph]="glyph"></fd-icon>
+                <fd-icon [glyph]="glyph" [font]="glyphFont"></fd-icon>
             }
         </div>
     </div>

--- a/libs/core/timeline/components/timeline-node/timeline-node.component.ts
+++ b/libs/core/timeline/components/timeline-node/timeline-node.component.ts
@@ -8,7 +8,7 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { TimelinePositionControlService } from '../../services/timeline-position-control.service';
 import { TimelineNodeComponentInterface } from './timeline-node-component.interface';
 
@@ -28,6 +28,10 @@ export class TimelineNodeComponent implements TimelineNodeComponentInterface, On
     /** Glyph of the current timeline node.*/
     @Input()
     glyph: string;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Aria label for the current timeline node. */
     @Input()

--- a/libs/core/token/tokenizer.component.html
+++ b/libs/core/token/tokenizer.component.html
@@ -28,7 +28,14 @@
     </div>
     @if (glyph) {
         <span fd-input-group-addon #inputGroupAddOn [button]="true" placement="after">
-            <button fd-button class="fd-tokenizer-addon" fdType="transparent" [glyph]="glyph" type="button"></button>
+            <button
+                fd-button
+                class="fd-tokenizer-addon"
+                fdType="transparent"
+                [glyph]="glyph"
+                [glyphFont]="glyphFont"
+                type="button"
+            ></button>
         </span>
     }
 </div>

--- a/libs/core/token/tokenizer.component.ts
+++ b/libs/core/token/tokenizer.component.ts
@@ -46,6 +46,7 @@ import {
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { FormControlComponent } from '@fundamental-ngx/core/form';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 import { ListModule } from '@fundamental-ngx/core/list';
 import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
@@ -147,6 +148,10 @@ export class TokenizerComponent implements AfterViewInit, OnDestroy, CssClassBui
     /** Icon of the button on the right of the input field. */
     @Input()
     glyph: string;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Word to use for when there are extra tokens. */
     @Input()

--- a/libs/core/wizard/wizard-step-indicator/wizard-step-indicator.component.html
+++ b/libs/core/wizard/wizard-step-indicator/wizard-step-indicator.component.html
@@ -11,6 +11,7 @@
                     fd-action-sheet-item
                     [label]="step.label"
                     [glyph]="step.glyph"
+                    [glyphFont]="glyphFont"
                     [disabled]="!step.visited"
                     (click)="stepItemClicked(step, $event)"
                 ></li>

--- a/libs/core/wizard/wizard-step-indicator/wizard-step-indicator.component.ts
+++ b/libs/core/wizard/wizard-step-indicator/wizard-step-indicator.component.ts
@@ -16,7 +16,7 @@ import {
     ActionSheetControlComponent,
     ActionSheetItemComponent
 } from '@fundamental-ngx/core/action-sheet';
-import { IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { Subscription } from 'rxjs';
 import { FD_WIZARD_STEP_INDICATOR } from '../constants';
 import { WizardStepIndicator } from '../models/wizard-step';
@@ -48,6 +48,10 @@ export class WizardStepIndicatorComponent implements WizardStepIndicator, OnDest
      */
     @Input()
     glyph: Nullable<string>;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /**
      * Event emitted when this step indicator is clicked.

--- a/libs/docs/core/message-box/e2e/message-box.po.ts
+++ b/libs/docs/core/message-box/e2e/message-box.po.ts
@@ -18,7 +18,7 @@ export class MessageBoxPo extends CoreBaseComponentPo {
     okButton = 'fd-button-bar:nth-child(1)';
     cancelButton = 'fd-button-bar:nth-child(2)';
     resultTxt = 'p';
-    messageIcon = this.messageBoxExample + 'fd-message-box-semantic-icon > i';
+    messageIcon = this.messageBoxExample + 'fd-message-box-semantic-icon > fd-icon';
 
     async open(): Promise<void> {
         await super.open(this.url);

--- a/libs/docs/core/object-marker/e2e/object-marker.po.ts
+++ b/libs/docs/core/object-marker/e2e/object-marker.po.ts
@@ -8,7 +8,7 @@ export class ObjectMarkerPo extends CoreBaseComponentPo {
     iconOnlyMarkers = 'fd-object-marker-example span';
     objectMarkerClickableExample = 'fd-object-marker-clickable-example ';
     link = 'a';
-    icon = 'i';
+    icon = 'fd-icon';
 
     async open(): Promise<void> {
         await super.open(this.url);

--- a/libs/docs/platform/menu/e2e/menu.po.ts
+++ b/libs/docs/platform/menu/e2e/menu.po.ts
@@ -10,7 +10,7 @@ export class MenuPo extends PlatformBaseComponentPo {
     menuHorizontalAvatarBtn = 'fdp-platform-menu-x-position-example fd-avatar';
     menuItemArr = '#fdp-menu-basic-menu fdp-menu-item';
     menuItemTextArr = '#fdp-menu-basic-menu fdp-menu-item span';
-    iconMenuIconArr = 'component-example fd-icon';
+    iconMenuIconArr = 'component-example .fd-doc-component fd-icon';
     menuItemOverlay = '.cdk-overlay-container';
 
     cascadingMenuBtn = 'fdp-platform-menu-cascade-example button';

--- a/libs/platform/button/button.component.html
+++ b/libs/platform/button/button.component.html
@@ -14,6 +14,7 @@
     [type]="type"
     [toggled]="toggled || ariaPressed || ariaSelected"
     [glyph]="glyph"
+    [glyphFont]="glyphFont"
     [disabled]="disabled"
     [fdType]="buttonType"
     [class.is-disabled]="ariaDisabled"

--- a/libs/platform/button/button.component.ts
+++ b/libs/platform/button/button.component.ts
@@ -11,6 +11,7 @@ import {
 
 import { ModuleDeprecation, Nullable, warnOnce } from '@fundamental-ngx/cdk/utils';
 import { ButtonType, ButtonComponent as CoreButtonComponent, GlyphPosition } from '@fundamental-ngx/core/button';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
 
 /**
@@ -41,6 +42,10 @@ export class ButtonComponent extends BaseComponent implements AfterViewInit {
      */
     @Input()
     glyph: string;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** The buttonType of the button. Types includes
      'standard','positive', 'negative', 'attention', 'ghost',

--- a/libs/platform/form/select/commons/base-select.ts
+++ b/libs/platform/form/select/commons/base-select.ts
@@ -32,6 +32,7 @@ import {
     TemplateDirective,
     warnOnce
 } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { ListComponent } from '@fundamental-ngx/core/list';
 import { MobileModeConfig } from '@fundamental-ngx/core/mobile-mode';
 import { PopoverFillMode } from '@fundamental-ngx/core/shared';
@@ -97,6 +98,10 @@ export abstract class BaseSelect
     /** Glyph to add icon in the select component. */
     @Input()
     glyph = 'slim-arrow-down';
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** The element to which the popover should be appended. */
     @Input()

--- a/libs/platform/form/select/select/select.component.html
+++ b/libs/platform/form/select/select/select.component.html
@@ -1,6 +1,7 @@
 <fd-select
     [placeholder]="placeholder"
     [glyph]="glyph"
+    [glyphFont]="glyphFont"
     [disabled]="disabled"
     [readonly]="readonly"
     [closeOnOutsideClick]="closeOnOutsideClick"

--- a/libs/platform/icon-tab-bar/components/popovers/icon-tab-bar-popover/icon-tab-bar-popover.component.html
+++ b/libs/platform/icon-tab-bar/components/popovers/icon-tab-bar-popover/icon-tab-bar-popover.component.html
@@ -2,7 +2,7 @@
     <fd-popover-control>
         <button class="fd-icon-tab-bar__overflow">
             <span class="fd-icon-tab-bar__overflow-text">{{ label }}</span>
-            <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+            <fd-icon glyph="slim-arrow-down" role="presentation"></fd-icon>
         </button>
     </fd-popover-control>
     <fd-popover-body class="fd-icon-tab-bar">

--- a/libs/platform/icon-tab-bar/components/popovers/text-type-popover/text-type-popover.component.html
+++ b/libs/platform/icon-tab-bar/components/popovers/text-type-popover/text-type-popover.component.html
@@ -3,7 +3,7 @@
         <fd-popover-control>
             <button class="fd-icon-tab-bar__overflow">
                 <span class="fd-icon-tab-bar__overflow-text">More</span>
-                <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                <fd-icon glyph="slim-arrow-down" role="presentation"></fd-icon>
             </button>
         </fd-popover-control>
         <fd-popover-body class="fd-icon-tab-bar">
@@ -31,7 +31,7 @@
                 <div class="fd-icon-tab-bar__tab-container">
                     <span class="fd-icon-tab-bar__tag">{{ parentTab.label }}</span>
                     <span class="fd-icon-tab-bar__arrow">
-                        <i class="sap-icon--slim-arrow-down" role="presentation"></i>
+                        <fd-icon glyph="slim-arrow-down" role="presentation"></fd-icon>
                     </span>
                     @if (parentTab.badge) {
                         <span class="fd-icon-tab-bar__badge"></span>

--- a/libs/platform/menu-button/menu-button.component.html
+++ b/libs/platform/menu-button/menu-button.component.html
@@ -5,6 +5,7 @@
     [fdMenu]="true"
     [label]="label"
     [glyph]="icon"
+    [glyphFont]="iconFont"
     [disabled]="disabled"
     [attr.aria-disabled]="disabled"
     [attr.aria-labelledby]="ariaLabelledBy ? ariaLabelledBy + ' ' + id : null"

--- a/libs/platform/menu-button/menu-button.component.ts
+++ b/libs/platform/menu-button/menu-button.component.ts
@@ -10,6 +10,7 @@ import {
 
 import { warnOnce } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent, ButtonType } from '@fundamental-ngx/core/button';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
 
 /**
@@ -33,9 +34,13 @@ export class MenuButtonComponent extends BaseComponent {
     @Input()
     title: string;
 
-    /** The Sap-icon to include in the menu-button */
+    /** The Icon to include in the menu-button */
     @Input()
     icon: string;
+
+    /** Glyph font family */
+    @Input()
+    iconFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** The type of the button. Types include 'standard', 'positive', 'negative', 'transparent', 'attention', 'emphasized', 'ghost'.
      * Leave empty for default.'*/

--- a/libs/platform/object-marker/object-marker.component.html
+++ b/libs/platform/object-marker/object-marker.component.html
@@ -2,6 +2,7 @@
     <span
         fd-object-marker
         [glyph]="glyph"
+        [glyphFont]="glyphFont"
         [attr.aria-label]="ariaLabel"
         [attr.aria-hidden]="ariaHidden"
         [attr.title]="title"
@@ -14,6 +15,7 @@
         [attr.href]="link"
         fd-object-marker
         [glyph]="glyph"
+        [glyphFont]="glyphFont"
         [clickable]="clickable"
         [attr.aria-label]="ariaLabel"
         [attr.aria-hidden]="ariaHidden"

--- a/libs/platform/object-marker/object-marker.component.spec.ts
+++ b/libs/platform/object-marker/object-marker.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { PlatformObjectMarkerComponent } from './object-marker.component';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 
 @Component({
     selector: 'fdp-test-object-marker',
@@ -43,12 +44,12 @@ describe('PlatformObjectMarkerComponent', () => {
     it('Should Validate diffrent object icon', () => {
         host.glyph = 'add-favorite';
         fixture.detectChanges();
-        let linkElement = fixture.debugElement.query(By.css('i'));
+        let linkElement = fixture.debugElement.query(By.directive(IconComponent));
         expect(linkElement.nativeElement.classList.contains('fd-object-marker__icon')).toBe(true);
         expect(linkElement.nativeElement.classList.contains('sap-icon--add-favorite')).toBe(true);
         host.glyph = 'private';
         fixture.detectChanges();
-        linkElement = fixture.debugElement.query(By.css('i'));
+        linkElement = fixture.debugElement.query(By.directive(IconComponent));
         expect(linkElement.nativeElement.classList.contains('fd-object-marker__icon')).toBe(true);
         expect(linkElement.nativeElement.classList.contains('sap-icon--private')).toBe(true);
     });

--- a/libs/platform/object-marker/object-marker.component.ts
+++ b/libs/platform/object-marker/object-marker.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 
 import { Nullable, warnOnce } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { ObjectMarkerComponent } from '@fundamental-ngx/core/object-marker';
 
 /**
@@ -19,6 +20,10 @@ export class PlatformObjectMarkerComponent {
      */
     @Input()
     glyph: string;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** Whether the Object marker is clickable. */
     @Input()

--- a/libs/platform/object-status/object-status.component.html
+++ b/libs/platform/object-status/object-status.component.html
@@ -3,6 +3,7 @@
     [attr.role]="clickable ? 'button' : null"
     [status]="status"
     [glyph]="glyph"
+    [glyphFont]="glyphFont"
     [indicationColor]="indicationColor"
     [clickable]="clickable"
     [inverted]="inverted"

--- a/libs/platform/object-status/object-status.component.ts
+++ b/libs/platform/object-status/object-status.component.ts
@@ -14,6 +14,7 @@ import {
 } from '@angular/core';
 
 import { ColorAccent, KeyUtil, Nullable, warnOnce } from '@fundamental-ngx/cdk/utils';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { ObjectStatusComponent as CoreObjectStatusComponent, ObjectStatus } from '@fundamental-ngx/core/object-status';
 
 @Directive({
@@ -59,6 +60,10 @@ export class ObjectStatusComponent {
      */
     @Input()
     glyph: Nullable<string>;
+
+    /** Glyph font family */
+    @Input()
+    glyphFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /**
      * A number representing the indication color.

--- a/libs/platform/split-menu-button/split-menu-button.component.html
+++ b/libs/platform/split-menu-button/split-menu-button.component.html
@@ -19,6 +19,7 @@
         [disabled]="disabled"
         [fdType]="type"
         [glyph]="icon"
+        [glyphFont]="iconFont"
         [attr.tabindex]="tabindex"
         (click)="primaryButtonClicked($event)"
     ></button>

--- a/libs/platform/split-menu-button/split-menu-button.component.ts
+++ b/libs/platform/split-menu-button/split-menu-button.component.ts
@@ -16,6 +16,7 @@ import { Subscription } from 'rxjs';
 
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent, ButtonType } from '@fundamental-ngx/core/button';
+import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
 import { MenuComponent, MenuTriggerDirective } from '@fundamental-ngx/platform/menu';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
 
@@ -58,9 +59,13 @@ export class SplitMenuButtonComponent extends BaseComponent implements OnInit, A
     @Input()
     menu: MenuComponent;
 
-    /** The Sap-icon to include in the menu-button */
+    /** The icon to include in the menu-button */
     @Input()
     icon: string;
+
+    /** Glyph font family */
+    @Input()
+    iconFont: IconFont = FD_DEFAULT_ICON_FONT_FAMILY;
 
     /** The type of the button.
      * 'Emphasized', 'Ghost', 'standard', 'positive', 'negative', 'transparent'

--- a/libs/platform/table/components/table-row/table-row.component.html
+++ b/libs/platform/table/components/table-row/table-row.component.html
@@ -193,12 +193,12 @@
 @if (_fdpTableService._isShownNavigationColumn$ | async) {
     <td fd-table-cell class="fdp-table__cell--navigation is-last-child" fdkDisabled [addDisabledClass]="false">
         @if (row.navigatable) {
-            <i
+            <fd-icon
                 fd-table-icon
                 [navigation]="true"
-                [class]="_rtl ? 'sap-icon--slim-arrow-left' : 'sap-icon--slim-arrow-right'"
+                [glyph]="_rtl ? 'slim-arrow-left' : 'slim-arrow-right'"
                 class="fdp-table__navigation-indicator"
-            ></i>
+            ></fd-icon>
         }
     </td>
 }

--- a/libs/platform/table/components/table-row/table-row.component.ts
+++ b/libs/platform/table/components/table-row/table-row.component.ts
@@ -35,6 +35,7 @@ import {
 } from '@fundamental-ngx/cdk/utils';
 import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
 import { ContentDensityObserver } from '@fundamental-ngx/core/content-density';
+import { IconComponent } from '@fundamental-ngx/core/icon';
 import {
     TableCellDirective,
     TableIconDirective,
@@ -100,7 +101,8 @@ import { TableEditableCellComponent } from '../table-editable-cell/table-editabl
         FdTranslatePipe,
         SelectionCellStylesPipe,
         TableCellStylesPipe,
-        ColumnResizableSidePipe
+        ColumnResizableSidePipe,
+        IconComponent
     ]
 })
 export class TableRowComponent<T> extends TableRowDirective implements OnInit, AfterViewInit, OnDestroy, OnChanges {


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #5483

## Description
- Added `glyphFont` input property for components and directives that have input property that is passed as `glyph` to inner `fd-icon` component.
- Updated some of the components to use `fd-icon` instead of plain `<i class="sap-icon--...">` for better readability and code support.