### PR TITLE
fix(core): add additional options to set the flexible column layout splitter title

### DIFF
--- a/libs/core/flexible-column-layout/flexible-column-layout.component.html
+++ b/libs/core/flexible-column-layout/flexible-column-layout.component.html
@@ -25,7 +25,11 @@
                 fdCompact
                 fdType="transparent"
                 class="fd-flexible-column-layout__button"
-                [title]="_leftColumnSeparator === 'left' ? expandTitle : collapseTitle"
+                [title]="
+                    _leftColumnSeparator === 'left'
+                        ? expandTitleStartBtn || expandTitle
+                        : collapseTitleStartBtn || collapseTitle
+                "
             >
                 <fd-icon
                     [glyph]="_leftColumnSeparator ? 'slim-arrow-' + _leftColumnSeparator : ''"
@@ -56,7 +60,11 @@
                 fdCompact
                 fdType="transparent"
                 class="fd-flexible-column-layout__button"
-                [title]="_rightColumnSeparator === 'left' ? expandTitle : collapseTitle"
+                [title]="
+                    _rightColumnSeparator === 'left'
+                        ? expandTitleEndBtn || expandTitle
+                        : collapseTitleEndBtn || collapseTitle
+                "
             >
                 <fd-icon
                     [glyph]="_rightColumnSeparator ? 'slim-arrow-' + _rightColumnSeparator : ''"

--- a/libs/core/flexible-column-layout/flexible-column-layout.component.ts
+++ b/libs/core/flexible-column-layout/flexible-column-layout.component.ts
@@ -137,6 +137,22 @@ export class FlexibleColumnLayoutComponent implements AfterViewInit, OnChanges, 
     @Input()
     collapseTitle: string;
 
+    /** title for expanded state of the button between start and mid column */
+    @Input()
+    expandTitleStartBtn: string;
+
+    /** title for collapsed state of the button between start and mid column */
+    @Input()
+    collapseTitleStartBtn: string;
+
+    /** title for expanded state of the button between mid and end column */
+    @Input()
+    expandTitleEndBtn: string;
+
+    /** title for collapsed state of the button between mid and end column */
+    @Input()
+    collapseTitleEndBtn: string;
+
     /**
      * @hidden
      * left column separator value (between start and middle columns)

--- a/libs/docs/core/flexible-column-layout/examples/default/flexible-column-layout-example.component.html
+++ b/libs/docs/core/flexible-column-layout/examples/default/flexible-column-layout-example.component.html
@@ -6,7 +6,13 @@
                 <button fd-button (click)="exitFullscreenExample($event)">Exit Example</button>
             </div>
             <!-- Flexible Column Layout -->
-            <fd-flexible-column-layout [(layout)]="localLayout">
+            <fd-flexible-column-layout
+                [(layout)]="localLayout"
+                expandTitleStartBtn="Expand first column"
+                collapseTitleStartBtn="Collapse first column"
+                expandTitleEndBtn="Expand last column"
+                collapseTitleEndBtn="Collapse last column"
+            >
                 <ng-template #startColumn>
                     <div class="docs-fcl-example-section">
                         <h2>Start Column</h2>


### PR DESCRIPTION

## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13146

## Description
We previously provided titles for the splitter buttons using the expandTitle and collapseTitle input properties. I’ve added four additional inputs to allow different titles for the expand and collapse states of the button between the start and mid columns, as well as the button between the mid and end columns. Previously, both buttons shared the same titles.