### PR TITLE
fix(core): add a11y fixes for Select control

### DIFF
--- a/libs/core/select/select.component.html
+++ b/libs/core/select/select.component.html
@@ -38,11 +38,11 @@
         [attr.aria-active]="_isOpen"
         aria-live="polite"
         role="combobox"
+        aria-haspopup="listbox"
         aria-roledescription="listbox"
         [attr.aria-expanded]="_isOpen"
         [attr.aria-disabled]="disabled"
         [attr.aria-controls]="controlId + '-list-box'"
-        [attr.aria-haspopup]="!(this.readonly || this.disabled)"
         [attr.aria-required]="required"
         [attr.title]="triggerValue"
         [attr.aria-label]="ariaLabel || ('platformSelect.selectOptionLabel' | fdTranslate)"
@@ -51,7 +51,7 @@
         (focus)="_onFocus()"
         (blur)="_onBlur()"
     >
-        <div role="listitem" class="fd-select__text-content" [attr.aria-label]="triggerValue">
+        <div class="fd-select__text-content" [attr.aria-label]="triggerValue">
             <ng-template
                 [ngTemplateOutlet]="controlTemplate ? controlTemplate : defaultSelectContent"
                 [ngTemplateOutletContext]="{ $implicit: triggerValue, selected: selected }"


### PR DESCRIPTION
## Related Issue(s)

part of https://github.com/SAP/fundamental-ngx/issues/11547 

## Description

Addresses this issue:

![Screenshot 2024-03-14 at 3 55 46 PM](https://github.com/SAP/fundamental-ngx/assets/39598672/bf034f45-4af1-483e-a5bb-e49c5307b34a)

- removed the role="listitem" from the div as it doesn't belong to a list element. Its parent is a div with role="combobox"
- added aria-haspopup to the combobox as per the Mdn guidelines:
![Screenshot 2024-03-14 at 3 58 49 PM](https://github.com/SAP/fundamental-ngx/assets/39598672/4ddec6a8-fbf8-4fec-87e7-2d23124245a6)
