### PR TITLE
fix(core): fix the Inline Help text cut corners

### DIFF
--- a/libs/core/popover/popover-body/popover-body.component.scss
+++ b/libs/core/popover/popover-body/popover-body.component.scss
@@ -52,6 +52,10 @@ fd-popover-body {
 
         &--inline-help.fd-inline-help__content {
             white-space: initial;
+
+            > .fd-scrollbar {
+                border-radius: 0;
+            }
         }
 
         &.fd-form-message {


### PR DESCRIPTION
## Related Issue(s)


part of https://github.com/SAP/fundamental-ngx/issues/13200

## Description
In some cases, the text of the Inline Help is cut, which is caused by the popover inner container inheriting the border radius of the popover body. The fix was to set this radius to 0 in case of Inline Help.

Before:
<img width="283" alt="Screenshot 2025-04-14 at 2 38 43 PM" src="https://github.com/user-attachments/assets/0da8f26b-7861-4548-8414-fcef9c4cee12" />
<img width="353" alt="Screenshot 2025-04-14 at 2 38 49 PM" src="https://github.com/user-attachments/assets/7e1d8aef-1a39-4a8e-b716-1aa8e6bc1a94" />


After:
<img width="408" alt="Screenshot 2025-04-14 at 2 38 07 PM" src="https://github.com/user-attachments/assets/5e020a76-cae2-41b2-a8ba-7d24065fad40" />
<img width="409" alt="Screenshot 2025-04-14 at 2 38 15 PM" src="https://github.com/user-attachments/assets/c0b1b180-c84e-40b3-bba0-1139d30616ac" />

