### PR TITLE
fix(docs): vhd value comparator fix

### DIFF
--- a/libs/docs/platform/vhd/examples/platform-vhd-multi-input-example.component.html
+++ b/libs/docs/platform/vhd/examples/platform-vhd-multi-input-example.component.html
@@ -4,6 +4,7 @@
         placeholder="Search here"
         [displayFn]="displayFunc"
         [allowNewTokens]="true"
+        [valueFn]="valueFn"
         [newTokenParseFn]="parseFunc"
         [(ngModel)]="selected"
         (selectedChange)="multiSelectChange()"

--- a/libs/docs/platform/vhd/examples/platform-vhd-multi-input-example.component.ts
+++ b/libs/docs/platform/vhd/examples/platform-vhd-multi-input-example.component.ts
@@ -62,7 +62,9 @@ export class PlatformVhdMultiInputExampleComponent implements OnInit {
     originalData: ExampleTestModel[];
     dataSource: ValueHelpDialogDataSource<ExampleTestModel>;
     currentValue: Partial<VhdValue> = {};
-    selected: ExampleTestModel[] = [];
+    selected: ExampleTestModel['id'][] = [];
+
+    valueFn = (item: ExampleTestModel) => item.id;
 
     constructor(private readonly _changeDetectorRef: ChangeDetectorRef) {}
 
@@ -74,7 +76,7 @@ export class PlatformVhdMultiInputExampleComponent implements OnInit {
     }
 
     valueChange($event: VhdValueChangeEvent<ExampleTestModel>): void {
-        this.selected = [...$event.selected];
+        this.selected = [...$event.selected.map((i) => i.id)];
         this._changeDetectorRef.detectChanges();
     }
 
@@ -83,7 +85,7 @@ export class PlatformVhdMultiInputExampleComponent implements OnInit {
     }
 
     multiSelectChange(): void {
-        this.currentValue.selected = this.selected;
+        this.currentValue.selected = this.originalData.filter((i) => this.selected.includes(i.id));
         this._changeDetectorRef.detectChanges();
     }
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #11380

## Description
Previously there was no value comparator between multi input and vhd component, that resulted in an unexpected `selected` rows selection.
This PR adds value comparator by ID's that handles accurate selection for multi input and for vhd.
