### PR TITLE
fix(core): add option to set the matching strategy for multi combobox

### DIFF
--- a/libs/cdk/utils/pipes/search-highlight.pipe.ts
+++ b/libs/cdk/utils/pipes/search-highlight.pipe.ts
@@ -25,7 +25,7 @@ export class SearchHighlightPipe implements PipeTransform {
                 const testStr: string = escape(matches.trim().toLowerCase());
                 const startIndex = value.toLowerCase().indexOf(testStr);
                 if (startIndex !== -1) {
-                    const matchingString = value.substring(startIndex, testStr.length);
+                    const matchingString = value.substring(startIndex, startIndex + testStr.length);
                     result = value.replace(matchingString, '<strong>' + matchingString + '</strong>');
                 }
             }

--- a/libs/core/multi-combobox/base-multi-combobox.class.ts
+++ b/libs/core/multi-combobox/base-multi-combobox.class.ts
@@ -426,7 +426,7 @@ export abstract class BaseMultiCombobox<T = any> {
      * @hidden
      * Prepares the data stream and subscribes to it.
      */
-    protected _openDataStream(): void {
+    protected _openDataStream(matchingStrategy: MatchingStrategy): void {
         const dataSourceProvider = this.dataSourceDirective.dataSourceProvider;
 
         if (!dataSourceProvider) {
@@ -445,7 +445,7 @@ export abstract class BaseMultiCombobox<T = any> {
         }
 
         dataSourceProvider.dataProvider.setMatchingBy(matchingBy);
-        dataSourceProvider.dataProvider.setMatchingStrategy(this._matchingStrategy);
+        dataSourceProvider.dataProvider.setMatchingStrategy(matchingStrategy);
 
         // initial data fetch
         const map = new Map();

--- a/libs/core/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/multi-combobox/multi-combobox.component.ts
@@ -17,7 +17,7 @@ import {
     ViewContainerRef,
     ViewEncapsulation
 } from '@angular/core';
-import { DataSourceDirective, FD_DATA_SOURCE_TRANSFORMER } from '@fundamental-ngx/cdk/data-source';
+import { DataSourceDirective, FD_DATA_SOURCE_TRANSFORMER, MatchingStrategy } from '@fundamental-ngx/cdk/data-source';
 import { CvaControl, CvaDirective, OptionItem, SelectItem, SelectableOptionItem } from '@fundamental-ngx/cdk/forms';
 import {
     AutoCompleteDirective,
@@ -288,6 +288,13 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     @Input()
     invalidEntryDisplayTime = 3000;
 
+    /**
+     * String matching strategy for typeahead list.
+     * Available options: 'starts with per term', 'starts with', 'contains'
+     * Default: 'starts with per term' */
+    @Input()
+    matchingStrategy = MatchingStrategy.STARTS_WITH_PER_TERM;
+
     /** Event emitted when item is selected. */
     @Output()
     selectionChange = new EventEmitter<MultiComboboxSelectionChangeEvent>();
@@ -424,7 +431,7 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     /** @hidden */
     ngOnInit(): void {
         this.cvaControl.listenToChanges();
-        this._openDataStream();
+        this._openDataStream(this.matchingStrategy);
     }
 
     /** @hidden */

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-datasource/multi-combobox-datasource-example.component.html
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-datasource/multi-combobox-datasource-example.component.html
@@ -1,9 +1,10 @@
 <form [formGroup]="formGroup">
     <div fd-form-item>
-        <label fd-form-label for="array-of-strings">Array of Strings:</label>
+        <label fd-form-label for="array-of-strings">Array of Strings (Matching strategy - contains):</label>
         <fd-multi-combobox
             [showSelectAll]="true"
             [autoResize]="true"
+            [matchingStrategy]="matchingStategy"
             name="array-of-strings"
             inputId="array-of-strings"
             placeholder="Type some text..."
@@ -18,7 +19,9 @@
 <p>Selected: {{ selectedItems1 }}</p>
 
 <div fd-form-item>
-    <label fd-form-label for="array-of-objects">Array of Objects:</label>
+    <label fd-form-label for="array-of-objects"
+        >Array of Objects (Matching strategy - starts with per term (default)):</label
+    >
     <fd-multi-combobox
         [autoResize]="true"
         name="array-of-objects"

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-datasource/multi-combobox-datasource-example.component.ts
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-datasource/multi-combobox-datasource-example.component.ts
@@ -1,7 +1,7 @@
 import { JsonPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
-import { DataSourceDirective } from '@fundamental-ngx/cdk/data-source';
+import { DataSourceDirective, MatchingStrategy } from '@fundamental-ngx/cdk/data-source';
 import { CvaDirective } from '@fundamental-ngx/cdk/forms';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { FormItemComponent, FormLabelComponent } from '@fundamental-ngx/core/form';
@@ -30,6 +30,7 @@ import { of } from 'rxjs';
 })
 export class MultiComboboxDatasourceExampleComponent {
     isLimitless = true;
+    matchingStategy = MatchingStrategy.CONTAINS;
 
     dataSourceStrings = ['Apple', 'Banana', 'Pineapple', 'Strawberry', 'Broccoli', 'Carrot', 'Jalapeño', 'Spinach'];
 


### PR DESCRIPTION
## Related Issue(s)


closes https://github.com/SAP/fundamental-ngx/issues/12040

## Description
- adds option to set the matching strategy from the component
- adds fix for highlighting the matching string in the list items