### PR TITLE
fix(core): add possibility to set aria-label for input-group

### DIFF
--- a/libs/core/input-group/input-group.component.html
+++ b/libs/core/input-group/input-group.component.html
@@ -72,7 +72,8 @@
     <input
         [(ngModel)]="inputText"
         [id]="_inputId"
-        [attr.aria-labelledby]="_inputAriaLabelledBy"
+        [attr.aria-label]="ariaLabel"
+        [attr.aria-labelledby]="ariaLabel ? null : _inputAriaLabelledBy"
         [class.fd-shellbar__input-group-input]="inShellbar"
         fd-input-group-input
         [type]="type"

--- a/libs/core/input-group/input-group.component.ts
+++ b/libs/core/input-group/input-group.component.ts
@@ -153,6 +153,10 @@ export class InputGroupComponent implements AfterViewInit, FormItemControl, OnIn
     @Input()
     ariaLabelledBy: Nullable<string>;
 
+    /** aria-label for the input field */
+    @Input()
+    ariaLabel: Nullable<string>;
+
     /** Event emitted when the add-on button is clicked. */
     @Output()
     addOnButtonClicked = new EventEmitter<Event>();

--- a/libs/docs/core/input-group/examples/input-group-text-example.component.html
+++ b/libs/docs/core/input-group/examples/input-group-text-example.component.html
@@ -14,3 +14,16 @@
     <label fd-form-label for="fd-input-group-text-2" id="fd-input-group-label-2">Right Aligned Text Add-on</label>
     <fd-input-group id="fd-input-group-text-2" addOnText="$" placement="after" placeholder="Amount"> </fd-input-group>
 </div>
+
+<br />
+<h4>Input group without a label, using <code>aria-label</code></h4>
+<div fd-form-item>
+    <fd-input-group
+        id="fd-input-group-text-3"
+        addOnText="$"
+        placement="after"
+        placeholder="Amount"
+        ariaLabel="Right Aligned Text Add-on"
+    >
+    </fd-input-group>
+</div>


### PR DESCRIPTION
## Related Issue(s)


closes https://github.com/SAP/fundamental-ngx/issues/11940

## Description
If the input group is used without a label there's no way to set aria-label for the input field. 
The PR contains the following changes:
- adds aria-label input
- if aria-label is provided, aria-labelledby is null
- updated the examples