### PR TITLE
fix(core, platform): add option to make individual Table header cells non-interactive

### DIFF
--- a/libs/core/table/directives/table-cell.directive.ts
+++ b/libs/core/table/directives/table-cell.directive.ts
@@ -67,6 +67,11 @@ export class TableCellDirective extends FocusableItemDirective implements AfterC
     @Input()
     noData = false;
 
+    /** Whether the table cell inside table header should be non-interactive */
+    @HostBinding('class.fd-table__cell--non-interactive')
+    @Input()
+    nonInteractive = false;
+
     /** Key of a cell element, it's used to identify this cell with certain column */
     @Input()
     key: string;

--- a/libs/core/table/table.component.scss
+++ b/libs/core/table/table.component.scss
@@ -17,3 +17,17 @@
 .fd-table__cell--focusable[aria-selected='true']:after {
     border-color: var(--sapContent_FocusColor) !important;
 }
+
+.fd-table__header .fd-table__cell.fd-table__cell--non-interactive {
+    &:hover,
+    &.is-hover {
+        background-color: var(--sapList_HeaderBackground);
+        color: var(--sapList_HeaderTextColor);
+    }
+
+    &:active,
+    &.is-active {
+        background-color: var(--sapList_HeaderBackground);
+        color: var(--sapList_HeaderTextColor);
+    }
+}

--- a/libs/docs/core/table/examples/table-example.component.html
+++ b/libs/docs/core/table/examples/table-example.component.html
@@ -32,6 +32,41 @@
 </table>
 
 <br /><br />
+<h4>individual non-interactive header cells</h4>
+<table fd-table aria-label="Default">
+    <thead fd-table-header>
+        <tr fd-table-row>
+            <th fd-table-cell [nonInteractive]="true">Non-interactive Column Header</th>
+            <th fd-table-cell>Column Header</th>
+            <th fd-table-cell>Column Header</th>
+            <th fd-table-cell>Column Header</th>
+            <th fd-table-cell [nonInteractive]="true">Non-interactive Column Header</th>
+        </tr>
+    </thead>
+    <tbody fd-table-body>
+        @for (row of tableRows; track row) {
+            <tr fd-table-row>
+                <td fd-table-cell>
+                    <a fd-link href="#">{{ row.column1 }}</a>
+                </td>
+                <td fd-table-cell>
+                    <p fd-table-text maxWidth="250px" [noWrap]="true">
+                        {{ row.column2 }}
+                    </p>
+                </td>
+                <td fd-table-cell>
+                    <p fd-table-text maxWidth="250px">
+                        {{ row.column3 }}
+                    </p>
+                </td>
+                <td fd-table-cell>{{ row.date }}</td>
+                <td fd-table-cell><fd-icon [glyph]="row.type"></fd-icon></td>
+            </tr>
+        }
+    </tbody>
+</table>
+
+<br /><br />
 <h4>non-interactive header cells</h4>
 <table fd-table aria-label="Default">
     <thead fd-table-header [nonInteractive]="true">

--- a/libs/docs/platform/table/examples/platform-table-custom-column-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-custom-column-example.component.html
@@ -60,19 +60,19 @@
             </fdp-input>
         </fdp-table-cell>
     </fdp-column>
-    <fdp-column name="price" key="price.value">
+    <fdp-column name="price" key="price.value" [nonInteractive]="true">
         <fdp-table-header *fdpHeaderCellDef>Price</fdp-table-header>
         <fdp-table-cell *fdpCellDef="let item; as: exampleItemType">
             {{ item.price.value }} {{ item.price.currency }}
         </fdp-table-cell>
     </fdp-column>
-    <fdp-column name="status" key="status">
+    <fdp-column name="status" key="status" [nonInteractive]="true">
         <fdp-table-header *fdpHeaderCellDef>Status</fdp-table-header>
         <fdp-table-cell *fdpCellDef="let item; as: exampleItemType">
             <span fd-object-status [status]="item.statusColor" [label]="item.status"></span>
         </fdp-table-cell>
     </fdp-column>
-    <fdp-column name="index" key="index">
+    <fdp-column name="index" key="index" [nonInteractive]="true">
         <fdp-table-header *fdpHeaderCellDef>Row index</fdp-table-header>
         <fdp-table-cell *fdpCellDef="let item; as: exampleItemType; let i = rowIndex">
             <span>Row index {{ i }}</span>

--- a/libs/docs/platform/table/examples/platform-table-custom-width-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-custom-width-example.component.html
@@ -1,4 +1,4 @@
-<fdp-table [dataSource]="source" emptyTableMessage="No data found">
+<fdp-table [dataSource]="source" emptyTableMessage="No data found" [nonInteractiveHeader]="true">
     <fdp-table-toolbar title="Order Line Items" [hideItemCount]="false">
         <fdp-table-toolbar-actions>
             <fdp-button label="Action One" (click)="alert('Action One')"></fdp-button>

--- a/libs/docs/platform/table/examples/platform-table-default-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-default-example.component.html
@@ -1,4 +1,4 @@
-<fdp-table [dataSource]="source" [trackBy]="trackBy" emptyTableMessage="No data found" [nonInteractiveHeader]="true">
+<fdp-table [dataSource]="source" [trackBy]="trackBy" emptyTableMessage="No data found">
     <fdp-table-toolbar title="Order Line Items" [shouldOverflow]="true" [disableRefresh]="true">
         <fdp-table-toolbar-actions>
             <fdp-button label="Action One" (click)="alert('Action One')"></fdp-button>
@@ -6,11 +6,11 @@
         </fdp-table-toolbar-actions>
     </fdp-table-toolbar>
 
-    <fdp-column name="name" key="name" label="Name" align="start"> </fdp-column>
+    <fdp-column [nonInteractive]="true" name="name" key="name" label="Name" align="start"> </fdp-column>
 
     <fdp-column name="description" key="description" label="Description"> </fdp-column>
 
     <fdp-column name="price" key="price.value" label="Price" align="end"> </fdp-column>
 
-    <fdp-column name="status" key="status" label="Status" align="center"> </fdp-column>
+    <fdp-column [nonInteractive]="true" name="status" key="status" label="Status" align="center"> </fdp-column>
 </fdp-table>

--- a/libs/platform/table-helpers/table-column.ts
+++ b/libs/platform/table-helpers/table-column.ts
@@ -42,6 +42,9 @@ export abstract class TableColumn {
     /** Toggles end column freeze/unfreeze feature in the column header. */
     abstract endFreezable: boolean;
 
+    /**  Whether the table cell inside table header should be non-interactive. */
+    abstract nonInteractive: boolean;
+
     /** Initial visibility state of the column. */
     abstract visible: boolean;
 

--- a/libs/platform/table/components/table-column/table-column.component.ts
+++ b/libs/platform/table/components/table-column/table-column.component.ts
@@ -107,6 +107,10 @@ export class TableColumnComponent extends TableColumn implements OnInit, OnChang
     @Input()
     endFreezable = false;
 
+    /** Whether the table cell inside table header should be non-interactive. */
+    @Input()
+    nonInteractive = false;
+
     /** Width of the column cells. */
     @Input()
     set width(value: string) {

--- a/libs/platform/table/components/table-header-row/table-header-row.component.html
+++ b/libs/platform/table/components/table-header-row/table-header-row.component.html
@@ -61,6 +61,7 @@
         [id]="rowId + '__' + column.name"
         [attr.aria-colindex]="$index"
         [attr.aria-sort]="_fdpTableService.sortRules$().get(column.key) | fdpTableColumnSortingDirection"
+        [class.fd-table__cell--non-interactive]="column.nonInteractive"
         [ngClass]="[
             'fdp-table__col--' + column.name,
             column._freezed ? 'fd-table__cell--fixed' : '',


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11919

## Description
- adds CSS to make cells inside Table header non-interactive (**will be removed when we adopt the latest fund-styles version**)
- Core: adds `nonInteractive` input to `table-cell` directive
- Platform: adds `nonInteractive` input to `table-column` component
- update examples