### PR TITLE
fix(core): address some Dynamic Page header issues

### DIFF
--- a/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
+++ b/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
@@ -9,8 +9,8 @@
     >
         <ng-content></ng-content>
     </section>
-    <div class="fd-dynamic-page__collapsible-header-visibility-container" #pincollapseContainer>
-        @if (collapsible) {
+    @if (collapsible) {
+        <div class="fd-dynamic-page__collapsible-header-visibility-container" #pincollapseContainer>
             <div class="fd-dynamic-page__collapsible-header-visibility-container--left-gradient"></div>
             <div role="toolbar" class="fd-dynamic-page__collapsible-header-visibility-container--button-group">
                 <button
@@ -39,6 +39,6 @@
                 }
             </div>
             <div class="fd-dynamic-page__collapsible-header-visibility-container--right-gradient"></div>
-        }
-    </div>
+        </div>
+    }
 </div>

--- a/libs/core/dynamic-page/dynamic-page.component.scss
+++ b/libs/core/dynamic-page/dynamic-page.component.scss
@@ -93,8 +93,18 @@
     padding: 0 !important;
 }
 
+.fd-dynamic-page__collapsible-header:has(.fd-has-display-none) {
+    padding-block: 0;
+    padding-inline: 0;
+}
+
 .fd-dynamic-page .fd-dynamic-page__title-container {
     .fd-facet.fd-facet--image {
         margin-inline-end: 1rem;
     }
+}
+
+.fd-dynamic-page__header.fd-dynamic-page__header--not-collapsible {
+    position: relative;
+    box-shadow: var(--sapContent_HeaderShadow);
 }

--- a/libs/docs/core/dynamic-page/examples/dynamic-page-routing/dynamic-page-routing-example.component.html
+++ b/libs/docs/core/dynamic-page/examples/dynamic-page-routing/dynamic-page-routing-example.component.html
@@ -68,13 +68,10 @@
                     </fd-toolbar>
                 </fd-dynamic-page-layout-actions>
             </fd-dynamic-page-header>
-            <fd-dynamic-page-subheader [collapsible]="true" [pinnable]="true" [collapsed]="false">
-                <!-- collapsible header content goes here -->
-                <span
-                    >Lorem ipsum, dolor sit amet consectetur adipisicing elit. Ullam possimus corrupti architecto
-                    perspiciatis, delectus necessitatibus incidunt numquam asperiores tenetur iure. Cum consequuntur
-                    impedit repellendus esse, facere autem optio consequatur nobis?</span
-                >
+            <fd-dynamic-page-subheader [collapsible]="false" [pinnable]="false" [collapsed]="false">
+                <fd-message-strip type="success" [dismissible]="true">
+                    A dismissible success message strip.
+                </fd-message-strip>
             </fd-dynamic-page-subheader>
             <fdp-icon-tab-bar
                 [tabsConfig]="tabsConfig"

--- a/libs/docs/core/dynamic-page/examples/dynamic-page-routing/dynamic-page-routing-example.component.ts
+++ b/libs/docs/core/dynamic-page/examples/dynamic-page-routing/dynamic-page-routing-example.component.ts
@@ -9,6 +9,7 @@ import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityDirective } from '@fundamental-ngx/core/content-density';
 import { DynamicPageModule } from '@fundamental-ngx/core/dynamic-page';
 import { LinkComponent } from '@fundamental-ngx/core/link';
+import { MessageStripModule } from '@fundamental-ngx/core/message-strip';
 import { MessageToastModule, MessageToastService } from '@fundamental-ngx/core/message-toast';
 import { ToolbarComponent, ToolbarItemDirective, ToolbarSeparatorComponent } from '@fundamental-ngx/core/toolbar';
 import { FDP_ICON_TAB_BAR, IconTabBarItem, TabConfig } from '@fundamental-ngx/platform/icon-tab-bar';
@@ -56,7 +57,8 @@ export class DummyComponent {
         BarModule,
         MessageToastModule,
         RouterLink,
-        RouterOutlet
+        RouterOutlet,
+        MessageStripModule
     ],
     templateUrl: './dynamic-page-routing-example.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes https://github.com/SAP/fundamental-ngx/issues/10550
closes https://github.com/SAP/fundamental-ngx/issues/12411
 
## Description
- when Message strip is dismissed, the element is still present in the DOM and for this reason the container ignores the CSS that checks for empty container. Now we set the padding to 0 when the container has class `.fd-has-display-none`. This will remove the extra spacing when Message Strip is dismissed (issue 12411)
- the div element with class `fd-dynamic-page__collapsible-header-visibility-container` is displayed even if there's no content inside. This is due to having the if condition inside the div, not outside. With the current fix, if there's collapsible content only then this container is rendered. The "border" that appears when collapsible is set to false now don't appear (issue 10550)

To test the fixes go to Dynamic Page component => Routing inside Dynamic Page example
![Screenshot 2024-09-18 at 3 25 47 PM](https://github.com/user-attachments/assets/be8b8fd2-3bf9-44fb-a02e-ada669f9a081)
![Screenshot 2024-09-18 at 3 25 56 PM](https://github.com/user-attachments/assets/87970540-7de3-46b6-91b3-5afd5cdbdea3)


