### PR TITLE
fix(core): remove navigation role from List

### DIFF
--- a/libs/core/list/list.component.ts
+++ b/libs/core/list/list.component.ts
@@ -258,9 +258,7 @@ export class ListComponent implements ListComponentInterface, ListUnreadIndicato
     private _recheckLinks(): void {
         const items = this.items.filter((item) => item.link);
         this.hasNavigation = items.length > 0;
-        if (!this.selection) {
-            this._defaultRole = this.hasNavigation ? 'navigation' : 'list';
-        } else {
+        if (this.selection) {
             this._defaultRole = 'listbox';
         }
     }


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11592

## Description
role=navigation should not be used on `<ul>` tag as it's invalid role for ul tag