### PR TITLE
fix(core): hiding action sheet in shellbar if not needed

### DIFF
--- a/libs/core/shellbar/shellbar-actions-mobile/shellbar-actions-mobile.component.html
+++ b/libs/core/shellbar/shellbar-actions-mobile/shellbar-actions-mobile.component.html
@@ -1,43 +1,45 @@
-<div class="fd-shellbar-collapse">
-    <fd-action-sheet placement="bottom-end" #actionSheet>
-        <fd-action-sheet-control>
-            <button
-                fd-button
-                fdType="transparent"
-                glyph="overflow"
-                class="fd-shellbar__button"
-                [attr.aria-label]="'coreShellbar.collapsedItemMenuLabel' | fdTranslate"
-            >
-                @if (totalNotifications) {
-                    <span class="fd-button__badge">
-                        {{ totalNotifications }}
-                    </span>
-                }
-            </button>
-        </fd-action-sheet-control>
-        <fd-action-sheet-body>
-            @if (searchExists) {
-                <li
-                    fd-action-sheet-item
-                    tabindex="-1"
-                    glyph="search"
-                    [label]="'coreShellbar.search' | fdTranslate"
-                    (click)="showSearch.emit(); actionSheet.close()"
-                ></li>
-            }
-            @for (action of shellbarActions; track action) {
-                <li
-                    fd-action-sheet-item
-                    tabindex="-1"
-                    [glyph]="action.glyph"
-                    [label]="action.label"
-                    (click)="actionClicked(action, $event)"
+@if (shellbarActions.length > 0 || searchExists) {
+    <div class="fd-shellbar-collapse">
+        <fd-action-sheet placement="bottom-end" #actionSheet>
+            <fd-action-sheet-control>
+                <button
+                    fd-button
+                    fdType="transparent"
+                    glyph="overflow"
+                    class="fd-shellbar__button"
+                    [attr.aria-label]="'coreShellbar.collapsedItemMenuLabel' | fdTranslate"
                 >
-                    @if (action.notificationCount) {
-                        <span class="fd-button__badge">{{ action.notificationCount }}</span>
+                    @if (totalNotifications) {
+                        <span class="fd-button__badge">
+                            {{ totalNotifications }}
+                        </span>
                     }
-                </li>
-            }
-        </fd-action-sheet-body>
-    </fd-action-sheet>
-</div>
+                </button>
+            </fd-action-sheet-control>
+            <fd-action-sheet-body>
+                @if (searchExists) {
+                    <li
+                        fd-action-sheet-item
+                        tabindex="-1"
+                        glyph="search"
+                        [label]="'coreShellbar.search' | fdTranslate"
+                        (click)="showSearch.emit(); actionSheet.close()"
+                    ></li>
+                }
+                @for (action of shellbarActions; track action) {
+                    <li
+                        fd-action-sheet-item
+                        tabindex="-1"
+                        [glyph]="action.glyph"
+                        [label]="action.label"
+                        (click)="actionClicked(action, $event)"
+                    >
+                        @if (action.notificationCount) {
+                            <span class="fd-button__badge">{{ action.notificationCount }}</span>
+                        }
+                    </li>
+                }
+            </fd-action-sheet-body>
+        </fd-action-sheet>
+    </div>
+}


### PR DESCRIPTION
## Related Issue(s)

closes #11386

## Description

Hiding shellbar action sheet if there is no search element and actions