### PR TITLE
fix(platform): bug with horizontal and vertical switched for table header cells

### DIFF
--- a/libs/platform/table-helpers/pipes/cell-styles.pipe.ts
+++ b/libs/platform/table-helpers/pipes/cell-styles.pipe.ts
@@ -16,8 +16,8 @@ export class TableCellStylesPipe implements PipeTransform {
         columnWidth: string,
         nextColumnWidthPx: number | null,
         noBorders?: boolean,
-        noBordersY?: boolean,
-        noBordersX?: boolean
+        noHorizontalBorders?: boolean,
+        noVerticalBorders?: boolean
     ): Record<string, number | string> {
         const styles: { [property: string]: number | string } = {};
 
@@ -32,12 +32,12 @@ export class TableCellStylesPipe implements PipeTransform {
             styles[key] = (nextColumnWidthPx || 0).toString();
         }
 
-        if (noBordersY) {
+        if (noHorizontalBorders) {
             styles['border-top'] = 'none';
             styles['border-bottom'] = 'none';
         }
 
-        if (noBordersX) {
+        if (noVerticalBorders) {
             styles['border-left'] = 'none';
             styles['border-right'] = 'none';
         }

--- a/libs/platform/table/components/table-header-row/table-header-row.component.html
+++ b/libs/platform/table/components/table-header-row/table-header-row.component.html
@@ -98,8 +98,8 @@
                     : _tableColumnResizeService.getColumnWidthStyle(column.name)
                     : _tableColumnResizeService.getNextColumnsWidth(column.name)
                     : noBorders
-                    : noVerticalBorders
                     : noHorizontalBorders
+                    : noVerticalBorders
         "
         [fdPopoverTrigger]="(column | isColumnHasHeaderMenu) ? tablePopover.popover : null"
         (cellFocused)="_tableRowService.cellFocused($event)"


### PR DESCRIPTION
Fixes a bug where "vertical" and "horizontal" were switched on the header cells in regards to the inputs that show/hide the borders.

Before:

https://github.com/user-attachments/assets/8430efa8-d8d3-40c1-978e-840ca7147741

After:

https://github.com/user-attachments/assets/ae5b5842-e881-4d5a-b2b9-dc83e9e35771

