### PR TITLE
fix(core): add an option to provide more descriptive title for Message Strip dismiss btn

### DIFF
--- a/libs/core/message-strip/message-strip.component.html
+++ b/libs/core/message-strip/message-strip.component.html
@@ -19,7 +19,7 @@
         fdCompact
         (click)="dismiss()"
         [attr.aria-controls]="id"
-        [attr.aria-label]="'coreMessageStrip.dismissLabel' | fdTranslate"
-        [attr.title]="'coreMessageStrip.dismissLabel' | fdTranslate"
+        [attr.aria-label]="dismissBtnTitle || ('coreMessageStrip.dismissLabel' | fdTranslate)"
+        [attr.title]="dismissBtnTitle || ('coreMessageStrip.dismissLabel' | fdTranslate)"
     ></button>
 }

--- a/libs/core/message-strip/message-strip.component.ts
+++ b/libs/core/message-strip/message-strip.component.ts
@@ -54,6 +54,10 @@ export class MessageStripComponent implements OnInit, OnChanges, CssClassBuilder
     @HostBinding('class.fd-message-strip--dismissible')
     dismissible: BooleanInput = true;
 
+    /** Title for dismiss button */
+    @Input()
+    dismissBtnTitle: string;
+
     /** The default message strip does not have an icon.
      * The other types (warning, success, information and error) have icons by default.
      * To remove the icon set the property to true.

--- a/libs/docs/core/message-strip/examples/message-strip-example.component.html
+++ b/libs/docs/core/message-strip/examples/message-strip-example.component.html
@@ -1,4 +1,6 @@
-<fd-message-strip type="warning"> A dismissible warning message strip. </fd-message-strip>
+<fd-message-strip type="warning" dismissBtnTitle="Warning message strip close button">
+    A dismissible warning message strip.
+</fd-message-strip>
 <fd-message-strip type="success" [dismissible]="false"> A non-dismissible success message strip. </fd-message-strip>
 <fd-message-strip type="information"> A dismissible information message strip. </fd-message-strip>
 <fd-message-strip type="error" [dismissible]="false"> A non-dismissible error message strip. </fd-message-strip>


### PR DESCRIPTION

## Related Issue(s) 
closes https://github.com/SAP/fundamental-ngx/issues/13106

## Description
Added an input prop `dismissBtnTitle` that will allow the user to provide more descriptive information about the button.'
Provided an example update