### PR TITLE
fix(core): fix the title font size and alignment for Grid List Item

### DIFF
--- a/libs/core/grid-list/components/grid-list-item/grid-list-item.component.html
+++ b/libs/core/grid-list/components/grid-list-item/grid-list-item.component.html
@@ -101,7 +101,13 @@
         @if (title || description) {
             <div class="fd-grid-list__item-header">
                 @if (title) {
-                    <h4 fd-title>{{ title }}</h4>
+                    <div
+                        role="heading"
+                        [attr.aria-level]="titleLevel"
+                        class="fd-title fd-title--h4 fd-grid-list__item-title"
+                    >
+                        {{ title }}
+                    </div>
                 }
                 @if (description) {
                     <span class="fd-grid-list__item-subtitle">{{ description }}</span>
@@ -122,7 +128,7 @@
     <input
         [attr.tabindex]="selectionMode === 'singleSelect' ? -1 : 0"
         type="radio"
-        class="fd-radio is-compact fd-grid-list__radio-input"
+        class="fd-radio fd-grid-list__radio-input"
         [style.display]="selectionMode === 'singleSelect' ? 'none' : ''"
         [id]="id + '-radio'"
         [name]="'fd-grid-list-item-toolbar-' + selectionMode"
@@ -143,7 +149,7 @@
 <ng-template #checkbox>
     <input
         type="checkbox"
-        class="fd-checkbox is-compact fd-grid-list__checkbox-input"
+        class="fd-checkbox fd-grid-list__checkbox-input"
         [id]="id + '-checkbox'"
         [attr.aria-label]="ariaLabel"
         [attr.aria-labelledby]="ariaLabelledBy"

--- a/libs/core/grid-list/components/grid-list-item/grid-list-item.component.ts
+++ b/libs/core/grid-list/components/grid-list-item/grid-list-item.component.ts
@@ -23,7 +23,12 @@ import { KeyUtil, Nullable } from '@fundamental-ngx/cdk/utils';
 import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { ContentDensityDirective } from '@fundamental-ngx/core/content-density';
+import {
+    ContentDensityModule,
+    ContentDensityObserver,
+    contentDensityObserverProviders
+} from '@fundamental-ngx/core/content-density';
+
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { ObjectStatusComponent } from '@fundamental-ngx/core/object-status';
 import { TitleComponent } from '@fundamental-ngx/core/title';
@@ -58,13 +63,14 @@ export type GridListItemStatus = 'success' | 'warning' | 'error' | 'neutral';
         NgTemplateOutlet,
         GridListTitleBarSpacerComponent,
         ButtonComponent,
-        ContentDensityDirective,
         IconComponent,
         TitleComponent,
         FormsModule,
         ObjectStatusComponent,
-        FdTranslatePipe
-    ]
+        FdTranslatePipe,
+        ContentDensityModule
+    ],
+    providers: [contentDensityObserverProviders()]
 })
 export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
     /** id for the Element */
@@ -159,6 +165,14 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
     /** Title of the item */
     @Input()
     title: string;
+
+    /**
+     * Aria-level of the title
+     * Available options: 1, 2, 3, 4, 5, 6
+     * Default: 4
+     */
+    @Input()
+    titleLevel: 1 | 2 | 3 | 4 | 5 | 6 = 4;
 
     /** Description of the item */
     @Input()
@@ -285,7 +299,8 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
         private readonly _cd: ChangeDetectorRef,
         private readonly _elementRef: ElementRef,
         private readonly _render: Renderer2,
-        private readonly _gridList: GridList<T>
+        private readonly _gridList: GridList<T>,
+        readonly _contentDensityObserver: ContentDensityObserver
     ) {
         const selectedItemsSub = this._gridList._selectedItems$.subscribe((items) => {
             this._selectedItem = items.selection.find((item) => item === this.value);

--- a/libs/core/grid-list/components/grid-list/grid-list.component.scss
+++ b/libs/core/grid-list/components/grid-list/grid-list.component.scss
@@ -2,3 +2,9 @@
 @import 'fundamental-styles/dist/checkbox';
 @import 'fundamental-styles/dist/layout-grid';
 @import 'fundamental-styles/dist/grid-list';
+
+.fd-grid-list--mode-multi-select {
+    .fd-toolbar.fd-grid-list__item-toolbar {
+        padding-inline: 0.5rem 1rem;
+    }
+}


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/12048

## Description
- the title of the Grid List Item is hard-coded and can't be customized. Changed the `h4` element to a div with `role='heading'` and aria-level that can be set by the user. The default is level 4. 
- added the missing class `fd-grid-list__item-title` to the title which was causing the incorrect size and weight bug.
- removed the hard-coded `is-compact` classes for the radio button and checkbox. Now is using the content density service.  Removing the hard-coded `is-compact` fixed the misalignment of the elements. 
- the CSS fix is added to comply with the visual specs for multi select grid list item:
![Screenshot 2024-07-02 at 3 10 51 PM](https://github.com/SAP/fundamental-ngx/assets/39598672/2b33121f-d1cd-40d3-b442-5da18ee99a0f)