### PR TITLE
feat(core): add full width modifier for Step Input

### DIFF
--- a/libs/core/step-input/step-input.component.html
+++ b/libs/core/step-input/step-input.component.html
@@ -6,6 +6,7 @@
         [class.is-readonly]="readonly"
         [class.is-disabled]="disabled"
         [class.fd-step-input--without-buttons]="!hasStepButtons"
+        [class.fd-step-input--full-width]="isFullWidth"
     >
         @if (hasStepButtons) {
             <button

--- a/libs/core/step-input/step-input.component.ts
+++ b/libs/core/step-input/step-input.component.ts
@@ -81,6 +81,10 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
     @Input()
     locale: string;
 
+    /** Sets the Step Input to take the full width of the container element */
+    @Input()
+    isFullWidth = false;
+
     /** Specifies algorithm used to match locale. Check Intl.NumberFormat documentation for more information */
     @Input()
     localeMatcher: Nullable<string>;

--- a/libs/docs/core/step-input/examples/step-inpt-default-example/step-input-default-example.component.ts
+++ b/libs/docs/core/step-input/examples/step-inpt-default-example/step-input-default-example.component.ts
@@ -6,7 +6,7 @@ import { StepInputModule } from '@fundamental-ngx/core/step-input';
 @Component({
     selector: 'fd-step-input-default-example',
     template: `
-        <div class="step-input-example-container" style="justify-content: space-evenly;">
+        <div class="step-input-example-container" style="justify-content: space-between;">
             <div class="step-input-example">
                 <label fd-form-label for="default-input">Default</label>
                 <fd-step-input inputId="default-input" [(value)]="value1"></fd-step-input>
@@ -19,6 +19,14 @@ import { StepInputModule } from '@fundamental-ngx/core/step-input';
                 <small>Value: {{ value2 }}</small>
             </div>
         </div>
+        <br />
+        <div class="step-input-example-container" style="width: 100%;">
+            <div class="step-input-example">
+                <label fd-form-label for="full-width-input">Full Width</label>
+                <fd-step-input inputId="full-width-input" [isFullWidth]="true" [(value)]="value3"></fd-step-input>
+                <small>Value: {{ value3 }}</small>
+            </div>
+        </div>
     `,
     standalone: true,
     imports: [FormLabelComponent, StepInputModule, ContentDensityDirective]
@@ -26,4 +34,5 @@ import { StepInputModule } from '@fundamental-ngx/core/step-input';
 export class StepInputDefaultExampleComponent {
     value1: number | null = 0;
     value2: number | null = 0;
+    value3: number | null = 0;
 }


### PR DESCRIPTION
Add a prop `isFullWidth` to Step Input that would allow the user to set the control to full width. This way the control will take the entire width of the wrapping element. 

Note: the css class will come with the latest version of fund-styles