### PR TITLE
fix(platform): platform table header popover screenreader fixes

### DIFF
--- a/libs/docs/platform/table/examples/platform-table-custom-column-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-custom-column-example.component.html
@@ -17,25 +17,25 @@
                     <button fdCompact fd-button glyph="menu2"></button>
                 </fd-popover-control>
                 <fd-popover-body>
-                    <fdp-list [navigated]="true">
-                        <li fdp-free-content-list-item>
+                    <fdp-list [navigated]="true" [role]="'listbox'">
+                        <li fdp-free-content-list-item [ariaRole]="'option'">
                             <a fd-list-link>
                                 <i fd-list-icon glyph="history"></i>
                                 <span fd-list-title> Link List item 1 </span>
                             </a>
                         </li>
-                        <li fdp-free-content-list-item>
+                        <li fdp-free-content-list-item [ariaRole]="'option'">
                             <a fd-list-link>
                                 <i fd-list-icon glyph="cart"></i>
                                 <span fd-list-title> Link List item 2 </span>
                             </a>
                         </li>
-                        <li fdp-free-content-list-item>
+                        <li fdp-free-content-list-item [ariaRole]="'option'">
                             <a fd-list-link>
                                 <span fd-list-title> Link List item 3</span>
                             </a>
                         </li>
-                        <li fdp-free-content-list-item *ngFor="let item of items | async">
+                        <li fdp-free-content-list-item [ariaRole]="'option'" *ngFor="let item of items | async">
                             <ng-template
                                 [ngTemplateOutlet]="item"
                                 [ngTemplateOutletContext]="{ popover: popover }"

--- a/libs/platform/src/lib/list/free-content-list-item/free-content-list-item.component.html
+++ b/libs/platform/src/lib/list/free-content-list-item/free-content-list-item.component.html
@@ -16,6 +16,7 @@
     [attr.aria-posinset]="ariaPosinset"
     [attr.aria-setsize]="ariaSetSize | async"
     [attr.aria-selected]="_selectedAttr"
+    [ariaRole]="ariaRole"
 >
     <ng-content></ng-content>
 </div>

--- a/libs/platform/src/lib/list/free-content-list-item/free-content-list-item.component.ts
+++ b/libs/platform/src/lib/list/free-content-list-item/free-content-list-item.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, forwardRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewEncapsulation } from '@angular/core';
 import { BaseListItem } from '../base-list-item';
 
 @Component({
@@ -9,7 +9,11 @@ import { BaseListItem } from '../base-list-item';
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [{ provide: BaseListItem, useExisting: forwardRef(() => FreeContentListItemComponent) }],
     host: {
-        role: 'listitem'
+        role: 'group'
     }
 })
-export class FreeContentListItemComponent extends BaseListItem {}
+export class FreeContentListItemComponent extends BaseListItem {
+    /** Role of the child fd-list-item element. */
+    @Input()
+    ariaRole: string;
+}

--- a/libs/platform/src/lib/table/components/table-cell-header-popover/table-cell-header-popover.component.html
+++ b/libs/platform/src/lib/table/components/table-cell-header-popover/table-cell-header-popover.component.html
@@ -8,8 +8,8 @@
     [triggers]="_headerPopoverTriggers"
     (isOpenChange)="_popoverOpened($event)"
 >
-    <fdp-list [noBorder]="true" [navigated]="true">
-        <li fdp-free-content-list-item *ngFor="let item of _popoverItems$.asObservable() | async">
+    <fdp-list [noBorder]="true" [navigated]="true" [role]="'listbox'">
+        <li fdp-free-content-list-item *ngFor="let item of _popoverItems$.asObservable() | async" [ariaRole]="'option'">
             <ng-template [ngTemplateOutlet]="item" [ngTemplateOutletContext]="{ popover: popover }"></ng-template>
         </li>
     </fdp-list>
@@ -25,24 +25,20 @@
     <ng-template fdkTemplate="sortingAscPopoverItem" let-popover="popover">
         <a
             fd-list-link
-            [focusable]="true"
-            role="button"
             (click)="_setColumnHeaderSortBy(column.key, SORT_DIRECTION.ASC)"
             (keydown.enter)="_setColumnHeaderSortBy(column.key, SORT_DIRECTION.ASC)"
         >
-            <span fd-list-icon glyph="sort-ascending"></span>
+            <i fd-list-icon glyph="sort-ascending"></i>
             <span fd-list-title>{{ 'platformTable.headerMenuSortAsc' | fdTranslate }}</span>
         </a>
     </ng-template>
     <ng-template fdkTemplate="sortingDescPopoverItem" let-popover="popover">
         <a
             fd-list-link
-            [focusable]="true"
-            role="button"
             (click)="_setColumnHeaderSortBy(column.key, SORT_DIRECTION.DESC)"
             (keydown.enter)="_setColumnHeaderSortBy(column.key, SORT_DIRECTION.DESC)"
         >
-            <span fd-list-icon glyph="sort-descending"></span>
+            <i fd-list-icon glyph="sort-descending"></i>
             <span fd-list-title>{{ 'platformTable.headerMenuSortDesc' | fdTranslate }}</span>
         </a>
     </ng-template>
@@ -52,8 +48,6 @@
     <ng-template fdkTemplate="groupPopoverItem" let-popover="popover">
         <a
             fd-list-link
-            [focusable]="true"
-            role="button"
             (click)="_setColumnHeaderGroupBy(column.key)"
             (keydown.enter)="_setColumnHeaderGroupBy(column.key)"
         >
@@ -65,7 +59,7 @@
 <ng-container *ngIf="column?.freezable || column?.endFreezable">
     <ng-template fdkTemplate="freezePopoverItem" let-popover="popover">
         <ng-container *ngIf="!columnFrozen; else unfreezeTpl">
-            <a fd-list-link [focusable]="true" (click)="_freeze()" role="button" (keydown.enter)="_freeze()">
+            <a fd-list-link (click)="_freeze()" (keydown.enter)="_freeze()">
                 <span fd-list-title>
                     {{
                         (!column.endFreezable
@@ -79,7 +73,7 @@
             </a>
         </ng-container>
         <ng-template #unfreezeTpl>
-            <a fd-list-link [focusable]="true" (click)="_unFreeze()" role="button" (keydown.enter)="_unFreeze()">
+            <a fd-list-link (click)="_unFreeze()" (keydown.enter)="_unFreeze()">
                 <span fd-list-title>{{
                     (columnIndex > 0 ? 'platformTable.headerMenuUnfreezePlural' : 'platformTable.headerMenuUnfreeze')
                         | fdTranslate
@@ -91,7 +85,7 @@
 
 <ng-container *ngIf="column?.filterable && !filteringFromHeaderDisabled">
     <ng-template fdkTemplate="filteringPopoverItem" let-popover="popover">
-        <a fd-list-link style="cursor: auto" [focusable]="true">
+        <a fd-list-link style="cursor: auto">
             <i fd-list-icon glyph="filter"></i>
             <div fd-form-item [horizontal]="true" (click)="$event.stopPropagation()">
                 <label fd-form-label [for]="'fdp-table-column-filtering-' + column.name">{{


### PR DESCRIPTION
fixes #12034 

Before: JAWS not announcing aria-setsize or aria-posinset for items in header cell popover

After:
<img width="735" alt="Screenshot 2024-08-29 at 3 15 44 PM" src="https://github.com/user-attachments/assets/a144de2a-649f-4977-8d84-ad5e9cfe54be">
<img width="778" alt="Screenshot 2024-08-29 at 3 18 05 PM" src="https://github.com/user-attachments/assets/c4e7c0e9-b7c8-41f8-b4b1-ca2479bdc5c9">
