### PR TITLE
chore: fix translation executor not being able to stage files for commit

### DIFF
--- a/libs/nx-plugin/src/executors/transform-translations/executor.ts
+++ b/libs/nx-plugin/src/executors/transform-translations/executor.ts
@@ -50,15 +50,17 @@ export default async function runExecutor(options: TransformPropertiesExecutorSc
                 { ...prettierConfig, parser: 'typescript' }
             )
         );
-        execSync(`git add ${newFilePath}`);
-        execSync(`git add ${newFileSpecPath}`);
     }
     updateTypings(host, Object.keys(parseProperties(host.read(propertiesFiles[0], 'utf-8') as string)));
-    execSync(`git add libs/i18n/src/lib/models/fd-language-key-identifier.ts`);
     await formatFiles(host);
     const changes = host.listChanges();
     printChanges(changes);
+    // need to call flushChanges because the files to git add have yet to actually change on the filesystem
     flushChanges(host.root, changes);
+    execSync(`git add libs/i18n/src/lib/models/fd-language-key-identifier.ts`);
+    for (const change of changes) {
+        execSync(`git add ${change.path}`);
+    }
     return {
         success: true
     };


### PR DESCRIPTION
Fixes a problem with our translation nx generator, which was ran as a pre-commit hook. Files modified by NX were not being properly staged.

Nx provides the `FsTree` for modifying files on the filesystem. As a built-in failsafe, nx does not actually persist changes to the filesystem as soon as the script sees the `FsTree.write()` function. By default, files modified within the generator aren't actually persisted to the filesystem until after the generator's successful completion. However you can get around this by calling `flushChanges` in the generator script. We were seeing our translation commit problem because we were attempting to `git add` the modified files inside the generator before calling `flushChanges`, so there wasn't actually anything to `git add` yet