### PR TITLE
fix(core): add bigger z-index to show Dynamic page box-shadow

### DIFF
--- a/libs/core/dynamic-page/dynamic-page.component.scss
+++ b/libs/core/dynamic-page/dynamic-page.component.scss
@@ -108,3 +108,7 @@
     position: relative;
     box-shadow: var(--sapContent_HeaderShadow);
 }
+
+.fd-dynamic-page__header {
+    z-index: 15;
+}


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/12558

## Description
add to Dynamic Page header higher z-index than the one Table header has so that the  Dynamic Page header box-shadow is not hidden.

## Screenshots

### Before:
<img width="1247" alt="Screenshot 2024-10-16 at 1 55 09 PM" src="https://github.com/user-attachments/assets/d65cdb1b-0c92-41ea-b566-3ddf9afea7e5">


### After:
<img width="1246" alt="Screenshot 2024-10-16 at 1 54 30 PM" src="https://github.com/user-attachments/assets/a8de214f-6bc1-46ca-85ae-40d41a3b5449">
