### PR TITLE
fix(core): add fix for broken list height in Multi Combobox

### DIFF
--- a/libs/core/multi-combobox/multi-combobox.component.html
+++ b/libs/core/multi-combobox/multi-combobox.component.html
@@ -145,7 +145,7 @@
     <ul
         fd-list
         [byline]="byline"
-        [selection]="true"
+        [selection]="byline"
         (focusEscapeList)="_handleListFocusEscape($event)"
         class="fd-multi-combobox__list fd-list--multi-input"
         [id]="_cva.id + '-result'"


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11404

## Description
The height of the list element was broken because of `fd-list--selection` class. We need this class in multiline list case so we add it if the list is Byline
