### PR TITLE
[WIP]fix(core): add a11y improvements for Message Box

### DIFF
--- a/libs/core/message-box/message-box-body/message-box-body.component.ts
+++ b/libs/core/message-box/message-box-body/message-box-body.component.ts
@@ -10,7 +10,9 @@ import { MessageBoxConfig, MessageBoxHost } from '../utils/message-box-config.cl
  */
 @Component({
     selector: 'fd-message-box-body',
-    template: '<ng-content></ng-content>',
+    template: `<section>
+        <ng-content></ng-content>
+    </section> `,
     host: {
         '[class.fd-message-box__body]': 'true',
         '[class.fd-message-box__body--no-vertical-padding]': '!messageBoxConfig.verticalPadding'

--- a/libs/core/message-box/message-box-default/message-box-default.component.html
+++ b/libs/core/message-box/message-box-default/message-box-default.component.html
@@ -1,9 +1,16 @@
 @if (_messageBoxContent) {
     <fd-message-box>
         <fd-message-box-header>
-            <h1 fd-title>{{ _messageBoxContent.title }}</h1>
+            <div
+                fd-title
+                role="heading"
+                [ariaLevel]="_messageBoxContent.titleHeadingLevel || 2"
+                [id]="_messageBoxContent.titleId || messageBoxTitleId"
+            >
+                {{ _messageBoxContent.title }}
+            </div>
         </fd-message-box-header>
-        <fd-message-box-body>
+        <fd-message-box-body [id]="_messageBoxContent.contentId || messageBoxContentId">
             <ng-template [ngTemplateOutlet]="_contentTemplate"></ng-template>
         </fd-message-box-body>
         @if (_footerVisible) {

--- a/libs/core/message-box/message-box-default/message-box-default.component.ts
+++ b/libs/core/message-box/message-box-default/message-box-default.component.ts
@@ -19,6 +19,9 @@ import { MessageBoxComponent } from '../message-box.component';
 import { MessageBoxConfig } from '../utils/message-box-config.class';
 import { MessageBoxContent } from '../utils/message-box-content.class';
 
+let mbTitleId = 0;
+let mbContentId = 0;
+
 /** Message box component used to create the message box in object based approach */
 @Component({
     selector: 'fd-message-box-default',
@@ -50,6 +53,18 @@ export class MessageBoxDefaultComponent implements OnInit, AfterViewInit {
     /** @hidden */
     _footerVisible: boolean;
 
+    /**
+     * message box title id
+     * if not set, a default value is provided
+     */
+    messageBoxTitleId = 'fd-message-box-title-id-' + mbTitleId++;
+
+    /**
+     * message box content id
+     * if not set, a default value is provided
+     */
+    messageBoxContentId = 'fd-message-box-content-id-' + mbContentId++;
+
     /** @hidden */
     constructor(
         public _messageBoxConfig: MessageBoxConfig,
@@ -64,6 +79,16 @@ export class MessageBoxDefaultComponent implements OnInit, AfterViewInit {
     /** @hidden */
     ngAfterViewInit(): void {
         this._setContentTemplate();
+
+        /**
+         * If the configuration object doesn't provide values for ariaLabelledBy and/or ariaDescribedBy
+         * use the default generated ids for title and content
+         */
+
+        if (this._messageBoxConfig) {
+            this._messageBoxConfig.ariaLabelledBy ??= this.messageBoxTitleId;
+            this._messageBoxConfig.ariaDescribedBy ??= this.messageBoxContentId;
+        }
     }
 
     /** @hidden */
@@ -87,7 +112,6 @@ export class MessageBoxDefaultComponent implements OnInit, AfterViewInit {
             this._messageBoxContent?.content instanceof TemplateRef
                 ? this._messageBoxContent.content
                 : this._textContentTemplate;
-
         this._changeDetectorRef.detectChanges();
     }
 }

--- a/libs/core/message-box/message-box-header/message-box-header.component.html
+++ b/libs/core/message-box/message-box-header/message-box-header.component.html
@@ -1,4 +1,4 @@
-<div
+<header
     fd-bar
     class="fd-message-box__header"
     [fdCozy]="messageBoxConfig.mobile"
@@ -18,7 +18,7 @@
             </fd-bar-element>
         </div>
     </ng-template>
-</div>
+</header>
 @if (subHeaderTemplate) {
     <div fd-bar class="fd-message-box__subheader" barDesign="subheader" [fdCozy]="messageBoxConfig.mobile">
         <ng-template [ngTemplateOutlet]="subHeaderTemplate"></ng-template>

--- a/libs/core/message-box/utils/message-box-content.class.ts
+++ b/libs/core/message-box/utils/message-box-content.class.ts
@@ -1,4 +1,10 @@
 import { TemplateRef } from '@angular/core';
 import { DialogContentBase } from '@fundamental-ngx/core/dialog';
 
-export class MessageBoxContent extends DialogContentBase<TemplateRef<any> | string> {}
+export class MessageBoxContent extends DialogContentBase<TemplateRef<any> | string> {
+    /** Heading level for the Message Box title (e.g. h1, h2, etc.) */
+    titleHeadingLevel?: 1 | 2 | 3 | 4 | 5 | 6 = 2;
+
+    /** ID for the Message Box content element */
+    contentId?: string;
+}

--- a/libs/docs/core/message-box/examples/complex-template/complex-template-example.component.ts
+++ b/libs/docs/core/message-box/examples/complex-template/complex-template-example.component.ts
@@ -21,7 +21,8 @@ export class ComplexTemplateExampleComponent {
     open(): void {
         this._messageBoxService.open(MessageBoxComplexExampleComponent, {
             width: '400px',
-            ariaLabel: 'aria-label attr for the Message Box'
+            ariaLabelledBy: 'fd-message-box-complex-template-header fd-message-box-complex-template-header-2',
+            ariaDescribedBy: 'fd-message-box-complex-template-body'
         });
     }
 }

--- a/libs/docs/core/message-box/examples/component-based/component-based-message-box-example.component.ts
+++ b/libs/docs/core/message-box/examples/component-based/component-based-message-box-example.component.ts
@@ -41,7 +41,8 @@ export class ComponentBasedMessageBoxExampleComponent {
             showSemanticIcon: true,
             customSemanticIcon: 'thumb-up',
             width: '400px',
-            ariaLabelledBy: 'fd-message-box-component-base-header fd-message-box-component-base-body'
+            ariaLabelledBy: 'fd-message-box-component-base-header',
+            ariaDescribedBy: 'fd-message-box-component-base-body'
         });
 
         messageBoxRef.afterClosed.subscribe(

--- a/libs/docs/core/message-box/examples/custom-position/message-box-position-example.component.ts
+++ b/libs/docs/core/message-box/examples/custom-position/message-box-position-example.component.ts
@@ -32,8 +32,7 @@ export class MessageBoxPositionExampleComponent {
 
         const messageBoxRef = this._messageBoxService.open(content, {
             width: '300px',
-            position: { top: '25px' },
-            ariaLabelledBy: `fd-message-box-custom-position-header fd-message-box-custom-position-body`
+            position: { top: '25px' }
         });
     }
 }

--- a/libs/docs/core/message-box/examples/mobile-mode/message-box-mobile-example.component.ts
+++ b/libs/docs/core/message-box/examples/mobile-mode/message-box-mobile-example.component.ts
@@ -22,7 +22,9 @@ export class MessageBoxMobileExampleComponent {
     open(): void {
         const content: MessageBoxContent = {
             title: this.title,
+            titleId: 'fd-message-box-mobile-header',
             content: this.content,
+            contentId: 'fd-message-box-mobile-body',
             approveButton: 'Ok',
             cancelButton: 'Cancel',
             approveButtonCallback: () => messageBoxRef.close('Approved'),
@@ -32,7 +34,8 @@ export class MessageBoxMobileExampleComponent {
 
         const messageBoxRef = this._messageBoxService.open(content, {
             mobile: true,
-            ariaLabelledBy: `fd-message-box-mobile-header fd-message-box-mobile-body`
+            ariaLabelledBy: 'fd-message-box-mobile-header',
+            ariaDescribedBy: 'fd-message-box-mobile-body'
         });
     }
 }

--- a/libs/docs/core/message-box/examples/object-based/object-based-message-box-example.component.ts
+++ b/libs/docs/core/message-box/examples/object-based/object-based-message-box-example.component.ts
@@ -27,6 +27,8 @@ export class ObjectBasedMessageBoxExampleComponent {
     open(): void {
         const content: MessageBoxContent = {
             title: this.title,
+            titleId: 'message-box-title-id-1',
+            contentId: 'message-box-content-id-1',
             content: this.content,
             approveButton: 'Ok',
             cancelButton: 'Cancel',
@@ -36,7 +38,8 @@ export class ObjectBasedMessageBoxExampleComponent {
         };
 
         const messageBoxRef = this._messageBoxService.open(content, {
-            ariaLabelledBy: 'fd-message-box-object-based-header fd-message-box-object-based-body'
+            ariaLabelledBy: 'message-box-title-id-1',
+            ariaDescribedBy: 'message-box-content-id-1'
         });
 
         messageBoxRef.afterClosed.subscribe({

--- a/libs/docs/core/message-box/examples/semantic-types/semantic-types-example.component.ts
+++ b/libs/docs/core/message-box/examples/semantic-types/semantic-types-example.component.ts
@@ -17,6 +17,8 @@ export class SemanticTypesExampleComponent {
     title = 'Fruit facts';
     content = 'Strawberries have more vitamin C than oranges.';
     types = '';
+    titleId = '';
+    contentId = '';
 
     constructor(private _messageBoxService: MessageBoxService) {}
 
@@ -24,10 +26,15 @@ export class SemanticTypesExampleComponent {
         this.types = `Message box uses the semantic type "${type}" ${
             customSemanticIcon ? 'with custom icon' : 'with default icon'
         }`;
+        this.titleId = `fd-message-box-semantic-title-${type}`;
+        this.contentId = `fd-message-box-semantic-content-${type}`;
+
         const messageBoxRef = this._messageBoxService.open(
             {
                 title: this.title,
+                titleId: this.titleId,
                 content: this.content,
+                contentId: this.contentId,
                 approveButton: 'Ok',
                 cancelButton: 'Cancel',
                 approveButtonCallback: () => messageBoxRef.close('Approved'),
@@ -38,8 +45,8 @@ export class SemanticTypesExampleComponent {
                 type,
                 showSemanticIcon,
                 customSemanticIcon,
-                ariaLabelledBy: 'fd-message-box-semantic-types-header fd-message-box-semantic-types-body',
-                ariaDescribedBy: 'fd-message-box-semantic-types-types'
+                ariaLabelledBy: this.titleId,
+                ariaDescribedBy: this.contentId
             }
         );
     }

--- a/libs/docs/core/message-box/examples/template-based/template-based-message-box-example.component.ts
+++ b/libs/docs/core/message-box/examples/template-based/template-based-message-box-example.component.ts
@@ -22,7 +22,8 @@ export class TemplateBasedMessageBoxExampleComponent {
 
     open(messageBox: TemplateRef<any>): void {
         const messageBoxRef = this._messageBoxService.open(messageBox, {
-            ariaLabel: 'aria-label attr for the Message Box',
+            ariaLabelledBy: 'fd-message-box-template-base-header',
+            ariaDescribedBy: 'fd-message-box-template-base-body',
             focusTrapped: true
         });
 


### PR DESCRIPTION
## Related Issue(s)
closes none

## Description
The following additions/improvements were made regarding a11y:
- the Message box body content is wrapper in a section
- in the default case (with config object), the user can specify the title heading level 
- in the default case (with config object), title and body content have default IDs in case the user doesn't specify in the config object
- in the default case (with config object), aria-labelledby and aria-describedby have fallback values in case the user doesn't specify in the config object
- the examples in the documentation were updated accordingly
