### PR TITLE
fix(core) add proper spacings for facets in Dynamic Page

### DIFF
--- a/libs/core/dynamic-page/dynamic-page.component.scss
+++ b/libs/core/dynamic-page/dynamic-page.component.scss
@@ -82,9 +82,19 @@
 
     .fd-dynamic-page__title-container {
         align-items: center;
+
+        .fd-facet.fd-facet--image {
+            margin-inline-end: 1rem;
+        }
     }
 }
 
 .fd-dynamic-page__collapsible-header:empty {
     padding: 0 !important;
+}
+
+.fd-dynamic-page .fd-dynamic-page__title-container {
+    .fd-facet.fd-facet--image {
+        margin-inline-end: 1rem;
+    }
 }

--- a/libs/core/facets/facet-group.component.scss
+++ b/libs/core/facets/facet-group.component.scss
@@ -6,3 +6,7 @@
     flex-direction: column;
     align-items: flex-end;
 }
+
+.fd-title.fd-margin-bottom--sm {
+    margin-block-end: 1rem;
+}


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes https://github.com/SAP/fundamental-ngx/issues/12357

## Description
- when the Dynamic Page header is collapsed the Avatar should have 1 rem margin right
- the spacing between Facet title and the content should be 1rem