### PR TITLE
fix(platform): tree table text overflow

### DIFF
--- a/libs/platform/table/table.component.scss
+++ b/libs/platform/table/table.component.scss
@@ -230,6 +230,10 @@ fdk-dynamic-portal {
             .fd-replace-indicator {
                 top: auto;
             }
+
+            .#{$fd-block}__text {
+                white-space: nowrap;
+            }
         }
 
         &.fd-table--condensed,


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #11089

Added `white-space: nowrap` styling for tree table cells.