### PR TITLE
fix(platform): Recheck loadingState before refocus table cell

### DIFF
--- a/libs/platform/src/lib/table/table.component.ts
+++ b/libs/platform/src/lib/table/table.component.ts
@@ -2211,7 +2211,7 @@ export class TableComponent<T = any>
         this._subscriptions.add(
             this._tableService.tableLoading$.pipe(filter((loadingState) => !loadingState)).subscribe(() => {
                 setTimeout(() => {
-                    if (this._tableHeaderResizer.focusedCellPosition && this._focusableGrid) {
+                    if (this._tableHeaderResizer.focusedCellPosition && this._focusableGrid && !this.loadingState) {
                         this._focusableGrid.focusCell(this._tableHeaderResizer.focusedCellPosition);
                     }
                 });


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes https://github.com/SAP/fundamental-ngx/issues/12450

## Description

<!-- Enter short description of the change -->

Issue: We have a listener on tableLoading to perform cell refocus whenever `loadingState` is false. However, this is executed asynchronously in `setTimeout`. Since table loading can be triggered either from internal or provided by application through `[loading]`, there is a chance that it still runs when `loadingState` is true. For example, `loadingState` is set true from application when fetching the table and busy indicator is displayed on UI and `scrollIntoView` from `focusCell` will use busy indicator instead of table for position recalculation which gives the wrong position to scroll the table.

Solution: Add `loadingState` recheck to ensure that the code is only run when table is not loading.