### PR TITLE
fix(platform): remove emtpy tab in dynamic page with tabs

### DIFF
--- a/libs/platform/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/dynamic-page/dynamic-page.component.html
@@ -94,7 +94,6 @@
                         ></ng-template> </fd-dynamic-page-content
                 ></fdp-icon-tab-bar-tab>
             }
-            <fdp-icon-tab-bar-tab></fdp-icon-tab-bar-tab>
         </fdp-icon-tab-bar>
     }
     @if (!_isTabbed && contentComponent) {


### PR DESCRIPTION
closes #12738 

remove emtpy tab in dynamic page with tabs