### PR TITLE
[WIP] fix(platform): when loading child datasource, need to recursively check all expanded children for insertion index

### DIFF
--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1690,8 +1690,6 @@ export class TableComponent<T = any>
 
                     tallyExpandedChildren(parentRow);
 
-                    console.log(expandedChildrenCount);
-
                     this._tableRows.splice(parentRow.index + expandedChildrenCount + 1, 0, ...rows);
 
                     parentRow.children.push(...rows);

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1677,7 +1677,22 @@ export class TableComponent<T = any>
             )
             .subscribe((items) => {
                 items.forEach((rows, parentRow) => {
-                    this._tableRows.splice(parentRow.index + parentRow.children.length + 1, 0, ...rows);
+                    let expandedChildrenCount = 0;
+
+                    function tallyExpandedChildren(parent: TableRow<T>): void {
+                        if (parent.children && parent.expanded) {
+                            expandedChildrenCount = expandedChildrenCount + parent.children.length;
+                            parent.children.forEach((child) => {
+                                tallyExpandedChildren(child);
+                            });
+                        }
+                    }
+
+                    tallyExpandedChildren(parentRow);
+
+                    console.log(expandedChildrenCount);
+
+                    this._tableRows.splice(parentRow.index + expandedChildrenCount + 1, 0, ...rows);
 
                     parentRow.children.push(...rows);
 

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1694,7 +1694,7 @@ export class TableComponent<T = any>
 
                     parentRow.children.push(...rows);
 
-                    parentRow.lastChild = parentRow.children[parentRow.children.length - 1];
+                    parentRow.lastChild = parentRow.children[expandedChildrenCount - 1];
                     this._setTableRows(this._tableRows);
                 });
             });


### PR DESCRIPTION
fixes #12070 

Fixes a bug where newly loaded rows from a child datasource would be inserted at the incorrect index in the table, because internally, we needed to be counting all expanded child nodes, and recursively checking for any children of the children