### PR TITLE
fix(platform): fix p13n focus elements

### DIFF
--- a/libs/platform/table/components/table-p13-dialog/columns/columns.component.html
+++ b/libs/platform/table/components/table-p13-dialog/columns/columns.component.html
@@ -101,7 +101,6 @@
                 <li
                     fd-list-item
                     [class.fd-select-item--selected]="item.selected"
-                    [class.is-focus]="item.active"
                     [selected]="item.selected"
                     (focus)="_setActiveColumn(item)"
                 >

--- a/libs/platform/table/components/table-p13-dialog/columns/columns.component.ts
+++ b/libs/platform/table/components/table-p13-dialog/columns/columns.component.ts
@@ -17,7 +17,7 @@ import { SearchInput } from '@fundamental-ngx/platform/search-field';
 import { CdkScrollable } from '@angular/cdk/overlay';
 import { AsyncPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { TemplateDirective } from '@fundamental-ngx/cdk/utils';
+import { InitialFocusDirective, TemplateDirective } from '@fundamental-ngx/cdk/utils';
 import {
     BarElementDirective,
     BarLeftDirective,
@@ -102,7 +102,8 @@ const INITIAL_SHOW_ALL_ITEMS = true;
         DialogFooterComponent,
         ButtonBarComponent,
         AsyncPipe,
-        FdTranslatePipe
+        FdTranslatePipe,
+        InitialFocusDirective
     ]
 })
 export class P13ColumnsDialogComponent implements Resettable, OnInit, OnDestroy {

--- a/libs/platform/table/components/table-p13-dialog/filtering/filtering.component.html
+++ b/libs/platform/table/components/table-p13-dialog/filtering/filtering.component.html
@@ -123,7 +123,6 @@
         ></fd-button-bar>
         <fd-button-bar
             fdType="transparent"
-            fdkInitialFocus
             [label]="'platformTable.P13FilterDialogCancelBtnLabel' | fdTranslate"
             (click)="cancel()"
         ></fd-button-bar>

--- a/libs/platform/table/components/table-p13-dialog/grouping/grouping.component.html
+++ b/libs/platform/table/components/table-p13-dialog/grouping/grouping.component.html
@@ -69,7 +69,6 @@
 
         <fd-button-bar
             fdType="transparent"
-            fdkInitialFocus
             [label]="'platformTable.P13GroupDialogCancelBtnLabel' | fdTranslate"
             (click)="cancel()"
         ></fd-button-bar>

--- a/libs/platform/table/components/table-p13-dialog/sorting/sorting.component.html
+++ b/libs/platform/table/components/table-p13-dialog/sorting/sorting.component.html
@@ -73,7 +73,6 @@
         ></fd-button-bar>
         <fd-button-bar
             fdType="transparent"
-            fdkInitialFocus
             [label]="'platformTable.P13SortDialogCancelBtnLabel' | fdTranslate"
             (click)="cancel()"
         ></fd-button-bar>


### PR DESCRIPTION
fixing few issues:
- remove the usages of `fdkInitialFocus` from the wrong buttons
- import the directive `fdkInitialFocus` in the column dialog
- remove focus styling from the item wrongly added
