### PR TITLE
fix(platform): quick fix performance for platform table with many columns

### DIFF
--- a/libs/docs/platform/table/child-docs/advanced/advanced-examples-docs.component.html
+++ b/libs/docs/platform/table/child-docs/advanced/advanced-examples-docs.component.html
@@ -21,3 +21,29 @@
     <fdp-doc-advanced-scrolling-example></fdp-doc-advanced-scrolling-example>
 </component-example>
 <code-example [exampleFiles]="pageScrollingTableFiles"></code-example>
+
+<fd-docs-section-title id="enhanced-page-scrolling" componentName="table"
+    >Handling large amount of data and columns</fd-docs-section-title
+>
+<description>
+    <p>One of the scenarios of using Platform Table component, is to render the large amount of items.</p>
+    <p>Storing this amount directly in memory may lead to a browser performance issues.</p>
+    <p>
+        In order to keep the performance on a normal level, Platform Table component supports lazy loading of the items
+        on scroll, and reusing rendered row components for row items.
+    </p>
+    <p>Additionally, Platform Table component supports lazy loading for a child row items.</p>
+    <p>
+        For this, developers need to pass Data source class that retrieves row's children into
+        <code>[childDataSource]</code> input property.
+    </p>
+    <p>
+        <strong>IMPORTANT:</strong> due to complexity of the children lazy loading logic, [childDataSource] can only
+        accept classes derived from <code>TableChildrenDataProvider</code>.
+    </p>
+    <p>This example shows combination of virtual scroll and lazy loading for item on each level.</p>
+</description>
+<component-example>
+    <fdp-doc-advanced-scrolling-example [enhancedRendering]="true"></fdp-doc-advanced-scrolling-example>
+</component-example>
+<code-example [exampleFiles]="pageScrollingTableFiles"></code-example>

--- a/libs/docs/platform/table/child-docs/advanced/advanced-examples-docs.component.html
+++ b/libs/docs/platform/table/child-docs/advanced/advanced-examples-docs.component.html
@@ -26,20 +26,15 @@
     >Handling large amount of data and columns</fd-docs-section-title
 >
 <description>
-    <p>One of the scenarios of using Platform Table component, is to render the large amount of items.</p>
-    <p>Storing this amount directly in memory may lead to a browser performance issues.</p>
+    <p>Another scenario of using Platform Table component, is to render the large amount of columns.</p>
+    <p>Virtual scroll and lazy loading only handles vertical scrolling.</p>
     <p>
-        In order to keep the performance on a normal level, Platform Table component supports lazy loading of the items
-        on scroll, and reusing rendered row components for row items.
-    </p>
-    <p>Additionally, Platform Table component supports lazy loading for a child row items.</p>
-    <p>
-        For this, developers need to pass Data source class that retrieves row's children into
-        <code>[childDataSource]</code> input property.
+        In order to keep the performance on a normal level, Platform Table component introduces ways to handle rendering
+        in viewport which reduces DOM elements and improves performance, impacting horizontal scrolling.
     </p>
     <p>
-        <strong>IMPORTANT:</strong> due to complexity of the children lazy loading logic, [childDataSource] can only
-        accept classes derived from <code>TableChildrenDataProvider</code>.
+        For this, developers need to pass boolean into
+        <code>[enhancedRendering]</code> input property.
     </p>
     <p>This example shows combination of virtual scroll and lazy loading for item on each level.</p>
 </description>

--- a/libs/docs/platform/table/child-docs/advanced/advanced-examples-docs.component.html
+++ b/libs/docs/platform/table/child-docs/advanced/advanced-examples-docs.component.html
@@ -34,11 +34,12 @@
     </p>
     <p>
         For this, developers need to pass boolean into
-        <code>[enhancedRendering]</code> input property.
+        <code>[onlyRenderVisibleCells]</code> input property. Placeholder [fd-busy-indicator] for cell can be enabled by
+        passing boolean into <code>[useCellPlaceholder]</code> input property
     </p>
     <p>This example shows combination of virtual scroll and lazy loading for item on each level.</p>
 </description>
 <component-example>
-    <fdp-doc-advanced-scrolling-example [enhancedRendering]="true"></fdp-doc-advanced-scrolling-example>
+    <fdp-doc-advanced-scrolling-example [onlyRenderVisibleCells]="true"></fdp-doc-advanced-scrolling-example>
 </component-example>
 <code-example [exampleFiles]="pageScrollingTableFiles"></code-example>

--- a/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.html
+++ b/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.html
@@ -8,7 +8,8 @@
     emptyTableMessage="No data found"
     bodyHeight="300px"
     [virtualScroll]="true"
-    [enhancedRendering]="enhancedRendering"
+    [onlyRenderVisibleCells]="onlyRenderVisibleCells"
+    [useCellPlaceholder]="cellPlaceholder"
     [pageScrolling]="true"
     [pageSize]="20"
     [renderAhead]="20"
@@ -17,8 +18,9 @@
     [expandOnInit]="true"
 >
     <fdp-table-toolbar title="Order Line Items" [hideItemCount]="false" [hideSearchInput]="true">
-        <fdp-table-toolbar-actions *ngIf="enhancedRendering">
+        <fdp-table-toolbar-actions *ngIf="onlyRenderVisibleCells">
             <fdp-button label="Add column" (click)="addColumn()"></fdp-button>
+            <fdp-button label="Toggle cell placeholder" (click)="toggleCellPlaceholder()"></fdp-button>
         </fdp-table-toolbar-actions>
     </fdp-table-toolbar>
 
@@ -57,7 +59,7 @@
     >
     </fdp-column>
 
-    <ng-container *ngIf="enhancedRendering">
+    <ng-container *ngIf="onlyRenderVisibleCells">
         <fdp-column
             width="100px"
             *ngFor="let column of columns; let i = index"

--- a/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.html
+++ b/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.html
@@ -8,14 +8,19 @@
     emptyTableMessage="No data found"
     bodyHeight="300px"
     [virtualScroll]="true"
+    [enhancedRendering]="enhancedRendering"
     [pageScrolling]="true"
-    [pageSize]="50"
-    [renderAhead]="50"
+    [pageSize]="20"
+    [renderAhead]="20"
     [pageScrollingThreshold]="80"
     hasChildrenKey="hasChildren"
     [expandOnInit]="true"
 >
-    <fdp-table-toolbar title="Order Line Items" [hideItemCount]="false" [hideSearchInput]="true"> </fdp-table-toolbar>
+    <fdp-table-toolbar title="Order Line Items" [hideItemCount]="false" [hideSearchInput]="true">
+        <fdp-table-toolbar-actions *ngIf="enhancedRendering">
+            <fdp-button label="Add column" (click)="addColumn()"></fdp-button>
+        </fdp-table-toolbar-actions>
+    </fdp-table-toolbar>
 
     <fdp-column
         name="name"
@@ -51,6 +56,19 @@
         [dataType]="dataTypeEnum.STRING"
     >
     </fdp-column>
+
+    <ng-container *ngIf="enhancedRendering">
+        <fdp-column
+            width="100px"
+            *ngFor="let column of columns; let i = index"
+            [name]="column.key"
+            [label]="column.label"
+        >
+            <fdp-table-cell *fdpCellDef="let node; let idx = rowIndex">
+                Some text here {{ i + 1 }} {{ idx }}</fdp-table-cell
+            >
+        </fdp-column>
+    </ng-container>
 </fdp-table>
 
 <!-- Connect P13 Dialog to the table -->

--- a/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.ts
+++ b/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, ViewEncapsulation } from '@angular/core';
 import { DatetimeAdapter, FdDate } from '@fundamental-ngx/core/datetime';
 import {
     ChildTableDataSource,
@@ -27,14 +27,27 @@ import { delay } from 'rxjs/operators';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AdvancedScrollingExampleComponent {
+    @Input() enhancedRendering: boolean = false;
+
     source: TableDataSource<ExampleItem>;
     childSource: ChildTableDataSource<ExampleItem>;
     readonly filterTypeEnum = FilterType;
     readonly dataTypeEnum = FilterableColumnDataType;
+    columns: any[] = [];
 
-    constructor() {
+    constructor(private _cd: ChangeDetectorRef) {
         this.source = new TableDataSource(new TableDataProviderExample());
         this.childSource = new ChildTableDataSource(new ChildTableProviderExample());
+    }
+
+    addColumn(): void {
+        this.columns.push({
+            key: `col_${this.columns.length + 1}`,
+            label: `col_${this.columns.length + 1}`,
+            isDataSource: false
+        });
+
+        this._cd.detectChanges();
     }
 }
 

--- a/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.ts
+++ b/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.ts
@@ -27,13 +27,14 @@ import { delay } from 'rxjs/operators';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AdvancedScrollingExampleComponent {
-    @Input() enhancedRendering: boolean = false;
+    @Input() onlyRenderVisibleCells: boolean = false;
 
     source: TableDataSource<ExampleItem>;
     childSource: ChildTableDataSource<ExampleItem>;
     readonly filterTypeEnum = FilterType;
     readonly dataTypeEnum = FilterableColumnDataType;
     columns: any[] = [];
+    cellPlaceholder = false;
 
     constructor(private _cd: ChangeDetectorRef) {
         this.source = new TableDataSource(new TableDataProviderExample());
@@ -48,6 +49,10 @@ export class AdvancedScrollingExampleComponent {
         });
 
         this._cd.detectChanges();
+    }
+
+    toggleCellPlaceholder(): void {
+        this.cellPlaceholder = !this.cellPlaceholder;
     }
 }
 

--- a/libs/platform/src/lib/table-helpers/directives/index.ts
+++ b/libs/platform/src/lib/table-helpers/directives/index.ts
@@ -10,4 +10,4 @@ export * from './table-cell.directive';
 export * from './table-header.directive';
 export * from './table-scrollable.directive';
 export * from './table-view-settings-filter-custom.directive';
-export * from './table-advanced-viewport.directive';
+export * from './table-visible-cell.directive';

--- a/libs/platform/src/lib/table-helpers/directives/index.ts
+++ b/libs/platform/src/lib/table-helpers/directives/index.ts
@@ -10,3 +10,4 @@ export * from './table-cell.directive';
 export * from './table-header.directive';
 export * from './table-scrollable.directive';
 export * from './table-view-settings-filter-custom.directive';
+export * from './table-advanced-viewport.directive';

--- a/libs/platform/src/lib/table-helpers/directives/table-advanced-viewport.directive.ts
+++ b/libs/platform/src/lib/table-helpers/directives/table-advanced-viewport.directive.ts
@@ -1,0 +1,116 @@
+import {
+    Directive,
+    ElementRef,
+    Input,
+    Renderer2,
+    OnInit,
+    TemplateRef,
+    ViewContainerRef,
+    ChangeDetectorRef,
+    inject
+} from '@angular/core';
+import { Observable, debounceTime, take, takeUntil } from 'rxjs';
+import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { ViewportRootService } from '../services/table-advanced-viewport-root.service';
+
+@Directive({
+    selector: '[fdpTableViewport]',
+    standalone: true,
+    providers: [DestroyedService]
+})
+export class ViewportDirective implements OnInit {
+    /** @hidden */
+    @Input()
+    tableViewport: TemplateRef<any>;
+
+    /** @hidden */
+    @Input()
+    viewportFallback: TemplateRef<any>;
+
+    /** @hidden */
+    private readonly _destroy$ = inject(DestroyedService);
+
+    /** @hidden */
+    private readonly _viewportRootService = inject(ViewportRootService);
+
+    /** @hidden */
+    private currentTemplate: TemplateRef<any>;
+    /** @hidden */
+    constructor(
+        /** @hidden */
+        private el: ElementRef,
+        /** @hidden */
+        private renderer: Renderer2,
+        /** @hidden */
+        private viewContainer: ViewContainerRef,
+        private cdr: ChangeDetectorRef
+    ) {}
+
+    /** @hidden */
+    ngOnInit(): void {
+        if (!this._viewportRootService.getRootNode()) {
+            this._viewportRootService.rootElement$.pipe(take(1)).subscribe((rootNode) => {
+                if (rootNode) {
+                    this.checkViewport();
+                }
+            });
+        } else {
+            this.checkViewport();
+        }
+    }
+
+    /** @hidden */
+    checkViewport(): void {
+        const options: IntersectionObserverInit = {
+            root: this._viewportRootService.getRootNode(),
+            rootMargin: '10px 10px 10px 10px',
+            threshold: 0.0
+        };
+
+        const observer = new Observable<boolean>((subscriber) => {
+            const intersectionObserver = new IntersectionObserver((entries) => {
+                const { isIntersecting } = entries[0];
+                subscriber.next(isIntersecting);
+            }, options);
+
+            intersectionObserver.observe(this.el.nativeElement.parentElement);
+
+            return {
+                unsubscribe() {
+                    intersectionObserver.disconnect();
+                }
+            };
+        });
+
+        observer
+            .pipe(takeUntil(this._destroy$))
+            .pipe(debounceTime(50))
+            .subscribe((inViewPort) => {
+                this.updateView(inViewPort);
+            });
+    }
+
+    /** @hidden */
+    private updateView(inViewPort: boolean): void {
+        if (this.viewContainer.length === 0) {
+            if (inViewPort) {
+                this.viewContainer.createEmbeddedView(this.tableViewport);
+                this.currentTemplate = this.tableViewport;
+            } else {
+                this.viewContainer.createEmbeddedView(this.viewportFallback);
+                this.currentTemplate = this.viewportFallback;
+            }
+        } else {
+            if (inViewPort && this.currentTemplate !== this.tableViewport) {
+                this.viewContainer.clear();
+                this.viewContainer.createEmbeddedView(this.tableViewport);
+                this.currentTemplate = this.tableViewport;
+            } else if (!inViewPort && this.currentTemplate !== this.viewportFallback) {
+                this.viewContainer.clear();
+                this.viewContainer.createEmbeddedView(this.viewportFallback);
+                this.currentTemplate = this.viewportFallback;
+            }
+        }
+        this.cdr.markForCheck(); // Mark parent component for change detection
+    }
+}

--- a/libs/platform/src/lib/table-helpers/directives/table-visible-cell.directive.ts
+++ b/libs/platform/src/lib/table-helpers/directives/table-visible-cell.directive.ts
@@ -15,11 +15,11 @@ import { DestroyedService } from '@fundamental-ngx/cdk/utils';
 import { ViewportRootService } from '../services/table-advanced-viewport-root.service';
 
 @Directive({
-    selector: '[fdpTableViewport]',
+    selector: '[fdpOnlyRenderVisibleCell]',
     standalone: true,
     providers: [DestroyedService]
 })
-export class ViewportDirective implements OnInit, OnDestroy {
+export class FdpRenderVisibleCellDirective implements OnInit, OnDestroy {
     /** @hidden */
     @Input()
     tableViewport: TemplateRef<any>;

--- a/libs/platform/src/lib/table-helpers/index.ts
+++ b/libs/platform/src/lib/table-helpers/index.ts
@@ -24,6 +24,7 @@ export * from './services/table-row.service';
 export * from './services/table-column-resize.service';
 export * from './services/table-responsive.service';
 export * from './services/table-scroll-dispatcher.service';
+export * from './services/table-advanced-viewport-root.service';
 
 export * from './pipes';
 

--- a/libs/platform/src/lib/table-helpers/services/table-advanced-viewport-root.service.ts
+++ b/libs/platform/src/lib/table-helpers/services/table-advanced-viewport-root.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable()
+export class ViewportRootService {
+    /** hidden */
+    private rootNode: HTMLElement | null = null;
+
+    /** hidden */
+    public rootElement$: Subject<HTMLElement> = new Subject<HTMLElement>();
+
+    /** hidden */
+    setRootNode(node: HTMLElement): void {
+        this.rootNode = node;
+        this.rootElement$.next(this.rootNode);
+    }
+
+    /** hidden */
+    getRootNode(): HTMLElement | null {
+        return this.rootNode;
+    }
+}

--- a/libs/platform/src/lib/table-helpers/table-helpers.module.ts
+++ b/libs/platform/src/lib/table-helpers/table-helpers.module.ts
@@ -15,7 +15,8 @@ import {
     TableHeaderResizerDirective,
     TableInitialStateDirective,
     TableScrollableDirective,
-    TableVirtualScrollDirective
+    TableVirtualScrollDirective,
+    ViewportDirective
 } from './directives';
 import {
     ColumnResizableSidePipe,
@@ -49,7 +50,8 @@ const importExports = [
     TableCellStylesPipe,
     ColumnResizableSidePipe,
     RowClassesPipe,
-    TableColumnSortingDirectionPipe
+    TableColumnSortingDirectionPipe,
+    ViewportDirective
 ];
 
 @NgModule({

--- a/libs/platform/src/lib/table-helpers/table-helpers.module.ts
+++ b/libs/platform/src/lib/table-helpers/table-helpers.module.ts
@@ -16,7 +16,7 @@ import {
     TableInitialStateDirective,
     TableScrollableDirective,
     TableVirtualScrollDirective,
-    ViewportDirective
+    FdpRenderVisibleCellDirective
 } from './directives';
 import {
     ColumnResizableSidePipe,
@@ -51,7 +51,7 @@ const importExports = [
     ColumnResizableSidePipe,
     RowClassesPipe,
     TableColumnSortingDirectionPipe,
-    ViewportDirective
+    FdpRenderVisibleCellDirective
 ];
 
 @NgModule({

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.html
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.html
@@ -1,5 +1,5 @@
 <ng-template #fallbackContent>
-    <fd-skeleton style="margin: auto 0" type="text" textLines="1" width="60%"></fd-skeleton>
+    <fd-busy-indicator [loading]="true" size="s" [block]="true"> </fd-busy-indicator>
 </ng-template>
 
 <ng-template

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.html
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.html
@@ -1,10 +1,10 @@
 <ng-template #fallbackContent>
-    <fd-busy-indicator [loading]="true" size="s" [block]="true"> </fd-busy-indicator>
+    <fd-busy-indicator *ngIf="useCellPlaceholder" [loading]="true" size="s" [block]="true"> </fd-busy-indicator>
 </ng-template>
 
 <ng-template
-    *ngIf="enhancedRendering; else tdPrimaryContent"
-    fdpTableViewport
+    *ngIf="onlyRenderVisibleCells; else tdPrimaryContent"
+    fdpOnlyRenderVisibleCell
     [tableViewport]="tdPrimaryContent"
     [viewportFallback]="fallbackContent"
 >
@@ -175,7 +175,7 @@
 
                 <ng-container *ngIf="row.state === 'readonly'; else editModeCell">
                     <span
-                        *ngIf="tableTextContainer?.innerText?.trim() === ''"
+                        *ngIf="tableTextContainer?.textContent?.trim() === ''"
                         style="
                             position: absolute !important;
                             height: 1px;
@@ -220,8 +220,8 @@
         </ng-template>
 
         <ng-template
-            *ngIf="enhancedRendering; else primaryTextContainer"
-            fdpTableViewport
+            *ngIf="onlyRenderVisibleCells; else primaryTextContainer"
+            fdpOnlyRenderVisibleCell
             [tableViewport]="primaryTextContainer"
             [viewportFallback]="fallbackContent"
         >

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.html
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.html
@@ -1,228 +1,258 @@
-<td
-    *ngIf="_fdpTableService._semanticHighlighting$ | async as semanticHighlighting"
-    fd-table-cell
-    fd-table-status-indicator
-    fdkDisabled
-    [addDisabledClass]="false"
-    [status]="row.value[semanticHighlighting]"
-    [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
-></td>
-
-<!-- hidden text for screenreader -->
-<ng-template #selectionScreenReaderText>
-    <span
-        aria-hidden="true"
-        [attr.id]="_rowSelectionHelperTextId"
-        [ngStyle]="{
-            position: 'absolute !important',
-            height: '1px',
-            width: '1px',
-            overflow: 'hidden',
-            clip: 'rect(1px, 1px, 1px, 1px)',
-            color: 'transparent',
-            display: 'block'
-        }"
-    >
-        {{ (row.checked ? 'platformTable.deselectSingleRow' : 'platformTable.selectSingleRow') | fdTranslate }}
-    </span>
+<ng-template #fallbackContent>
+    <fd-skeleton style="margin: auto 0" type="text" textLines="1" width="60%"></fd-skeleton>
 </ng-template>
 
-<!-- Row Selection Cell -->
-<ng-container [ngSwitch]="selectionMode">
-    <ng-container *ngSwitchCase="SELECTION_MODE.SINGLE">
-        <td
-            *ngIf="row.value[selectableKey] !== false; else selectionMock"
-            class="fd-table__cell--checkbox"
-            [class.fd-table__cell--fixed]="fixed"
-            [attr.role]="_hasRowHeaderColumn ? 'rowheader' : 'gridcell'"
-            fd-table-cell
-            [focusable]="true"
-            [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
-            [style]="
-                _contentDensityObserver
-                    | async
-                    | selectionCellStyles : _rtl : (_fdpTableService._semanticHighlightingColumnWidth$ | async)
-            "
-            [attr.aria-selected]="row.checked"
-            [attr.aria-labelledby]="_rowSelectionHelperTextId"
-            (click)="_toggleSingleSelectableRow()"
-            (keydown.enter)="_toggleSingleSelectableRow($event)"
-            (keydown.space)="_toggleSingleSelectableRow($event)"
-        >
-            <ng-template [ngTemplateOutlet]="selectionScreenReaderText"></ng-template>
-        </td>
-    </ng-container>
+<ng-template
+    *ngIf="enhancedRendering; else tdPrimaryContent"
+    fdpTableViewport
+    [tableViewport]="tdPrimaryContent"
+    [viewportFallback]="fallbackContent"
+>
+    <ng-template [ngTemplateOutlet]="tdPrimaryContent"></ng-template>
+</ng-template>
 
-    <ng-container *ngSwitchCase="SELECTION_MODE.MULTIPLE">
-        <td
-            *ngIf="row.value[selectableKey] !== false; else selectionMock"
-            class="fd-table__cell--checkbox"
-            [class.fd-table__cell--fixed]="fixed"
-            role="cell"
-            fd-table-cell
-            [focusable]="true"
-            [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
-            (keydown.enter)="_toggleMultiSelectRow(row, $event)"
-            (keydown.space)="_toggleMultiSelectRow(row, $event)"
-            [attr.aria-selected]="row.checked"
-            [attr.aria-labelledby]="_rowSelectionHelperTextId"
-            [style]="
-                _contentDensityObserver
-                    | async
-                    | selectionCellStyles : _rtl : (_fdpTableService._semanticHighlightingColumnWidth$ | async)
-            "
-        >
-            <ng-template [ngTemplateOutlet]="selectionScreenReaderText"></ng-template>
-            <fd-checkbox
-                tabIndexValue="-1"
-                labelClass="fd-table__checkbox-label"
-                [tristate]="enableTristateMode"
-                [tristateSelectable]="false"
-                [ngModel]="row.checked$ | async"
-                (ngModelChange)="_toggleMultiSelectRow(row)"
-            ></fd-checkbox>
-        </td>
-    </ng-container>
-</ng-container>
-
-<ng-template #selectionMock>
+<ng-template #tdPrimaryContent>
     <td
-        class="fd-table__cell--checkbox"
-        role="gridcell"
+        *ngIf="_fdpTableService._semanticHighlighting$ | async as semanticHighlighting"
         fd-table-cell
+        fd-table-status-indicator
         fdkDisabled
         [addDisabledClass]="false"
-        [class.fd-table__cell--fixed]="fixed"
+        [status]="row.value[semanticHighlighting]"
         [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
     ></td>
-</ng-template>
 
-<td
-    *ngFor="
-        let column of _fdpTableService.visibleColumns$ | async;
-        let colIdx = index;
-        last as isLast;
-        trackBy: _columnTrackBy
-    "
-    #tableCellElement
-    [fdpTableCellResizable]="
-        colIdx
-            | columnResizableSide
-                : _fdpTableService.visibleColumnsLength
-                : (_fdpTableService._isShownNavigationColumn$ | async) === true
-    "
-    [columnName]="column.name"
-    [focusable]="true"
-    [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
-    [attr.role]="column.role"
-    [headers]="rowId + '__' + column.name"
-    [ngClass]="[
-        'fdp-table__col--' + column.name,
-        column._freezed ? 'fd-table__cell--fixed' : '',
-        column.name === freezeColumnsTo ? 'fd-table__cell--fixed-last' : '',
-        column._endFreezed ? 'fd-table__cell--fixed-end' : '',
-        column.name === freezeEndColumnsTo ? 'fd-table__cell--fixed-end-last' : '',
-        row.isTree && colIdx === 0 ? 'fd-table__cell--expand' : '',
-        isLast && (_fdpTableService._isShownNavigationColumn$ | async) === false ? 'is-last-child' : ''
-    ]"
-    [ngStyle]="
-        column
-            | tableCellStyles
-                : _rtl
-                : (_fdpTableService._semanticHighlightingColumnWidth$ | async)
-                : selectionColumnWidth
-                : column._freezed
-                : column._endFreezed
-                : _tableColumnResizeService.getPrevColumnsWidth(column.name)
-                : _tableColumnResizeService.getColumnWidthStyle(column.name)
-                : _tableColumnResizeService.getNextColumnsWidth(column.name)
-    "
-    [attr.aria-expanded]="_isTreeRowFirstCell(colIdx, row) ? row.expanded : null"
-    [attr.data-nesting-level]="colIdx === 0 ? row.level + 1 : null"
-    (cellFocused)="_tableRowService.cellFocused($event); _tableRowService.cellActivate(colIdx, row)"
-    (click)="_tableRowService.cellClicked({ index: colIdx, row })"
-    (keydown.enter)="_isTreeRowFirstCell(colIdx, row, $event) && _toggleGroupRow()"
-    (keydown.arrowLeft)="_tableRowService.scrollToOverlappedCell()"
-    (keydown.arrowRight)="_tableRowService.scrollToOverlappedCell()"
-    (keydown.space)="_handleCellSpaceKey(colIdx, tableCellElement, $event)"
->
-    <div [class.fd-table__text]="column.applyText" [class.fd-table__text--no-wrap]="column.noWrap" #tableTextContainer>
+    <!-- hidden text for screenreader -->
+    <ng-template #selectionScreenReaderText>
         <span
-            *ngIf="_isTreeRowFirstCell(colIdx, row)"
-            class="fd-table__expand"
-            [class.fd-table__expand--open]="row.expanded$ | async"
             aria-hidden="true"
-        ></span>
+            [attr.id]="_rowSelectionHelperTextId"
+            [ngStyle]="{
+                position: 'absolute !important',
+                height: '1px',
+                width: '1px',
+                overflow: 'hidden',
+                clip: 'rect(1px, 1px, 1px, 1px)',
+                color: 'transparent',
+                display: 'block'
+            }"
+        >
+            {{ (row.checked ? 'platformTable.deselectSingleRow' : 'platformTable.selectSingleRow') | fdTranslate }}
+        </span>
+    </ng-template>
 
-        <ng-container *ngIf="row.state === 'readonly'; else editModeCell">
-            <span
-                *ngIf="tableTextContainer?.innerText?.trim() === ''"
-                style="
-                    position: absolute !important;
-                    height: 1px;
-                    width: 1px;
-                    overflow: hidden;
-                    opacity: 0;
-                    clip: rect(1px 1px 1px 1px);
-                    clip: rect(1px, 1px, 1px, 1px);
+    <!-- Row Selection Cell -->
+    <ng-container [ngSwitch]="selectionMode">
+        <ng-container *ngSwitchCase="SELECTION_MODE.SINGLE">
+            <td
+                *ngIf="row.value[selectableKey] !== false; else selectionMock"
+                class="fd-table__cell--checkbox"
+                [class.fd-table__cell--fixed]="fixed"
+                [attr.role]="_hasRowHeaderColumn ? 'rowheader' : 'gridcell'"
+                fd-table-cell
+                [focusable]="true"
+                [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
+                [style]="
+                    _contentDensityObserver
+                        | async
+                        | selectionCellStyles : _rtl : (_fdpTableService._semanticHighlightingColumnWidth$ | async)
                 "
-                >{{ 'platformTable.emptyCell' | fdTranslate }}</span
+                [attr.aria-selected]="row.checked"
+                [attr.aria-labelledby]="_rowSelectionHelperTextId"
+                (click)="_toggleSingleSelectableRow()"
+                (keydown.enter)="_toggleSingleSelectableRow($event)"
+                (keydown.space)="_toggleSingleSelectableRow($event)"
             >
-            <ng-container *ngIf="column?.columnCellTemplate; else defaultTableCellTemplate">
-                <ng-container
-                    *ngTemplateOutlet="
-                        column.columnCellTemplate!;
-                        context: { $implicit: row.value, popping: false, rowIndex: row.index }
-                    "
-                ></ng-container>
-            </ng-container>
+                <ng-template [ngTemplateOutlet]="selectionScreenReaderText"></ng-template>
+            </td>
         </ng-container>
-        <ng-template #defaultTableCellTemplate>{{ row.value | valueByPath : column.key }}</ng-template>
 
-        <ng-template #editModeCell>
-            <ng-container *ngIf="column?.editableColumnCellTemplate; else defaultEditableTableCellTemplate">
-                <ng-container
-                    *ngTemplateOutlet="
-                        column.editableColumnCellTemplate!;
-                        context: { $implicit: row.value, popping: false, rowIndex: row.index }
-                    "
-                ></ng-container>
-            </ng-container>
+        <ng-container *ngSwitchCase="SELECTION_MODE.MULTIPLE">
+            <td
+                *ngIf="row.value[selectableKey] !== false; else selectionMock"
+                class="fd-table__cell--checkbox"
+                [class.fd-table__cell--fixed]="fixed"
+                role="cell"
+                fd-table-cell
+                [focusable]="true"
+                [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
+                (keydown.enter)="_toggleMultiSelectRow(row, $event)"
+                (keydown.space)="_toggleMultiSelectRow(row, $event)"
+                [attr.aria-selected]="row.checked"
+                [attr.aria-labelledby]="_rowSelectionHelperTextId"
+                [style]="
+                    _contentDensityObserver
+                        | async
+                        | selectionCellStyles : _rtl : (_fdpTableService._semanticHighlightingColumnWidth$ | async)
+                "
+            >
+                <ng-template [ngTemplateOutlet]="selectionScreenReaderText"></ng-template>
+                <fd-checkbox
+                    tabIndexValue="-1"
+                    labelClass="fd-table__checkbox-label"
+                    [tristate]="enableTristateMode"
+                    [tristateSelectable]="false"
+                    [ngModel]="row.checked$ | async"
+                    (ngModelChange)="_toggleMultiSelectRow(row)"
+                ></fd-checkbox>
+            </td>
+        </ng-container>
+    </ng-container>
 
-            <ng-template #defaultEditableTableCellTemplate>
-                <fdp-table-editable-cell
-                    [row]="row"
-                    [column]="column"
-                    [columnValue]="row.value | valueByPath : column.key"
-                ></fdp-table-editable-cell>
-            </ng-template>
+    <ng-template #selectionMock>
+        <td
+            class="fd-table__cell--checkbox"
+            role="gridcell"
+            fd-table-cell
+            fdkDisabled
+            [addDisabledClass]="false"
+            [class.fd-table__cell--fixed]="fixed"
+            [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
+        ></td>
+    </ng-template>
+
+    <td
+        *ngFor="
+            let column of _fdpTableService.visibleColumns$ | async;
+            let colIdx = index;
+            last as isLast;
+            trackBy: _columnTrackBy
+        "
+        #tableCellElement
+        [fdpTableCellResizable]="
+            colIdx
+                | columnResizableSide
+                    : _fdpTableService.visibleColumnsLength
+                    : (_fdpTableService._isShownNavigationColumn$ | async) === true
+        "
+        [columnName]="column.name"
+        [focusable]="true"
+        [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
+        [attr.role]="column.role"
+        [headers]="rowId + '__' + column.name"
+        [ngClass]="[
+            'fdp-table__col--' + column.name,
+            column._freezed ? 'fd-table__cell--fixed' : '',
+            column.name === freezeColumnsTo ? 'fd-table__cell--fixed-last' : '',
+            column._endFreezed ? 'fd-table__cell--fixed-end' : '',
+            column.name === freezeEndColumnsTo ? 'fd-table__cell--fixed-end-last' : '',
+            row.isTree && colIdx === 0 ? 'fd-table__cell--expand' : '',
+            isLast && (_fdpTableService._isShownNavigationColumn$ | async) === false ? 'is-last-child' : ''
+        ]"
+        [ngStyle]="
+            column
+                | tableCellStyles
+                    : _rtl
+                    : (_fdpTableService._semanticHighlightingColumnWidth$ | async)
+                    : selectionColumnWidth
+                    : column._freezed
+                    : column._endFreezed
+                    : _tableColumnResizeService.getPrevColumnsWidth(column.name)
+                    : _tableColumnResizeService.getColumnWidthStyle(column.name)
+                    : _tableColumnResizeService.getNextColumnsWidth(column.name)
+        "
+        [attr.aria-expanded]="_isTreeRowFirstCell(colIdx, row) ? row.expanded : null"
+        [attr.data-nesting-level]="colIdx === 0 ? row.level + 1 : null"
+        (cellFocused)="_tableRowService.cellFocused($event); _tableRowService.cellActivate(colIdx, row)"
+        (click)="_tableRowService.cellClicked({ index: colIdx, row })"
+        (keydown.enter)="_isTreeRowFirstCell(colIdx, row, $event) && _toggleGroupRow()"
+        (keydown.arrowLeft)="_tableRowService.scrollToOverlappedCell()"
+        (keydown.arrowRight)="_tableRowService.scrollToOverlappedCell()"
+        (keydown.space)="_handleCellSpaceKey(colIdx, tableCellElement, $event)"
+    >
+        <ng-template #primaryTextContainer>
+            <div
+                [class.fd-table__text]="column.applyText"
+                [class.fd-table__text--no-wrap]="column.noWrap"
+                #tableTextContainer
+            >
+                <span
+                    *ngIf="_isTreeRowFirstCell(colIdx, row)"
+                    class="fd-table__expand"
+                    [class.fd-table__expand--open]="row.expanded$ | async"
+                    aria-hidden="true"
+                ></span>
+
+                <ng-container *ngIf="row.state === 'readonly'; else editModeCell">
+                    <span
+                        *ngIf="tableTextContainer?.innerText?.trim() === ''"
+                        style="
+                            position: absolute !important;
+                            height: 1px;
+                            width: 1px;
+                            overflow: hidden;
+                            opacity: 0;
+                            clip: rect(1px 1px 1px 1px);
+                            clip: rect(1px, 1px, 1px, 1px);
+                        "
+                        >{{ 'platformTable.emptyCell' | fdTranslate }}</span
+                    >
+                    <ng-container *ngIf="column?.columnCellTemplate; else defaultTableCellTemplate">
+                        <ng-container
+                            *ngTemplateOutlet="
+                                column.columnCellTemplate!;
+                                context: { $implicit: row.value, popping: false, rowIndex: row.index }
+                            "
+                        ></ng-container>
+                    </ng-container>
+                </ng-container>
+                <ng-template #defaultTableCellTemplate>{{ row.value | valueByPath : column.key }}</ng-template>
+
+                <ng-template #editModeCell>
+                    <ng-container *ngIf="column?.editableColumnCellTemplate; else defaultEditableTableCellTemplate">
+                        <ng-container
+                            *ngTemplateOutlet="
+                                column.editableColumnCellTemplate!;
+                                context: { $implicit: row.value, popping: false, rowIndex: row.index }
+                            "
+                        ></ng-container>
+                    </ng-container>
+
+                    <ng-template #defaultEditableTableCellTemplate>
+                        <fdp-table-editable-cell
+                            [row]="row"
+                            [column]="column"
+                            [columnValue]="row.value | valueByPath : column.key"
+                        ></fdp-table-editable-cell>
+                    </ng-template>
+                </ng-template>
+            </div>
         </ng-template>
-    </div>
-</td>
 
-<ng-content></ng-content>
+        <ng-template
+            *ngIf="enhancedRendering; else primaryTextContainer"
+            fdpTableViewport
+            [tableViewport]="primaryTextContainer"
+            [viewportFallback]="fallbackContent"
+        >
+            <ng-template [ngTemplateOutlet]="primaryTextContainer"></ng-template>
+        </ng-template>
+    </td>
 
-<td
-    *ngIf="_fdpTableService._isShownNavigationColumn$ | async"
-    fd-table-cell
-    class="fdp-table__cell--navigation is-last-child"
-    fdkDisabled
-    [addDisabledClass]="false"
-    [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
->
-    <i
-        *ngIf="row.navigatable"
-        fd-table-icon
-        [navigation]="true"
-        [class]="_rtl ? 'sap-icon--slim-arrow-left' : 'sap-icon--slim-arrow-right'"
-        class="fdp-table__navigation-indicator"
-    ></i>
-</td>
+    <ng-content></ng-content>
 
-<td
-    aria-hidden="true"
-    class="fd-table__cell fd-table__cell--mock"
-    [class.fd-table__cell--mock-borderless]="(_tableColumnResizeService.cellMockVisible$ | async) !== true"
-    fdkDisabled
-    [addDisabledClass]="false"
-></td>
+    <td
+        *ngIf="_fdpTableService._isShownNavigationColumn$ | async"
+        fd-table-cell
+        class="fdp-table__cell--navigation is-last-child"
+        fdkDisabled
+        [addDisabledClass]="false"
+        [cellFocusedEventAnnouncer]="_itemFocusedEventAnnouncer"
+    >
+        <i
+            *ngIf="row.navigatable"
+            fd-table-icon
+            [navigation]="true"
+            [class]="_rtl ? 'sap-icon--slim-arrow-left' : 'sap-icon--slim-arrow-right'"
+            class="fdp-table__navigation-indicator"
+        ></i>
+    </td>
+
+    <td
+        aria-hidden="true"
+        class="fd-table__cell fd-table__cell--mock"
+        [class.fd-table__cell--mock-borderless]="(_tableColumnResizeService.cellMockVisible$ | async) !== true"
+        fdkDisabled
+        [addDisabledClass]="false"
+    ></td>
+</ng-template>

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.ts
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.ts
@@ -117,9 +117,16 @@ export class TableRowComponent<T> extends TableRowDirective implements OnInit, A
     @Input()
     isTreeRow: boolean;
 
-    /** Whether the row is only rendering within viewport */
+    /** Whether the cell is only rendering within viewport */
     @Input()
-    enhancedRendering: boolean;
+    onlyRenderVisibleCells: boolean;
+
+    /**
+     * Whether to use placeholder [fd-busy-indicator] for cells that are not in the viewport
+     * This option works only when `onlyRenderVisibleCells` is true
+     */
+    @Input()
+    useCellPlaceholder = false;
 
     /**
      * Event emitted when keyboard drag performed.

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.ts
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.ts
@@ -117,6 +117,10 @@ export class TableRowComponent<T> extends TableRowDirective implements OnInit, A
     @Input()
     isTreeRow: boolean;
 
+    /** Whether the row is only rendering within viewport */
+    @Input()
+    enhancedRendering: boolean;
+
     /**
      * Event emitted when keyboard drag performed.
      */

--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -120,7 +120,8 @@
                             [selectionColumnWidth]="_selectionColumnWidth"
                             [freezeColumnsTo]="freezeColumnsTo"
                             [freezeEndColumnsTo]="freezeEndColumnsTo"
-                            [enhancedRendering]="enhancedRendering"
+                            [onlyRenderVisibleCells]="onlyRenderVisibleCells"
+                            [useCellPlaceholder]="useCellPlaceholder"
                         ></tr>
 
                         <tr

--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -120,6 +120,7 @@
                             [selectionColumnWidth]="_selectionColumnWidth"
                             [freezeColumnsTo]="freezeColumnsTo"
                             [freezeEndColumnsTo]="freezeEndColumnsTo"
+                            [enhancedRendering]="enhancedRendering"
                         ></tr>
 
                         <tr

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -106,7 +106,8 @@ import {
     TableService,
     TableSortChangeEvent,
     TableState,
-    TableVirtualScroll
+    TableVirtualScroll,
+    ViewportRootService
 } from '@fundamental-ngx/platform/table-helpers';
 import equal from 'fast-deep-equal';
 import { BehaviorSubject, fromEvent, Observable, of, Subject, Subscription } from 'rxjs';
@@ -177,6 +178,7 @@ let tableUniqueId = 0;
         TableScrollDispatcherService,
         TableColumnResizeService,
         TableResponsiveService,
+        ViewportRootService,
         contentDensityObserverProviders({
             supportedContentDensity: [ContentDensityMode.COMPACT, ContentDensityMode.COZY, ContentDensityMode.CONDENSED]
         }),
@@ -420,6 +422,12 @@ export class TableComponent<T = any>
     get nonFrozenColumnsMinWidth(): number {
         return this._nonFrozenColumnsMinWidth;
     }
+
+    /**
+     * Whether to render row within viewport
+     */
+    @Input()
+    enhancedRendering = false;
 
     /** @hidden */
     private _nonFrozenColumnsMinWidth = 0;
@@ -744,7 +752,8 @@ export class TableComponent<T = any>
         @Optional() private readonly _rtlService: RtlService,
         readonly contentDensityObserver: ContentDensityObserver,
         readonly injector: Injector,
-        private readonly _tabbableService: TabbableElementService
+        private readonly _tabbableService: TabbableElementService,
+        private viewportService: ViewportRootService
     ) {
         super();
         this.initialState?.setTable(this);
@@ -864,6 +873,8 @@ export class TableComponent<T = any>
 
     /** @hidden */
     ngAfterViewInit(): void {
+        this.viewportService.setRootNode(this.tableContainer.nativeElement);
+
         this._viewInitiated = true;
 
         this.initialState?.setInitialState();

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -424,10 +424,21 @@ export class TableComponent<T = any>
     }
 
     /**
-     * Whether to render row within viewport
+     * Whether to render cells within viewport
      */
     @Input()
-    enhancedRendering = false;
+    onlyRenderVisibleCells = false;
+
+    /**
+     * Whether to use placeholder [fd-busy-indicator] for cells that are not in the viewport
+     * This option works only when `onlyRenderVisibleCells` is true
+     */
+    @Input()
+    useCellPlaceholder = false;
+
+    /**
+     * placeholder for
+     */
 
     /** @hidden */
     private _nonFrozenColumnsMinWidth = 0;


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

None (Requested by Sourcing)

## Description

<!-- Enter short description of the change -->
Currently, even with `virtualScroll`, which handles large amount of items, but platform table has issue with large amount of columns which causes some slowness and even page freeze. The idea in this quick fix is to render table cell data only in viewport and reduce DOMNodes, js event listener...

- Implement IntersectionObserver to control the rendering in viewport.
- Introduce property input `onlyRenderVisibleCells` which can be used with any platform table feature (`virtualScroll`, `pageScrolling`, etc...). This toggle is to enable this change.
- Introduce property input `useCellPlaceholder` to use placeholder [fd-busy-indicator] when cell is not within viewport.
- Change affects scrolling behavior and experience, for example, it affects `renderAhead` of `virtualScroll` as it only render data in viewport. It should be better enabled if there are many columns in table for now. 

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->


https://github.com/SAP/fundamental-ngx/assets/162270184/fb667b81-89c6-40c9-b375-3bf3c59f9737


