### PR TITLE
fix(btp): fix splitter style import

### DIFF
--- a/libs/btp/splitter/splitter.component.scss
+++ b/libs/btp/splitter/splitter.component.scss
@@ -1,1 +1,1 @@
-@import 'fundamental-styles/dist/splitter.css';
+@import 'fundamental-styles/dist/splitter';


### PR DESCRIPTION
fixes none, user reported on slack. splitter styles not being imported since the btp move