### PR TITLE
fix(platform): bug fix for search field not applying active style on initial focus

### DIFF
--- a/libs/platform/search-field/search-field.component.html
+++ b/libs/platform/search-field/search-field.component.html
@@ -66,6 +66,8 @@
             <input
                 #inputField
                 type="search"
+                (focus)="_isFocused = true"
+                (blur)="_isFocused = false; (null)"
                 [attr.placeholder]="placeholder"
                 class="fdp-search-field__input fd-input fd-input-group__input {{ appearance?.searchFieldClass }}"
                 [attr.id]="_inputId"

--- a/libs/platform/search-field/search-field.component.html
+++ b/libs/platform/search-field/search-field.component.html
@@ -54,7 +54,7 @@
         <div
             #inputGroup
             class="fdp-search-field__input-group fd-input-group {{ appearance?.searchClass }}"
-            [class.is-focus]="isFocused"
+            [class.is-focus]="_isFocused"
         >
             @if (_showCategoryDropdown) {
                 <span class="fd-input-group__addon fd-input-group__addon--button {{ appearance?.searchCategoryClass }}">

--- a/libs/platform/search-field/search-field.component.ts
+++ b/libs/platform/search-field/search-field.component.ts
@@ -292,9 +292,7 @@ export class SearchFieldComponent
         };
     }
     /** @hidden Focus state */
-    get isFocused(): boolean {
-        return this._document?.activeElement === this.inputField?.nativeElement;
-    }
+    _isFocused = false;
 
     /**
      * Observable list of string values taken from `suggestions` to populate dropdown menu.


### PR DESCRIPTION
fixed #12617 

Fixes a bug where tabbing to the platform search field input would not properly apply the border focus styles.