### PR TITLE
fix(core): remove padding when subheader is empty

### DIFF
--- a/libs/core/dynamic-page/dynamic-page.component.scss
+++ b/libs/core/dynamic-page/dynamic-page.component.scss
@@ -84,3 +84,7 @@
         align-items: center;
     }
 }
+
+.fd-dynamic-page__collapsible-header:empty {
+    padding: 0 !important;
+}


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11862

## Description

if no content is provided the padding should be removed

## Screenshots
No content:
![Screenshot 2024-05-27 at 4 21 50 PM](https://github.com/SAP/fundamental-ngx/assets/39598672/63477f08-5e6d-48e7-978a-be742dd6f853)

With content:
![Screenshot 2024-05-27 at 4 22 20 PM](https://github.com/SAP/fundamental-ngx/assets/39598672/ba6bb5e4-58bd-485c-aa06-59a791c67e13)

