### PR TITLE
fix(core): add control title to Action Sheet in mobile mode

### DIFF
--- a/libs/core/action-sheet/action-sheet.component.html
+++ b/libs/core/action-sheet/action-sheet.component.html
@@ -19,6 +19,17 @@
     <ng-template [ngTemplateOutlet]="actionSheetControl"></ng-template>
 }
 <ng-template #actionSheetBodyTemplate>
+    @if (mobile && controlTitle) {
+        <div class="fd-bar fd-action-sheet__bar" role="toolbar" aria-label="Bar">
+            <div class="fd-bar__left">
+                <div class="fd-bar__element">
+                    <div role="heading" [ariaLevel]="controlTitleHeading" class="fd-action-sheet__title">
+                        {{ controlTitle }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
     <ng-content select="fd-action-sheet-body"></ng-content>
 </ng-template>
 <ng-template #actionSheetControl>

--- a/libs/core/action-sheet/action-sheet.component.scss
+++ b/libs/core/action-sheet/action-sheet.component.scss
@@ -1,4 +1,5 @@
 @import 'fundamental-styles/dist/action-sheet.css';
+@import 'fundamental-styles/dist/bar.css';
 
 fd-action-sheet-body {
     width: 100%;
@@ -9,4 +10,9 @@ fd-action-sheet-body {
 .fd-action-sheet__wrapper--active {
     position: fixed;
     z-index: 999;
+}
+
+// Angular specific CSS
+.fd-action-sheet__wrapper .fd-action-sheet__bar.fd-bar + fd-action-sheet-body .fd-action-sheet.fd-action-sheet--mobile {
+    border-radius: 0 0 var(--sapPopover_BorderCornerRadius) var(--sapPopover_BorderCornerRadius);
 }

--- a/libs/core/action-sheet/action-sheet.component.ts
+++ b/libs/core/action-sheet/action-sheet.component.ts
@@ -27,9 +27,12 @@ import {
     destroyObservable,
     DynamicComponentService,
     FocusEscapeDirection,
-    KeyboardSupportService
+    KeyboardSupportService,
+    Nullable
 } from '@fundamental-ngx/cdk/utils';
+
 import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
+
 import { Placement } from '@fundamental-ngx/core/shared';
 
 import { NgTemplateOutlet } from '@angular/common';
@@ -75,6 +78,18 @@ export class ActionSheetComponent implements AfterContentInit, AfterViewInit, On
      */
     @Input()
     triggers: string[] = ['click'];
+
+    /** Value for the control title in mobile mode */
+    @Input()
+    controlTitle: Nullable<string>;
+
+    /**
+     * Value for the control title heading level
+     * A number between 1 and 6
+     * Default is set to 2
+     */
+    @Input()
+    controlTitleHeading: 1 | 2 | 3 | 4 | 5 | 6 = 2;
 
     /** Event thrown, when focus escapes the list */
     @Output()

--- a/libs/docs/core/action-sheet/examples/action-sheet-mobile/action-sheet-mobile-example.component.html
+++ b/libs/docs/core/action-sheet/examples/action-sheet-mobile/action-sheet-mobile-example.component.html
@@ -1,5 +1,10 @@
 <div [style.position]="'relative'">
-    <fd-action-sheet [mobile]="true" (isOpenChange)="isOpenChange($event)">
+    <fd-action-sheet
+        [mobile]="true"
+        (isOpenChange)="isOpenChange($event)"
+        controlTitle="Control Title"
+        [controlTitleHeading]="3"
+    >
         <fd-action-sheet-control>
             <button
                 fd-button


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description
Adopts the breaking changes from fund-styles version 0.40.0, where the control title is now placed in a Bar element. 
Added 2 new inputs: `controlTitle` and `controlTitleHeading`. 