### PR TITLE
fix(docs): use direct object assignment to trigger correct detection

### DIFF
--- a/libs/docs/platform/vhd/examples/platform-vhd-multi-input-example.component.ts
+++ b/libs/docs/platform/vhd/examples/platform-vhd-multi-input-example.component.ts
@@ -79,7 +79,9 @@ export class PlatformVhdMultiInputExampleComponent implements OnInit {
     }
 
     multiSelectChange(): void {
-        this.currentValue.selected = this.originalData.filter((i) => this.selected.includes(i.id));
+        this.currentValue = {
+            selected: [...this.originalData.filter((i) => this.selected.includes(i.id))]
+        };
         this._changeDetectorRef.detectChanges();
     }
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #11401

Previously we assigned nested object property with new selected value array.
This approach does not work correctly due to the fact that the reference to the object remains the same, meaning change detector does not detect any changes in the input property of vhd. This PR uses direct object assignment for cdr to detect changes in the object.