### PR TITLE
fix(core): a11y update for Feed Input

### DIFF
--- a/libs/core/feed-input/feed-input.component.html
+++ b/libs/core/feed-input/feed-input.component.html
@@ -1,3 +1,5 @@
-<div class="fd-feed-input" [class.is-disabled]="disabled">
-    <ng-content></ng-content>
+<div class="fd-feed-input" role="group" [attr.aria-label]="ariaLabel()" [class.is-disabled]="disabled">
+    <div class="fd-feed-input__container">
+        <ng-content></ng-content>
+    </div>
 </div>

--- a/libs/core/feed-input/feed-input.component.ts
+++ b/libs/core/feed-input/feed-input.component.ts
@@ -6,7 +6,8 @@ import {
     Input,
     OnDestroy,
     ViewEncapsulation,
-    forwardRef
+    forwardRef,
+    input
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { FeedInputButtonDirective } from './directives/feed-input-button.directive';
@@ -32,6 +33,9 @@ export class FeedInputComponent implements AfterContentInit, OnDestroy {
     /** @hidden */
     @ContentChild(forwardRef(() => FeedInputButtonDirective))
     buttonElement: FeedInputButtonDirective;
+
+    /** Value for aria label */
+    ariaLabel = input<string>();
 
     /** @hidden */
     private readonly _subscriptions = new Subscription();

--- a/libs/docs/core/feed-input/examples/feed-input-circle-avatar-example/feed-input-circle-avatar-example.component.html
+++ b/libs/docs/core/feed-input/examples/feed-input-circle-avatar-example/feed-input-circle-avatar-example.component.html
@@ -1,4 +1,4 @@
-<fd-feed-input aria-label="Feed input">
+<fd-feed-input ariaLabel="Feed input circle avatar">
     <fd-avatar
         fdFeedInputAvatar
         image="https://picsum.photos/id/1018/400"

--- a/libs/docs/core/feed-input/examples/feed-input-disabled-example/feed-input-disabled-example.component.html
+++ b/libs/docs/core/feed-input/examples/feed-input-disabled-example/feed-input-disabled-example.component.html
@@ -1,4 +1,4 @@
-<fd-feed-input [disabled]="true" aria-label="Feed input">
+<fd-feed-input [disabled]="true" ariaLabel="Feed input disabled">
     <fd-avatar
         fdFeedInputAvatar
         image="https://api.dicebear.com/7.x/pixel-art/svg"

--- a/libs/docs/core/feed-input/examples/feed-input-example/feed-input-example.component.html
+++ b/libs/docs/core/feed-input/examples/feed-input-example/feed-input-example.component.html
@@ -1,4 +1,4 @@
-<fd-feed-input aria-label="Feed input">
+<fd-feed-input ariaLabel="Feed input default">
     <fd-avatar
         fdFeedInputAvatar
         image="https://api.dicebear.com/7.x/pixel-art/svg"

--- a/libs/docs/core/feed-input/examples/feed-input-grow-example/feed-input-grow-example.component.html
+++ b/libs/docs/core/feed-input/examples/feed-input-grow-example/feed-input-grow-example.component.html
@@ -1,4 +1,4 @@
-<fd-feed-input aria-label="Feed input">
+<fd-feed-input ariaLabel="Feed input grow example">
     <fd-avatar
         fdFeedInputAvatar
         image="https://api.dicebear.com/7.x/pixel-art/svg"

--- a/libs/docs/core/feed-input/examples/feed-input-no-avatar-example/feed-input-no-avatar-example.component.html
+++ b/libs/docs/core/feed-input/examples/feed-input-no-avatar-example/feed-input-no-avatar-example.component.html
@@ -1,4 +1,4 @@
-<fd-feed-input aria-label="Feed input">
+<fd-feed-input ariaLabel="Feed input with no avatar">
     <textarea fd-form-control fdFeedInputTextarea placeholder="Post something here"></textarea>
 
     <button fdFeedInputButton aria-label="Send" title="Send"></button>

--- a/libs/docs/core/feed-input/examples/feed-input-placeholder-example/feed-input-placeholder-example.component.html
+++ b/libs/docs/core/feed-input/examples/feed-input-placeholder-example/feed-input-placeholder-example.component.html
@@ -1,4 +1,4 @@
-<fd-feed-input aria-label="Feed input">
+<fd-feed-input ariaLabel="Feed input placeholder example">
     <fd-avatar
         fdFeedInputAvatar
         [placeholder]="true"


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description
- adds the additional container div with class `fd-feed-input__container`
- updates role and aria-label for the parent element
- updates doc examples