### PR TITLE
fix(core): combobox dynamic groupFn

### DIFF
--- a/libs/core/combobox/combobox.component.html
+++ b/libs/core/combobox/combobox.component.html
@@ -132,11 +132,11 @@
     >
         <ng-content></ng-content>
         @if (groupFn) {
-            @for (group of displayedValues | listGroupPipe: groupFn; track group) {
+            @for (group of displayedValues | listGroupPipe: groupFn; track group.key) {
                 <li role="group" fd-list-group-header [tabindex]="0">
                     <span fd-list-title>{{ group.key }}</span>
                 </li>
-                @for (term of group.value; track term) {
+                @for (term of group.value; track term.name) {
                     <li
                         role="option"
                         fd-list-item

--- a/libs/core/combobox/combobox.component.html
+++ b/libs/core/combobox/combobox.component.html
@@ -137,7 +137,7 @@
                 <li role="group" fd-list-group-header [tabindex]="0">
                     <span fd-list-title>{{ group.key }}</span>
                 </li>
-                @for (term of group.value; track term.name) {
+                @for (term of group.value; track term) {
                     <li
                         role="option"
                         fd-list-item


### PR DESCRIPTION
fix(core): combobox dynamic groupFn

closes [#12518](https://github.com/SAP/fundamental-ngx/issues/12518)

## Description

Fixed dynamic function re-creation issue.

### Before 

[old.webm](https://github.com/user-attachments/assets/ed2eacfa-e867-43e4-8e6c-f69216a2aaa4)

***

### After

[new.webm](https://github.com/user-attachments/assets/422ed22d-d6b0-4f85-bd91-85dfa6d648cd)
