### PR TITLE
fix(docs): formatting on core wizard examples

### DIFF
--- a/libs/docs/core/wizard/e2e/wizard.po.ts
+++ b/libs/docs/core/wizard/e2e/wizard.po.ts
@@ -27,8 +27,8 @@ export class WizardPo extends CoreBaseComponentPo {
     customerInformationSection = this.wizard + '.fd-container:nth-child(4) ';
     column = '.fd-col';
     savedName = this.customerInformationSection + this.column + ':nth-child(2) ' + 'label:nth-child(1)';
-    savedFirstAdress = this.customerInformationSection + this.column + ':nth-child(2) ' + 'label:nth-child(3)';
-    savedSecAdress = this.customerInformationSection + this.column + ':nth-child(2) ' + 'label:nth-child(5)';
+    savedFirstAdress = this.customerInformationSection + this.column + ':nth-child(2) ' + 'label:nth-child(2)';
+    savedSecAdress = this.customerInformationSection + this.column + ':nth-child(2) ' + 'label:nth-child(3)';
     editButton = this.customerInformationSection + this.column + ':nth-child(3) ' + 'a';
 
     contentSection = this.wizard + '.fd-wizard__content ';

--- a/libs/docs/core/wizard/examples/wizard-dialog-example.component.html
+++ b/libs/docs/core/wizard/examples/wizard-dialog-example.component.html
@@ -167,7 +167,7 @@
                                 <fd-layout-grid [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Type:</label>
+                                            <label fd-form-label>Type:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <label fd-form-label [style.color]="'black'">Mobile</label>
@@ -189,22 +189,16 @@
                                 <fd-layout-grid>
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Full Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 1:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 2:</label><br />
+                                            <label fd-form-label>Full Name:</label>
+                                            <label fd-form-label>Address Line 1:</label>
+                                            <label fd-form-label>Address Line 2:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">{{ fullName }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine1 }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine2 }}</label
-                                            ><br />
+                                            <label fd-form-label [style.color]="'black'">{{ fullName }}</label>
+                                            <label fd-form-label [style.color]="'black'">{{ addressLine1 }}</label>
+                                            <label fd-form-label [style.color]="'black'">{{ addressLine2 }}</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 [routerLink]="['./']"
                                                 fd-link
@@ -221,21 +215,18 @@
                                 <fd-layout-grid>
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Weight:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Delicious:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Description:</label>
+                                            <label fd-form-label>Name:</label>
+                                            <label fd-form-label>Weight:</label>
+                                            <label fd-form-label>Delicious:</label>
+                                            <label fd-form-label>Description:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">Pineapple</label><br />
-                                            <label fd-form-label [style.color]="'black'">1kg</label><br />
-                                            <label fd-form-label [style.color]="'black'">Yes</label><br />
+                                            <label fd-form-label [style.color]="'black'">Pineapple</label>
+                                            <label fd-form-label [style.color]="'black'">1kg</label>
+                                            <label fd-form-label [style.color]="'black'">Yes</label>
                                             <label fd-form-label [style.color]="'black'">n/a</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 [routerLink]="['./']"
                                                 fd-link
@@ -250,10 +241,10 @@
                                 <fd-layout-grid>
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Payment Type:</label><br />
+                                            <label fd-form-label>Payment Type:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'"></label><br />
+                                            <label fd-form-label [style.color]="'black'"></label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <a [routerLink]="['./']" fd-link (click)="goToStep(4)">Edit</a>

--- a/libs/docs/core/wizard/examples/wizard-example.component.html
+++ b/libs/docs/core/wizard/examples/wizard-example.component.html
@@ -196,7 +196,7 @@
                                 <fd-layout-grid [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Type:</label>
+                                            <label fd-form-label>Type:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <label fd-form-label [style.color]="'black'">Mobile</label>
@@ -219,22 +219,16 @@
                                 <fd-layout-grid>
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Full Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 1:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 2:</label><br />
+                                            <label fd-form-label>Full Name:</label>
+                                            <label fd-form-label>Address Line 1:</label>
+                                            <label fd-form-label>Address Line 2:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">{{ fullName }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine1 }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine2 }}</label
-                                            ><br />
+                                            <label fd-form-label [style.color]="'black'">{{ fullName }}</label>
+                                            <label fd-form-label [style.color]="'black'">{{ addressLine1 }}</label>
+                                            <label fd-form-label [style.color]="'black'">{{ addressLine2 }}</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 [routerLink]="['./']"
                                                 fd-link
@@ -252,21 +246,18 @@
                                 <fd-layout-grid>
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Weight:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Delicious:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Description:</label>
+                                            <label fd-form-label>Name:</label>
+                                            <label fd-form-label>Weight:</label>
+                                            <label fd-form-label>Delicious:</label>
+                                            <label fd-form-label>Description:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">Pineapple</label><br />
-                                            <label fd-form-label [style.color]="'black'">1kg</label><br />
-                                            <label fd-form-label [style.color]="'black'">Yes</label><br />
+                                            <label fd-form-label [style.color]="'black'">Pineapple</label>
+                                            <label fd-form-label [style.color]="'black'">1kg</label>
+                                            <label fd-form-label [style.color]="'black'">Yes</label>
                                             <label fd-form-label [style.color]="'black'">n/a</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 [routerLink]="['./']"
                                                 fd-link
@@ -284,10 +275,10 @@
                                 <fd-layout-grid>
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Payment Type:</label><br />
+                                            <label fd-form-label>Payment Type:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'"></label><br />
+                                            <label fd-form-label [style.color]="'black'"></label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <a

--- a/libs/docs/core/wizard/examples/wizard-visible-summary-example.component.html
+++ b/libs/docs/core/wizard/examples/wizard-visible-summary-example.component.html
@@ -167,7 +167,7 @@
                                 <fd-layout-grid [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Type:</label>
+                                            <label fd-form-label>Type:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <label fd-form-label [style.color]="'black'">Mobile</label>
@@ -190,22 +190,16 @@
                                 <fd-layout-grid>
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Full Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 1:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 2:</label><br />
+                                            <label fd-form-label>Full Name:</label>
+                                            <label fd-form-label>Address Line 1:</label>
+                                            <label fd-form-label>Address Line 2:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">{{ fullName }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine1 }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine2 }}</label
-                                            ><br />
+                                            <label fd-form-label [style.color]="'black'">{{ fullName }}</label>
+                                            <label fd-form-label [style.color]="'black'">{{ addressLine1 }}</label>
+                                            <label fd-form-label [style.color]="'black'">{{ addressLine2 }}</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 aria-labelledby="fd-wizard-customer-info"
                                                 [routerLink]="['./']"
@@ -223,21 +217,18 @@
                                 <fd-layout-grid>
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Weight:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Delicious:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Description:</label>
+                                            <label fd-form-label>Name:</label>
+                                            <label fd-form-label>Weight:</label>
+                                            <label fd-form-label>Delicious:</label>
+                                            <label fd-form-label>Description:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">Pineapple</label><br />
-                                            <label fd-form-label [style.color]="'black'">1kg</label><br />
-                                            <label fd-form-label [style.color]="'black'">Yes</label><br />
+                                            <label fd-form-label [style.color]="'black'">Pineapple</label>
+                                            <label fd-form-label [style.color]="'black'">1kg</label>
+                                            <label fd-form-label [style.color]="'black'">Yes</label>
                                             <label fd-form-label [style.color]="'black'">n/a</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 aria-labelledby="fd-wizard-additional-info"
                                                 [routerLink]="['./']"
@@ -255,10 +246,10 @@
                                 <fd-layout-grid>
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Payment Type:</label><br />
+                                            <label fd-form-label>Payment Type:</label>
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'"></label><br />
+                                            <label fd-form-label [style.color]="'black'"></label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <a


### PR DESCRIPTION
fixes none

While investigating some open wizard issues, I noticed some misalignments with the labels in the core wizard I wanted to clean up

before:
![Screenshot 2024-11-12 at 4 39 32 PM](https://github.com/user-attachments/assets/18600666-fd41-47d5-8cee-999f2370e40f)

after:
![Screenshot 2024-11-12 at 4 43 05 PM](https://github.com/user-attachments/assets/2780b5ee-0c3b-4ea9-83fe-2f978c563fa2)
