### PR TITLE
fix(platform): use correct markup for the list in Filter dialog for Platform table

### DIFF
--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
@@ -3,14 +3,12 @@
 </ng-template>
 
 <ng-template #bodyTemplate>
-    <ul fd-list [navigationIndicator]="true">
+    <ul fd-list>
         <li fd-list-group-header>{{ 'platformTable.filterDialogFilterBy' | fdTranslate }}</li>
 
         @for (filter of filters; track filter) {
-            <li fd-list-item>
-                <a fd-list-link (click)="selectFilter.emit(filter)">
-                    <span fd-list-title>{{ filter.label }}</span>
-                </a>
+            <li fd-list-item [interactive]="true" (click)="selectFilter.emit(filter)">
+                <span fd-list-title>{{ filter.label }}</span>
             </li>
         }
     </ul>


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11964

## Description
Filter dialog in Platform table was using navigation list and then links inside the list items. Refactored the markup to use a normal list with interactive items (for the states).