### PR TITLE
fix(cdk): tabbable observer out of the zone

### DIFF
--- a/libs/cdk/src/lib/utils/directives/focusable-item/focusable-item.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-item/focusable-item.directive.ts
@@ -139,14 +139,17 @@ export class FocusableItemDirective implements HasElementRef {
 
     /** Set tabbable state */
     setTabbable(state: boolean): void {
-        this._tabbable = state;
-        this._renderer2.setAttribute(this.elementRef.nativeElement, 'tabindex', this._tabbable ? '0' : '-1');
+        return;
+        this._zone.runOutsideAngular(() => {
+            this._tabbable = state;
+            this._renderer2.setAttribute(this.elementRef.nativeElement, 'tabindex', this._tabbable ? '0' : '-1');
 
-        if (state) {
-            this._enableTabbableElements();
-        } else {
-            this._disableTabbableElements();
-        }
+            if (state) {
+                this._enableTabbableElements();
+            } else {
+                this._disableTabbableElements();
+            }
+        });
     }
 
     /** @hidden */

--- a/libs/cdk/src/lib/utils/directives/focusable-item/focusable-item.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/focusable-item/focusable-item.directive.ts
@@ -139,7 +139,6 @@ export class FocusableItemDirective implements HasElementRef {
 
     /** Set tabbable state */
     setTabbable(state: boolean): void {
-        return;
         this._zone.runOutsideAngular(() => {
             this._tabbable = state;
             this._renderer2.setAttribute(this.elementRef.nativeElement, 'tabindex', this._tabbable ? '0' : '-1');

--- a/libs/platform/src/lib/table/components/table-p13-dialog/columns/columns.component.html
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/columns/columns.component.html
@@ -106,6 +106,7 @@
                 fd-list-item
                 *ngFor="let item of _filteredColumns; trackBy: _filterByColumnKy"
                 [class.fd-select-item--selected]="item.selected"
+                [class.fd-select-item--active]="item.active"
                 [selected]="item.selected"
                 (click)="_setActiveColumn(item)"
             >


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes none

## Description
Original issue can be observed here: https://ng-15-downport--fundamental-ngx.netlify.app/#/core/popover
The cause of the issue was with `MutationObserverFactory` which triggered zone detection, which caused `ngAfterContentChecked` callback function of popover control component to be triggered infinitely.
This fix moves the mutation observer detection out of the Angular CDR cycle allowing us to manipulate native attributes without having `detectChanges` side-effects.
