### PR TITLE
fix(core): remove breadcrumb click proxy, allowing events on original breadcrumb item to be passed to overflow item

### DIFF
--- a/libs/core/src/lib/breadcrumb/breadcrumb-item.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb-item.component.ts
@@ -57,11 +57,6 @@ export class BreadcrumbItemComponent implements AfterViewInit {
     constructor(public readonly elementRef: ElementRef<HTMLElement>) {}
 
     /** @hidden */
-    get _needsClickProxy(): boolean {
-        return !!this.breadcrumbLink?.elementRef.nativeElement.getAttribute('href') || !!this.breadcrumbLink.routerLink;
-    }
-
-    /** @hidden */
     ngAfterViewInit(): void {
         this._attach();
     }

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.html
@@ -23,12 +23,7 @@
                         breadcrumbItem.item.breadcrumbLink ? breadcrumbItem.item.breadcrumbLink.disabled : false
                     "
                 >
-                    <a
-                        fd-menu-interactive
-                        (click)="itemClicked(breadcrumbItem.item, $event)"
-                        (keydown.enter)="itemClicked(breadcrumbItem.item, $event)"
-                        (keydown.space)="itemClicked(breadcrumbItem.item, $event)"
-                    >
+                    <a fd-menu-interactive (click)="itemClicked(breadcrumbItem.item, $event)">
                         <ng-container *ngIf="breadcrumbItem?.item.breadcrumbLink; else portalContent">
                             <ng-container *ngIf="breadcrumbItem.item.breadcrumbLink._prefixIconName">
                                 <fd-menu-addon

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -135,10 +135,8 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
      * if original element had router link we are proxying click to that element
      * */
     itemClicked(breadcrumbItem: BreadcrumbItemComponent, $event: any): void {
-        if (breadcrumbItem._needsClickProxy) {
-            $event.preventDefault();
-            breadcrumbItem.breadcrumbLink.elementRef.nativeElement.click();
-        }
+        $event.preventDefault();
+        breadcrumbItem.breadcrumbLink.elementRef.nativeElement.click();
     }
 
     /** @hidden */

--- a/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -131,9 +131,8 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit {
     }
 
     /**
-     * We catch interactions with item, Enter, Space, Mouse click and Touch click,
-     * if original element had router link we are proxying click to that element
-     * */
+     * Function that handles click, touch, enter and space events.
+     */
     itemClicked(breadcrumbItem: BreadcrumbItemComponent, $event: any): void {
         $event.preventDefault();
         breadcrumbItem.breadcrumbLink.elementRef.nativeElement.click();

--- a/libs/docs/core/breadcrumb/examples/breadcrumb-examples.component.ts
+++ b/libs/docs/core/breadcrumb/examples/breadcrumb-examples.component.ts
@@ -38,6 +38,6 @@ export class BreadcrumbRouterLinkExampleComponent {
 })
 export class BreadcrumbHrefExampleComponent {
     onClick(value: string): void {
-        console.log(value);
+        window.alert(value);
     }
 }

--- a/libs/docs/core/breadcrumb/examples/breadcrumb-examples.component.ts
+++ b/libs/docs/core/breadcrumb/examples/breadcrumb-examples.component.ts
@@ -36,4 +36,8 @@ export class BreadcrumbRouterLinkExampleComponent {
         `
     ]
 })
-export class BreadcrumbHrefExampleComponent {}
+export class BreadcrumbHrefExampleComponent {
+    onClick(value: string): void {
+        console.log(value);
+    }
+}

--- a/libs/docs/core/breadcrumb/examples/breadcrumb-href-example.component.html
+++ b/libs/docs/core/breadcrumb/examples/breadcrumb-href-example.component.html
@@ -1,6 +1,8 @@
 <fd-breadcrumb>
     <fd-breadcrumb-item>
-        <a fd-link href="/#/core/breadcrumb">Breadcrumb Level 1</a>
+        <a fd-link (click)="onClick('Breadcrumb Level 1 clicked')">
+            Breadcrumb Level <span [style.font-weight]="'bold'">1</span>
+        </a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
         <a fd-link href="/#/core/breadcrumb">Breadcrumb Level 2</a>

--- a/libs/docs/core/breadcrumb/examples/breadcrumb-routerLink-example.component.html
+++ b/libs/docs/core/breadcrumb/examples/breadcrumb-routerLink-example.component.html
@@ -1,12 +1,12 @@
 <fd-breadcrumb>
     <fd-breadcrumb-item>
-        <a fd-link routerLink="../../avatar"> Breadcrumb Level <span style="font-weight: bold">1</span> </a>
+        <a fd-link routerLink="/core/avatar"> Breadcrumb Level <span style="font-weight: bold">1</span> </a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
-        <a fd-link routerLink="../../alert">Breadcrumb Level 2</a>
+        <a fd-link routerLink="/core/alert">Breadcrumb Level 2</a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
-        <a fd-link routerLink="../../bar">Breadcrumb Level 3</a>
+        <a fd-link routerLink="/core/bar">Breadcrumb Level 3</a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
         <span>Breadcrumb Level 4</span>


### PR DESCRIPTION
fixes #11685
