### PR TITLE
fix(platform): do not set focus on list when there is IME processing

### DIFF
--- a/libs/cdk/src/lib/utils/functions/key-util.spec.ts
+++ b/libs/cdk/src/lib/utils/functions/key-util.spec.ts
@@ -113,7 +113,7 @@ describe('KeyUtil', () => {
     describe('isKeyType', () => {
         interface TestValue {
             event: KeyboardEvent;
-            keyType: 'numeric' | 'alphabetical' | null | undefined;
+            keyType: 'numeric' | 'alphabetical' | 'ime' | null | undefined;
         }
 
         const positiveTestValues: TestValue[] = [
@@ -160,6 +160,20 @@ describe('KeyUtil', () => {
                     keyCode: 57
                 },
                 keyType: 'numeric'
+            },
+            {
+                event: {
+                    ...new KeyboardEvent('Space', { code: 'Space' }),
+                    key: 'Process'
+                },
+                keyType: 'ime'
+            },
+            {
+                event: {
+                    ...new KeyboardEvent('Space', { code: 'Space' }),
+                    keyCode: 229
+                },
+                keyType: 'ime'
             }
         ];
 
@@ -191,6 +205,20 @@ describe('KeyUtil', () => {
                     keyCode: 48
                 },
                 keyType: 'alphabetical'
+            },
+            {
+                event: {
+                    ...new KeyboardEvent('Space', { code: 'Space' }),
+                    keyCode: 48
+                },
+                keyType: 'ime'
+            },
+            {
+                event: {
+                    ...new KeyboardEvent('Space', { code: 'Space' }),
+                    key: ' '
+                },
+                keyType: 'ime'
             }
         ];
 

--- a/libs/cdk/src/lib/utils/functions/key-util.ts
+++ b/libs/cdk/src/lib/utils/functions/key-util.ts
@@ -109,7 +109,7 @@ export class KeyUtil {
      * @param event     - KeyboardEvent
      * @param keyType   - Type of key
      * */
-    static isKeyType(event: KeyboardEvent, keyType: 'alphabetical' | 'numeric' | 'control'): boolean {
+    static isKeyType(event: KeyboardEvent, keyType: 'alphabetical' | 'numeric' | 'control' | 'ime'): boolean {
         if (event && keyType) {
             switch (keyType) {
                 case 'numeric':
@@ -123,6 +123,8 @@ export class KeyUtil {
                 // some service commands as alt, ctr, insert, print, f4 etc. All except letters, numbers and symbols
                 case 'control':
                     return event.keyCode < 48 || (event.keyCode >= 112 && event.keyCode <= 123);
+                case 'ime':
+                    return event.key?.toLowerCase() === 'process' || event.keyCode === 229;
             }
         }
 

--- a/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/src/lib/multi-combobox/multi-combobox.component.ts
@@ -693,7 +693,10 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
             this._showList(false);
         } else if (!KeyUtil.isKeyCode(event, [...this._nonOpeningKeys, CONTROL])) {
             this._showList(true);
-            const acceptedKeys = !KeyUtil.isKeyType(event, 'alphabetical') && !KeyUtil.isKeyType(event, 'numeric');
+            const acceptedKeys =
+                !KeyUtil.isKeyType(event, 'alphabetical') &&
+                !KeyUtil.isKeyType(event, 'numeric') &&
+                !KeyUtil.isKeyType(event, 'ime');
             if (acceptedKeys) {
                 // SetTimeout is needed for input to receive new value.
                 setTimeout(() => {

--- a/libs/platform/src/lib/form/combobox/commons/base-combobox.ts
+++ b/libs/platform/src/lib/form/combobox/commons/base-combobox.ts
@@ -508,6 +508,7 @@ export abstract class BaseCombobox
                 !KeyUtil.isKeyCode(event, SPACE) &&
                 !KeyUtil.isKeyType(event, 'alphabetical') &&
                 !KeyUtil.isKeyType(event, 'numeric') &&
+                !KeyUtil.isKeyType(event, 'ime') &&
                 !KeyUtil.isKeyCode(event, this._numberPadNumberKeys);
 
             if (this.isEmptyValue && acceptedKeys) {

--- a/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/src/lib/form/multi-combobox/commons/base-multi-combobox.ts
@@ -586,7 +586,10 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
             this.showList(false);
         } else if (!KeyUtil.isKeyCode(event, [...this._nonOpeningKeys, CONTROL])) {
             this.showList(true);
-            const acceptedKeys = !KeyUtil.isKeyType(event, 'alphabetical') && !KeyUtil.isKeyType(event, 'numeric');
+            const acceptedKeys =
+                !KeyUtil.isKeyType(event, 'alphabetical') &&
+                !KeyUtil.isKeyType(event, 'numeric') &&
+                !KeyUtil.isKeyType(event, 'ime');
             if (acceptedKeys) {
                 // SetTimeout is needed for input to receive new value.
                 setTimeout(() => {


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes https://github.com/SAP/fundamental-ngx/issues/13118

## Description

<!-- Enter short description of the change -->

When IME is used, on window, for spacebar or any keydown that IME detects that needs conversion, KeyboardEvent has properties of 'Process' as key and 229 as keyCode. On combobox keydown handler, this is not checked and will set focus on list which stops the processing input conversion.

When input method is processing, we should not interrupt the ime process and set focus on list in this case. Therefore, add check against it.

Relevant information: https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#ime_and_composition_keys

```
"Process" [3] | The Process key. Instructs the IME to process the conversion. | VK_PROCESSKEY (0xE5) |   |  
-- | -- | -- | -- | --
```
https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event#keydown_events_with_ime
