### PR TITLE
fix(platform): when loading child datasource, need to recursively check all expanded children for insertion index

### DIFF
--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1690,8 +1690,6 @@ export class TableComponent<T = any>
 
                     tallyExpandedChildren(parentRow);
 
-                    console.log(expandedChildrenCount);
-
                     this._tableRows.splice(parentRow.index + expandedChildrenCount + 1, 0, ...rows);
 
                     parentRow.children.push(...rows);

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1678,20 +1678,20 @@ export class TableComponent<T = any>
             )
             .subscribe((items) => {
                 items.forEach((rows, parentRow) => {
-                    let expandedChildrenCount = 0;
+                    let nestedChildrenCount = 0;
 
-                    function tallyExpandedChildren(parent: TableRow<T>): void {
-                        if (parent.children && parent.expanded) {
-                            expandedChildrenCount = expandedChildrenCount + parent.children.length;
+                    function tallyNestedChildren(parent: TableRow<T>): void {
+                        if (parent.children) {
+                            nestedChildrenCount = nestedChildrenCount + parent.children.length;
                             parent.children.forEach((child) => {
-                                tallyExpandedChildren(child);
+                                tallyNestedChildren(child);
                             });
                         }
                     }
 
-                    tallyExpandedChildren(parentRow);
+                    tallyNestedChildren(parentRow);
 
-                    this._tableRows.splice(parentRow.index + expandedChildrenCount + 1, 0, ...rows);
+                    this._tableRows.splice(parentRow.index + nestedChildrenCount + 1, 0, ...rows);
 
                     parentRow.children.push(...rows);
 

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1677,7 +1677,22 @@ export class TableComponent<T = any>
             )
             .subscribe((items) => {
                 items.forEach((rows, parentRow) => {
-                    this._tableRows.splice(parentRow.index + parentRow.children.length + 1, 0, ...rows);
+                    let expandedChildrenCount = 0;
+
+                    function tallyExpandedChildren(parent: TableRow<T>): void {
+                        if (parent.children && parent.expanded) {
+                            expandedChildrenCount = expandedChildrenCount + parent.children.length;
+                            parent.children.forEach((child) => {
+                                tallyExpandedChildren(child);
+                            });
+                        }
+                    }
+
+                    tallyExpandedChildren(parentRow);
+
+                    console.log(expandedChildrenCount);
+
+                    this._tableRows.splice(parentRow.index + expandedChildrenCount + 1, 0, ...rows);
 
                     parentRow.children.push(...rows);
 

--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -1581,6 +1581,7 @@ export class TableComponent<T = any>
 
     /** @hidden */
     onTableRowsChanged(): void {
+        this._reIndexTableRows();
         this._calculateVisibleTableRows();
         this._calculateCheckedAll();
     }
@@ -1883,7 +1884,6 @@ export class TableComponent<T = any>
     private _setTableRows(rows = this._dataSourceTableRows): void {
         this._dataSourceTableRows = rows;
         this._tableRows = [...this._newTableRows, ...this._dataSourceTableRows];
-        this._reIndexTableRows();
         this.onTableRowsChanged();
         this._calculateIsShownNavigationColumn();
         this._rangeSelector.reset();


### PR DESCRIPTION
fixes #12070 

When fetching new rows from a child data source, the table was previously inserting new data at the end of the parent row's children. It needs to be recursively searching through all children/grandchildren/etc of the parent, checking their expanded state, and setting the new start index based on that.