### PR TITLE
[WIP]fix(core): Grid List Keyboard support bugs

### DIFF
--- a/libs/core/grid-list/components/grid-list-item/grid-list-item.component.html
+++ b/libs/core/grid-list/components/grid-list-item/grid-list-item.component.html
@@ -1,7 +1,7 @@
 <div
     #gridListItem
     [id]="id"
-    tabindex="-1"
+    tabindex="0"
     class="fd-grid-list__item"
     role="option"
     [class.is-navigated]="isNavigated"


### PR DESCRIPTION
closes [#11968](https://github.com/SAP/fundamental-ngx/issues/11968)

fix(grid-list): ensure item level is in tab chain and enable arrow key navigation

## Description

- Resolved issue where tabbing inside the Grid List navigated only through interactive elements within items.
- Enabled arrow key navigation at the item level.