### PR TITLE
[WIP] fix(platform): adjustments to pageScrolling behavior while a load is in progress

### DIFF
--- a/libs/cdk/src/lib/utils/directives/intersection-spy/intersection-spy.directive.ts
+++ b/libs/cdk/src/lib/utils/directives/intersection-spy/intersection-spy.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, EventEmitter, inject, Input, Output } from '@angular/core';
+import { Directive, ElementRef, EventEmitter, inject, Input, OnInit, Output } from '@angular/core';
 import { map, takeUntil } from 'rxjs';
 import { intersectionObservable } from '../../functions';
 import { DestroyedService } from '../../services';
@@ -8,10 +8,10 @@ import { DestroyedService } from '../../services';
     standalone: true,
     providers: [DestroyedService]
 })
-export class IntersectionSpyDirective {
+export class IntersectionSpyDirective implements OnInit {
     /** Intersection offset in px. */
     @Input('fdkIntersectionSpy')
-    offset = 20;
+    offset = 0;
     /** Intersection observer options. */
     @Input()
     viewportOptions: IntersectionObserverInit;
@@ -28,6 +28,12 @@ export class IntersectionSpyDirective {
 
     /** @hidden */
     ngOnInit(): void {
+        if (!this.viewportOptions) {
+            this.viewportOptions = {};
+        }
+        if (!this.viewportOptions.rootMargin && this.offset) {
+            this.viewportOptions.rootMargin = this.offset + 'px';
+        }
         intersectionObservable(this._elementRef.nativeElement, this.viewportOptions)
             .pipe(
                 map((entries) => entries[0]),

--- a/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.html
+++ b/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.html
@@ -11,7 +11,7 @@
     [onlyRenderVisibleCells]="onlyRenderVisibleCells"
     [useCellPlaceholder]="cellPlaceholder"
     [pageScrolling]="true"
-    [pageSize]="20"
+    [pageSize]="250"
     [renderAhead]="20"
     [pageScrollingThreshold]="80"
     hasChildrenKey="hasChildren"

--- a/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.html
+++ b/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.html
@@ -11,9 +11,8 @@
     [onlyRenderVisibleCells]="onlyRenderVisibleCells"
     [useCellPlaceholder]="cellPlaceholder"
     [pageScrolling]="true"
-    [pageSize]="250"
+    [pageSize]="100"
     [renderAhead]="20"
-    [pageScrollingThreshold]="80"
     hasChildrenKey="hasChildren"
     [expandOnInit]="true"
 >

--- a/libs/platform/src/lib/table-helpers/services/table.service.ts
+++ b/libs/platform/src/lib/table-helpers/services/table.service.ts
@@ -78,6 +78,8 @@ export class TableService {
     readonly stateChange$ = new Subject<TableStateChange>();
     /** Stream that emits when loading state changes. */
     readonly tableLoading$ = new BehaviorSubject<boolean>(false);
+    /** Stream that emits when loading state changes via pageScrolling. */
+    readonly pageScrollLoading$ = new BehaviorSubject<boolean>(false);
     /** Listen for soft changes in table subcomponents (mostly table column) */
     readonly markForCheck$ = new Subject<void>();
     /** Listen for immediate changes in table subcomponents (mostly table column) */

--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -163,21 +163,11 @@
                                 (intersected)="$event && _tableRowService.loadChildRows(row.parent!)"
                                 [style.top.px]="pageScrollingThreshold * -1"
                             ></tr>
+                            <ng-container [ngTemplateOutlet]="loadingSkeletonRow"></ng-container>
                         </ng-container>
                     </ng-container>
                 </ng-container>
-                <tr
-                    fd-table-row
-                    *ngIf="
-                        pageScrolling &&
-                        (_tableService.tableLoading$ | async) === true &&
-                        _dataSourceDirective._firstLoadingDone
-                    "
-                >
-                    <td fd-table-cell *fdkRepeat="_tableColumnsLength">
-                        <fd-skeleton style="margin: auto 0" type="text" textLines="1" width="60%"></fd-skeleton>
-                    </td>
-                </tr>
+                <ng-container [ngTemplateOutlet]="loadingSkeletonRow"></ng-container>
                 <tr
                     aria-hidden="true"
                     *ngIf="pageScrolling && !_virtualScrollDirective?.scrollWholeRows"
@@ -240,4 +230,18 @@
             </td>
         </tr>
     </tbody>
+</ng-template>
+
+<!-- Template for a row that is loading -->
+<ng-template #loadingSkeletonRow>
+    <tr
+        fd-table-row
+        *ngIf="
+            pageScrolling && (_tableService.tableLoading$ | async) === true && _dataSourceDirective._firstLoadingDone
+        "
+    >
+        <td fd-table-cell *fdkRepeat="_tableColumnsLength">
+            <fd-skeleton style="margin: auto 0" type="text" textLines="1" width="60%"></fd-skeleton>
+        </td>
+    </tr>
 </ng-template>

--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -5,18 +5,13 @@
     [ngTemplateOutletContext]="_toolbarContext"
 ></ng-container>
 
-<fd-busy-indicator
-    [loading]="(_tableService.tableLoading$ | async) === true && _dataSourceDirective._firstLoadingDone"
-    [block]="true"
->
-    <!-- Table Container -->
-    <div class="fdp-table__container" #tableContainer>
-        <ng-container [ngTemplateOutlet]="tableTemplate"></ng-container>
+<!-- Table Container -->
+<div class="fdp-table__container" #tableContainer>
+    <ng-container [ngTemplateOutlet]="tableTemplate"></ng-container>
 
-        <!-- Table column resizer for visually representing the resizing process -->
-        <fdp-table-column-resizer *ngIf="enableDragResize" class="fdp-table__column-resizer"></fdp-table-column-resizer>
-    </div>
-</fd-busy-indicator>
+    <!-- Table column resizer for visually representing the resizing process -->
+    <fdp-table-column-resizer *ngIf="enableDragResize" class="fdp-table__column-resizer"></fdp-table-column-resizer>
+</div>
 
 <!-- Table Template -->
 <ng-template #tableTemplate>
@@ -34,6 +29,11 @@
         [class.fixed-height]="!!bodyHeight"
         [attr.role]="pageScrolling ? 'feed' : null"
         [class.fd-table--fixed]="_freezableColumns.size || fixed"
+        [style.overscroll-behavior-y]="
+            (_tableService.tableLoading$ | async) === true && _dataSourceDirective._firstLoadingDone
+                ? 'contain'
+                : 'auto'
+        "
     >
         <table
             fd-table
@@ -166,6 +166,18 @@
                         </ng-container>
                     </ng-container>
                 </ng-container>
+                <tr
+                    fd-table-row
+                    *ngIf="
+                        pageScrolling &&
+                        (_tableService.tableLoading$ | async) === true &&
+                        _dataSourceDirective._firstLoadingDone
+                    "
+                >
+                    <td fd-table-cell *fdkRepeat="_tableColumnsLength">
+                        <fd-skeleton style="margin: auto 0" type="text" textLines="1" width="60%"></fd-skeleton>
+                    </td>
+                </tr>
                 <tr
                     aria-hidden="true"
                     *ngIf="pageScrolling && !_virtualScrollDirective?.scrollWholeRows"

--- a/libs/platform/src/lib/table/table.component.html
+++ b/libs/platform/src/lib/table/table.component.html
@@ -5,13 +5,22 @@
     [ngTemplateOutletContext]="_toolbarContext"
 ></ng-container>
 
-<!-- Table Container -->
-<div class="fdp-table__container" #tableContainer>
-    <ng-container [ngTemplateOutlet]="tableTemplate"></ng-container>
+<fd-busy-indicator
+    [loading]="
+        (_tableService.tableLoading$ | async) === true &&
+        (_tableService.pageScrollLoading$ | async) === false &&
+        _dataSourceDirective._firstLoadingDone
+    "
+    [block]="true"
+>
+    <!-- Table Container -->
+    <div class="fdp-table__container" #tableContainer>
+        <ng-container [ngTemplateOutlet]="tableTemplate"></ng-container>
 
-    <!-- Table column resizer for visually representing the resizing process -->
-    <fdp-table-column-resizer *ngIf="enableDragResize" class="fdp-table__column-resizer"></fdp-table-column-resizer>
-</div>
+        <!-- Table column resizer for visually representing the resizing process -->
+        <fdp-table-column-resizer *ngIf="enableDragResize" class="fdp-table__column-resizer"></fdp-table-column-resizer>
+    </div>
+</fd-busy-indicator>
 
 <!-- Table Template -->
 <ng-template #tableTemplate>
@@ -160,7 +169,7 @@
                                 aria-hidden="true"
                                 class="fd-table__intersection-spy"
                                 [fdkIntersectionSpy]="pageScrollingThreshold"
-                                (intersected)="$event && _tableRowService.loadChildRows(row.parent!)"
+                                (intersected)="_childRowIntersected($event, row)"
                                 [style.top.px]="pageScrollingThreshold * -1"
                             ></tr>
                             <ng-container [ngTemplateOutlet]="loadingSkeletonRow"></ng-container>
@@ -237,7 +246,9 @@
     <tr
         fd-table-row
         *ngIf="
-            pageScrolling && (_tableService.tableLoading$ | async) === true && _dataSourceDirective._firstLoadingDone
+            pageScrolling &&
+            (_tableService.pageScrollLoading$ | async) === true &&
+            _dataSourceDirective._firstLoadingDone
         "
     >
         <td fd-table-cell *fdkRepeat="_tableColumnsLength">


### PR DESCRIPTION
fixes #12159 

Rather than displaying a busy indicator over the entire table during a page load when using pageScrolling, displays a single row with a loading skeleton so the user can still otherwise interact with the table.