### PR TITLE
fix(core): remove parent row tabindex when cell is focused to address screenreader issue

### DIFF
--- a/libs/core/src/lib/table/directives/table-cell.directive.spec.ts
+++ b/libs/core/src/lib/table/directives/table-cell.directive.spec.ts
@@ -7,10 +7,12 @@ import { TableCellDirective } from './table-cell.directive';
 
 @Component({
     template: `
-        <td fd-table-cell>
-            <fd-checkbox></fd-checkbox>
-        </td>
-        <td fd-table-cell [key]="key">{{ key }}</td>
+        <tr tabindex="-1">
+            <td fd-table-cell>
+                <fd-checkbox></fd-checkbox>
+            </td>
+            <td fd-table-cell [key]="key">{{ key }}</td>
+        </tr>
     `
 })
 class TestComponent {
@@ -55,5 +57,17 @@ describe('TableCellDirective', () => {
         fixture.detectChanges();
 
         expect(component.cell.elementRef.nativeElement.classList.length).toBe(8);
+    });
+
+    it('should handle focus events', () => {
+        const parentEl = component.cell.elementRef.nativeElement.parentElement as HTMLElement;
+        expect(parentEl).toBeTruthy();
+        spyOn(parentEl, 'setAttribute');
+        spyOn(parentEl, 'removeAttribute');
+        expect(parentEl?.tabIndex).toBe(-1);
+        component.cell.elementRef.nativeElement.focus();
+        expect(parentEl?.removeAttribute).toHaveBeenCalled();
+        component.cell.elementRef.nativeElement.blur();
+        expect(parentEl?.setAttribute).toHaveBeenCalledWith('tabindex', '-1');
     });
 });

--- a/libs/core/src/lib/table/directives/table-cell.directive.ts
+++ b/libs/core/src/lib/table/directives/table-cell.directive.ts
@@ -1,4 +1,12 @@
-import { AfterContentInit, Directive, HostBinding, Input, QueryList, ContentChildren } from '@angular/core';
+import {
+    AfterContentInit,
+    Directive,
+    HostBinding,
+    Input,
+    QueryList,
+    ContentChildren,
+    HostListener
+} from '@angular/core';
 import { CheckboxComponent, FD_CHECKBOX_COMPONENT } from '@fundamental-ngx/core/checkbox';
 import { DestroyedService, FDK_FOCUSABLE_ITEM_DIRECTIVE, FocusableItemDirective } from '@fundamental-ngx/cdk/utils';
 import { BooleanInput } from '@angular/cdk/coercion';
@@ -74,6 +82,26 @@ export class TableCellDirective extends FocusableItemDirective implements AfterC
     /** @hidden */
     @HostBinding('class.fd-table__cell')
     _fdTableCellClass = true;
+
+    /** @hidden */
+    private _parentPreviousTabIndex: number | undefined;
+
+    /** @hidden */
+    @HostListener('focusin')
+    private _focusIn(): void {
+        const parentEl = this.elementRef.nativeElement.parentElement;
+        this._parentPreviousTabIndex = parentEl?.tabIndex;
+        parentEl?.removeAttribute('tabindex');
+    }
+
+    /** @hidden */
+    @HostListener('focusout')
+    private _focusOut(): void {
+        const parentEl = this.elementRef.nativeElement.parentElement;
+        if (this._parentPreviousTabIndex) {
+            parentEl?.setAttribute('tabindex', this._parentPreviousTabIndex.toString());
+        }
+    }
 
     /** @hidden */
     constructor() {

--- a/libs/core/src/lib/table/table.component.ts
+++ b/libs/core/src/lib/table/table.component.ts
@@ -4,6 +4,7 @@ import {
     ChangeDetectionStrategy,
     Component,
     ContentChildren,
+    ElementRef,
     HostBinding,
     Input,
     NgZone,
@@ -104,7 +105,8 @@ export class TableComponent implements AfterContentInit, AfterViewInit {
         private readonly _tableService: TableService,
         private readonly _contentDensityObserver: ContentDensityObserver,
         private readonly _destroy$: DestroyedService,
-        private readonly _ngZone: NgZone
+        private readonly _ngZone: NgZone,
+        private readonly _elRef: ElementRef
     ) {
         this._contentDensityObserver.subscribe();
     }


### PR DESCRIPTION
fixes #11376 

Focusable grid/list uses tabindex to handle navigation via keyboard, not only for tab presses but also arrow keys. When a parent element has a tab index, and its children have tab indexes, the screenreader will read "x of y" when focusing a child, where x is the index and y is the number of children. This PR removes the parent row's tabindex when a cell receives focus, and puts it back when the cell is blurred.