### PR TITLE
feat(platform): virtual scroll whole rows enhancement for ng15

### DIFF
--- a/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.html
+++ b/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.html
@@ -47,3 +47,23 @@
     <fdp-platform-table-virtual-scroll-example></fdp-platform-table-virtual-scroll-example>
 </component-example>
 <code-example [exampleFiles]="virtualScrollTableFiles"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="virtual-scroll-whole-rows" componentName="table/scrolling"
+    >Virtual Scroll - Scrolling Whole Rows</fd-docs-section-title
+>
+<p>
+    Virtual scrolling can be further enhanced by setting the <code>[scrollWholeRow]</code> input to true. This will
+    change the behavior of virtual scrolling both behind the scenes and for the user. This will only render to the DOM
+    the rows which will actually be visible to the user. The <code>[renderAhead]</code> property no longer applies. It
+    changes the functionality of the table by scrolling entire rows when the user performs a scroll with the mousewheel
+    or with the scrollbar to the side of the container. In order to use this feature, all rows must have a shared, fixed
+    height. This height can be customized with the <code>[rowHeight]</code> property, or it will default to the current
+    content density. The height of rows will not expand depending on their content, but any truncated text will be
+    applied to the cell's title attribute.
+</p>
+<component-example>
+    <fdp-platform-table-virtual-scroll-whole-row-example></fdp-platform-table-virtual-scroll-whole-row-example>
+</component-example>
+<code-example [exampleFiles]="virtualScrollWholeRowTableFiles"></code-example>

--- a/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.html
+++ b/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.html
@@ -54,7 +54,7 @@
     >Virtual Scroll - Scrolling Whole Rows</fd-docs-section-title
 >
 <p>
-    Virtual scrolling can be further enhanced by setting the <code>[scrollWholeRow]</code> input to true. This will
+    Virtual scrolling can be further enhanced by setting the <code>[scrollWholeRows]</code> input to true. This will
     change the behavior of virtual scrolling both behind the scenes and for the user. This will only render to the DOM
     the rows which will actually be visible to the user. The <code>[renderAhead]</code> property no longer applies. It
     changes the functionality of the table by scrolling entire rows when the user performs a scroll with the mousewheel
@@ -62,6 +62,11 @@
     height. This height can be customized with the <code>[rowHeight]</code> property, or it will default to the current
     content density. The height of rows will not expand depending on their content, but any truncated text will be
     applied to the cell's title attribute.
+</p>
+<p>
+    Note that the <code>[scrollWholeRows]</code> feature can only be used if <code>[virtualScroll]="true"</code>.
+    Setting <code>[scrollWholeRows]</code> to true will automatically set <code>[virtualScroll]="true"</code> behind the
+    scenes.
 </p>
 <component-example>
     <fdp-platform-table-virtual-scroll-whole-row-example></fdp-platform-table-virtual-scroll-whole-row-example>

--- a/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.ts
+++ b/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.ts
@@ -6,6 +6,10 @@ const platformTablePageScrollingSrc = 'platform-table-page-scrolling-example.com
 const platformTablePageScrollingTsSrc = 'platform-table-page-scrolling-example.component.ts';
 const platformVirtualScrollTableDefaultSrc = 'virtual-scroll/platform-table-virtual-scroll-example.component.html';
 const platformVirtualScrollTableDefaultTsSrc = 'virtual-scroll/platform-table-virtual-scroll-example.component.ts';
+const platformVirtualScrollWholeRowTableDefaultSrc =
+    'virtual-scroll-whole-row/platform-table-whole-row-virtual-scroll-example.component.html';
+const platformVirtualScrollWholeRowTableDefaultTsSrc =
+    'virtual-scroll-whole-row/platform-table-whole-row-virtual-scroll-example.component.ts';
 @Component({
     selector: 'fd-table-scrolling-docs',
     templateUrl: './table-scrolling-docs.component.html',
@@ -44,6 +48,22 @@ export class TableScrollingDocsComponent {
             fileName: 'platform-table-virtual-scroll-example',
             component: 'PlatformTableVirtualScrollExampleComponent',
             name: 'platform-table-virtual-scroll-example.component.ts'
+        }
+    ];
+
+    virtualScrollWholeRowTableFiles: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(platformVirtualScrollWholeRowTableDefaultSrc),
+            fileName: 'platform-table-virtual-scroll-example',
+            name: 'platform-table-virtual-scroll-example.component.html'
+        },
+        {
+            language: 'typescript',
+            code: getAssetFromModuleAssets(platformVirtualScrollWholeRowTableDefaultTsSrc),
+            fileName: 'platform-table-virtual-scroll-whole-row-example',
+            component: 'PlatformTableVirtualScrollWholeRowExampleComponent',
+            name: 'platform-table-virtual-scroll-whole-row-example.component.ts'
         }
     ];
     constructor() {

--- a/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.ts
+++ b/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.ts
@@ -7,9 +7,9 @@ const platformTablePageScrollingTsSrc = 'platform-table-page-scrolling-example.c
 const platformVirtualScrollTableDefaultSrc = 'virtual-scroll/platform-table-virtual-scroll-example.component.html';
 const platformVirtualScrollTableDefaultTsSrc = 'virtual-scroll/platform-table-virtual-scroll-example.component.ts';
 const platformVirtualScrollWholeRowTableDefaultSrc =
-    'virtual-scroll-whole-row/platform-table-whole-row-virtual-scroll-example.component.html';
+    'virtual-scroll-whole-row/platform-table-virtual-scroll-whole-row-example.component.html';
 const platformVirtualScrollWholeRowTableDefaultTsSrc =
-    'virtual-scroll-whole-row/platform-table-whole-row-virtual-scroll-example.component.ts';
+    'virtual-scroll-whole-row/platform-table-virtual-scroll-whole-row-example.component.ts';
 @Component({
     selector: 'fd-table-scrolling-docs',
     templateUrl: './table-scrolling-docs.component.html',

--- a/libs/docs/platform/table/examples/platform-table-default-example.component.ts
+++ b/libs/docs/platform/table/examples/platform-table-default-example.component.ts
@@ -121,7 +121,8 @@ const ITEMS: ExampleItem[] = [
     {
         id: 3,
         name: 'Astro Phone 6',
-        description: 'penatibus et magnis',
+        description:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
         price: {
             value: 154.1,
             currency: 'IDR'

--- a/libs/docs/platform/table/examples/virtual-scroll-whole-row/platform-table-virtual-scroll-whole-row-example.component.html
+++ b/libs/docs/platform/table/examples/virtual-scroll-whole-row/platform-table-virtual-scroll-whole-row-example.component.html
@@ -1,0 +1,22 @@
+<fdp-table
+    [dataSource]="source"
+    [isTreeTable]="true"
+    [scrollWholeRows]="true"
+    selectionMode="multiple"
+    relationKey="children"
+    emptyTableMessage="No data found"
+    bodyHeight="300px"
+    [state]="state"
+    [virtualScroll]="true"
+    [expandOnInit]="true"
+>
+    <fdp-table-toolbar title="Order Line Items" [hideItemCount]="false" [hideSearchInput]="true"> </fdp-table-toolbar>
+
+    <fdp-column name="name" key="name" label="Name" align="start"> </fdp-column>
+
+    <fdp-column name="description" key="description" label="Description"> </fdp-column>
+
+    <fdp-column name="price" key="price.value" label="Price" align="end"> </fdp-column>
+
+    <fdp-column name="status" key="status" label="Status" align="center"> </fdp-column>
+</fdp-table>

--- a/libs/docs/platform/table/examples/virtual-scroll-whole-row/platform-table-virtual-scroll-whole-row-example.component.html
+++ b/libs/docs/platform/table/examples/virtual-scroll-whole-row/platform-table-virtual-scroll-whole-row-example.component.html
@@ -2,12 +2,12 @@
     [dataSource]="source"
     [isTreeTable]="true"
     [scrollWholeRows]="true"
+    [virtualScroll]="true"
     selectionMode="multiple"
     relationKey="children"
     emptyTableMessage="No data found"
     bodyHeight="300px"
     [state]="state"
-    [virtualScroll]="true"
     [expandOnInit]="true"
 >
     <fdp-table-toolbar title="Order Line Items" [hideItemCount]="false" [hideSearchInput]="true"> </fdp-table-toolbar>

--- a/libs/docs/platform/table/examples/virtual-scroll-whole-row/platform-table-virtual-scroll-whole-row-example.component.ts
+++ b/libs/docs/platform/table/examples/virtual-scroll-whole-row/platform-table-virtual-scroll-whole-row-example.component.ts
@@ -1,0 +1,121 @@
+import { ChangeDetectionStrategy, Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Observable, of } from 'rxjs';
+
+import { FdDate } from '@fundamental-ngx/core/datetime';
+import {
+    TableDataSource,
+    TableDataProvider,
+    TableState,
+    TableRowToggleOpenStateEvent,
+    TableRowsRearrangeEvent,
+    TableService
+} from '@fundamental-ngx/platform/table';
+
+@Component({
+    selector: 'fdp-platform-table-virtual-scroll-whole-row-example',
+    templateUrl: './platform-table-virtual-scroll-whole-row-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None
+})
+export class PlatformTableVirtualScrollWholeRowExampleComponent implements OnInit {
+    source: TableDataSource<ExampleItem>;
+    state: TableState;
+
+    constructor() {
+        this.source = new TableDataSource(new TableDataProviderExample());
+    }
+
+    ngOnInit(): void {
+        this.state = this._getDefaultState();
+    }
+
+    /**
+     * Simulating scroll position update. Once table is initialized app can set back preserved scrolling table
+     * position so table can scroll it its original state.
+     *
+     * Note: Bellow scrollTopPosition property is set based on the scrolling position that was read from
+     * this table example. Just some number to showcase this.
+     */
+    _getDefaultState(): TableState {
+        return {
+            columnKeys: [],
+            sortBy: [],
+            filterBy: [],
+            groupBy: [],
+            columns: [],
+            searchInput: {
+                category: null,
+                text: ''
+            },
+            freezeToColumn: null,
+            freezeToEndColumn: null,
+            page: {
+                pageSize: 0,
+                currentPage: 1
+            },
+            scrollTopPosition: 3310
+        };
+    }
+}
+
+export interface ExampleItem {
+    name: string;
+    description?: string;
+    price?: {
+        value: number;
+        currency: string;
+    };
+    status?: string;
+    statusColor?: string;
+    date?: FdDate;
+    verified?: boolean;
+    children?: ExampleItem[];
+}
+
+/**
+ * Table Data Provider Example
+ *
+ */
+export class TableDataProviderExample extends TableDataProvider<ExampleItem> {
+    items: ExampleItem[] = [...ITEMS];
+    totalItems = ITEMS.length;
+
+    fetch(tableState?: TableState): Observable<ExampleItem[]> {
+        this.items = [...ITEMS];
+
+        this.totalItems = this.items.length;
+
+        return of(this.items);
+    }
+}
+
+// Example items
+const ITEMS: ExampleItem[] = new Array(5000).fill(null).map((_, index) => ({
+    name: 'Laptops ' + index,
+    children: [
+        {
+            name: 'Astro Laptop 1516',
+            description: 'pede malesuada',
+            price: {
+                value: 489.01,
+                currency: 'EUR'
+            },
+            status: 'Out of stock',
+            statusColor: 'negative',
+            date: new FdDate(2020, 2, 5),
+            verified: true
+        },
+        {
+            name: 'Benda Laptop 1408',
+            description: 'suspendisse potenti cras in',
+            price: {
+                value: 243.49,
+                currency: 'CNY'
+            },
+            status: 'Stocked on demand',
+            statusColor: 'informative',
+            date: new FdDate(2020, 9, 22),
+            verified: true
+        }
+    ]
+}));

--- a/libs/docs/platform/table/platform-table-docs.component.html
+++ b/libs/docs/platform/table/platform-table-docs.component.html
@@ -23,6 +23,13 @@
         without width set it will be calculated automatically based on the body cell content but not header cell
         content.
     </p>
+    <p>
+        When using virtual scroll with the scroll whole rows feature, it is recommended to add a specified starting
+        width to the columns in your table. By default, each column will set its own width based upon the total width of
+        the table divided by the number of columns. Use
+        <code>width</code> on the table column for setting custom width for the column cells. The user has the ability
+        to drag column borders to their desired width.
+    </p>
 
     <p>Note that if width is set in percents (%), it will be calculated relatively to initial table width.</p>
 

--- a/libs/docs/platform/table/platform-table.module.ts
+++ b/libs/docs/platform/table/platform-table.module.ts
@@ -63,6 +63,7 @@ import { PlatformTableInitialLoadingExampleComponent } from './examples/initial-
 import { PlatformTableColumnsNgforExampleComponent } from './examples/platform-table-columns-ngfor-example.component';
 import { ToolbarModule } from '@fundamental-ngx/core/toolbar';
 import { PlatformTableVirtualScrollExampleComponent } from './examples/virtual-scroll/platform-table-virtual-scroll-example.component';
+import { PlatformTableVirtualScrollWholeRowExampleComponent } from './examples/virtual-scroll-whole-row/platform-table-virtual-scroll-whole-row-example.component';
 import { PlatformMenuModule } from '@fundamental-ngx/platform/menu';
 import { P13DialogDocsComponent } from './child-docs/p13-dialog/p13-dialog-docs.component';
 import { SettingsDialogDocsComponent } from './child-docs/settings-dialog/settings-dialog-docs.component';
@@ -154,6 +155,7 @@ const routes: Routes = [
         PlatformTableInitialLoadingExampleComponent,
         PlatformTableColumnsNgforExampleComponent,
         PlatformTableVirtualScrollExampleComponent,
+        PlatformTableVirtualScrollWholeRowExampleComponent,
         P13DialogDocsComponent,
         SettingsDialogDocsComponent,
         RowSelectionDocsComponent,

--- a/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
+++ b/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
@@ -1,12 +1,13 @@
-import { Directive, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { DestroyedService } from '@fundamental-ngx/cdk/utils';
+import { Directive, HostListener, inject, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { DestroyedService, FocusableItemPosition, KeyUtil } from '@fundamental-ngx/cdk/utils';
 import { ContentDensityMode } from '@fundamental-ngx/core/content-density';
-import { BehaviorSubject, filter } from 'rxjs';
+import { BehaviorSubject, filter, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { FDP_TABLE_VIRTUAL_SCROLL_DIRECTIVE, ROW_HEIGHT } from '../constants';
 import { TableVirtualScroll } from '../models';
 import { TableScrollDispatcherService } from '../services/table-scroll-dispatcher.service';
 import { Table } from '../table';
+import { DOWN_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 
 @Directive({
     // eslint-disable-next-line @angular-eslint/directive-selector
@@ -20,12 +21,20 @@ import { Table } from '../table';
         }
     ]
 })
-export class TableVirtualScrollDirective extends TableVirtualScroll implements OnChanges {
+export class TableVirtualScrollDirective extends TableVirtualScroll implements OnChanges, OnDestroy {
     /** Whether to show only visible rows in matter of performance
      * false by default, when true setting bodyHeight and rowHeight is required.
      */
     @Input()
     virtualScroll = false;
+
+    /**
+     * Whether to scroll whole rows rather than pixel by pixel when the user performs a scroll.
+     * This gives greater performance improvements but also lends to some potentially undesirable UX changes.
+     * A "rowHeight" must be provided when using this feature.
+     */
+    @Input()
+    scrollWholeRows = false;
 
     /** Cache size for the virtualScroll, default is 40 in each direction */
     @Input()
@@ -61,6 +70,48 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
     private readonly _destroy$ = inject(DestroyedService);
 
     /** @hidden */
+    private _wheelTimeout: any;
+
+    /** @hidden */
+    private _scrollMockTimeout: any;
+
+    /** @hidden */
+    private _lastMockScrollPosition = 0;
+
+    /** @hidden */
+    private _focusableGridSubscription: Subscription;
+
+    /** @hidden */
+    private _focusedCell: FocusableItemPosition;
+
+    /** @hidden */
+    private _previousStartNodeIndex: number | null = null;
+
+    /** @hidden */
+    @HostListener('keydown', ['$event'])
+    _keydownHandler(event: KeyboardEvent): void {
+        if (this.scrollWholeRows) {
+            if (this._focusedCell?.rowIndex === 0 && KeyUtil.isKeyCode(event, UP_ARROW)) {
+                if (this._table.tableContainer.nativeElement.querySelectorAll('tr')[1].ariaRowIndex !== '0') {
+                    const cellToFocus = {
+                        colIndex: this._focusedCell.colIndex,
+                        rowIndex: 1,
+                        totalCols: this._focusedCell.totalCols,
+                        totalRows: this._focusedCell.totalRows
+                    };
+                    this._table._focusableGrid.focusCell(cellToFocus);
+                }
+                this._scrollRow('up', -1);
+            } else if (
+                this._focusedCell?.rowIndex === this._getNumberOfRowsToDisplay() &&
+                KeyUtil.isKeyCode(event, DOWN_ARROW)
+            ) {
+                this._scrollRow('down', 1);
+            }
+        }
+    }
+
+    /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
         if (!this._table.tableScrollable) {
             return;
@@ -68,6 +119,11 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
         if (this.virtualScroll && (changes['rowHeight'] || changes['virtualScroll'] || changes['renderAhead'])) {
             this.calculateVirtualScrollRows();
         }
+    }
+
+    /** @hidden */
+    ngOnDestroy(): void {
+        this._focusableGridSubscription?.unsubscribe();
     }
 
     /** Sets table reference. */
@@ -79,62 +135,172 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
      * Calculates rows in viewport.
      */
     calculateVirtualScrollRows(): void {
-        if (!this.virtualScroll || !this.bodyHeight) {
-            return;
+        if (this.scrollWholeRows) {
+            if (!this._focusableGridSubscription) {
+                this._focusableGridSubscription = this._table._focusableGrid.itemFocused.subscribe((event) => {
+                    this._focusedCell = event;
+                });
+            }
+            if (!this.virtualScroll || !this.bodyHeight) {
+                return;
+            }
+
+            let startNodeIndex = 0;
+            const scrollTop = this._table.getTableState().scrollTopPosition;
+            if (scrollTop !== 0) {
+                startNodeIndex = Math.floor(scrollTop / this.rowHeight);
+            }
+
+            const rowsVisible = this._table._tableRowsVisible;
+            const totalNodeCount = rowsVisible.length;
+            let visibleNodeCount =
+                Math.ceil(this._table.tableContainer.nativeElement.clientHeight / this.rowHeight) * this.renderAhead;
+            visibleNodeCount = Math.min(totalNodeCount - startNodeIndex, visibleNodeCount);
+            this.virtualScrollTotalHeight = totalNodeCount * this.rowHeight - visibleNodeCount * this.rowHeight;
+
+            this._setRows(startNodeIndex);
+
+            this._table.tableScrollMockContainer.nativeElement.style.width = '1rem';
+            this._table.tableScrollMockContainer.nativeElement.style.maxHeight = this.bodyHeight;
+        } else {
+            if (!this.virtualScroll || !this.bodyHeight) {
+                return;
+            }
+
+            const rowHeight = this.rowHeight + 1;
+
+            const rowsVisible = this._table._tableRowsVisible;
+            const rowsInViewPort = this._table.getRowsInViewport();
+            const totalNodeCount = rowsVisible.length;
+            const scrollTop = this._table.tableScrollable.getScrollTop();
+
+            let startNodeIndex = Math.floor(scrollTop / rowHeight) - this.renderAhead;
+            startNodeIndex = Math.max(0, startNodeIndex);
+
+            let visibleNodeCount =
+                Math.ceil(this._table.tableContainer.nativeElement.clientHeight / rowHeight) + 2 * this.renderAhead;
+            visibleNodeCount = Math.min(totalNodeCount - startNodeIndex, visibleNodeCount);
+
+            this.virtualScrollTransform$.next(startNodeIndex * rowHeight);
+
+            // Simple caching to avoid unnecessary re-renderings
+            const isCached =
+                startNodeIndex === this._virtualScrollCache.startNodeIndex &&
+                visibleNodeCount === this._virtualScrollCache.visibleNodeCount &&
+                totalNodeCount === this._virtualScrollCache.totalNodeCount &&
+                // On rows change, even if the total number of rows is the same, the row object will be different
+                startNodeIndex === rowsInViewPort[0];
+
+            if (isCached) {
+                return;
+            }
+
+            this._virtualScrollCache = { startNodeIndex, visibleNodeCount, totalNodeCount };
+            this.virtualScrollTotalHeight = totalNodeCount * rowHeight - visibleNodeCount * rowHeight;
+            this._table.setRowsInViewport(
+                startNodeIndex,
+                rowsVisible.slice(startNodeIndex, startNodeIndex + visibleNodeCount).length
+            );
         }
-
-        const rowHeight = this.rowHeight + 1;
-
-        const rowsVisible = this._table._tableRowsVisible;
-        const rowsInViewPort = this._table.getRowsInViewport();
-        const totalNodeCount = rowsVisible.length;
-        const scrollTop = this._table.tableScrollable.getScrollTop();
-
-        let startNodeIndex = Math.floor(scrollTop / rowHeight) - this.renderAhead;
-        startNodeIndex = Math.max(0, startNodeIndex);
-
-        let visibleNodeCount =
-            Math.ceil(this._table.tableContainer.nativeElement.clientHeight / rowHeight) + 2 * this.renderAhead;
-        visibleNodeCount = Math.min(totalNodeCount - startNodeIndex, visibleNodeCount);
-
-        this.virtualScrollTransform$.next(startNodeIndex * rowHeight);
-
-        // Simple caching to avoid unnecessary re-renderings
-        const isCached =
-            startNodeIndex === this._virtualScrollCache.startNodeIndex &&
-            visibleNodeCount === this._virtualScrollCache.visibleNodeCount &&
-            totalNodeCount === this._virtualScrollCache.totalNodeCount &&
-            // On rows change, even if the total number of rows is the same, the row object will be different
-            startNodeIndex === rowsInViewPort[0];
-
-        if (isCached) {
-            return;
-        }
-
-        this._virtualScrollCache = { startNodeIndex, visibleNodeCount, totalNodeCount };
-        this.virtualScrollTotalHeight = totalNodeCount * rowHeight - visibleNodeCount * rowHeight;
-        this._table.setRowsInViewport(
-            startNodeIndex,
-            rowsVisible.slice(startNodeIndex, startNodeIndex + visibleNodeCount).length
-        );
     }
 
     /**
      * Initialises scroll listener.
      */
     listenOnVirtualScroll(): void {
-        this._tableScrollDispatcher
-            .verticallyScrolled()
-            .pipe(
-                filter(() => this.virtualScroll && !!this.bodyHeight),
-                takeUntil(this._destroy$)
-            )
-            .subscribe((scrollable) => {
-                this.calculateVirtualScrollRows();
-                this._table.setTableState({
-                    ...this._table.getTableState(),
-                    scrollTopPosition: scrollable.getScrollTop()
-                });
+        if (this.scrollWholeRows) {
+            this._table.tableContainer.nativeElement.addEventListener('wheel', this._wheelScrollListenerFunction, {
+                passive: false
             });
+            this._table.tableScrollMockContainer.nativeElement.addEventListener(
+                'scroll',
+                this._mockScrollbarListenerFunction,
+                { passive: false }
+            );
+        } else {
+            this._tableScrollDispatcher
+                .verticallyScrolled()
+                .pipe(
+                    filter(() => this.virtualScroll && !!this.bodyHeight),
+                    takeUntil(this._destroy$)
+                )
+                .subscribe((scrollable) => {
+                    this.calculateVirtualScrollRows();
+                    this._table.setTableState({
+                        ...this._table.getTableState(),
+                        scrollTopPosition: scrollable.getScrollTop()
+                    });
+                });
+        }
+    }
+
+    /** @hidden */
+    private _getNumberOfRowsToDisplay(): number {
+        let tableHeight = this._table.tableContainer.nativeElement.clientHeight;
+        tableHeight = tableHeight - this._table.tableContainer.nativeElement.querySelector('thead').clientHeight;
+        return Math.floor(tableHeight / (this.rowHeight + 2));
+    }
+
+    /** @hidden */
+    private _wheelScrollListenerFunction = (event: WheelEvent): void => {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        clearTimeout(this._wheelTimeout);
+        const deltaY = event.deltaY;
+        if (deltaY) {
+            this._wheelTimeout = setTimeout(() => {
+                this._table.tableScrollMockContainer.nativeElement.scrollBy({ top: deltaY });
+                this._scrollRow(deltaY > 0 ? 'down' : 'up', deltaY > 0 ? 1 : -1);
+                this._lastMockScrollPosition = this._table.tableScrollMockContainer.nativeElement.scrollTop;
+            }, 5);
+        }
+    };
+
+    /** @hidden */
+    private _mockScrollbarListenerFunction = (event: Event): void => {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        clearTimeout(this._scrollMockTimeout);
+        let deltaY = this._table.tableScrollMockContainer.nativeElement.scrollTop - this._lastMockScrollPosition;
+        deltaY = deltaY / this.rowHeight;
+        this._scrollMockTimeout = setTimeout(() => {
+            this._scrollRow(deltaY > 0 ? 'down' : 'up', deltaY);
+            this._lastMockScrollPosition = this._table.tableScrollMockContainer.nativeElement.scrollTop;
+            if (this._table.tableScrollMockContainer.nativeElement.scrollTop === 0) {
+                this._setRows(0);
+            }
+            if (
+                this._table.tableScrollMockContainer.nativeElement.scrollTop +
+                    this._table.tableContainer.nativeElement.getBoundingClientRect().height ===
+                this._table.tableScrollMockContainer.nativeElement.scrollHeight
+            ) {
+                this._setRows(this._table._tableRows.length - this._getNumberOfRowsToDisplay());
+            }
+        });
+    };
+
+    /** @hidden */
+    private _scrollRow(direction: 'up' | 'down', count: number): void {
+        let startingNode = 0;
+        if (this._previousStartNodeIndex !== null && this._previousStartNodeIndex >= 0) {
+            startingNode = this._previousStartNodeIndex;
+        }
+        if (startingNode + count + this._getNumberOfRowsToDisplay() <= this._table._tableRows.length) {
+            startingNode = Math.ceil(startingNode + count);
+        }
+        if (startingNode < 0) {
+            startingNode = 0;
+        }
+        this._setRows(startingNode);
+    }
+
+    /** @hidden */
+    private _setRows(startingNode: number): void {
+        this._table.setRowsInViewport(startingNode, this._getNumberOfRowsToDisplay());
+        this._previousStartNodeIndex = startingNode;
+        this._table.setTableState({
+            ...this._table.getTableState(),
+            scrollTopPosition: this.rowHeight * startingNode
+        });
     }
 }

--- a/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
+++ b/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
@@ -99,9 +99,7 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
                 if (this._table.tableContainer.nativeElement.querySelectorAll('tr')[1].ariaRowIndex !== '0') {
                     const cellToFocus = {
                         colIndex: this._focusedCell.colIndex,
-                        rowIndex: 1,
-                        totalCols: this._focusedCell.totalCols,
-                        totalRows: this._focusedCell.totalRows
+                        rowIndex: 1
                     };
                     this._table._focusableGrid.focusCell(cellToFocus);
                 }
@@ -283,7 +281,7 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
         }
         const tableScrollMockContainer = this._table.tableScrollMockContainer.nativeElement;
         let deltaY = tableScrollMockContainer.scrollTop - this._lastMockScrollPosition;
-        deltaY = deltaY / this.rowHeight;
+        deltaY = Math.ceil(deltaY / this.rowHeight);
         this._scrollMockTimeout = window.requestAnimationFrame(() => {
             this._scrollRow(deltaY, true);
             this._lastMockScrollPosition = tableScrollMockContainer.scrollTop;

--- a/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
+++ b/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
@@ -243,16 +243,18 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
 
     /** @hidden */
     private _wheelScrollListenerFunction = (event: WheelEvent): void => {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        clearTimeout(this._wheelTimeout);
-        const deltaY = event.deltaY;
-        if (deltaY) {
-            this._wheelTimeout = setTimeout(() => {
-                this._table.tableScrollMockContainer.nativeElement.scrollBy({ top: deltaY });
-                this._scrollRow(deltaY > 0 ? 'down' : 'up', deltaY > 0 ? 1 : -1);
-                this._lastMockScrollPosition = this._table.tableScrollMockContainer.nativeElement.scrollTop;
-            }, 5);
+        if (Math.abs(event.deltaX) < Math.abs(event.deltaY)) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            clearTimeout(this._wheelTimeout);
+            const deltaY = event.deltaY;
+            if (deltaY) {
+                this._wheelTimeout = setTimeout(() => {
+                    this._table.tableScrollMockContainer.nativeElement.scrollBy({ top: deltaY });
+                    this._scrollRow(deltaY > 0 ? 'down' : 'up', deltaY > 0 ? 1 : -1);
+                    this._lastMockScrollPosition = this._table.tableScrollMockContainer.nativeElement.scrollTop;
+                }, 5);
+            }
         }
     };
 

--- a/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
+++ b/libs/platform/src/lib/table-helpers/directives/table-virtual-scroll.directive.ts
@@ -163,6 +163,9 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
             const scrollTop = this._table.getTableState().scrollTopPosition;
             if (scrollTop !== 0) {
                 startNodeIndex = Math.floor(scrollTop / this.rowHeight);
+                if (startNodeIndex > this._table._tableRowsVisible.length) {
+                    startNodeIndex = 0;
+                }
             }
 
             const totalNodeCount = this._table._tableRowsVisible.length;
@@ -282,7 +285,7 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
         let deltaY = tableScrollMockContainer.scrollTop - this._lastMockScrollPosition;
         deltaY = deltaY / this.rowHeight;
         this._scrollMockTimeout = window.requestAnimationFrame(() => {
-            this._scrollRow(deltaY);
+            this._scrollRow(deltaY, true);
             this._lastMockScrollPosition = tableScrollMockContainer.scrollTop;
             if (tableScrollMockContainer.scrollTop === 0) {
                 this._setRows(0);
@@ -298,7 +301,7 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
     };
 
     /** @hidden */
-    private _scrollRow(count: number): void {
+    private _scrollRow(count: number, fromMockScrollbarListener = false): void {
         let startingNode = 0;
         if (this._previousStartNodeIndex !== null && this._previousStartNodeIndex >= 0) {
             startingNode = this._previousStartNodeIndex;
@@ -322,7 +325,9 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
         }
         this._setRows(startingNode);
         const tableScrollMockContainer = this._table.tableScrollMockContainer.nativeElement;
-        tableScrollMockContainer.scrollBy({ top: count * this.rowHeight });
+        if (!fromMockScrollbarListener) {
+            tableScrollMockContainer.scrollBy({ top: count * this.rowHeight });
+        }
         this._lastMockScrollPosition = tableScrollMockContainer.scrollTop;
     }
 

--- a/libs/platform/src/lib/table-helpers/models/directives.ts
+++ b/libs/platform/src/lib/table-helpers/models/directives.ts
@@ -37,6 +37,7 @@ export abstract class TableVirtualScroll {
     abstract virtualScrollTransform$: Observable<number>;
     abstract virtualScroll: boolean;
     abstract virtualScrollTotalHeight: number;
+    abstract scrollWholeRows: boolean;
     abstract setTable(table: Table): void;
     abstract listenOnVirtualScroll(): void;
     abstract calculateVirtualScrollRows(): void;

--- a/libs/platform/src/lib/table-helpers/services/table-column-resize.service.ts
+++ b/libs/platform/src/lib/table-helpers/services/table-column-resize.service.ts
@@ -255,8 +255,6 @@ export class TableColumnResizeService implements OnDestroy {
             this._resizerPosition = resizerPosition - TABLE_RESIZER_BORDER_WIDTH + scrollLeftOffset;
             this.resizerPosition$.next(this.resizerPosition);
         }
-
-        this._markForCheck.next();
     }
 
     /** Hide the column resizer. */
@@ -372,8 +370,6 @@ export class TableColumnResizeService implements OnDestroy {
 
                 this._resizerPosition = (this._startX ?? 0) + diffX;
                 this.resizerPosition$.next(this.resizerPosition);
-
-                this._markForCheck.next();
             });
     }
 

--- a/libs/platform/src/lib/table-helpers/services/table-column-resize.service.ts
+++ b/libs/platform/src/lib/table-helpers/services/table-column-resize.service.ts
@@ -72,6 +72,9 @@ export class TableColumnResizeService implements OnDestroy {
     /** @hidden */
     private _tableRef: Table;
 
+    /** @hidden */
+    private _initialTableWidth: number | null = null;
+
     /** Indicate if resizing process in progress. */
     get resizeInProgress(): boolean {
         return this._resizeInProgress;
@@ -178,9 +181,12 @@ export class TableColumnResizeService implements OnDestroy {
     /** Retrieves custom column value or returns `unset` */
     getColumnWidthStyle(columnName: string): string {
         if (this._tableRef._virtualScrollDirective?.scrollWholeRows) {
+            if (!this._initialTableWidth) {
+                this._initialTableWidth = this._tableRef._tableWidthPx;
+            }
             const selectionColumnWidth = SELECTION_COLUMN_WIDTH.get(this._tableRef.contentDensityObserver.value) ?? 0;
             let sizeDividedByColumnsCount =
-                this._tableRef._tableWidthPx / this._tableRef.getVisibleTableColumns().length -
+                this._initialTableWidth / this._tableRef.getVisibleTableColumns().length -
                 selectionColumnWidth / this._tableRef.getVisibleTableColumns().length;
             // In the event of tables with a very high number of columns, need to prevent the default behavior which
             // would make each column not wide enough to be usable and instead use a horizontal scrollbar.
@@ -358,6 +364,11 @@ export class TableColumnResizeService implements OnDestroy {
         const padding = parseInt(computed.paddingLeft, 10) + parseInt(computed.paddingRight, 10);
         this._updateHeaderOverflowState(updatedWidth - padding);
         this._markForCheck.next();
+    }
+
+    /** @hidden */
+    _setInitialTableWidth(): void {
+        this._initialTableWidth = this._tableRef._tableWidthPx;
     }
 
     /** Update column resizer position. */

--- a/libs/platform/src/lib/table-helpers/services/table-column-resize.service.ts
+++ b/libs/platform/src/lib/table-helpers/services/table-column-resize.service.ts
@@ -176,8 +176,15 @@ export class TableColumnResizeService implements OnDestroy {
 
     /** Retrieves custom column value or returns `unset` */
     getColumnWidthStyle(columnName: string): string {
-        const calculatedWidth = this._fixedColumnsWidthMap.get(columnName);
-        return calculatedWidth || 'unset';
+        if (this._tableRef._virtualScrollDirective?.scrollWholeRows) {
+            return (
+                this._fixedColumnsWidthMap.get(columnName) ||
+                this._tableRef._tableWidthPx / this._tableRef.getVisibleTableColumns().length + 'px'
+            );
+        } else {
+            const calculatedWidth = this._fixedColumnsWidthMap.get(columnName);
+            return calculatedWidth || 'unset';
+        }
     }
 
     /** Previous column name */

--- a/libs/platform/src/lib/table-helpers/table.ts
+++ b/libs/platform/src/lib/table-helpers/table.ts
@@ -13,6 +13,8 @@ import { TableState } from './interfaces/table-state.interface';
 import { PlatformTableManagedPreset, SaveRowsEvent, TableInitialState, TableRow, TableVirtualScroll } from './models';
 import { TableScrollable } from './services/table-scroll-dispatcher.service';
 import { TableColumn } from './table-column';
+import { SelectionModeValue } from './enums';
+import { ContentDensityObserver } from '@fundamental-ngx/core/content-density';
 
 export abstract class Table<T = any> implements PresetManagedComponent<PlatformTableManagedPreset> {
     abstract readonly name: string;
@@ -70,6 +72,10 @@ export abstract class Table<T = any> implements PresetManagedComponent<PlatformT
     abstract _tableRowsInViewPortPlaceholder: number[];
 
     abstract _focusableGrid: FocusableGridDirective;
+
+    abstract _selectionMode: SelectionModeValue;
+
+    abstract contentDensityObserver: ContentDensityObserver;
 
     /** Get table state */
     abstract getTableState(): TableState;
@@ -178,6 +184,8 @@ export abstract class Table<T = any> implements PresetManagedComponent<PlatformT
     abstract refreshDndList(): void;
 
     abstract clearTableRows(): void;
+
+    abstract _onSpyIntersect(intersected: boolean): void;
 
     /** Toolbar Sort Settings button click event */
     readonly openTableSortSettings: EventEmitter<void> = new EventEmitter<void>();

--- a/libs/platform/src/lib/table-helpers/table.ts
+++ b/libs/platform/src/lib/table-helpers/table.ts
@@ -4,13 +4,13 @@ import { SearchInput } from '@fundamental-ngx/platform/search-field';
 import { PresetManagedComponent } from '@fundamental-ngx/platform/shared';
 import { Observable } from 'rxjs';
 
-import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { FocusableGridDirective, Nullable } from '@fundamental-ngx/cdk/utils';
 import { TableDataSource } from './domain';
 import { CollectionFilter } from './interfaces/collection-filter.interface';
 import { CollectionGroup } from './interfaces/collection-group.interface';
 import { CollectionSort } from './interfaces/collection-sort.interface';
 import { TableState } from './interfaces/table-state.interface';
-import { PlatformTableManagedPreset, SaveRowsEvent, TableInitialState, TableRow } from './models';
+import { PlatformTableManagedPreset, SaveRowsEvent, TableInitialState, TableRow, TableVirtualScroll } from './models';
 import { TableScrollable } from './services/table-scroll-dispatcher.service';
 import { TableColumn } from './table-column';
 
@@ -57,13 +57,19 @@ export abstract class Table<T = any> implements PresetManagedComponent<PlatformT
 
     abstract readonly tableContainer: ElementRef;
 
+    abstract readonly tableScrollMockContainer: ElementRef;
+
     abstract readonly tableScrollable: TableScrollable;
+
+    abstract _virtualScrollDirective: TableVirtualScroll | null;
 
     abstract _tableRowsVisible: TableRow<T>[];
 
     abstract _tableRows: TableRow<T>[];
 
     abstract _tableRowsInViewPortPlaceholder: number[];
+
+    abstract _focusableGrid: FocusableGridDirective;
 
     /** Get table state */
     abstract getTableState(): TableState;

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.html
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.html
@@ -163,7 +163,13 @@
         <ng-template #primaryTextContainer>
             <div
                 [class.fd-table__text]="column.applyText"
-                [class.fd-table__text--no-wrap]="column.noWrap"
+                [class.fd-table__text--no-wrap]="column.applyText"
+                [class.fd-table__cell--truncate-txt]="column.applyText"
+                [attr.title]="
+                    tableTextContainer.offsetWidth < tableTextContainer.scrollWidth
+                        ? tableTextContainer.innerText
+                        : null
+                "
                 #tableTextContainer
             >
                 <span

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.html
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.html
@@ -167,7 +167,7 @@
                 [class.fd-table__cell--truncate-txt]="column.applyText"
                 [attr.title]="
                     tableTextContainer.offsetWidth < tableTextContainer.scrollWidth
-                        ? tableTextContainer.innerText
+                        ? tableTextContainer.textContent
                         : null
                 "
                 #tableTextContainer

--- a/libs/platform/src/lib/table/components/table-row/table-row.component.ts
+++ b/libs/platform/src/lib/table/components/table-row/table-row.component.ts
@@ -216,6 +216,7 @@ export class TableRowComponent<T> extends TableRowDirective implements OnInit, A
             )
             .subscribe(() => {
                 this._cdr.markForCheck();
+                this._cdr.detectChanges();
             });
 
         this._zone.runOutsideAngular(() => {

--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -163,7 +163,7 @@
                 </ng-container>
                 <tr
                     aria-hidden="true"
-                    *ngIf="pageScrolling"
+                    *ngIf="pageScrolling && !_virtualScrollDirective?.scrollWholeRows"
                     class="fd-table__intersection-spy"
                     [fdkIntersectionSpy]="pageScrollingThreshold"
                     (intersected)="$event && _onSpyIntersect($event)"
@@ -174,17 +174,23 @@
             <tbody *ngIf="pageScrolling" class="fd-table__body__focus-mock"></tbody>
 
             <!-- the tbody element below is so the scrollbar renders correctly -->
-            <tbody
-                *ngIf="_virtualScrollDirective?.virtualScroll"
-                [class.fd-table__body--scroll-mock]="!!_virtualScrollDirective?.scrollWholeRows"
-                [style.left]="!!_rtl ? '0 !important' : 'auto'"
-                #tableScrollMockContainer
-            >
+            <tbody *ngIf="_virtualScrollDirective?.virtualScroll && !_virtualScrollDirective?.scrollWholeRows">
                 <tr>
                     <td colspan="100%" [style.height.px]="_virtualScrollDirective?.virtualScrollTotalHeight"></td>
                 </tr>
             </tbody>
         </table>
+
+        <!-- the tbody element below is so the scrollbar renders correctly -->
+        <tbody
+            *ngIf="_virtualScrollDirective?.virtualScroll && _virtualScrollDirective?.scrollWholeRows"
+            [class.fd-table__body--scroll-mock]="!!_virtualScrollDirective?.scrollWholeRows"
+            #tableScrollMockContainer
+        >
+            <tr>
+                <td colspan="100%" [style.height.px]="_virtualScrollDirective?.virtualScrollTotalHeight"></td>
+            </tr>
+        </tbody>
     </div>
 </ng-template>
 

--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -80,6 +80,7 @@
                         <tr
                             *ngSwitchCase="'group'"
                             fdp-table-group-row
+                            [style.max-height.px]="_virtualScrollDirective?.scrollWholeRows ? rowHeight : 'auto'"
                             [index]="rowIndex"
                             [height]="rowHeight"
                             [draggable]="isDraggable"
@@ -102,6 +103,7 @@
                             [activable]="rowsActivable || !!row.navigatable"
                             [active]="rowIndex === _navigatedRowIndex"
                             [highlightActive]="highlightNavigatedRow"
+                            [style.max-height.px]="_virtualScrollDirective?.scrollWholeRows ? rowHeight : 'auto'"
                             [style.height.px]="rowHeight"
                             [attr.aria-level]="isTreeTable ? row.level + 1 : null"
                             (fdkClicked)="_onRowClick(row, $event)"
@@ -172,7 +174,12 @@
             <tbody *ngIf="pageScrolling" class="fd-table__body__focus-mock"></tbody>
 
             <!-- the tbody element below is so the scrollbar renders correctly -->
-            <tbody *ngIf="_virtualScrollDirective?.virtualScroll">
+            <tbody
+                *ngIf="_virtualScrollDirective?.virtualScroll"
+                [class.fd-table__body--scroll-mock]="!!_virtualScrollDirective?.scrollWholeRows"
+                [style.left]="!!_rtl ? '0 !important' : 'auto'"
+                #tableScrollMockContainer
+            >
                 <tr>
                     <td colspan="100%" [style.height.px]="_virtualScrollDirective?.virtualScrollTotalHeight"></td>
                 </tr>

--- a/libs/platform/src/lib/table/table.component.scss
+++ b/libs/platform/src/lib/table/table.component.scss
@@ -173,6 +173,7 @@ fdk-dynamic-portal {
             &,
             .fd-replace-indicator {
                 height: 2.75rem;
+                max-height: 2.75rem;
             }
         }
 
@@ -180,6 +181,7 @@ fdk-dynamic-portal {
             &,
             .fd-replace-indicator {
                 height: 2rem;
+                max-height: 2rem;
             }
         }
 
@@ -187,6 +189,7 @@ fdk-dynamic-portal {
             &,
             .fd-replace-indicator {
                 height: 1.563rem;
+                max-height: 1.563rem;
             }
         }
     }
@@ -505,11 +508,21 @@ fdk-dynamic-portal {
 
     &__body--virtual-scroll {
         position: relative;
-        will-change: scroll-position;
+        background-color: var(--sapList_Background, #fff);
+
+        .fd-table__body:not(:last-child) .fd-table__row:last-child .fd-table__cell {
+            border-bottom-color: var(--sapList_BorderColor) !important;
+        }
 
         .fd-table__body {
             position: static;
-            will-change: transform;
+
+            &--scroll-mock {
+                top: 0;
+                position: absolute;
+                overflow-y: auto;
+                z-index: 2;
+            }
         }
     }
 

--- a/libs/platform/src/lib/table/table.component.scss
+++ b/libs/platform/src/lib/table/table.component.scss
@@ -521,6 +521,7 @@ fdk-dynamic-portal {
                 position: absolute;
                 overflow-y: auto;
                 z-index: 2;
+                width: 1rem;
             }
         }
     }

--- a/libs/platform/src/lib/table/table.component.scss
+++ b/libs/platform/src/lib/table/table.component.scss
@@ -507,7 +507,6 @@ fdk-dynamic-portal {
     }
 
     &__body--virtual-scroll {
-        position: relative;
         background-color: var(--sapList_Background, #fff);
 
         .fd-table__body:not(:last-child) .fd-table__row:last-child .fd-table__cell {

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -124,6 +124,7 @@ import {
 } from 'rxjs/operators';
 import { TABLE_TOOLBAR, TableToolbarInterface } from './components';
 import { uniq } from 'lodash-es';
+import { TableHeaderRowComponent } from './components/table-header-row/table-header-row.component';
 
 interface ToolbarContext {
     counter: Observable<number>;
@@ -351,6 +352,10 @@ export class TableComponent<T = any>
 
     /** @hidden */
     _selectionMode: SelectionModeValue = SelectionMode.NONE;
+
+    /** @hidden */
+    @ViewChild(TableHeaderRowComponent)
+    _header: TableHeaderRowComponent;
 
     /** Sets selection mode for the table. 'single' | 'multiple' | 'none' */
     @Input()
@@ -796,6 +801,9 @@ export class TableComponent<T = any>
             this._subscriptions.add(
                 this._rtlService.rtl.subscribe((isRtl) => {
                     this._rtl = isRtl;
+                    if (this._virtualScrollDirective?.scrollWholeRows) {
+                        this._setMockScrollbarPosition();
+                    }
                     this._cdr.markForCheck();
                 })
             );
@@ -954,12 +962,7 @@ export class TableComponent<T = any>
         }
 
         if (this._virtualScrollDirective?.scrollWholeRows) {
-            this._setMockScrollbarPosition(this._rtlService?.rtl.value);
-            this._subscriptions.add(
-                this._rtlService?.rtl.subscribe((isRtl) => {
-                    this._setMockScrollbarPosition(isRtl);
-                })
-            );
+            this._setMockScrollbarPosition();
         }
     }
 
@@ -1609,6 +1612,10 @@ export class TableComponent<T = any>
     onTableRowsChanged(): void {
         this._calculateVisibleTableRows();
         this._calculateCheckedAll();
+
+        if (this._virtualScrollDirective) {
+            this._virtualScrollDirective.calculateVirtualScrollRows();
+        }
     }
 
     /** @hidden */
@@ -2101,7 +2108,7 @@ export class TableComponent<T = any>
 
                     this.tableScrolled.emit(scrollTop);
 
-                    // Instead of having two places to record this possition, we could just subscribe once.
+                    // Instead of having two places to record this position, we could just subscribe once.
                     this.getTableState().scrollTopPosition = scrollTop;
                 })
         );
@@ -2287,10 +2294,10 @@ export class TableComponent<T = any>
     }
 
     /** @hidden */
-    private _setMockScrollbarPosition(isRtl: boolean | undefined): void {
+    private _setMockScrollbarPosition(): void {
         if (this.tableScrollMockContainer) {
-            this.tableScrollMockContainer.nativeElement.style.left = isRtl ? '0' : 'auto';
-            this.tableScrollMockContainer.nativeElement.style.right = isRtl ? 'auto' : '0';
+            this.tableScrollMockContainer.nativeElement.style.left = this._rtl ? '0' : 'auto';
+            this.tableScrollMockContainer.nativeElement.style.right = this._rtl ? 'auto' : '0';
         }
     }
 }

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1231,6 +1231,7 @@ export class TableComponent<T = any>
 
     /** Manually triggers column's width recalculation */
     recalculateTableColumnWidth(): void {
+        this._tableColumnResizeService._setInitialTableWidth();
         this._tableColumnResizeService.setColumnNames(this._visibleColumns.map((column) => column.name));
         this._setFreezableInfo();
     }

--- a/libs/platform/src/lib/table/tests/table.component-virtual-scrolling.spec.ts
+++ b/libs/platform/src/lib/table/tests/table.component-virtual-scrolling.spec.ts
@@ -154,7 +154,6 @@ describe('TableComponent Virtual Scrolling', async () => {
             it('Should calculateVirtualScrollRows for scrollWholeRows', () => {
                 hostComponent.virtualScrollDirective.calculateVirtualScrollRows();
                 expect(hostComponent.virtualScrollDirective.virtualScrollTotalHeight).toBe(1892);
-                expect(tableComponent.tableScrollMockContainer.nativeElement.style.width).toBe('1rem');
                 expect(tableComponent.tableScrollMockContainer.nativeElement.style.maxHeight).toBe('20rem');
                 expect(setRowsInViewportMock).toHaveBeenCalledWith(9, 6);
                 expect(setTableStateMock).toHaveBeenCalledWith({

--- a/libs/platform/src/lib/table/tests/table.component-virtual-scrolling.spec.ts
+++ b/libs/platform/src/lib/table/tests/table.component-virtual-scrolling.spec.ts
@@ -1,0 +1,212 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import {
+    TableDataProvider,
+    TableDataSource,
+    TableState,
+    TableVirtualScrollDirective
+} from '@fundamental-ngx/platform/table-helpers';
+import { Observable, of } from 'rxjs';
+import { SourceItem, generateItems } from './helpers';
+import { TableComponent } from '../table.component';
+import { PlatformTableModule } from '../table.module';
+import { RtlService } from '@fundamental-ngx/cdk/utils';
+import Spy = jasmine.Spy;
+
+class TableDataExampleProvider extends TableDataProvider<SourceItem> {
+    private readonly ALL_ITEMS = generateItems(200);
+
+    items: SourceItem[] = [];
+    totalItems = 0;
+
+    fetch(state: TableState): Observable<SourceItem[]> {
+        const { currentPage, pageSize } = state.page;
+
+        const items = [...this.ALL_ITEMS];
+
+        this.totalItems = items.length;
+
+        const startIndex = (currentPage - 1) * pageSize;
+        this.items = items.slice(startIndex, startIndex + pageSize);
+
+        return of(this.items);
+    }
+}
+
+@Component({
+    template: `
+        <fdp-table
+            [dataSource]="source"
+            fdCompact
+            [virtualScroll]="true"
+            [pageScrolling]="true"
+            [pageSize]="50"
+            bodyHeight="20rem"
+        >
+            <fdp-column name="name" key="name" label="Name"></fdp-column>
+            <fdp-column name="description" key="description" label="Description"></fdp-column>
+            <fdp-column name="status" key="status" label="Status"></fdp-column>
+        </fdp-table>
+    `
+})
+class TableHostComponent {
+    @ViewChild(TableComponent) table: TableComponent;
+    @ViewChild(TableVirtualScrollDirective) virtualScrollDirective: TableVirtualScrollDirective;
+
+    source = new TableDataSource(new TableDataExampleProvider());
+}
+
+describe('TableComponent Virtual Scrolling', async () => {
+    let hostComponent: TableHostComponent;
+    let fixture: ComponentFixture<TableHostComponent>;
+    let tableComponent: TableComponent<SourceItem>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [PlatformTableModule, RouterModule, RouterTestingModule],
+            declarations: [TableHostComponent],
+            providers: [RtlService]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TableHostComponent);
+        hostComponent = fixture.componentInstance;
+
+        const originFetch = hostComponent.source.fetch;
+        spyOn(hostComponent.source, 'fetch').and.callFake((state: TableState) =>
+            originFetch.call(hostComponent.source, state)
+        );
+
+        fixture.detectChanges();
+
+        tableComponent = hostComponent.table;
+    });
+
+    describe('Virtual Scroll - Scroll Whole Row tests', () => {
+        let focusCellMock: Spy, setRowsInViewportMock: Spy, setTableStateMock: Spy, mockScrollbarScrollMock: Spy;
+        beforeEach(() => {
+            hostComponent.virtualScrollDirective.scrollWholeRows = true;
+            hostComponent.virtualScrollDirective.rowHeight = 44;
+            const tableState = {
+                columnKeys: [],
+                sortBy: [],
+                filterBy: [],
+                groupBy: [],
+                columns: [],
+                searchInput: {
+                    category: null,
+                    text: ''
+                },
+                freezeToColumn: null,
+                freezeToEndColumn: null,
+                page: {
+                    pageSize: 0,
+                    currentPage: 1
+                },
+                scrollTopPosition: 400
+            };
+            tableComponent.setTableState(tableState);
+            hostComponent.virtualScrollDirective.calculateVirtualScrollRows();
+            fixture.detectChanges();
+            focusCellMock = spyOn(tableComponent._focusableGrid, 'focusCell').and.callThrough();
+            setRowsInViewportMock = spyOn(tableComponent, 'setRowsInViewport');
+            setTableStateMock = spyOn(tableComponent, 'setTableState');
+            mockScrollbarScrollMock = spyOn(tableComponent.tableScrollMockContainer.nativeElement, 'scrollBy');
+            focusCellMock.calls.reset();
+            setRowsInViewportMock.calls.reset();
+            setTableStateMock.calls.reset();
+            mockScrollbarScrollMock.calls.reset();
+        });
+
+        describe('Should handle keydown events', () => {
+            it('Should handle up arrow press when the focused cell is at rowIndex: 0', () => {
+                tableComponent._focusableGrid.focusCell({ rowIndex: 0, colIndex: 1 });
+                hostComponent.virtualScrollDirective.calculateVirtualScrollRows();
+                hostComponent.virtualScrollDirective._keydownHandler(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+                expect(focusCellMock).toHaveBeenCalledWith({ colIndex: 1, rowIndex: 1 });
+                expect(setRowsInViewportMock).toHaveBeenCalledWith(8, 6);
+                expect(setTableStateMock).toHaveBeenCalledWith({
+                    ...tableComponent.getTableState(),
+                    scrollTopPosition: 352
+                });
+            });
+            it('Should handle down arrow press when the focused cell is the last visible cell', () => {
+                tableComponent._focusableGrid.focusCell({ rowIndex: 5, colIndex: 1 });
+                hostComponent.virtualScrollDirective.calculateVirtualScrollRows();
+                hostComponent.virtualScrollDirective._keydownHandler(
+                    new KeyboardEvent('keydown', { key: 'ArrowDown' })
+                );
+                expect(setRowsInViewportMock).toHaveBeenCalledWith(9, 6);
+                expect(setTableStateMock).toHaveBeenCalledWith({
+                    ...tableComponent.getTableState(),
+                    scrollTopPosition: 396
+                });
+            });
+            it('Should automatically turn on virtualScroll if scrollWholeRows is true', () => {
+                hostComponent.virtualScrollDirective.virtualScroll = false;
+                hostComponent.virtualScrollDirective.scrollWholeRows = true;
+                hostComponent.virtualScrollDirective.ngOnInit();
+                expect(hostComponent.virtualScrollDirective.virtualScroll).toBeTrue();
+            });
+            it('Should calculateVirtualScrollRows for scrollWholeRows', () => {
+                hostComponent.virtualScrollDirective.calculateVirtualScrollRows();
+                expect(hostComponent.virtualScrollDirective.virtualScrollTotalHeight).toBe(1892);
+                expect(tableComponent.tableScrollMockContainer.nativeElement.style.width).toBe('1rem');
+                expect(tableComponent.tableScrollMockContainer.nativeElement.style.maxHeight).toBe('20rem');
+                expect(setRowsInViewportMock).toHaveBeenCalledWith(9, 6);
+                expect(setTableStateMock).toHaveBeenCalledWith({
+                    ...tableComponent.getTableState(),
+                    scrollTopPosition: 396
+                });
+            });
+            it('Should handle wheel events', fakeAsync(() => {
+                hostComponent.virtualScrollDirective.listenOnVirtualScroll();
+                tableComponent.tableContainer.nativeElement.dispatchEvent(new WheelEvent('wheel', { deltaY: 10 }));
+                tick(20);
+                expect(mockScrollbarScrollMock).toHaveBeenCalledWith({ top: 44 });
+                expect(setRowsInViewportMock).toHaveBeenCalledWith(10, 6);
+                expect(setTableStateMock).toHaveBeenCalledWith({
+                    ...tableComponent.getTableState(),
+                    scrollTopPosition: 440
+                });
+                mockScrollbarScrollMock.calls.reset();
+                setRowsInViewportMock.calls.reset();
+                setTableStateMock.calls.reset();
+                tableComponent.tableContainer.nativeElement.dispatchEvent(new WheelEvent('wheel', { deltaY: -10 }));
+                tick(20);
+                expect(mockScrollbarScrollMock).toHaveBeenCalledWith({ top: -44 });
+                expect(setRowsInViewportMock).toHaveBeenCalledWith(9, 6);
+                expect(setTableStateMock).toHaveBeenCalledWith({
+                    ...tableComponent.getTableState(),
+                    scrollTopPosition: 396
+                });
+                flush();
+            }));
+            it('Should handle mock scrollbar events', fakeAsync(() => {
+                hostComponent.virtualScrollDirective.listenOnVirtualScroll();
+                tableComponent.tableScrollMockContainer.nativeElement.scrollTop = 100;
+                tableComponent.tableScrollMockContainer.nativeElement.dispatchEvent(new Event('scroll'));
+                tick(20);
+                expect(setRowsInViewportMock).toHaveBeenCalledWith(12, 6);
+                expect(setTableStateMock).toHaveBeenCalledWith({
+                    ...tableComponent.getTableState(),
+                    scrollTopPosition: 528
+                });
+                setRowsInViewportMock.calls.reset();
+                setTableStateMock.calls.reset();
+                tableComponent.tableScrollMockContainer.nativeElement.scrollTop = 50;
+                tableComponent.tableScrollMockContainer.nativeElement.dispatchEvent(new Event('scroll'));
+                tick(20);
+                expect(setRowsInViewportMock).toHaveBeenCalledWith(11, 6);
+                expect(setTableStateMock).toHaveBeenCalledWith({
+                    ...tableComponent.getTableState(),
+                    scrollTopPosition: 484
+                });
+                flush();
+            }));
+        });
+    });
+});


### PR DESCRIPTION
fixes #11491 

Adds a new input to the platform table `[scrollWholeRows]`, intended to be used in conjunction with `[virtualScroll]="true"`. Modifies the behavior of (vertical) virtual scrolling for the table. When the user performs a scroll (via mousewheel, scrollbar, keyboard arrows, etc), rather than scrolling pixel by pixel, an entire row will be scrolled. This changes the UX to more closely match that of UI5. It also comes with some inherent performance improvements such as not rendering hidden `<tr>`s.

This is added as a new feature. If the developer does not add `[scrollWholeRows]="true"`, they'll see the previous virtual scrolling behavior