### PR TITLE
chore: multi combobox. Empty dataSource leads to initially invalid fo…

### DIFF
--- a/libs/cdk/forms/cva/cva.directive.ts
+++ b/libs/cdk/forms/cva/cva.directive.ts
@@ -196,7 +196,7 @@ export class CvaDirective<T = any>
             return 'default';
         }
 
-        return this.formField?.getPriorityState() || 'error';
+        return this.formField?.getPriorityState() || 'default';
     });
 
     /**

--- a/libs/core/multi-combobox/base-multi-combobox.class.ts
+++ b/libs/core/multi-combobox/base-multi-combobox.class.ts
@@ -537,13 +537,18 @@ export abstract class BaseMultiCombobox<T = any> {
 
     /** @hidden */
     protected _processingEmptyData(): void {
-        this.inputText = this._previousInputText;
-
-        this._setInvalidEntry();
-
-        if (this._timerSub$) {
-            this._timerSub$.unsubscribe();
+        if (this._cva.disabled) {
+            return;
         }
+
+        if (this._cva.controlInvalid && this._cva.ngControl?.hasError) {
+            this._setInvalidEntry();
+
+            if (this._timerSub$) {
+                this._timerSub$.unsubscribe();
+            }
+        }
+        this.inputText = this._previousInputText;
 
         this._timerSub$ = timer(this.invalidEntryDisplayTime).subscribe(() => this._unsetInvalidEntry());
 


### PR DESCRIPTION
chore: multi combobox. Empty dataSource leads to initially invalid fo…

closes [#12427](https://github.com/SAP/fundamental-ngx/issues/12427)

## Description
- Fix formField priority state fallback value in CvaDirective

https://github.com/user-attachments/assets/6395fc70-9aca-4108-aa83-eb12a8781cfd