### PR TITLE
fix(platform): virtual scroll should account for popping columns

### DIFF
--- a/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.html
+++ b/libs/docs/platform/table/child-docs/scrolling/table-scrolling-docs.component.html
@@ -32,8 +32,8 @@
     <li><code>[virtualScroll]="true"</code> - enables virtual scroll</li>
     <li><code>[bodyHeight]="value"</code> - sets the height of the table body (viewport)</li>
     <li>
-        <code>[rowHeight]="value"</code> - sets the height of the table row if it is different from default for the
-        current content density
+        <code>[rowHeight]="value"</code> - sets the minimum height of the table row if it is different from default for
+        the current content density
     </li>
 </ul>
 
@@ -41,6 +41,20 @@
     Additionally, you may set the <code>renderAhead</code> input property to specify how many rows should be rendered
     ahead of the current viewport. Default is 20. Or control the table <code>state</code> on the application level to
     control for example a scrolling position so it can be properly restored.
+</p>
+
+<p>
+    Note that all rows must be of the same height in order for virtual scrolling to perform well. As mentioned before,
+    you can set the minimum height with the <code>[rowHeight]</code> input. When using <code>popping</code> columns on
+    smaller width screens, it is recommended to provide a pixel value to the <code>[secondaryRowHeight]</code> input.
+    This input works similarly to <code>[rowHeight]</code> but instead applies to the popping column data that is placed
+    beneath the original row.
+    <br />
+    It is imperative that cells in the popping columns are all the same height as well. If the data loaded in to the
+    cells causes their contents to exceed the height of <code>[rowHeight]</code> or <code>[secondaryRowHeight]</code>,
+    and therefore causing the heights of rows to differ, we recommend using <code>*fdpEditableCellDef</code> or
+    <code>*fdpCellDef</code> to define custom cell templates that will make the contents of the cell fit more
+    predictably.
 </p>
 <description> </description>
 <component-example>

--- a/libs/platform/table-helpers/directives/table-virtual-scroll.directive.ts
+++ b/libs/platform/table-helpers/directives/table-virtual-scroll.directive.ts
@@ -5,6 +5,7 @@ import { BehaviorSubject, filter } from 'rxjs';
 import { FDP_TABLE_VIRTUAL_SCROLL_DIRECTIVE, ROW_HEIGHT } from '../constants';
 import { TableVirtualScroll } from '../models';
 import { TableScrollDispatcherService } from '../services/table-scroll-dispatcher.service';
+import { TableService } from '../services/table.service';
 import { Table } from '../table';
 
 @Directive({
@@ -59,6 +60,11 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
     private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
+    constructor(readonly _tableService: TableService) {
+        super();
+    }
+
+    /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
         if (!this._table.tableScrollable) {
             return;
@@ -81,7 +87,14 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
             return;
         }
 
-        const rowHeight = this.rowHeight + 1;
+        let rowHeight = this.rowHeight + 1;
+
+        if (this._tableService.poppingColumns$().length > 0) {
+            rowHeight =
+                rowHeight +
+                this._table.tableContainer.nativeElement.getElementsByClassName('fd-table__row--secondary')[0]
+                    .clientHeight;
+        }
 
         const rowsVisible = this._table._tableRowsVisible;
         const currentlyRenderedRows = this._table.getCurrentlyRenderedRows();

--- a/libs/platform/table-helpers/directives/table-virtual-scroll.directive.ts
+++ b/libs/platform/table-helpers/directives/table-virtual-scroll.directive.ts
@@ -35,11 +35,17 @@ export class TableVirtualScrollDirective extends TableVirtualScroll implements O
     bodyHeight: string;
 
     /**
-     * Height of the row, required for the virtualScroll,
+     * Minimum height of the row, required for the virtualScroll,
      * default is 44px in cozy, 32px in compact and 24px in condensed (set automatically)
      */
     @Input()
     rowHeight = ROW_HEIGHT.get(ContentDensityMode.COZY)!;
+
+    /**
+     * Minimum height of the popping column when displayed in pop-in mode. Required when using popping columns and virtual scroll.
+     */
+    @Input()
+    secondaryRowHeight: number | undefined;
 
     /** @hidden */
     virtualScrollTotalHeight = 0;

--- a/libs/platform/table-helpers/models/directives.ts
+++ b/libs/platform/table-helpers/models/directives.ts
@@ -34,6 +34,7 @@ export abstract class TableInitialState {
 
 export abstract class TableVirtualScroll {
     abstract rowHeight: number;
+    abstract secondaryRowHeight: number | undefined;
     abstract virtualScrollTransform$: Observable<number>;
     abstract virtualScroll: boolean;
     abstract virtualScrollTotalHeight: number;

--- a/libs/platform/table/table.component.html
+++ b/libs/platform/table/table.component.html
@@ -130,6 +130,7 @@
                                 <tr
                                     fdp-table-popping-row
                                     [secondary]="true"
+                                    [style.height.px]="secondaryRowHeight"
                                     [selectionMode]="selectionMode"
                                     [row]="row"
                                     [checked]="row.checked"

--- a/libs/platform/table/table.component.scss
+++ b/libs/platform/table/table.component.scss
@@ -492,6 +492,10 @@ fdk-dynamic-portal {
             .fd-table__row--secondary {
                 .fd-table__cell {
                     border-bottom: var(--sapList_BorderWidth) solid var(--sapList_BorderColor);
+
+                    .fd-table__text {
+                        white-space: nowrap !important;
+                    }
                 }
             }
 

--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -397,11 +397,16 @@ export class TableComponent<T = any>
     @Input()
     expandOnInit = false;
     /**
-     * Height of the row, required for the virtualScroll,
+     * Minimum height of the row, required for the virtualScroll,
      * default is 44px in cozy, 32px in compact and 24px in condensed (set automatically)
      */
     @Input()
     rowHeight = ROW_HEIGHT.get(ContentDensityMode.COZY)!;
+    /**
+     * Minimum height of the popping column when displayed in pop-in mode. Required when using popping columns and virtual scroll.
+     */
+    @Input()
+    secondaryRowHeight: number | undefined;
     /** Event emitted when the current preset configuration has been changed. */
     /**
      * Whether to load previous pages.
@@ -2006,6 +2011,7 @@ export class TableComponent<T = any>
                     this.rowHeight = ROW_HEIGHT.get(contentDensity) ?? ROW_HEIGHT.get(ContentDensityMode.COZY)!;
                     if (this._virtualScrollDirective?.virtualScroll) {
                         this._virtualScrollDirective.rowHeight = this.rowHeight;
+                        this._virtualScrollDirective.secondaryRowHeight = this.secondaryRowHeight;
                         this._virtualScrollDirective.calculateVirtualScrollRows();
                     }
                 })


### PR DESCRIPTION
fixes #12263 

Updates virtual scroll logic to cooperate with "popping" columns on small screens. Also adds a new input `[secondaryRowHeight]` which behaves similarly to `[rowHeight]`, but for the popping columns which are moved into the first column when the screen is set to a small width. Additionally, this PR updates the docs to explain that `[rowHeight]` (as well as `[secondaryRowHeight]`) behaves more like a minimum height, rather than a height. More on that [here](https://github.com/SAP/fundamental-ngx/issues/12475). Lastly, some more updates to the virtual scrolling docs stressing the importance that each row must be of the same height for virtual scrolling to behave smoothly.