### PR TITLE
docs: remove now-unused i18n link

### DIFF
--- a/libs/docs/platform/docs-data.json
+++ b/libs/docs/platform/docs-data.json
@@ -7,10 +7,6 @@
         {
             "url": "platform/new-component",
             "name": "New Component"
-        },
-        {
-            "url": "platform/i18n",
-            "name": "I18n"
         }
     ],
     "components": [


### PR DESCRIPTION
fixes none, something I just noticed

![Screenshot 2024-07-03 at 10 55 57 AM](https://github.com/SAP/fundamental-ngx/assets/2471874/9eee8548-9d7c-4294-b4a7-5f9ee80e3086)
