### PR TITLE
feat(core): add more and less expander for Notifications

### DIFF
--- a/libs/core/notification/directives/notification-paragraph.directive.ts
+++ b/libs/core/notification/directives/notification-paragraph.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, input } from '@angular/core';
+import { Directive, ElementRef, inject, input } from '@angular/core';
 import { FD_NOTIFICATION_PARAGRAPH } from '../token';
 
 let notificationParagraphCounter = 0;
@@ -23,4 +23,7 @@ export class NotificationParagraphDirective {
      * if not set, a default value is provided
      */
     id = input('fd-notification-paragraph-' + ++notificationParagraphCounter);
+
+    /** @hidden */
+    elementRef = inject(ElementRef);
 }

--- a/libs/core/notification/directives/notification-title.directive.ts
+++ b/libs/core/notification/directives/notification-title.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, input } from '@angular/core';
+import { Directive, ElementRef, inject, input } from '@angular/core';
 import { FD_NOTIFICATION_TITLE } from '../token';
 
 let notificationTitleCounter = 0;
@@ -30,4 +30,7 @@ export class NotificationTitleDirective {
      * if not set, a default value is provided
      */
     id = input('fd-notification-title-' + ++notificationTitleCounter);
+
+    /** @hidden */
+    elementRef = inject(ElementRef);
 }

--- a/libs/core/notification/notification-footer/notification-footer.component.ts
+++ b/libs/core/notification/notification-footer/notification-footer.component.ts
@@ -1,13 +1,71 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, signal, ViewEncapsulation } from '@angular/core';
+import { resolveTranslationSignal } from '@fundamental-ngx/i18n';
+import { FD_NOTIFICATION_FOOTER } from '../token';
 
 @Component({
     selector: 'fd-notification-footer',
-    template: `<ng-content></ng-content>`,
+    template: `<ng-content></ng-content>
+        @if (showTrigger()) {
+            <a role="button" class="fd-link fd-notification__link" tabindex="0" (click)="onTriggerClick()">
+                <span class="fd-link__content">{{ triggerLabel }}</span>
+            </a>
+        } `,
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
     host: {
         class: 'fd-notification__footer'
-    }
+    },
+    providers: [
+        {
+            provide: FD_NOTIFICATION_FOOTER,
+            useExisting: NotificationFooterComponent
+        }
+    ]
 })
-export class NotificationFooterComponent {}
+export class NotificationFooterComponent {
+    /**
+     * Controls the visibility of the expand/collapse button.
+     * Set to `true` when the title or description is truncated or the content is expanded.
+     */
+    showTrigger = signal(false);
+
+    /**
+     * Indicates whether the content is currently expanded.
+     * When `true`, the full title and description are shown;
+     * when `false`, they are truncated after the second line.
+     */
+    expanded = signal(false);
+
+    /**
+     * Custom label for the expand button.
+     * Defaults to `'More'`.
+     */
+    moreLabel = input<string>();
+
+    /** Custom label for the collapse button.
+     * Defaults to `'Less'`.
+     */
+    lessLabel = input<string>();
+
+    /** @hidden */
+    private _defaultMoreLabel = resolveTranslationSignal('coreNotification.triggerMoreLabel');
+
+    /** @hidden */
+    private _defaultLessLabel = resolveTranslationSignal('coreNotification.triggerLessLabel');
+
+    /** @hidden */
+    onTriggerClick(): void {
+        this.expanded.set(!this.expanded());
+    }
+
+    /**
+     * Label for the trigger button
+     * @hidden
+     **/
+    get triggerLabel(): string {
+        const moreLabel = this.moreLabel() || this._defaultMoreLabel();
+        const lessLabel = this.lessLabel() || this._defaultLessLabel();
+        return this.expanded() ? lessLabel : moreLabel;
+    }
+}

--- a/libs/core/notification/notification/notification.component.scss
+++ b/libs/core/notification/notification/notification.component.scss
@@ -15,3 +15,10 @@
         margin-block-end: 0.5rem;
     }
 }
+
+.fd-notification__title.is-expanded,
+.fd-notification__paragraph.is-expanded {
+    display: block;
+    overflow: visible;
+    max-height: max-content;
+}

--- a/libs/core/notification/token.ts
+++ b/libs/core/notification/token.ts
@@ -6,3 +6,4 @@ export const FD_NOTIFICATION_PARAGRAPH = new InjectionToken('FdNotificationParag
 export const FD_NOTIFICATION_GROUP_HEADER = new InjectionToken('FdNotificationGroupHeaderComponent');
 export const FD_NOTIFICATION_GROUP_HEADER_TITLE = new InjectionToken('FdNotificationGroupHeaderTitleDirective');
 export const FD_NOTIFICATION_GROUP_LIST = new InjectionToken('FdNotificationGroupListComponent');
+export const FD_NOTIFICATION_FOOTER = new InjectionToken('FdNotificationFooterComponent');

--- a/libs/docs/core/notification/examples/notification-options/notification-options-example.component.html
+++ b/libs/docs/core/notification/examples/notification-options/notification-options-example.component.html
@@ -8,12 +8,21 @@
                 <h4 fd-notification-title [unread]="true">
                     Notification Title (unread) lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
                     tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur
-                    adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum
+                    dolor sit amet consectetur adipisicing elit. Officiis fuga animi est nisi quaerat autem, distinctio
+                    officia deserunt voluptatem eos perferendis nam nulla illum eius ab? Amet placeat harum adipisci.
                 </h4>
             </fd-notification-header>
             <p fd-notification-paragraph>
                 Description of notification topic lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-                eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum, dolor sit amet consectetur
+                adipisicing elit. Labore amet possimus expedita recusandae dolore, accusamus molestias impedit quaerat
+                odit officiis ex magnam fugit minus ipsum cupiditate dolorem ipsa debitis eos? Lorem ipsum dolor sit
+                amet consectetur adipisicing elit. Autem quidem ipsam delectus modi, explicabo officiis sint dolore,
+                odio ullam natus, voluptatibus nesciunt. Consequatur illo, accusamus nesciunt ab sunt vitae quidem.
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit. Reiciendis doloribus amet odio, deserunt ad
+                numquam exercitationem incidunt excepturi optio modi eveniet laborum, consequuntur dolorem labore
+                facilis, molestias libero vel. Aliquid.
             </p>
             <fd-notification-footer>
                 <span fd-notification-footer-content>Product Name</span>
@@ -47,7 +56,10 @@
                 <fd-icon glyph="information" color="information"></fd-icon>
                 <h4 fd-notification-title>Notification Title</h4>
             </fd-notification-header>
-            <p fd-notification-paragraph>Description of notification topic</p>
+            <p fd-notification-paragraph>
+                Description of notification topic Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita
+                atque officia impedit voluptas error.Necessitatibus odit nam dolores quas adipisci corrupti.
+            </p>
             <fd-notification-footer>
                 <span fd-notification-footer-content>Product Name</span>
                 <span fd-notification-separator></span>
@@ -126,14 +138,17 @@
                 <h4 fd-notification-title [unread]="true">
                     Notification Title (unread) lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
                     tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur
-                    adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum
+                    dolor sit amet consectetur adipisicing elit. Inventore cupiditate expedita at quaerat voluptatum
+                    fugit dolore ut, similique obcaecati perspiciatis praesentium quos repellendus laboriosam quidem
+                    iure? Natus quia ex praesentium.
                 </h4>
             </fd-notification-header>
             <p fd-notification-paragraph>
                 Description of notification topic lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt ut labore et dolore magna aliqua.
             </p>
-            <fd-notification-footer>
+            <fd-notification-footer moreLabel="Show More" lessLabel="Show Less">
                 <span fd-notification-footer-content>Product Name</span>
                 <span fd-notification-separator></span>
                 <span fd-notification-footer-content>Feature Name</span>

--- a/libs/docs/core/notification/notification-docs-header/notification-docs-header.component.html
+++ b/libs/docs/core/notification/notification-docs-header/notification-docs-header.component.html
@@ -98,6 +98,13 @@
                 <code>fd-notification-group-growing-item</code>.
             </li>
         </ul>
+
+        <h3>More/Less Trigger</h3>
+        <p>
+            In case Title or Description truncates in an ellipsis, the meta is followed by the text expansion trigger
+            ("More" / "Less" text, following ellipsis). The text for expanded and collapsed state can be specified with
+            <code>moreLabel</code> and <code>lessLabel</code> input properties of NotificationFooterComponent.
+        </p>
     </description>
     <fd-header-tabs></fd-header-tabs>
 </fd-doc-page>

--- a/libs/i18n/src/lib/models/fd-language-key-identifier.ts
+++ b/libs/i18n/src/lib/models/fd-language-key-identifier.ts
@@ -487,4 +487,6 @@ export type FdLanguageKeyIdentifier =
     | 'coreNotification.groupHeaderTitle'
     | 'coreNotification.groupAriaDescription'
     | 'coreNotification.groupAriaDescriptionExpanded'
-    | 'coreNotification.groupAriaDescriptionCollapsed';
+    | 'coreNotification.groupAriaDescriptionCollapsed'
+    | 'coreNotification.triggerMoreLabel'
+    | 'coreNotification.triggerLessLabel';

--- a/libs/i18n/src/lib/models/fd-language.ts
+++ b/libs/i18n/src/lib/models/fd-language.ts
@@ -716,4 +716,12 @@ export interface FdLanguage {
     btpToolHeader: {
         menuButtonAriaLabel: FdLanguageKey;
     };
+    coreNotification: {
+        groupHeaderTitle: FdLanguageKey;
+        groupAriaDescription: FdLanguageKey;
+        groupAriaDescriptionExpanded: FdLanguageKey;
+        groupAriaDescriptionCollapsed: FdLanguageKey;
+        triggerMoreLabel: FdLanguageKey;
+        triggerLessLabel: FdLanguageKey;
+    };
 }

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -968,3 +968,7 @@ coreNotification.groupAriaDescription = Notification Group
 coreNotification.groupAriaDescriptionExpanded = expanded
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed = collapsed
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations.properties instead
 export default {
     coreCalendar: {
@@ -198,7 +199,7 @@ export default {
         ariaLabel: 'Wizard'
     },
     coreBreadcrumb: {
-        overflowTitleMore: 'More',
+        overflowTitleMore: 'Click or press enter to view more details',
         breadcrumbTrailLabel: 'Breadcrumb Trail'
     },
     platformApprovalFlow: {
@@ -596,6 +597,8 @@ export default {
         groupHeaderTitle: 'Expand/Collapse',
         groupAriaDescription: 'Notification Group',
         groupAriaDescriptionExpanded: 'expanded',
-        groupAriaDescriptionCollapsed: 'collapsed'
+        groupAriaDescriptionCollapsed: 'collapsed',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ar.properties
+++ b/libs/i18n/src/lib/translations/translations_ar.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=مجموعة الإشعارات
 coreNotification.groupAriaDescriptionExpanded=موسَّع
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=تم طيه
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ar.properties instead
 export default {
     coreCalendar: {
@@ -594,6 +595,8 @@ export default {
         groupHeaderTitle: 'توسيع/طي',
         groupAriaDescription: 'مجموعة الإشعارات',
         groupAriaDescriptionExpanded: 'موسَّع',
-        groupAriaDescriptionCollapsed: 'تم طيه'
+        groupAriaDescriptionCollapsed: 'تم طيه',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_bg.properties
+++ b/libs/i18n/src/lib/translations/translations_bg.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Група за известия
 coreNotification.groupAriaDescriptionExpanded=разгърнато
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=свито
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Разгъване/свиване',
         groupAriaDescription: 'Група за известия',
         groupAriaDescriptionExpanded: 'разгърнато',
-        groupAriaDescriptionCollapsed: 'свито'
+        groupAriaDescriptionCollapsed: 'свито',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_cs.properties
+++ b/libs/i18n/src/lib/translations/translations_cs.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Skupina oznámení
 coreNotification.groupAriaDescriptionExpanded=rozbaleno
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=sbaleno
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_cs.properties instead
 export default {
     coreCalendar: {
@@ -595,6 +596,8 @@ export default {
         groupHeaderTitle: 'Rozbalit/sbalit',
         groupAriaDescription: 'Skupina oznámení',
         groupAriaDescriptionExpanded: 'rozbaleno',
-        groupAriaDescriptionCollapsed: 'sbaleno'
+        groupAriaDescriptionCollapsed: 'sbaleno',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_da.properties
+++ b/libs/i18n/src/lib/translations/translations_da.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Meddelelsesgruppe
 coreNotification.groupAriaDescriptionExpanded=udvidet
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=minimeret
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Udvid/minimer',
         groupAriaDescription: 'Meddelelsesgruppe',
         groupAriaDescriptionExpanded: 'udvidet',
-        groupAriaDescriptionCollapsed: 'minimeret'
+        groupAriaDescriptionCollapsed: 'minimeret',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_de.properties
+++ b/libs/i18n/src/lib/translations/translations_de.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Benachrichtigungsgruppe
 coreNotification.groupAriaDescriptionExpanded=erweitert
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=reduziert
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -597,6 +597,8 @@ export default {
         groupHeaderTitle: 'Erweitern/reduzieren',
         groupAriaDescription: 'Benachrichtigungsgruppe',
         groupAriaDescriptionExpanded: 'erweitert',
-        groupAriaDescriptionCollapsed: 'reduziert'
+        groupAriaDescriptionCollapsed: 'reduziert',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_el.properties
+++ b/libs/i18n/src/lib/translations/translations_el.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Ομάδα Ειδοποιήσεων
 coreNotification.groupAriaDescriptionExpanded=επεκτάθηκε
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=συμπτύχθηκε
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -597,6 +597,8 @@ export default {
         groupHeaderTitle: 'Επέκταση/Σύμπτηξη',
         groupAriaDescription: 'Ομάδα Ειδοποιήσεων',
         groupAriaDescriptionExpanded: 'επεκτάθηκε',
-        groupAriaDescriptionCollapsed: 'συμπτύχθηκε'
+        groupAriaDescriptionCollapsed: 'συμπτύχθηκε',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
@@ -968,3 +968,7 @@ coreNotification.groupAriaDescription=[[[Ńŏţįƒįċąţįŏŋ Ģŗŏűρ∙�
 coreNotification.groupAriaDescriptionExpanded=[[[ēχρąŋƌēƌ∙∙∙∙∙∙]]]
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=[[[ċŏĺĺąρşēƌ∙∙∙∙∙]]]
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -111,7 +111,8 @@ export default {
     coreShellbar: {
         collapsedItemMenuLabel: '[[[Ĉŏĺĺąρşēƌ Ĭţēɱ Μēŋű∙∙∙∙∙]]]',
         cancel: '[[[Ĉąŋċēĺ∙∙∙∙∙∙∙∙]]]',
-        search: '[[[Ŝēąŗċĥ∙∙∙∙∙∙∙∙]]]'
+        search: '[[[Ŝēąŗċĥ∙∙∙∙∙∙∙∙]]]',
+        assistiveTools: '[[[Āşşįşţįʋē Ţŏŏĺş∙∙∙∙]]]'
     },
     coreSlider: {
         singleMinMaxDetails: '[[[Ŝĺįƌēŗ ɱįŋįɱűɱ ʋąĺűē įş {ɱįŋ}, ɱąχįɱűɱ ʋąĺűē įş {ɱąχ}∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙]]]',
@@ -201,7 +202,7 @@ export default {
         ariaLabel: '[[[Ŵįžąŗƌ∙∙∙∙∙∙∙∙]]]'
     },
     coreBreadcrumb: {
-        overflowTitleMore: '[[[Μŏŗē]]]',
+        overflowTitleMore: '[[[Ĉĺįċķ ŏŗ ρŗēşş ēŋţēŗ ţŏ ʋįēŵ ɱŏŗē ƌēţąįĺş∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙]]]',
         breadcrumbTrailLabel: '[[[Ɓŗēąƌċŗűɱƃ Ţŗąįĺ∙∙∙∙∙∙∙∙]]]'
     },
     platformApprovalFlow: {
@@ -604,6 +605,8 @@ export default {
         groupHeaderTitle: '[[[Ĕχρąŋƌ/Ĉŏĺĺąρşē∙∙∙∙]]]',
         groupAriaDescription: '[[[Ńŏţįƒįċąţįŏŋ Ģŗŏűρ∙∙∙∙∙∙]]]',
         groupAriaDescriptionExpanded: '[[[ēχρąŋƌēƌ∙∙∙∙∙∙]]]',
-        groupAriaDescriptionCollapsed: '[[[ċŏĺĺąρşēƌ∙∙∙∙∙]]]'
+        groupAriaDescriptionCollapsed: '[[[ċŏĺĺąρşēƌ∙∙∙∙∙]]]',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_es.properties
+++ b/libs/i18n/src/lib/translations/translations_es.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Grupo de notificaciones
 coreNotification.groupAriaDescriptionExpanded=expandido
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=contraído
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -597,6 +597,8 @@ export default {
         groupHeaderTitle: 'Expandir/Contraer',
         groupAriaDescription: 'Grupo de notificaciones',
         groupAriaDescriptionExpanded: 'expandido',
-        groupAriaDescriptionCollapsed: 'contraído'
+        groupAriaDescriptionCollapsed: 'contraído',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_fi.properties
+++ b/libs/i18n/src/lib/translations/translations_fi.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Ilmoitusryhmä
 coreNotification.groupAriaDescriptionExpanded=laajennettu
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=tiivistetty
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Laajenna/tiivistä',
         groupAriaDescription: 'Ilmoitusryhmä',
         groupAriaDescriptionExpanded: 'laajennettu',
-        groupAriaDescriptionCollapsed: 'tiivistetty'
+        groupAriaDescriptionCollapsed: 'tiivistetty',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_fr.properties
+++ b/libs/i18n/src/lib/translations/translations_fr.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Groupe de notifications
 coreNotification.groupAriaDescriptionExpanded=développé
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=réduit
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -598,6 +598,8 @@ export default {
         groupHeaderTitle: 'Développer/Réduire',
         groupAriaDescription: 'Groupe de notifications',
         groupAriaDescriptionExpanded: 'développé',
-        groupAriaDescriptionCollapsed: 'réduit'
+        groupAriaDescriptionCollapsed: 'réduit',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_he.properties
+++ b/libs/i18n/src/lib/translations/translations_he.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=קבוצת הודעות
 coreNotification.groupAriaDescriptionExpanded=מורחב
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=מצומצם
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_he.properties instead
 export default {
     coreCalendar: {
@@ -593,6 +594,8 @@ export default {
         groupHeaderTitle: 'הרחבה/כיווץ',
         groupAriaDescription: 'קבוצת הודעות',
         groupAriaDescriptionExpanded: 'מורחב',
-        groupAriaDescriptionCollapsed: 'מצומצם'
+        groupAriaDescriptionCollapsed: 'מצומצם',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_hi.properties
+++ b/libs/i18n/src/lib/translations/translations_hi.properties
@@ -462,3 +462,7 @@ btpSearchField.clearButtonLabel = साफ़ करें
 btpSearchField.searchInputPlaceholder = खोजें
 btpSearchField.searchInputAriaLabel = खोजें
 btpToolHeader.menuButtonAriaLabel = मेनू बटन
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -573,5 +573,9 @@ export default {
     },
     btpToolHeader: {
         menuButtonAriaLabel: 'मेनू बटन'
+    },
+    coreNotification: {
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_hr.properties
+++ b/libs/i18n/src/lib/translations/translations_hr.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Grupa obavijesti
 coreNotification.groupAriaDescriptionExpanded=prošireno
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=sažeto
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Proširi/sažmi',
         groupAriaDescription: 'Grupa obavijesti',
         groupAriaDescriptionExpanded: 'prošireno',
-        groupAriaDescriptionCollapsed: 'sažeto'
+        groupAriaDescriptionCollapsed: 'sažeto',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_hu.properties
+++ b/libs/i18n/src/lib/translations/translations_hu.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Értesítési csoport
 coreNotification.groupAriaDescriptionExpanded=kibontva
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=visszazárva
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_hu.properties instead
 export default {
     coreCalendar: {
@@ -595,6 +596,8 @@ export default {
         groupHeaderTitle: 'Kibontás/visszazárás',
         groupAriaDescription: 'Értesítési csoport',
         groupAriaDescriptionExpanded: 'kibontva',
-        groupAriaDescriptionCollapsed: 'visszazárva'
+        groupAriaDescriptionCollapsed: 'visszazárva',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_it.properties
+++ b/libs/i18n/src/lib/translations/translations_it.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Gruppo di notifiche
 coreNotification.groupAriaDescriptionExpanded=espanso
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=compresso
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -597,6 +597,8 @@ export default {
         groupHeaderTitle: 'Espandi/comprimi',
         groupAriaDescription: 'Gruppo di notifiche',
         groupAriaDescriptionExpanded: 'espanso',
-        groupAriaDescriptionCollapsed: 'compresso'
+        groupAriaDescriptionCollapsed: 'compresso',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ja.properties
+++ b/libs/i18n/src/lib/translations/translations_ja.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=通知グループ
 coreNotification.groupAriaDescriptionExpanded=表示
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=非表示
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ja.properties instead
 export default {
     coreCalendar: {
@@ -595,6 +596,8 @@ export default {
         groupHeaderTitle: '展開/圧縮',
         groupAriaDescription: '通知グループ',
         groupAriaDescriptionExpanded: '表示',
-        groupAriaDescriptionCollapsed: '非表示'
+        groupAriaDescriptionCollapsed: '非表示',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ka.properties
+++ b/libs/i18n/src/lib/translations/translations_ka.properties
@@ -462,3 +462,7 @@ btpSearchField.clearButtonLabel = გასუფთავება
 btpSearchField.searchInputPlaceholder = ძებნა
 btpSearchField.searchInputAriaLabel = ძებნა
 btpToolHeader.menuButtonAriaLabel = მენიუს ღილაკი
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -573,5 +573,9 @@ export default {
     },
     btpToolHeader: {
         menuButtonAriaLabel: 'მენიუს ღილაკი'
+    },
+    coreNotification: {
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_kk.properties
+++ b/libs/i18n/src/lib/translations/translations_kk.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Хабарландыру тобы
 coreNotification.groupAriaDescriptionExpanded=жайылған
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=жиылған
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Жаю/жию',
         groupAriaDescription: 'Хабарландыру тобы',
         groupAriaDescriptionExpanded: 'жайылған',
-        groupAriaDescriptionCollapsed: 'жиылған'
+        groupAriaDescriptionCollapsed: 'жиылған',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ko.properties
+++ b/libs/i18n/src/lib/translations/translations_ko.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=통지 그룹
 coreNotification.groupAriaDescriptionExpanded=펼친 상태
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=접힌 상태
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ko.properties instead
 export default {
     coreCalendar: {
@@ -593,6 +594,8 @@ export default {
         groupHeaderTitle: '펼치기/접기',
         groupAriaDescription: '통지 그룹',
         groupAriaDescriptionExpanded: '펼친 상태',
-        groupAriaDescriptionCollapsed: '접힌 상태'
+        groupAriaDescriptionCollapsed: '접힌 상태',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ms.properties
+++ b/libs/i18n/src/lib/translations/translations_ms.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Kumpulan Pemberitahuan
 coreNotification.groupAriaDescriptionExpanded=dikembangkan
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=diruntuhkan
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -595,6 +595,8 @@ export default {
         groupHeaderTitle: 'Kembangkan/Runtuhkan',
         groupAriaDescription: 'Kumpulan Pemberitahuan',
         groupAriaDescriptionExpanded: 'dikembangkan',
-        groupAriaDescriptionCollapsed: 'diruntuhkan'
+        groupAriaDescriptionCollapsed: 'diruntuhkan',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_nl.properties
+++ b/libs/i18n/src/lib/translations/translations_nl.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Meldingsgroep
 coreNotification.groupAriaDescriptionExpanded=uitgevouwen
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=samengevouwen
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_nl.properties instead
 export default {
     coreCalendar: {
@@ -596,6 +597,8 @@ export default {
         groupHeaderTitle: 'Uitvouwen/samenvouwen',
         groupAriaDescription: 'Meldingsgroep',
         groupAriaDescriptionExpanded: 'uitgevouwen',
-        groupAriaDescriptionCollapsed: 'samengevouwen'
+        groupAriaDescriptionCollapsed: 'samengevouwen',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_no.properties
+++ b/libs/i18n/src/lib/translations/translations_no.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Meldingsgruppe
 coreNotification.groupAriaDescriptionExpanded=utvidet
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=komprimert
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -597,6 +597,8 @@ export default {
         groupHeaderTitle: 'Utvid/skjul',
         groupAriaDescription: 'Meldingsgruppe',
         groupAriaDescriptionExpanded: 'utvidet',
-        groupAriaDescriptionCollapsed: 'komprimert'
+        groupAriaDescriptionCollapsed: 'komprimert',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_pl.properties
+++ b/libs/i18n/src/lib/translations/translations_pl.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Grupa zawiadomień
 coreNotification.groupAriaDescriptionExpanded=rozwinięte
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=zwinięte
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Rozwiń/zwiń',
         groupAriaDescription: 'Grupa zawiadomień',
         groupAriaDescriptionExpanded: 'rozwinięte',
-        groupAriaDescriptionCollapsed: 'zwinięte'
+        groupAriaDescriptionCollapsed: 'zwinięte',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_pt.properties
+++ b/libs/i18n/src/lib/translations/translations_pt.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Grupo de notificações
 coreNotification.groupAriaDescriptionExpanded=expandido
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=recolhido
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Expandir/recolher',
         groupAriaDescription: 'Grupo de notificações',
         groupAriaDescriptionExpanded: 'expandido',
-        groupAriaDescriptionCollapsed: 'recolhido'
+        groupAriaDescriptionCollapsed: 'recolhido',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ro.properties
+++ b/libs/i18n/src/lib/translations/translations_ro.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Grup de notificări
 coreNotification.groupAriaDescriptionExpanded=extins
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=restrâns
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -597,6 +597,8 @@ export default {
         groupHeaderTitle: 'Extindere/Restrângere',
         groupAriaDescription: 'Grup de notificări',
         groupAriaDescriptionExpanded: 'extins',
-        groupAriaDescriptionCollapsed: 'restrâns'
+        groupAriaDescriptionCollapsed: 'restrâns',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ru.properties
+++ b/libs/i18n/src/lib/translations/translations_ru.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Группа уведомлений
 coreNotification.groupAriaDescriptionExpanded=развернуто
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=свернуто
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ru.properties instead
 export default {
     coreCalendar: {
@@ -595,6 +596,8 @@ export default {
         groupHeaderTitle: 'Развернуть/свернуть',
         groupAriaDescription: 'Группа уведомлений',
         groupAriaDescriptionExpanded: 'развернуто',
-        groupAriaDescriptionCollapsed: 'свернуто'
+        groupAriaDescriptionCollapsed: 'свернуто',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_sh.properties
+++ b/libs/i18n/src/lib/translations/translations_sh.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Grupa obaveštenja
 coreNotification.groupAriaDescriptionExpanded=prošireno
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=sažeto
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Proširi/sažmi',
         groupAriaDescription: 'Grupa obaveštenja',
         groupAriaDescriptionExpanded: 'prošireno',
-        groupAriaDescriptionCollapsed: 'sažeto'
+        groupAriaDescriptionCollapsed: 'sažeto',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_sk.properties
+++ b/libs/i18n/src/lib/translations/translations_sk.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Skupina oznámení
 coreNotification.groupAriaDescriptionExpanded=rozbalené
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=zbalené
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Rozbaliť/zbaliť',
         groupAriaDescription: 'Skupina oznámení',
         groupAriaDescriptionExpanded: 'rozbalené',
-        groupAriaDescriptionCollapsed: 'zbalené'
+        groupAriaDescriptionCollapsed: 'zbalené',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_sl.properties
+++ b/libs/i18n/src/lib/translations/translations_sl.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Skupina obvestil
 coreNotification.groupAriaDescriptionExpanded=razširjeno
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=strnjeno
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -596,6 +596,8 @@ export default {
         groupHeaderTitle: 'Razširitev/strnitev',
         groupAriaDescription: 'Skupina obvestil',
         groupAriaDescriptionExpanded: 'razširjeno',
-        groupAriaDescriptionCollapsed: 'strnjeno'
+        groupAriaDescriptionCollapsed: 'strnjeno',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_sq.properties
+++ b/libs/i18n/src/lib/translations/translations_sq.properties
@@ -462,3 +462,5 @@ btpSearchField.clearButtonLabel = Pastro
 btpSearchField.searchInputPlaceholder = Kërko
 btpSearchField.searchInputAriaLabel = Kërko
 btpToolHeader.menuButtonAriaLabel = Butoni i menysë
+coreNotification.triggerMoreLabel = More
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_sq.ts
+++ b/libs/i18n/src/lib/translations/translations_sq.ts
@@ -574,5 +574,9 @@ export default {
     },
     btpToolHeader: {
         menuButtonAriaLabel: 'Butoni i menysë'
+    },
+    coreNotification: {
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_sv.properties
+++ b/libs/i18n/src/lib/translations/translations_sv.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Aviseringsgrupp
 coreNotification.groupAriaDescriptionExpanded=expandera
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=komprimera
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_sv.properties instead
 export default {
     coreCalendar: {
@@ -595,6 +596,8 @@ export default {
         groupHeaderTitle: 'Expandera/komprimera',
         groupAriaDescription: 'Aviseringsgrupp',
         groupAriaDescriptionExpanded: 'expandera',
-        groupAriaDescriptionCollapsed: 'komprimera'
+        groupAriaDescriptionCollapsed: 'komprimera',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_th.properties
+++ b/libs/i18n/src/lib/translations/translations_th.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=กลุ่มการแจ้งให
 coreNotification.groupAriaDescriptionExpanded=ขยาย
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=ยุบรวม
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_th.properties instead
 export default {
     coreCalendar: {
@@ -595,6 +596,8 @@ export default {
         groupHeaderTitle: 'ขยาย/ยุบรวม',
         groupAriaDescription: 'กลุ่มการแจ้งให้ทราบ',
         groupAriaDescriptionExpanded: 'ขยาย',
-        groupAriaDescriptionCollapsed: 'ยุบรวม'
+        groupAriaDescriptionCollapsed: 'ยุบรวม',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_tr.properties
+++ b/libs/i18n/src/lib/translations/translations_tr.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Bildirim Grubu
 coreNotification.groupAriaDescriptionExpanded=genişletildi
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=daraltıldı
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_tr.properties instead
 export default {
     coreCalendar: {
@@ -596,6 +597,8 @@ export default {
         groupHeaderTitle: 'Genişlet/Daralt',
         groupAriaDescription: 'Bildirim Grubu',
         groupAriaDescriptionExpanded: 'genişletildi',
-        groupAriaDescriptionCollapsed: 'daraltıldı'
+        groupAriaDescriptionCollapsed: 'daraltıldı',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_uk.properties
+++ b/libs/i18n/src/lib/translations/translations_uk.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=Група сповіщень
 coreNotification.groupAriaDescriptionExpanded=розгорнуто
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=згорнуто
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_uk.properties instead
 export default {
     coreCalendar: {
@@ -596,6 +597,8 @@ export default {
         groupHeaderTitle: 'Розгорнути/згорнути',
         groupAriaDescription: 'Група сповіщень',
         groupAriaDescriptionExpanded: 'розгорнуто',
-        groupAriaDescriptionCollapsed: 'згорнуто'
+        groupAriaDescriptionCollapsed: 'згорнуто',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_zh_CN.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=通知组
 coreNotification.groupAriaDescriptionExpanded=已展开
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=已折叠
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_zh_CN.properties instead
 export default {
     coreCalendar: {
@@ -592,6 +593,8 @@ export default {
         groupHeaderTitle: '展开/折叠',
         groupAriaDescription: '通知组',
         groupAriaDescriptionExpanded: '已展开',
-        groupAriaDescriptionCollapsed: '已折叠'
+        groupAriaDescriptionCollapsed: '已折叠',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_zh_TW.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.properties
@@ -964,3 +964,7 @@ coreNotification.groupAriaDescription=通知群組
 coreNotification.groupAriaDescriptionExpanded=已展開
 #XACT Aria description for Notification Group collapsed state
 coreNotification.groupAriaDescriptionCollapsed=已摺疊
+#XACT Text for the trigger for expand state, show more
+coreNotification.triggerMoreLabel = More
+#XACT Text for the trigger for collapse state, show less
+coreNotification.triggerLessLabel = Less

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_zh_TW.properties instead
 export default {
     coreCalendar: {
@@ -592,6 +593,8 @@ export default {
         groupHeaderTitle: '展開/摺疊',
         groupAriaDescription: '通知群組',
         groupAriaDescriptionExpanded: '已展開',
-        groupAriaDescriptionCollapsed: '已摺疊'
+        groupAriaDescriptionCollapsed: '已摺疊',
+        triggerMoreLabel: 'More',
+        triggerLessLabel: 'Less'
     }
 };

--- a/package.json
+++ b/package.json
@@ -167,14 +167,14 @@
         "nx": "20.6.2"
     },
     "lint-staged": {
+        "*.properties": [
+            "yarn nx run i18n:transform-translations"
+        ],
         "*": [
             "yarn nx format:write --uncommitted"
         ],
         "*.{js,ts,html,md,json,yml}": [
             "eslint --fix --flag unstable_config_lookup_from_file"
-        ],
-        "*.properties": [
-            "yarn nx run i18n:transform-translations"
         ]
     }
 }


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13181

## Description
Long Title and Description in Notifications should truncate after 2 lines and an expander should be shown in the Footer (meta) with configurable text. 