### PR TITLE
fix(platform): add visual fixes for option list in VHD

### DIFF
--- a/libs/platform/value-help-dialog/components/define-tab/define-tab.component.html
+++ b/libs/platform/value-help-dialog/components/define-tab/define-tab.component.html
@@ -32,7 +32,9 @@
                 >
                     @if (_includeStrategy.length) {
                         <li fd-list-group-header>
-                            {{ 'platformVHD.defineConditionConditionsGroupHeaderInclude' | fdTranslate }}
+                            <span fd-list-title>{{
+                                'platformVHD.defineConditionConditionsGroupHeaderInclude' | fdTranslate
+                            }}</span>
                         </li>
                         @for (strategy of _includeStrategy; track strategy) {
                             <li fd-option [value]="strategy.key">
@@ -45,7 +47,9 @@
                     }
                     @if (_excludeStrategy.length) {
                         <li fd-list-group-header>
-                            {{ 'platformVHD.defineConditionConditionsGroupHeaderExclude' | fdTranslate }}
+                            <span fd-list-title>{{
+                                'platformVHD.defineConditionConditionsGroupHeaderExclude' | fdTranslate
+                            }}</span>
                         </li>
                         @for (strategy of _excludeStrategy; track strategy) {
                             <li fd-option [value]="strategy.key">

--- a/libs/platform/value-help-dialog/components/define-tab/define-tab.component.scss
+++ b/libs/platform/value-help-dialog/components/define-tab/define-tab.component.scss
@@ -44,3 +44,7 @@ $block: fdp-value-help-dialog;
         }
     }
 }
+
+.fd-list--dropdown .fd-list__item.fd-list__group-header {
+    border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
+}

--- a/libs/platform/value-help-dialog/components/define-tab/define-tab.component.ts
+++ b/libs/platform/value-help-dialog/components/define-tab/define-tab.component.ts
@@ -21,7 +21,7 @@ import {
     FormMessageComponent
 } from '@fundamental-ngx/core/form';
 import { LayoutGridColDirective, LayoutGridComponent, LayoutGridRowDirective } from '@fundamental-ngx/core/layout-grid';
-import { ListGroupHeaderDirective } from '@fundamental-ngx/core/list';
+import { ListGroupHeaderDirective, ListTitleDirective } from '@fundamental-ngx/core/list';
 import { OptionComponent, SelectComponent } from '@fundamental-ngx/core/select';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
@@ -67,6 +67,7 @@ let titleUniqueId = 0;
         SelectComponent,
         FormsModule,
         ListGroupHeaderDirective,
+        ListTitleDirective,
         OptionComponent,
         NgTemplateOutlet,
         FormInputMessageGroupComponent,


### PR DESCRIPTION
## Related Issue(s)

part of https://github.com/SAP/fundamental-ngx/issues/11494

## Description
The list group headers in VHD were not rendered properly because the text content was not wrapped in a element with `fd-list-title` directive. Additionally added CSS for showing border-bottom for the group item in a list with no separators. 

## Screenshots
### Before:
![Screenshot 2024-03-20 at 1 45 06 PM](https://github.com/SAP/fundamental-ngx/assets/39598672/ee198a8e-49fd-4b2f-83fb-8125e6db3767)

### After:
![Screenshot 2024-03-20 at 1 44 47 PM](https://github.com/SAP/fundamental-ngx/assets/39598672/4936db9d-8cb2-4268-be34-5551a531a888)
