### PR TITLE
fix(core): message displayed in select component is being truncated

### DIFF
--- a/libs/core/select/select.component.scss
+++ b/libs/core/select/select.component.scss
@@ -40,6 +40,7 @@ $block: fd-select;
             font-weight: normal;
             padding: 0 0.625rem;
             color: var(--sapField_PlaceholderTextColor);
+            white-space: normal !important; /* or pre-wrap */
 
             [class*='sap-icon'] {
                 font-style: italic;

--- a/libs/core/select/select.component.scss
+++ b/libs/core/select/select.component.scss
@@ -40,7 +40,7 @@ $block: fd-select;
             font-weight: normal;
             padding: 0 0.625rem;
             color: var(--sapField_PlaceholderTextColor);
-            white-space: normal !important; /* or pre-wrap */
+            white-space: normal !important;
 
             [class*='sap-icon'] {
                 font-style: italic;


### PR DESCRIPTION
#11430

Introduced text wrapping

![White-space](https://github.com/SAP/fundamental-ngx/assets/151554219/402d6406-707c-48da-abb7-76e04c97cf90)
