### PR TITLE
fix(core): remove role region from Dynamic Page component

### DIFF
--- a/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
+++ b/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
@@ -4,7 +4,6 @@
         [attr.aria-label]="headerAriaLabel"
         [attr.aria-hidden]="_dynamicPageService.collapsed()"
         [attr.id]="collapsibleHeaderId"
-        role="region"
         #headerContent
     >
         <ng-content></ng-content>

--- a/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.ts
+++ b/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.ts
@@ -75,11 +75,6 @@ export class DynamicPageSubheaderComponent {
     @Input()
     collapseLabel: string;
 
-    /** Header role  */
-    @Input()
-    @HostBinding('attr.role')
-    role = 'region';
-
     /**
      * id for header
      */

--- a/libs/core/dynamic-page/dynamic-page.component.html
+++ b/libs/core/dynamic-page/dynamic-page.component.html
@@ -1,4 +1,4 @@
-<section
+<article
     #dynamicPageElement
     class="fd-dynamic-page"
     [class.fd-dynamic-page--sm]="size === 'small'"
@@ -31,4 +31,4 @@
     <footer>
         <ng-content select="fd-dynamic-page-footer"></ng-content>
     </footer>
-</section>
+</article>

--- a/libs/core/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/dynamic-page/dynamic-page.component.ts
@@ -8,7 +8,6 @@ import {
     ContentChildren,
     DestroyRef,
     ElementRef,
-    HostBinding,
     inject,
     Inject,
     Input,
@@ -61,11 +60,6 @@ import { FD_DYNAMIC_PAGE } from './dynamic-page.tokens';
 export class DynamicPageComponent implements AfterViewInit, DynamicPage {
     /** Whether DynamicPage should snap on scroll */
     @Input() disableSnapOnScroll = false;
-
-    /** Page role  */
-    @Input()
-    @HostBinding('attr.role')
-    role = 'region';
 
     /** aria label for the page */
     @Input() ariaLabel: Nullable<string>;

--- a/libs/core/dynamic-page/dynamic-page.interface.ts
+++ b/libs/core/dynamic-page/dynamic-page.interface.ts
@@ -4,7 +4,6 @@ import { DynamicPageBackgroundType, DynamicPageResponsiveSize } from './constant
 
 export interface DynamicPage {
     disableSnapOnScroll: boolean;
-    role: string;
     ariaLabel: Nullable<string>;
     background: DynamicPageBackgroundType;
     autoResponsive: boolean;

--- a/libs/docs/platform/dynamic-page/e2e/dynamic-page.po.ts
+++ b/libs/docs/platform/dynamic-page/e2e/dynamic-page.po.ts
@@ -18,11 +18,12 @@ export class DynamicPagePo extends PlatformBaseComponentPo {
     dynamicPageTabsContent = '.fd-dynamic-page__content';
     dynamicPageToolBarAccept = this.dynamicPage + ' .fd-button--positive';
     dynamicPageToolBarReject = this.dynamicPage + ' .fd-button--negative';
-    dynamicPageCollapsibleHeader = this.dynamicPage + ' .fd-dynamic-page__collapsible-header-container';
+    dynamicPageCollapsibleHeader =
+        this.dynamicPage + ' .fd-dynamic-page__collapsible-header-container .fd-dynamic-page__collapsible-header';
 
     columnSection = 'section';
     openColumnButton = '.docs-fcl-example-section button';
-    columnSectionHeader = 'section header';
+    columnSectionHeader = 'article header';
     columnSectionExpandIcon = '.fd-flexible-column-layout__button';
 
     async open(): Promise<void> {

--- a/libs/docs/platform/dynamic-page/e2e/dynamic-page.po.ts
+++ b/libs/docs/platform/dynamic-page/e2e/dynamic-page.po.ts
@@ -18,7 +18,7 @@ export class DynamicPagePo extends PlatformBaseComponentPo {
     dynamicPageTabsContent = '.fd-dynamic-page__content';
     dynamicPageToolBarAccept = this.dynamicPage + ' .fd-button--positive';
     dynamicPageToolBarReject = this.dynamicPage + ' .fd-button--negative';
-    dynamicPageCollapsibleHeader = this.dynamicPage + ' .fd-dynamic-page__collapsible-header-container [role="region"]';
+    dynamicPageCollapsibleHeader = this.dynamicPage + ' .fd-dynamic-page__collapsible-header-container';
 
     columnSection = 'section';
     openColumnButton = '.docs-fcl-example-section button';

--- a/libs/platform/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/dynamic-page/dynamic-page.component.html
@@ -66,7 +66,6 @@
             [pinnable]="headerComponent.pinnable"
             [expandLabel]="headerComponent.expandLabel"
             [collapseLabel]="headerComponent.collapseLabel"
-            [role]="headerComponent.role"
             [id]="headerComponent.id"
             [headerAriaLabel]="headerComponent.headerAriaLabel"
             [pinAriaLabel]="headerComponent.pinAriaLabel"


### PR DESCRIPTION
## Related Issue(s)


closes https://github.com/SAP/fundamental-ngx/issues/11549

## Description
- removed role="region" from Dynamic Page component
- removed role="region" from Dynamic Page Subheader component
- changed `section` to `article` in Dynamic Page component