### PR TITLE
fix(core): a11y fix for Shellbar component

### DIFF
--- a/libs/core/shellbar/product-menu/product-menu.component.html
+++ b/libs/core/shellbar/product-menu/product-menu.component.html
@@ -1,4 +1,5 @@
 @if (items && items.length > 0) {
+    <h1 class="fd-sr-only">{{ control }}</h1>
     <button
         fd-button
         fdType="transparent"
@@ -35,7 +36,7 @@
         }
     </fd-menu>
 } @else {
-    <span class="fd-shellbar__title fd-product-menu__title">
+    <h1 class="fd-shellbar__title fd-product-menu__title">
         {{ control }}
-    </span>
+    </h1>
 }

--- a/libs/core/shellbar/product-menu/product-menu.component.scss
+++ b/libs/core/shellbar/product-menu/product-menu.component.scss
@@ -1,0 +1,11 @@
+.fd-sr-only {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    height: 1px;
+    width: 1px;
+    border: 0;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    white-space: nowrap;
+}

--- a/libs/core/shellbar/product-menu/product-menu.component.ts
+++ b/libs/core/shellbar/product-menu/product-menu.component.ts
@@ -19,6 +19,7 @@ import { ShellbarMenuItem } from '../model/shellbar-menu-item';
 @Component({
     selector: 'fd-product-menu',
     templateUrl: './product-menu.component.html',
+    styleUrl: './product-menu.component.scss',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,

--- a/libs/core/shellbar/shellbar-title/shellbar-title.component.html
+++ b/libs/core/shellbar/shellbar-title/shellbar-title.component.html
@@ -1,3 +1,3 @@
-<span class="fd-shellbar__title">
+<h1 class="fd-shellbar__title">
     <ng-content></ng-content>
-</span>
+</h1>


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11611

## Description

- made Shellbar title heading 1 element
- in case of Product menu, the span element with the text remains a span as we can't put a heading element inside a button. To handle this problem we add a visually hidden heading 1 element as a sibling to the button