### PR TITLE
fix(core): remove Dynamic page shadow when used with Icon Tab Bar

### DIFF
--- a/libs/core/dynamic-page/dynamic-page.component.scss
+++ b/libs/core/dynamic-page/dynamic-page.component.scss
@@ -112,3 +112,7 @@
 .fd-dynamic-page__header {
     z-index: 15;
 }
+
+.fd-dynamic-page__header.fd-dynamic-page__header--not-collapsible:has(+ fdp-icon-tab-bar) {
+    box-shadow: none;
+}


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/12932

## Description
Non collapsible header of Dynamic page displays box-shadow when used with Icon Tab Bar. This PR removes the shadow. 

## Screenshots

### Before:
<img width="850" alt="Screenshot 2025-03-24 at 11 53 14 AM" src="https://github.com/user-attachments/assets/5d87217d-8d20-4940-b714-68829cd7f541" />

### After:
<img width="1086" alt="Screenshot 2025-03-24 at 11 59 05 AM" src="https://github.com/user-attachments/assets/3851a81b-7b4f-46b5-9077-dabb70e641e7" />
