### PR TITLE
fix(platform): when loading child datasource, need to recursively check all expanded children for insertion index

### DIFF
--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -1626,6 +1626,7 @@ export class TableComponent<T = any>
 
     /** @hidden */
     onTableRowsChanged(): void {
+        this._reIndexTableRows();
         this._calculateVisibleTableRows();
         this._calculateCheckedAll();
     }
@@ -1923,7 +1924,6 @@ export class TableComponent<T = any>
         this._dataSourceTableRows = rows;
         this._tableRows = [...this._newTableRows, ...this._dataSourceTableRows];
         this.loadedRows$.set(this._tableRows.length);
-        this._reIndexTableRows();
         this.onTableRowsChanged();
         this._calculateIsShownNavigationColumn();
         this._rangeSelector.reset();

--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -1722,7 +1722,20 @@ export class TableComponent<T = any>
             )
             .subscribe((items) => {
                 items.forEach((rows, parentRow) => {
-                    this._tableRows.splice(parentRow.index + parentRow.children.length + 1, 0, ...rows);
+                    let expandedChildrenCount = 0;
+
+                    function tallyExpandedChildren(parent: TableRow<T>): void {
+                        if (parent.children && parent.expanded) {
+                            expandedChildrenCount = expandedChildrenCount + parent.children.length;
+                            parent.children.forEach((child) => {
+                                tallyExpandedChildren(child);
+                            });
+                        }
+                    }
+
+                    tallyExpandedChildren(parentRow);
+
+                    this._tableRows.splice(parentRow.index + expandedChildrenCount + 1, 0, ...rows);
 
                     parentRow.children.push(...rows);
 

--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -1723,20 +1723,20 @@ export class TableComponent<T = any>
             )
             .subscribe((items) => {
                 items.forEach((rows, parentRow) => {
-                    let expandedChildrenCount = 0;
+                    let nestedChildrenCount = 0;
 
-                    function tallyExpandedChildren(parent: TableRow<T>): void {
-                        if (parent.children && parent.expanded) {
-                            expandedChildrenCount = expandedChildrenCount + parent.children.length;
+                    function tallyNestedChildren(parent: TableRow<T>): void {
+                        if (parent.children) {
+                            nestedChildrenCount = nestedChildrenCount + parent.children.length;
                             parent.children.forEach((child) => {
-                                tallyExpandedChildren(child);
+                                tallyNestedChildren(child);
                             });
                         }
                     }
 
-                    tallyExpandedChildren(parentRow);
+                    tallyNestedChildren(parentRow);
 
-                    this._tableRows.splice(parentRow.index + expandedChildrenCount + 1, 0, ...rows);
+                    this._tableRows.splice(parentRow.index + nestedChildrenCount + 1, 0, ...rows);
 
                     parentRow.children.push(...rows);
 
@@ -1920,8 +1920,12 @@ export class TableComponent<T = any>
     }
 
     /** @hidden */
-    private _setTableRows(rows = this._dataSourceTableRows): void {
-        this._dataSourceTableRows = rows;
+    private _setTableRows(rows?: TableRow<T>[]): void {
+        if (!rows || !rows.length) {
+            rows = this._dataSourceTableRows;
+        } else {
+            this._dataSourceTableRows = rows;
+        }
         this._tableRows = [...this._newTableRows, ...this._dataSourceTableRows];
         this.loadedRows$.set(this._tableRows.length);
         this.onTableRowsChanged();

--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -1920,12 +1920,8 @@ export class TableComponent<T = any>
     }
 
     /** @hidden */
-    private _setTableRows(rows?: TableRow<T>[]): void {
-        if (!rows || !rows.length) {
-            rows = this._dataSourceTableRows;
-        } else {
-            this._dataSourceTableRows = rows;
-        }
+    private _setTableRows(rows = this._dataSourceTableRows): void {
+        this._dataSourceTableRows = rows;
         this._tableRows = [...this._newTableRows, ...this._dataSourceTableRows];
         this.loadedRows$.set(this._tableRows.length);
         this.onTableRowsChanged();


### PR DESCRIPTION
fixes #12070 