### PR TITLE
fix(cdk): data source package tsconfig

### DIFF
--- a/libs/cdk/data-source/tsconfig.json
+++ b/libs/cdk/data-source/tsconfig.json
@@ -7,9 +7,6 @@
             "path": "./tsconfig.lib.json"
         },
         {
-            "path": "./tsconfig.lib.prod.json"
-        },
-        {
             "path": "./tsconfig.spec.json"
         }
     ],

--- a/libs/cdk/data-source/tsconfig.lib.json
+++ b/libs/cdk/data-source/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-    "extends": "./tsconfig.lib.json",
+    "extends": "./tsconfig.json",
     "compilerOptions": {
         "declarationMap": false,
         "target": "ES2022",


### PR DESCRIPTION
closes none

There was an issue with tsconfig references which resulted in invalid typescript configuration.