### PR TITLE
fix(core): fd-list-group-header should not be adjacent to fd-list-item

### DIFF
--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
@@ -5,17 +5,18 @@
 <ng-template #bodyTemplate>
     <ul fd-list>
         <li fd-list-group-header>{{ 'platformTable.filterDialogFilterBy' | fdTranslate }}</li>
-
-        @for (filter of filters; track filter) {
-            <li
-                fd-list-item
-                [interactive]="true"
-                (click)="selectFilter.emit(filter)"
-                (keydown.space)="selectFilter.emit(filter)"
-                (keydown.enter)="selectFilter.emit(filter)"
-            >
-                <span fd-list-title>{{ filter.label }}</span>
-            </li>
-        }
+        <ul fd-list>
+            @for (filter of filters; track filter) {
+                <li
+                    fd-list-item
+                    [interactive]="true"
+                    (click)="selectFilter.emit(filter)"
+                    (keydown.space)="selectFilter.emit(filter)"
+                    (keydown.enter)="selectFilter.emit(filter)"
+                >
+                    <span fd-list-title>{{ filter.label }}</span>
+                </li>
+            }
+        </ul>
     </ul>
 </ng-template>

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
@@ -3,8 +3,10 @@
 </ng-template>
 
 <ng-template #bodyTemplate>
-    <h3 fd-list-group-header>{{ 'platformTable.filterDialogFilterBy' | fdTranslate }}</h3>
-    <ul fd-list>
+    <h3 fd-list-group-header id="platformTableInternalFilterListGroupHeader">
+        {{ 'platformTable.filterDialogFilterBy' | fdTranslate }}
+    </h3>
+    <ul fd-list aria-labelledby="platformTableInternalFilterListGroupHeader">
         @for (filter of filters; track filter) {
             <li
                 fd-list-item

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
@@ -3,7 +3,7 @@
 </ng-template>
 
 <ng-template #bodyTemplate>
-    <h5 fd-list-group-header>{{ 'platformTable.filterDialogFilterBy' | fdTranslate }}</h5>
+    <h3 fd-list-group-header>{{ 'platformTable.filterDialogFilterBy' | fdTranslate }}</h3>
     <ul fd-list>
         @for (filter of filters; track filter) {
             <li

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
@@ -3,20 +3,18 @@
 </ng-template>
 
 <ng-template #bodyTemplate>
+    <h5 fd-list-group-header>{{ 'platformTable.filterDialogFilterBy' | fdTranslate }}</h5>
     <ul fd-list>
-        <li fd-list-group-header>{{ 'platformTable.filterDialogFilterBy' | fdTranslate }}</li>
-        <ul fd-list>
-            @for (filter of filters; track filter) {
-                <li
-                    fd-list-item
-                    [interactive]="true"
-                    (click)="selectFilter.emit(filter)"
-                    (keydown.space)="selectFilter.emit(filter)"
-                    (keydown.enter)="selectFilter.emit(filter)"
-                >
-                    <span fd-list-title>{{ filter.label }}</span>
-                </li>
-            }
-        </ul>
+        @for (filter of filters; track filter) {
+            <li
+                fd-list-item
+                [interactive]="true"
+                (click)="selectFilter.emit(filter)"
+                (keydown.space)="selectFilter.emit(filter)"
+                (keydown.enter)="selectFilter.emit(filter)"
+            >
+                <span fd-list-title>{{ filter.label }}</span>
+            </li>
+        }
     </ul>
 </ng-template>


### PR DESCRIPTION
fixes none. A problem I noticed when working on screenreader for platform table filter dialog. 

My first thought was to use `role="heading"` on all `<li fd-list-group-header>` elements, but `heading` is not a valid child role of `ul` elements.  I think this may be the best option, which unfortunately would mean we need to make this change all over the library and docs. Looking for your opinions @InnaAtanasova @droshev 

before:
<img width="1040" alt="Screenshot 2025-05-02 at 1 51 25 PM" src="https://github.com/user-attachments/assets/947f851b-4b67-402e-bfb4-413ce1067cc8" />

after:
<img width="1045" alt="Screenshot 2025-05-02 at 1 52 06 PM" src="https://github.com/user-attachments/assets/25431085-4c61-4802-bbfa-8f76911cd2bb" />
