### PR TITLE
fix(core): remove tabindex from dynamic page header

### DIFF
--- a/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
+++ b/libs/core/src/lib/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
@@ -37,9 +37,6 @@ export const ActionSquashBreakpointPx = 1280;
     styleUrls: ['./dynamic-page-header.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    host: {
-        '[attr.tabindex]': '0'
-    },
     providers: [
         {
             provide: DYNAMIC_PAGE_HEADER_TOKEN,

--- a/libs/platform/src/lib/dynamic-page/dynamic-page-header/title/dynamic-page-title.component.spec.ts
+++ b/libs/platform/src/lib/dynamic-page/dynamic-page-header/title/dynamic-page-title.component.spec.ts
@@ -113,8 +113,8 @@ describe('DynamicPageTitleComponent', () => {
         ).toBeTruthy();
     });
 
-    it('should add tabindex to host', async () => {
-        expect(titleComponentDebugElement.attributes['tabindex']).toEqual('0');
+    it('should not add tabindex to host', async () => {
+        expect(titleComponentDebugElement.attributes['tabindex']).toBeUndefined();
     });
 
     describe('title text', () => {


### PR DESCRIPTION
fixes #11614 

already fixed by @InnaAtanasova on main here: https://github.com/SAP/fundamental-ngx/pull/11767/files#diff-9147dfcd23f2e521ff9713a02abe871d8307183e4baac7361497f7760299359bL42