### PR TITLE
fix(core): add aria-labelledby for Card component

### DIFF
--- a/libs/core/card/card-title.directive.ts
+++ b/libs/core/card/card-title.directive.ts
@@ -1,14 +1,28 @@
-import { Directive, ElementRef, OnInit } from '@angular/core';
+import { Directive, ElementRef, HostBinding, Input, OnInit } from '@angular/core';
 import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
 
 import { CLASS_NAME } from './constants';
+import { FD_CARD_TITLE } from './token';
+
+let cardTitleId = 0;
 
 @Directive({
     // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[fd-card-title]',
-    standalone: true
+    standalone: true,
+    providers: [
+        {
+            provide: FD_CARD_TITLE,
+            useExisting: CardTitleDirective
+        }
+    ]
 })
 export class CardTitleDirective implements OnInit, CssClassBuilder {
+    /** Card title id, it has some default value if not set,  */
+    @Input()
+    @HostBinding('attr.id')
+    id = 'fd-card-title-id-' + cardTitleId++;
+
     /** @hidden */
     class: string;
 

--- a/libs/core/card/card.component.ts
+++ b/libs/core/card/card.component.ts
@@ -1,6 +1,7 @@
 import {
     ChangeDetectionStrategy,
     Component,
+    ContentChild,
     ElementRef,
     HostBinding,
     Input,
@@ -10,11 +11,13 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
-import { applyCssClass, CssClassBuilder } from '@fundamental-ngx/cdk/utils';
+import { applyCssClass, CssClassBuilder, Nullable } from '@fundamental-ngx/cdk/utils';
 
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { Subscription } from 'rxjs';
+import { CardTitleDirective } from './card-title.directive';
 import { CardType, CLASS_NAME } from './constants';
+import { FD_CARD_TITLE } from './token';
 import { getCardModifierClassNameByCardType } from './utils';
 
 let cardId = 0;
@@ -54,6 +57,14 @@ export class CardComponent implements OnChanges, OnInit, CssClassBuilder, OnDest
     @HostBinding('attr.role')
     role = 'region';
 
+    /** Card aria-labelledby  */
+    @HostBinding('attr.aria-labelledby')
+    cardTitleId: Nullable<string>;
+
+    /** @hidden */
+    @ContentChild(FD_CARD_TITLE, { static: true })
+    cardTitle: CardTitleDirective;
+
     /** @hidden */
     class: string;
 
@@ -76,6 +87,10 @@ export class CardComponent implements OnChanges, OnInit, CssClassBuilder, OnDest
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
+
+        if (this.cardTitle) {
+            this.cardTitleId = this.cardTitle.id;
+        }
     }
 
     /** @hidden */

--- a/libs/core/card/index.ts
+++ b/libs/core/card/index.ts
@@ -18,3 +18,5 @@ export { CardKpiHeaderComponent } from './kpi/card-kpi-header.component';
 export { CardKpiScaleIconDirective } from './kpi/card-kpi-scale-icon.directive';
 export { CardKpiScaleTextDirective } from './kpi/card-kpi-scale-text.directive';
 export { CardKpiValueDirective } from './kpi/card-kpi-value.directive';
+
+export * from './token';

--- a/libs/core/card/token.ts
+++ b/libs/core/card/token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const FD_CARD_TITLE = new InjectionToken('FdCardTitleDirective');


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11548

## Description
Cards have `role='region'` which should be labeled by the Card title. 
The current PR:
- adds id to Card Title component
- uses this id for `aria-labelledby` of the parent Card component