### PR TITLE
fix(core): update breadcrumb overflow button label

### DIFF
--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -272,8 +272,8 @@ coreUploadCollection.menuCancelAriaLabel = Cancel
 coreUploadCollection.formItemPlaceholder = Filename
 #XFLD: Label for the Wizard component.
 coreWizard.ariaLabel = Wizard
-#XFLD: Label for the Button that expands hidden elements.
-coreBreadcrumb.overflowTitleMore = More
+#XFLD: Label for the breadcrumb overflow button that expands hidden elements.
+coreBreadcrumb.overflowTitleMore = Click or press enter to view more details
 #XFLD: Label for the entire breadcrumb component.
 coreBreadcrumb.breadcrumbTrailLabel = Breadcrumb Trail
 #XFLD: Label for the list of people.


### PR DESCRIPTION
part of #13121 

SAP translation service will deliver updated translations and we'll need to downport to the ng15 branch before we can close the linked issue