### PR TITLE
fix(platform): table spanning

### DIFF
--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -2119,7 +2119,9 @@ export class TableComponent<T = any>
 
     /** @hidden */
     private _calculateTableColumnsLength(): void {
-        this._tableColumnsLength = this.getTableColumns().length + (this._isSelectionColumnShown ? 1 : 0);
+        const isGroupable = this.initialState?.initialGroupBy.length;
+        this._tableColumnsLength =
+            this.getTableColumns().length + (this._isSelectionColumnShown || isGroupable ? 1 : 0);
     }
 
     /** @hidden */


### PR DESCRIPTION
 closes [#12677](https://github.com/SAP/fundamental-ngx/issues/12677)

Fixed an issue where using `semanticHighlighting` and `group` properties simultaneously in `fdp-table` caused unexpected behavior. Updated logic to ensure compatibility and proper rendering when these features are used together.


## Snapshots


https://github.com/user-attachments/assets/afc02800-6207-4dd4-8e0a-ac4b789a7415



