### PR TITLE
fix(core) Add Support for Multi-line Messages in Select Component Dropdown

### DIFF
--- a/libs/core/select/select.component.html
+++ b/libs/core/select/select.component.html
@@ -96,8 +96,11 @@
                 tabindex="-1"
                 role="presentation"
                 [type]="state || 'default'"
-                [innerHtml]="stateMessage"
-            ></li>
+            >
+                <span fd-list-title>
+                    {{ stateMessage }}
+                </span>
+            </li>
         }
         @if (advancedStateMessage?.hasErrors && advancedStateMessage?.template) {
             <li fd-list-message tabindex="-1" role="presentation" [type]="state || 'default'">

--- a/libs/core/select/select.component.html
+++ b/libs/core/select/select.component.html
@@ -87,20 +87,27 @@
         [hasMessage]="!!stateMessage || (!!advancedStateMessage?.hasErrors && !!advancedStateMessage?.template)"
         [attr.id]="controlId + '-list-box'"
         [style.max-height]="maxHeight || calculatedMaxHeight + 'px'"
+        [style.padding-block-start.rem]="!showEllipsis ? 0 : 2"
         [attr.tooltip]="triggerValue"
     >
         @if (stateMessage) {
             <li
                 [attr.aria-label]="stateMessage"
                 fd-list-message
-                class="fd-select-message"
+                [class.fd-select-message]="!showEllipsis"
                 tabindex="-1"
                 role="presentation"
                 [type]="state || 'default'"
             >
-                <span fd-list-title>
-                    {{ stateMessage }}
-                </span>
+                @if (!showEllipsis) {
+                    <span fd-list-title>
+                        {{ stateMessage }}
+                    </span>
+                } @else {
+                    <span>
+                        {{ stateMessage }}
+                    </span>
+                }
             </li>
         }
         @if (advancedStateMessage?.hasErrors && advancedStateMessage?.template) {

--- a/libs/core/select/select.component.html
+++ b/libs/core/select/select.component.html
@@ -97,6 +97,7 @@
                 role="presentation"
                 [type]="state || 'default'"
             >
+                <!--                @ !TODO problem is in fd-list-message component-->
                 <span fd-list-title>
                     {{ stateMessage }}
                 </span>

--- a/libs/core/select/select.component.html
+++ b/libs/core/select/select.component.html
@@ -93,11 +93,11 @@
             <li
                 [attr.aria-label]="stateMessage"
                 fd-list-message
+                class="fd-select-message"
                 tabindex="-1"
                 role="presentation"
                 [type]="state || 'default'"
             >
-                <!--                @ !TODO problem is in fd-list-message component-->
                 <span fd-list-title>
                     {{ stateMessage }}
                 </span>

--- a/libs/core/select/select.component.scss
+++ b/libs/core/select/select.component.scss
@@ -52,7 +52,6 @@ $block: fd-select;
 }
 
 .#{$block}-options {
-    padding-top: 0 !important; // TODO Override padding top property styles. Open for discussion.
     .#{$block}-message {
         min-height: 2rem;
         height: auto;

--- a/libs/core/select/select.component.scss
+++ b/libs/core/select/select.component.scss
@@ -51,6 +51,17 @@ $block: fd-select;
     }
 }
 
+.#{$block}-options {
+    padding-top: 0 !important; // TODO Override padding top property styles. Open for discussion.
+    .#{$block}-message {
+        min-height: 2rem;
+        height: auto;
+        display: flex;
+        align-items: center;
+        position: relative;
+    }
+}
+
 .fd-popover__body {
     .#{$block}__form-message {
         // Compensate form field margin.

--- a/libs/core/select/select.component.ts
+++ b/libs/core/select/select.component.ts
@@ -71,6 +71,13 @@ export const SELECT_PANEL_MAX_HEIGHT = 250;
 /** The height of the select items in `rem` units. */
 export const SELECT_ITEM_HEIGHT_EM = 4;
 
+export type TextOverflowMode = 'full' | 'ellipsis';
+
+export enum TextOverflowModeEnum {
+    FULL = 'full',
+    ELLIPSIS = 'ellipsis'
+}
+
 /**
  * Select component intended to mimic
  * the behaviour of the native select element.
@@ -142,6 +149,15 @@ export class SelectComponent<T = any>
     /** Scrolling strategy to be used for popover. */
     @Input()
     scrollStrategy: ScrollStrategy;
+
+    /**
+     * Controls how long text is displayed in the dropdown list of the Select component.
+     *
+     * - `'ellipsis'`: Truncates the text with an ellipsis (`...`) if it exceeds a certain length.
+     * - `'full'`: Displays the entire text on multiple lines, ensuring full visibility.
+     */
+    @Input()
+    textOverflow: TextOverflowMode = 'ellipsis';
 
     /** The ID of the control. */
     @Input()
@@ -328,6 +344,11 @@ export class SelectComponent<T = any>
 
     /** @hidden */
     _selectionModel: SelectionModel<OptionComponent>;
+
+    /** @hidden */
+    get showEllipsis(): boolean {
+        return this.textOverflow === TextOverflowModeEnum.ELLIPSIS;
+    }
 
     /**
      * @hidden

--- a/libs/core/select/select.component.ts
+++ b/libs/core/select/select.component.ts
@@ -55,12 +55,7 @@ import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
 import { ListComponent, ListMessageDirective, ListTitleDirective } from '@fundamental-ngx/core/list';
-import {
-    PopoverBodyComponent,
-    PopoverComponent,
-    PopoverControlComponent,
-    PopoverModule
-} from '@fundamental-ngx/core/popover';
+import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { FdOptionSelectionChange, OptionComponent } from './option/option.component';
 import { SelectKeyManagerService } from './select-key-manager.service';
@@ -116,8 +111,7 @@ export const SELECT_ITEM_HEIGHT_EM = 4;
         FdTranslatePipe,
         ButtonComponent,
         ListTitleDirective,
-        OptionComponent,
-        PopoverModule
+        OptionComponent
     ]
 })
 export class SelectComponent<T = any>

--- a/libs/core/select/select.component.ts
+++ b/libs/core/select/select.component.ts
@@ -54,8 +54,13 @@ import { FormFieldAdvancedStateMessage, FormStates, SingleDropdownValueControl }
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent, IconFont } from '@fundamental-ngx/core/icon';
-import { ListComponent, ListMessageDirective } from '@fundamental-ngx/core/list';
-import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
+import { ListComponent, ListMessageDirective, ListTitleDirective } from '@fundamental-ngx/core/list';
+import {
+    PopoverBodyComponent,
+    PopoverComponent,
+    PopoverControlComponent,
+    PopoverModule
+} from '@fundamental-ngx/core/popover';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { FdOptionSelectionChange, OptionComponent } from './option/option.component';
 import { SelectKeyManagerService } from './select-key-manager.service';
@@ -109,7 +114,10 @@ export const SELECT_ITEM_HEIGHT_EM = 4;
         ListComponent,
         ListMessageDirective,
         FdTranslatePipe,
-        ButtonComponent
+        ButtonComponent,
+        ListTitleDirective,
+        OptionComponent,
+        PopoverModule
     ]
 })
 export class SelectComponent<T = any>

--- a/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
+++ b/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
@@ -1,6 +1,12 @@
-<h4>Success state</h4>
+<h4>Success state (with visible long text)</h4>
 <div fd-form-item>
-    <fd-select placeholder="Select value" stateMessage="Success message" [(value)]="selectedValue1" state="success">
+    <fd-select
+        textOverflow="full"
+        placeholder="Select value"
+        stateMessage="Success message. This is a longer success message to provide more detailed feedback to the user about the successful state of the selection. Please ensure that you have selected the correct option and proceed with the next steps as required."
+        [(value)]="selectedValue1"
+        state="success"
+    >
         @for (option of options; track option) {
             <li fd-option [value]="option">{{ option }}</li>
         }

--- a/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
+++ b/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
@@ -9,12 +9,7 @@
 </div>
 <h4>Warning state</h4>
 <div fd-form-item>
-    <fd-select
-        placeholder="Select value"
-        stateMessage="Warning message Warning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning message"
-        [(value)]="selectedValue2"
-        state="warning"
-    >
+    <fd-select placeholder="Select value" stateMessage="Warning message" [(value)]="selectedValue2" state="warning">
         @for (option of options; track option) {
             <li fd-option [value]="option">{{ option }}</li>
         }
@@ -34,7 +29,7 @@
 <div fd-form-item>
     <fd-select
         placeholder="Select value"
-        stateMessage="Information message Information messageInformation messageInformation messageInformation messageInformation messageInformation messageInformation messageInformation messageInformation messageInformation message"
+        stateMessage="Information message"
         [(value)]="selectedValue4"
         state="information"
     >

--- a/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
+++ b/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
@@ -9,7 +9,12 @@
 </div>
 <h4>Warning state</h4>
 <div fd-form-item>
-    <fd-select placeholder="Select value" stateMessage="Warning message" [(value)]="selectedValue2" state="warning">
+    <fd-select
+        placeholder="Select value"
+        stateMessage="Warning message Warning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning messageWarning message"
+        [(value)]="selectedValue2"
+        state="warning"
+    >
         @for (option of options; track option) {
             <li fd-option [value]="option">{{ option }}</li>
         }
@@ -29,7 +34,7 @@
 <div fd-form-item>
     <fd-select
         placeholder="Select value"
-        stateMessage="Information message"
+        stateMessage="Information message Information messageInformation messageInformation messageInformation messageInformation messageInformation messageInformation messageInformation messageInformation messageInformation message"
         [(value)]="selectedValue4"
         state="information"
     >

--- a/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.ts
+++ b/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.ts
@@ -9,12 +9,7 @@ import { SelectModule } from '@fundamental-ngx/core/select';
     imports: [FormItemComponent, SelectModule, FormMessageComponent, FormInputMessageGroupComponent]
 })
 export class SelectSemanticStateExampleComponent {
-    options: string[] = [
-        'Apple  Apple Apple Apple Apple Apple Apple Apple  Apple Apple Apple Apple Apple Apple Apple  Apple Apple Apple Apple Apple Apple Apple  Apple Apple Apple Apple Apple Apple Apple  Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple',
-        'Pineapple',
-        'Tomato',
-        'Strawberry'
-    ];
+    options: string[] = ['Apple', 'Pineapple', 'Tomato', 'Strawberry'];
     selectedValue1: string;
     selectedValue2: string;
     selectedValue3: string;

--- a/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.ts
+++ b/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.ts
@@ -9,7 +9,12 @@ import { SelectModule } from '@fundamental-ngx/core/select';
     imports: [FormItemComponent, SelectModule, FormMessageComponent, FormInputMessageGroupComponent]
 })
 export class SelectSemanticStateExampleComponent {
-    options: string[] = ['Apple', 'Pineapple', 'Tomato', 'Strawberry'];
+    options: string[] = [
+        'Apple  Apple Apple Apple Apple Apple Apple Apple  Apple Apple Apple Apple Apple Apple Apple  Apple Apple Apple Apple Apple Apple Apple  Apple Apple Apple Apple Apple Apple Apple  Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple Apple',
+        'Pineapple',
+        'Tomato',
+        'Strawberry'
+    ];
     selectedValue1: string;
     selectedValue2: string;
     selectedValue3: string;


### PR DESCRIPTION
fix(core): Add Support for Multi-line Messages in Select Component Dropdown

closes [#11430](https://github.com/SAP/fundamental-ngx/issues/11430)

## Description
- Refactored the select component to manage text display mode.
- Adjusted padding in the select component message to eliminate unnecessary space.
- Introduced a new input property, textOverflow, to control how text is displayed in the dropdown list, allowing for either ellipsis or full text.
***

### After 

<img width="712" alt="Screenshot 2024-10-18 at 02 39 57" src="https://github.com/user-attachments/assets/10d77a33-4937-4ed9-bfe8-cd515e143a70">
