### PR TITLE
docs: update dialog documentation

### DIFF
--- a/libs/docs/core/dialog/dialog-docs.component.ts
+++ b/libs/docs/core/dialog/dialog-docs.component.ts
@@ -5,7 +5,17 @@ import { AsyncPipe, JsonPipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogService, ExtendedDialogConfig } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogCloseButtonComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogFullScreenTogglerButtonComponent,
+    DialogHeaderComponent,
+    DialogService,
+    DialogTemplateDirective,
+    ExtendedDialogConfig
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 import { Schema, SchemaFactoryService } from '@fundamental-ngx/docs/schema';
@@ -104,14 +114,20 @@ const popoverDialogTs = 'dialog-inner-popover/dialog-inner-popover.component.ts'
         DialogInnerPopoverComponent,
         PlayGroundComponent,
         ButtonComponent,
-        DialogModule,
         TitleComponent,
         CdkScrollable,
         ScrollbarDirective,
         BarModule,
         DialogFullScreenExampleComponent,
         AsyncPipe,
-        JsonPipe
+        JsonPipe,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogCloseButtonComponent,
+        DialogFullScreenTogglerButtonComponent,
+        DialogHeaderComponent,
+        DialogComponent,
+        DialogTemplateDirective
     ]
 })
 export class DialogDocsComponent {

--- a/libs/docs/core/dialog/examples/auto-label/auto-label-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/auto-label/auto-label-dialog-example.component.ts
@@ -2,7 +2,14 @@ import { CdkScrollable } from '@angular/cdk/overlay';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, TemplateRef } from '@angular/core';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogService,
+    DialogTitleDirective
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 
@@ -11,7 +18,18 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     changeDetection: ChangeDetectionStrategy.OnPush,
     templateUrl: './auto-label-dialog-example.component.html',
     standalone: true,
-    imports: [DialogModule, TitleComponent, CdkScrollable, ScrollbarDirective, BarModule, ButtonComponent]
+    imports: [
+        TitleComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        BarModule,
+        ButtonComponent,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogTitleDirective,
+        DialogComponent
+    ]
 })
 export class AutoLabelDialogExampleComponent {
     confirmationReason: string;

--- a/libs/docs/core/dialog/examples/component-based/dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/component-based/dialog-example.component.ts
@@ -3,7 +3,13 @@ import { CdkScrollable } from '@angular/cdk/overlay';
 import { NgStyle } from '@angular/common';
 import { Component } from '@angular/core';
 import { BarModule } from '@fundamental-ngx/core/bar';
-import { DialogModule, DialogRef } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogRef
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 
@@ -44,7 +50,17 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
         </fd-dialog>
     `,
     standalone: true,
-    imports: [DialogModule, TitleComponent, CdkScrollable, ScrollbarDirective, BarModule, NgStyle]
+    imports: [
+        TitleComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        BarModule,
+        NgStyle,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogComponent
+    ]
 })
 export class DialogExampleComponent {
     constructor(public dialogRef: DialogRef) {}

--- a/libs/docs/core/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.ts
@@ -2,7 +2,14 @@ import { CdkScrollable } from '@angular/cdk/overlay';
 import { Component } from '@angular/core';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogCloseButtonComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 
@@ -22,7 +29,18 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
         `
     ],
     standalone: true,
-    imports: [ButtonComponent, DialogModule, TitleComponent, CdkScrollable, ScrollbarDirective, BarModule]
+    imports: [
+        ButtonComponent,
+        TitleComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        BarModule,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogCloseButtonComponent,
+        DialogHeaderComponent,
+        DialogComponent
+    ]
 })
 export class DialogBackdropContainerExampleComponent {
     constructor(private _dialogService: DialogService) {}

--- a/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.ts
@@ -5,7 +5,14 @@ import { FormsModule } from '@angular/forms';
 import { InitialFocusDirective, TemplateDirective } from '@fundamental-ngx/cdk/utils';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogRef,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 import { ListModule, ListSecondaryDirective } from '@fundamental-ngx/core/list';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
@@ -22,7 +29,6 @@ interface Fruit {
     templateUrl: './dialog-complex-example.component.html',
     standalone: true,
     imports: [
-        DialogModule,
         TemplateDirective,
         BarModule,
         TitleComponent,
@@ -35,7 +41,11 @@ interface Fruit {
         NgClass,
         ListSecondaryDirective,
         ButtonComponent,
-        AsyncPipe
+        AsyncPipe,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogComponent
     ]
 })
 export class DialogComplexExampleComponent {

--- a/libs/docs/core/dialog/examples/dialog-configuration/dialog-configuration-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-configuration/dialog-configuration-example.component.ts
@@ -2,7 +2,13 @@ import { CdkScrollable } from '@angular/cdk/overlay';
 import { Component } from '@angular/core';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 
@@ -11,7 +17,17 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     templateUrl: './dialog-configuration-example.component.html',
     styleUrls: ['./dialog-configuration-example.component.scss'],
     standalone: true,
-    imports: [DialogModule, TitleComponent, CdkScrollable, ScrollbarDirective, BarModule, ButtonComponent]
+    imports: [
+        TitleComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        BarModule,
+        ButtonComponent,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogComponent
+    ]
 })
 export class DialogConfigurationExampleComponent {
     constructor(public _dialogService: DialogService) {}

--- a/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.ts
@@ -4,7 +4,13 @@ import { FormsModule } from '@angular/forms';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
-import { DialogModule, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 
@@ -14,14 +20,17 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     templateUrl: './form-dialog-example.component.html',
     standalone: true,
     imports: [
-        DialogModule,
         TitleComponent,
         CdkScrollable,
         ScrollbarDirective,
         BarModule,
         CheckboxComponent,
         FormsModule,
-        ButtonComponent
+        ButtonComponent,
+        DialogHeaderComponent,
+        DialogBodyComponent,
+        DialogFooterComponent,
+        DialogComponent
     ]
 })
 export class FormDialogExampleComponent {

--- a/libs/docs/core/dialog/examples/dialog-full-screen/dialog-full-screen-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-full-screen/dialog-full-screen-example.component.ts
@@ -11,7 +11,16 @@ import {
 import { InitialFocusDirective } from '@fundamental-ngx/cdk/utils';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogDefaultContent, DialogModule, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogDefaultContent,
+    DialogFooterComponent,
+    DialogFullScreenTogglerButtonComponent,
+    DialogHeaderComponent,
+    DialogRef,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
@@ -19,7 +28,7 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
 @Component({
     selector: 'fd-dialog-full-screen-inner-example',
     standalone: true,
-    template: `<fd-dialog>
+    template: ` <fd-dialog>
         <fd-dialog-header>
             <h1 id="fd-dialog-header-1" fd-title>{{ dialogRef.data.title }}</h1>
             <button
@@ -61,7 +70,19 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     </fd-dialog>`,
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [DialogModule, TitleComponent, CdkScrollable, ScrollbarDirective, BarModule, AsyncPipe, NgStyle]
+    imports: [
+        TitleComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        BarModule,
+        AsyncPipe,
+        NgStyle,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogFullScreenTogglerButtonComponent,
+        DialogHeaderComponent,
+        DialogComponent
+    ]
 })
 export class DialogFullScreenInnerExampleComponent {
     constructor(public dialogRef: DialogRef) {}
@@ -70,7 +91,19 @@ export class DialogFullScreenInnerExampleComponent {
 @Component({
     selector: 'fd-dialog-full-screen-example',
     standalone: true,
-    imports: [ButtonComponent, BarModule, InputGroupModule, InitialFocusDirective, DialogModule, AsyncPipe],
+    imports: [
+        ButtonComponent,
+        BarModule,
+        InputGroupModule,
+        InitialFocusDirective,
+        AsyncPipe,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogFullScreenTogglerButtonComponent,
+        TitleComponent,
+        DialogHeaderComponent,
+        DialogComponent
+    ],
     templateUrl: './dialog-full-screen-example.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/libs/docs/core/dialog/examples/dialog-inner-popover/dialog-inner-popover.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-inner-popover/dialog-inner-popover.component.ts
@@ -3,7 +3,14 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogRef,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { MultiInputComponent } from '@fundamental-ngx/core/multi-input';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
@@ -122,13 +129,16 @@ export class DialogInnerPopoverComponent {
     `,
     standalone: true,
     imports: [
-        DialogModule,
         TitleComponent,
         CdkScrollable,
         ScrollbarDirective,
         MultiInputComponent,
         FormsModule,
-        BarModule
+        BarModule,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogComponent
     ]
 })
 export class DialogInnerPopoverExampleComponent {

--- a/libs/docs/core/dialog/examples/dialog-mobile/dialog-mobile-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-mobile/dialog-mobile-example.component.ts
@@ -2,7 +2,13 @@ import { CdkScrollable } from '@angular/cdk/overlay';
 import { Component } from '@angular/core';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 
@@ -10,7 +16,17 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     selector: 'fd-dialog-mobile-example',
     templateUrl: './dialog-mobile-example.component.html',
     standalone: true,
-    imports: [DialogModule, TitleComponent, CdkScrollable, ScrollbarDirective, BarModule, ButtonComponent]
+    imports: [
+        TitleComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        BarModule,
+        ButtonComponent,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogComponent
+    ]
 })
 export class DialogMobileExampleComponent {
     constructor(public _dialogService: DialogService) {}

--- a/libs/docs/core/dialog/examples/dialog-position/dialog-position-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-position/dialog-position-example.component.ts
@@ -2,7 +2,13 @@ import { CdkScrollable } from '@angular/cdk/overlay';
 import { Component } from '@angular/core';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 
@@ -10,7 +16,17 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     selector: 'fd-dialog-position-example',
     templateUrl: './dialog-position-example.component.html',
     standalone: true,
-    imports: [DialogModule, TitleComponent, CdkScrollable, ScrollbarDirective, BarModule, ButtonComponent]
+    imports: [
+        TitleComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        BarModule,
+        ButtonComponent,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogComponent
+    ]
 })
 export class DialogPositionExampleComponent {
     constructor(public _dialogService: DialogService) {}

--- a/libs/docs/core/dialog/examples/dialog-state/dialog-state-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-state/dialog-state-example.component.ts
@@ -3,7 +3,13 @@ import { Component } from '@angular/core';
 import { InitialFocusDirective } from '@fundamental-ngx/cdk/utils';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 
@@ -13,13 +19,16 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     styleUrls: ['./dialog-state-example.component.scss'],
     standalone: true,
     imports: [
-        DialogModule,
         TitleComponent,
         CdkScrollable,
         ScrollbarDirective,
         BarModule,
         InitialFocusDirective,
-        ButtonComponent
+        ButtonComponent,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogComponent
     ]
 })
 export class DialogStateExampleComponent {

--- a/libs/docs/core/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
@@ -2,7 +2,15 @@ import { CdkScrollable } from '@angular/cdk/overlay';
 import { Component } from '@angular/core';
 import { InitialFocusDirective } from '@fundamental-ngx/cdk/utils';
 import { BarModule } from '@fundamental-ngx/core/bar';
-import { DialogModule, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogCloseButtonComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogRef,
+    DialogService
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 import { SecondDialogExampleComponent } from './second-dialog-example.component';
@@ -35,7 +43,18 @@ import { SecondDialogExampleComponent } from './second-dialog-example.component'
         </fd-dialog>
     `,
     standalone: true,
-    imports: [DialogModule, TitleComponent, CdkScrollable, ScrollbarDirective, BarModule, InitialFocusDirective]
+    imports: [
+        TitleComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        BarModule,
+        InitialFocusDirective,
+        DialogFooterComponent,
+        DialogBodyComponent,
+        DialogCloseButtonComponent,
+        DialogHeaderComponent,
+        DialogComponent
+    ]
 })
 export class FirstDialogExampleComponent {
     constructor(

--- a/libs/docs/core/dialog/examples/template-based/template-based-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/template-based/template-based-dialog-example.component.ts
@@ -1,8 +1,17 @@
 import { CdkScrollable } from '@angular/cdk/overlay';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, TemplateRef } from '@angular/core';
-import { BarModule } from '@fundamental-ngx/core/bar';
+import { ButtonBarComponent } from '@fundamental-ngx/core';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { DialogModule, DialogService } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogFullScreenTogglerButtonComponent,
+    DialogHeaderComponent,
+    DialogService,
+    DialogTemplateDirective,
+    DialogTitleDirective
+} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 
@@ -11,7 +20,20 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     changeDetection: ChangeDetectionStrategy.OnPush,
     templateUrl: './template-based-dialog-example.component.html',
     standalone: true,
-    imports: [DialogModule, TitleComponent, CdkScrollable, ScrollbarDirective, BarModule, ButtonComponent]
+    imports: [
+        TitleComponent,
+        DialogTemplateDirective,
+        DialogFooterComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        ButtonComponent,
+        DialogComponent,
+        ButtonBarComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogTitleDirective,
+        DialogFullScreenTogglerButtonComponent
+    ]
 })
 export class TemplateBasedDialogExampleComponent {
     confirmationReason: string;

--- a/libs/platform/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.ts
+++ b/libs/platform/wizard-generator/components/dialog-wizard-generator/dialog-wizard-generator.component.ts
@@ -9,7 +9,7 @@ import { InitialFocusDirective } from '@fundamental-ngx/cdk/utils';
 import { BarModule } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityDirective } from '@fundamental-ngx/core/content-density';
-import { DialogModule, DialogRef } from '@fundamental-ngx/core/dialog';
+import { DialogBodyComponent, DialogComponent, DialogHeaderComponent, DialogRef } from '@fundamental-ngx/core/dialog';
 import { MessageBoxModule, MessageBoxService } from '@fundamental-ngx/core/message-box';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { TitleComponent } from '@fundamental-ngx/core/title';
@@ -27,7 +27,6 @@ import { WizardBodyComponent } from '../wizard-body/wizard-body.component';
     providers: [WizardGeneratorService, FormGeneratorService],
     standalone: true,
     imports: [
-        DialogModule,
         TitleComponent,
         CdkScrollable,
         ScrollbarDirective,
@@ -37,7 +36,10 @@ import { WizardBodyComponent } from '../wizard-body/wizard-body.component';
         ContentDensityDirective,
         NgTemplateOutlet,
         MessageBoxModule,
-        InitialFocusDirective
+        InitialFocusDirective,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        DialogComponent
     ]
 })
 export class DialogWizardGeneratorComponent extends BaseWizardGenerator {


### PR DESCRIPTION
closes https://github.com/SAP/fundamental-ngx/issues/11873 fix(dialogs): Updated documentation

Description:
Updated documentation of dialog component, removed deprecated DialogModule and replaced with standalone components