### PR TITLE
fix(platform): add proper z-index to Table toolbar so checkboxes don't go over it

### DIFF
--- a/libs/platform/table/components/table-p13-dialog/columns/columns.component.scss
+++ b/libs/platform/table/components/table-p13-dialog/columns/columns.component.scss
@@ -2,7 +2,7 @@
     fd-toolbar {
         position: sticky;
         top: 0;
-        z-index: 1;
+        z-index: 10;
     }
 
     .fd-select-item--active {


### PR DESCRIPTION

## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11551

## Description

bumped the z-index of the toolbar to 10 so that the checkboxes with z-index 5 go under it
