### PR TITLE
chore: fix links in platform table documentation

### DIFF
--- a/libs/docs/platform/table/child-docs/advanced/advanced-examples-docs.component.html
+++ b/libs/docs/platform/table/child-docs/advanced/advanced-examples-docs.component.html
@@ -1,4 +1,6 @@
-<fd-docs-section-title id="page-scrolling" componentName="table">Handling large amount of data</fd-docs-section-title>
+<fd-docs-section-title id="page-scrolling" componentName="table/advanced"
+    >Handling large amount of data</fd-docs-section-title
+>
 <description>
     <p>One of the scenarios of using Platform Table component, is to render the large amount of items.</p>
     <p>Storing this amount directly in memory may lead to a browser performance issues.</p>

--- a/libs/docs/platform/table/child-docs/clickable-rows/clickable-rows-docs.component.html
+++ b/libs/docs/platform/table/child-docs/clickable-rows/clickable-rows-docs.component.html
@@ -1,4 +1,6 @@
-<fd-docs-section-title id="actiable-rows" componentName="table">Activable Cells and Rows</fd-docs-section-title>
+<fd-docs-section-title id="actiable-rows" componentName="table/clickable-rows"
+    >Activable Cells and Rows</fd-docs-section-title
+>
 <description>
     <p>This example shows activable cells and rows</p>
 
@@ -18,7 +20,9 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="navigatable-row" componentName="table"> Navigatable rows</fd-docs-section-title>
+<fd-docs-section-title id="navigatable-row" componentName="table/clickable-rows">
+    Navigatable rows</fd-docs-section-title
+>
 <description>
     This example shows navigatable rows.
 

--- a/libs/docs/platform/table/child-docs/p13-dialog/p13-dialog-docs.component.html
+++ b/libs/docs/platform/table/child-docs/p13-dialog/p13-dialog-docs.component.html
@@ -1,4 +1,4 @@
-<fd-docs-section-title id="p13" componentName="table"> Personalization Dialog.</fd-docs-section-title>
+<fd-docs-section-title id="p13" componentName="table/p13-dialog-table"> Personalization Dialog.</fd-docs-section-title>
 <description>
     The p13n dialog control provides a dialog for tables that allows the user to personalize one or more of the
     following attributes:
@@ -10,7 +10,7 @@
     </ul>
 </description>
 
-<fd-docs-section-title id="p13-table-columns" componentName="table">
+<fd-docs-section-title id="p13-table-columns" componentName="table/p13-dialog-table">
     Table columns visibility and order
 </fd-docs-section-title>
 <description>
@@ -25,7 +25,9 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="p13-table-sort" componentName="table"> Sorting by multiple columns</fd-docs-section-title>
+<fd-docs-section-title id="p13-table-sort" componentName="table/p13-dialog-table">
+    Sorting by multiple columns</fd-docs-section-title
+>
 <description>
     <ul>
         <li>
@@ -46,7 +48,7 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="p13-table-filter" componentName="table">
+<fd-docs-section-title id="p13-table-filter" componentName="table/p13-dialog-table">
     Filtering by multiple columns
 </fd-docs-section-title>
 <description>
@@ -77,7 +79,9 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="p13-table-group" componentName="table"> Grouping by multiple columns</fd-docs-section-title>
+<fd-docs-section-title id="p13-table-group" componentName="table/p13-dialog-table">
+    Grouping by multiple columns</fd-docs-section-title
+>
 <description>
     <ul>
         <li>

--- a/libs/docs/platform/table/child-docs/pagination/table-pagination-docs.component.html
+++ b/libs/docs/platform/table/child-docs/pagination/table-pagination-docs.component.html
@@ -1,4 +1,4 @@
-<fd-docs-section-title id="built-in-pagination" componentName="table">Growing button</fd-docs-section-title>
+<fd-docs-section-title id="built-in-pagination" componentName="table/pagination">Growing button</fd-docs-section-title>
 <description>
     <p>Platform table allows developers to display Growing Button to load more rows.</p>
 </description>
@@ -9,7 +9,7 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="built-in-pagination-outer-scroll" componentName="table"
+<fd-docs-section-title id="built-in-pagination-outer-scroll" componentName="table/pagination"
     >Growing button with outer scroll</fd-docs-section-title
 >
 <description>
@@ -25,7 +25,7 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="pagination" componentName="table">Standard pagination</fd-docs-section-title>
+<fd-docs-section-title id="pagination" componentName="table/pagination">Standard pagination</fd-docs-section-title>
 <description>
     <p>
         Alternative to Growing Button approach, developers can connect Core

--- a/libs/docs/platform/table/child-docs/preserving-state/preserved-state-docs.component.html
+++ b/libs/docs/platform/table/child-docs/preserving-state/preserved-state-docs.component.html
@@ -1,4 +1,6 @@
-<fd-docs-section-title id="preserved-state" componentName="table"> Preserving table state</fd-docs-section-title>
+<fd-docs-section-title id="preserved-state" componentName="table/preserved-state">
+    Preserving table state</fd-docs-section-title
+>
 <description>
     <p>
         In some cases, application should preserve the state of the table (current page, filters, grouping, sorting,

--- a/libs/docs/platform/table/child-docs/row-selection/row-selection-docs.component.html
+++ b/libs/docs/platform/table/child-docs/row-selection/row-selection-docs.component.html
@@ -1,4 +1,6 @@
-<fd-docs-section-title id="single-row-selection" componentName="table"> Single Row Selection</fd-docs-section-title>
+<fd-docs-section-title id="single-row-selection" componentName="table/row-selection">
+    Single Row Selection</fd-docs-section-title
+>
 <description>
     <p>This example shows single row selection</p>
 
@@ -18,7 +20,7 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="multiple-row-selection" componentName="table">
+<fd-docs-section-title id="multiple-row-selection" componentName="table/row-selection">
     Multiple Row Selection
 </fd-docs-section-title>
 <description>

--- a/libs/docs/platform/table/child-docs/settings-dialog/settings-dialog-docs.component.html
+++ b/libs/docs/platform/table/child-docs/settings-dialog/settings-dialog-docs.component.html
@@ -1,4 +1,4 @@
-<fd-docs-section-title id="sortable" componentName="table"> Column Sorting</fd-docs-section-title>
+<fd-docs-section-title id="sortable" componentName="table/settings-dialog-table"> Column Sorting</fd-docs-section-title>
 <description>
     <p>Use <code>[sortable]="true"</code> to mark a column as an sortable one.</p>
     <p>
@@ -16,7 +16,9 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="filterable" componentName="table"> Column Filtering</fd-docs-section-title>
+<fd-docs-section-title id="filterable" componentName="table/settings-dialog-table">
+    Column Filtering</fd-docs-section-title
+>
 <description>
     There are two ways to add filtering. The first one is to use the column option <code>[filterable]="true"</code>.
     This will add filter input field in the column header menu.
@@ -37,7 +39,9 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="groupable" componentName="table"> Column Grouping</fd-docs-section-title>
+<fd-docs-section-title id="groupable" componentName="table/settings-dialog-table">
+    Column Grouping</fd-docs-section-title
+>
 <description>
     Use <code>[groupable]="true"</code> to mark a column as one that can be used to group by.
     <br />
@@ -54,7 +58,7 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="combined-settings" componentName="table">
+<fd-docs-section-title id="combined-settings" componentName="table/settings-dialog-table">
     Combined Table Settings Dialog</fd-docs-section-title
 >
 <description>

--- a/libs/docs/platform/table/index.ts
+++ b/libs/docs/platform/table/index.ts
@@ -10,11 +10,6 @@ export const ROUTES: Routes = [
         providers: [ExampleChildService, RtlService],
         children: [
             {
-                path: '',
-                redirectTo: 'basic',
-                pathMatch: 'full'
-            },
-            {
                 path: 'basic',
                 loadComponent: () => import('./platform-table-docs.component').then((c) => c.PlatformTableDocsComponent)
             },


### PR DESCRIPTION
fixes none

Many examples in the platform table docs had incorrect direct links, often making things difficult to communicate with developers looking for solutions