### PR TITLE
fix(core): use Button component inside Select instead of classes

### DIFF
--- a/libs/core/button/button.component.ts
+++ b/libs/core/button/button.component.ts
@@ -29,7 +29,7 @@ import { FD_BUTTON_COMPONENT } from './tokens';
  */
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
-    selector: 'button[fd-button], a[fd-button]',
+    selector: 'button[fd-button], a[fd-button], span[fd-button]',
     exportAs: 'fd-button',
     templateUrl: './button.component.html',
     styleUrl: './button.component.scss',

--- a/libs/core/select/select.component.html
+++ b/libs/core/select/select.component.html
@@ -63,7 +63,9 @@
         </div>
         @if (!readonly) {
             <span
-                class="fd-button fd-button--transparent fd-select__button"
+                fd-button
+                fdType="transparent"
+                class="fd-select__button"
                 [ngClass]="selectDropdownButtonClass"
                 [class.is-disabled]="disabled"
             >

--- a/libs/core/select/select.component.ts
+++ b/libs/core/select/select.component.ts
@@ -51,6 +51,7 @@ import { ENTER, ESCAPE, SPACE } from '@angular/cdk/keycodes';
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormFieldAdvancedStateMessage, FormStates, SingleDropdownValueControl } from '@fundamental-ngx/cdk/forms';
+import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { ListComponent, ListMessageDirective } from '@fundamental-ngx/core/list';
@@ -107,7 +108,8 @@ export const SELECT_ITEM_HEIGHT_EM = 4;
         IconComponent,
         ListComponent,
         ListMessageDirective,
-        FdTranslatePipe
+        FdTranslatePipe,
+        ButtonComponent
     ]
 })
 export class SelectComponent<T = any>


### PR DESCRIPTION
## Description
The css for Button is not coming in Select component if Button component is never used in an application. This PR uses the `fd-button` component in Select instead of a span with css classes. For this to work I added a new selector to Button component `span[fd-button]`