### PR TITLE
fix(core,platform): clear input and close options list on checkbox selection for Multi combobox

### DIFF
--- a/libs/core/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/multi-combobox/multi-combobox.component.ts
@@ -469,6 +469,7 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     _onOptionCheckboxClicked(event: MouseEvent, index: number): void {
         event.stopPropagation();
         this._onListElementClicked(event, index);
+        this.close();
     }
 
     /** @hidden */

--- a/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.ts
+++ b/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.ts
@@ -178,6 +178,7 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
     onOptionCheckboxClicked(event: MouseEvent, index: number): void {
         event.stopPropagation();
         this._onListElementClicked(event, index);
+        this.close();
     }
 
     /** @hidden */


### PR DESCRIPTION

## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/12102

## Description
The provided fix will clear the search input and close the options list when the user makes the selection by clicking on the checkbox. Currently this happens only when the user clicks on the text. 