### PR TITLE
fix(core): css tweaks for core multi-combobox from old DH

### DIFF
--- a/libs/core/multi-combobox/multi-combobox.component.scss
+++ b/libs/core/multi-combobox/multi-combobox.component.scss
@@ -60,7 +60,7 @@ $block: fd-multi-combobox;
 
 .fd-dialog__body {
     fd-form-message {
-        display: block;
         max-width: 100%;
+        border-radius: 0 !important;
     }
 }

--- a/libs/core/multi-combobox/select-all-toggler/select-all-toggler.component.scss
+++ b/libs/core/multi-combobox/select-all-toggler/select-all-toggler.component.scss
@@ -11,7 +11,7 @@ fd-multi-combobox-select-all-toggler {
     @include sap-fiori-focus();
 
     .fd-toolbar {
-        padding-left: 1rem;
+        padding-left: 0;
         padding-right: 0;
     }
 


### PR DESCRIPTION
part of DH 123. noticed this was still open and assigned to me

before:
![Screenshot 2024-03-11 at 5 25 32 PM](https://github.com/SAP/fundamental-ngx/assets/2471874/a73f0069-7a45-48b8-8de9-e14cb521c317)

after:
![Screenshot 2024-03-11 at 5 25 20 PM](https://github.com/SAP/fundamental-ngx/assets/2471874/cc1f5808-97c6-4503-8fc4-01b68f853dda)

before:
![Screenshot 2024-03-11 at 5 29 35 PM](https://github.com/SAP/fundamental-ngx/assets/2471874/e1896399-b585-4f70-9a5d-e71c9c9a0e1c)

after:
![Screenshot 2024-03-11 at 5 27 32 PM](https://github.com/SAP/fundamental-ngx/assets/2471874/9e054d00-52e5-47ad-8262-41b0db191271)
