### PR TITLE
fix(core): combo box communicate by object negative case fixed(when s…

### DIFF
--- a/libs/core/combobox/combobox.component.spec.ts
+++ b/libs/core/combobox/combobox.component.spec.ts
@@ -88,7 +88,7 @@ describe('ComboboxComponent', () => {
             }
         };
         component.inputText = 'otherDisplayedValue';
-        expect(component.onChange).toHaveBeenCalledWith(null);
+        expect(component.onChange).toHaveBeenCalledWith('otherDisplayedValue');
     });
 
     it('should handle write value from outside on dropdown mode', () => {
@@ -255,5 +255,140 @@ describe('ComboboxComponent', () => {
         // user edits the selected value
         component.inputText = 'value43';
         expect(component.isSelected(preselected)).toBe(false);
+    });
+
+
+    describe('communicateByObject', () => {
+        const enum Category {
+            Fruit = 'Fruit',
+            Vegetable = 'Vegetable'
+        }
+        interface Product {
+            name: string;
+            uniqueCode: string;
+            type: Category;
+        }
+
+        let allProducts: Product[] = [];
+
+        beforeEach(() => {
+            allProducts = [
+                {
+                    name: 'Apple',
+                    uniqueCode: 'apl',
+                    type: Category.Fruit
+                },
+                {
+                    name: 'Mango',
+                    uniqueCode: 'mng',
+                    type: Category.Fruit
+                },
+                {
+                    name: 'Orange',
+                    uniqueCode: 'org',
+                    type: Category.Fruit
+                },
+                {
+                    name: 'Carrot',
+                    uniqueCode: 'crt',
+                    type: Category.Vegetable
+                },
+                {
+                    name: 'Tomato',
+                    uniqueCode: 'tmt',
+                    type: Category.Vegetable
+                },
+                {
+                    name: 'Chilli',
+                    uniqueCode: 'chl',
+                    type: Category.Vegetable
+                }
+            ];
+        });
+
+        it('should set the selected value from drop down and trigger onChange event with the selected option', () => {
+            jest.spyOn(component, 'onChange');
+
+            component.displayFn = (product: Product): string => product?.name ?? '';
+
+            component.communicateByObject = true;
+
+            component.dropdownValues = allProducts;
+
+            component.groupFn = (products: Product[]) => {
+                const productTypes: Record<string, Product[]> = {
+                    [Category.Fruit]: [],
+                    [Category.Vegetable]: []
+                };
+
+                products.forEach((product) => {
+                    productTypes[product.type].push(product);
+                });
+
+                return productTypes;
+            };
+
+            component.inputText = 'Apple';
+
+            expect(component.onChange).toHaveBeenCalledWith({
+                name: 'Apple',
+                uniqueCode: 'apl',
+                type: Category.Fruit
+            });
+        });
+
+        it('should set the value as per the search term and trigger onChange event with the search term', () => {
+            jest.spyOn(component, 'onChange');
+
+            component.displayFn = (product: Product): string => product?.name ?? '';
+
+            component.communicateByObject = true;
+
+            component.dropdownValues = allProducts;
+
+            component.groupFn = (products: Product[]) => {
+                const productTypes: Record<string, Product[]> = {
+                    [Category.Fruit]: [],
+                    [Category.Vegetable]: []
+                };
+
+                products.forEach((product) => {
+                    productTypes[product.type].push(product);
+                });
+
+                return productTypes;
+            };
+
+            component.inputText = 'app';
+
+            expect(component.onChange).toHaveBeenCalledWith('app');
+        });
+
+        it('should set the value as blank when search term is empty and trigger onChange event with empty search term', () => {
+            jest.spyOn(component, 'onChange');
+
+            component.displayFn = (product: Product): string => product?.name ?? '';
+
+            component.communicateByObject = true;
+
+            component.dropdownValues = allProducts;
+
+            component.groupFn = (products: Product[]) => {
+                const productTypes: Record<string, Product[]> = {
+                    [Category.Fruit]: [],
+                    [Category.Vegetable]: []
+                };
+
+                products.forEach((product) => {
+                    productTypes[product.type].push(product);
+                });
+
+                return productTypes;
+            };
+
+            component.inputText = '';
+
+            expect(component.onChange).toHaveBeenCalledWith('');
+        });
     });
 });

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -822,7 +822,7 @@ export class ComboboxComponent<T = any>
             if (values.length === 1 && this.displayFn(values[0]) !== this.displayFn(this.getValue())) {
                 this.setValue(values[0]);
             } else if (values.length === 0) {
-                this.setValue(null);
+                this.setValue(this.inputText);
             }
             this.onChange(this.getValue());
         } else {


### PR DESCRIPTION
successor of #12205

## Related Issue(s)

closes [Combobox - Reactive form not working properly with [communicateObject]](https://github.com/SAP/fundamental-ngx/issues/12097)

## Description

When Combox(communicate by object) is configured in a reactive form, it fails to update the json value correctly in negative cases.

**Detailed explanation:**
When the search term does not match any values in the dropdown, then the combo box used to return the previously selected value, but with the recent fix(https://github.com/SAP/fundamental-ngx/pull/12100) from @[InnaAtanasova](https://github.com/InnaAtanasova), we get "null" when,

1. The search term doesn't match any value in the dropdown
2. If the search term is a blank or empty string.

However this fix doesn't fully address the issue, because we are returning null in negative cases instead, we should return the actual search term, so that the consuming application or component can use this value to validate the given search term against the list of options in the dropdown and throw appropriate validation message on UI. 

Please refer to the below screenshots for a better understanding.


## Screenshots

### Before:

With invalid search term, json value is null :
![before_fix_invalid_search_term](https://github.com/user-attachments/assets/6f59829f-e401-4e53-a24d-fc1c0d7e3e96)

With blank search term, json value is null :
![before_fix_blank _string](https://github.com/user-attachments/assets/4d22f034-56af-44f0-9e0b-7b76063d4d84)


### After:

Valid DataType found in combox:
![valid_dt_from_dropdown](https://github.com/user-attachments/assets/17ae2087-078a-4297-9afe-b7c57bd34c4d)

when invalid search term is used(generic error message is shown):
![invalid_dt_with_search_term](https://github.com/user-attachments/assets/9d40d206-090d-4145-8c49-e4bfa11c7032)

when invalid search term is used(actual search string is shown in error message):
![invalid_dt_with_search_term_in_msg](https://github.com/user-attachments/assets/f2895b67-0abf-4f97-8def-0eb3f225f974)

when invalid search(blank string is used:
![invalid_dt_with_blank_string](https://github.com/user-attachments/assets/235ca5f2-6982-46b1-a270-269accd24475)