### PR TITLE
fix(core): fixed missing role on focusable dynamic page element

### DIFF
--- a/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
+++ b/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
@@ -13,10 +13,15 @@
                 <ng-content select="fd-facet"></ng-content>
             }
             <div class="fd-dynamic-page__title-subtitle-container">
-                <h2 class="fd-dynamic-page__title-container">
+                <div class="fd-dynamic-page__title-container">
                     <span
+                        tabindex="0"
+                        role="heading"
+                        aria-level="2"
                         class="fd-dynamic-page__title"
                         [class.fd-dynamic-page__title--wrap]="titleWrap"
+                        (focus)="headingFocused$.set(true)"
+                        (blur)="headingFocused$.set(false)"
                         fdkIgnoreClickOnSelection
                     >
                         <ng-template [ngTemplateOutlet]="_titleTemplate ? titleRef : defaultTitle"></ng-template>
@@ -28,7 +33,7 @@
                             <ng-template [ngTemplateOutlet]="dynamicPageLayoutActionsRef"></ng-template>
                         }
                     </div>
-                </h2>
+                </div>
                 @if (_dynamicPageService.collapsed() && (subtitle || _subtitleTemplate)) {
                     <div
                         class="fd-dynamic-page__subtitle"

--- a/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
+++ b/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
@@ -10,7 +10,8 @@ import {
     OnInit,
     Renderer2,
     ViewEncapsulation,
-    computed
+    computed,
+    signal
 } from '@angular/core';
 
 import { Subject } from 'rxjs';
@@ -38,7 +39,7 @@ export const ActionSquashBreakpointPx = 1280;
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[attr.tabindex]': '0'
+        '[class.is-focus]': 'headingFocused$()'
     },
     providers: [
         {
@@ -101,6 +102,9 @@ export class DynamicPageHeaderComponent implements OnInit, AfterViewInit, OnDest
 
     /** @hidden */
     _size: DynamicPageResponsiveSize;
+
+    /** @hidden */
+    protected headingFocused$ = signal(false);
 
     /** @hidden **/
     private readonly _onDestroy$: Subject<void> = new Subject<void>();


### PR DESCRIPTION
## Related Issue(s)

closes #11253

## Description

- Removed tabindex from the header
- Added tabindex to the title element and the role of heading to it. When it gets focus through mouse or the tab it will activate the focus design to not break the styling
- Removed h2 and used div instead, because aria-level and heading is now the actual title that is in it