### PR TITLE
fix(core): ensure grid list item selection works

### DIFF
--- a/libs/core/grid-list/components/grid-list-item/grid-list-item.component.ts
+++ b/libs/core/grid-list/components/grid-list-item/grid-list-item.component.ts
@@ -407,6 +407,9 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
 
     /** @hidden */
     _onClick(event: MouseEvent): void {
+        console.log({
+            target: event.target
+        });
         if (!this._isElementCanBeClicked(event)) {
             return;
         }
@@ -465,7 +468,8 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
             !classList.contains('fd-grid-list__radio-label') &&
             !classList.contains('fd-grid-list__radio-input') &&
             !classList.contains('fd-grid-list__checkbox-label') &&
-            !classList.contains('fd-grid-list__checkbox-input')
+            !classList.contains('fd-grid-list__checkbox-input') &&
+            !classList.contains('fd-checkbox__checkmark')
         );
     }
 

--- a/libs/core/grid-list/components/grid-list-item/grid-list-item.component.ts
+++ b/libs/core/grid-list/components/grid-list-item/grid-list-item.component.ts
@@ -407,9 +407,6 @@ export class GridListItemComponent<T> implements AfterViewInit, OnDestroy {
 
     /** @hidden */
     _onClick(event: MouseEvent): void {
-        console.log({
-            target: event.target
-        });
         if (!this._isElementCanBeClicked(event)) {
             return;
         }


### PR DESCRIPTION
fix(core): ensure grid list item selection works with navigation in multiselect mode.

closes [#12218](https://github.com/SAP/fundamental-ngx/issues/12218)

## Description
When trying to select a grid list item that has navigation in multiselect mode with a mouse click, only the navigation event was fired, and the select did not go through. This fix ensures that both the navigation and selection events are handled correctly.

