### PR TITLE
fix(core): CSS fix to allow long text to wrap for Inline Help

### DIFF
--- a/libs/core/popover/popover-body/popover-body.component.scss
+++ b/libs/core/popover/popover-body/popover-body.component.scss
@@ -50,6 +50,10 @@ fd-popover-body {
             -webkit-transition: none !important;
         }
 
+        &--inline-help.fd-inline-help__content {
+            white-space: initial;
+        }
+
         &.fd-form-message {
             &::before {
                 width: auto;

--- a/libs/docs/core/inline-help/examples/inline-help-example.component.html
+++ b/libs/docs/core/inline-help/examples/inline-help-example.component.html
@@ -20,7 +20,12 @@
 
 <div class="fd-inline-help-example">
     <span>Bottom Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="bottom" tabindex="0"></fd-icon>
+    <fd-icon
+        glyph="question-mark"
+        fd-inline-help="Inline Help Tooltip Lorem ipsum, dolor sit amet consectetur adipisicing elit. Officia vitae ipsum facilis quasi similique! Aperiam incidunt perspiciatis quam architecto. Culpa minima odio adipisci tempora reprehenderit necessitatibus, repellendus dolor tempore pariatur?"
+        placement="bottom"
+        tabindex="0"
+    ></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">


### PR DESCRIPTION
## Related Issue(s)
closes none, reported by designers

## Description
Inline help long text doesn't wrap on multiple lines. Added a CSS fix.
<img width="651" alt="Screenshot 2024-07-02 at 5 15 48 PM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/604322f3-4423-4575-9dee-2a1bfbd73e1f">

