### PR TITLE
fix(core): a11y updates for Dialog and Message Box

### DIFF
--- a/libs/core/bar/bar.component.ts
+++ b/libs/core/bar/bar.component.ts
@@ -2,13 +2,14 @@ import {
     ChangeDetectionStrategy,
     Component,
     ElementRef,
+    input,
     Input,
     OnChanges,
     OnDestroy,
     OnInit,
     ViewEncapsulation
 } from '@angular/core';
-import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { applyCssClass, CssClassBuilder } from '@fundamental-ngx/cdk/utils';
 import {
     ContentDensityMode,
     ContentDensityObserver,
@@ -37,7 +38,7 @@ export type BarDesignType = 'header' | 'subheader' | 'header-with-subheader' | '
         })
     ],
     host: {
-        role: 'toolbar'
+        '[attr.role]': 'role()'
     },
     standalone: true
 })
@@ -65,6 +66,11 @@ export class BarComponent implements OnChanges, OnInit, CssClassBuilder, OnDestr
      */
     @Input()
     size: SizeType = '';
+
+    /** Aria role for the Bar
+     * default is toolbar
+     */
+    role = input('toolbar');
 
     /** @hidden */
     private _subscriptions = new Subscription();

--- a/libs/core/dialog/base/dialog-content-base.class.ts
+++ b/libs/core/dialog/base/dialog-content-base.class.ts
@@ -7,8 +7,14 @@ export class DialogContentBase<ContentType = unknown> {
     /** Dialog Title */
     title?: string;
 
+    /** Dialog Title Heading Level. Default is 1 */
+    titleHeadingLevel?: 1 | 2 | 3 | 4 | 5 | 6 = 1;
+
     /** Dialog Body */
     content?: ContentType;
+
+    /** Dialog Body Id */
+    contentId?: string;
 
     /** Aria Modal for the dialog component element */
     ariaModal?: boolean;

--- a/libs/core/dialog/dialog-body/dialog-body.component.html
+++ b/libs/core/dialog/dialog-body/dialog-body.component.html
@@ -1,9 +1,12 @@
-<ng-content></ng-content>
-@if (dialogRef.onLoading | async) {
-    <div class="fd-dialog__loader fd-busy-indicator-dialog">
-        @if (dialogRef.loadingContent) {
-            <fdk-dynamic-portal class="fd-text" [auto]="dialogRef.loadingContent"></fdk-dynamic-portal>
-        }
-        <fd-busy-indicator [loading]="true" size="l" [label]="dialogRef.loadingLabel"></fd-busy-indicator>
-    </div>
-}
+<section>
+    <ng-content></ng-content>
+
+    @if (dialogRef.onLoading | async) {
+        <div class="fd-dialog__loader fd-busy-indicator-dialog">
+            @if (dialogRef.loadingContent) {
+                <fdk-dynamic-portal class="fd-text" [auto]="dialogRef.loadingContent"></fdk-dynamic-portal>
+            }
+            <fd-busy-indicator [loading]="true" size="l" [label]="dialogRef.loadingLabel"></fd-busy-indicator>
+        </div>
+    }
+</section>

--- a/libs/core/dialog/dialog-default/dialog-default.component.html
+++ b/libs/core/dialog/dialog-default/dialog-default.component.html
@@ -1,6 +1,13 @@
 <fd-dialog>
     <fd-dialog-header>
-        <h1 fd-title [id]="_defaultDialogContent?.titleId">{{ _defaultDialogContent?.title }}</h1>
+        <div
+            role="heading"
+            [attr.aria-level]="_defaultDialogContent?.titleHeadingLevel || 1"
+            fd-title
+            [id]="_defaultDialogContent?.titleId || dialogTitleId"
+        >
+            {{ _defaultDialogContent?.title }}
+        </div>
         @if (_defaultDialogContent?.allowFullScreen) {
             <button
                 fd-dialog-full-screen-toggler-button
@@ -28,7 +35,7 @@
         }
     </fd-dialog-header>
     @if (_defaultDialogContent?.content) {
-        <fd-dialog-body>
+        <fd-dialog-body [id]="_defaultDialogContent?.contentId || dialogContentId">
             <ng-template [ngTemplateOutlet]="_defaultDialogContent?.content!"></ng-template>
         </fd-dialog-body>
     }

--- a/libs/core/dialog/dialog-default/dialog-default.component.ts
+++ b/libs/core/dialog/dialog-default/dialog-default.component.ts
@@ -17,6 +17,9 @@ import { DialogComponent } from '../dialog.component';
 import { DialogConfig } from '../utils/dialog-config.class';
 import { DialogDefaultContent } from '../utils/dialog-default-content.class';
 
+let dTitleId = 0;
+let dContentId = 0;
+
 /** Dialog component used to create the dialog in object based approach */
 @Component({
     selector: 'fd-dialog-default',
@@ -47,13 +50,33 @@ export class DialogDefaultComponent implements AfterViewInit {
     /** @hidden */
     _defaultDialogConfiguration: DialogConfig;
 
+    /**
+     * dialog title id
+     * if not set, a default value is provided
+     */
+    dialogTitleId = 'fd-dialog-title-id-' + dTitleId++;
+
+    /**
+     * dialog content id
+     * if not set, a default value is provided
+     */
+    dialogContentId = 'fd-dialog-content-id-' + dContentId++;
+
     /** @hidden */
-    constructor(private _changeDetectorRef: ChangeDetectorRef) {}
+    constructor(
+        private _changeDetectorRef: ChangeDetectorRef,
+        public _dialogConfig: DialogConfig
+    ) {}
 
     /** @hidden
      * TODO: Inspect why DialogDefaultComponents needs change detection re-run to render adjusted content (dialog header title)
      * */
     ngAfterViewInit(): void {
+        if (this._dialogConfig) {
+            this._dialogConfig.ariaLabelledBy ??= this.dialogTitleId;
+            this._dialogConfig.ariaDescribedBy ??= this.dialogContentId;
+        }
+
         this._changeDetectorRef.detectChanges();
     }
 

--- a/libs/core/dialog/dialog-footer/dialog-footer.component.html
+++ b/libs/core/dialog/dialog-footer/dialog-footer.component.html
@@ -1,9 +1,11 @@
-<footer fd-bar class="fd-dialog__footer" barDesign="footer" [fdContentDensity]="dialogConfig.contentDensity ?? ''">
-    <ng-template [ngTemplateOutlet]="footerTemplate ? footerTemplate : defaultTemplate"></ng-template>
+<footer>
+    <div fd-bar class="fd-dialog__footer" barDesign="footer" [fdContentDensity]="dialogConfig.contentDensity ?? ''">
+        <ng-template [ngTemplateOutlet]="footerTemplate ? footerTemplate : defaultTemplate"></ng-template>
 
-    <ng-template #defaultTemplate>
-        <div fd-bar-right>
-            <ng-content></ng-content>
-        </div>
-    </ng-template>
+        <ng-template #defaultTemplate>
+            <div fd-bar-right>
+                <ng-content></ng-content>
+            </div>
+        </ng-template>
+    </div>
 </footer>

--- a/libs/core/dialog/dialog-footer/dialog-footer.component.spec.ts
+++ b/libs/core/dialog/dialog-footer/dialog-footer.component.spec.ts
@@ -2,8 +2,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ChangeDetectionStrategy, Component, Type, ViewChild } from '@angular/core';
 import { TemplateDirective } from '@fundamental-ngx/cdk/utils';
-import { BarModule } from '@fundamental-ngx/core/bar';
-import { ContentDensityMode } from '@fundamental-ngx/core/content-density';
+import { BarMiddleDirective, ButtonBarComponent } from '@fundamental-ngx/core/bar';
 import { DialogConfig } from '../utils/dialog-config.class';
 import { DialogButtonClass, DialogFooterComponent } from './dialog-footer.component';
 
@@ -18,7 +17,7 @@ import { DialogButtonClass, DialogFooterComponent } from './dialog-footer.compon
         </fd-dialog-footer>
     `,
     standalone: true,
-    imports: [DialogFooterComponent, TemplateDirective, BarModule]
+    imports: [DialogFooterComponent, TemplateDirective, BarMiddleDirective, ButtonBarComponent]
 })
 class CustomFooterTestComponent {
     @ViewChild(DialogFooterComponent) dialogFooterRef: DialogFooterComponent;
@@ -31,7 +30,7 @@ class CustomFooterTestComponent {
         </fd-dialog-footer>
     `,
     standalone: true,
-    imports: [DialogFooterComponent, BarModule]
+    imports: [DialogFooterComponent, BarMiddleDirective, ButtonBarComponent]
 })
 class DefaultFooterTestComponent {
     @ViewChild(DialogFooterComponent) dialogFooterRef: DialogFooterComponent;
@@ -68,21 +67,6 @@ describe('DialogFooterComponent', () => {
 
         expect(component).toBeTruthy();
         expect(component.dialogFooterRef).toBeTruthy();
-    });
-
-    it('should display in mobile mode', async () => {
-        const { fixture, component } = setup<DefaultFooterTestComponent>(DefaultFooterTestComponent);
-
-        await wait(fixture);
-
-        component.dialogFooterRef.dialogConfig.mobile = true;
-        component.dialogFooterRef.dialogConfig.contentDensity = ContentDensityMode.COZY;
-
-        await wait(fixture);
-        const footerEl = fixture.nativeElement.querySelector('footer');
-
-        expect(footerEl.classList).toContain('fd-dialog__footer');
-        expect(footerEl.classList).toContain('is-cozy');
     });
 
     it('should use default template', async () => {

--- a/libs/core/dialog/dialog-header/dialog-header.component.html
+++ b/libs/core/dialog/dialog-header/dialog-header.component.html
@@ -1,33 +1,36 @@
-<div
-    fd-bar
-    class="fd-dialog__header"
-    [fdContentDensity]="dialogConfig.contentDensity ?? ''"
-    [barDesign]="subHeaderTemplate ? 'header-with-subheader' : 'header'"
->
-    <ng-template [ngTemplateOutlet]="headerTemplate ? headerTemplate : defaultTemplate"></ng-template>
-    <ng-template #defaultTemplate>
-        <div fd-bar-left>
-            <fd-bar-element [fullWidth]="true">
-                <ng-content select="[fd-title]"></ng-content>
-            </fd-bar-element>
-        </div>
-        <div fd-bar-right>
-            <fd-bar-element>
-                @if (!dialogConfig.mobile) {
-                    <ng-content select="[fd-dialog-full-screen-toggler-button]"></ng-content>
-                }
-                <ng-content select="[fd-dialog-close-button]"></ng-content>
-            </fd-bar-element>
-        </div>
-    </ng-template>
-</div>
-@if (subHeaderTemplate) {
+<header>
     <div
         fd-bar
-        class="fd-dialog__subheader"
-        barDesign="subheader"
+        role="group"
+        class="fd-dialog__header"
         [fdContentDensity]="dialogConfig.contentDensity ?? ''"
+        [barDesign]="subHeaderTemplate ? 'header-with-subheader' : 'header'"
     >
-        <ng-template [ngTemplateOutlet]="subHeaderTemplate"></ng-template>
+        <ng-template [ngTemplateOutlet]="headerTemplate ? headerTemplate : defaultTemplate"></ng-template>
+        <ng-template #defaultTemplate>
+            <div fd-bar-left>
+                <fd-bar-element [fullWidth]="true">
+                    <ng-content select="[fd-title]"></ng-content>
+                </fd-bar-element>
+            </div>
+            <div fd-bar-right>
+                <fd-bar-element>
+                    @if (!dialogConfig.mobile) {
+                        <ng-content select="[fd-dialog-full-screen-toggler-button]"></ng-content>
+                    }
+                    <ng-content select="[fd-dialog-close-button]"></ng-content>
+                </fd-bar-element>
+            </div>
+        </ng-template>
     </div>
-}
+    @if (subHeaderTemplate) {
+        <div
+            fd-bar
+            class="fd-dialog__subheader"
+            barDesign="subheader"
+            [fdContentDensity]="dialogConfig.contentDensity ?? ''"
+        >
+            <ng-template [ngTemplateOutlet]="subHeaderTemplate"></ng-template>
+        </div>
+    }
+</header>

--- a/libs/core/dialog/dialog.component.html
+++ b/libs/core/dialog/dialog.component.html
@@ -28,13 +28,12 @@
     [attr.aria-label]="dialogConfig.ariaLabel"
     [attr.aria-labelledby]="dialogConfig.ariaLabelledBy"
     [attr.aria-describedby]="dialogConfig.ariaDescribedBy"
-    [attr.aria-modal]="dialogConfig.ariaModal"
     (cdkDragStarted)="isDragged = true"
     (cdkDragEnded)="isDragged = false"
     (onResizeEnd)="adjustResponsivePadding()"
 >
     @if (dialogConfig.resizable && !_fullScreen && !dialogConfig.mobile) {
-        <span fdkResizeHandle class="fd-dialog__resize-handle"></span>
+        <span fdkResizeHandle class="fd-dialog__resize-handle" role="presentation" aria-hidden="true"></span>
     }
     <div cdkDragHandle [cdkDragHandleDisabled]="!dialogConfig.draggable">
         <ng-content select="fd-dialog-header"></ng-content>

--- a/libs/core/dialog/dialog.component.scss
+++ b/libs/core/dialog/dialog.component.scss
@@ -7,12 +7,6 @@
 
 .fd-dialog__resize-handle {
     z-index: 1001;
-    bottom: 0;
-    overflow: hidden;
-    &:after {
-        margin-bottom: -0.125rem;
-        display: block;
-    }
 }
 
 .fd-dialog__content-full-screen {
@@ -31,14 +25,28 @@
 }
 
 // TODO: move to fundamental-styles
-.fd-dialog__content--mobile {
+.fd-dialog__content.fd-dialog__content--mobile {
     height: 100%;
     max-height: 100%;
     max-width: 100%;
     width: 100%;
     position: fixed !important;
+
+    .fd-dialog__header.fd-bar {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+    }
+
+    .fd-dialog__footer.fd-bar {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
 }
 
 .fd-dialog__footer {
     overflow: hidden;
+}
+
+.fd-dialog__content:has(.fd-dialog__resize-handle) {
+    overflow: visible !important;
 }

--- a/libs/core/dialog/directives/dialog-title.directive.ts
+++ b/libs/core/dialog/directives/dialog-title.directive.ts
@@ -8,7 +8,7 @@ let titleUniqueId = 1;
     // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[fd-dialog-title]',
     host: {
-        '[attr.id]': 'id'
+        '[attr.id]': 'id()'
     },
     standalone: true
 })

--- a/libs/core/message-box/message-box-body/message-box-body.component.ts
+++ b/libs/core/message-box/message-box-body/message-box-body.component.ts
@@ -10,7 +10,9 @@ import { MessageBoxConfig, MessageBoxHost } from '../utils/message-box-config.cl
  */
 @Component({
     selector: 'fd-message-box-body',
-    template: '<ng-content></ng-content>',
+    template: `<section>
+        <ng-content></ng-content>
+    </section>`,
     host: {
         '[class.fd-message-box__body]': 'true',
         '[class.fd-message-box__body--no-vertical-padding]': '!messageBoxConfig.verticalPadding'

--- a/libs/core/message-box/message-box-default/message-box-default.component.html
+++ b/libs/core/message-box/message-box-default/message-box-default.component.html
@@ -1,9 +1,16 @@
 @if (_messageBoxContent) {
     <fd-message-box>
         <fd-message-box-header>
-            <h1 fd-title>{{ _messageBoxContent.title }}</h1>
+            <div
+                fd-title
+                role="heading"
+                [ariaLevel]="_messageBoxContent.titleHeadingLevel || 2"
+                [id]="_messageBoxContent.titleId || messageBoxTitleId"
+            >
+                {{ _messageBoxContent.title }}
+            </div>
         </fd-message-box-header>
-        <fd-message-box-body>
+        <fd-message-box-body [id]="_messageBoxContent.contentId || messageBoxContentId">
             <ng-template [ngTemplateOutlet]="_contentTemplate"></ng-template>
         </fd-message-box-body>
         @if (_footerVisible) {

--- a/libs/core/message-box/message-box-default/message-box-default.component.ts
+++ b/libs/core/message-box/message-box-default/message-box-default.component.ts
@@ -19,6 +19,9 @@ import { MessageBoxComponent } from '../message-box.component';
 import { MessageBoxConfig } from '../utils/message-box-config.class';
 import { MessageBoxContent } from '../utils/message-box-content.class';
 
+let mbTitleId = 0;
+let mbContentId = 0;
+
 /** Message box component used to create the message box in object based approach */
 @Component({
     selector: 'fd-message-box-default',
@@ -50,6 +53,18 @@ export class MessageBoxDefaultComponent implements OnInit, AfterViewInit {
     /** @hidden */
     _footerVisible: boolean;
 
+    /**
+     * message box title id
+     * if not set, a default value is provided
+     */
+    messageBoxTitleId = 'fd-message-box-title-id-' + mbTitleId++;
+
+    /**
+     * message box content id
+     * if not set, a default value is provided
+     */
+    messageBoxContentId = 'fd-message-box-content-id-' + mbContentId++;
+
     /** @hidden */
     constructor(
         public _messageBoxConfig: MessageBoxConfig,
@@ -64,6 +79,16 @@ export class MessageBoxDefaultComponent implements OnInit, AfterViewInit {
     /** @hidden */
     ngAfterViewInit(): void {
         this._setContentTemplate();
+
+        /**
+         * If the configuration object doesn't provide values for ariaLabelledBy and/or ariaDescribedBy
+         * use the default generated ids for title and content
+         */
+
+        if (this._messageBoxConfig) {
+            this._messageBoxConfig.ariaLabelledBy ??= this.messageBoxTitleId;
+            this._messageBoxConfig.ariaDescribedBy ??= this.messageBoxContentId;
+        }
     }
 
     /** @hidden */

--- a/libs/core/message-box/message-box-header/message-box-header.component.html
+++ b/libs/core/message-box/message-box-header/message-box-header.component.html
@@ -1,26 +1,29 @@
-<div
-    fd-bar
-    class="fd-message-box__header"
-    [fdCozy]="messageBoxConfig.mobile"
-    [barDesign]="subHeaderTemplate ? 'header-with-subheader' : 'header'"
->
-    <ng-template [ngTemplateOutlet]="headerTemplate ? headerTemplate : defaultTemplate"></ng-template>
-    <ng-template #defaultTemplate>
-        <div fd-bar-left>
-            <fd-bar-element #defaultTemplateHeaderBar>
-                @if (_showSemanticIcon) {
-                    <fd-message-box-semantic-icon
-                        class="fd-message-box__internal-semantic-icon"
-                    ></fd-message-box-semantic-icon>
-                }
-                <ng-content select="fd-message-box-semantic-icon"></ng-content>
-                <ng-content select="[fd-title]"></ng-content>
-            </fd-bar-element>
-        </div>
-    </ng-template>
-</div>
-@if (subHeaderTemplate) {
-    <div fd-bar class="fd-message-box__subheader" barDesign="subheader" [fdCozy]="messageBoxConfig.mobile">
-        <ng-template [ngTemplateOutlet]="subHeaderTemplate"></ng-template>
+<header>
+    <div
+        fd-bar
+        role="group"
+        class="fd-message-box__header"
+        [fdCozy]="messageBoxConfig.mobile"
+        [barDesign]="subHeaderTemplate ? 'header-with-subheader' : 'header'"
+    >
+        <ng-template [ngTemplateOutlet]="headerTemplate ? headerTemplate : defaultTemplate"></ng-template>
+        <ng-template #defaultTemplate>
+            <div fd-bar-left>
+                <fd-bar-element #defaultTemplateHeaderBar>
+                    @if (_showSemanticIcon) {
+                        <fd-message-box-semantic-icon
+                            class="fd-message-box__internal-semantic-icon"
+                        ></fd-message-box-semantic-icon>
+                    }
+                    <ng-content select="fd-message-box-semantic-icon"></ng-content>
+                    <ng-content select="[fd-title]"></ng-content>
+                </fd-bar-element>
+            </div>
+        </ng-template>
     </div>
-}
+    @if (subHeaderTemplate) {
+        <div fd-bar class="fd-message-box__subheader" barDesign="subheader" [fdCozy]="messageBoxConfig.mobile">
+            <ng-template [ngTemplateOutlet]="subHeaderTemplate"></ng-template>
+        </div>
+    }
+</header>

--- a/libs/core/message-box/message-box-semantic-icon/message-box-semantic-icon.component.ts
+++ b/libs/core/message-box/message-box-semantic-icon/message-box-semantic-icon.component.ts
@@ -13,7 +13,11 @@ import { MessageBoxConfig, MessageBoxHost } from '../utils/message-box-config.cl
     selector: 'fd-message-box-semantic-icon',
     template: `<fd-icon [glyph]="_getIcon" [font]="glyphFont" role="presentation"></fd-icon>`,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [IconComponent]
+    imports: [IconComponent],
+    host: {
+        role: 'presentation',
+        '[attr.aria-hidden]': 'true'
+    }
 })
 export class MessageBoxSemanticIconComponent {
     /** Custom semantic icon */

--- a/libs/docs/core/dialog/examples/auto-label/auto-label-dialog-example.component.html
+++ b/libs/docs/core/dialog/examples/auto-label/auto-label-dialog-example.component.html
@@ -1,11 +1,11 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #confirmationDialog>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-10" fd-title fd-dialog-title>The History of Pineapple</h1>
+            <h1 id="fd-dialog-header-auto" fd-title fd-dialog-title>The History of Pineapple</h1>
         </fd-dialog-header>
 
         <fd-dialog-body>
-            <div id="fd-dialog-body-10">Are you interested in The Great History of Pineapple?</div>
+            <div id="fd-dialog-body-auto">Are you interested in The Great History of Pineapple?</div>
         </fd-dialog-body>
 
         <fd-dialog-footer>
@@ -13,7 +13,7 @@
                 fdType="emphasized"
                 label="Interested"
                 (click)="dialog.close('Continue')"
-                ariaLabel="Interested Emphasized"
+                ariaLabel="Interested"
             ></fd-button-bar>
 
             <fd-button-bar label="Cancel" (click)="dialog.dismiss('Cancel')" ariaLabel="Cancel"></fd-button-bar>

--- a/libs/docs/core/dialog/examples/component-based/component-based-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/component-based/component-based-dialog-example.component.ts
@@ -45,8 +45,8 @@ export class ComponentBasedDialogExampleComponent {
                 ]
             },
             width: '400px',
-            ariaLabelledBy: 'fd-dialog-header-1',
-            ariaDescribedBy: 'fd-dialog-body-1',
+            ariaLabelledBy: 'fd-dialog-header-c',
+            ariaDescribedBy: 'fd-dialog-body-c',
             responsivePadding: true,
             focusTrapped: true
         });

--- a/libs/docs/core/dialog/examples/component-based/dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/component-based/dialog-example.component.ts
@@ -17,10 +17,10 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     template: `
         <fd-dialog>
             <fd-dialog-header>
-                <h1 id="fd-dialog-header-1" fd-title>{{ dialogRef.data.title }}</h1>
+                <h1 id="fd-dialog-header-c" fd-title>{{ dialogRef.data.title }}</h1>
             </fd-dialog-header>
             <fd-dialog-body>
-                <p id="fd-dialog-body-1" [ngStyle]="{ 'text-align': 'justify', margin: 0 }">
+                <p id="fd-dialog-body-c" [ngStyle]="{ 'text-align': 'justify', margin: 0 }">
                     {{ dialogRef.data.pinnapleDescription }}
                 </p>
                 <ul [style.margin-bottom]="0">
@@ -36,7 +36,7 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
                     label="Interesting"
                     fdType="emphasized"
                     (click)="dialogRef.close('Continue')"
-                    ariaLabel="Interesting Emphasized"
+                    ariaLabel="Interesting"
                 >
                 </fd-button-bar>
                 <fd-button-bar

--- a/libs/docs/core/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.html
@@ -9,12 +9,12 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>
     <fd-dialog [dialogRef]="dialog" [dialogConfig]="dialogConfig">
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-2" fd-title>Backdrop Configuration</h1>
+            <h1 id="fd-dialog-header-backdrop" fd-title>Backdrop Configuration</h1>
             <button fd-dialog-close-button (click)="dialog.dismiss()" title="close"></button>
         </fd-dialog-header>
 
         <fd-dialog-body>
-            <div id="fd-dialog-body-2">{{ dialog.data }}</div>
+            <div id="fd-dialog-body-backdrop">{{ dialog.data }}</div>
         </fd-dialog-body>
 
         <fd-dialog-footer>

--- a/libs/docs/core/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-backdrop-container/dialog-backdrop-container-example.component.ts
@@ -50,8 +50,8 @@ export class DialogBackdropContainerExampleComponent {
             responsivePadding: true,
             backdropClass: 'dialog-custom-overlay-example',
             data: `This dialog has a custom backdrop!`,
-            ariaLabelledBy: 'fd-dialog-header-2',
-            ariaDescribedBy: 'fd-dialog-body-2'
+            ariaLabelledBy: 'fd-dialog-header-backdrop',
+            ariaDescribedBy: 'fd-dialog-body-backdrop'
         });
     }
 
@@ -61,8 +61,8 @@ export class DialogBackdropContainerExampleComponent {
             container: containerRef,
             responsivePadding: true,
             data: `This dialog has been opened inside a local div!`,
-            ariaLabelledBy: 'fd-dialog-header-2',
-            ariaDescribedBy: 'fd-dialog-body-2'
+            ariaLabelledBy: 'fd-dialog-header-backdrop',
+            ariaDescribedBy: 'fd-dialog-body-backdrop'
         });
     }
 
@@ -74,8 +74,8 @@ export class DialogBackdropContainerExampleComponent {
             responsivePadding: true,
             backdropClass: 'static-dialog',
             data: `This dialog has been opened inside a local div and displayed as a static element!`,
-            ariaLabelledBy: 'fd-dialog-header-2',
-            ariaDescribedBy: 'fd-dialog-body-2'
+            ariaLabelledBy: 'fd-dialog-header-backdrop',
+            ariaDescribedBy: 'fd-dialog-body-backdrop'
         });
     }
 }

--- a/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.html
@@ -4,8 +4,8 @@
             <ng-template fdkTemplate="header">
                 <div fd-bar-left>
                     <fd-bar-element>
-                        <h1 id="fd-dialog-header-3" fd-title>Fresh Market</h1>
-                        <span style="display: none" aria-hidden="true" id="fd-dialog-description-3"
+                        <h1 id="fd-dialog-header-complex" fd-title>Fresh Market</h1>
+                        <span style="display: none" aria-hidden="true" id="fd-dialog-description-complex"
                             >Search for fresh produce items</span
                         >
                     </fd-bar-element>

--- a/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-complex/dialog-complex-example.component.ts
@@ -82,8 +82,8 @@ export class DialogComplexExampleComponent {
             draggable: true,
             resizable: true,
             verticalPadding: false,
-            ariaLabelledBy: 'fd-dialog-header-3',
-            ariaDescribedBy: 'fd-dialog-description-3'
+            ariaLabelledBy: 'fd-dialog-header-complex',
+            ariaDescribedBy: 'fd-dialog-description-complex'
         });
         this.dialogRef.loading(true);
         setTimeout(() => this.dialogRef.loading(false), 2000);

--- a/libs/docs/core/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-configuration/dialog-configuration-example.component.html
@@ -1,11 +1,11 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-4" fd-title>Origin of the Pineapple Word</h1>
+            <h1 id="fd-dialog-header-config" fd-title>Origin of the Pineapple Word</h1>
         </fd-dialog-header>
 
         <fd-dialog-body>
-            <div id="fd-dialog-body-4">
+            <div id="fd-dialog-body-config">
                 The word pineapple in English was first recorded in 1398, when it was originally used to describe the
                 reproductive organs of conifer trees (now termed pine cones). When European explorers discovered this
                 tropical fruit they called them pineapples (term first recorded in that sense in 1664) because of their
@@ -15,12 +15,7 @@
         </fd-dialog-body>
 
         <fd-dialog-footer>
-            <fd-button-bar
-                fdType="emphasized"
-                label="Interesting"
-                (click)="dialog.close()"
-                ariaLabel="Interesting Emphasized"
-            >
+            <fd-button-bar fdType="emphasized" label="Interesting" (click)="dialog.close()" ariaLabel="Interesting">
             </fd-button-bar>
         </fd-dialog-footer>
     </fd-dialog>

--- a/libs/docs/core/dialog/examples/dialog-configuration/dialog-configuration-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-configuration/dialog-configuration-example.component.ts
@@ -37,8 +37,8 @@ export class DialogConfigurationExampleComponent {
             draggable: true,
             responsivePadding: true,
             backdropClickCloseable: true,
-            ariaLabelledBy: 'fd-dialog-header-4',
-            ariaDescribedBy: 'fd-dialog-body-4'
+            ariaLabelledBy: 'fd-dialog-header-config',
+            ariaDescribedBy: 'fd-dialog-body-config'
         });
     }
 
@@ -48,8 +48,8 @@ export class DialogConfigurationExampleComponent {
             resizable: true,
             responsivePadding: true,
             backdropClickCloseable: true,
-            ariaLabelledBy: 'fd-dialog-header-4',
-            ariaDescribedBy: 'fd-dialog-body-4'
+            ariaLabelledBy: 'fd-dialog-header-config',
+            ariaDescribedBy: 'fd-dialog-body-config'
         });
     }
 
@@ -58,8 +58,8 @@ export class DialogConfigurationExampleComponent {
             width: '300px',
             escKeyCloseable: false,
             responsivePadding: true,
-            ariaLabelledBy: 'fd-dialog-header-4',
-            ariaDescribedBy: 'fd-dialog-body-4'
+            ariaLabelledBy: 'fd-dialog-header-config',
+            ariaDescribedBy: 'fd-dialog-body-config'
         });
     }
 }

--- a/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.html
@@ -1,7 +1,7 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #confirmationDialog>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-10" fd-title>The History of Pineapple</h1>
+            <h1 id="fd-dialog-header-form" fd-title>The History of Pineapple</h1>
         </fd-dialog-header>
 
         <fd-dialog-body>

--- a/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-form/form-dialog-example.component.ts
@@ -46,7 +46,8 @@ export class FormDialogExampleComponent {
         const dialogRef = this._dialogService.open(dialog, {
             responsivePadding: this.responsivePadding,
             focusTrapped: true,
-            verticalPadding: this.verticalPadding
+            verticalPadding: this.verticalPadding,
+            ariaLabelledBy: 'fd-dialog-header-form'
         });
 
         dialogRef.afterClosed.subscribe(

--- a/libs/docs/core/dialog/examples/dialog-full-screen/dialog-full-screen-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-full-screen/dialog-full-screen-example.component.html
@@ -20,7 +20,7 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #confirmationDialog>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-10" fd-title>The History of Pineapple</h1>
+            <h1 id="fd-dialog-header-fs-template" fd-title>The History of Pineapple</h1>
             <button
                 fd-dialog-full-screen-toggler-button
                 [dialogRef]="dialog"
@@ -30,7 +30,7 @@
         </fd-dialog-header>
 
         <fd-dialog-body>
-            <p id="fd-dialog-body-10">Are you interested in The Great History of Pineapple?</p>
+            <p id="fd-dialog-body-fs-template">Are you interested in The Great History of Pineapple?</p>
         </fd-dialog-body>
 
         <fd-dialog-footer>
@@ -38,7 +38,7 @@
                 fdType="emphasized"
                 label="Interested"
                 (click)="dialog.close('Continue')"
-                ariaLabel="Interested Emphasized"
+                ariaLabel="Interested"
             ></fd-button-bar>
 
             <fd-button-bar label="Cancel" (click)="dialog.dismiss('Cancel')" ariaLabel="Cancel"></fd-button-bar>

--- a/libs/docs/core/dialog/examples/dialog-full-screen/dialog-full-screen-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-full-screen/dialog-full-screen-example.component.ts
@@ -29,7 +29,7 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     selector: 'fd-dialog-full-screen-inner-example',
     template: ` <fd-dialog>
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-1" fd-title>{{ dialogRef.data.title }}</h1>
+            <h1 id="fd-dialog-header-fs-component" fd-title>{{ dialogRef.data.title }}</h1>
             <button
                 fd-dialog-full-screen-toggler-button
                 [title]="(dialogRef.fullScreen | async) === true ? 'Leave full-screen mode' : 'Enter full-screen mode'"
@@ -38,7 +38,7 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
         </fd-dialog-header>
         <fd-dialog-body>
             <p
-                id="fd-dialog-body-1"
+                id="fd-dialog-body-fs-component"
                 [ngStyle]="{
                     'text-align': 'justify',
                     margin: 0
@@ -59,7 +59,7 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
                 label="Interesting"
                 fdType="emphasized"
                 (click)="dialogRef.close('Continue')"
-                ariaLabel="Interesting Emphasized"
+                ariaLabel="Interesting"
             >
             </fd-button-bar>
             <fd-button-bar label="Cancel" fdType="transparent" (click)="dialogRef.dismiss('Cancel')" ariaLabel="Cancel">
@@ -150,8 +150,8 @@ export class DialogFullScreenExampleComponent {
                 ]
             },
             width: '400px',
-            ariaLabelledBy: 'fd-dialog-header-1',
-            ariaDescribedBy: 'fd-dialog-body-1',
+            ariaLabelledBy: 'fd-dialog-header-fs-component',
+            ariaDescribedBy: 'fd-dialog-body-fs-component',
             responsivePadding: true,
             draggable: true,
             resizable: true,
@@ -175,8 +175,8 @@ export class DialogFullScreenExampleComponent {
             responsivePadding: true,
             draggable: true,
             resizable: true,
-            ariaLabelledBy: 'fd-dialog-header-full-screen',
-            ariaDescribedBy: 'fd-dialog-header-full-screen',
+            ariaLabelledBy: 'fd-dialog-header-fs-template',
+            ariaDescribedBy: 'fd-dialog-body-fs-template',
             focusTrapped: true
         });
 
@@ -195,8 +195,9 @@ export class DialogFullScreenExampleComponent {
     openDialog(): void {
         const object: DialogDefaultContent = {
             title: 'Dialog Title',
-            titleId: 'fd-dialog-header-full-screen',
+            titleId: 'fd-dialog-header-fs-object',
             content: this.dialogContent,
+            contentId: 'fd-dialog-body-fs-object',
             subHeader: this.dialogSubHeader,
             approveButton: 'Ok',
             approveButtonAriaLabel: 'Ok Emphasized',
@@ -212,8 +213,8 @@ export class DialogFullScreenExampleComponent {
         };
 
         this._dialogReference = this._dialogService.open(object, {
-            ariaLabelledBy: 'fd-dialog-header-full-screen',
-            ariaDescribedBy: 'fd-dialog-body-full-screen',
+            ariaLabelledBy: 'fd-dialog-header-fs-object',
+            ariaDescribedBy: 'fd-dialog-body-fs-object',
             focusTrapped: true,
             resizable: true,
             draggable: true

--- a/libs/docs/core/dialog/examples/dialog-inner-popover/dialog-inner-popover.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-inner-popover/dialog-inner-popover.component.ts
@@ -62,8 +62,8 @@ export class DialogInnerPopoverComponent {
                 ]
             },
             width: '400px',
-            ariaLabelledBy: 'fd-dialog-header-1',
-            ariaDescribedBy: 'fd-dialog-body-1',
+            ariaLabelledBy: 'fd-dialog-header-pop',
+            ariaDescribedBy: 'fd-dialog-body-pop',
             responsivePadding: true
         });
 
@@ -82,11 +82,11 @@ export class DialogInnerPopoverComponent {
     template: `
         <fd-dialog>
             <fd-dialog-header>
-                <h1 id="fd-dialog-header-1" fd-title>{{ dialogRef.data.title }}</h1>
+                <h1 id="fd-dialog-header-pop" fd-title>{{ dialogRef.data.title }}</h1>
             </fd-dialog-header>
 
             <fd-dialog-body>
-                <div id="fd-dialog-body-1" role="listbox">
+                <div id="fd-dialog-body-pop" role="listbox">
                     <label for="first-list">The first list of options:</label>
                     <fd-multi-input
                         inputId="first-list"
@@ -113,7 +113,7 @@ export class DialogInnerPopoverComponent {
                     label="Interesting"
                     fdType="emphasized"
                     (click)="dialogRef.close('Interesting')"
-                    ariaLabel="Interesting Emphasized"
+                    ariaLabel="Interesting"
                 >
                 </fd-button-bar>
                 <fd-button-bar

--- a/libs/docs/core/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-mobile/dialog-mobile-example.component.html
@@ -1,23 +1,18 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-5" fd-title>Wild pineapples</h1>
+            <h1 id="fd-dialog-header-mobile" fd-title>Wild pineapples</h1>
         </fd-dialog-header>
 
         <fd-dialog-body>
-            <div id="fd-dialog-body-5">
+            <div id="fd-dialog-body-mobile">
                 Certain bat-pollinated wild pineapples, members of the Bromeliad family, do the exact opposite of most
                 flowers by opening their flowers at night and closing them during the day.
             </div>
         </fd-dialog-body>
 
         <fd-dialog-footer>
-            <fd-button-bar
-                fdType="emphasized"
-                label="Interesting"
-                (click)="dialog.close()"
-                ariaLabel="Interesting Emphasized"
-            >
+            <fd-button-bar fdType="emphasized" label="Interesting" (click)="dialog.close()" ariaLabel="Interesting">
             </fd-button-bar>
         </fd-dialog-footer>
     </fd-dialog>

--- a/libs/docs/core/dialog/examples/dialog-mobile/dialog-mobile-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-mobile/dialog-mobile-example.component.ts
@@ -35,8 +35,8 @@ export class DialogMobileExampleComponent {
         this._dialogService.open(dialogTemplate, {
             mobile: true,
             responsivePadding: true,
-            ariaLabelledBy: 'fd-dialog-header-5',
-            ariaDescribedBy: 'fd-dialog-body-5',
+            ariaLabelledBy: 'fd-dialog-header-mobile',
+            ariaDescribedBy: 'fd-dialog-body-mobile',
             contentDensity: ContentDensityMode.COZY
         });
     }

--- a/libs/docs/core/dialog/examples/dialog-object-example/dialog-object-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-object-example/dialog-object-example.component.ts
@@ -30,7 +30,6 @@ export class DialogObjectExampleComponent {
     openDialog(): void {
         const object: DialogDefaultContent = {
             title: 'Dialog Title',
-            titleId: 'fd-dialog-header-12',
             content: this.dialogContent,
             subHeader: this.dialogSubHeader,
             approveButton: 'Ok',
@@ -44,8 +43,6 @@ export class DialogObjectExampleComponent {
         };
 
         this._dialogReference = this._dialogService.open(object, {
-            ariaLabelledBy: 'fd-dialog-header-12',
-            ariaDescribedBy: 'fd-dialog-body-12',
             focusTrapped: true
         });
 

--- a/libs/docs/core/dialog/examples/dialog-position/dialog-position-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-position/dialog-position-example.component.html
@@ -1,11 +1,11 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-6" fd-title>More Facts about the Pineapple</h1>
+            <h1 id="fd-dialog-header-position" fd-title>More Facts about the Pineapple</h1>
         </fd-dialog-header>
 
         <fd-dialog-body>
-            <div id="fd-dialog-body-6">
+            <div id="fd-dialog-body-position">
                 The natural (or most common) pollinator of the pineapple is the hummingbird. Pollination is required for
                 seed formation; the presence of seeds negatively affects the quality of the fruit. In Hawaii, where
                 pineapple is cultivated on an agricultural scale, importation of hummingbirds is prohibited for this
@@ -14,12 +14,7 @@
         </fd-dialog-body>
 
         <fd-dialog-footer>
-            <fd-button-bar
-                fdType="emphasized"
-                label="Interesting"
-                (click)="dialog.close()"
-                ariaLabel="Interesting Emphasized"
-            >
+            <fd-button-bar fdType="emphasized" label="Interesting" (click)="dialog.close()" ariaLabel="Interesting">
             </fd-button-bar>
         </fd-dialog-footer>
     </fd-dialog>

--- a/libs/docs/core/dialog/examples/dialog-position/dialog-position-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-position/dialog-position-example.component.ts
@@ -35,8 +35,8 @@ export class DialogPositionExampleComponent {
             width: '300px',
             responsivePadding: true,
             position: { bottom: '100px', right: '100px' },
-            ariaLabelledBy: 'fd-dialog-header-6',
-            ariaDescribedBy: 'fd-dialog-body-6'
+            ariaLabelledBy: 'fd-dialog-header-position',
+            ariaDescribedBy: 'fd-dialog-body-position'
         });
     }
 }

--- a/libs/docs/core/dialog/examples/dialog-state/dialog-state-example.component.html
+++ b/libs/docs/core/dialog/examples/dialog-state/dialog-state-example.component.html
@@ -1,21 +1,15 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-7" fd-title>Dialog states</h1>
+            <h1 id="fd-dialog-header-state" fd-title>Dialog states</h1>
         </fd-dialog-header>
 
         <fd-dialog-body>
-            <div id="fd-dialog-body-7">{{ dialog.data }}</div>
+            <div id="fd-dialog-body-state">{{ dialog.data }}</div>
         </fd-dialog-body>
 
         <fd-dialog-footer>
-            <fd-button-bar
-                fdkInitialFocus
-                fdType="emphasized"
-                label="Ok"
-                (click)="dialog.close()"
-                ariaLabel="Ok Emphasized"
-            >
+            <fd-button-bar fdkInitialFocus fdType="emphasized" label="Ok" (click)="dialog.close()" ariaLabel="Ok">
             </fd-button-bar>
         </fd-dialog-footer>
     </fd-dialog>

--- a/libs/docs/core/dialog/examples/dialog-state/dialog-state-example.component.ts
+++ b/libs/docs/core/dialog/examples/dialog-state/dialog-state-example.component.ts
@@ -38,8 +38,8 @@ export class DialogStateExampleComponent {
             width: '300px',
             responsivePadding: true,
             data: 'This Dialog will be closed after 4s',
-            ariaLabelledBy: 'fd-dialog-header-7',
-            ariaDescribedBy: 'fd-dialog-body-7'
+            ariaLabelledBy: 'fd-dialog-header-state',
+            ariaDescribedBy: 'fd-dialog-body-state'
         });
         setTimeout(() => dialogRef.close(), 4000);
     }
@@ -49,8 +49,8 @@ export class DialogStateExampleComponent {
             width: '300px',
             responsivePadding: true,
             data: 'This Dialog will be dismissed after 4s',
-            ariaLabelledBy: 'fd-dialog-header-7',
-            ariaDescribedBy: 'fd-dialog-body-7'
+            ariaLabelledBy: 'fd-dialog-header-state',
+            ariaDescribedBy: 'fd-dialog-body-state'
         });
         setTimeout(() => dialogRef.dismiss(), 4000);
     }
@@ -60,8 +60,8 @@ export class DialogStateExampleComponent {
             width: '300px',
             responsivePadding: true,
             data: 'This Dialog will be hidden after 4s',
-            ariaLabelledBy: 'fd-dialog-header-7',
-            ariaDescribedBy: 'fd-dialog-body-7'
+            ariaLabelledBy: 'fd-dialog-header-state',
+            ariaDescribedBy: 'fd-dialog-body-state'
         });
         setTimeout(() => dialogRef.hide(true), 4000);
     }
@@ -70,8 +70,8 @@ export class DialogStateExampleComponent {
         const dialogRef = this.dialogService.open(template, {
             width: '300px',
             responsivePadding: true,
-            ariaLabelledBy: 'fd-dialog-header-7',
-            ariaDescribedBy: 'fd-dialog-body-7'
+            ariaLabelledBy: 'fd-dialog-header-state',
+            ariaDescribedBy: 'fd-dialog-body-state'
         });
         dialogRef.loading({
             isLoading: true,

--- a/libs/docs/core/dialog/examples/stacked-dialogs/dialog-stacked-example.component.ts
+++ b/libs/docs/core/dialog/examples/stacked-dialogs/dialog-stacked-example.component.ts
@@ -14,8 +14,8 @@ export class DialogStackedExampleComponent {
     openDialog(): void {
         this._dialogService.open(FirstDialogExampleComponent, {
             responsivePadding: true,
-            ariaLabelledBy: 'fd-dialog-header-8',
-            ariaDescribedBy: 'fd-dialog-body-8'
+            ariaLabelledBy: 'fd-dialog-header-first',
+            ariaDescribedBy: 'fd-dialog-body-first'
         });
     }
 }

--- a/libs/docs/core/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/stacked-dialogs/first-dialog-example.component.ts
@@ -19,12 +19,12 @@ import { SecondDialogExampleComponent } from './second-dialog-example.component'
     template: `
         <fd-dialog>
             <fd-dialog-header>
-                <h1 id="fd-dialog-header-8" fd-title>First Dialog</h1>
+                <h1 id="fd-dialog-header-first" fd-title>First Dialog</h1>
                 <button fd-dialog-close-button (click)="dialogRef.dismiss('x')" title="close"></button>
             </fd-dialog-header>
 
             <fd-dialog-body>
-                <div id="fd-dialog-body-8">
+                <div id="fd-dialog-body-first">
                     This is the first dialog!<br />
                     Click the button below to open the second dialog.
                 </div>
@@ -64,8 +64,8 @@ export class FirstDialogExampleComponent {
     openDialog(): void {
         this._dialogService.open(SecondDialogExampleComponent, {
             responsivePadding: true,
-            ariaLabelledBy: 'fd-dialog-header-9',
-            ariaDescribedBy: 'fd-dialog-body-9'
+            ariaLabelledBy: 'fd-dialog-header-second',
+            ariaDescribedBy: 'fd-dialog-body-second'
         });
     }
 }

--- a/libs/docs/core/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/stacked-dialogs/second-dialog-example.component.ts
@@ -10,12 +10,12 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
     template: `
         <fd-dialog>
             <fd-dialog-header>
-                <h1 id="fd-dialog-header-9" fd-title>Second Dialog</h1>
+                <h1 id="fd-dialog-header-second" fd-title>Second Dialog</h1>
                 <button fd-dialog-close-button (click)="dialogRef.dismiss()" title="close"></button>
             </fd-dialog-header>
 
             <fd-dialog-body>
-                <div id="fd-dialog-body-9">
+                <div id="fd-dialog-body-second">
                     This is the second dialog!<br />
                     It is completely independent from the first dialog and can be controlled separately!
                 </div>

--- a/libs/docs/core/dialog/examples/template-based/template-based-dialog-example.component.html
+++ b/libs/docs/core/dialog/examples/template-based/template-based-dialog-example.component.html
@@ -1,11 +1,11 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #confirmationDialog>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
         <fd-dialog-header>
-            <h1 id="fd-dialog-header-10" fd-title>The History of Pineapple</h1>
+            <h1 id="fd-dialog-header-tpl" fd-title>The History of Pineapple</h1>
         </fd-dialog-header>
 
         <fd-dialog-body>
-            <p id="fd-dialog-body-10">Are you interested in The Great History of Pineapple?</p>
+            <p id="fd-dialog-body-tpl">Are you interested in The Great History of Pineapple?</p>
         </fd-dialog-body>
 
         <fd-dialog-footer>

--- a/libs/docs/core/dialog/examples/template-based/template-based-dialog-example.component.ts
+++ b/libs/docs/core/dialog/examples/template-based/template-based-dialog-example.component.ts
@@ -45,8 +45,8 @@ export class TemplateBasedDialogExampleComponent {
     openDialog(dialog: TemplateRef<any>): void {
         const dialogRef = this._dialogService.open(dialog, {
             responsivePadding: true,
-            ariaLabelledBy: 'fd-dialog-header-10',
-            ariaDescribedBy: 'fd-dialog-body-10',
+            ariaLabelledBy: 'fd-dialog-header-tpl',
+            ariaDescribedBy: 'fd-dialog-body-tpl',
             focusTrapped: true
         });
 

--- a/libs/docs/core/message-box/examples/complex-template/complex-template-example.component.ts
+++ b/libs/docs/core/message-box/examples/complex-template/complex-template-example.component.ts
@@ -21,7 +21,8 @@ export class ComplexTemplateExampleComponent {
     open(): void {
         this._messageBoxService.open(MessageBoxComplexExampleComponent, {
             width: '400px',
-            ariaLabel: 'aria-label attr for the Message Box'
+            ariaLabelledBy: 'fd-message-box-complex-template-header fd-message-box-complex-template-header-2',
+            ariaDescribedBy: 'fd-message-box-complex-template-body'
         });
     }
 }

--- a/libs/docs/core/message-box/examples/component-based/component-based-message-box-example.component.ts
+++ b/libs/docs/core/message-box/examples/component-based/component-based-message-box-example.component.ts
@@ -41,7 +41,8 @@ export class ComponentBasedMessageBoxExampleComponent {
             showSemanticIcon: true,
             customSemanticIcon: 'thumb-up',
             width: '400px',
-            ariaLabelledBy: 'fd-message-box-component-base-header fd-message-box-component-base-body'
+            ariaLabelledBy: 'fd-message-box-component-base-header',
+            ariaDescribedBy: 'fd-message-box-component-base-body'
         });
 
         messageBoxRef.afterClosed.subscribe(

--- a/libs/docs/core/message-box/examples/custom-position/message-box-position-example.component.ts
+++ b/libs/docs/core/message-box/examples/custom-position/message-box-position-example.component.ts
@@ -32,8 +32,7 @@ export class MessageBoxPositionExampleComponent {
 
         const messageBoxRef = this._messageBoxService.open(content, {
             width: '300px',
-            position: { top: '25px' },
-            ariaLabelledBy: `fd-message-box-custom-position-header fd-message-box-custom-position-body`
+            position: { top: '25px' }
         });
     }
 }

--- a/libs/docs/core/message-box/examples/mobile-mode/message-box-mobile-example.component.ts
+++ b/libs/docs/core/message-box/examples/mobile-mode/message-box-mobile-example.component.ts
@@ -31,8 +31,7 @@ export class MessageBoxMobileExampleComponent {
         };
 
         const messageBoxRef = this._messageBoxService.open(content, {
-            mobile: true,
-            ariaLabelledBy: `fd-message-box-mobile-header fd-message-box-mobile-body`
+            mobile: true
         });
     }
 }

--- a/libs/docs/core/message-box/examples/object-based/object-based-message-box-example.component.ts
+++ b/libs/docs/core/message-box/examples/object-based/object-based-message-box-example.component.ts
@@ -35,9 +35,7 @@ export class ObjectBasedMessageBoxExampleComponent {
             closeButtonCallback: () => messageBoxRef.dismiss('Dismissed')
         };
 
-        const messageBoxRef = this._messageBoxService.open(content, {
-            ariaLabelledBy: 'fd-message-box-object-based-header fd-message-box-object-based-body'
-        });
+        const messageBoxRef = this._messageBoxService.open(content);
 
         messageBoxRef.afterClosed.subscribe({
             next: (result) => {

--- a/libs/docs/core/message-box/examples/semantic-types/semantic-types-example.component.ts
+++ b/libs/docs/core/message-box/examples/semantic-types/semantic-types-example.component.ts
@@ -17,6 +17,8 @@ export class SemanticTypesExampleComponent {
     title = 'Fruit facts';
     content = 'Strawberries have more vitamin C than oranges.';
     types = '';
+    titleId = '';
+    contentId = '';
 
     constructor(private _messageBoxService: MessageBoxService) {}
 
@@ -24,10 +26,14 @@ export class SemanticTypesExampleComponent {
         this.types = `Message box uses the semantic type "${type}" ${
             customSemanticIcon ? 'with custom icon' : 'with default icon'
         }`;
+        this.titleId = `fd-message-box-semantic-title-${type}`;
+        this.contentId = `fd-message-box-semantic-content-${type}`;
         const messageBoxRef = this._messageBoxService.open(
             {
                 title: this.title,
+                titleId: this.titleId,
                 content: this.content,
+                contentId: this.contentId,
                 approveButton: 'Ok',
                 cancelButton: 'Cancel',
                 approveButtonCallback: () => messageBoxRef.close('Approved'),
@@ -38,8 +44,8 @@ export class SemanticTypesExampleComponent {
                 type,
                 showSemanticIcon,
                 customSemanticIcon,
-                ariaLabelledBy: 'fd-message-box-semantic-types-header fd-message-box-semantic-types-body',
-                ariaDescribedBy: 'fd-message-box-semantic-types-types'
+                ariaLabelledBy: this.titleId,
+                ariaDescribedBy: this.contentId
             }
         );
     }

--- a/libs/docs/core/message-box/examples/template-based/template-based-message-box-example.component.ts
+++ b/libs/docs/core/message-box/examples/template-based/template-based-message-box-example.component.ts
@@ -22,8 +22,9 @@ export class TemplateBasedMessageBoxExampleComponent {
 
     open(messageBox: TemplateRef<any>): void {
         const messageBoxRef = this._messageBoxService.open(messageBox, {
-            ariaLabel: 'aria-label attr for the Message Box',
-            focusTrapped: true
+            focusTrapped: true,
+            ariaLabelledBy: 'fd-message-box-template-base-header',
+            ariaDescribedBy: 'fd-message-box-template-base-body'
         });
 
         messageBoxRef.afterClosed.subscribe(


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description
- **updates for Bar**: role can be an input, default is `toolbar`. This is needed because in Dialog and Message Box components the Bar parent element should have role `group`.
- **updates for Dialog**
1. in the base case, when Dialog is built with an object configuration, the title had `h1` and was not configurable by the user. Added an option to configure the heading level with `titleHeadingLevel`. 
2. The conf object can now accept id value for the dialog content, which is used for `aria-describedby` 
3. The Dialog body is placed in a `section`
4. In case the user has not provided ids for the title and/or body, default ones are generated
5. Header markup update
6. Footer markup update
7. CSS updates: for the resize handle WCAG 2.2 and for mobile mode remove the rounded corners
8. Fixed a bug for Dialog title id -> wrong call of signal value


- **updates for Message Box**
1. The body is placed inside a section
2. The title heading level can be configured
3. Default ids for title and body
4. Markup update for the heading
5. Semantic icon a11y update

- **examples updates for Dialog and Message Box**
