### PR TITLE
fix(platform): update grouping selection flow to prevent duplications

### DIFF
--- a/libs/platform/table/components/table-p13-dialog/grouping/grouping.component.html
+++ b/libs/platform/table/components/table-p13-dialog/grouping/grouping.component.html
@@ -15,7 +15,7 @@
     </fd-dialog-header>
 
     <fd-dialog-body>
-        @for (rule of rules; track rule) {
+        @for (rule of rules; track rule; let i = $index) {
             <div class="group-row">
                 <fd-select
                     class="group-row__select"
@@ -23,7 +23,7 @@
                     (valueChange)="_onRuleColumnKeyChange(rule, $event)"
                     [placeholder]="'platformTable.P13GroupDialogNoneSelectedColumnSelectPlaceholder' | fdTranslate"
                 >
-                    @for (column of columns; track column) {
+                    @for (column of getAvailableColumns(rule); track column) {
                         <li fd-option [value]="column.key">
                             {{ column.label }}
                         </li>
@@ -45,6 +45,7 @@
                         [attr.aria-label]="'platformTable.P13GroupDialogRemoveGroupBtnTitle' | fdTranslate"
                         [title]="'platformTable.P13GroupDialogRemoveGroupBtnTitle' | fdTranslate"
                         (click)="_removeRule(rule)"
+                        [disabled]="!rule.columnKey"
                     ></button>
 
                     <button
@@ -53,7 +54,8 @@
                         glyph="add"
                         [attr.aria-label]="'platformTable.P13GroupDialogAddNewGroupBtnTitle' | fdTranslate"
                         [title]="'platformTable.P13GroupDialogAddNewGroupBtnTitle' | fdTranslate"
-                        (click)="_addNew($index)"
+                        (click)="_addNew(i)"
+                        [disabled]="rules.length >= columns.length || !rule.columnKey"
                     ></button>
                 </div>
             </div>

--- a/libs/platform/table/components/table-p13-dialog/grouping/grouping.component.ts
+++ b/libs/platform/table/components/table-p13-dialog/grouping/grouping.component.ts
@@ -1,12 +1,18 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, ViewEncapsulation } from '@angular/core';
 import {
     CollectionGroup,
+    getUniqueListValuesByKey,
     SortDirection,
-    TableDialogCommonData,
-    getUniqueListValuesByKey
+    TableDialogCommonData
 } from '@fundamental-ngx/platform/table-helpers';
 
-import { DialogRef } from '@fundamental-ngx/core/dialog';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogRef
+} from '@fundamental-ngx/core/dialog';
 
 import { CdkScrollable } from '@angular/cdk/overlay';
 
@@ -20,17 +26,11 @@ import {
 } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
-import {
-    DialogBodyComponent,
-    DialogComponent,
-    DialogFooterComponent,
-    DialogHeaderComponent
-} from '@fundamental-ngx/core/dialog';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { OptionComponent, SelectComponent } from '@fundamental-ngx/core/select';
 import { TitleComponent } from '@fundamental-ngx/core/title';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
-import { RESETTABLE_TOKEN, ResetButtonComponent, Resettable } from '../../reset-button/reset-button.component';
+import { ResetButtonComponent, Resettable, RESETTABLE_TOKEN } from '../../reset-button/reset-button.component';
 
 export interface GroupDialogColumn {
     label: string;
@@ -159,6 +159,12 @@ export class P13GroupingDialogComponent implements Resettable {
     _onRuleShowAsColumnChange(rule: GroupRule, value: boolean): void {
         rule.showAsColumn = value;
         this._recalculateResetAvailability();
+    }
+
+    /** Get available columns for a rule */
+    getAvailableColumns(rule: GroupRule): GroupDialogColumn[] {
+        const selectedKeys = this.rules.map((r) => r.columnKey).filter((key) => key !== NOT_SELECTED_OPTION_VALUE);
+        return this.columns.filter((column) => !selectedKeys.includes(column.key) || column.key === rule.columnKey);
     }
 
     /** @hidden */


### PR DESCRIPTION
…oupings

## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #11605 

## Description
fix: update grouping selection flow to prevent duplicate groupings

- Disable "Add" button when the number of rules equals the number of columns.
- Disable "Add" and "Remove" buttons if the rule's column key is not selected.
- Filter available columns for each rule based on already selected columns.
- Ensure the "Add" button is disabled if all columns are used.
- Ensure the "Add" and "Remove" buttons are disabled if no rule is selected.

<!-- Enter short description of the change -->

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:
![image](https://github.com/user-attachments/assets/84a5d81c-133e-41c4-868f-1a06e30589c9)


### After:
<img width="573" alt="image" src="https://github.com/user-attachments/assets/7e00ec50-0035-4181-86d6-a08375c36155">

