### PR TITLE
fix(platform): fdp-table  Enhance the <fdp-table-p13-dialog [table]="table"> component to emit an event with the selected column

### DIFF
--- a/libs/docs/platform/table/examples/platform-table-p13-columns-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-p13-columns-example.component.html
@@ -13,4 +13,4 @@
 </fdp-table>
 
 <!-- Connect P13 Dialog to the table -->
-<fdp-table-p13-dialog (closeDialog)="handleDialogClose($event)" [table]="table"></fdp-table-p13-dialog>
+<fdp-table-p13-dialog (dialogClosed)="handleDialogClose($event)" [table]="table"></fdp-table-p13-dialog>

--- a/libs/docs/platform/table/examples/platform-table-p13-columns-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-p13-columns-example.component.html
@@ -13,4 +13,4 @@
 </fdp-table>
 
 <!-- Connect P13 Dialog to the table -->
-<fdp-table-p13-dialog [table]="table"></fdp-table-p13-dialog>
+<fdp-table-p13-dialog (closeDialog)="handleDialogClose($event)" [table]="table"></fdp-table-p13-dialog>

--- a/libs/docs/platform/table/examples/platform-table-p13-columns-example.component.ts
+++ b/libs/docs/platform/table/examples/platform-table-p13-columns-example.component.ts
@@ -29,6 +29,10 @@ export class PlatformTableP13ColumnsExampleComponent {
     constructor() {
         this.source = new TableDataSource(new TableDataProviderExample());
     }
+
+    handleDialogClose(visibleColumns: string[]) {
+        console.log(visibleColumns);
+    }
 }
 
 export interface ExampleItem {

--- a/libs/platform/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -88,7 +88,7 @@ export class TableP13DialogComponent implements OnDestroy {
 
     /** Event emitted when dialog is closed. */
     @Output()
-    closeDialog = new EventEmitter<string[]>();
+    dialogClosed = new EventEmitter<string[]>();
 
     /** @hidden */
     @ContentChild(TableP13SortComponent)
@@ -267,7 +267,7 @@ export class TableP13DialogComponent implements OnDestroy {
             this._dialogRef.afterClosed
                 .pipe(filter((result) => !!result))
                 .subscribe(({ visibleColumns: result }: ColumnsDialogResultData) => {
-                    this.closeDialog.emit(result);
+                    this.dialogClosed.emit(result);
                     this._applyColumns(result);
                 })
         );

--- a/libs/platform/table/components/table-p13-dialog/table-p13-dialog.component.ts
+++ b/libs/platform/table/components/table-p13-dialog/table-p13-dialog.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, ContentChild, Input, OnDestroy } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    ContentChild,
+    EventEmitter,
+    Input,
+    OnDestroy,
+    Output
+} from '@angular/core';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -77,6 +85,10 @@ export class TableP13DialogComponent implements OnDestroy {
     get table(): Table {
         return this._table;
     }
+
+    /** Event emitted when dialog is closed. */
+    @Output()
+    closeDialog = new EventEmitter<string[]>();
 
     /** @hidden */
     @ContentChild(TableP13SortComponent)
@@ -255,6 +267,7 @@ export class TableP13DialogComponent implements OnDestroy {
             this._dialogRef.afterClosed
                 .pipe(filter((result) => !!result))
                 .subscribe(({ visibleColumns: result }: ColumnsDialogResultData) => {
+                    this.closeDialog.emit(result);
                     this._applyColumns(result);
                 })
         );


### PR DESCRIPTION
closes [#12293](https://github.com/SAP/fundamental-ngx/issues/12293)

## Description
- Enhance the <fdp-table-p13-dialog [table]="table"></fdp-table-p13-dialog> component to emit an event with the selected column details when the OK button is clicked in the dialog.
- This allows the application to subscribe to this event and persist the user’s selected columns.