### PR TITLE
fix(platform): match filter strategies for string data type columns

### DIFF
--- a/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-custom-filter-example.component.ts
+++ b/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-custom-filter-example.component.ts
@@ -389,7 +389,6 @@ export class TableDataProviderExample extends TableDataProvider<ExampleItem> {
      */
     private _filterString(item: ExampleItem, filter: CollectionStringFilter): boolean {
         const filterValue = filter.value && filter.value.toLocaleLowerCase();
-        const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
         let itemValue = get(item, filter.field);
 
         itemValue = itemValue ? itemValue.toLocaleLowerCase() : itemValue;
@@ -399,21 +398,6 @@ export class TableDataProviderExample extends TableDataProvider<ExampleItem> {
         switch (filter.strategy) {
             case 'equalTo':
                 result = itemValue === filterValue;
-                break;
-            case 'greaterThan':
-                result = itemValue > filterValue;
-                break;
-            case 'greaterThanOrEqualTo':
-                result = itemValue >= filterValue;
-                break;
-            case 'lessThan':
-                result = itemValue < filterValue;
-                break;
-            case 'lessThanOrEqualTo':
-                result = itemValue <= filterValue;
-                break;
-            case 'between':
-                result = itemValue >= filterValue && itemValue <= filterValue2;
                 break;
             case 'beginsWith':
                 result = itemValue.startsWith(filterValue);

--- a/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-observable-example.component.ts
+++ b/libs/docs/platform/smart-filter-bar/examples/platform-smart-filter-bar-observable-example.component.ts
@@ -247,7 +247,6 @@ export class ObservableTableDataProviderExample extends ObservableTableDataProvi
      */
     private _filterString(item: ExampleItem, filter: CollectionStringFilter): boolean {
         const filterValue = filter.value && filter.value.toLocaleLowerCase();
-        const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
         let itemValue = get(item, filter.field);
 
         itemValue = itemValue ? itemValue.toLocaleLowerCase() : itemValue;
@@ -257,21 +256,6 @@ export class ObservableTableDataProviderExample extends ObservableTableDataProvi
         switch (filter.strategy) {
             case 'equalTo':
                 result = itemValue === filterValue;
-                break;
-            case 'greaterThan':
-                result = itemValue > filterValue;
-                break;
-            case 'greaterThanOrEqualTo':
-                result = itemValue >= filterValue;
-                break;
-            case 'lessThan':
-                result = itemValue < filterValue;
-                break;
-            case 'lessThanOrEqualTo':
-                result = itemValue <= filterValue;
-                break;
-            case 'between':
-                result = itemValue >= filterValue && itemValue <= filterValue2;
                 break;
             case 'beginsWith':
                 result = itemValue.startsWith(filterValue);

--- a/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.ts
+++ b/libs/docs/platform/table/examples/advanced-scrolling/advanced-scrolling-example.component.ts
@@ -317,28 +317,12 @@ function getNestedValue<T extends Record<string, any>>(key: string, object: T): 
 
 const filterByString = (item: ExampleItem, filter: CollectionStringFilter): boolean => {
     const filterValue = filter.value && filter.value.toLocaleLowerCase();
-    const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
     const itemValue = getNestedValue(filter.field, item).toLocaleLowerCase();
     let result = false;
 
     switch (filter.strategy) {
         case 'equalTo':
             result = itemValue === filterValue;
-            break;
-        case 'greaterThan':
-            result = itemValue > filterValue;
-            break;
-        case 'greaterThanOrEqualTo':
-            result = itemValue >= filterValue;
-            break;
-        case 'lessThan':
-            result = itemValue < filterValue;
-            break;
-        case 'lessThanOrEqualTo':
-            result = itemValue <= filterValue;
-            break;
-        case 'between':
-            result = itemValue >= filterValue && itemValue <= filterValue2;
             break;
         case 'beginsWith':
             result = itemValue.startsWith(filterValue);

--- a/libs/docs/platform/table/examples/editable-rows/platform-table-editable-rows-example.component.ts
+++ b/libs/docs/platform/table/examples/editable-rows/platform-table-editable-rows-example.component.ts
@@ -252,28 +252,12 @@ function getNestedValue<T extends Record<string, any>>(key: string, object: T): 
 
 const filterByString = (item: ExampleItem, filter: CollectionStringFilter): boolean => {
     const filterValue = filter.value && filter.value.toLocaleLowerCase();
-    const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
     const itemValue = getNestedValue(filter.field, item).toLocaleLowerCase();
     let result = false;
 
     switch (filter.strategy) {
         case 'equalTo':
             result = itemValue === filterValue;
-            break;
-        case 'greaterThan':
-            result = itemValue > filterValue;
-            break;
-        case 'greaterThanOrEqualTo':
-            result = itemValue >= filterValue;
-            break;
-        case 'lessThan':
-            result = itemValue < filterValue;
-            break;
-        case 'lessThanOrEqualTo':
-            result = itemValue <= filterValue;
-            break;
-        case 'between':
-            result = itemValue >= filterValue && itemValue <= filterValue2;
             break;
         case 'beginsWith':
             result = itemValue.startsWith(filterValue);

--- a/libs/docs/platform/table/examples/platform-table-data-provider-example.ts
+++ b/libs/docs/platform/table/examples/platform-table-data-provider-example.ts
@@ -182,28 +182,12 @@ function getNestedValue<T extends Record<string, any>>(key: string, object: T): 
 
 const filterByString = (item: ExampleItem, filter: CollectionStringFilter): boolean => {
     const filterValue = filter.value && filter.value.toLocaleLowerCase();
-    const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
     const itemValue = getNestedValue(filter.field, item).toLocaleLowerCase();
     let result = false;
 
     switch (filter.strategy) {
         case 'equalTo':
             result = itemValue === filterValue;
-            break;
-        case 'greaterThan':
-            result = itemValue > filterValue;
-            break;
-        case 'greaterThanOrEqualTo':
-            result = itemValue >= filterValue;
-            break;
-        case 'lessThan':
-            result = itemValue < filterValue;
-            break;
-        case 'lessThanOrEqualTo':
-            result = itemValue <= filterValue;
-            break;
-        case 'between':
-            result = itemValue >= filterValue && itemValue <= filterValue2;
             break;
         case 'beginsWith':
             result = itemValue.startsWith(filterValue);

--- a/libs/docs/platform/table/examples/platform-table-filterable-example.component.ts
+++ b/libs/docs/platform/table/examples/platform-table-filterable-example.component.ts
@@ -226,28 +226,12 @@ function getNestedValue<T extends Record<string, any>>(key: string, object: T): 
 
 const filterByString = (item: ExampleItem, filter: CollectionStringFilter): boolean => {
     const filterValue = filter.value && filter.value.toLocaleLowerCase();
-    const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
     const itemValue = getNestedValue(filter.field, item).toLocaleLowerCase();
     let result = false;
 
     switch (filter.strategy) {
         case 'equalTo':
             result = itemValue === filterValue;
-            break;
-        case 'greaterThan':
-            result = itemValue > filterValue;
-            break;
-        case 'greaterThanOrEqualTo':
-            result = itemValue >= filterValue;
-            break;
-        case 'lessThan':
-            result = itemValue < filterValue;
-            break;
-        case 'lessThanOrEqualTo':
-            result = itemValue <= filterValue;
-            break;
-        case 'between':
-            result = itemValue >= filterValue && itemValue <= filterValue2;
             break;
         case 'beginsWith':
             result = itemValue.startsWith(filterValue);

--- a/libs/docs/platform/table/examples/platform-table-initial-state-example.component.ts
+++ b/libs/docs/platform/table/examples/platform-table-initial-state-example.component.ts
@@ -229,28 +229,12 @@ function getNestedValue<T extends Record<string, any>>(key: string, object: T): 
 
 const filterByString = (item: ExampleItem, filter: CollectionStringFilter): boolean => {
     const filterValue = filter.value && filter.value.toLocaleLowerCase();
-    const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
     const itemValue = getNestedValue(filter.field, item).toLocaleLowerCase();
     let result = false;
 
     switch (filter.strategy) {
         case 'equalTo':
             result = itemValue === filterValue;
-            break;
-        case 'greaterThan':
-            result = itemValue > filterValue;
-            break;
-        case 'greaterThanOrEqualTo':
-            result = itemValue >= filterValue;
-            break;
-        case 'lessThan':
-            result = itemValue < filterValue;
-            break;
-        case 'lessThanOrEqualTo':
-            result = itemValue <= filterValue;
-            break;
-        case 'between':
-            result = itemValue >= filterValue && itemValue <= filterValue2;
             break;
         case 'beginsWith':
             result = itemValue.startsWith(filterValue);

--- a/libs/docs/platform/table/examples/platform-table-p13-filter-example.component.ts
+++ b/libs/docs/platform/table/examples/platform-table-p13-filter-example.component.ts
@@ -218,28 +218,12 @@ function getNestedValue<T extends Record<string, any>>(key: string, object: T): 
 
 const filterByString = (item: ExampleItem, filter: CollectionStringFilter): boolean => {
     const filterValue = filter.value && filter.value.toLocaleLowerCase();
-    const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
     const itemValue = getNestedValue(filter.field, item).toLocaleLowerCase();
     let result = false;
 
     switch (filter.strategy) {
         case 'equalTo':
             result = itemValue === filterValue;
-            break;
-        case 'greaterThan':
-            result = itemValue > filterValue;
-            break;
-        case 'greaterThanOrEqualTo':
-            result = itemValue >= filterValue;
-            break;
-        case 'lessThan':
-            result = itemValue < filterValue;
-            break;
-        case 'lessThanOrEqualTo':
-            result = itemValue <= filterValue;
-            break;
-        case 'between':
-            result = itemValue >= filterValue && itemValue <= filterValue2;
             break;
         case 'beginsWith':
             result = itemValue.startsWith(filterValue);

--- a/libs/docs/platform/table/examples/preserved-state/platform-table-preserved-state-example.component.ts
+++ b/libs/docs/platform/table/examples/preserved-state/platform-table-preserved-state-example.component.ts
@@ -317,28 +317,12 @@ export class ExampleTableProvider extends TableDataProvider<ExampleItem> {
 
 const filterByString = (item: ExampleItem, filter: CollectionStringFilter): boolean => {
     const filterValue = filter.value && filter.value.toLocaleLowerCase();
-    const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
     const itemValue = getNestedValue(filter.field, item).toLocaleLowerCase();
     let result = false;
 
     switch (filter.strategy) {
         case 'equalTo':
             result = itemValue === filterValue;
-            break;
-        case 'greaterThan':
-            result = itemValue > filterValue;
-            break;
-        case 'greaterThanOrEqualTo':
-            result = itemValue >= filterValue;
-            break;
-        case 'lessThan':
-            result = itemValue < filterValue;
-            break;
-        case 'lessThanOrEqualTo':
-            result = itemValue <= filterValue;
-            break;
-        case 'between':
-            result = itemValue >= filterValue && itemValue <= filterValue2;
             break;
         case 'beginsWith':
             result = itemValue.startsWith(filterValue);

--- a/libs/docs/platform/variant-management/examples/table/variant-management-table-example.component.ts
+++ b/libs/docs/platform/variant-management/examples/table/variant-management-table-example.component.ts
@@ -329,28 +329,12 @@ function getNestedValue<T extends Record<string, any>>(key: string, object: T): 
 
 const filterByString = (item: ExampleItem, filter: CollectionStringFilter): boolean => {
     const filterValue = filter.value && filter.value.toLocaleLowerCase();
-    const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
     const itemValue = getNestedValue(filter.field, item).toLocaleLowerCase();
     let result = false;
 
     switch (filter.strategy) {
         case 'equalTo':
             result = itemValue === filterValue;
-            break;
-        case 'greaterThan':
-            result = itemValue > filterValue;
-            break;
-        case 'greaterThanOrEqualTo':
-            result = itemValue >= filterValue;
-            break;
-        case 'lessThan':
-            result = itemValue < filterValue;
-            break;
-        case 'lessThanOrEqualTo':
-            result = itemValue <= filterValue;
-            break;
-        case 'between':
-            result = itemValue >= filterValue && itemValue <= filterValue2;
             break;
         case 'beginsWith':
             result = itemValue.startsWith(filterValue);

--- a/libs/docs/shared/src/lib/core-helpers/code-example/code-example.component.ts
+++ b/libs/docs/shared/src/lib/core-helpers/code-example/code-example.component.ts
@@ -139,7 +139,8 @@ export class CodeExampleComponent implements OnInit {
     }
 
     openStackBlitz(): void {
-        this.stackBlitzService.openCode(this._exampleFiles);
+        console.log(this._exampleFiles);
+        // this.stackBlitzService.openCode(this._exampleFiles);
     }
 
     copyText(): void {

--- a/libs/docs/shared/src/lib/core-helpers/code-example/code-example.component.ts
+++ b/libs/docs/shared/src/lib/core-helpers/code-example/code-example.component.ts
@@ -139,8 +139,7 @@ export class CodeExampleComponent implements OnInit {
     }
 
     openStackBlitz(): void {
-        console.log(this._exampleFiles);
-        // this.stackBlitzService.openCode(this._exampleFiles);
+        this.stackBlitzService.openCode(this._exampleFiles);
     }
 
     copyText(): void {

--- a/libs/platform/table-helpers/domain/table-data-provider.ts
+++ b/libs/platform/table-helpers/domain/table-data-provider.ts
@@ -163,7 +163,6 @@ export abstract class BaseTableDataProvider<T, P = T[]> {
      */
     protected filterString(item: T, filter: CollectionStringFilter): boolean {
         const filterValue = filter.value && filter.value.toLocaleLowerCase();
-        const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
         let itemValue = get(item, filter.field);
 
         itemValue = itemValue ? itemValue.toLocaleLowerCase() : itemValue;
@@ -173,21 +172,6 @@ export abstract class BaseTableDataProvider<T, P = T[]> {
         switch (filter.strategy) {
             case 'equalTo':
                 result = itemValue === filterValue;
-                break;
-            case 'greaterThan':
-                result = itemValue > filterValue;
-                break;
-            case 'greaterThanOrEqualTo':
-                result = itemValue >= filterValue;
-                break;
-            case 'lessThan':
-                result = itemValue < filterValue;
-                break;
-            case 'lessThanOrEqualTo':
-                result = itemValue <= filterValue;
-                break;
-            case 'between':
-                result = itemValue >= filterValue && itemValue <= filterValue2;
                 break;
             case 'beginsWith':
                 result = itemValue.startsWith(filterValue);

--- a/libs/platform/table-helpers/enums/collection-filter.enum.ts
+++ b/libs/platform/table-helpers/enums/collection-filter.enum.ts
@@ -70,19 +70,11 @@ export type FilterNumberStrategy = (typeof FILTER_NUMBER_STRATEGY)[keyof typeof 
 export const FILTER_NUMBER_STRATEGIES: ReadonlyArray<FilterNumberStrategy> = Object.values(FILTER_NUMBER_STRATEGY);
 
 /** String Filter Strategies */
-export const FILTER_STRING_STRATEGY: Pick<
-    FilterStrategyType,
-    'BETWEEN' | 'CONTAINS' | 'EQ' | 'BEGINS_WITH' | 'ENDS_WITH' | 'GT' | 'GTE' | 'LT' | 'LTE'
-> = {
+export const FILTER_STRING_STRATEGY: Pick<FilterStrategyType, 'EQ' | 'CONTAINS' | 'BEGINS_WITH' | 'ENDS_WITH'> = {
     CONTAINS: 'contains',
     EQ: 'equalTo',
     BEGINS_WITH: 'beginsWith',
-    BETWEEN: 'between',
-    ENDS_WITH: 'endsWith',
-    GT: 'greaterThan',
-    GTE: 'greaterThanOrEqualTo',
-    LT: 'lessThan',
-    LTE: 'lessThanOrEqualTo'
+    ENDS_WITH: 'endsWith'
 };
 
 export type FilterAllStrategy = (typeof FILTER_STRATEGY)[keyof typeof FILTER_STRATEGY];
@@ -112,7 +104,11 @@ export const FILTER_DEFAULT_STRATEGIES: ReadonlyArray<FilterStringStrategy> = Ob
 // Get Possible strategies based on data type
 export const getFilterStrategiesBasedOnDataType = (
     dataType: FilterableColumnDataType
-): readonly FilterStringStrategy[] | readonly FilterDateStrategy[] => {
+):
+    | readonly FilterStringStrategy[]
+    | readonly FilterDateStrategy[]
+    | readonly FilterNumberStrategy[]
+    | readonly FilterBooleanStrategy[] => {
     switch (dataType) {
         case FilterableColumnDataType.STRING:
             return FILTER_STRING_STRATEGIES;
@@ -122,7 +118,6 @@ export const getFilterStrategiesBasedOnDataType = (
             return FILTER_DATE_STRATEGIES;
         case FilterableColumnDataType.BOOLEAN:
             return FILTER_BOOLEAN_STRATEGIES;
-
         default:
             return FILTER_DEFAULT_STRATEGIES;
     }

--- a/libs/platform/table-helpers/utils.ts
+++ b/libs/platform/table-helpers/utils.ts
@@ -12,24 +12,10 @@ import { TableRow } from './models/table-row.model';
 
 export const filterByString = (rows: TableRow[], filter: CollectionStringFilter): TableRow[] => {
     const filterValue = filter.value && filter.value.toLocaleLowerCase();
-    const filterValue2 = (filter.value2 && filter.value2.toLocaleLowerCase()) || '';
 
     switch (filter.strategy) {
         case FILTER_STRING_STRATEGY.EQ:
             return rows.filter((r) => get(r.value, filter.field).toLocaleLowerCase() === filterValue);
-        case FILTER_STRING_STRATEGY.GT:
-            return rows.filter((r) => get(r.value, filter.field).toLocaleLowerCase() > filterValue);
-        case FILTER_STRING_STRATEGY.GTE:
-            return rows.filter((r) => get(r.value, filter.field).toLocaleLowerCase() >= filterValue);
-        case FILTER_STRING_STRATEGY.LT:
-            return rows.filter((r) => get(r.value, filter.field).toLocaleLowerCase() < filterValue);
-        case FILTER_STRING_STRATEGY.LTE:
-            return rows.filter((r) => get(r.value, filter.field).toLocaleLowerCase() <= filterValue);
-        case FILTER_STRING_STRATEGY.BETWEEN:
-            return rows.filter((r) => {
-                const rowValue = get(r.value, filter.field).toLocaleLowerCase();
-                return rowValue >= filterValue && rowValue <= filterValue2;
-            });
         case FILTER_STRING_STRATEGY.BEGINS_WITH:
             return rows.filter((r) => get(r.value, filter.field).toLocaleLowerCase().startsWith(filterValue));
         case FILTER_STRING_STRATEGY.ENDS_WITH:


### PR DESCRIPTION
## Description

Matched the strategy filter to display only strategies relevant to the string data type when the column is of type string. Previously, the filter dialog was showing strategies for both number and string data types for columns with a string data type. This update ensures that only the appropriate strategies for string data types are shown when the column is of type string.

### Before:
![before](https://github.com/user-attachments/assets/c9b99bce-cad7-48c1-87e3-560e27a3cdc2)

### After:
![after](https://github.com/user-attachments/assets/2551c37f-0f1c-4cec-aa2d-91602b245d95)

