### PR TITLE
fix(core): add css fix for missing error in combobox

### DIFF
--- a/libs/core/input-group/input-group.component.scss
+++ b/libs/core/input-group/input-group.component.scss
@@ -6,9 +6,7 @@ fd-input-group {
         max-height: 100%;
         height: 100%;
     }
-    .fd-button.fd-button--transparent {
-        background: transparent;
-    }
+
     .fd-input-group__addon:not(:first-child) .fd-input-group__button {
         &:focus {
             border: none;


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11585

## Description
On focus state the information combobox button in Quartz loses the arrow. It's due to the arrow becoming white and the background becoming transparent. The transparent background was coming from fund-ngx library and for this reason wan't taking the proper color from fundamental-styles.

**Before:**
<img width="398" alt="Screenshot 2024-03-19 at 12 50 50 PM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/63fbffeb-b00e-4a29-be8a-731db14cdd65">

**After:**
<img width="403" alt="Screenshot 2024-03-19 at 12 50 43 PM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/016ae4b3-2cc5-48e1-8eb9-aa0309dea7d4">

