### PR TITLE
docs(core,platform): update the state icons for Object Status

### DIFF
--- a/libs/docs/core/object-status/examples/object-status-clickable-and-icon-example.component.html
+++ b/libs/docs/core/object-status/examples/object-status-clickable-and-icon-example.component.html
@@ -1,7 +1,7 @@
 <a
     fd-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [clickable]="true"
     label="Negative"
     aria-label="Object Status Negative"
@@ -9,7 +9,7 @@
 <a
     fd-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [clickable]="true"
     label="Critical"
     aria-label="Object Status Critical"
@@ -17,7 +17,7 @@
 <a
     fd-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [clickable]="true"
     label="Positive"
     aria-label="Object Status Positive"
@@ -25,7 +25,7 @@
 <a
     fd-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [clickable]="true"
     label="Informative"
     aria-label="Object Status Informative"

--- a/libs/docs/core/object-status/examples/object-status-default-example.component.html
+++ b/libs/docs/core/object-status/examples/object-status-default-example.component.html
@@ -1,11 +1,5 @@
 <span fd-object-status glyphAriaLabel="Check for review" title="Default"></span>
-<span fd-object-status status="negative" glyph="message-error" glyphAriaLabel="Negative" title="Negative"></span>
-<span fd-object-status status="critical" glyph="message-warning" glyphAriaLabel="Critical" title="Critical"></span>
-<span fd-object-status status="positive" glyph="message-success" glyphAriaLabel="Positive" title="Positive"></span>
-<span
-    fd-object-status
-    status="informative"
-    glyph="message-information"
-    glyphAriaLabel="Show More"
-    title="Informative"
-></span>
+<span fd-object-status status="negative" glyph="error" glyphAriaLabel="Negative" title="Negative"></span>
+<span fd-object-status status="critical" glyph="alert" glyphAriaLabel="Critical" title="Critical"></span>
+<span fd-object-status status="positive" glyph="sys-enter-2" glyphAriaLabel="Positive" title="Positive"></span>
+<span fd-object-status status="informative" glyph="information" glyphAriaLabel="Show More" title="Informative"></span>

--- a/libs/docs/core/object-status/examples/object-status-icon-text-example.component.html
+++ b/libs/docs/core/object-status/examples/object-status-icon-text-example.component.html
@@ -1,28 +1,16 @@
-<span
-    fd-object-status
-    status="negative"
-    glyph="message-error"
-    label="Negative"
-    aria-label="Object status Negative"
-></span>
-<span
-    fd-object-status
-    status="critical"
-    glyph="message-warning"
-    label="Critical"
-    aria-label="Object status Critical"
-></span>
+<span fd-object-status status="negative" glyph="error" label="Negative" aria-label="Object status Negative"></span>
+<span fd-object-status status="critical" glyph="alert" label="Critical" aria-label="Object status Critical"></span>
 <span
     fd-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     label="Positive"
     aria-label="Object status Positive"
 ></span>
 <span
     fd-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     label="Informative"
     aria-label="Object status Informative"
 ></span>

--- a/libs/docs/core/object-status/examples/object-status-inverted-example.component.html
+++ b/libs/docs/core/object-status/examples/object-status-inverted-example.component.html
@@ -1,7 +1,7 @@
 <span
     fd-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [inverted]="true"
     title="Negative"
     aria-label="Object status Negative Inverted"
@@ -9,7 +9,7 @@
 <span
     fd-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [inverted]="true"
     title="Critical"
     aria-label="Object status Critical Inverted"
@@ -17,7 +17,7 @@
 <span
     fd-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [inverted]="true"
     title="Positive"
     aria-label="Object status Positive Inverted"
@@ -25,7 +25,7 @@
 <span
     fd-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [inverted]="true"
     title="Informative"
     aria-label="Object status Informative Inverted"
@@ -120,7 +120,7 @@
 <span
     fd-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [inverted]="true"
     label="Negative"
     aria-label="Object status Negative Icon and Text Inverted"
@@ -128,7 +128,7 @@
 <span
     fd-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [inverted]="true"
     label="Critical"
     aria-label="Object status Critical Icon and Text Inverted"
@@ -136,7 +136,7 @@
 <span
     fd-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [inverted]="true"
     label="Positive"
     aria-label="Object status Positive Icon and Text Inverted"
@@ -144,7 +144,7 @@
 <span
     fd-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [inverted]="true"
     label="Informative"
     aria-label="Object status Informative Icon and Text Inverted"
@@ -161,7 +161,7 @@
 <a
     fd-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [clickable]="true"
     [inverted]="true"
     label="Negative"
@@ -170,7 +170,7 @@
 <a
     fd-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [clickable]="true"
     [inverted]="true"
     label="Critical"
@@ -179,7 +179,7 @@
 <a
     fd-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [clickable]="true"
     [inverted]="true"
     label="Positive"
@@ -188,7 +188,7 @@
 <a
     fd-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [clickable]="true"
     [inverted]="true"
     label="Informative"

--- a/libs/docs/core/object-status/examples/object-status-large-example.component.html
+++ b/libs/docs/core/object-status/examples/object-status-large-example.component.html
@@ -1,7 +1,7 @@
 <span
     fd-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [inverted]="true"
     [large]="true"
     title="Negative"
@@ -10,7 +10,7 @@
 <span
     fd-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [inverted]="true"
     [large]="true"
     title="Critical"
@@ -19,7 +19,7 @@
 <span
     fd-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [inverted]="true"
     [large]="true"
     title="Positive"
@@ -28,7 +28,7 @@
 <span
     fd-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [inverted]="true"
     [large]="true"
     title="Informative"
@@ -118,7 +118,7 @@
 <span
     fd-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [large]="true"
     label="Negative"
     aria-label="Object Status Informative icon and large text"
@@ -126,7 +126,7 @@
 <span
     fd-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [large]="true"
     label="Critical"
     aria-label="Object Status Critical icon and large text"
@@ -134,7 +134,7 @@
 <span
     fd-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [large]="true"
     label="Positive"
     aria-label="Object Status Positive icon and large text"
@@ -142,7 +142,7 @@
 <span
     fd-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [large]="true"
     label="Informative"
     aria-label="Object Status Informative icon and large text"
@@ -154,7 +154,7 @@
 <a
     fd-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -164,7 +164,7 @@
 <a
     fd-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -174,7 +174,7 @@
 <a
     fd-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -184,7 +184,7 @@
 <a
     fd-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [clickable]="true"
     [large]="true"
     [inverted]="true"

--- a/libs/docs/platform/object-status/examples/platform-object-status-clickable-and-icon-example.component.html
+++ b/libs/docs/platform/object-status/examples/platform-object-status-clickable-and-icon-example.component.html
@@ -1,6 +1,6 @@
 <fdp-object-status
     status="negative"
-    glyph="message-information"
+    glyph="error"
     [clickable]="true"
     (objectStatusClick)="showObjectStatus()"
     label="Negative"
@@ -8,7 +8,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [clickable]="true"
     (objectStatusClick)="showObjectStatus()"
     label="Critical"
@@ -16,7 +16,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [clickable]="true"
     (objectStatusClick)="showObjectStatus()"
     label="Positive"
@@ -24,7 +24,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [clickable]="true"
     (objectStatusClick)="showObjectStatus()"
     label="Informative"

--- a/libs/docs/platform/object-status/examples/platform-object-status-icon-text-example.component.html
+++ b/libs/docs/platform/object-status/examples/platform-object-status-icon-text-example.component.html
@@ -1,24 +1,24 @@
 <fdp-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     label="Negative"
     ariaLabel="Object status Negative"
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     label="Critical"
     ariaLabel="Object status Critical"
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     label="Positive"
     ariaLabel="Object status Positive"
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     label="Informative"
     ariaLabel="Object status Informative"
 ></fdp-object-status>

--- a/libs/docs/platform/object-status/examples/platform-object-status-inverted-example.component.html
+++ b/libs/docs/platform/object-status/examples/platform-object-status-inverted-example.component.html
@@ -1,27 +1,27 @@
 <fdp-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [inverted]="true"
     title="Status Negative"
     ariaLabel="Object status Negative inverted"
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [inverted]="true"
     title="Status Critical"
     ariaLabel="Object status Critical inverted"
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [inverted]="true"
     title="Status Positive"
     ariaLabel="Object status Positive inverted"
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [inverted]="true"
     title="Status Informative"
     ariaLabel="Object status Informative inverted"
@@ -105,28 +105,28 @@
 
 <fdp-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [inverted]="true"
     ariaLabel="Object status Negative inverted"
     label="Negative"
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [inverted]="true"
     ariaLabel="Object status Critical inverted"
     label="Critical"
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [inverted]="true"
     ariaLabel="Object status Positive inverted"
     label="Positive"
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [inverted]="true"
     ariaLabel="Object status Informative inverted"
     label="Informative"
@@ -137,7 +137,7 @@
 
 <fdp-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [clickable]="true"
     [inverted]="true"
     label="Negative"
@@ -145,7 +145,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [clickable]="true"
     [inverted]="true"
     label="Critical"
@@ -153,7 +153,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [clickable]="true"
     [inverted]="true"
     label="Positive"
@@ -161,7 +161,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [clickable]="true"
     [inverted]="true"
     label="Informative"

--- a/libs/docs/platform/object-status/examples/platform-object-status-large-example.component.html
+++ b/libs/docs/platform/object-status/examples/platform-object-status-large-example.component.html
@@ -1,6 +1,6 @@
 <fdp-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [inverted]="true"
     [large]="true"
     title="Status Negative"
@@ -8,7 +8,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [inverted]="true"
     [large]="true"
     title="Status Critical"
@@ -16,7 +16,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [inverted]="true"
     [large]="true"
     title="Status Positive"
@@ -24,7 +24,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [inverted]="true"
     [large]="true"
     title="Status Informative"
@@ -105,28 +105,28 @@
 
 <fdp-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [large]="true"
     label="Negative"
     ariaLabel="Object status Negative large"
 ></fdp-object-status>
 <fdp-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [large]="true"
     label="Critical"
     ariaLabel="Object status Critical large"
 ></fdp-object-status>
 <fdp-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [large]="true"
     label="Positive"
     ariaLabel="Object status Positive large"
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [large]="true"
     label="Informative"
     ariaLabel="Object status Informative large"
@@ -137,7 +137,7 @@
 
 <fdp-object-status
     status="negative"
-    glyph="message-error"
+    glyph="error"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -149,7 +149,7 @@
 >
 <fdp-object-status
     status="critical"
-    glyph="message-warning"
+    glyph="alert"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -161,7 +161,7 @@
 >
 <fdp-object-status
     status="positive"
-    glyph="message-success"
+    glyph="sys-enter-2"
     [clickable]="true"
     [large]="true"
     [inverted]="true"
@@ -173,7 +173,7 @@
 ></fdp-object-status>
 <fdp-object-status
     status="informative"
-    glyph="message-information"
+    glyph="information"
     [clickable]="true"
     [large]="true"
     [inverted]="true"


### PR DESCRIPTION
## Related Issue(s)

none, reported by designers

## Description

update the examples of Object Status with the correct icons representing the state
