### PR TITLE
fix(core): add proper styling for Select placeholder

### DIFF
--- a/libs/core/select/select.component.html
+++ b/libs/core/select/select.component.html
@@ -33,6 +33,7 @@
         [class.is-expanded]="_isOpen"
         [class.is-disabled]="disabled"
         [class.is-readonly]="readonly"
+        [class.is-placeholder]="!selected"
         [attr.tabindex]="_tabIndex"
         [attr.id]="controlId"
         [attr.aria-active]="_isOpen"

--- a/libs/core/select/select.component.scss
+++ b/libs/core/select/select.component.scss
@@ -35,7 +35,7 @@ $block: fd-select;
         }
     }
 
-    .#{$block}__control[aria-selected='false'] {
+    .#{$block}__control.is-placeholder {
         .#{$block}__text-content {
             font-style: italic;
             font-weight: normal;


### PR DESCRIPTION
## Related Issue(s)

related to https://github.com/SAP/fundamental-ngx/issues/10088
Was fixed before and then broke again

## Description
The select placeholder was not rendered with proper styling. Was due to removing aria-selected attribute, which was also used to determine if the control has a placeholder text. 