### PR TITLE
fix(core): date picker today btn i18n

### DIFF
--- a/libs/core/date-picker/date-picker.component.html
+++ b/libs/core/date-picker/date-picker.component.html
@@ -102,7 +102,11 @@
         <div fd-bar barDesign="footer" class="fd-date-picker__bar">
             <div fd-bar-right>
                 <fd-bar-element>
-                    <button fd-button [label]="todayButtonLabel" (click)="onTodayButtonClick()"></button>
+                    <button
+                        fd-button
+                        [label]="'coreCalendar.todayLabel' | fdTranslate"
+                        (click)="onTodayButtonClick()"
+                    ></button>
                 </fd-bar-element>
             </div>
         </div>

--- a/libs/docs/core/date-picker/examples/date-picker-i18n-example.component.ts
+++ b/libs/docs/core/date-picker/examples/date-picker-i18n-example.component.ts
@@ -29,17 +29,18 @@ const CUSTOM_DATETIME_FORMATS = {
     template: `
         <label fd-form-label for="language">Select language:</label>
         <fd-segmented-button id="language" [style.margin-bottom.px]="20">
-            <button fd-button label="French" (click)="setLocale('fr')" [class.is-selected]="'fr' === locale"></button>
-            <button fd-button label="German" (click)="setLocale('de')" [class.is-selected]="'de' === locale"></button>
-            <button
-                fd-button
-                label="Bulgarian"
-                (click)="setLocale('bg')"
-                [class.is-selected]="'bg' === locale"
-            ></button>
+            <button fd-button label="French" (click)="setLocale('fr')" [class.is-selected]="'fr' === locale">
+                &nbsp;
+            </button>
+            <button fd-button label="German" (click)="setLocale('de')" [class.is-selected]="'de' === locale">
+                &nbsp;
+            </button>
+            <button fd-button label="Bulgarian" (click)="setLocale('bg')" [class.is-selected]="'bg' === locale">
+                &nbsp;
+            </button>
         </fd-segmented-button>
         <br />
-        <fd-date-picker [(ngModel)]="date" [startingDayOfWeek]="1"></fd-date-picker>
+        <fd-date-picker [(ngModel)]="date" [startingDayOfWeek]="1" [showTodayButton]="true"></fd-date-picker>
         <p>Selected: {{ date }}</p>
     `,
     // Note that this can be provided in the root of your application.
@@ -57,7 +58,8 @@ const CUSTOM_DATETIME_FORMATS = {
                 nextYearLabel: 'Année suivante',
                 monthSelectionLabel: 'Sélection du mois',
                 previousMonthLabel: 'Mois précédent',
-                nextMonthLabel: 'Mois suivant'
+                nextMonthLabel: 'Mois suivant',
+                todayLabel: `Aujourd'hui`
             }
         }),
         {


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13143

## Description

Add option to change Today button label through the config object:
<img width="505" alt="Screenshot 2025-04-01 at 1 35 45 PM" src="https://github.com/user-attachments/assets/05a8e4fb-14dd-46e6-bc13-31f7e8d37f98" />


Results in:
<img width="348" alt="Screenshot 2025-04-01 at 1 35 31 PM" src="https://github.com/user-attachments/assets/6b5fe539-d7a6-4e64-a472-194b0cd408ec" />

