### PR TITLE
fix(core): Message strip alert complete

### DIFF
--- a/libs/core/message-strip/alert/message-strip-alert.service.ts
+++ b/libs/core/message-strip/alert/message-strip-alert.service.ts
@@ -118,6 +118,7 @@ export class MessageStripAlertService {
                                             config.messageStrip.onDismiss &&
                                             config.messageStrip.onDismiss();
                                         onDismiss$.next();
+                                        onDismiss$.complete();
                                     }
                                 }
                             }

--- a/libs/docs/core/message-strip/examples/message-strip-auto-dismiss-example.component.ts
+++ b/libs/docs/core/message-strip/examples/message-strip-auto-dismiss-example.component.ts
@@ -1,6 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnDestroy } from '@angular/core';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import { AutoDismissMessageStripDirective, MessageStripComponent } from '@fundamental-ngx/core/message-strip';
+import {
+    AutoDismissMessageStripDirective,
+    MessageStripAlertService,
+    MessageStripComponent
+} from '@fundamental-ngx/core/message-strip';
 
 @Component({
     selector: 'fd-message-strip-auto-dismiss-example',
@@ -15,9 +19,37 @@ import { AutoDismissMessageStripDirective, MessageStripComponent } from '@fundam
             Will be auto dismissed in 5 seconds, if mouse will not be over the message strip. If it's over it, then it
             will be dismissed in 5 seconds after mouse leaves.
         </fd-message-strip>
-        <button fd-button (click)="messageStripComponent.open()">Open message strip</button>
+        <button fd-button (click)="onClick()">Open message strip</button>
     `,
     standalone: true,
     imports: [MessageStripComponent, AutoDismissMessageStripDirective, ButtonComponent]
 })
-export class MessageStripAutoDismissExampleComponent {}
+export class MessageStripAutoDismissExampleComponent implements OnDestroy {
+    private _msgStripService = inject(MessageStripAlertService);
+
+    ngOnDestroy(): void {
+        console.log('destroyed');
+    }
+
+    onClick() {
+        const ref = this._msgStripService.open({
+            position: 'bottom-middle',
+            content: 'Message from the future',
+            closeOnNavigation: true,
+            messageStrip: {
+                duration: 2000,
+                mousePersist: true,
+                type: 'error',
+                dismissible: true
+            }
+        });
+        ref.onDismiss$.subscribe({
+            next: () => {
+                console.log('dismissed alright ');
+            },
+            complete: () => {
+                console.log('completed dismiss');
+            }
+        });
+    }
+}

--- a/libs/docs/core/message-strip/examples/message-strip-auto-dismiss-example.component.ts
+++ b/libs/docs/core/message-strip/examples/message-strip-auto-dismiss-example.component.ts
@@ -1,10 +1,6 @@
-import { Component, inject, OnDestroy } from '@angular/core';
+import { Component } from '@angular/core';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
-import {
-    AutoDismissMessageStripDirective,
-    MessageStripAlertService,
-    MessageStripComponent
-} from '@fundamental-ngx/core/message-strip';
+import { AutoDismissMessageStripDirective, MessageStripComponent } from '@fundamental-ngx/core/message-strip';
 
 @Component({
     selector: 'fd-message-strip-auto-dismiss-example',
@@ -19,37 +15,9 @@ import {
             Will be auto dismissed in 5 seconds, if mouse will not be over the message strip. If it's over it, then it
             will be dismissed in 5 seconds after mouse leaves.
         </fd-message-strip>
-        <button fd-button (click)="onClick()">Open message strip</button>
+        <button fd-button (click)="messageStripComponent.open()">Open message strip</button>
     `,
     standalone: true,
     imports: [MessageStripComponent, AutoDismissMessageStripDirective, ButtonComponent]
 })
-export class MessageStripAutoDismissExampleComponent implements OnDestroy {
-    private _msgStripService = inject(MessageStripAlertService);
-
-    ngOnDestroy(): void {
-        console.log('destroyed');
-    }
-
-    onClick() {
-        const ref = this._msgStripService.open({
-            position: 'bottom-middle',
-            content: 'Message from the future',
-            closeOnNavigation: true,
-            messageStrip: {
-                duration: 2000,
-                mousePersist: true,
-                type: 'error',
-                dismissible: true
-            }
-        });
-        ref.onDismiss$.subscribe({
-            next: () => {
-                console.log('dismissed alright ');
-            },
-            complete: () => {
-                console.log('completed dismiss');
-            }
-        });
-    }
-}
+export class MessageStripAutoDismissExampleComponent {}


### PR DESCRIPTION
## Description
One-off Observable never completes, only if `ref.dismiss()` is called on the alert reference directly.

### Before:
![image](https://github.com/user-attachments/assets/bc35c8a8-9145-4000-b7f4-92a0ccebea87)

### After:
![image](https://github.com/user-attachments/assets/0742b9c0-e6df-4651-a348-e15fb91a94a7)


First commit contains reproduction for the above images 👆 


