### PR TITLE
feat(platform): form-generator Add support for dynamic width in select

### DIFF
--- a/libs/docs/platform/form-generator/examples/platform-form-generator-example.component.ts
+++ b/libs/docs/platform/form-generator/examples/platform-form-generator-example.component.ts
@@ -155,7 +155,10 @@ export class PlatformFormGeneratorExampleComponent {
             default: 'IT',
             choices: ['IT', 'Accounting', 'Management'],
             guiOptions: {
-                column: 2
+                column: 2,
+                additionalData: {
+                    width: '290px'
+                }
             }
         },
         {

--- a/libs/platform/form/form-generator/controls/dynamic-form-generator-select/dynamic-form-generator-select.component.html
+++ b/libs/platform/form/form-generator/controls/dynamic-form-generator-select/dynamic-form-generator-select.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form">
     <ng-container [formGroupName]="formGroupName">
         <fdp-select
+            [width]="formItem.guiOptions?.additionalData?.width"
             [id]="id"
             [placeholder]="placeholder"
             [inline]="formItem.guiOptions?.inline !== false"


### PR DESCRIPTION
feat(platform): form-generator Add support for dynamic width in `Select` component through width property
                               

closes [#12302](https://github.com/SAP/fundamental-ngx/issues/12302)

## Description
This implementation allows users to specify the width property on the Select component, enabling them to dynamically adjust its width as needed.

### Before 
![image](https://github.com/user-attachments/assets/21487b13-2326-4b20-8d37-938ed78626e8)


### After 
![image](https://github.com/user-attachments/assets/9d1acaed-9bbe-435c-b6c9-ca088610593d)
