### PR TITLE
docs: add link to version 0.48 as docs

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,9 @@
 [
     {
+        "id": "0.48",
+        "url": "https://docs-0-48--fundamental-ngx.netlify.app/"
+    },
+    {
         "id": "0.47",
         "url": "https://docs-0-47--fundamental-ngx.netlify.app/"
     },


### PR DESCRIPTION
add link to version 0.48 as docs so it will be available in the older doc switcher