### PR TITLE
fix(platform): initial visible columns

### DIFF
--- a/libs/platform/table-helpers/directives/table-initial-state.directive.ts
+++ b/libs/platform/table-helpers/directives/table-initial-state.directive.ts
@@ -67,7 +67,7 @@ export class TableInitialStateDirective extends TableInitialState {
         const page = prevState.page;
         const visibleColumns =
             this.initialVisibleColumns ||
-            (prevState.columns.length ? prevState.columns : columns.map(({ name }) => name));
+            (prevState.columns.length ? prevState.columns : columns.filter((c) => c.visible).map(({ name }) => name));
 
         const directiveInitialPage = this.initialPage ?? 1;
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #11201

## Description
Previously, `TableInitialStateDirective` did not take into account `visible` input property of the column, which resulted in rendering all available columns during table initialization.
