### PR TITLE
fix(core): Checkbox link in  label  is not clickable

### DIFF
--- a/libs/core/checkbox/checkbox/checkbox.component.scss
+++ b/libs/core/checkbox/checkbox/checkbox.component.scss
@@ -7,6 +7,10 @@ fd-checkbox {
 
     .fd-checkbox__label {
         user-select: none;
+
+        .fd-checkbox__label-container {
+            pointer-events: auto;
+        }
     }
 
     &.fd-checkbox--standalone {


### PR DESCRIPTION
fix(core): Checkbox link in  label  is not clickable

closes [#12577](https://github.com/SAP/fundamental-ngx/issues/12577)

## Description
Updated the checkbox component to ensure that links within custom labels are clickable and function as intended. This resolves the issue observed in the documentation example.

### Before
[Screencast from 2024-10-23 16-34-31.webm](https://github.com/user-attachments/assets/449361b0-1f49-444d-aba0-bcbed78f6c98)


### After
[new.webm](https://github.com/user-attachments/assets/b82613d0-a3d6-44e3-a98e-8ab89934aaa0)
