### PR TITLE
fix(core): reactive tabindex property

### DIFF
--- a/libs/core/list/list-focus-item.model.ts
+++ b/libs/core/list/list-focus-item.model.ts
@@ -1,5 +1,5 @@
 import { coerceNumberProperty } from '@angular/cdk/coercion';
-import { Directive, ElementRef, EventEmitter, HostBinding, HostListener, Input, inject } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, HostListener, Input, computed, inject, signal } from '@angular/core';
 import { KeyboardSupportItemInterface } from '@fundamental-ngx/cdk/utils';
 import { Subject } from 'rxjs';
 
@@ -7,15 +7,11 @@ import { Subject } from 'rxjs';
 export abstract class ListFocusItem<T = any> implements KeyboardSupportItemInterface {
     /** tab index attribute */
     @Input()
-    @HostBinding('attr.tabindex')
     set tabindex(value: number) {
-        this._tabIndex = coerceNumberProperty(value, -1);
+        this._tabIndex$.set(coerceNumberProperty(value, -1));
     }
     get tabindex(): number {
-        if (this._isFirstItem && isNaN(this._tabIndex as number)) {
-            return 0;
-        }
-        return this._tabIndex ?? -1;
+        return this._normalizedTabIndex$();
     }
 
     /**
@@ -38,10 +34,18 @@ export abstract class ListFocusItem<T = any> implements KeyboardSupportItemInter
     readonly _clicked$ = new Subject<MouseEvent>();
 
     /** @hidden */
-    protected _isFirstItem = false;
+    protected _isFirstItem$ = signal(false);
 
     /** @hidden */
-    protected _tabIndex: number | undefined;
+    protected _tabIndex$ = signal<number | undefined>(undefined);
+
+    /** @hidden */
+    protected _normalizedTabIndex$ = computed(() => {
+        if (this._isFirstItem$() && isNaN(this._tabIndex$() as number)) {
+            return 0;
+        }
+        return this._tabIndex$() ?? -1;
+    });
 
     /** @hidden */
     @HostListener('focusin', ['$event'])
@@ -63,6 +67,6 @@ export abstract class ListFocusItem<T = any> implements KeyboardSupportItemInter
 
     /** @hidden */
     setIsFirst(value: boolean): void {
-        this._isFirstItem = value;
+        this._isFirstItem$.set(value);
     }
 }

--- a/libs/core/list/list-item/list-item.component.ts
+++ b/libs/core/list/list-item/list-item.component.ts
@@ -43,7 +43,8 @@ let listItemUniqueId = 0;
     selector: '[fdListItem] ,[fd-list-item]',
     templateUrl: './list-item.component.html',
     host: {
-        class: 'fd-list__item'
+        class: 'fd-list__item',
+        '[attr.tabindex]': '_normalizedTabIndex$()'
     },
     providers: [
         {


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #11289

## Description
Previously list item tabindex relied on static get property, thus if used inside `OnPush` component with async data, correct attribute may not have being applied.
This PR uses signal-based tabIndex attribute which automatically notifies parent view for detection if value changed.
