### PR TITLE
fix(core): trim search term in MultiInputComponent to handle leading/trailing spaces

### DIFF
--- a/libs/core/multi-input/multi-input.component.ts
+++ b/libs/core/multi-input/multi-input.component.ts
@@ -859,12 +859,12 @@ export class MultiInputComponent<ItemType = any, ValueType = any>
 
     /** @hidden */
     private _defaultFilter(contentArray: this['dropdownValues'], searchTerm: string = ''): this['dropdownValues'] {
-        const searchLower = searchTerm.toLocaleLowerCase();
+        const trimmedSearchTerm = searchTerm.trim().toLocaleLowerCase();
         return contentArray.filter((item) => {
             if (item) {
                 const displayedValue = isOptionItem(item) ? item.label : this.displayFn(item);
                 const term = displayedValue?.toLocaleLowerCase() || '';
-                return this.typeAheadMatcher(term, searchLower);
+                return this.typeAheadMatcher(term, trimmedSearchTerm);
             }
         });
     }


### PR DESCRIPTION
fix(core): trim search term in MultiInputComponent to handle leading/trailing spaces

closes [#12635](https://github.com/SAP/fundamental-ngx/issues/12635)

## Description

- Updated `_defaultFilter` method to trim the search term before filtering.
- Ensured that accidental spaces do not affect search results.

## Snapshots 

### Before 


https://github.com/user-attachments/assets/c0c8c015-ab7f-40d1-bf89-7685cb8de3e1


### After 


https://github.com/user-attachments/assets/ccf8bfbc-a4f6-4991-acba-d736c9928fb4

