### PR TITLE
fix(core,platform): tabs programmatic overflow item open

### DIFF
--- a/libs/core/tabs/tab-list.component.ts
+++ b/libs/core/tabs/tab-list.component.ts
@@ -390,7 +390,13 @@ export class TabListComponent
                 switchMap((tabPanels) => merge(...tabPanels)),
                 takeUntilDestroyed(this._destroyRef)
             )
-            .subscribe((event) => this._expandTab(event.target, event.state));
+            .subscribe((event) => {
+                this._tabArray.forEach((tab) => {
+                    tab.panel._forcedVisibility = tab.panel === event.target;
+                });
+                this._expandTab(event.target, event.state);
+                this._overflowLayout.triggerRecalculation();
+            });
     }
 
     /** @hidden */

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-base.class.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-base.class.ts
@@ -134,6 +134,13 @@ export abstract class IconTabBarBase implements OnInit, OnChanges, AfterViewInit
         if (changes.isRtl && !changes.isRtl.firstChange) {
             this._triggerRecalculationVisibleItems();
         }
+
+        if (changes.selectedUid && !changes.selectedUid.firstChange) {
+            const isExtraTab = this._extraTabs$().find((tab) => tab.uId === this.selectedUid);
+            if (isExtraTab) {
+                this._selectExtraItem(isExtraTab);
+            }
+        }
     }
 
     /** @hidden */

--- a/libs/platform/icon-tab-bar/icon-tab-bar.component.ts
+++ b/libs/platform/icon-tab-bar/icon-tab-bar.component.ts
@@ -327,6 +327,7 @@ export class IconTabBarComponent implements OnInit, AfterViewInit, TabList {
         }
         this._selectedUid.set(selectedItem.uId);
         this._selectItem(selectedItem);
+        this._cd.detectChanges();
     }
 
     /** @hidden */


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #10969

## Description
Previously icon tab bar and core tabs could open only tabs that are located outside overflow menu.
This PR fixes the issue and allows opening tabs that are hidden under overflow menu.
