### PR TITLE
fix(core): dynamic page accessibility bugs

### DIFF
--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
@@ -14,7 +14,7 @@
             </ng-container>
 
             <div class="fd-dynamic-page__title-subtitle-container">
-                <div class="fd-dynamic-page__title-container">
+                <div class="fd-dynamic-page__title-container" role="heading" aria-level="2">
                     <span
                         class="fd-dynamic-page__title"
                         [class.fd-dynamic-page__title--wrap]="titleWrap"

--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
@@ -14,7 +14,7 @@
             </ng-container>
 
             <div class="fd-dynamic-page__title-subtitle-container">
-                <div class="fd-dynamic-page__title-container" role="heading" aria-level="2">
+                <h2 class="fd-dynamic-page__title-container">
                     <span
                         class="fd-dynamic-page__title"
                         [class.fd-dynamic-page__title--wrap]="titleWrap"
@@ -29,7 +29,7 @@
                             <ng-container *ngTemplateOutlet="dynamicPageLayoutActionsRef"></ng-container>
                         </ng-container>
                     </div>
-                </div>
+                </h2>
                 <div
                     *ngIf="_collapsed && (subtitle || _subtitleTemplate)"
                     class="fd-dynamic-page__subtitle"

--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
@@ -23,8 +23,7 @@
                     [attr.aria-controls]="id"
                     (click)="toggleCollapse()"
                 >
-                    <i *ngIf="!collapsed" class="sap-icon--slim-arrow-up"></i>
-                    <i *ngIf="collapsed" class="sap-icon--slim-arrow-down"></i>
+                    <i [style.transform]="collapsed ? '' : 'rotate(180deg)'" class="sap-icon--slim-arrow-down"></i>
                 </button>
                 <button
                     fd-button

--- a/libs/core/src/lib/facets/facet/facet.component.html
+++ b/libs/core/src/lib/facets/facet/facet.component.html
@@ -3,9 +3,17 @@
 </ng-container>
 
 <ng-container *ngIf="type !== 'image'">
-    <span *ngIf="facetTitle" fd-title [headerSize]="5" class="fd-margin-bottom--sm" [id]="titleId">{{
-        facetTitle
-    }}</span>
+    <span
+        *ngIf="facetTitle"
+        style="display: block"
+        [attr.role]="!!headingLevel ? 'heading' : null"
+        [attr.aria-level]="headingLevel"
+        fd-title
+        [headerSize]="5"
+        class="fd-margin-bottom--sm"
+        [id]="titleId"
+        >{{ facetTitle }}</span
+    >
     <ng-container *ngIf="type === 'form'">
         <ng-container *ngTemplateOutlet="contentTemplate"></ng-container>
     </ng-container>

--- a/libs/core/src/lib/facets/facet/facet.component.html
+++ b/libs/core/src/lib/facets/facet/facet.component.html
@@ -3,7 +3,9 @@
 </ng-container>
 
 <ng-container *ngIf="type !== 'image'">
-    <h1 *ngIf="facetTitle" fd-title [headerSize]="5" class="fd-margin-bottom--sm" [id]="titleId">{{ facetTitle }}</h1>
+    <span *ngIf="facetTitle" fd-title [headerSize]="5" class="fd-margin-bottom--sm" [id]="titleId">{{
+        facetTitle
+    }}</span>
     <ng-container *ngIf="type === 'form'">
         <ng-container *ngTemplateOutlet="contentTemplate"></ng-container>
     </ng-container>

--- a/libs/core/src/lib/facets/facet/facet.component.ts
+++ b/libs/core/src/lib/facets/facet/facet.component.ts
@@ -8,6 +8,7 @@ import {
     AfterViewInit,
     HostBinding
 } from '@angular/core';
+import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { FacetType, FACET_CLASS_NAME } from '../constants';
 import { addClassNameToFacetElement } from '../utils';
 
@@ -52,6 +53,12 @@ export class FacetComponent implements AfterViewInit {
      */
     @Input()
     alignEnd = false;
+
+    /**
+     * Heading level (i.e. <h1>, <h2>, etc.) of the facet title.
+     */
+    @Input()
+    headingLevel: Nullable<1 | 2 | 3 | 4 | 5 | 6>;
 
     /** @hidden
      * the appropriate role for each facet type

--- a/libs/core/src/lib/title/title.component.ts
+++ b/libs/core/src/lib/title/title.component.ts
@@ -10,7 +10,7 @@ export abstract class TitleToken {
 
 @Component({
     // eslint-disable-next-line
-    selector: 'h1[fd-title], h2[fd-title], h3[fd-title], h4[fd-title], h5[fd-title], h6[fd-title]',
+    selector: 'h1[fd-title], h2[fd-title], h3[fd-title], h4[fd-title], h5[fd-title], h6[fd-title], span[fd-title]',
     exportAs: 'fd-title',
     template: '<ng-content></ng-content>',
     host: {

--- a/libs/docs/core/dynamic-page/examples/dynamic-page-facets-example/dynamic-page-facets-example.component.html
+++ b/libs/docs/core/dynamic-page/examples/dynamic-page-facets-example/dynamic-page-facets-example.component.html
@@ -83,7 +83,7 @@
             (collapsedChange)="onCollapseChange()"
         >
             <fd-facet-group ariaLabel="Facet Group">
-                <fd-facet type="form" facetTitle="Technical Data" id="facet1">
+                <fd-facet type="form" facetTitle="Technical Data" [headingLevel]="3" id="facet1">
                     <fd-facet-content>
                         <label fd-form-label [colon]="true" for="form-value-10">Base unit</label>
                         <fd-text text="Each" id="form-value-10"></fd-text>
@@ -101,7 +101,13 @@
                         <fd-text text="20.8 Centimeter" id="form-value-13"></fd-text>
                     </fd-facet-content>
                 </fd-facet>
-                <fd-facet type="rating-indicator" facetTitle="Rating Indicator" subtitle="6 reviews" id="facet2">
+                <fd-facet
+                    type="rating-indicator"
+                    facetTitle="Rating Indicator"
+                    [headingLevel]="3"
+                    subtitle="6 reviews"
+                    id="facet2"
+                >
                     <fd-facet-content>
                         <fd-rating-indicator size="md" dynamicTextIndicator="of" [value]="2.51"></fd-rating-indicator>
                     </fd-facet-content>
@@ -119,7 +125,7 @@
                         aria-label="Delivery"
                     ></span>
                 </fd-facet>
-                <fd-facet type="key-value" facetTitle="Delivery Time" id="facet5">
+                <fd-facet type="key-value" facetTitle="Delivery Time" [headingLevel]="3" id="facet5">
                     <span
                         fd-object-status
                         status="critical"
@@ -130,7 +136,7 @@
                         aria-label="12 days"
                     ></span>
                 </fd-facet>
-                <fd-facet type="key-value" facetTitle="Assembly Option" id="facet6">
+                <fd-facet type="key-value" facetTitle="Assembly Option" [headingLevel]="3" id="facet6">
                     <span
                         fd-object-status
                         status="negative"
@@ -140,7 +146,7 @@
                         aria-label="To be selected"
                     ></span>
                 </fd-facet>
-                <fd-facet type="key-value" facetTitle="Pricing" id="facet7">
+                <fd-facet type="key-value" facetTitle="Pricing" [headingLevel]="3" id="facet7">
                     <fd-object-number
                         [number]="100.88"
                         [large]="true"

--- a/libs/docs/platform/dynamic-page/examples/platform-dynamic-page-facets-example/platform-dynamic-page-facets-example.component.html
+++ b/libs/docs/platform/dynamic-page/examples/platform-dynamic-page-facets-example/platform-dynamic-page-facets-example.component.html
@@ -97,7 +97,7 @@
                 (collapsedChange)="onCollapseChange()"
             >
                 <fd-facet-group ariaLabel="Facet Group">
-                    <fd-facet type="form" facetTitle="Technical Data" id="facet1">
+                    <fd-facet type="form" facetTitle="Technical Data" [headingLevel]="3" id="facet1">
                         <fd-facet-content>
                             <label fd-form-label [colon]="true" for="form-value-10">Base unit</label>
                             <fd-text text="Each" id="form-value-10"></fd-text>
@@ -115,7 +115,13 @@
                             <fd-text text="20.8 Centimeter" id="form-value-13"></fd-text>
                         </fd-facet-content>
                     </fd-facet>
-                    <fd-facet type="rating-indicator" facetTitle="Rating Indicator" subtitle="6 reviews" id="facet2">
+                    <fd-facet
+                        type="rating-indicator"
+                        facetTitle="Rating Indicator"
+                        [headingLevel]="3"
+                        subtitle="6 reviews"
+                        id="facet2"
+                    >
                         <fd-facet-content>
                             <fd-rating-indicator
                                 size="md"
@@ -127,7 +133,7 @@
                     <fd-facet type="image" id="facet3">
                         <fd-avatar title="Nature" image="http://picsum.photos/id/1018/400" size="l"></fd-avatar>
                     </fd-facet>
-                    <fd-facet type="key-value" facetTitle="Status" id="facet4">
+                    <fd-facet type="key-value" facetTitle="Status" [headingLevel]="3" id="facet4">
                         <span
                             fd-object-status
                             status="positive"
@@ -137,7 +143,7 @@
                             aria-label="Delivery"
                         ></span>
                     </fd-facet>
-                    <fd-facet type="key-value" facetTitle="Delivery Time" id="facet5">
+                    <fd-facet type="key-value" facetTitle="Delivery Time" [headingLevel]="3" id="facet5">
                         <span
                             fd-object-status
                             status="critical"
@@ -148,7 +154,7 @@
                             aria-label="12 days"
                         ></span>
                     </fd-facet>
-                    <fd-facet type="key-value" facetTitle="Assembly Option" id="facet6">
+                    <fd-facet type="key-value" facetTitle="Assembly Option" [headingLevel]="3" id="facet6">
                         <span
                             fd-object-status
                             status="negative"
@@ -158,7 +164,7 @@
                             aria-label="To be selected"
                         ></span>
                     </fd-facet>
-                    <fd-facet type="key-value" facetTitle="Pricing" id="facet7">
+                    <fd-facet type="key-value" facetTitle="Pricing" [headingLevel]="3" id="facet7">
                         <fd-object-number
                             [number]="100.88"
                             [large]="true"


### PR DESCRIPTION
fixes #10351 

Regarding the `[style.transform]` line, I am not sure why the arrow was always rendering pointing down previously. If you changed the previous lines to 

```
                    <i *ngIf="!collapsed" class="sap-icon--customer"></i>
                    <i *ngIf="collapsed" class="sap-icon--calendar"></i>
```

You would see the customer when the page was not collapsed, and the calendar when it is. Unclear as to why the icon would not change for `"sap-icon--slim-arrow-up"` vs `"sap-icon--slim-arrow-down"`