### PR TITLE
[WIP] fix(core): onChange emitters running on objects only

### DIFF
--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -831,10 +831,7 @@ export class ComboboxComponent<T = any>
             } else if (values.length === 0) {
                 this.setValue(this.inputText);
             }
-            const thisValue = this.getValue();
-            if (typeof thisValue === 'object') {
-                this.onChange(thisValue);
-            }
+            this.onChange(this.getValue());
         } else {
             this.onChange(this.inputText);
         }


### PR DESCRIPTION
Preventing to run emitters like ngOnChange on dropdown items that weren't obects; i.e., strings

closes #13002 