### PR TITLE
fix(core): remove the default background for autofill input

### DIFF
--- a/libs/core/input-group/input-group.component.scss
+++ b/libs/core/input-group/input-group.component.scss
@@ -12,4 +12,13 @@ fd-input-group {
             border: none;
         }
     }
+
+    .fd-input.fd-input-group__input {
+        &:-webkit-autofill,
+        &:-webkit-autofill:hover,
+        &:-webkit-autofill:focus,
+        &:-webkit-autofill:active {
+            -webkit-background-clip: text;
+        }
+    }
 }


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description
This PR removes the input background colour for Chrome autocomplete.

**NOTE: a fix is provided also in FNGX**

**_Before:_**
![Screenshot 2024-08-07 at 10 27 03 AM](https://github.com/user-attachments/assets/95bfc59e-a777-4a2b-ac6d-26b7d9aa7011)
![Screenshot 2024-08-07 at 10 27 13 AM](https://github.com/user-attachments/assets/68243aa8-68c2-448e-aaf2-1a16b9f22a0e)


**_After:_**
![Screenshot 2024-08-07 at 10 26 49 AM](https://github.com/user-attachments/assets/1ca4ab34-34a0-4816-af42-ae9ee43e5273)
![Screenshot 2024-08-07 at 10 26 44 AM](https://github.com/user-attachments/assets/321b944b-5d87-4481-be52-c3071a1ff15d)

