### PR TITLE
fix(platform): add border to Toolbar in all types of Platfrm table

### DIFF
--- a/libs/platform/table/components/table-toolbar/table-toolbar.component.html
+++ b/libs/platform/table/components/table-toolbar/table-toolbar.component.html
@@ -9,7 +9,6 @@
 >
     <fd-toolbar
         fdType="transparent"
-        [clearBorder]="true"
         [titleId]="tableToolbarTitleId"
         [title]="title && !hideItemCount ? title + ' (' + counter() + ')' : title"
         [shouldOverflow]="shouldOverflow"

--- a/libs/platform/table/table.component.scss
+++ b/libs/platform/table/table.component.scss
@@ -328,6 +328,10 @@ fdk-dynamic-portal {
             vertical-align: text-bottom;
             max-width: 100%;
         }
+
+        th.fd-table__cell {
+            border-block-start: none;
+        }
     }
 
     &__body {


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/12408

## Description
By design specs, the Toolbar in Table should have border bottom. Currently, this border is visible in most cases because the table header cells have borders all around. In the case of **noOuterBorders**, the lack of border bottom in Toolbar is causing discrepancy with the design. 
- removed the property that hides the border of the Toolbar
- removed the top border of table header cells as it was causing "double" border effect.