### PR TITLE
fix(platform): add fix for incorrect font weight for column header in sorted state

### DIFF
--- a/libs/platform/table/table.component.scss
+++ b/libs/platform/table/table.component.scss
@@ -634,3 +634,7 @@ fdk-dynamic-portal {
 .fdp-table--no-outer-border.fd-table--no-vertical-borders .fd-table__cell:last-child {
     border-left-style: none;
 }
+
+th.fd-table__cell .fd-table__inner {
+    font-weight: 700;
+}


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11979

## Description

When a table is sorted by a specific column, the respective column header changes the text font weight from 700 (semibold) to 400 (regular). It should stay consistent with the other column headers at 700. Added a CSS fix.

## Screenshots

### Before:
![Screenshot 2024-06-19 at 9 45 53 AM](https://github.com/SAP/fundamental-ngx/assets/39598672/6202f58d-d6d0-46cd-8e3f-a33d71bba875)


### After:
![Screenshot 2024-06-19 at 9 46 02 AM](https://github.com/SAP/fundamental-ngx/assets/39598672/e8c8b4fa-2c87-4e44-a1f7-1d6f31f8046a)
