### PR TITLE
fix(core): set correct height for List with Byline group header

### DIFF
--- a/libs/core/list/list.component.scss
+++ b/libs/core/list/list.component.scss
@@ -4,3 +4,9 @@
 .fd-list {
     max-width: 100% !important;
 }
+
+.fd-list--byline .fd-list__group-header {
+    min-height: var(--sapElement_LineHeight);
+    height: var(--sapElement_LineHeight);
+    max-height: var(--sapElement_LineHeight);
+}

--- a/libs/docs/core/list-byline/examples/list-byline-standard-example/list-byline-standard-example.component.html
+++ b/libs/docs/core/list-byline/examples/list-byline-standard-example/list-byline-standard-example.component.html
@@ -1,5 +1,9 @@
 <h4>Standard Size</h4>
 <ul fd-list [byline]="true">
+    <li fd-list-group-header>
+        <span fd-list-title>List Group Header</span>
+    </li>
+
     <li fd-list-item>
         <span fd-list-thumbnail><fd-icon glyph="activate"></fd-icon></span>
         <!-- for byline, fd-list-content is mandatory -->


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13107

## Description
Use specificity to ensure correct height of the group header in byline list