### PR TITLE
fix(platform): set default color in _generateTabBarItems to prevent i…

### DIFF
--- a/libs/platform/icon-tab-bar/icon-tab-bar.component.ts
+++ b/libs/platform/icon-tab-bar/icon-tab-bar.component.ts
@@ -352,6 +352,9 @@ export class IconTabBarComponent implements OnInit, TabList {
         flatIndexRef = flatIndexRef || { value: 0 };
         return config.map((item, index) => {
             const uId = `${indexPrefix}${index}`;
+            if (!('color' in item)) {
+                item.color = 'default';
+            }
             const result: IconTabBarItem = {
                 ...item,
                 index,


### PR DESCRIPTION
set default color in _generateTabBarItems to prevent incorrect calculations

## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #12119 


