### PR TITLE
fix(platform): smart filter bar service scope fix

### DIFF
--- a/libs/platform/smart-filter-bar/smart-filter-bar.component.ts
+++ b/libs/platform/smart-filter-bar/smart-filter-bar.component.ts
@@ -8,6 +8,7 @@ import {
     DestroyRef,
     EventEmitter,
     forwardRef,
+    inject,
     Injector,
     Input,
     OnDestroy,
@@ -230,10 +231,17 @@ export class SmartFilterBarComponent extends SmartFilterBar implements AfterView
     /** @hidden */
     private _refresh$ = new Subject<void>();
 
+    /**
+     * @hidden
+     * Smart filter bar service may be provided by parent component that adds custom configuration, so we need to check if it's provided.
+     */
+    private readonly _smartFilterBarService =
+        inject(SmartFilterBarService, { optional: true, skipSelf: true }) ??
+        inject(SmartFilterBarService, { self: true });
+
     /** @hidden */
     constructor(
         private _dialogService: DialogService,
-        private _smartFilterBarService: SmartFilterBarService,
         private _fgService: FormGeneratorService,
         private _injector: Injector,
         private readonly _destroyRef: DestroyRef


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes none

## Description
After standalone migration, we made `SmartFilterBarService` provided in `SmartFilterBarComponent`. This resulted in unexpected behavior when users would provide this service in their components to add additional configuration, e.g. custom component renderers. Since SmartFilterBarComponent also provides `SmartFilterBarService`, it receives different instance than the config was applied to.
This PR tries to inject parent service and falls back to the local one.
