### PR TITLE
fix(core): Remove redundant api calls on dynamic page

### DIFF
--- a/libs/core/src/lib/tabs/tab-list.component.ts
+++ b/libs/core/src/lib/tabs/tab-list.component.ts
@@ -26,7 +26,7 @@ import { MenuComponent } from '@fundamental-ngx/core/menu';
 import { OverflowLayoutComponent } from '@fundamental-ngx/core/overflow-layout';
 import { ScrollSpyDirective } from '@fundamental-ngx/core/scroll-spy';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
-import { Observable, Subject, Subscription, fromEvent, merge } from 'rxjs';
+import { Observable, Subject, Subscription, fromEvent, merge, take } from 'rxjs';
 import { debounceTime, delay, filter, first, map, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { TabItemExpandComponent } from './tab-item-expand/tab-item-expand.component';
 import { TabItemDirective } from './tab-item/tab-item.directive';
@@ -175,6 +175,9 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
     /** @hidden */
     _init = true;
 
+    /** @hidden */
+    _currentNumberOfTabs = 0;
+
     /** Event is thrown always when tab is selected by keyboard actions */
     readonly tabSelected: Subject<number> = new Subject<number>();
 
@@ -307,7 +310,12 @@ export class TabListComponent implements TabListComponentInterface, AfterContent
                 takeUntil(this._onDestroy$)
             )
             .subscribe(() => {
-                this.stackContent && this._scrollSpy?.onScroll(undefined, true);
+                if (this.stackContent && this._currentNumberOfTabs !== this._tabArray.length) {
+                    this._zone.onMicrotaskEmpty.pipe(take(1)).subscribe(() => {
+                        this._scrollSpy?.onScroll(undefined, true);
+                        this._currentNumberOfTabs = this._tabArray.length;
+                    });
+                }
             });
     }
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes https://github.com/SAP/fundamental-ngx/issues/12035

## Description

<!-- Enter short description of the change -->

The fix from https://github.com/SAP/fundamental-ngx/pull/10762 handles content body with static height and when there is a new item being added asynchronously. However, it created a side effect which triggers many calls on `onScroll` from scroll-spy directive even when there is no change to dynamic content body.

The scenario mentioned above has only handled if there is a new change to tab list. Therefore, this fix will add a check if there is a change to the size of tab list and will only execute `onScroll` from scroll-spy directive if that is a case.

After fix:

Remove redundant calls and regression check on previous fix:

 

https://github.com/user-attachments/assets/3507b243-6a3d-408a-801f-9330654b6a6c

