### PR TITLE
fix(core): popover footer button overflow

### DIFF
--- a/libs/core/date-picker/date-picker.component.html
+++ b/libs/core/date-picker/date-picker.component.html
@@ -92,7 +92,7 @@
         (closeCalendar)="closeFromCalendar()"
     ></fd-calendar>
     @if (showTodayButton) {
-        <div fd-bar barDesign="footer">
+        <div fd-bar barDesign="footer" class="fd-date-picker__bar">
             <div fd-bar-right>
                 <fd-bar-element>
                     <button fd-button [label]="todayButtonLabel" (click)="onTodayButtonClick()"></button>

--- a/libs/core/date-picker/date-picker.component.scss
+++ b/libs/core/date-picker/date-picker.component.scss
@@ -10,3 +10,7 @@
         border-radius: var(--sapElement_BorderCornerRadius, 0.25rem);
     }
 }
+
+.fd-date-picker__bar {
+    overflow: hidden;
+}

--- a/libs/core/datetime-picker/datetime-picker.component.html
+++ b/libs/core/datetime-picker/datetime-picker.component.html
@@ -132,7 +132,7 @@
         </div>
         @if (!mobile && showFooter) {
             <div fd-popover-body-footer>
-                <div fd-bar barDesign="footer">
+                <div class="fd-datetime__bar" fd-bar barDesign="footer">
                     <div fd-bar-right>
                         <fd-bar-element>
                             <button

--- a/libs/core/datetime-picker/datetime-picker.component.scss
+++ b/libs/core/datetime-picker/datetime-picker.component.scss
@@ -3,6 +3,10 @@ $block: fd-datetime;
 .#{$block} {
     display: block;
 
+    &__bar {
+        overflow: hidden;
+    }
+
     &__wrapper {
         max-height: 80vh;
         max-width: 80vw;
@@ -22,9 +26,6 @@ $block: fd-datetime;
             > *:not(.#{$block}__mobile-display) {
                 display: none !important;
             }
-            // .#{$block}__mobile-display {
-            //     display: block !important;
-            // }
         }
     }
 

--- a/libs/core/dialog/dialog.component.scss
+++ b/libs/core/dialog/dialog.component.scss
@@ -37,3 +37,7 @@
     width: 100%;
     position: fixed !important;
 }
+
+.fd-dialog__footer {
+    overflow: hidden;
+}


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #11209 

## Description
When user opens some of the popovers or dialogs that have buttons in the footer, it may result in additional scrollbar appearing, even though the height is visibly enough to fit all of the elements.

The issue appears due to the click area of the button which has absolute positioning and messing around with the calculated height of the content.
This PR adds overflow: hidden for date picker and dialog components

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![image](https://github.com/SAP/fundamental-ngx/assets/6586561/74b9ca41-5262-4071-abcc-ae6ac7123c58)
![image](https://github.com/SAP/fundamental-ngx/assets/6586561/b8218284-531f-4ae4-af2e-32bd4f2936eb)

### After:
![image](https://github.com/SAP/fundamental-ngx/assets/6586561/54a8ea74-1898-4f4e-a7b9-94b743cdd501)
![image](https://github.com/SAP/fundamental-ngx/assets/6586561/9bf6118b-320f-48ae-a324-99843b5db0bb)
