### PR TITLE
fix(core): adopt the a11y changes for Busy Indicator from v0.40.0

### DIFF
--- a/libs/core/busy-indicator/busy-indicator.component.ts
+++ b/libs/core/busy-indicator/busy-indicator.component.ts
@@ -33,6 +33,9 @@ export type BusyIndicatorSize = 's' | 'm' | 'l';
         '[attr.aria-busy]': 'loading',
         '[attr.aria-live]': 'ariaLive',
         '[attr.aria-label]': 'ariaLabel',
+        '[attr.aria-valuetext]': 'ariaValueText',
+        '[attr.aria-valuemin]': '0',
+        '[attr.aria-valuemax]': '100',
         '[attr.title]': 'title',
         '[class.fd-busy-indicator__container]': 'true',
         '[class.fd-busy-indicator__container--inline]': '!block'
@@ -55,6 +58,10 @@ export class BusyIndicatorComponent {
     /** Aria label attribute value. */
     @Input()
     ariaLabel: Nullable<string>;
+
+    /** Aria-valuetext attribute value. */
+    @Input()
+    ariaValueText: Nullable<string>;
 
     /** title attribute value for tooltip. */
     @Input()

--- a/libs/docs/core/busy-indicator/examples/busy-indicator-basic-example.component.html
+++ b/libs/docs/core/busy-indicator/examples/busy-indicator-basic-example.component.html
@@ -1,3 +1,8 @@
 <div [style.text-align]="'center'">
-    <fd-busy-indicator [loading]="true" ariaLabel="loading" title="Please Wait"></fd-busy-indicator>
+    <fd-busy-indicator
+        [loading]="true"
+        ariaLabel="loading"
+        title="Please wait"
+        ariaValueText="Busy"
+    ></fd-busy-indicator>
 </div>

--- a/libs/docs/core/busy-indicator/examples/busy-indicator-extended-example.component.html
+++ b/libs/docs/core/busy-indicator/examples/busy-indicator-extended-example.component.html
@@ -3,6 +3,11 @@
 
 <ng-template #template>
     <div fd-busy-indicator-extended>
-        <fd-busy-indicator [loading]="true" label="Please Wait..." title="Please wait"></fd-busy-indicator>
+        <fd-busy-indicator
+            [loading]="true"
+            ariaLabel="loading"
+            title="Please wait"
+            ariaValueText="Busy"
+        ></fd-busy-indicator>
     </div>
 </ng-template>

--- a/libs/docs/core/busy-indicator/examples/busy-indicator-label-example.component.html
+++ b/libs/docs/core/busy-indicator/examples/busy-indicator-label-example.component.html
@@ -1,3 +1,8 @@
 <div fd-busy-indicator-extended>
-    <fd-busy-indicator [loading]="true" label="Please wait" title="Please wait"></fd-busy-indicator>
+    <fd-busy-indicator
+        [loading]="true"
+        ariaLabel="loading"
+        title="Please wait"
+        ariaValueText="Busy"
+    ></fd-busy-indicator>
 </div>

--- a/libs/docs/core/busy-indicator/examples/busy-indicator-size-example.component.html
+++ b/libs/docs/core/busy-indicator/examples/busy-indicator-size-example.component.html
@@ -1,5 +1,11 @@
 @for (size of sizes; track size) {
     <div [style.text-align]="'center'">
-        <fd-busy-indicator [loading]="true" [size]="size" [title]="size + ' ' + 'size loading'"></fd-busy-indicator>
+        <fd-busy-indicator
+            [loading]="true"
+            [size]="size"
+            [ariaLabel]="size + ' ' + 'size loading'"
+            title="Please wait"
+            ariaValueText="Busy"
+        ></fd-busy-indicator>
     </div>
 }

--- a/libs/docs/core/busy-indicator/examples/busy-indicator-wrapper-example.component.html
+++ b/libs/docs/core/busy-indicator/examples/busy-indicator-wrapper-example.component.html
@@ -1,5 +1,11 @@
-<h5 id="fd-busy-indicator-label-1">Use Busy Indicator as a block wrapper</h5>
-<fd-busy-indicator [loading]="loading" [block]="true" aria-labelledby="fd-busy-indicator-label-1" title="Block Wrapper">
+<h5 id="fd-busy-indicator-label-1">Busy Indicator as a block wrapper</h5>
+<fd-busy-indicator
+    [loading]="loading"
+    [block]="true"
+    aria-labelledby="fd-busy-indicator-label-1"
+    title="Please wait"
+    ariaValueText="Busy"
+>
     <form>
         <div fd-form-item>
             <label fd-form-label for="name">Name:</label>
@@ -18,8 +24,14 @@
     </form>
 </fd-busy-indicator>
 
-<h5 id="fd-busy-indicator-label-2">Use Busy Indicator as a inline wrapper</h5>
-<fd-busy-indicator [loading]="loading" size="s" aria-labelledby="fd-busy-indicator-label-2" title="Inline Wrapper">
+<h5 id="fd-busy-indicator-label-2">Busy Indicator as a inline wrapper</h5>
+<fd-busy-indicator
+    [loading]="loading"
+    size="s"
+    aria-labelledby="fd-busy-indicator-label-2"
+    title="Please wait"
+    ariaValueText="Busy"
+>
     <button fd-button label="Save"></button>
 </fd-busy-indicator>
 


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

- new input prop ariaValueText
- added aria-valuetext, aria-valuemin and aria-valuemax attributes
- updated the examples in the documentation