### PR TITLE
fix(platform): fix performance by using another markup properties

### DIFF
--- a/libs/platform/src/lib/table/components/table-row/table-row.component.html
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.html
@@ -156,7 +156,7 @@
 
         <ng-container *ngIf="row.state === 'readonly'; else editModeCell">
             <span
-                *ngIf="tableTextContainer?.innerText?.trim() === ''"
+                *ngIf="tableTextContainer?.textContent?.trim() === ''"
                 style="
                     position: absolute !important;
                     height: 1px;


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

partial fix https://github.com/SAP/fundamental-ngx/issues/11899

## Description

<!-- Enter short description of the change -->

innerText triggers reflow issue which cause performance as we have more contents in platform table.

As per doc: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext

```
Moreover, since innerText takes CSS styles into account, reading the value of innerText triggers a [reflow](https://developer.mozilla.org/en-US/docs/Glossary/Reflow) to ensure up-to-date computed styles. (Reflows can be computationally expensive, and thus should be avoided when possible.)
```

There is another difference based on doc. Given the context from the table row component, this should not have impact, but this will need confirmation.
