### PR TITLE
fix(core): fix for readonly input z-index again

### DIFF
--- a/libs/core/form/form-control/form-control.component.scss
+++ b/libs/core/form/form-control/form-control.component.scss
@@ -5,5 +5,23 @@
 .fd-input.is-readonly,
 .fd-input[aria-readonly='true'],
 .fd-input[readonly] {
-    z-index: 1;
+    z-index: 1 !important;
+}
+
+.fd-input.is-readonly.is-hover,
+.fd-input.is-readonly:hover,
+.fd-input[aria-readonly='true'].is-hover,
+.fd-input[aria-readonly='true']:hover,
+.fd-input[readonly].is-hover,
+.fd-input[readonly]:hover {
+    z-index: 1 !important;
+}
+
+.fd-input.is-readonly.is-focus,
+.fd-input.is-readonly:focus,
+.fd-input[aria-readonly='true'].is-focus,
+.fd-input[aria-readonly='true']:focus,
+.fd-input[readonly].is-focus,
+.fd-input[readonly]:focus {
+    z-index: 1 !important;
 }


### PR DESCRIPTION
## Related Issue(s)


closes https://github.com/SAP/fundamental-ngx/issues/13208

## Description
temporary fix for the z-index of readonly input, this time also includes hover and focus states