### PR TITLE
fix(platform): check validator before open Filtering Settings Dialog

### DIFF
--- a/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -146,9 +146,10 @@ export class TableP13DialogComponent implements OnDestroy {
         const dialogData: FilterDialogData = {
             columns: columns.map(({ label, key, dataType, filterable }) => ({ label, key, dataType, filterable })),
             collectionFilter: filterBy,
-            validator: this.filter.validator
         };
-
+        if (this.filter && this.filter.validator) {
+            dialogData.validator = this.filter.validator;
+        }
         const dialogRef = this._dialogService.open(
             P13FilteringDialogComponent,
             {

--- a/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -145,7 +145,7 @@ export class TableP13DialogComponent implements OnDestroy {
         const filterBy = state?.filterBy;
         const dialogData: FilterDialogData = {
             columns: columns.map(({ label, key, dataType, filterable }) => ({ label, key, dataType, filterable })),
-            collectionFilter: filterBy,
+            collectionFilter: filterBy
         };
         if (this.filter && this.filter.validator) {
             dialogData.validator = this.filter.validator;


### PR DESCRIPTION
PR https://github.com/SAP/fundamental-ngx/pull/11535 added validator input for p13 filter component. 

But it caused a regression, when there is no  `<fdp-table-p13n-filter [validator]="validator" />` inside 
```html
<fdp-table-p13-dialog [table]="table"> </fdp-table-p13-dialog>
``` 
Table filter cannot be opened.

This issue can be reproduced on both 0.49 and 0.43
- StackBlitiz https://stackblitz.com/edit/p6cmyh?file=src%2Fapp%2Fplatform-table-p13-filter-example.component.html