### PR TITLE
fix(core,platform): clicking list item in p13 dialog should not toggle checkbox

### DIFF
--- a/libs/core/src/lib/list/list-item/list-item.component.ts
+++ b/libs/core/src/lib/list/list-item/list-item.component.ts
@@ -137,6 +137,13 @@ export class ListItemComponent<T = any>
     @Input()
     ariaRole: Nullable<string>;
 
+    /**
+     * Whether to prevent built-in click event logic on the list item.
+     * Helpful when using lists with checkboxes or radio buttons when the list item should be clickable, but should not select/deselect the list item.
+     */
+    @Input()
+    preventClick = false;
+
     /** @hidden */
     @ContentChild(FD_RADIO_BUTTON_COMPONENT)
     set radio(value: RadioButtonComponent) {
@@ -265,16 +272,18 @@ export class ListItemComponent<T = any>
     /** Handler for mouse events */
     @HostListener('click', ['$event'])
     onClick(event: MouseEvent): void {
-        this._clicked$.next(event);
-        if (this.checkbox && !this.link) {
-            if (!this.checkbox.elementRef.nativeElement.contains(event.target as Node)) {
-                // clicking on the checkbox is not suppressed
-                // so we should only process clicks if clicked on the list-item, not checkbox itself
-                this.checkbox.nextValue();
+        if (!this.preventClick) {
+            this._clicked$.next(event);
+            if (this.checkbox && !this.link) {
+                if (!this.checkbox.elementRef.nativeElement.contains(event.target as Node)) {
+                    // clicking on the checkbox is not suppressed
+                    // so we should only process clicks if clicked on the list-item, not checkbox itself
+                    this.checkbox.nextValue();
+                }
             }
-        }
-        if (this.radio && !this.link) {
-            this.radio.labelClicked(event, false);
+            if (this.radio && !this.link) {
+                this.radio.labelClicked(event, false);
+            }
         }
     }
 

--- a/libs/platform/src/lib/table/components/table-p13-dialog/columns/columns.component.html
+++ b/libs/platform/src/lib/table/components/table-p13-dialog/columns/columns.component.html
@@ -109,6 +109,7 @@
                 [class.fd-select-item--active]="item.active"
                 [selected]="item.selected"
                 (focus)="_setActiveColumn(item)"
+                [preventClick]="true"
             >
                 <fd-checkbox [(ngModel)]="item.selected" (ngModelChange)="_onToggleColumn()"></fd-checkbox>
                 <span fd-list-title>


### PR DESCRIPTION
fixes #12672 for the main branch

- Adds an input `preventClick` to the list item component which allows the user to disable default selection/deselection behavior for list items
- Utilizes this new input on the platform table p13 dialog so that clicking a list item doesn't handle selection - user must manually click the checkbox