### PR TITLE
feat(platform): add option to hide refresh and search buttons in Table toolbar search

### DIFF
--- a/libs/docs/platform/table/examples/platform-table-default-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-default-example.component.html
@@ -1,5 +1,5 @@
 <fdp-table [dataSource]="source" [trackBy]="trackBy" emptyTableMessage="No data found" [nonInteractiveHeader]="true">
-    <fdp-table-toolbar title="Order Line Items" [shouldOverflow]="true">
+    <fdp-table-toolbar title="Order Line Items" [shouldOverflow]="true" [disableRefresh]="true">
         <fdp-table-toolbar-actions>
             <fdp-button label="Action One" (click)="alert('Action One')"></fdp-button>
             <fdp-button label="Action Two" (click)="alert('Action Two')"></fdp-button>

--- a/libs/platform/table/components/table-toolbar/table-toolbar.component.html
+++ b/libs/platform/table/components/table-toolbar/table-toolbar.component.html
@@ -31,6 +31,8 @@
                 [inputText]="_searchInputText"
                 [disabled]="!!(tableLoading$ | async)"
                 [suggestions]="searchSuggestions"
+                [disableRefresh]="disableRefresh"
+                [disableSearch]="disableSearch"
                 [ariaLabel]="searchFieldAriaLabel"
                 [ariaLabelledBy]="searchFieldAriaLabel ? null : tableToolbarTitleId"
                 (searchSubmit)="submitSearch($event)"

--- a/libs/platform/table/components/table-toolbar/table-toolbar.component.ts
+++ b/libs/platform/table/components/table-toolbar/table-toolbar.component.ts
@@ -125,6 +125,14 @@ export class TableToolbarComponent implements TableToolbarInterface {
     @Input()
     editMode: EditMode = 'none';
 
+    /** Whether display Refresh button in the search field */
+    @Input()
+    disableRefresh = false;
+
+    /** Whether display search button in the search field */
+    @Input()
+    disableSearch = false;
+
     /** @hidden */
     @ContentChild(TableToolbarActionsComponent)
     tableToolbarActionsComponent: TableToolbarActionsComponent;


### PR DESCRIPTION

closes https://github.com/SAP/fundamental-ngx/issues/12236

## Description
exposes the input props of the search field in Table toolbar