### PR TITLE
fix(platform): update Valiant Management list item state on select event

### DIFF
--- a/libs/platform/variant-management/variant-management.component.html
+++ b/libs/platform/variant-management/variant-management.component.html
@@ -64,7 +64,7 @@
                     variant of _variants | fdFilterStrings: { searchTerm: _filterPhrase, key: 'name' };
                     track variant.id
                 ) {
-                    <li fd-list-item (click)="selectVariant(variant)">
+                    <li fd-list-item [selected]="variant.name === activeVariant.name" (click)="selectVariant(variant)">
                         <span fd-list-link>
                             <span fd-list-title>{{ variant.name }}</span>
                         </span>


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/12391

## Description
- on select event the list item gets the proper state (selected)
- the focus is on the first item per List behaviour/specs
