### PR TITLE
fix(core): remove index/total from cx list translation

### DIFF
--- a/libs/core/nested-list/nested-list/nested-list.directive.ts
+++ b/libs/core/nested-list/nested-list/nested-list.directive.ts
@@ -199,8 +199,8 @@ export class NestedListDirective implements AfterContentInit, NestedListInterfac
                 item.linkItem.ariaDescribedby = this._nestedListHeader?.id || null;
                 item.linkItem._ariaLabel = this._translationResolver.resolve(lang, 'coreNestedList.linkItemAriaLabel', {
                     itemDetails: item.linkItem.getTitle(),
-                    index: i + 1,
-                    total: this.nestedItems.length,
+                    index: i + 1, // TODO: this property has been deprecated and will be removed from translations
+                    total: this.nestedItems.length, // TODO: this property has been deprecated and will be removed from translations
                     selectedDescription:
                         !this._nestedListStateService.selectable && item.linkItem.selected
                             ? ', ' + this.ariaLabelSelected

--- a/libs/cx/nested-list/nested-list/nested-list.component.ts
+++ b/libs/cx/nested-list/nested-list/nested-list.component.ts
@@ -175,8 +175,8 @@ export class NestedListComponent implements AfterContentInit, NestedListInterfac
                 item.linkItem.ariaDescribedby = this._nestedListHeader?.id || null;
                 item.linkItem._ariaLabel = this._translationResolver.resolve(lang, 'coreNestedList.linkItemAriaLabel', {
                     itemDetails: item.linkItem.getTitle(),
-                    index: i + 1,
-                    total: this.nestedItems.length,
+                    index: i + 1, // TODO: this property has been deprecated and will be removed from translations
+                    total: this.nestedItems.length, // TODO: this property has been deprecated and will be removed from translations
                     selectedDescription:
                         !this._nestedListStateService.selectable && item.linkItem.selected
                             ? ', ' + this.ariaLabelSelected

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -119,7 +119,7 @@ coreNavigation.mainNavigation = Main Navigation
 #unused
 coreNavigation.navigationPath = Navigation Path
 #XMIT: In the side navigation, the name of the item and its index and position in the list.
-coreNestedList.linkItemAriaLabel = Tree Item {itemDetails}, {index} of {total}{selectedDescription}
+coreNestedList.linkItemAriaLabel = Tree Item {itemDetails}, {selectedDescription}
 #XFLD: The {count} more label for the number of items that are overflowing in the overflow layout component.
 coreOverflowLayout.moreItemsButton = {count} more
 #XBUT: The label for the button used to change to the {pageNumber} page in the pagination component.

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -85,7 +85,7 @@ export default {
         navigationPath: 'Navigation Path'
     },
     coreNestedList: {
-        linkItemAriaLabel: 'Tree Item {itemDetails}, {index} of {total}{selectedDescription}'
+        linkItemAriaLabel: 'Tree Item {itemDetails}, {selectedDescription}'
     },
     coreOverflowLayout: {
         moreItemsButton: '{count} more'

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_en_US_sappsd.properties instead
 export default {
     coreCalendar: {
@@ -111,10 +112,9 @@ export default {
         collapsedItemMenuLabel: '[[[Ĉŏĺĺąρşēƌ Ĭţēɱ Μēŋű∙∙∙∙∙]]]',
         cancel: '[[[Ĉąŋċēĺ∙∙∙∙∙∙∙∙]]]',
         search: '[[[Ŝēąŗċĥ∙∙∙∙∙∙∙∙]]]',
-
         assistiveTools: '[[[Āşşįşţįʋē Ţŏŏĺş∙∙∙∙]]]',
-        backButtonLabel: 'Back',
-        navigationButtonLabel: 'Navigation'
+        backButtonLabel: '[[[Ɓąċķ]]]',
+        navigationButtonLabel: '[[[Ńąʋįğąţįŏŋ∙∙∙∙]]]'
     },
     coreSlider: {
         singleMinMaxDetails: '[[[Ŝĺįƌēŗ ɱįŋįɱűɱ ʋąĺűē įş {ɱįŋ}, ɱąχįɱűɱ ʋąĺűē įş {ɱąχ}∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙]]]',
@@ -608,7 +608,7 @@ export default {
         groupAriaDescription: '[[[Ńŏţįƒįċąţįŏŋ Ģŗŏűρ∙∙∙∙∙∙]]]',
         groupAriaDescriptionExpanded: '[[[ēχρąŋƌēƌ∙∙∙∙∙∙]]]',
         groupAriaDescriptionCollapsed: '[[[ċŏĺĺąρşēƌ∙∙∙∙∙]]]',
-        triggerMoreLabel: 'More',
-        triggerLessLabel: 'Less'
+        triggerMoreLabel: '[[[Μŏŗē]]]',
+        triggerLessLabel: '[[[Ļēşş]]]'
     }
 };


### PR DESCRIPTION
part of #12692 

The index/total count of each item in the side nav was being announced twice, once by default as it typically does for all lists, and again a second time because we had added it manually - not sure exactly why it had been added manually, that would take some digging through the history. 

But looking in to this problem did make me realize that we have no mechanism for removing variables from the more complex translations that require some arguments to be passed with the string to be translated. I think, in cases like this where we would need to do that, it'll have to be a multi-step process:

1. The `translations.properties` file needs to be altered to have the new ideal translation in the default language. See [here](https://github.com/SAP/fundamental-ngx/compare/fix/12692?expand=1#diff-9d3bb5fda60695f81adbda113c79bc353e72677afe07184d0bfc224ebe6ed903L122)
2. A pull request is made, reviewed, merged, etc
3. The translation delivery service needs to deliver the updated translations for other languages. Those need to be merged
4. The arguments can be removed from where they originate. In this example it'd be [here](https://github.com/SAP/fundamental-ngx/blob/main/libs/cx/nested-list/nested-list/nested-list.component.ts#L178-L179)