### PR TITLE
fix(core): add option to set a custom width to Combobox

### DIFF
--- a/libs/core/combobox/combobox.component.html
+++ b/libs/core/combobox/combobox.component.html
@@ -11,6 +11,7 @@
         [triggers]="triggers"
         [disabled]="disabled || readOnly"
         [maxWidth]="640"
+        [style.width]="width && '100%'"
         [closeOnOutsideClick]="closeOnOutsideClick"
     >
         <fd-popover-control>

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -111,7 +111,8 @@ let comboboxUniqueId = 0;
     host: {
         '[class.fd-combobox-custom-class]': 'true',
         '[class.fd-combobox-input]': 'true',
-        '[class.fd-combobox-custom-class--mobile]': 'mobile'
+        '[class.fd-combobox-custom-class--mobile]': 'mobile',
+        '[style.width]': 'width'
     },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -243,6 +244,10 @@ export class ComboboxComponent<T = any>
     /** Max height of the popover. Any overflowing elements will be accessible through scrolling. */
     @Input()
     maxHeight = '50vh';
+
+    /** Custom width of the control. */
+    @Input()
+    width: Nullable<string>;
 
     /** Search function to execute when the Enter key is pressed on the main input. */
     @Input()

--- a/libs/docs/core/combobox/examples/combobox-example.component.html
+++ b/libs/docs/core/combobox/examples/combobox-example.component.html
@@ -1,10 +1,11 @@
 <div class="examples-column">
     <div fd-form-item>
-        <label fd-form-label for="comboboxID1">Standard</label>
+        <label fd-form-label for="comboboxID1">Standard with custom width</label>
         <fd-combobox
             inputId="comboboxID1"
             ariaLabel="Standard"
             maxHeight="250px"
+            width="300px"
             placeholder="Type some text..."
             [dropdownValues]="fruits"
             [(ngModel)]="searchTermOne"
@@ -87,4 +88,18 @@
         </fd-combobox>
     </div>
     <small>Search Term: {{ searchTermSix }}</small>
+
+    <div fd-form-item>
+        <label fd-form-label for="comboboxID1">Standard</label>
+        <fd-combobox
+            inputId="comboboxID1"
+            ariaLabel="Standard"
+            maxHeight="250px"
+            placeholder="Type some text..."
+            [dropdownValues]="fruits"
+            [(ngModel)]="searchTermOne"
+        >
+        </fd-combobox>
+    </div>
+    <small>Search Term: {{ searchTermOne }}</small>
 </div>


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/12545

## Description
adds `width` property that enabled the user to set a custom width for the Combobox
<img width="1047" alt="Screenshot 2024-10-17 at 1 10 15 PM" src="https://github.com/user-attachments/assets/aef1e3bb-1320-45c6-9f8b-49dbf64d719b">

<img width="683" alt="Screenshot 2024-10-17 at 1 12 07 PM" src="https://github.com/user-attachments/assets/5451bd11-21ef-4018-90f3-0549596f2084">
