### PR TITLE
fix(core): wizard section add role attribute

### DIFF
--- a/libs/core/wizard/wizard-content/wizard-content.component.html
+++ b/libs/core/wizard/wizard-content/wizard-content.component.html
@@ -1,5 +1,6 @@
 <ng-template #contentTemplate>
     <section
+        role="tabpanel"
         [id]="wizardContentId"
         class="fd-wizard__content"
         [class]="


### PR DESCRIPTION
fix(core): wizard section add role attribute


closes [#12674](https://github.com/SAP/fundamental-ngx/issues/12674)

- Added `role="tabpanel"` role to wizard section

![Screenshot 2024-11-18 180855](https://github.com/user-attachments/assets/b5746cd1-5304-4825-b021-5da5a9e23e0a)
