### PR TITLE
fix(core): avatar group rendering/width calculation

### DIFF
--- a/libs/core/avatar-group/directives/avatar-group-item-renderer.directive.ts
+++ b/libs/core/avatar-group/directives/avatar-group-item-renderer.directive.ts
@@ -56,13 +56,19 @@ export class AvatarGroupItemRendererDirective implements OnInit, FocusableItem {
      **/
     get width(): number {
         if (this.visible) {
-            this._lastSavedWidth =
-                this.element.getBoundingClientRect().width +
-                parseFloat(getComputedStyle(this.element).marginLeft) +
-                parseFloat(getComputedStyle(this.element).marginRight);
+            const rect = this.element.getBoundingClientRect();
+            const style = getComputedStyle(this.element);
+            const width = rect.width;
+            const marginLeft = parseFloat(style.marginLeft);
+            const marginRight = parseFloat(style.marginRight);
+
+            if (!isNaN(width) && !isNaN(marginLeft) && !isNaN(marginRight)) {
+                this._lastSavedWidth = width + marginLeft + marginRight;
+            }
         }
         return this._lastSavedWidth;
     }
+
 
     /**
      * Rendered element's height or it's last saved height.

--- a/libs/core/avatar-group/directives/avatar-group-item-renderer.directive.ts
+++ b/libs/core/avatar-group/directives/avatar-group-item-renderer.directive.ts
@@ -69,7 +69,6 @@ export class AvatarGroupItemRendererDirective implements OnInit, FocusableItem {
         return this._lastSavedWidth;
     }
 
-
     /**
      * Rendered element's height or it's last saved height.
      **/


### PR DESCRIPTION
fix(core): avatar group rendering/width calculation

closes [#12400](https://github.com/SAP/fundamental-ngx/issues/12400)

## Description
- Fixed the  problem where users were unable to see the avatar group items

## Media

### Before

[Old.webm](https://github.com/user-attachments/assets/dbfa1870-9c6c-4c3d-bd65-4f3e193ed735)

### After

[new.webm](https://github.com/user-attachments/assets/7408036d-2bbe-41a6-88ad-925c6b143bbf)
