### PR TITLE
fix(platform): platform table border fix

### DIFF
--- a/libs/docs/platform/table/examples/platform-table-default-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-default-example.component.html
@@ -1,15 +1,4 @@
-<!-- @TODO redo the changes-->
-<fdp-table
-    [noBorders]="true"
-    [noBodyBorders]="true"
-    [noHorizontalBorders]="true"
-    [noVerticalBorders]="true"
-    [noOuterBorders]="true"
-    [dataSource]="source"
-    [trackBy]="trackBy"
-    emptyTableMessage="No data found"
-    [nonInteractiveHeader]="true"
->
+<fdp-table [dataSource]="source" [trackBy]="trackBy" emptyTableMessage="No data found" [nonInteractiveHeader]="true">
     <fdp-table-toolbar title="Order Line Items" [shouldOverflow]="true" [disableRefresh]="true">
         <fdp-table-toolbar-actions>
             <fdp-button label="Action One" (click)="alert('Action One')"></fdp-button>

--- a/libs/docs/platform/table/examples/platform-table-default-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-default-example.component.html
@@ -1,4 +1,15 @@
-<fdp-table [dataSource]="source" [trackBy]="trackBy" emptyTableMessage="No data found" [nonInteractiveHeader]="true">
+<!-- @TODO redo the changes-->
+<fdp-table
+    [noBorders]="true"
+    [noBodyBorders]="true"
+    [noHorizontalBorders]="true"
+    [noVerticalBorders]="true"
+    [noOuterBorders]="true"
+    [dataSource]="source"
+    [trackBy]="trackBy"
+    emptyTableMessage="No data found"
+    [nonInteractiveHeader]="true"
+>
     <fdp-table-toolbar title="Order Line Items" [shouldOverflow]="true" [disableRefresh]="true">
         <fdp-table-toolbar-actions>
             <fdp-button label="Action One" (click)="alert('Action One')"></fdp-button>

--- a/libs/platform/table-helpers/pipes/cell-styles.pipe.ts
+++ b/libs/platform/table-helpers/pipes/cell-styles.pipe.ts
@@ -14,7 +14,10 @@ export class TableCellStylesPipe implements PipeTransform {
         isFrozenEndColumn: boolean,
         prevColumnWidthPx: number | null,
         columnWidth: string,
-        nextColumnWidthPx: number | null
+        nextColumnWidthPx: number | null,
+        noBorders?: boolean,
+        noBordersY?: boolean,
+        noBordersX?: boolean
     ): Record<string, number | string> {
         const styles: { [property: string]: number | string } = {};
 
@@ -29,9 +32,23 @@ export class TableCellStylesPipe implements PipeTransform {
             styles[key] = (nextColumnWidthPx || 0).toString();
         }
 
-        styles['min-width'] = columnWidth;
-        styles['max-width'] = columnWidth;
-        styles['width'] = columnWidth;
+        if (noBordersY) {
+            styles['border-top'] = 'none';
+            styles['border-bottom'] = 'none';
+        }
+
+        if (noBordersX) {
+            styles['border-left'] = 'none';
+            styles['border-right'] = 'none';
+        }
+
+        if (noBorders) {
+            styles['border'] = 'none';
+        } else {
+            styles['min-width'] = columnWidth;
+            styles['max-width'] = columnWidth;
+            styles['width'] = columnWidth;
+        }
 
         // The "start" value does align left when you are using a LTR browser.
         // In RTL browsers, the "start" value aligns right.

--- a/libs/platform/table/components/table-header-row/table-header-row.component.html
+++ b/libs/platform/table/components/table-header-row/table-header-row.component.html
@@ -2,6 +2,10 @@
     <th
         [class.fd-table__cell--fixed]="fixed"
         fd-table-cell
+        [ngClass]="{
+            'fd-table__cell--no-horizontal-border': noHorizontalBorders || noBorders,
+            'fd-table__cell--no-vertical-border': noVerticalBorders || noBorders
+        }"
         fd-table-status-indicator
         fdkDisabled
         [style.min-width]="_fdpTableService._semanticHighlightingColumnWidth$()"
@@ -12,6 +16,10 @@
 @if (isShownSelectionColumn) {
     <th
         fd-table-cell
+        [ngClass]="{
+            'fd-table__cell--no-horizontal-border': noHorizontalBorders || noBorders,
+            'fd-table__cell--no-vertical-border': noVerticalBorders || noBorders
+        }"
         [focusable]="true"
         [class.fd-table__cell--fixed]="fixed"
         class="fd-table__cell--checkbox"
@@ -81,6 +89,9 @@
                     : _tableColumnResizeService.getPrevColumnsWidth(column.name)
                     : _tableColumnResizeService.getColumnWidthStyle(column.name)
                     : _tableColumnResizeService.getNextColumnsWidth(column.name)
+                    : noBorders
+                    : noVerticalBorders
+                    : noHorizontalBorders
         "
         [fdPopoverTrigger]="(column | isColumnHasHeaderMenu) ? tablePopover.popover : null"
         (cellFocused)="_tableRowService.cellFocused($event)"
@@ -103,12 +114,24 @@
 }
 
 @if (_fdpTableService._isShownNavigationColumn$()) {
-    <th fd-table-cell class="fdp-table__cell--navigation is-last-child" role="columnheader"></th>
+    <th
+        fd-table-cell
+        [ngClass]="{
+            'fd-table__cell--no-horizontal-border': noHorizontalBorders || noBorders,
+            'fd-table__cell--no-vertical-border': noVerticalBorders || noBorders
+        }"
+        class="fdp-table__cell--navigation is-last-child"
+        role="columnheader"
+    ></th>
 }
 
 <th
     aria-hidden="true"
     class="fd-table__cell fd-table__cell--mock"
     [class.fd-table__cell--mock-borderless]="!_tableColumnResizeService.cellMockVisible$()"
+    [ngClass]="{
+        'fd-table__cell--no-horizontal-border': noHorizontalBorders || noBorders,
+        'fd-table__cell--no-vertical-border': noVerticalBorders || noBorders
+    }"
     fdkDisabled
 ></th>

--- a/libs/platform/table/components/table-header-row/table-header-row.component.html
+++ b/libs/platform/table/components/table-header-row/table-header-row.component.html
@@ -129,9 +129,5 @@
     aria-hidden="true"
     class="fd-table__cell fd-table__cell--mock"
     [class.fd-table__cell--mock-borderless]="!_tableColumnResizeService.cellMockVisible$()"
-    [ngClass]="{
-        'fd-table__cell--no-horizontal-border': noHorizontalBorders || noBorders,
-        'fd-table__cell--no-vertical-border': noVerticalBorders || noBorders
-    }"
     fdkDisabled
 ></th>

--- a/libs/platform/table/components/table-header-row/table-header-row.component.ts
+++ b/libs/platform/table/components/table-header-row/table-header-row.component.ts
@@ -122,6 +122,18 @@ export class TableHeaderRowComponent extends TableRowDirective implements OnInit
     @Input()
     freezeColumnsTo: string;
 
+    /** Table without horizontal borders. */
+    @Input()
+    noHorizontalBorders = false;
+
+    /** Table without vertical borders. */
+    @Input()
+    noVerticalBorders = false;
+
+    /** Table without borders. */
+    @Input()
+    noBorders = false;
+
     /** The column `name` to freeze columns after and including. */
     @Input()
     freezeEndColumnsTo: string;

--- a/libs/platform/table/table.component.html
+++ b/libs/platform/table/table.component.html
@@ -45,6 +45,9 @@
             <thead fd-table-header [nonInteractive]="nonInteractiveHeader" class="fdp-table__header">
                 <tr
                     fdp-table-header-row
+                    [noBorders]="noBorders"
+                    [noHorizontalBorders]="noHorizontalBorders"
+                    [noVerticalBorders]="noVerticalBorders"
                     [rowId]="id"
                     [fixed]="fixed"
                     [isShownSelectionColumn]="isSelectionColumnShown"

--- a/libs/platform/table/table.component.scss
+++ b/libs/platform/table/table.component.scss
@@ -433,6 +433,8 @@ fdk-dynamic-portal {
             &.fd-table__cell--mock-borderless {
                 border-left: none !important;
                 border-right: none !important;
+                border-bottom: none !important;
+                border-top: none !important;
             }
         }
 

--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -460,6 +460,7 @@ export class TableComponent<T = any>
         this._semanticHighlightingKey = value;
         this._setSemanticHighlighting();
     }
+
     get semanticHighlighting(): string {
         if (!this._semanticHighlightingKey && this._forceSemanticHighlighting) {
             return DEFAULT_HIGHLIGHTING_KEY;


### PR DESCRIPTION
fix(platform): table ensure all borders are hidden when border options are enabled

closes [#10729](https://github.com/SAP/fundamental-ngx/issues/10729)

## Description

This fix addresses the issue where vertical and horizontal borders are still displayed in the Platform Table component, despite enabling the `noHorizontalBorders`, `noVerticalBorders`, `noBorders`, `noOuterBorders`, and `noBodyBorders` options. Specifically:

- Removed the vertical border before the last column.
- Removed the horizontal border below the table header when border-hiding options are applied.

### Before 
![image](https://github.com/user-attachments/assets/8d14ff23-536b-4daf-a0e6-b140fe5bfc0e)

### After 
![image](https://github.com/user-attachments/assets/ef07fac8-b7e7-4bd4-a5a5-ae9e71027a04)
