### PR TITLE
fix(core): step input disabled state

### DIFF
--- a/libs/core/step-input/step-input.component.ts
+++ b/libs/core/step-input/step-input.component.ts
@@ -322,6 +322,7 @@ export class StepInputComponent implements OnInit, AfterViewInit, OnDestroy, Con
     /** @hidden */
     setDisabledState(isDisabled: boolean): void {
         this.disabled = isDisabled;
+        this._changeDetectorRef.detectChanges();
     }
 
     /** @hidden */

--- a/libs/docs/core/step-input/examples/step-input-form-example/step-input-form-example.component.ts
+++ b/libs/docs/core/step-input/examples/step-input-form-example/step-input-form-example.component.ts
@@ -61,6 +61,7 @@ import { StepInputModule } from '@fundamental-ngx/core/step-input';
                         <td>{{ stepInputFormControl2.status }}</td>
                     </tr>
                 </table>
+                <button fd-button (click)="toggleDisabledState()">Toggle disabled state</button>
             </div>
 
             <div class="step-input-example">
@@ -78,4 +79,10 @@ export class StepInputFormExampleComponent {
     stepInputFormControl2 = new FormControl({ disabled: true, value: 100 });
     value1: number | null = 100;
     value2: number | null = 100;
+
+    toggleDisabledState(): void {
+        this.stepInputFormControl2.enabled
+            ? this.stepInputFormControl2.disable()
+            : this.stepInputFormControl2.enable();
+    }
 }


### PR DESCRIPTION
## Related Issue(s)

Same problem as #10961  only with the step-input

Same fix as #10994 

Note: using `detectChanges` is more performant in such localised changes for low level components. [`markForCheck`](https://github.com/angular/angular/blob/8cd1b2323ac32ad09ec1a7f97a6413c93b7efe6f/packages/core/src/render3/instructions/mark_view_dirty.ts#L15) would run change detection for all ancestors (eventually), while `detectChanges` runs only for this component and its children, which are very few.
