### PR TITLE
fix(core): bug where line clamp directive would not set textContent when originalText is falsy

### DIFF
--- a/libs/cdk/utils/directives/line-clamp/line-clamp.directive.ts
+++ b/libs/cdk/utils/directives/line-clamp/line-clamp.directive.ts
@@ -135,7 +135,7 @@ export class LineClampDirective implements OnChanges, AfterViewInit {
 
     /** @hidden */
     reset(): void {
-        if (this._lineClampTarget && this._originalText) {
+        if (this._lineClampTarget) {
             this._lineClampTarget.textContent = this._originalText;
         }
         if (this._isNativeSupport) {


### PR DESCRIPTION
fixes #11872 