### PR TITLE
fix(platform): dismiss existing dialogs before rendering new one

### DIFF
--- a/libs/platform/table/components/table-p13-dialog/table-p13-dialog.component.spec.ts
+++ b/libs/platform/table/components/table-p13-dialog/table-p13-dialog.component.spec.ts
@@ -1,24 +1,200 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { TableP13DialogComponent } from './table-p13-dialog.component';
+import { DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
+import { CollectionFilter, CollectionGroup, CollectionSort, SortDirection, Table, TableColumn, TableState } from '@fundamental-ngx/platform/table-helpers';
+import { EventEmitter } from '@angular/core';
+import { BehaviorSubject, of } from 'rxjs';
+import { SortDialogResultData } from './sorting/sorting.component';
+import { FilterDialogResultData } from './filtering/filtering.model';
+import { GroupDialogResultData } from './grouping/grouping.component';
 
 describe('TableP13DialogComponent', () => {
     let component: TableP13DialogComponent;
     let fixture: ComponentFixture<TableP13DialogComponent>;
+    let dialogServiceStub: Partial<DialogService>;
+    const dialogRef = new DialogRef();
 
     beforeEach(waitForAsync(() => {
+        dialogServiceStub = {
+            open: jest.fn(),
+            dismissAll: jest.fn()
+          };
         TestBed.configureTestingModule({
-            imports: [TableP13DialogComponent]
+            imports: [TableP13DialogComponent],
+            providers: [ { provide: DialogService, useValue: dialogServiceStub }, { provide: DialogRef, useValue: dialogRef },]
         }).compileComponents();
     }));
 
     beforeEach(() => {
+        class TableComponentMock
+            implements
+                Pick<
+                    Table,
+                    | 'search'
+                    | 'openTableSortSettings'
+                    | 'openTableFilterSettings'
+                    | 'openTableGroupSettings'
+                    | 'openTableColumnSettings'
+                    | 'emptyRowAdded'
+                    | 'save'
+                    | 'cancel'
+                    | 'presetChanged'
+                    | 'expandAll'
+                    | 'collapseAll'
+                    | 'getTableState'
+                    | 'getTableColumns'
+                    | 'showSortSettingsInToolbar'
+                    | 'showGroupSettingsInToolbar'
+                    | 'showColumnSettingsInToolbar'
+                    | 'showFilterSettingsInToolbar'
+                    | 'setHeaderColumnFilteringDisabled'
+                    | 'sort'
+                    | 'filter'
+                >
+        {
+            openTableSortSettings = new EventEmitter();
+            openTableFilterSettings = new EventEmitter();
+            openTableGroupSettings = new EventEmitter();
+            openTableColumnSettings = new EventEmitter();
+            _tableColumnsSubject = new BehaviorSubject<TableColumn[]>([]);
+            tableColumnsStream = this._tableColumnsSubject.asObservable();
+            emptyRowAdded = new EventEmitter();
+            save = new EventEmitter();
+            cancel = new EventEmitter();
+            presetChanged = new EventEmitter();
+
+            search(): void {}
+            expandAll(): void {}
+            collapseAll(): void {}
+            showSortSettingsInToolbar(): void {}
+            showGroupSettingsInToolbar(): void {}
+            showColumnSettingsInToolbar(): void {}
+            showFilterSettingsInToolbar(): void {}
+            setHeaderColumnFilteringDisabled(): void {}
+            sort(): void {}
+            filter(): void {}
+            getTableState(): TableState {
+                return {} as TableState;
+            }
+            getTableColumns(): TableColumn[] {
+                return [];
+            } 
+            
+        }
+
         fixture = TestBed.createComponent(TableP13DialogComponent);
         component = fixture.componentInstance;
+        component.table = new TableComponentMock() as any;
         fixture.detectChanges();
     });
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    describe('showSortingSettings', () => {
+        it('should show sorting settings dialog', () => {
+            const mockCollectionSort: CollectionSort[] = [
+                { field: 'status', direction: SortDirection.ASC },
+             { field: 'name', direction: SortDirection.DESC },
+             { field: 'grp', direction: SortDirection.ASC },];
+            const mockSortDialogResultData: SortDialogResultData = { collectionSort: mockCollectionSort };
+            
+            jest.spyOn(dialogServiceStub, 'open').mockReturnValue({ afterClosed: of({ ...mockSortDialogResultData }), dismiss: jest.fn() } as any);
+
+            jest.spyOn(dialogRef, 'dismiss');
+
+            component.showSortingSettings();
+
+            expect(dialogRef.dismiss).not.toHaveBeenCalled();
+            expect(dialogServiceStub.open).toHaveBeenCalled();
+
+            dialogRef.afterClosed.subscribe((result: SortDialogResultData) => {
+                expect(result).toEqual(mockSortDialogResultData);
+              });
+        });
+
+        it('should show sorting settings dialog by dimissing already initialized sortings dialog', () => {
+            const mockCollectionSort: CollectionSort[] = [
+                { field: 'status', direction: SortDirection.ASC },
+             { field: 'name', direction: SortDirection.DESC },
+             { field: 'grp', direction: SortDirection.ASC },];
+            const mockSortDialogResultData: SortDialogResultData = { collectionSort: mockCollectionSort };
+            
+            jest.spyOn(dialogServiceStub, 'open').mockReturnValue({ afterClosed: of({ ...mockSortDialogResultData }), dismiss: jest.fn() } as any);
+            jest.spyOn(dialogRef, 'dismiss');
+
+            component._dialogRef = { dismiss: jest.fn() } as any;
+            component.showSortingSettings();
+
+            expect(dialogRef.dismiss).not.toHaveBeenCalled();
+            expect(dialogServiceStub.open).toHaveBeenCalled();
+
+            dialogRef.afterClosed.subscribe((result: SortDialogResultData) => {
+                expect(result).toEqual(mockSortDialogResultData);
+              });
+        });
+    });
+
+    describe('showFilteringSettings', () => {
+        it('should show filter settings dialog', () => {
+            const mockCollectionFilter: CollectionFilter[] = [
+                { field: 'status', value: 'valid', strategy: 'equalTo', exclude: false } ,
+              { field: 'name', value: 'valid', strategy: 'equalTo', exclude: false }];
+            const mockFilterDialogResultData: FilterDialogResultData = { collectionFilter: mockCollectionFilter };
+            
+            jest.spyOn(dialogServiceStub, 'open').mockReturnValue({ afterClosed: of({ ...mockFilterDialogResultData }), dismiss: jest.fn() } as any);
+            jest.spyOn(dialogRef, 'dismiss');
+
+            component.showFilteringSettings();
+
+            expect(dialogRef.dismiss).not.toHaveBeenCalled();
+            expect(dialogServiceStub.open).toHaveBeenCalled();
+
+            dialogRef.afterClosed.subscribe((result: FilterDialogResultData) => {
+                expect(result).toEqual(mockFilterDialogResultData);
+              });
+        });
+
+        it('should show filter settings dialog by dimissing already initialized sortings dialog', () => {
+            const mockCollectionFilter: CollectionFilter[] = [
+                { field: 'status', value: 'valid', strategy: 'equalTo', exclude: false } ,
+              { field: 'name', value: 'valid', strategy: 'equalTo', exclude: false }];
+            const mockFilterDialogResultData: FilterDialogResultData = { collectionFilter: mockCollectionFilter };
+            
+            jest.spyOn(dialogServiceStub, 'open').mockReturnValue({ afterClosed: of({ ...mockFilterDialogResultData }), dismiss: jest.fn() } as any);
+            jest.spyOn(dialogRef, 'dismiss');
+
+            component._dialogRef = { dismiss: jest.fn() } as any;
+            component.showFilteringSettings();
+
+            expect(dialogServiceStub.open).toHaveBeenCalled();
+
+            dialogRef.afterClosed.subscribe((result: FilterDialogResultData) => {
+                expect(result).toEqual(mockFilterDialogResultData);
+              });
+        });
+    });
+
+    describe('showGroupingSettings', () => {
+        it('should show group settings dialog', () => {
+            const mockCollectionGroup: CollectionGroup[] = [
+                 { field: 'status', direction: SortDirection.ASC, showAsColumn: true },
+                   { field: 'name', direction: SortDirection.DESC, showAsColumn: true }];
+            const mockGroupDialogResultData: GroupDialogResultData = { collectionGroup: mockCollectionGroup };
+            
+            jest.spyOn(dialogServiceStub, 'open').mockReturnValue({ afterClosed: of({ ...mockGroupDialogResultData }), dismiss: jest.fn() } as any);
+            jest.spyOn(dialogRef, 'dismiss');
+
+            component.showGroupingSettings();
+
+            expect(dialogRef.dismiss).not.toHaveBeenCalled();
+            expect(dialogServiceStub.open).toHaveBeenCalled();
+
+            dialogRef.afterClosed.subscribe((result: GroupDialogResultData) => {
+                expect(result).toEqual(mockGroupDialogResultData);
+              });
+        });
     });
 });

--- a/libs/platform/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, ContentChild, Input, OnDestroy } fr
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { DialogConfig, DialogService } from '@fundamental-ngx/core/dialog';
+import { DialogConfig, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
 
 import {
     CollectionFilter,
@@ -10,6 +10,7 @@ import {
     CollectionSort,
     Table,
     TableColumn,
+    TableDialogCommonData,
     TableState
 } from '@fundamental-ngx/platform/table-helpers';
 
@@ -97,6 +98,9 @@ export class TableP13DialogComponent implements OnDestroy {
     _table: Table;
 
     /** @hidden */
+    _dialogRef: DialogRef<TableDialogCommonData, any>;
+
+    /** @hidden */
     private _subscriptions = new Subscription();
 
     /** @hidden */
@@ -121,7 +125,12 @@ export class TableP13DialogComponent implements OnDestroy {
             collectionSort: sortBy
         };
 
-        const dialogRef = this._dialogService.open(
+        // dismiss any open dialog, before opening a new one
+        if (this._dialogRef) {
+            this._dialogRef.dismiss();
+        }
+
+        this._dialogRef = this._dialogService.open(
             P13SortingDialogComponent,
             {
                 ...dialogConfig,
@@ -131,7 +140,7 @@ export class TableP13DialogComponent implements OnDestroy {
         );
 
         this._subscriptions.add(
-            dialogRef.afterClosed
+            this._dialogRef.afterClosed
                 .pipe(filter((result) => !!result))
                 .subscribe(({ collectionSort }: SortDialogResultData) => {
                     this._applySorting(collectionSort);
@@ -153,7 +162,12 @@ export class TableP13DialogComponent implements OnDestroy {
             dialogData.validator = this.filter.validator;
         }
 
-        const dialogRef = this._dialogService.open(
+        // dismiss any open dialog, before opening a new one
+        if (this._dialogRef) {
+            this._dialogRef.dismiss();
+        }
+
+        this._dialogRef = this._dialogService.open(
             P13FilteringDialogComponent,
             {
                 ...dialogConfig,
@@ -165,7 +179,7 @@ export class TableP13DialogComponent implements OnDestroy {
         );
 
         this._subscriptions.add(
-            dialogRef.afterClosed
+            this._dialogRef.afterClosed
                 .pipe(filter((result) => !!result))
                 .subscribe(({ collectionFilter }: FilterDialogResultData) => {
                     this._applyFiltering(collectionFilter);
@@ -188,7 +202,12 @@ export class TableP13DialogComponent implements OnDestroy {
             collectionGroup: groupBy
         };
 
-        const dialogRef = this._dialogService.open(
+        // dismiss any open dialog, before opening a new one
+        if (this._dialogRef) {
+            this._dialogRef.dismiss();
+        }
+
+        this._dialogRef = this._dialogService.open(
             P13GroupingDialogComponent,
             {
                 ...dialogConfig,
@@ -198,7 +217,7 @@ export class TableP13DialogComponent implements OnDestroy {
         );
 
         this._subscriptions.add(
-            dialogRef.afterClosed
+            this._dialogRef.afterClosed
                 .pipe(filter((result) => !!result))
                 .subscribe(({ collectionGroup }: GroupDialogResultData) => {
                     this._applyGrouping(collectionGroup);
@@ -216,7 +235,12 @@ export class TableP13DialogComponent implements OnDestroy {
             visibleColumns
         };
 
-        const dialogRef = this._dialogService.open(
+        // dismiss any open dialog, before opening a new one
+        if (this._dialogRef) {
+            this._dialogRef.dismiss();
+        }
+
+        this._dialogRef = this._dialogService.open(
             P13ColumnsDialogComponent,
             {
                 ...dialogConfig,
@@ -228,7 +252,7 @@ export class TableP13DialogComponent implements OnDestroy {
         );
 
         this._subscriptions.add(
-            dialogRef.afterClosed
+            this._dialogRef.afterClosed
                 .pipe(filter((result) => !!result))
                 .subscribe(({ visibleColumns: result }: ColumnsDialogResultData) => {
                     this._applyColumns(result);

--- a/libs/platform/table/components/table-view-settings-dialog/table-view-settings-dialog.component.ts
+++ b/libs/platform/table/components/table-view-settings-dialog/table-view-settings-dialog.component.ts
@@ -12,12 +12,13 @@ import {
 import { Subscription } from 'rxjs';
 import { filter, startWith } from 'rxjs/operators';
 
-import { DialogConfig, DialogService } from '@fundamental-ngx/core/dialog';
+import { DialogConfig, DialogRef, DialogService } from '@fundamental-ngx/core/dialog';
 import {
     CollectionFilter,
     SortDirection,
     Table,
     TableColumn,
+    TableDialogCommonData,
     TableState
 } from '@fundamental-ngx/platform/table-helpers';
 import { FiltersComponent, FiltersDialogData, FiltersDialogResultData } from './filtering/filters.component';
@@ -85,6 +86,9 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
     _table: Table;
 
     /** @hidden */
+    _dialogRef: DialogRef<TableDialogCommonData, any>;
+
+    /** @hidden */
     private _subscriptions = new Subscription();
 
     /** @hidden */
@@ -116,7 +120,12 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
             allowDisablingSorting: this.allowDisablingSorting
         };
 
-        const dialogRef = this._dialogService.open(
+        // dismiss any open dialog, before opening a new one
+        if (this._dialogRef) {
+            this._dialogRef.dismiss();
+        }
+
+        this._dialogRef = this._dialogService.open(
             SortingComponent,
             {
                 ...dialogConfig,
@@ -126,7 +135,7 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
         );
 
         this._subscriptions.add(
-            dialogRef.afterClosed
+            this._dialogRef.afterClosed
                 .pipe(filter((result) => !!result))
                 .subscribe(({ field, direction }: SettingsSortDialogResultData) => {
                     this._applySorting(field, direction);
@@ -144,7 +153,12 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
             filterBy: state?.filterBy
         };
 
-        const dialogRef = this._dialogService.open(
+        // dismiss any open dialog, before opening a new one
+        if (this._dialogRef) {
+            this._dialogRef.dismiss();
+        }
+
+        this._dialogRef = this._dialogService.open(
             FiltersComponent,
             {
                 ...dialogConfig,
@@ -154,7 +168,7 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
         );
 
         this._subscriptions.add(
-            dialogRef.afterClosed
+            this._dialogRef.afterClosed
                 .pipe(filter((result) => !!result))
                 .subscribe(({ filterBy }: FiltersDialogResultData) => this._applyFiltering(filterBy))
         );
@@ -170,7 +184,12 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
             field: state.groupBy?.[0]?.field
         };
 
-        const dialogRef = this._dialogService.open(
+        // dismiss any open dialog, before opening a new one
+        if (this._dialogRef) {
+            this._dialogRef.dismiss();
+        }
+
+        this._dialogRef = this._dialogService.open(
             GroupingComponent,
             {
                 ...dialogConfig,
@@ -180,7 +199,7 @@ export class TableViewSettingsDialogComponent implements AfterViewInit, OnDestro
         );
 
         this._subscriptions.add(
-            dialogRef.afterClosed
+            this._dialogRef.afterClosed
                 .pipe(filter((result) => !!result))
                 .subscribe(({ field, direction }: SettingsGroupDialogResultData) => {
                     this._applyGrouping(field, direction);


### PR DESCRIPTION
## Related Issue(s)

closes [#12095](https://github.com/SAP/fundamental-ngx/issues/12095)

## Description

When the filter/sort/group settings dialog is triggered multiple times(only happens when the component is busy with other functionality), the settings dialogs are rendered in a stacked order multiple times.

below is the link to the stackblitz, where the problem can be reproduced(click on reload multiple times and then click the sorting button on the header multiple times, after a few seconds multiple sort settings dialog is rendered on the screen)
https://stackblitz.com/edit/6vfrhd-4ghmut?file=src%2Fapp%2Fplatform-table-sortable-example.component.ts

## Screenshots

### Before:

https://github.com/user-attachments/assets/bfc80b68-afd2-4758-814f-f85b38d6f6e8

### After:


https://github.com/user-attachments/assets/b500d2f9-bcd3-40e5-9191-ce60892a253d


#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [x] update `README.md`
-   [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
