### PR TITLE
fix(core,platform): wizard template, a11y updates

### DIFF
--- a/libs/core/form/form-label/form-label.component.html
+++ b/libs/core/form/form-label/form-label.component.html
@@ -17,7 +17,12 @@
 @if (inlineHelpPlacement === 'before' && inlineHelpContent) {
     <ng-template [ngTemplateOutlet]="inlineHelpRef"></ng-template>
 }
-<span class="fd-form-label" [class.fd-form-label--required]="required" [class.fd-form-label--colon]="colon">
+<span
+    class="fd-form-label"
+    [class.fd-form-label--allow-wrap]="allowWrap"
+    [class.fd-form-label--required]="required"
+    [class.fd-form-label--colon]="colon"
+>
     <ng-content></ng-content>
 </span>
 @if (inlineHelpPlacement === 'after' && inlineHelpContent) {

--- a/libs/core/form/form-label/form-label.component.scss
+++ b/libs/core/form/form-label/form-label.component.scss
@@ -29,6 +29,10 @@ $form-label-bottom-spacing: 0.125rem;
         position: relative;
         top: 0.125rem;
     }
+
+    &--allow-wrap {
+        text-wrap: auto;
+    }
 }
 
 .fd-form-label__wrapper {

--- a/libs/core/form/form-label/form-label.component.ts
+++ b/libs/core/form/form-label/form-label.component.ts
@@ -81,6 +81,10 @@ export class FormLabelComponent implements OnChanges {
     @Input()
     inlineHelpPlacement: InlineHelpFormPlacement = 'after';
 
+    /** Whether to allow the text of the form label to wrap. */
+    @Input()
+    allowWrap = false;
+
     /** Inline help label. */
     @Input()
     set inlineHelpLabel(label: string) {

--- a/libs/docs/core/wizard/e2e/wizard.po.ts
+++ b/libs/docs/core/wizard/e2e/wizard.po.ts
@@ -24,12 +24,11 @@ export class WizardPo extends CoreBaseComponentPo {
     firstAdressInput = '#input-2';
     secAdressInput = '#input-3';
 
-    customerInformationSection = this.wizard + '.fd-container:nth-child(4) ';
-    column = '.fd-col';
-    savedName = this.customerInformationSection + this.column + ':nth-child(2) ' + 'label:nth-child(1)';
-    savedFirstAdress = this.customerInformationSection + this.column + ':nth-child(2) ' + 'label:nth-child(3)';
-    savedSecAdress = this.customerInformationSection + this.column + ':nth-child(2) ' + 'label:nth-child(5)';
-    editButton = this.customerInformationSection + this.column + ':nth-child(3) ' + 'a';
+    customerInformationSection = this.wizard + '.fd-container:nth-of-type(2) ';
+    savedName = this.customerInformationSection + 'div:nth-of-type(1) div:nth-of-type(2) label';
+    savedFirstAdress = this.customerInformationSection + 'div:nth-of-type(2) div:nth-of-type(2) label';
+    savedSecAdress = this.customerInformationSection + 'div:nth-of-type(3) div:nth-of-type(2) label';
+    editButton = this.customerInformationSection + 'div:nth-of-type(3) div:nth-of-type(3) a';
 
     contentSection = this.wizard + '.fd-wizard__content ';
     radioButton = this.contentSection + '.fd-radio';

--- a/libs/docs/core/wizard/examples/wizard-dialog-example.component.html
+++ b/libs/docs/core/wizard/examples/wizard-dialog-example.component.html
@@ -163,14 +163,24 @@
                         >
                             <fd-wizard-step-indicator>5</fd-wizard-step-indicator>
                             <fd-wizard-content size="sm">
-                                <h4 class="fd-title fd-title--h4" id="product-type-title">1. Product Type</h4>
-                                <fd-layout-grid [style.margin-bottom.rem]="2">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="product-type-title"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
+                                    1. Product Type
+                                </h4>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Type:</label>
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Type:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">Mobile</label>
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true"
+                                                >Mobile</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <a
@@ -183,28 +193,50 @@
                                         </div>
                                     </div>
                                 </fd-layout-grid>
-                                <h4 class="fd-title fd-title--h4" id="customer-information-title">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="customer-information-title"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
                                     2. Customer Information
                                 </h4>
-                                <fd-layout-grid>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Full Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 1:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 2:</label><br />
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Full Name:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">{{ fullName }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine1 }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine2 }}</label
-                                            ><br />
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">{{
+                                                fullName
+                                            }}</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Address Line 1:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">{{
+                                                addressLine1
+                                            }}</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Address Line 2:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">{{
+                                                addressLine2
+                                            }}</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 [routerLink]="['./']"
                                                 fd-link
@@ -215,27 +247,56 @@
                                         </div>
                                     </div>
                                 </fd-layout-grid>
-                                <h4 class="fd-title fd-title--h4" id="additional-information-id">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="additional-information-id"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
                                     3. Additional Information
                                 </h4>
-                                <fd-layout-grid>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Weight:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Delicious:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Description:</label>
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Name:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">Pineapple</label><br />
-                                            <label fd-form-label [style.color]="'black'">1kg</label><br />
-                                            <label fd-form-label [style.color]="'black'">Yes</label><br />
-                                            <label fd-form-label [style.color]="'black'">n/a</label>
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true"
+                                                >Pineapple</label
+                                            >
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Weight:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">1kg</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Delicious:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">Yes</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Description:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">n/a</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 [routerLink]="['./']"
                                                 fd-link
@@ -246,14 +307,18 @@
                                         </div>
                                     </div>
                                 </fd-layout-grid>
-                                <h4 class="fd-title fd-title--h4">4. Payment Information</h4>
-                                <fd-layout-grid>
+                                <h4 class="fd-title fd-title--h4" [style.margin-bottom.rem]="0.5">
+                                    4. Payment Information
+                                </h4>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Payment Type:</label><br />
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Payment Type:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'"></label><br />
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true"></label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <a [routerLink]="['./']" fd-link (click)="goToStep(4)">Edit</a>

--- a/libs/docs/core/wizard/examples/wizard-example.component.html
+++ b/libs/docs/core/wizard/examples/wizard-example.component.html
@@ -192,14 +192,24 @@
                             (keydown)="handleFocus($event, 4)"
                         >
                             <fd-wizard-content size="lg">
-                                <h4 class="fd-title fd-title--h4" id="fd-wizard-product-type">1. Product Type</h4>
-                                <fd-layout-grid [style.margin-bottom.rem]="2">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="fd-wizard-product-type"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
+                                    1. Product Type
+                                </h4>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Type:</label>
+                                            <label fd-form-label [allowWrap]="true" [style.float]="'right'"
+                                                >Type:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">Mobile</label>
+                                            <label fd-form-label [allowWrap]="true" [style.color]="'black'"
+                                                >Mobile</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <a
@@ -213,28 +223,50 @@
                                         </div>
                                     </div>
                                 </fd-layout-grid>
-                                <h4 class="fd-title fd-title--h4" id="fd-wizard-customer-info">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="fd-wizard-customer-info"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
                                     2. Customer Information
                                 </h4>
-                                <fd-layout-grid>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Full Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 1:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 2:</label><br />
+                                            <label fd-form-label [allowWrap]="true" [style.float]="'right'"
+                                                >Full Name:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">{{ fullName }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine1 }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine2 }}</label
-                                            ><br />
+                                            <label fd-form-label [allowWrap]="true" [style.color]="'black'">{{
+                                                fullName
+                                            }}</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [allowWrap]="true" [style.float]="'right'"
+                                                >Address Line 1:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [allowWrap]="true" [style.color]="'black'">{{
+                                                addressLine1
+                                            }}</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [allowWrap]="true" [style.float]="'right'"
+                                                >Address Line 2:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [allowWrap]="true" [style.color]="'black'">{{
+                                                addressLine2
+                                            }}</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 [routerLink]="['./']"
                                                 fd-link
@@ -246,27 +278,56 @@
                                         </div>
                                     </div>
                                 </fd-layout-grid>
-                                <h4 class="fd-title fd-title--h4" id="fd-wizard-addition-info">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="fd-wizard-addition-info"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
                                     3. Additional Information
                                 </h4>
-                                <fd-layout-grid>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Weight:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Delicious:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Description:</label>
+                                            <label fd-form-label [allowWrap]="true" [style.float]="'right'"
+                                                >Name:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">Pineapple</label><br />
-                                            <label fd-form-label [style.color]="'black'">1kg</label><br />
-                                            <label fd-form-label [style.color]="'black'">Yes</label><br />
-                                            <label fd-form-label [style.color]="'black'">n/a</label>
+                                            <label fd-form-label [allowWrap]="true" [style.color]="'black'"
+                                                >Pineapple</label
+                                            >
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [allowWrap]="true" [style.float]="'right'"
+                                                >Weight:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [allowWrap]="true" [style.color]="'black'">1kg</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [allowWrap]="true" [style.float]="'right'"
+                                                >Delicious:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [allowWrap]="true" [style.color]="'black'">Yes</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [allowWrap]="true" [style.float]="'right'"
+                                                >Description:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [allowWrap]="true" [style.color]="'black'">n/a</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 [routerLink]="['./']"
                                                 fd-link
@@ -278,16 +339,22 @@
                                         </div>
                                     </div>
                                 </fd-layout-grid>
-                                <h4 class="fd-title fd-title--h4" id="fd-wizard-payment-info">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="fd-wizard-payment-info"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
                                     4. Payment Information
                                 </h4>
-                                <fd-layout-grid>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Payment Type:</label><br />
+                                            <label fd-form-label [allowWrap]="true" [style.float]="'right'"
+                                                >Payment Type:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'"></label><br />
+                                            <label fd-form-label [allowWrap]="true" [style.color]="'black'"></label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <a

--- a/libs/docs/core/wizard/examples/wizard-visible-summary-example.component.html
+++ b/libs/docs/core/wizard/examples/wizard-visible-summary-example.component.html
@@ -163,14 +163,24 @@
                         >
                             <fd-wizard-step-indicator>5</fd-wizard-step-indicator>
                             <fd-wizard-content size="sm">
-                                <h4 class="fd-title fd-title--h4" id="fd-wizard-product-type">1. Product Type</h4>
-                                <fd-layout-grid [style.margin-bottom.rem]="2">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="fd-wizard-product-type"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
+                                    1. Product Type
+                                </h4>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Type:</label>
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Type:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">Mobile</label>
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true"
+                                                >Mobile</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <a
@@ -184,28 +194,50 @@
                                         </div>
                                     </div>
                                 </fd-layout-grid>
-                                <h4 class="fd-title fd-title--h4" id="fd-wizard-customer-info">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="fd-wizard-customer-info"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
                                     2. Customer Information
                                 </h4>
-                                <fd-layout-grid>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Full Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 1:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Address Line 2:</label><br />
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Full Name:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">{{ fullName }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine1 }}</label
-                                            ><br />
-                                            <label fd-form-label [style.color]="'black'">{{ addressLine2 }}</label
-                                            ><br />
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">{{
+                                                fullName
+                                            }}</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Address Line 1:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">{{
+                                                addressLine1
+                                            }}</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Address Line 2:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">{{
+                                                addressLine2
+                                            }}</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 aria-labelledby="fd-wizard-customer-info"
                                                 [routerLink]="['./']"
@@ -217,27 +249,56 @@
                                         </div>
                                     </div>
                                 </fd-layout-grid>
-                                <h4 class="fd-title fd-title--h4" id="fd-wizard-additional-info">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="fd-wizard-additional-info"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
                                     3. Additional Information
                                 </h4>
-                                <fd-layout-grid>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Name:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Weight:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Delicious:</label><br />
-                                            <label fd-form-label [style.float]="'right'">Description:</label>
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Name:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'">Pineapple</label><br />
-                                            <label fd-form-label [style.color]="'black'">1kg</label><br />
-                                            <label fd-form-label [style.color]="'black'">Yes</label><br />
-                                            <label fd-form-label [style.color]="'black'">n/a</label>
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true"
+                                                >Pineapple</label
+                                            >
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Weight:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">1kg</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Delicious:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">Yes</label>
+                                        </div>
+                                    </div>
+                                    <div fdLayoutGridRow>
+                                        <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Description:</label
+                                            >
+                                        </div>
+                                        <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
+                                            <label fd-form-label [style.color]="'black'" [allowWrap]="true">n/a</label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <br />
-                                            <br />
-                                            <br />
                                             <a
                                                 aria-labelledby="fd-wizard-additional-info"
                                                 [routerLink]="['./']"
@@ -249,16 +310,22 @@
                                         </div>
                                     </div>
                                 </fd-layout-grid>
-                                <h4 class="fd-title fd-title--h4" id="fd-wizard-payment-info">
+                                <h4
+                                    class="fd-title fd-title--h4"
+                                    id="fd-wizard-payment-info"
+                                    [style.margin-bottom.rem]="0.5"
+                                >
                                     4. Payment Information
                                 </h4>
-                                <fd-layout-grid>
+                                <fd-layout-grid [noVerticalGap]="true" [style.margin-bottom.rem]="2">
                                     <div fdLayoutGridRow>
                                         <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                                            <label fd-form-label [style.float]="'right'">Payment Type:</label><br />
+                                            <label fd-form-label [style.float]="'right'" [allowWrap]="true"
+                                                >Payment Type:</label
+                                            >
                                         </div>
                                         <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                                            <label fd-form-label [style.color]="'black'"></label><br />
+                                            <label fd-form-label [style.color]="'black'"></label>
                                         </div>
                                         <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
                                             <a

--- a/libs/platform/wizard-generator/components/wizard-summary-step/wizard-summary-section/wizard-summary-section.component.html
+++ b/libs/platform/wizard-generator/components/wizard-summary-step/wizard-summary-section/wizard-summary-section.component.html
@@ -1,28 +1,28 @@
 @for (group of step.forms; track _trackFn($index, group)) {
     <h4 fd-title [headerSize]="4">{{ group.title }}</h4>
     <fd-layout-grid [style.margin-bottom.rem]="2">
-        <div fdLayoutGridRow>
-            <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
-                @for (item of group.items; track item) {
+        @for (item of group.items; track item; let index = $index) {
+            <div fdLayoutGridRow>
+                <div [fdLayoutGridCol]="4" [colMd]="2" [colLg]="2" [colXl]="2">
                     <div>
-                        <label fd-form-label> {{ item.label }}: </label>
+                        <label fd-form-label [allowWrap]="true" [alignLabelEnd]="true"> {{ item.label }}: </label>
                     </div>
-                }
-            </div>
-            <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
-                @for (item of group.items; track item) {
+                </div>
+                <div [fdLayoutGridCol]="4" [colMd]="5" [colLg]="5" [colXl]="5">
                     <div>
-                        <label fd-form-label>
+                        <label fd-form-label [allowWrap]="true">
                             {{ item.value || '-' }}
                         </label>
                     </div>
+                </div>
+                @if (index === group.items.length - 1) {
+                    <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
+                        <fdp-link href="#" (click)="_editStep($event)">
+                            {{ 'platformWizardGenerator.summarySectionEditStep' | fdTranslate }}
+                        </fdp-link>
+                    </div>
                 }
             </div>
-            <div [fdLayoutGridCol]="1" [colMd]="5" [colLg]="5" [colXl]="5">
-                <fdp-link href="#" (click)="_editStep($event)">
-                    {{ 'platformWizardGenerator.summarySectionEditStep' | fdTranslate }}
-                </fdp-link>
-            </div>
-        </div>
+        }
     </fd-layout-grid>
 }


### PR DESCRIPTION
fixes #11385 

- platform wizard generator labels and data now wrap automatically on the summary page
- core wizard example default documentation edited to demonstrate how to handle text wrapping (not obvious in example)
- added class to fd-form-label to allow for text wrapping