### PR TITLE
fix(platform): table empty cell screenreader text

### DIFF
--- a/libs/docs/platform/table/examples/platform-table-custom-title-example.component.ts
+++ b/libs/docs/platform/table/examples/platform-table-custom-title-example.component.ts
@@ -145,7 +145,7 @@ const ITEMS: ExampleItem[] = [
     {
         id: 4,
         name: 'Beam Breaker B-1',
-        description: 'fermentum donec ut',
+        description: '',
         price: {
             value: 36.56,
             currency: 'NZD'

--- a/libs/platform/table/components/table-row/table-row.component.html
+++ b/libs/platform/table/components/table-row/table-row.component.html
@@ -152,7 +152,7 @@
                 ></span>
             }
             @if (row.state === 'readonly') {
-                @if ((row.value | valueByPath: column.key) === '' || (row.value | valueByPath: column.key) === null) {
+                @if (!(row.value | valueByPath: column.key)) {
                     <span
                         [ngStyle]="{
                             position: 'absolute !important',


### PR DESCRIPTION
fixes #11596. Wasn't working for tree table empty cells