### PR TITLE
fix(core,platform): provide translation for multi-combobox Invalid Entry message

### DIFF
--- a/libs/core/multi-combobox/base-multi-combobox.class.ts
+++ b/libs/core/multi-combobox/base-multi-combobox.class.ts
@@ -46,7 +46,7 @@ export abstract class BaseMultiCombobox<T = any> {
     abstract secondaryKey: string;
     abstract showSecondaryText: boolean;
     abstract lookupKey: string;
-    abstract invalidEntryMessage: string;
+    abstract invalidEntryMessage: Nullable<string>;
     abstract invalidEntryDisplayTime: number;
     abstract limitless: boolean;
     abstract isGroup: boolean;

--- a/libs/core/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/multi-combobox/multi-combobox.component.ts
@@ -15,7 +15,8 @@ import {
     TemplateRef,
     ViewChild,
     ViewContainerRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    inject
 } from '@angular/core';
 import { DataSourceDirective, FD_DATA_SOURCE_TRANSFORMER, MatchingStrategy } from '@fundamental-ngx/cdk/data-source';
 import { CvaControl, CvaDirective, OptionItem, SelectItem, SelectableOptionItem } from '@fundamental-ngx/cdk/forms';
@@ -63,7 +64,7 @@ import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
 import { FormControlComponent, FormInputMessageGroupComponent, FormMessageComponent } from '@fundamental-ngx/core/form';
 import { InputGroupComponent, InputGroupInputDirective } from '@fundamental-ngx/core/input-group';
 import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
-import { FdTranslatePipe } from '@fundamental-ngx/i18n';
+import { FD_LANGUAGE, FdLanguage, FdTranslatePipe, TranslationResolver } from '@fundamental-ngx/i18n';
 import { getSelectItemByInputValue, getTokenIndexByIdlOrValue } from './helpers';
 import { MultiComboboxSelectionChangeEvent } from './models/selection-change.event';
 import { MultiAnnouncerDirective } from './multi-announcer/multi-announcer.directive';
@@ -252,9 +253,12 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     @Input()
     addonIconTitle: string;
 
-    /** Sets invalid entry message. */
+    /**
+     * @deprecated Use the i18n module to modify the translation for this string.
+     * Sets invalid entry message.
+     * */
     @Input()
-    invalidEntryMessage = 'Invalid entry';
+    invalidEntryMessage: Nullable<string>;
 
     /** Turns limitless mode, ON or OFF */
     @Input()
@@ -417,6 +421,12 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     private _selectedItems: T[] = [];
 
     /** @hidden */
+    private readonly _lang$ = inject(FD_LANGUAGE);
+
+    /** @hidden */
+    private _translationResolver = new TranslationResolver();
+
+    /** @hidden */
     constructor(
         private readonly _elementRef: ElementRef,
         private readonly _injector: Injector,
@@ -432,6 +442,13 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
     ngOnInit(): void {
         this.cvaControl.listenToChanges();
         this._openDataStream(this.matchingStrategy);
+
+        this._lang$.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((lang: FdLanguage) => {
+            this.invalidEntryMessage = this._translationResolver.resolve(
+                lang,
+                'platformMultiCombobox.invalidEntryError'
+            );
+        });
     }
 
     /** @hidden */

--- a/libs/i18n/src/lib/models/fd-language-key-identifier.ts
+++ b/libs/i18n/src/lib/models/fd-language-key-identifier.ts
@@ -260,6 +260,7 @@ export type FdLanguageKeyIdentifier =
     | 'platformMultiCombobox.inputIconTitle'
     | 'platformMultiCombobox.mobileShowAllItemsButton'
     | 'platformMultiCombobox.mobileShowSelectedItemsButton'
+    | 'platformMultiCombobox.invalidEntryError'
     | 'platformTextarea.counterMessageCharactersOverTheLimitSingular'
     | 'platformTextarea.counterMessageCharactersOverTheLimitPlural'
     | 'platformTextarea.counterMessageCharactersRemainingSingular'

--- a/libs/i18n/src/lib/models/fd-language.ts
+++ b/libs/i18n/src/lib/models/fd-language.ts
@@ -462,6 +462,7 @@ export interface FdLanguage {
         inputIconTitle: FdLanguageKey;
         mobileShowAllItemsButton: FdLanguageKey;
         mobileShowSelectedItemsButton: FdLanguageKey;
+        invalidEntryError: FdLanguageKey;
     };
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: FdLanguageKey;

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle = Select Options
 platformMultiCombobox.mobileShowAllItemsButton = Show all items
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton = Show selected items
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular = 1 character over the limit
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -328,7 +328,8 @@ export default {
         inputGlyphAriaLabel: 'Select Options',
         inputIconTitle: 'Select Options',
         mobileShowAllItemsButton: 'Show all items',
-        mobileShowSelectedItemsButton: 'Show selected items'
+        mobileShowSelectedItemsButton: 'Show selected items',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 character over the limit',

--- a/libs/i18n/src/lib/translations/translations_ar.properties
+++ b/libs/i18n/src/lib/translations/translations_ar.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=تحديد الخيارات
 platformMultiCombobox.mobileShowAllItemsButton=إظهار جميع البنود
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=إظهار البنود المحددة
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=تم تجاوز الحد بحرف واحد
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -328,7 +328,8 @@ export default {
         inputGlyphAriaLabel: 'تحديد الخيارات',
         inputIconTitle: 'تحديد الخيارات',
         mobileShowAllItemsButton: 'إظهار جميع البنود',
-        mobileShowSelectedItemsButton: 'إظهار البنود المحددة'
+        mobileShowSelectedItemsButton: 'إظهار البنود المحددة',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'تم تجاوز الحد بحرف واحد',

--- a/libs/i18n/src/lib/translations/translations_bg.properties
+++ b/libs/i18n/src/lib/translations/translations_bg.properties
@@ -509,9 +509,11 @@ platformMultiCombobox.inputGlyphAriaLabel=Избор на опции
 #XACT: Text for the title attribute of the button representing 'Select Options' of Platform Multi-Combobox input group
 platformMultiCombobox.inputIconTitle=Избор на опции
 #XACT: Text for the title attribute of the button representing 'Show all items' of Platform Multi-Combobox input group
-platformMultiCombobox.mobileShowAllItemsButton=Показване на всички позиции 
+platformMultiCombobox.mobileShowAllItemsButton=Показване на всички позиции
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Показване на избраните позиции
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 символ над ограничението
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters
@@ -543,7 +545,7 @@ platformSearchField.synchronizeButtonTitle=Синхронизиране
 #XMSG: Message displaying the number of suggestions found
 platformSearchField.searchSuggestionMessage=Намерени са {count} предложения.
 #XMSG: Message with keyboard instructions for navigation
-platformSearchField.searchSuggestionNavigateMessage=за придвижване, използвайте стрелките нагоре и надолу 
+platformSearchField.searchSuggestionNavigateMessage=за придвижване, използвайте стрелките нагоре и надолу
 #XACT: Text for the ARIA label attribute of Platform Switch
 platformSwitch.ariaLabel=Въвеждане на превключвател
 #XFLD: Text for the placeholder of Platform Smart Filter Bar input field

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Избор на опции',
         inputIconTitle: 'Избор на опции',
         mobileShowAllItemsButton: 'Показване на всички позиции',
-        mobileShowSelectedItemsButton: 'Показване на избраните позиции'
+        mobileShowSelectedItemsButton: 'Показване на избраните позиции',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 символ над ограничението',

--- a/libs/i18n/src/lib/translations/translations_cs.properties
+++ b/libs/i18n/src/lib/translations/translations_cs.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Vybrat možnosti
 platformMultiCombobox.mobileShowAllItemsButton=Zobrazit všechny položky
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Zobrazit vybrané položky
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 znak nad limit
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Vybrat možnosti',
         inputIconTitle: 'Vybrat možnosti',
         mobileShowAllItemsButton: 'Zobrazit všechny položky',
-        mobileShowSelectedItemsButton: 'Zobrazit vybrané položky'
+        mobileShowSelectedItemsButton: 'Zobrazit vybrané položky',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 znak nad limit',

--- a/libs/i18n/src/lib/translations/translations_da.properties
+++ b/libs/i18n/src/lib/translations/translations_da.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Vælg muligheder
 platformMultiCombobox.mobileShowAllItemsButton=Vis alle elementer
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Vis valgte elementer
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 tegn over grænsen
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Vælg muligheder',
         inputIconTitle: 'Vælg muligheder',
         mobileShowAllItemsButton: 'Vis alle elementer',
-        mobileShowSelectedItemsButton: 'Vis valgte elementer'
+        mobileShowSelectedItemsButton: 'Vis valgte elementer',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 tegn over grænsen',

--- a/libs/i18n/src/lib/translations/translations_de.properties
+++ b/libs/i18n/src/lib/translations/translations_de.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Optionen auswählen
 platformMultiCombobox.mobileShowAllItemsButton=Alle Elemente anzeigen
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Ausgewählte Elemente anzeigen
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 Zeichen über dem Limit
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -330,7 +330,8 @@ export default {
         inputGlyphAriaLabel: 'Optionen auswählen',
         inputIconTitle: 'Optionen auswählen',
         mobileShowAllItemsButton: 'Alle Elemente anzeigen',
-        mobileShowSelectedItemsButton: 'Ausgewählte Elemente anzeigen'
+        mobileShowSelectedItemsButton: 'Ausgewählte Elemente anzeigen',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 Zeichen über dem Limit',

--- a/libs/i18n/src/lib/translations/translations_el.properties
+++ b/libs/i18n/src/lib/translations/translations_el.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Επιλογή Δυνατοτήτων
 platformMultiCombobox.mobileShowAllItemsButton=Εμφάνιση όλων των στοιχείων
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Εμφάνιση επιλεγμένων στοιχείων
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 χαρακτήρας πάνω από το όριο
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -330,7 +330,8 @@ export default {
         inputGlyphAriaLabel: 'Επιλογή Δυνατοτήτων',
         inputIconTitle: 'Επιλογή Δυνατοτήτων',
         mobileShowAllItemsButton: 'Εμφάνιση όλων των στοιχείων',
-        mobileShowSelectedItemsButton: 'Εμφάνιση επιλεγμένων στοιχείων'
+        mobileShowSelectedItemsButton: 'Εμφάνιση επιλεγμένων στοιχείων',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 χαρακτήρας πάνω από το όριο',

--- a/libs/i18n/src/lib/translations/translations_es.properties
+++ b/libs/i18n/src/lib/translations/translations_es.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Seleccionar opciones
 platformMultiCombobox.mobileShowAllItemsButton=Mostrar todos los elementos
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Mostrar elementos seleccionados
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 carácter por encima del límite
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -330,7 +330,8 @@ export default {
         inputGlyphAriaLabel: 'Seleccionar opciones',
         inputIconTitle: 'Seleccionar opciones',
         mobileShowAllItemsButton: 'Mostrar todos los elementos',
-        mobileShowSelectedItemsButton: 'Mostrar elementos seleccionados'
+        mobileShowSelectedItemsButton: 'Mostrar elementos seleccionados',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 carácter por encima del límite',

--- a/libs/i18n/src/lib/translations/translations_fi.properties
+++ b/libs/i18n/src/lib/translations/translations_fi.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Valitse vaihtoehdot
 platformMultiCombobox.mobileShowAllItemsButton=Näytä kaikki kohteet
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Näytä valitut kohteet
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 merkki yli rajan
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Valitse vaihtoehdot',
         inputIconTitle: 'Valitse vaihtoehdot',
         mobileShowAllItemsButton: 'Näytä kaikki kohteet',
-        mobileShowSelectedItemsButton: 'Näytä valitut kohteet'
+        mobileShowSelectedItemsButton: 'Näytä valitut kohteet',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 merkki yli rajan',

--- a/libs/i18n/src/lib/translations/translations_fr.properties
+++ b/libs/i18n/src/lib/translations/translations_fr.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Sélectionner des options
 platformMultiCombobox.mobileShowAllItemsButton=Afficher tous les éléments
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Afficher les éléments sélectionnés
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 caractère en trop
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -331,7 +331,8 @@ export default {
         inputGlyphAriaLabel: 'Sélectionner des options',
         inputIconTitle: 'Sélectionner des options',
         mobileShowAllItemsButton: 'Afficher tous les éléments',
-        mobileShowSelectedItemsButton: 'Afficher les éléments sélectionnés'
+        mobileShowSelectedItemsButton: 'Afficher les éléments sélectionnés',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 caractère en trop',

--- a/libs/i18n/src/lib/translations/translations_he.properties
+++ b/libs/i18n/src/lib/translations/translations_he.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=בחר אפשרויות
 platformMultiCombobox.mobileShowAllItemsButton=הצג את כל הפריטים
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=הצג פריטים נבחרים
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=תו אחד יותר מהמגבלה
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -328,7 +328,8 @@ export default {
         inputGlyphAriaLabel: 'בחר אפשרויות',
         inputIconTitle: 'בחר אפשרויות',
         mobileShowAllItemsButton: 'הצג את כל הפריטים',
-        mobileShowSelectedItemsButton: 'הצג פריטים נבחרים'
+        mobileShowSelectedItemsButton: 'הצג פריטים נבחרים',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'תו אחד יותר מהמגבלה',

--- a/libs/i18n/src/lib/translations/translations_hi.properties
+++ b/libs/i18n/src/lib/translations/translations_hi.properties
@@ -256,6 +256,7 @@ platformMultiCombobox.inputGlyphAriaLabel = विकल्प चुनें
 platformMultiCombobox.inputIconTitle = विकल्प चुनें
 platformMultiCombobox.mobileShowAllItemsButton = सभी आइटम दिखाएं
 platformMultiCombobox.mobileShowSelectedItemsButton = सभी आइटम दिखाएं
+platformMultiCombobox.invalidEntryError = Invalid Entry
 platformTextarea.counterMessageCharactersOverTheLimitSingular = 1 सीमा से अधिक चरित्र
 platformTextarea.counterMessageCharactersOverTheLimitPlural = {count} सीमा से अधिक वर्ण
 platformTextarea.counterMessageCharactersRemainingSingular = 1 चरित्र शेष

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'विकल्प चुनें',
         inputIconTitle: 'विकल्प चुनें',
         mobileShowAllItemsButton: 'सभी आइटम दिखाएं',
-        mobileShowSelectedItemsButton: 'सभी आइटम दिखाएं'
+        mobileShowSelectedItemsButton: 'सभी आइटम दिखाएं',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 सीमा से अधिक चरित्र',

--- a/libs/i18n/src/lib/translations/translations_hr.properties
+++ b/libs/i18n/src/lib/translations/translations_hr.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Odaberi mogućnosti
 platformMultiCombobox.mobileShowAllItemsButton=Prikaži sve stavke
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Prikaži odabrane stavke
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=Broj znakova više od ograničenja: 1
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Odaberi mogućnosti',
         inputIconTitle: 'Odaberi mogućnosti',
         mobileShowAllItemsButton: 'Prikaži sve stavke',
-        mobileShowSelectedItemsButton: 'Prikaži odabrane stavke'
+        mobileShowSelectedItemsButton: 'Prikaži odabrane stavke',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'Broj znakova više od ograničenja: 1',

--- a/libs/i18n/src/lib/translations/translations_hu.properties
+++ b/libs/i18n/src/lib/translations/translations_hu.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Kiválasztási beállítások
 platformMultiCombobox.mobileShowAllItemsButton=Minden elem megjelenítése
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=A kiválasztott elemek megjelenítése
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 karakterrel több a megengedettnél
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Kiválasztási beállítások',
         inputIconTitle: 'Kiválasztási beállítások',
         mobileShowAllItemsButton: 'Minden elem megjelenítése',
-        mobileShowSelectedItemsButton: 'A kiválasztott elemek megjelenítése'
+        mobileShowSelectedItemsButton: 'A kiválasztott elemek megjelenítése',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 karakterrel több a megengedettnél',

--- a/libs/i18n/src/lib/translations/translations_it.properties
+++ b/libs/i18n/src/lib/translations/translations_it.properties
@@ -349,7 +349,7 @@ platformApprovalFlow.nodeVariousTeams=Vari team
 #XFLD: Due date label if due date is today.
 platformApprovalFlow.nodeStatusDueToday=Scade oggi
 #XFLD: Due date label if due date is not today and not overdue.
-platformApprovalFlow.nodeStatusDueInXDays=Scade tra {count} giorni 
+platformApprovalFlow.nodeStatusDueInXDays=Scade tra {count} giorni
 #XFLD: Due date label if due date is overdue.
 platformApprovalFlow.nodeStatusXDaysOverdue=Scaduto da {count} giorni
 #XMIT: Menu item for adding approvers before selected node.
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Seleziona opzioni
 platformMultiCombobox.mobileShowAllItemsButton=Mostra tutte le voci
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Mostra le voci selezionate
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 carattere oltre il limite
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters
@@ -829,9 +831,9 @@ platformTable.selectAllCheckboxLabel=Seleziona tutto
 #XFLD Label for the checkbox, which deselects all rows in the table
 platformTable.deselectAllCheckboxLabel=Deseleziona tutto
 #XACT Text, which is read by screen reader, tells instruction of how to deselect a row
-platformTable.deselectSingleRow=Per deselezionare la riga, premere la BARRA SPAZIATRICE 
+platformTable.deselectSingleRow=Per deselezionare la riga, premere la BARRA SPAZIATRICE
 #XACT Text, which is read by screen reader, tells instruction of how to select a row
-platformTable.selectSingleRow=Per selezionare la riga, premere la BARRA SPAZIATRICE 
+platformTable.selectSingleRow=Per selezionare la riga, premere la BARRA SPAZIATRICE
 #XBUT Label for the button, which loads additional rows
 platformTable.loadMore=Carica di più
 #XBUT Label for the button, navigates to the edit section of the wizard

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -330,7 +330,8 @@ export default {
         inputGlyphAriaLabel: 'Seleziona opzioni',
         inputIconTitle: 'Seleziona opzioni',
         mobileShowAllItemsButton: 'Mostra tutte le voci',
-        mobileShowSelectedItemsButton: 'Mostra le voci selezionate'
+        mobileShowSelectedItemsButton: 'Mostra le voci selezionate',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 carattere oltre il limite',

--- a/libs/i18n/src/lib/translations/translations_ja.properties
+++ b/libs/i18n/src/lib/translations/translations_ja.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=オプションを選択
 platformMultiCombobox.mobileShowAllItemsButton=すべての項目を表示
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=選択した項目を表示
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=上限を1文字超えています。
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'オプションを選択',
         inputIconTitle: 'オプションを選択',
         mobileShowAllItemsButton: 'すべての項目を表示',
-        mobileShowSelectedItemsButton: '選択した項目を表示'
+        mobileShowSelectedItemsButton: '選択した項目を表示',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '上限を1文字超えています。',

--- a/libs/i18n/src/lib/translations/translations_ka.properties
+++ b/libs/i18n/src/lib/translations/translations_ka.properties
@@ -256,6 +256,7 @@ platformMultiCombobox.inputGlyphAriaLabel = აირჩიეთ ოფცი�
 platformMultiCombobox.inputIconTitle = აირჩიეთ ოფციები
 platformMultiCombobox.mobileShowAllItemsButton = მაჩვენე ყველა
 platformMultiCombobox.mobileShowSelectedItemsButton = მაჩვენე არჩეული
+platformMultiCombobox.invalidEntryError = Invalid Entry
 platformTextarea.counterMessageCharactersOverTheLimitSingular = 1 სიმბოლო აღემატება ლიმიტს
 platformTextarea.counterMessageCharactersOverTheLimitPlural = {count} სიმბოლო აღემატება ლიმიტს
 platformTextarea.counterMessageCharactersRemainingSingular = დარჩა 1 სიმბოლო

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'აირჩიეთ ოფციები',
         inputIconTitle: 'აირჩიეთ ოფციები',
         mobileShowAllItemsButton: 'მაჩვენე ყველა',
-        mobileShowSelectedItemsButton: 'მაჩვენე არჩეული'
+        mobileShowSelectedItemsButton: 'მაჩვენე არჩეული',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 სიმბოლო აღემატება ლიმიტს',

--- a/libs/i18n/src/lib/translations/translations_kk.properties
+++ b/libs/i18n/src/lib/translations/translations_kk.properties
@@ -293,7 +293,7 @@ platformApprovalFlow.addNodeDialogNodeType=Параллель немесе ті�
 #XMIT: "Serial" option
 platformApprovalFlow.addNodeDialogNodeTypeSerial=Тізбекті
 #XMIT: "Parallel" option
-platformApprovalFlow.addNodeDialogNodeTypeParallel=Параллель 
+platformApprovalFlow.addNodeDialogNodeTypeParallel=Параллель
 #XMEN: "Approver type" picker label.
 platformApprovalFlow.addNodeDialogApproverType=Бекітуші түрі
 #XMIT: User option
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Таңдау опциялары
 platformMultiCombobox.mobileShowAllItemsButton=Барлық тармақтарды көрсету
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Таңдалған тармақтарды көрсету
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 таңбаға шектен асып кетті
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Таңдау опциялары',
         inputIconTitle: 'Таңдау опциялары',
         mobileShowAllItemsButton: 'Барлық тармақтарды көрсету',
-        mobileShowSelectedItemsButton: 'Таңдалған тармақтарды көрсету'
+        mobileShowSelectedItemsButton: 'Таңдалған тармақтарды көрсету',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 таңбаға шектен асып кетті',

--- a/libs/i18n/src/lib/translations/translations_ko.properties
+++ b/libs/i18n/src/lib/translations/translations_ko.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=옵션 선택
 platformMultiCombobox.mobileShowAllItemsButton=모든 항목 표시
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=선택한 항목 표시
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=제한 1자 초과
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -328,7 +328,8 @@ export default {
         inputGlyphAriaLabel: '옵션 선택',
         inputIconTitle: '옵션 선택',
         mobileShowAllItemsButton: '모든 항목 표시',
-        mobileShowSelectedItemsButton: '선택한 항목 표시'
+        mobileShowSelectedItemsButton: '선택한 항목 표시',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '제한 1자 초과',

--- a/libs/i18n/src/lib/translations/translations_ms.properties
+++ b/libs/i18n/src/lib/translations/translations_ms.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Pilih Pilihan
 platformMultiCombobox.mobileShowAllItemsButton=Tunjukkan semua item
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Tunjukkan item dipilih
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 aksara melebihi had
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -328,7 +328,8 @@ export default {
         inputGlyphAriaLabel: 'Pilih Pilihan',
         inputIconTitle: 'Pilih Pilihan',
         mobileShowAllItemsButton: 'Tunjukkan semua item',
-        mobileShowSelectedItemsButton: 'Tunjukkan item dipilih'
+        mobileShowSelectedItemsButton: 'Tunjukkan item dipilih',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 aksara melebihi had',

--- a/libs/i18n/src/lib/translations/translations_nl.properties
+++ b/libs/i18n/src/lib/translations/translations_nl.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Opties selecteren
 platformMultiCombobox.mobileShowAllItemsButton=Alle items weergeven
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Geselecteerde items weergeven
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 teken boven de limiet
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -330,7 +330,8 @@ export default {
         inputGlyphAriaLabel: 'Opties selecteren',
         inputIconTitle: 'Opties selecteren',
         mobileShowAllItemsButton: 'Alle items weergeven',
-        mobileShowSelectedItemsButton: 'Geselecteerde items weergeven'
+        mobileShowSelectedItemsButton: 'Geselecteerde items weergeven',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 teken boven de limiet',

--- a/libs/i18n/src/lib/translations/translations_no.properties
+++ b/libs/i18n/src/lib/translations/translations_no.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Velg alternativer
 platformMultiCombobox.mobileShowAllItemsButton=Vis alle elementer
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Vis valgte elementer
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 tegn over grensen
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -330,7 +330,8 @@ export default {
         inputGlyphAriaLabel: 'Velg alternativer',
         inputIconTitle: 'Velg alternativer',
         mobileShowAllItemsButton: 'Vis alle elementer',
-        mobileShowSelectedItemsButton: 'Vis valgte elementer'
+        mobileShowSelectedItemsButton: 'Vis valgte elementer',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 tegn over grensen',

--- a/libs/i18n/src/lib/translations/translations_pl.properties
+++ b/libs/i18n/src/lib/translations/translations_pl.properties
@@ -445,7 +445,7 @@ platformVHD.selectMobileTabBackBtnTitle=Wstecz
 #XALT: "Open dialog" button title.
 platformVHD.selectMobileTabBtnOpenDialogLabel=Otwórz okno dialogowe
 #XTBS: Current tab name.
-platformVHD.selectMobileTabTitle=Karta {title} 
+platformVHD.selectMobileTabTitle=Karta {title}
 #XMIT: "Empty" field value condition.
 platformVHD.selectMobileConditionEmpty=Puste
 #XHED: Conditions section header for mobile mode.
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Wybór opcji
 platformMultiCombobox.mobileShowAllItemsButton=Wyświetl wszystkie pozycje
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Wyświetl wybrane pozycje
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 znak ponad limit
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Wybór opcji',
         inputIconTitle: 'Wybór opcji',
         mobileShowAllItemsButton: 'Wyświetl wszystkie pozycje',
-        mobileShowSelectedItemsButton: 'Wyświetl wybrane pozycje'
+        mobileShowSelectedItemsButton: 'Wyświetl wybrane pozycje',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 znak ponad limit',

--- a/libs/i18n/src/lib/translations/translations_pt.properties
+++ b/libs/i18n/src/lib/translations/translations_pt.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Selecionar opções
 platformMultiCombobox.mobileShowAllItemsButton=Mostrar todos os itens
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Mostrar itens selecionados
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 caractere acima do limite
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Selecionar opções',
         inputIconTitle: 'Selecionar opções',
         mobileShowAllItemsButton: 'Mostrar todos os itens',
-        mobileShowSelectedItemsButton: 'Mostrar itens selecionados'
+        mobileShowSelectedItemsButton: 'Mostrar itens selecionados',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 caractere acima do limite',

--- a/libs/i18n/src/lib/translations/translations_ro.properties
+++ b/libs/i18n/src/lib/translations/translations_ro.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Opțiuni de selecție
 platformMultiCombobox.mobileShowAllItemsButton=Afișare toate articolele
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Afișare articole selectate
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 caracter peste limită
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -330,7 +330,8 @@ export default {
         inputGlyphAriaLabel: 'Opțiuni de selecție',
         inputIconTitle: 'Opțiuni de selecție',
         mobileShowAllItemsButton: 'Afișare toate articolele',
-        mobileShowSelectedItemsButton: 'Afișare articole selectate'
+        mobileShowSelectedItemsButton: 'Afișare articole selectate',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 caracter peste limită',

--- a/libs/i18n/src/lib/translations/translations_ru.properties
+++ b/libs/i18n/src/lib/translations/translations_ru.properties
@@ -256,6 +256,7 @@ platformMultiCombobox.inputGlyphAriaLabel = Выбрать опции
 platformMultiCombobox.inputIconTitle = Выбрать опции
 platformMultiCombobox.mobileShowAllItemsButton = Показать все элементы
 platformMultiCombobox.mobileShowSelectedItemsButton = Показать выбранные элементы
+platformMultiCombobox.invalidEntryError = Invalid Entry
 platformTextarea.counterMessageCharactersOverTheLimitSingular = Превышен лимит на 1 символ
 platformTextarea.counterMessageCharactersOverTheLimitPlural = Превышен лимит на { count, plural, one {1 символ} few {\# символа} other {\# символов} }
 platformTextarea.counterMessageCharactersRemainingSingular = Остался 1 символ

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -333,7 +333,8 @@ export default {
         inputGlyphAriaLabel: 'Выбрать опции',
         inputIconTitle: 'Выбрать опции',
         mobileShowAllItemsButton: 'Показать все элементы',
-        mobileShowSelectedItemsButton: 'Показать выбранные элементы'
+        mobileShowSelectedItemsButton: 'Показать выбранные элементы',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'Превышен лимит на 1 символ',

--- a/libs/i18n/src/lib/translations/translations_sh.properties
+++ b/libs/i18n/src/lib/translations/translations_sh.properties
@@ -415,7 +415,7 @@ platformVHD.footerClearSelectedTitle=izbriši odabrane stavke
 #XACT: Button aria label.
 platformVHD.footerClearSelectedAriaLabel=izbriši odabrane stavke
 #XBUT: Search button text.
-platformVHD.searchButtonLabel=Idi 
+platformVHD.searchButtonLabel=Idi
 #XBUT: Submit button text
 platformVHD.successButtonLabel=OK
 #XBUT: Cancel button text.
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Odaberi opcije
 platformMultiCombobox.mobileShowAllItemsButton=Pokaži sve stavke
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Pokaži odabrane stavke
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 znak preko ograničenja
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Odaberi opcije',
         inputIconTitle: 'Odaberi opcije',
         mobileShowAllItemsButton: 'Pokaži sve stavke',
-        mobileShowSelectedItemsButton: 'Pokaži odabrane stavke'
+        mobileShowSelectedItemsButton: 'Pokaži odabrane stavke',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 znak preko ograničenja',

--- a/libs/i18n/src/lib/translations/translations_sk.properties
+++ b/libs/i18n/src/lib/translations/translations_sk.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Výber - možnosti
 platformMultiCombobox.mobileShowAllItemsButton=Zobraziť všetky položky
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Zobraziť vybrané položky
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=Počet znakov nad limit
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Výber - možnosti',
         inputIconTitle: 'Výber - možnosti',
         mobileShowAllItemsButton: 'Zobraziť všetky položky',
-        mobileShowSelectedItemsButton: 'Zobraziť vybrané položky'
+        mobileShowSelectedItemsButton: 'Zobraziť vybrané položky',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'Počet znakov nad limit',

--- a/libs/i18n/src/lib/translations/translations_sl.properties
+++ b/libs/i18n/src/lib/translations/translations_sl.properties
@@ -233,7 +233,7 @@ coreTime.periodLabel=Obdobje
 #XBUT: Label for the button that decreases the period (am/pm)
 coreTime.decreasePeriodLabel=Zmanjšanje obdobja
 #YACT: screen reader text explaining how the user can navigate and use the time picker with their keyboard.
-coreTime.navigationInstruction=Če se želite premikati med elementi na tem seznamu, pritisnite puščico zgoraj ali puščico spodaj. Za preklapljanje med seznami pritisnite levo puščico ali desno puščico. 
+coreTime.navigationInstruction=Če se želite premikati med elementi na tem seznamu, pritisnite puščico zgoraj ali puščico spodaj. Za preklapljanje med seznami pritisnite levo puščico ali desno puščico.
 #XFLD: Label for the time picker input.
 coreTimePicker.timePickerInputLabel=Vnos izbirnika časa
 #XBUT: Label for the button that opens the time picker.
@@ -275,7 +275,7 @@ platformApprovalFlow.prevButtonAriaLabel=Pojdi na prejšnji diapozitiv
 #XBUT: Text for the button that saves the form.
 platformApprovalFlow.editModeSaveButtonLabel=Shrani
 #XBUT: Text for the button that cancel editing the form.
-platformApprovalFlow.editModeExitButtonLabel=Izhod 
+platformApprovalFlow.editModeExitButtonLabel=Izhod
 #XHED: Text of the edit form.
 platformApprovalFlow.emptyTitle=Začnite dodajati odobritelje in opazovalce
 #XLGD: Edit form description.
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Izbira možnosti
 platformMultiCombobox.mobileShowAllItemsButton=Prikaz vseh elementov
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Prikaz izbranih elementov
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 znak, ki presega omejitev
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Izbira možnosti',
         inputIconTitle: 'Izbira možnosti',
         mobileShowAllItemsButton: 'Prikaz vseh elementov',
-        mobileShowSelectedItemsButton: 'Prikaz izbranih elementov'
+        mobileShowSelectedItemsButton: 'Prikaz izbranih elementov',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 znak, ki presega omejitev',

--- a/libs/i18n/src/lib/translations/translations_sq.properties
+++ b/libs/i18n/src/lib/translations/translations_sq.properties
@@ -256,6 +256,7 @@ platformMultiCombobox.inputGlyphAriaLabel = Zgjidhni Opsionet
 platformMultiCombobox.inputIconTitle = Zgjidhni Opsionet
 platformMultiCombobox.mobileShowAllItemsButton = Shfaq të gjithë artikujt
 platformMultiCombobox.mobileShowSelectedItemsButton = Shfaq artikujt e zgjedhur
+platformMultiCombobox.invalidEntryError = Invalid Entry
 platformTextarea.counterMessageCharactersOverTheLimitSingular = 1 karakter mbi limitin
 platformTextarea.counterMessageCharactersOverTheLimitPlural = {count} karaktere mbi limitin
 platformTextarea.counterMessageCharactersRemainingSingular = 1 karakter i mbetur

--- a/libs/i18n/src/lib/translations/translations_sq.ts
+++ b/libs/i18n/src/lib/translations/translations_sq.ts
@@ -330,7 +330,8 @@ export default {
         inputGlyphAriaLabel: 'Zgjidhni Opsionet',
         inputIconTitle: 'Zgjidhni Opsionet',
         mobileShowAllItemsButton: 'Shfaq të gjithë artikujt',
-        mobileShowSelectedItemsButton: 'Shfaq artikujt e zgjedhur'
+        mobileShowSelectedItemsButton: 'Shfaq artikujt e zgjedhur',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 karakter mbi limitin',

--- a/libs/i18n/src/lib/translations/translations_sv.properties
+++ b/libs/i18n/src/lib/translations/translations_sv.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Välj alternativ
 platformMultiCombobox.mobileShowAllItemsButton=Visa alla artiklar
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Visa valda artiklar
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=1 tecken över gränsen
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'Välj alternativ',
         inputIconTitle: 'Välj alternativ',
         mobileShowAllItemsButton: 'Visa alla artiklar',
-        mobileShowSelectedItemsButton: 'Visa valda artiklar'
+        mobileShowSelectedItemsButton: 'Visa valda artiklar',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '1 tecken över gränsen',

--- a/libs/i18n/src/lib/translations/translations_th.properties
+++ b/libs/i18n/src/lib/translations/translations_th.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=เลือกตัวเลือก
 platformMultiCombobox.mobileShowAllItemsButton=แสดงไอเท็มทั้งหมด
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=แสดงไอเท็มที่เลือก
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=เกินขีดจำกัด 1 อักขระ
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -329,7 +329,8 @@ export default {
         inputGlyphAriaLabel: 'เลือกตัวเลือก',
         inputIconTitle: 'เลือกตัวเลือก',
         mobileShowAllItemsButton: 'แสดงไอเท็มทั้งหมด',
-        mobileShowSelectedItemsButton: 'แสดงไอเท็มที่เลือก'
+        mobileShowSelectedItemsButton: 'แสดงไอเท็มที่เลือก',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'เกินขีดจำกัด 1 อักขระ',

--- a/libs/i18n/src/lib/translations/translations_tr.properties
+++ b/libs/i18n/src/lib/translations/translations_tr.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=Seçenekleri Belirle
 platformMultiCombobox.mobileShowAllItemsButton=Tüm öğeleri göster
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=Seçilen öğeleri göster
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=Limitin 1 karakter üzerinde
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -330,7 +330,8 @@ export default {
         inputGlyphAriaLabel: 'Seçenekleri Belirle',
         inputIconTitle: 'Seçenekleri Belirle',
         mobileShowAllItemsButton: 'Tüm öğeleri göster',
-        mobileShowSelectedItemsButton: 'Seçilen öğeleri göster'
+        mobileShowSelectedItemsButton: 'Seçilen öğeleri göster',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'Limitin 1 karakter üzerinde',

--- a/libs/i18n/src/lib/translations/translations_uk.properties
+++ b/libs/i18n/src/lib/translations/translations_uk.properties
@@ -256,6 +256,7 @@ platformMultiCombobox.inputGlyphAriaLabel = Вибрати опції
 platformMultiCombobox.inputIconTitle = Вибрати опції
 platformMultiCombobox.mobileShowAllItemsButton = Показати всі елементи
 platformMultiCombobox.mobileShowSelectedItemsButton = Показати вибрані елементи
+platformMultiCombobox.invalidEntryError = Invalid Entry
 platformTextarea.counterMessageCharactersOverTheLimitSingular = Перевищено ліміт на 1 символ
 platformTextarea.counterMessageCharactersOverTheLimitPlural = Перевищено ліміт на { count, plural, one {1 символ} few {\# символи} other {\# символів} }
 platformTextarea.counterMessageCharactersRemainingSingular = Залишився 1 символ

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -334,7 +334,8 @@ export default {
         inputGlyphAriaLabel: 'Вибрати опції',
         inputIconTitle: 'Вибрати опції',
         mobileShowAllItemsButton: 'Показати всі елементи',
-        mobileShowSelectedItemsButton: 'Показати вибрані елементи'
+        mobileShowSelectedItemsButton: 'Показати вибрані елементи',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: 'Перевищено ліміт на 1 символ',

--- a/libs/i18n/src/lib/translations/translations_zh_CN.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=选择选项
 platformMultiCombobox.mobileShowAllItemsButton=显示所有项目
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=显示所选项目
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=超出限制 1 个字符
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -327,7 +327,8 @@ export default {
         inputGlyphAriaLabel: '选择选项',
         inputIconTitle: '选择选项',
         mobileShowAllItemsButton: '显示所有项目',
-        mobileShowSelectedItemsButton: '显示所选项目'
+        mobileShowSelectedItemsButton: '显示所选项目',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '超出限制 1 个字符',

--- a/libs/i18n/src/lib/translations/translations_zh_TW.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.properties
@@ -512,6 +512,8 @@ platformMultiCombobox.inputIconTitle=選擇選項
 platformMultiCombobox.mobileShowAllItemsButton=顯示所有項目
 #XACT: Text for the title attribute of the button representing 'Show selected items' of Platform Multi-Combobox input group
 platformMultiCombobox.mobileShowSelectedItemsButton=顯示所選項目
+#XMSG: Text for error message when the user enters an invalid entry.
+platformMultiCombobox.invalidEntryError = Invalid Entry
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by 1 character
 platformTextarea.counterMessageCharactersOverTheLimitSingular=超過上限 1 個字元
 #XMSG: Message displayed under the Platform Textarea when the max length is exceeded by multiple characters

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -327,7 +327,8 @@ export default {
         inputGlyphAriaLabel: '選擇選項',
         inputIconTitle: '選擇選項',
         mobileShowAllItemsButton: '顯示所有項目',
-        mobileShowSelectedItemsButton: '顯示所選項目'
+        mobileShowSelectedItemsButton: '顯示所選項目',
+        invalidEntryError: 'Invalid Entry'
     },
     platformTextarea: {
         counterMessageCharactersOverTheLimitSingular: '超過上限 1 個字元',

--- a/libs/platform/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/form/multi-combobox/commons/base-multi-combobox.ts
@@ -65,6 +65,7 @@ import {
 } from '@fundamental-ngx/platform/shared';
 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FD_LANGUAGE, FdLanguage, TranslationResolver } from '@fundamental-ngx/i18n';
 import { TextAlignment } from '../../combobox';
 import { MultiComboboxConfig } from '../multi-combobox.config';
 
@@ -192,9 +193,12 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
     @Input()
     addonIconTitle: string;
 
-    /** Sets invalid entry message. */
+    /**
+     * @deprecated Use the i18n module to modify the translation for this string.
+     * Sets invalid entry message.
+     * */
     @Input()
-    invalidEntryMessage = 'Invalid entry';
+    invalidEntryMessage: Nullable<string>;
 
     /** Turns limitless mode, ON or OFF */
     @Input()
@@ -391,6 +395,12 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
     private readonly _mapLimit = inject(MAP_LIMIT);
 
     /** @hidden */
+    private readonly _lang$ = inject(FD_LANGUAGE);
+
+    /** @hidden */
+    private _translationResolver = new TranslationResolver();
+
+    /** @hidden */
     protected constructor() {
         super();
         this._contentDensity = this.multiComboboxConfig.contentDensity;
@@ -410,6 +420,14 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
         this._initWindowResize();
         this._assignCustomTemplates();
         this._previousInputText = this.inputText;
+        this._subscriptions.add(
+            this._lang$.subscribe((lang: FdLanguage) => {
+                this.invalidEntryMessage = this._translationResolver.resolve(
+                    lang,
+                    'platformMultiCombobox.invalidEntryError'
+                );
+            })
+        );
         super.ngAfterViewInit();
     }
 


### PR DESCRIPTION
part of #12336 

This sets up the "Invalid Entry" message for translation, however we still need translations for each language from SAP