### PR TITLE
fix(core): control value not updating properly on user input

### DIFF
--- a/libs/core/combobox/combobox.component.spec.ts
+++ b/libs/core/combobox/combobox.component.spec.ts
@@ -72,7 +72,7 @@ describe('ComboboxComponent', () => {
     it('should handle input entry on dropdown mode', () => {
         jest.spyOn(component, 'onChange');
         component.communicateByObject = true;
-        component.displayFn = (item: any): string => item.displayedValue;
+        component.displayFn = (item: any): string => item?.displayedValue;
         component.onMenuClickHandler(component.dropdownValues[1]);
         expect(component.onChange).toHaveBeenCalledWith(component.dropdownValues[1]);
     });
@@ -246,5 +246,14 @@ describe('ComboboxComponent', () => {
                 expect(button.classList.contains('fd-shellbar__button')).toBe(true);
             });
         });
+    });
+
+    it('should update (control) value as well when the user edits the input field', () => {
+        const preselected = { value: 'value', displayedValue: 'displayedValue' };
+        component.writeValue(preselected);
+        expect(component.isSelected(preselected)).toBe(true);
+        // user edits the selected value
+        component.inputText = 'value43';
+        expect(component.isSelected(preselected)).toBe(false);
     });
 });

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -576,6 +576,9 @@ export class ComboboxComponent<T = any>
     /** Input text of the input. */
     set inputText(value: string) {
         this.inputTextValue = value;
+        if (!this.communicateByObject) {
+            this._value = value;
+        }
         this.inputTextChange.emit(value);
         if (!this.mobile) {
             this._propagateChange();
@@ -785,8 +788,8 @@ export class ComboboxComponent<T = any>
             this.isOpenChangeHandle(false);
         }
         if (this.fillOnSelect) {
-            this.setValue(term);
             this.inputText = this.displayFn(term);
+            this.setValue(term);
             this.searchInputElement.nativeElement.value = this.inputText;
             this._cdRef.detectChanges();
 


### PR DESCRIPTION
## Related Issue(s)

https://github.com/SAP/fundamental-ngx/issues/11848

## Description

Keeping input and form control value in sync (unless using objects only).
One exceptional scenario is when the user do not use `communicateByObject`, but does use `displayFn`. `displayFn` expects one of the `item` objects, that is why in `inputText` setter we need to set `_value`, not call `setValue`.

3. Documentation and Example validations
[this example](https://fundamental-ngx.netlify.app/#/core/combobox#display-object) and many others can be used to validate. select one of the items, modify the text input and open the select again by the chevron button. there should be no selected highlighting when `communicateByObject` is false, since the new valid value is what the user typed.
