### PR TITLE
fix(core): combobox handle IME input correctly to prevent accidental deletion of characters

### DIFF
--- a/libs/cdk/utils/directives/auto-complete/auto-complete.directive.ts
+++ b/libs/cdk/utils/directives/auto-complete/auto-complete.directive.ts
@@ -58,7 +58,7 @@ export class AutoCompleteDirective {
     private lastKeyUpEvent: KeyboardEvent;
 
     /** @hidden */
-    private isComposing = false;
+    private _isComposing = false;
 
     /** @hidden */
     private readonly _elementRef = inject(ElementRef);
@@ -94,11 +94,11 @@ export class AutoCompleteDirective {
                 .subscribe((evt) => this._handleKeyboardEvent(evt));
 
             compositionStartEvent.pipe(takeUntilDestroyed()).subscribe(() => {
-                this.isComposing = true;
+                this._isComposing = true;
             });
 
             compositionEndEvent.pipe(takeUntilDestroyed()).subscribe(() => {
-                this.isComposing = false;
+                this._isComposing = false;
                 this.inputText = this._elementRef.nativeElement.value;
             });
         });
@@ -110,7 +110,7 @@ export class AutoCompleteDirective {
 
     /** @hidden */
     _handleKeyboardEvent(event: KeyboardEvent): void {
-        if (this.enable && !this.isComposing) {
+        if (this.enable && !this._isComposing) {
             if (KeyUtil.isKeyCode(event, this._stopKeys)) {
                 this._elementRef.nativeElement.value = this.inputText;
             } else if (KeyUtil.isKeyCode(event, this._completeKeys)) {


### PR DESCRIPTION
fix(core): handle IME input correctly to prevent accidental deletion of characters

closes [#12232](https://github.com/SAP/fundamental-ngx/issues/12232)

## Description
- Added handling for `compositionstart` and `compositionend` events to properly manage IME input (e.g., Chinese, Japanese).
- Introduced `isComposing` flag to bypass autocomplete logic during IME composition.
- Updated `inputText` synchronization after IME input ends to ensure it matches the finalized value.
- Prevented unwanted modifications of input value when using IME, addressing the issue where typing and deleting partially composed characters could remove the last English character.