### PR TITLE
fix(platform): add fix for overflow button not working in Icon Tab Bar

### DIFF
--- a/libs/docs/core/dynamic-page/examples/dynamic-page-tabs-example/dynamic-page-tabs-example.component.html
+++ b/libs/docs/core/dynamic-page/examples/dynamic-page-tabs-example/dynamic-page-tabs-example.component.html
@@ -63,7 +63,41 @@
                 >
             </fd-dynamic-page-subheader>
             <fdp-icon-tab-bar [stackContent]="stackedTabs" maxContentHeight="auto" ariaRoledescription="Tab Bar">
-                @for (tab of ['Tab 1', 'Tab 2', 'Tab 3']; track tab) {
+                @for (
+                    tab of [
+                        'Tab 1',
+                        'Tab 2',
+                        'Tab 3',
+                        'Tab 4',
+                        'Tab 5',
+                        'Tab 6',
+                        'Tab 7',
+                        'Tab 8',
+                        'Tab 9',
+                        'Tab 10',
+                        'Tab 11',
+                        'Tab 12',
+                        'Tab 13',
+                        'Tab 14',
+                        'Tab 15',
+                        'Tab 16',
+                        'Tab 17',
+                        'Tab 18',
+                        'Tab 19',
+                        'Tab 20',
+                        'Tab 21',
+                        'Tab 21',
+                        'Tab 23',
+                        'Tab 24',
+                        'Tab 25',
+                        'Tab 26',
+                        'Tab 27',
+                        'Tab 28',
+                        'Tab 29',
+                        'Tab 30'
+                    ];
+                    track tab
+                ) {
                     <fdp-icon-tab-bar-tab [label]="tab">
                         <fd-dynamic-page-content [id]="tab" cdkScrollable>
                             <div class="fd-dynamic-page-section-example">{{ tab }} content.</div>

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-tab/icon-tab-bar-tab.component.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-tab/icon-tab-bar-tab.component.ts
@@ -47,7 +47,7 @@ export class IconTabBarTabComponent implements ReactiveTabConfig {
     label = input<Nullable<string>>();
 
     /** Tab text color. */
-    color = input<SemanticColor>();
+    color = input<SemanticColor>('default');
 
     /** Tab icon. */
     icon = input<string>();

--- a/libs/platform/icon-tab-bar/interfaces/tab-config.interface.ts
+++ b/libs/platform/icon-tab-bar/interfaces/tab-config.interface.ts
@@ -25,7 +25,7 @@ export type TabConfig = NullableObject<{
 export type ReactiveTabConfig = NullableObject<{
     icon?: InputSignal<string | undefined>;
     label: InputSignal<Nullable<string>>;
-    color: InputSignal<SemanticColor | undefined>;
+    color: InputSignal<SemanticColor>;
     counter: InputSignal<Nullable<number>>;
     /** whether the tab is selected */
     active: InputSignalWithTransform<boolean, unknown>;

--- a/libs/platform/icon-tab-bar/types.ts
+++ b/libs/platform/icon-tab-bar/types.ts
@@ -1,5 +1,5 @@
 export type TabType = 'text' | 'icon' | 'icon-only' | 'filter' | 'process';
 export type TabDestinyMode = 'cozy' | 'compact' | 'condensed' | 'inherit';
-export type SemanticColor = 'negative' | 'critical' | 'positive' | 'informative';
+export type SemanticColor = 'negative' | 'critical' | 'positive' | 'informative' | 'default';
 export type IconTabBarBackground = 'solid' | 'translucent' | 'transparent';
 export type IconTabBarSize = 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'responsive-paddings';


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes https://github.com/SAP/fundamental-ngx/issues/12022

## Description
- fix the problem with overflow btn (more) not working on smaller screens
- update the example in Dynamic Page using Tabs