### PR TITLE
fix(core,platform): touched correct usage

### DIFF
--- a/libs/core/multi-combobox/multi-combobox.component.html
+++ b/libs/core/multi-combobox/multi-combobox.component.html
@@ -79,7 +79,7 @@
                     [(ngModel)]="inputText"
                     (ngModelChange)="_searchTermChanged()"
                     [placeholder]="_cva.placeholder"
-                    (focus)="_cva.onTouched(); tokenizer._showAllTokens()"
+                    (focus)="tokenizer._showAllTokens()"
                     (blur)="!mobile && _onBlur($event); tokenizer._hideTokens()"
                     [attr.aria-expanded]="isOpen"
                     [readonly]="_cva.readonly"
@@ -185,7 +185,7 @@
                         fd-list-item
                         role="option"
                         [tabindex]="0"
-                        (click)="!mobile && close()"
+                        (click)="!mobile && _onOptionClicked($event, i)"
                         (keydown)="_onItemKeyDownHandler($event)"
                         [selected]="!!optionItem.selected"
                     >

--- a/libs/core/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/multi-combobox/multi-combobox.component.ts
@@ -510,6 +510,7 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
             this._showList(false);
             this.inputText = '';
         }
+        this._cva.onTouched();
     }
 
     /** @hidden */
@@ -564,6 +565,9 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     _popoverOpenChangeHandle(isOpen: boolean): void {
         this.isOpen = isOpen;
         this._rangeSelector.reset();
+        if (!isOpen) {
+            this._cva.onTouched();
+        }
     }
 
     /** Opens the select popover body. */
@@ -582,6 +586,7 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
 
         this.isOpen = false;
         this.isOpenChange.emit(this.isOpen);
+        this._cva.onTouched();
         this._cd.markForCheck();
     }
 

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-datasource/multi-combobox-datasource-example.component.html
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-datasource/multi-combobox-datasource-example.component.html
@@ -1,16 +1,19 @@
-<div fd-form-item>
-    <label fd-form-label for="array-of-strings">Array of Strings:</label>
-    <fd-multi-combobox
-        [showSelectAll]="true"
-        [autoResize]="true"
-        name="array-of-strings"
-        inputId="array-of-strings"
-        placeholder="Type some text..."
-        [dataSource]="dataSourceStrings"
-        [selectedItems]="selectedItems1"
-        (selectionChange)="onSelect1($event)"
-    ></fd-multi-combobox>
-</div>
+<form [formGroup]="formGroup">
+    <div fd-form-item>
+        <label fd-form-label for="array-of-strings">Array of Strings:</label>
+        <fd-multi-combobox
+            [showSelectAll]="true"
+            [autoResize]="true"
+            name="array-of-strings"
+            inputId="array-of-strings"
+            placeholder="Type some text..."
+            [dataSource]="dataSourceStrings"
+            [selectedItems]="selectedItems1"
+            (selectionChange)="onSelect1($event)"
+            formControlName="multiGroupComboBox"
+        ></fd-multi-combobox>
+    </div>
+</form>
 
 <p>Selected: {{ selectedItems1 }}</p>
 

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-datasource/multi-combobox-datasource-example.component.ts
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-datasource/multi-combobox-datasource-example.component.ts
@@ -1,5 +1,6 @@
 import { JsonPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { DataSourceDirective } from '@fundamental-ngx/cdk/data-source';
 import { CvaDirective } from '@fundamental-ngx/cdk/forms';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
@@ -23,7 +24,8 @@ import { of } from 'rxjs';
         DataSourceDirective,
         MultiComboboxComponent,
         ButtonComponent,
-        JsonPipe
+        JsonPipe,
+        ReactiveFormsModule
     ]
 })
 export class MultiComboboxDatasourceExampleComponent {
@@ -77,6 +79,16 @@ export class MultiComboboxDatasourceExampleComponent {
         this.dataSourceStrings[4]
     ];
     selectedItems6 = [];
+
+    fb = inject(FormBuilder);
+
+    formGroup = this.fb.group({ multiGroupComboBox: [[]] }, { updateOn: 'blur' });
+
+    ngOnInit(): void {
+        this.formGroup.get('multiGroupComboBox')?.valueChanges.subscribe(() => {
+            console.log('value change event is triggered now -> ', this.formGroup.get('multiGroupComboBox')?.value);
+        });
+    }
 
     onSelect1(item: MultiComboboxSelectionChangeEvent): void {
         this.selectedItems1 = item.selectedItems;

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.html
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.html
@@ -14,4 +14,7 @@
     </div>
     <p>Selected Item: {{ selectedItems | json }}</p>
     <p>Form Selected Item: {{ customForm.getRawValue() | json }}</p>
+    <p>Dirty: {{ customForm.controls.field.dirty }}</p>
+    <p>Touched: {{ customForm.controls.field.touched }}</p>
+    <p>Pristine: {{ customForm.controls.field.pristine }}</p>
 </form>

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-group/multi-combobox-group-example.component.html
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-group/multi-combobox-group-example.component.html
@@ -1,18 +1,21 @@
-<div fd-form-item>
-    <label fd-form-label for="group-with-key">Group with Key:</label>
-    <fd-multi-combobox
-        name="group"
-        inputId="group-with-key"
-        placeholder="Type some text..."
-        [dataSource]="dataSource"
-        displayKey="name"
-        [group]="true"
-        groupKey="type"
-        (selectionChange)="onSelect($event)"
-        [selectedItems]="selectedItems"
-    ></fd-multi-combobox>
-</div>
-<p>Selected: {{ selectedItems | json }}</p>
+<form [formGroup]="formGroup">
+    <div fd-form-item>
+        <label fd-form-label for="group-with-key">Group with Key:</label>
+        <fd-multi-combobox
+            name="group"
+            inputId="group-with-key"
+            placeholder="Type some text..."
+            [dataSource]="dataSource"
+            displayKey="name"
+            [group]="true"
+            groupKey="type"
+            (selectionChange)="onSelect($event)"
+            [selectedItems]="selectedItems"
+            formControlName="multiGroupComboBox"
+        ></fd-multi-combobox>
+    </div>
+    <p>Selected: {{ selectedItems | json }}</p>
+</form>
 
 <div fd-form-item>
     <label fd-form-label for="group-without-key">Group without Key:</label>

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-group/multi-combobox-group-example.component.ts
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-group/multi-combobox-group-example.component.ts
@@ -1,5 +1,6 @@
 import { JsonPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { DataSourceDirective } from '@fundamental-ngx/cdk/data-source';
 import { CvaDirective } from '@fundamental-ngx/cdk/forms';
 import { FormItemComponent, FormLabelComponent } from '@fundamental-ngx/core/form';
@@ -16,7 +17,8 @@ import { MultiComboboxComponent, MultiComboboxSelectionChangeEvent } from '@fund
         CvaDirective,
         DataSourceDirective,
         MultiComboboxComponent,
-        JsonPipe
+        JsonPipe,
+        ReactiveFormsModule
     ]
 })
 export class MultiComboboxGroupExampleComponent {
@@ -33,6 +35,16 @@ export class MultiComboboxGroupExampleComponent {
 
     selectedItems = [this.dataSource[1]];
     selectedItems1 = [];
+
+    fb = inject(FormBuilder);
+
+    formGroup = this.fb.group({ multiGroupComboBox: [[]] }, { updateOn: 'blur' });
+
+    ngOnInit(): void {
+        this.formGroup.get('multiGroupComboBox')?.valueChanges.subscribe(() => {
+            console.log('value change event is triggered now -> ', this.formGroup.get('multiGroupComboBox')?.value);
+        });
+    }
 
     onSelect(item: MultiComboboxSelectionChangeEvent): void {
         this.selectedItems = item.selectedItems;

--- a/libs/docs/platform/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.html
+++ b/libs/docs/platform/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.html
@@ -11,5 +11,8 @@
         ></fdp-multi-combobox>
         <p>Selected Item: {{ selectedItems | json }}</p>
         <p>Form Selected Item: {{ customForm.getRawValue() | json }}</p>
+        <p>Dirty: {{ customForm.controls.field.dirty }}</p>
+        <p>Touched: {{ customForm.controls.field.touched }}</p>
+        <p>Pristine: {{ customForm.controls.field.pristine }}</p>
     </fdp-form-field>
 </fdp-form-group>

--- a/libs/platform/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/form/multi-combobox/commons/base-multi-combobox.ts
@@ -432,6 +432,9 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
     popoverOpenChangeHandle(isOpen: boolean): void {
         this.isOpen = isOpen;
         this._rangeSelector.reset();
+        if (!isOpen) {
+            this.onTouched();
+        }
         this._onOpenChange(this.isOpen);
     }
 

--- a/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.html
+++ b/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.html
@@ -189,7 +189,7 @@
                     <li
                         fd-list-item
                         role="option"
-                        (click)="!mobile && close()"
+                        (click)="!mobile && onOptionClicked($event, $index)"
                         (keyDown)="onItemKeyDownHandler($event)"
                         [selected]="!!optionItem.selected"
                     >


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10958

## Description
Previously we called `onTouched` callback function when user focused the input field. Now it is being called when user focuses out the input field and when the dropdown list is closed.
