### PR TITLE
fix(core, platform): add custom IDs to Setting Generator list items

### DIFF
--- a/libs/core/list/list-item/list-item.component.ts
+++ b/libs/core/list/list-item/list-item.component.ts
@@ -111,7 +111,7 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
 
     /** The ID of the list item element */
     @Input()
-    id = 'fd-list-item-' + ++listItemUniqueId;
+    id: Nullable<string> = 'fd-list-item-' + ++listItemUniqueId;
 
     /** @hidden Implementation of KeyboardSupportItemInterface | TODO Revisit KeyboardSupportItemInterface*/
     @Output()

--- a/libs/platform/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-layout.component.html
+++ b/libs/platform/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-layout.component.html
@@ -7,7 +7,7 @@
 >
     <ul fd-list [byline]="true" [navigationIndicator]="true">
         @for (item of settings?.items; track item; let i = $index) {
-            <li (click)="_setSelectedIndex(i)" fd-list-item [selected]="i === _selectedIndex">
+            <li (click)="_setSelectedIndex(i)" fd-list-item [selected]="i === _selectedIndex" [id]="item.id">
                 <a fd-list-link [navigated]="i === _selectedIndex">
                     @if (item.thumbnail) {
                         <span fd-list-thumbnail>

--- a/libs/platform/settings-generator/models/settings.model.ts
+++ b/libs/platform/settings-generator/models/settings.model.ts
@@ -130,6 +130,8 @@ export interface TemplateSettingsItem extends BaseSettingsItem {
 
 export interface GroupedTemplateSettingsItem extends BaseSettingsItem {
     /** @hidden */
+    id?: string;
+    /** @hidden */
     items?: never;
     /** @hidden */
     template?: never;


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/12546

## Description
Settings Generator was not taking into account the `id` that were passed in the config object, the IDs were auto generated from List component. 
## Screenshots
### Before:
<img width="1517" alt="Screenshot 2024-10-17 at 12 37 04 PM" src="https://github.com/user-attachments/assets/4cab6362-06be-42d9-a36d-491bb9d74252">
### After:

<img width="1701" alt="Screenshot 2024-10-17 at 12 36 28 PM" src="https://github.com/user-attachments/assets/58f8b485-1733-4dd4-be50-c9221fce22d5">

