### PR TITLE
fix(platform): vhd content min height

### DIFF
--- a/libs/platform/value-help-dialog/value-help-dialog/value-help-dialog.component.scss
+++ b/libs/platform/value-help-dialog/value-help-dialog/value-help-dialog.component.scss
@@ -114,6 +114,7 @@ $block: fdp-value-help-dialog;
         height: 100%;
         width: 100%;
         overflow: hidden;
+        min-height: 20rem;
     }
 
     &__row {


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #11224

## Description
This PR introduces minimal height of the VHD select tab content.
## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![image](https://github.com/SAP/fundamental-ngx/assets/6586561/14fc7208-b53d-4200-964a-daec43fd29f6)

### After:
![image](https://github.com/SAP/fundamental-ngx/assets/6586561/910af044-ac16-4a9e-b4f9-930c7e93afee)
