### PR TITLE
fix(platform): table headers are not sticky when body is overflowing

### DIFF
--- a/libs/platform/table/table.component.spec.ts
+++ b/libs/platform/table/table.component.spec.ts
@@ -1,0 +1,102 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Table, TableDataSource, TableDataSourceDirective } from '@fundamental-ngx/platform/table-helpers';
+
+import { PlatformTableModule } from './table.module';
+import { TableComponent } from './table.component';
+import { TableDataProviderMock } from './tests/helpers';
+
+describe('TableComponent', () => {
+    let component: TableComponent;
+    let fixture: ComponentFixture<TableComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: Table, useValue: {} },
+            ],
+            imports: [PlatformTableModule, NoopAnimationsModule, TableDataSourceDirective]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TableComponent);
+        component = fixture.componentInstance;
+        component._dataSourceDirective.dataSource = new TableDataSource(new TableDataProviderMock());
+
+        fixture.detectChanges();
+    });
+
+    it('should create sucessfully', () => {
+        expect(component).toBeTruthy();
+    });
+
+
+    describe('isBodyHeightValid', () => {
+        it('should return true when valid body height is passed in pixels', () => {
+            component.bodyHeight = '30px';
+            expect(component.isBodyHeightValid).toBeTruthy();
+        });
+
+        it('should return false when invalid body height is passed in pixels', () => {
+            component.bodyHeight = 'thirtypx';
+            expect(component.isBodyHeightValid).toBeFalsy();
+        });
+
+        it('should return false when invalid body height is passed(without units)', () => {
+            component.bodyHeight = '100';
+            expect(component.isBodyHeightValid).toBeFalsy();
+        });
+
+        it('should return true when valid body height is passed in percentage', () => {
+            component.bodyHeight = '75%';
+            expect(component.isBodyHeightValid).toBeTruthy();
+        });
+
+        it('should return false when invalid body height is passed in pixels', () => {
+            component.bodyHeight = 'seventyfive%';
+            expect(component.isBodyHeightValid).toBeFalsy();
+        });
+
+        it('should return false when invalid body height(undefined)', () => {
+            component.bodyHeight = 'seventyfive%';
+            expect(component.isBodyHeightValid).toBeFalsy();
+        });
+    });
+
+    describe('tableBodyHeight', ()=> {
+        it('should return body height of the table when its valid',()=> {
+            const mockBodyHeight = '750px';
+            component.bodyHeight = mockBodyHeight;
+
+            expect(component.tableBodyHeight).toEqual(mockBodyHeight);
+        });
+
+
+        it('should return default body height(100%) when its in-valid case 1(seventyFivepx)',()=> {
+            const mockBodyHeight = 'seventyFivepx';
+            component.bodyHeight = mockBodyHeight;
+
+            expect(component.tableBodyHeight).toEqual('100%');
+        });
+
+        it('should return default body height(100%) when its in-valid case 2(thirty%)',()=> {
+            const mockBodyHeight = 'thirty%';
+            component.bodyHeight = mockBodyHeight;
+
+            expect(component.tableBodyHeight).toEqual('100%');
+        });
+
+        it('should return default body height(100%) when its in-valid case 3(blank string)',()=> {
+            const mockBodyHeight = '';
+            component.bodyHeight = mockBodyHeight;
+
+            expect(component.tableBodyHeight).toEqual('100%');
+        });
+
+        it('should return default body height(100%) when its in-valid case 3(undefined)',()=> {
+
+            expect(component.tableBodyHeight).toEqual('100%');
+        });
+    });
+});

--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -605,10 +605,15 @@ export class TableComponent<T = any>
      */
     get isBodyHeightValid(): boolean {
         const height = this.bodyHeight;
-        return (
-            (!!height && height.endsWith('px') && this._isValidInteger(height.split('px')[0])) ||
-            (height.endsWith('%') && this._isValidInteger(height.split('%')[0]))
-        );
+
+        if (height) {
+            return (
+                (height.endsWith('px') && this._isValidInteger(height.split('px')[0])) ||
+                (height.endsWith('%') && this._isValidInteger(height.split('%')[0]))
+            );
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -495,6 +495,9 @@ export class TableComponent<T = any>
     /** @hidden */
     private _calculateFrozenColumnRefresh$ = new Subject<void>();
 
+    /** @hidden */
+    private _defaultBodyHeight = '100%';
+
     /** Event emitted when current preset configuration has been changed. */
     @Output()
     presetChanged = new EventEmitter<PlatformTableManagedPreset>();
@@ -594,6 +597,27 @@ export class TableComponent<T = any>
     /** @hidden */
     get initialSortBy(): CollectionSort[] {
         return this.initialState?.initialSortBy ?? [];
+    }
+
+    /**
+     * @hidden
+     * verify if the bodyheight provided is valid in percentage or pixels
+     */
+    get isBodyHeightValid(): boolean {
+        const height = this.bodyHeight;
+        return (
+            (!!height && height.endsWith('px') && this._isValidInteger(height.split('px')[0])) ||
+            (height.endsWith('%') && this._isValidInteger(height.split('%')[0]))
+        );
+    }
+
+    /**
+     * @hidden
+     * if the bodyHeight is valid, then set that as value as body height for table
+     * else set default body height for table as 100%
+     */
+    get tableBodyHeight(): string {
+        return this.isBodyHeightValid ? this.bodyHeight : this._defaultBodyHeight;
     }
 
     /**
@@ -1113,15 +1137,6 @@ export class TableComponent<T = any>
         }
         this._markAsExpanded(expandableRows);
         this.allRowsExpanded.emit();
-    }
-
-    /** @hidden */
-    private _markAsExpanded(rows: TableRow<T>[]): void {
-        rows.forEach((e) => {
-            e.expanded = true;
-            e.hidden = false;
-        });
-        this.onTableRowsChanged();
     }
 
     /** collapse all rows */
@@ -1672,6 +1687,20 @@ export class TableComponent<T = any>
     /** Manually update index after we add new items to the main array */
     private _reIndexTableRows(): void {
         this._tableRows.map((row, index) => (row.index = index));
+    }
+
+    /** @hidden */
+    private _isValidInteger(value: string): boolean {
+        return Number.isInteger(parseInt(value, 10));
+    }
+
+    /** @hidden */
+    private _markAsExpanded(rows: TableRow<T>[]): void {
+        rows.forEach((e) => {
+            e.expanded = true;
+            e.hidden = false;
+        });
+        this.onTableRowsChanged();
     }
 
     /** @hidden */


### PR DESCRIPTION
## Related Issue(s)

closes [11877](https://github.com/SAP/fundamental-ngx/issues/11877)

## Description

Fdp Table Headers were not sticky because the enclosing container's height was not definite.
 As part of the fix, if the `bodyHeight` is not passed or  invalid, the default container size is set to `100%`.

## Screenshots

### Before:
Without the default `bodyHeight`, the content overflows and the headers don't get sticky on scrolling.

https://github.com/user-attachments/assets/9ad222f9-d069-4486-9218-360780aabfd4


### After:
When predefined `bodyHeight` is provided, eg 330px,

https://github.com/user-attachments/assets/11d8597f-863a-4cec-90da-f0801e18551c

When invalid  `bodyHeight`  or empty `bodyHeight` or no `bodyHeight` provided, then we have fallback height as 100%
 
https://github.com/user-attachments/assets/987a1ba5-0eed-48ef-93d9-4bd2d566de22


#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] check Light/Dark/HCB/HCW themes
-   [x] RTL/LTR - proper rendering and labeling
-   [x] responsiveness(resize)
-   [x] Content Density (Cozy/Compact/(Condensed))
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Interaction/Animation - open/close, expand/collapse, add/remove, check/uncheck
-   [x] Mouse vs. Keyboard support
-   [x] Text Truncation

2. API and functional correctness

-   [x] check for console logs (warnings, errors)
-   [x] API boundary values
-   [x] different combinations of components - free style
-   [x] change the API values during testing

3. Documentation and Example validations

-   [x] missing API documentation or it is not understandable
-   [x] poor examples
-   [x] Stackblitz works for all examples

4. Accessibility testing
5. Browser Testing - Edge, Safari, Chrome, Firefox

##### PR Quality

-   [x] the commit message(s) follows the guideline:
        https://github.com/SAP/fundamental-ngx/blob/main/CONTRIBUTING.md
-   [x] tests for the changes that have been done
-   [x] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/fundamental-ngx/wiki/PR-Review-Checklist
-   [x] Run npm run build-pack-library and test in external application
-   [x] update `README.md`
-   [x] [Breaking Changes Wiki](https://github.com/SAP/fundamental-ngx/wiki/Breaking-Changes)
