### PR TITLE
[WIP]fix(core): add `needsClickProxy` input for fd-breadcrumb-item to pass click event

### DIFF
--- a/libs/core/breadcrumb/breadcrumb-item.component.ts
+++ b/libs/core/breadcrumb/breadcrumb-item.component.ts
@@ -4,7 +4,7 @@ import {
     ChangeDetectionStrategy,
     Component,
     ContentChild,
-    ElementRef,
+    ElementRef, Input,
     ViewEncapsulation
 } from '@angular/core';
 import { FD_LINK_COMPONENT, LinkComponent } from '@fundamental-ngx/core/link';
@@ -36,6 +36,10 @@ import { FD_BREADCRUMB_ITEM_COMPONENT } from './tokens';
     standalone: true
 })
 export class BreadcrumbItemComponent implements AfterViewInit {
+    /** If true, we will proxy the click to the original element. */
+    @Input()
+    needsClickProxy = false;
+
     /** @hidden */
     @ContentChild(FD_LINK_COMPONENT)
     breadcrumbLink: LinkComponent;
@@ -59,7 +63,7 @@ export class BreadcrumbItemComponent implements AfterViewInit {
 
     /** @hidden */
     get _needsClickProxy(): boolean {
-        return !!this.breadcrumbLink?.elementRef.nativeElement.getAttribute('href') || !!this.breadcrumbLink.routerLink;
+        return this.needsClickProxy || !!this.breadcrumbLink?.elementRef.nativeElement.getAttribute('href') || !!this.breadcrumbLink.routerLink;
     }
 
     /** @hidden */

--- a/libs/core/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/breadcrumb/breadcrumb.component.ts
@@ -144,7 +144,7 @@ export class BreadcrumbComponent implements AfterViewInit, HasElementRef {
 
     /**
      * We catch interactions with item, Enter, Space, Mouse click and Touch click,
-     * if original element had router link we are proxying click to that element
+     * if original element had router link or needClickProxy is true, we are proxying click to that element
      * */
     itemClicked(breadcrumbItem: BreadcrumbItemComponent, $event: Event): void {
         if (breadcrumbItem._needsClickProxy) {

--- a/libs/docs/core/breadcrumb/breadcrumb-docs.component.html
+++ b/libs/docs/core/breadcrumb/breadcrumb-docs.component.html
@@ -20,3 +20,15 @@
     <fd-breadcrumb-href-example></fd-breadcrumb-href-example>
 </component-example>
 <code-example [exampleFiles]="breadcrumbHrefHtml"></code-example>
+
+
+<fd-docs-section-title id="proxy-link" componentName="breadcrumb"> An example using <code>needsClickProxy</code> input </fd-docs-section-title>
+<description>
+    Menu item click event will be proxy if there is a <code>href</code> attribute or <code>routerLink</code> directive or explicitly set <code>[needsClickProxy]</code> to true
+</description>
+<component-example>
+    <div style="max-width: 200px;">
+        <fd-breadcrumb-click-proxy-example></fd-breadcrumb-click-proxy-example>
+    </div>
+</component-example>
+<code-example [exampleFiles]="breadcrumbClickProxyHtml"></code-example>

--- a/libs/docs/core/breadcrumb/breadcrumb-docs.component.ts
+++ b/libs/docs/core/breadcrumb/breadcrumb-docs.component.ts
@@ -13,9 +13,14 @@ import {
     BreadcrumbHrefExampleComponent,
     BreadcrumbRouterLinkExampleComponent
 } from './examples/breadcrumb-examples.component';
+import { BreadcrumbClickProxyExampleComponent } from './examples/breadcrumb-click-proxy-example.component';
 
 const breadcrumbHrefExample = 'breadcrumb-href-example.component.html';
 const breadcrumbRouterLinkExample = 'breadcrumb-routerLink-example.component.html';
+const breadcrumbClickProxyExample = 'breadcrumb-click-proxy-example.component.html';
+const breadcrumbClickProxyExampleTs = 'breadcrumb-click-proxy-example.component.ts';
+
+
 
 @Component({
     selector: 'app-breadcrumb',
@@ -28,7 +33,8 @@ const breadcrumbRouterLinkExample = 'breadcrumb-routerLink-example.component.htm
         BreadcrumbRouterLinkExampleComponent,
         CodeExampleComponent,
         SeparatorComponent,
-        BreadcrumbHrefExampleComponent
+        BreadcrumbHrefExampleComponent,
+        BreadcrumbClickProxyExampleComponent
     ]
 })
 export class BreadcrumbDocsComponent {
@@ -45,6 +51,20 @@ export class BreadcrumbDocsComponent {
             language: 'html',
             code: getAssetFromModuleAssets(breadcrumbHrefExample),
             fileName: 'fd-breadcrumb-href-example'
+        }
+    ];
+
+    breadcrumbClickProxyHtml: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(breadcrumbClickProxyExample),
+            fileName: 'fd-breadcrumb-click-proxy-example'
+        },
+        {
+            language: 'typescript',
+            code: getAssetFromModuleAssets(breadcrumbClickProxyExampleTs),
+            fileName: 'fd-breadcrumb-click-proxy-example',
+            component: 'BreadcrumbClickProxyExampleComponent'
         }
     ];
 }

--- a/libs/docs/core/breadcrumb/examples/breadcrumb-click-proxy-example.component.html
+++ b/libs/docs/core/breadcrumb/examples/breadcrumb-click-proxy-example.component.html
@@ -1,0 +1,17 @@
+<fd-breadcrumb>
+    <fd-breadcrumb-item [needsClickProxy]="true">
+        <a fd-link href="/#/core/breadcrumb">Breadcrumb Level 1</a>
+    </fd-breadcrumb-item>
+    <fd-breadcrumb-item [needsClickProxy]="true">
+        <a fd-link (click)="onBreadCrumbClick('2')">Breadcrumb Level 2</a>
+    </fd-breadcrumb-item>
+    <fd-breadcrumb-item [needsClickProxy]="true">
+        <a fd-link (click)="onBreadCrumbClick('3')">Breadcrumb Level 3</a>
+    </fd-breadcrumb-item>
+    <fd-breadcrumb-item [needsClickProxy]="true">
+        <span fd-link (click)="onBreadCrumbClick('4')">Breadcrumb Level 4</span>
+    </fd-breadcrumb-item>
+    <fd-breadcrumb-item [needsClickProxy]="true">
+        <span fd-link (click)="onBreadCrumbClick('5')">Breadcrumb Level 5</span>
+    </fd-breadcrumb-item>
+</fd-breadcrumb>

--- a/libs/docs/core/breadcrumb/examples/breadcrumb-click-proxy-example.component.ts
+++ b/libs/docs/core/breadcrumb/examples/breadcrumb-click-proxy-example.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { BreadcrumbModule } from '@fundamental-ngx/core/breadcrumb';
+import { LinkComponent } from '@fundamental-ngx/core/link';
+
+@Component({
+    selector: 'fd-breadcrumb-click-proxy-example',
+    templateUrl: './breadcrumb-click-proxy-example.component.html',
+    styles: [
+        `
+            :host {
+                display: block;
+                width: 100%;
+            }
+        `
+    ],
+    standalone: true,
+    imports: [BreadcrumbModule, LinkComponent, RouterLink]
+})
+export class BreadcrumbClickProxyExampleComponent {
+
+    constructor() {
+    }
+
+    onBreadCrumbClick(level: string) {
+        alert('BreadCrumb Click! Level' + level)
+    }
+}


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes https://github.com/SAP/fundamental-ngx/issues/11685

## Description

<!-- Enter short description of the change -->
When view size is not enough, breadcrumb will be pushed into menu. If breadcrumb is in a menu, before, we only pass click event if there is a <code>href</code> attribute or <code>routerLink</code> directive.

Changes:
- Add new `needsClickProxy` Input to pass the click event
- Add a new document example

