### PR TITLE
fix(core): add a11y role and aria-checked to the checkbox

### DIFF
--- a/libs/core/checkbox/checkbox/checkbox.component.html
+++ b/libs/core/checkbox/checkbox/checkbox.component.html
@@ -8,6 +8,8 @@
     [indeterminate]="isIndeterminate"
     [checked]="isChecked"
     [attr.tabindex]="tabIndexValue"
+    [attr.role]="role"
+    [attr.aria-checked]="isChecked"
     [attr.aria-label]="ariaLabel"
     [attr.aria-labelledby]="ariaLabelledBy"
     [attr.aria-describedby]="ariaDescribedBy"

--- a/libs/core/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/checkbox/checkbox/checkbox.component.ts
@@ -77,6 +77,13 @@ export class CheckboxComponent<T = unknown> implements ControlValueAccessor, Aft
     @Input()
     ariaLabel: Nullable<string>;
 
+    /**
+     * Sets the `role` attribute to the element.
+     * Default: checkbox
+     */
+    @Input()
+    role = 'checkbox';
+
     /** Current selection state of the checkbox component */
     @Input()
     set value(value: T) {


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes https://github.com/SAP/fundamental-ngx/issues/11939

## Description
- the input of the checkbox has role="checkbox"
- the role is exposed as an input property so can be modified
- added aria-checked to the input