### PR TITLE
fix(core): relative position property for Dynamic Page

### DIFF
--- a/libs/core/dynamic-page/dynamic-page.component.html
+++ b/libs/core/dynamic-page/dynamic-page.component.html
@@ -8,6 +8,7 @@
     [class.fd-dynamic-page--transparent-bg]="background === 'transparent'"
     [class.fd-dynamic-page--list-bg]="background === 'list'"
     [attr.aria-label]="ariaLabel"
+    [style.position]="positionRelative ? 'relative' : null"
 >
     <header class="fd-dynamic-page__header" [class.fd-dynamic-page__header--not-collapsible]="!_headerCollapsible">
         <div>

--- a/libs/core/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/dynamic-page/dynamic-page.component.ts
@@ -102,6 +102,12 @@ export class DynamicPageComponent implements AfterViewInit, DynamicPage {
      */
     @Input() expandContent = true;
 
+    /**
+     * Whether dynamic page has position relative.
+     * This is needed in cases where Dynamic Page is used in Flexible Column Layout and has a floating footer
+     */
+    @Input() positionRelative = false;
+
     /** @hidden reference to header component  */
     @ContentChild(DynamicPageSubheaderComponent)
     _pageSubheaderComponent: DynamicPageSubheaderComponent;

--- a/libs/docs/core/dynamic-page/dynamic-page-docs.component.html
+++ b/libs/docs/core/dynamic-page/dynamic-page-docs.component.html
@@ -19,8 +19,12 @@
 <separator></separator>
 
 <fd-docs-section-title id="layout" componentName="dynamic-page">
-    Dynamic Page inside Column Layout
+    Dynamic Page inside Flexible Column Layout
 </fd-docs-section-title>
+<description>
+    If Dynamic Page has a floating footer you need to add <code>[positionRelative]="true"</code> so that the footer only
+    occupies the width of the column within the Flexible Column Layout.
+</description>
 <component-example>
     <fd-dynamic-page-column-layout-example></fd-dynamic-page-column-layout-example>
 </component-example>

--- a/libs/docs/core/dynamic-page/examples/dynamic-page-column-layout-example/dynamic-page-column-layout-example.component.html
+++ b/libs/docs/core/dynamic-page/examples/dynamic-page-column-layout-example/dynamic-page-column-layout-example.component.html
@@ -9,7 +9,7 @@
             (layoutChange)="changeLayout($event)"
         >
             <ng-template #startColumn>
-                <fd-dynamic-page [autoResponsive]="true" ariaLabel="Example Dynamic Page">
+                <fd-dynamic-page [autoResponsive]="true" ariaLabel="Example Dynamic Page" [positionRelative]="true">
                     <fd-dynamic-page-header
                         title="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
                         subtitle="sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/11640

## Description
The floating footer of Dynamic page occupies the entire width of the page. When Dynamic page is placed inside Flexible Column Layout the footer needs to span within the column that Dynamic page occupies. For this to work we need to set the position of Dynamic page to relative. I added an input property that could allow this

## Screenshots
### Before:
<img width="2549" alt="Screenshot 2024-04-01 at 3 15 57 PM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/35c6f834-c26e-43d4-ab22-6b0c434c9b9f">


### After:
<img width="2556" alt="Screenshot 2024-04-01 at 2 35 23 PM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/81cbd2fa-e904-4678-9d33-74c08c899f35">