### PR TITLE
fix: roll back tabindex change

### DIFF
--- a/libs/cdk/utils/directives/focusable-item/focusable-item.directive.ts
+++ b/libs/cdk/utils/directives/focusable-item/focusable-item.directive.ts
@@ -147,11 +147,7 @@ export class FocusableItemDirective implements FocusableItem, HasElementRef {
     /** Set tabbable state */
     setTabbable(state: boolean): void {
         this._tabbable = state;
-        if (this._tabbable) {
-            this._renderer2.setAttribute(this.elementRef.nativeElement, 'tabindex', '0');
-        } else {
-            this._renderer2.removeAttribute(this.elementRef.nativeElement, 'tabindex');
-        }
+        this._renderer2.setAttribute(this.elementRef.nativeElement, 'tabindex', this._tabbable ? '0' : '-1');
 
         if (state) {
             this._enableTabbableElements();


### PR DESCRIPTION
fixes none. Rolls back a PR that broke keyboard support when using [allCellsFocusable]="true"