### PR TITLE
fix(core): clear the json value if input is empty in Combobox

### DIFF
--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -821,6 +821,8 @@ export class ComboboxComponent<T = any>
             // Do not set new value if theres multiple items that have same label.
             if (values.length === 1 && this.displayFn(values[0]) !== this.displayFn(this.getValue())) {
                 this.setValue(values[0]);
+            } else if (values.length === 0) {
+                this.setValue(null);
             }
             this.onChange(this.getValue());
         } else {


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/12097

## Description
Step 1: select a value, the json value is updated
<img width="456" alt="Screenshot 2024-07-11 at 12 45 45 PM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/2952e13f-9569-48d9-9643-83cd4510f274">

Step 2: clear the input, the json value is set to null
<img width="475" alt="Screenshot 2024-07-11 at 12 45 53 PM" src="https://github.com/SAP/fundamental-ngx/assets/39598672/826be544-b035-4ee3-b1c1-d915228cc694">

Before the fix the json value was keeping the previous selection when the input was cleared.
