### PR TITLE
fix(core): remove neg z-index from readonly input

### DIFF
--- a/libs/core/form/form-control/form-control.component.scss
+++ b/libs/core/form/form-control/form-control.component.scss
@@ -1,2 +1,9 @@
 @import 'fundamental-styles/dist/input.css';
 @import 'fundamental-styles/dist/textarea.css';
+
+// @todo: to be removed after the release of fund-styles versions above v0.39.2
+.fd-input.is-readonly,
+.fd-input[aria-readonly='true'],
+.fd-input[readonly] {
+    z-index: 1;
+}


### PR DESCRIPTION
## Related Issue(s)

closes none (reported on Slack)

## Description
The negative z-index of input didn't show the element in the docs. The issue is fixed in fund-styles, this one is a temporary one and will be removed after we adopt fund-styles version above  v0.39.2
### Before:
<img width="1891" alt="Screenshot 2025-04-10 at 3 13 11 PM" src="https://github.com/user-attachments/assets/c794ec41-c213-4caa-bb83-627a3503ea5e" />


### After:

<img width="1882" alt="Screenshot 2025-04-10 at 3 20 14 PM" src="https://github.com/user-attachments/assets/0f059735-92df-429c-8ef5-ab09a208c257" />
