### PR TITLE
fix(core): users cannot customize class names on form-messages

### DIFF
--- a/libs/core/form/form-message/form-message.component.ts
+++ b/libs/core/form/form-message/form-message.component.ts
@@ -42,7 +42,7 @@ export class FormMessageComponent implements CssClassBuilder, OnInit, OnChanges 
     @Input()
     embedded = false;
 
-    /** @hidden User's custom classes */
+    /** User's custom classes */
     @Input()
     class: string;
 


### PR DESCRIPTION
## Description

I see no reason to hide this configurability. On the flip side in cases where you'd want to have a notification and a dropdown as well (e.g. required multi input shows message to the users) it makes styling harder as you can only target (without good old CSS reflection) the other element, cannot set a clear precedence between the 2.

## Screenshots

![image](https://github.com/user-attachments/assets/e50a3a13-5c07-4d05-baea-fda3bf5cfa10)

