### PR TITLE
fix(core, platform): add option to remove additional paddings from table settings dialogs

### DIFF
--- a/libs/core/dialog/dialog-body/dialog-body.component.ts
+++ b/libs/core/dialog/dialog-body/dialog-body.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, ElementRef, Optional, ViewEncapsulation } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    Optional,
+    ViewEncapsulation,
+    booleanAttribute,
+    input
+} from '@angular/core';
 import { FD_DIALOG_BODY_COMPONENT } from '../tokens';
 
 import { AsyncPipe } from '@angular/common';
@@ -25,7 +33,7 @@ import { DialogRef } from '../utils/dialog-ref.class';
         '[class.fd-dialog__body--no-vertical-padding]': '!dialogConfig.verticalPadding',
         '[class.fd-dialog__body--no-horizontal-padding]': '!dialogConfig.horizontalPadding',
         '[style.min-height]': 'dialogConfig.bodyMinHeight',
-        '[style.padding]': 'dialogConfig.disablePaddings ? 0 : "1rem"'
+        '[style.padding]': 'dialogConfig.disablePaddings || disablePaddings() ? 0 : "1rem"'
     },
     providers: [
         {
@@ -40,6 +48,12 @@ import { DialogRef } from '../utils/dialog-ref.class';
     imports: [DynamicPortalComponent, BusyIndicatorComponent, AsyncPipe]
 })
 export class DialogBodyComponent {
+    /**
+     * property to remove the horizontal and vertical paddings from the body
+     * default is set to false
+     */
+    disablePaddings = input(false, { transform: booleanAttribute });
+
     /** @hidden */
     constructor(
         public readonly elementRef: ElementRef,

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters.component.html
@@ -15,7 +15,7 @@
             </div>
         </ng-template>
     </fd-dialog-header>
-    <fd-dialog-body>
+    <fd-dialog-body disablePaddings>
         @if (activeFilterStepView?.bodyTemplateRef) {
             <ng-container [ngTemplateOutlet]="activeFilterStepView.bodyTemplateRef"></ng-container>
         }

--- a/libs/platform/table/components/table-view-settings-dialog/grouping/grouping.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/grouping/grouping.component.html
@@ -14,7 +14,7 @@
         </ng-template>
     </fd-dialog-header>
 
-    <fd-dialog-body>
+    <fd-dialog-body disablePaddings>
         <ul fd-list [selection]="true">
             <li fd-list-group-header>
                 <span fd-list-title>{{ 'platformTable.groupDialogGroupOrderHeader' | fdTranslate }}</span>

--- a/libs/platform/table/components/table-view-settings-dialog/sorting/sorting.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/sorting/sorting.component.html
@@ -13,7 +13,7 @@
             </div>
         </ng-template>
     </fd-dialog-header>
-    <fd-dialog-body>
+    <fd-dialog-body disablePaddings>
         <ul fd-list [selection]="true">
             <li fd-list-group-header>
                 <span fd-list-title>{{ 'platformTable.sortDialogSortOrderHeader' | fdTranslate }}</span>


### PR DESCRIPTION

## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/11980

## Description
The table settings dialogs (sorting, grouping and filtering dialogs) have an additional padding around the list in their content area.
The fix:
- added an input prop to dialog body that is not set through dialog config
- set the prop to true for table dialogs

## Screenshots

### Before:
![Screenshot 2024-06-19 at 10 43 29 AM](https://github.com/SAP/fundamental-ngx/assets/39598672/33eb63c8-ca3b-4ad5-a472-5aa76fdcd613)
![Screenshot 2024-06-19 at 10 43 23 AM](https://github.com/SAP/fundamental-ngx/assets/39598672/690711ff-09be-4c4f-88fc-0ab995c91dd8)


### After:
![Screenshot 2024-06-19 at 10 44 00 AM](https://github.com/SAP/fundamental-ngx/assets/39598672/e6a327c7-a231-4563-b894-dd93e8d3628b)
![Screenshot 2024-06-19 at 10 43 51 AM](https://github.com/SAP/fundamental-ngx/assets/39598672/242436ed-31f6-4c14-8f31-0ff69cea8f64)

