### PR TITLE
fix(platform): Combobox with asyc dataSource

### DIFF
--- a/libs/platform/form/combobox/commons/base-combobox.ts
+++ b/libs/platform/form/combobox/commons/base-combobox.ts
@@ -165,7 +165,7 @@ export abstract class BaseCombobox
 
     /** Datasource for suggestion list */
     @Input()
-    set dataSource(value: FdpComboBoxDataSource<any> | null) {
+    set dataSource(value: FdpComboBoxDataSource<any>) {
         if (value) {
             this._initializeDataSource(value);
         }

--- a/libs/platform/form/combobox/commons/base-combobox.ts
+++ b/libs/platform/form/combobox/commons/base-combobox.ts
@@ -66,7 +66,7 @@ import { ComboboxConfig } from '../combobox.config';
 import { FDP_COMBOBOX_ITEM_DEF, FdpComboboxItemDef } from '../directives/combobox-item.directive';
 
 export type TextAlignment = 'left' | 'right';
-export type FdpComboBoxDataSource<T> = ComboBoxDataSource<T> | Observable<T[]> | T[];
+export type FdpComboBoxDataSource<T> = ComboBoxDataSource<T> | Observable<T[]> | T[] | null;
 
 @Directive()
 export abstract class BaseCombobox
@@ -165,9 +165,12 @@ export abstract class BaseCombobox
 
     /** Datasource for suggestion list */
     @Input()
-    set dataSource(value: FdpComboBoxDataSource<any>) {
-        if (value) {
+    set dataSource(value: FdpComboBoxDataSource<any> | null) {
+        if (value !== null) {
             this._initializeDataSource(value);
+        } else {
+            this._dataSource = null;
+            this._suggestions = [];
         }
     }
 

--- a/libs/platform/form/combobox/commons/base-combobox.ts
+++ b/libs/platform/form/combobox/commons/base-combobox.ts
@@ -66,7 +66,7 @@ import { ComboboxConfig } from '../combobox.config';
 import { FDP_COMBOBOX_ITEM_DEF, FdpComboboxItemDef } from '../directives/combobox-item.directive';
 
 export type TextAlignment = 'left' | 'right';
-export type FdpComboBoxDataSource<T> = ComboBoxDataSource<T> | Observable<T[]> | T[] | null;
+export type FdpComboBoxDataSource<T> = ComboBoxDataSource<T> | Observable<T[]> | T[];
 
 @Directive()
 export abstract class BaseCombobox
@@ -166,11 +166,8 @@ export abstract class BaseCombobox
     /** Datasource for suggestion list */
     @Input()
     set dataSource(value: FdpComboBoxDataSource<any> | null) {
-        if (value !== null) {
+        if (value) {
             this._initializeDataSource(value);
-        } else {
-            this._dataSource = null;
-            this._suggestions = [];
         }
     }
 
@@ -253,7 +250,7 @@ export abstract class BaseCombobox
     }
 
     /** @hidden List of matched suggestions */
-    _suggestions: OptionItem[];
+    _suggestions: OptionItem[] = [];
 
     /** @hidden Max width of list container */
     maxWidth?: number;


### PR DESCRIPTION
closes [#12036](https://github.com/SAP/fundamental-ngx/issues/12036)

fix(combobox): support null as `dataSource`

Description:
Updated base combobox component, now it supports null as `dataSource`