### PR TITLE
fix(core): update Message Box status icons

### DIFF
--- a/libs/core/message-box/message-box-semantic-icon/message-box-semantic-icon.component.ts
+++ b/libs/core/message-box/message-box-semantic-icon/message-box-semantic-icon.component.ts
@@ -47,15 +47,15 @@ export class MessageBoxSemanticIconComponent {
     get _semanticIcon(): string {
         switch (this.messageBoxConfig.type) {
             case 'error':
-                return 'message-error';
+                return 'error';
             case 'success':
-                return 'message-success';
+                return 'sys-enter-2';
             case 'warning':
-                return 'message-warning';
+                return 'alert';
             case 'information':
-                return 'message-information';
+                return 'information';
             case 'confirmation':
-                return 'question-mark';
+                return 'sys-help-2';
             default:
                 return '';
         }


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/11995

## Description
updated the default status icons for Message Box