### PR TITLE
fix(core): a11y updates for Carousel

### DIFF
--- a/libs/core/carousel/carousel-item/carousel-item.component.ts
+++ b/libs/core/carousel/carousel-item/carousel-item.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, ViewEncapsulation } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    HostBinding,
+    Input,
+    signal,
+    ViewEncapsulation
+} from '@angular/core';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { BusyIndicatorComponent } from '@fundamental-ngx/core/busy-indicator';
 import { CarouselItemInterface } from '../carousel.service';
@@ -21,6 +29,14 @@ let carouselItemCounter = 0;
             }
         `
     ],
+    host: {
+        role: 'option',
+        class: 'fd-carousel__item fd-carousel__item--active',
+        '[attr.aria-setsize]': 'ariaSetsize()',
+        '[attr.aria-posinset]': 'ariaPosinset()',
+        '[attr.aria-selected]': 'ariaSelected()',
+        '[attr.aria-hidden]': 'ariaHidden()'
+    },
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     imports: [BusyIndicatorComponent]
@@ -69,17 +85,21 @@ export class CarouselItemComponent<T = any> implements CarouselItemInterface {
     @Input()
     value: T;
 
-    /** @hidden */
-    @HostBinding('class.fd-carousel__item')
-    carouselItem = true;
-
-    /** @hidden */
-    @HostBinding('class.fd-carousel__item--active')
-    carouselItemActive = true;
-
     /** @hidden Hide/show slide, useful for managing tab order */
     @HostBinding('style.visibility')
     _visibility: Visibility = 'visible';
+
+    /** @hidden value for aria-setsize attribute */
+    ariaSetsize = signal<number>(0);
+
+    /** @hidden value for aria-posinset attribute */
+    ariaPosinset = signal<number>(0);
+
+    /** @hidden value for aria-selected attribute */
+    ariaSelected = signal<boolean>(false);
+
+    /** @hidden value for aria-hidden attribute */
+    ariaHidden = signal<boolean>(false);
 
     /** @hidden */
     set visibility(visibility: Visibility) {

--- a/libs/core/carousel/carousel.component.html
+++ b/libs/core/carousel/carousel.component.html
@@ -1,12 +1,13 @@
-<div
+<section
     class="fd-carousel"
     [class.fd-carousel--no-navigation]="!navigation"
-    data-ride="carousel"
     tabindex="0"
     [style.height]="height"
     [style.width]="width"
     [attr.dir]="_dir$()"
-    role="region"
+    role="listbox"
+    aria-roledescription="Carousel"
+    [attr.aria-activedescendant]="ariaActivedescendant"
     #carouselContainer
     (click)="_focus()"
 >
@@ -35,7 +36,7 @@
     <div [style.display]="'none'" role="region" [attr.id]="id + '-accessibility'" aria-live="polite" dir="ltr">
         {{ screenReaderLabel }}
     </div>
-</div>
+</section>
 <ng-template #pageIndicatorContainer>
     <div
         class="fd-carousel__page-indicator-container"
@@ -62,27 +63,30 @@
         </div>
     }
     @if (!numericIndicator && _showNavigationButtonInPageIndicatorContainer) {
-        <ol class="fd-carousel__page-indicators" [attr.dir]="_dir$()">
+        <div class="fd-carousel__page-indicators" [attr.dir]="_dir$()">
             @if (pageIndicator) {
                 @for (item of pageIndicatorsCountArray; track item; let i = $index) {
-                    <li
-                        [attr.data-slide-to]="i + 1"
+                    <span
+                        role="img"
+                        [attr.aria-label]="
+                            'coreCarousel.pageIndicatorLabel' | fdTranslate: { itemNum: i + 1, totalNum: totalSlides }
+                        "
                         class="fd-carousel__page-indicator"
                         [class.fd-carousel__page-indicator--active]="i === currentActiveSlidesStartIndex"
-                    ></li>
+                    ></span>
                 }
             }
-        </ol>
+        </div>
     }
 </ng-template>
 <ng-template #buttonLeft>
     <button
         fd-button
+        role="button"
         class="fd-carousel__button"
         [class.fd-carousel__button--left]="!vertical"
         [class.fd-carousel__button--up]="vertical"
         [style.z-index]="1"
-        data-slide="previous"
         [attr.aria-label]="'coreCarousel.leftNavigationBtnLabel' | fdTranslate"
         (click)="previous(); $event.stopPropagation()"
         [disabled]="leftButtonDisabled"
@@ -93,11 +97,11 @@
 <ng-template #buttonRight>
     <button
         fd-button
+        role="button"
         class="fd-carousel__button"
         [class.fd-carousel__button--right]="!vertical"
         [class.fd-carousel__button--down]="vertical"
         [style.z-index]="1"
-        data-slide="next"
         [attr.aria-label]="'coreCarousel.rightNavigationBtnLabel' | fdTranslate"
         (click)="next(); $event.stopPropagation()"
         [disabled]="rightButtonDisabled"

--- a/libs/i18n/src/lib/models/fd-language-key-identifier.ts
+++ b/libs/i18n/src/lib/models/fd-language-key-identifier.ts
@@ -24,6 +24,7 @@ export type FdLanguageKeyIdentifier =
     | 'coreCalendar.calendarYearsRangeViewDescription'
     | 'coreMultiComboBox.multiComboBoxAriaLabel'
     | 'coreMultiComboBox.selectAllLabel'
+    | 'coreCarousel.pageIndicatorLabel'
     | 'coreCarousel.leftNavigationBtnLabel'
     | 'coreCarousel.rightNavigationBtnLabel'
     | 'coreDatePicker.dateInputLabel'

--- a/libs/i18n/src/lib/models/fd-language.ts
+++ b/libs/i18n/src/lib/models/fd-language.ts
@@ -68,6 +68,7 @@ export interface FdLanguage {
         selectAllLabel: FdLanguageKey;
     };
     coreCarousel: {
+        pageIndicatorLabel: FdLanguageKey;
         leftNavigationBtnLabel: FdLanguageKey;
         rightNavigationBtnLabel: FdLanguageKey;
     };

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -40,6 +40,10 @@ coreCalendar.calendarYearsRangeViewDescription = Years range picker
 coreMultiComboBox.multiComboBoxAriaLabel = Multi Value Combo Box
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel = Select all ({selectedItems} of {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel = Go to previous item
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations.properties instead
 export default {
     coreCalendar: {
@@ -27,6 +26,7 @@ export default {
         selectAllLabel: 'Select all ({selectedItems} of {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Go to previous item',
         rightNavigationBtnLabel: 'Go to next item'
     },

--- a/libs/i18n/src/lib/translations/translations_ar.properties
+++ b/libs/i18n/src/lib/translations/translations_ar.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=أداة انتقاء نطاق ا
 coreMultiComboBox.multiComboBoxAriaLabel=مربع تحرير وسرد متعدد القيم
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=تحديد الكل ({selectedItems} من {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=انتقال إلى البند السابق
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ar.properties instead
 export default {
     coreCalendar: {
@@ -27,6 +26,7 @@ export default {
         selectAllLabel: 'تحديد الكل ({selectedItems} من {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'انتقال إلى البند السابق',
         rightNavigationBtnLabel: 'انتقال إلى البند التالي'
     },

--- a/libs/i18n/src/lib/translations/translations_bg.properties
+++ b/libs/i18n/src/lib/translations/translations_bg.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Средство за избор 
 coreMultiComboBox.multiComboBoxAriaLabel=Комбинирано поле с множество стойности
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Избор на всички ({selectedItems} от {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Към предишната позиция
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Избор на всички ({selectedItems} от {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Към предишната позиция',
         rightNavigationBtnLabel: 'Към следващата позиция'
     },

--- a/libs/i18n/src/lib/translations/translations_cs.properties
+++ b/libs/i18n/src/lib/translations/translations_cs.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Výběr rozsahu let
 coreMultiComboBox.multiComboBoxAriaLabel=Vícehodnotový výklopný seznam
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Vybrat vše ({selectedItems} z {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Přejít na předchozí položku
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Vybrat vše ({selectedItems} z {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Přejít na předchozí položku',
         rightNavigationBtnLabel: 'Přejít na další položku'
     },

--- a/libs/i18n/src/lib/translations/translations_da.properties
+++ b/libs/i18n/src/lib/translations/translations_da.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Vælger af årsinterval
 coreMultiComboBox.multiComboBoxAriaLabel=Multiværdikombinationsboks
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Vælg alle ({selectedItems} ud af {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Gå til forrige element
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Vælg alle ({selectedItems} ud af {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Gå til forrige element',
         rightNavigationBtnLabel: 'Gå til næste element'
     },

--- a/libs/i18n/src/lib/translations/translations_de.properties
+++ b/libs/i18n/src/lib/translations/translations_de.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Jahresbereichsauswahl
 coreMultiComboBox.multiComboBoxAriaLabel=Mehrwert-Combobox
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Alle ({selectedItems} von {totalItems}) auswählen
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Zum vorherigen Element wechseln
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Alle ({selectedItems} von {totalItems}) auswählen'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Zum vorherigen Element wechseln',
         rightNavigationBtnLabel: 'Zum nächsten Element wechseln'
     },

--- a/libs/i18n/src/lib/translations/translations_el.properties
+++ b/libs/i18n/src/lib/translations/translations_el.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Επιλογέας εύρους �
 coreMultiComboBox.multiComboBoxAriaLabel=Σύνθετο Πλαίσιο Πολλών Τιμών
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Επιλογή όλων ({selectedItems} of {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Προς προηγούμενο στοιχείο
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Επιλογή όλων ({selectedItems} of {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Προς προηγούμενο στοιχείο',
         rightNavigationBtnLabel: 'Προς επόμενο στοιχείο'
     },

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=[[[Ŷēąŗş ŗąŋğē ρįċķ
 coreMultiComboBox.multiComboBoxAriaLabel=[[[Μűĺţį Ʋąĺűē Ĉŏɱƃŏ Ɓŏχ∙∙∙∙∙]]]
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=[[[Ŝēĺēċţ ąĺĺ ({şēĺēċţēƌĬţēɱş} ŏƒ {ţŏţąĺĬţēɱş})∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙]]]
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=[[[Ģŏ ţŏ ρŗēʋįŏűş įţēɱ∙∙∙∙∙]]]
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: '[[[Ŝēĺēċţ ąĺĺ ({şēĺēċţēƌĬţēɱş} ŏƒ {ţŏţąĺĬţēɱş})∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙]]]'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: '[[[Ģŏ ţŏ ρŗēʋįŏűş įţēɱ∙∙∙∙∙]]]',
         rightNavigationBtnLabel: '[[[Ģŏ ţŏ ŋēχţ įţēɱ∙∙∙∙]]]'
     },

--- a/libs/i18n/src/lib/translations/translations_es.properties
+++ b/libs/i18n/src/lib/translations/translations_es.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Selector de rango de años
 coreMultiComboBox.multiComboBoxAriaLabel=Cuadro combinado de varios valores
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Seleccionar todos ({selectedItems} de {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Ir a elemento anterior
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Seleccionar todos ({selectedItems} de {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Ir a elemento anterior',
         rightNavigationBtnLabel: 'Ir a siguiente elemento'
     },

--- a/libs/i18n/src/lib/translations/translations_fi.properties
+++ b/libs/i18n/src/lib/translations/translations_fi.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Vuosialuevalitsin
 coreMultiComboBox.multiComboBoxAriaLabel=Moninkertaisen arvon yhdistelmäruutu
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Valitse kaikki ({selectedItems} / {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Siirry edelliseen kohteeseen
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Valitse kaikki ({selectedItems} / {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Siirry edelliseen kohteeseen',
         rightNavigationBtnLabel: 'SIirry seuraavaan kohteeseen'
     },

--- a/libs/i18n/src/lib/translations/translations_fr.properties
+++ b/libs/i18n/src/lib/translations/translations_fr.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Sélecteur de plage d'années
 coreMultiComboBox.multiComboBoxAriaLabel=Zone combinée multiple
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Tout sélectionner ({selectedItems} sur {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Aller à l'élément précédent
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Tout sélectionner ({selectedItems} sur {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: "Aller à l'élément précédent",
         rightNavigationBtnLabel: "Aller à l'élément suivant"
     },

--- a/libs/i18n/src/lib/translations/translations_he.properties
+++ b/libs/i18n/src/lib/translations/translations_he.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=בוחר טווח שנים
 coreMultiComboBox.multiComboBoxAriaLabel=תיבה משולבת עם ערכים מרובים
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=בחר הכול ({selectedItems} מתוך {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=עבור לפריט הקודם
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'בחר הכול ({selectedItems} מתוך {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'עבור לפריט הקודם',
         rightNavigationBtnLabel: 'עבור לפריט הבא'
     },

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_hi.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_hr.properties
+++ b/libs/i18n/src/lib/translations/translations_hr.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Odabir raspona godina
 coreMultiComboBox.multiComboBoxAriaLabel=Kombinirani okvir s više vrijednosti
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Odaberi sve ({selectedItems} od {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Idi na prethodnu stavku
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Odaberi sve ({selectedItems} od {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Idi na prethodnu stavku',
         rightNavigationBtnLabel: 'Idi na sljedeću stavku'
     },

--- a/libs/i18n/src/lib/translations/translations_hu.properties
+++ b/libs/i18n/src/lib/translations/translations_hu.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Évtartomány-választó
 coreMultiComboBox.multiComboBoxAriaLabel=Többértékes kombinált lista
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Összes kiválasztása ({selectedItems} / {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Ugrás az előző elemre
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Összes kiválasztása ({selectedItems} / {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Ugrás az előző elemre',
         rightNavigationBtnLabel: 'Ugrás a következő elemre'
     },

--- a/libs/i18n/src/lib/translations/translations_it.properties
+++ b/libs/i18n/src/lib/translations/translations_it.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Selettore intervallo di anni
 coreMultiComboBox.multiComboBoxAriaLabel=Casella combinata multivalore
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Seleziona tutti ({selectedItems} di {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Vai all'elemento precedente
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Seleziona tutti ({selectedItems} di {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: "Vai all'elemento precedente",
         rightNavigationBtnLabel: "Vai all'elemento successivo"
     },

--- a/libs/i18n/src/lib/translations/translations_ja.properties
+++ b/libs/i18n/src/lib/translations/translations_ja.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=年範囲選択
 coreMultiComboBox.multiComboBoxAriaLabel=複数値コンボボックス
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=すべて選択 ({selectedItems}/{totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=前の項目へ
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'すべて選択 ({selectedItems}/{totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: '前の項目へ',
         rightNavigationBtnLabel: '次の項目へ'
     },

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ka.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_kk.properties
+++ b/libs/i18n/src/lib/translations/translations_kk.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Жылдар ауқымын та�
 coreMultiComboBox.multiComboBoxAriaLabel=Бірнеше мәннің құрама ұясы
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Барлық ({selectedItems}/{totalItems}) таңдаңыз
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Алдыңғы тармаққа өту
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Барлық ({selectedItems}/{totalItems}) таңдаңыз'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Алдыңғы тармаққа өту',
         rightNavigationBtnLabel: 'Келесі тармаққа өту'
     },

--- a/libs/i18n/src/lib/translations/translations_ko.properties
+++ b/libs/i18n/src/lib/translations/translations_ko.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=연도 범위 선택 도구
 coreMultiComboBox.multiComboBoxAriaLabel=다중 값 콤보 박스
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=모두 선택({totalItems}개 중 {selectedItems}개)
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=이전 항목으로 이동
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: '모두 선택({totalItems}개 중 {selectedItems}개)'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: '이전 항목으로 이동',
         rightNavigationBtnLabel: '다음 항목으로 이동'
     },

--- a/libs/i18n/src/lib/translations/translations_ms.properties
+++ b/libs/i18n/src/lib/translations/translations_ms.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Pemilih julat tahun
 coreMultiComboBox.multiComboBoxAriaLabel=Kotak Kombo Nilai Berbilang
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Pilih semua ({selectedItems} daripada {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Pergi ke item sebelumnya
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Pilih semua ({selectedItems} daripada {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Pergi ke item sebelumnya',
         rightNavigationBtnLabel: 'Pergi ke item seterusnya'
     },

--- a/libs/i18n/src/lib/translations/translations_nl.properties
+++ b/libs/i18n/src/lib/translations/translations_nl.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Jarenbereikkiezer
 coreMultiComboBox.multiComboBoxAriaLabel=Keuzelijst met invoerveld met meerdere waarden
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Alle ({selectedItems} van {totalItems}) selecteren
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Naar vorige item
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Alle ({selectedItems} van {totalItems}) selecteren'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Naar vorige item',
         rightNavigationBtnLabel: 'Naar volgende item'
     },

--- a/libs/i18n/src/lib/translations/translations_no.properties
+++ b/libs/i18n/src/lib/translations/translations_no.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Velger av årsintervall
 coreMultiComboBox.multiComboBoxAriaLabel=Kombinasjonsboks for flere verdier
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Merk alle ({selectedItems} av {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Gå til forrige element
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Merk alle ({selectedItems} av {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Gå til forrige element',
         rightNavigationBtnLabel: 'Gå til neste element'
     },

--- a/libs/i18n/src/lib/translations/translations_pl.properties
+++ b/libs/i18n/src/lib/translations/translations_pl.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Selektor zakresu lat
 coreMultiComboBox.multiComboBoxAriaLabel=Pole wielokrotnego wyboru
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Wybierz wszystkie ({selectedItems} z {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Przejdź do poprzedniej pozycji
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Wybierz wszystkie ({selectedItems} z {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Przejdź do poprzedniej pozycji',
         rightNavigationBtnLabel: 'Przejdź do następnej pozycji'
     },

--- a/libs/i18n/src/lib/translations/translations_pt.properties
+++ b/libs/i18n/src/lib/translations/translations_pt.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Selecionador de intervalo de anos
 coreMultiComboBox.multiComboBoxAriaLabel=Combobox de valores múltiplos
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Selecionar todos os ({selectedItems} de {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Ir para o item anterior
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Selecionar todos os ({selectedItems} de {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Ir para o item anterior',
         rightNavigationBtnLabel: 'Ir para o próximo item'
     },

--- a/libs/i18n/src/lib/translations/translations_ro.properties
+++ b/libs/i18n/src/lib/translations/translations_ro.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Selector interval de ani
 coreMultiComboBox.multiComboBoxAriaLabel=Casetă combinată cu valori multiple
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Selectare toate ({selectedItems} din {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Salt la articol anterior
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Selectare toate ({selectedItems} din {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Salt la articol anterior',
         rightNavigationBtnLabel: 'Salt la articol următor'
     },

--- a/libs/i18n/src/lib/translations/translations_ru.properties
+++ b/libs/i18n/src/lib/translations/translations_ru.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Выбор диапазона г�
 coreMultiComboBox.multiComboBoxAriaLabel=Поле со списком значений
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Выбрать все ({selectedItems} из {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=К предыдущей позиции
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Выбрать все ({selectedItems} из {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'К предыдущей позиции',
         rightNavigationBtnLabel: 'К следующей позиции'
     },

--- a/libs/i18n/src/lib/translations/translations_sh.properties
+++ b/libs/i18n/src/lib/translations/translations_sh.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Birač raspona godina
 coreMultiComboBox.multiComboBoxAriaLabel=Combo box višestruke vrednosti
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Odaberi svih ({selectedItems} od {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Idi na prethodnu stavku
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Odaberi svih ({selectedItems} od {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Idi na prethodnu stavku',
         rightNavigationBtnLabel: 'Idi na sledeću stavku'
     },

--- a/libs/i18n/src/lib/translations/translations_sk.properties
+++ b/libs/i18n/src/lib/translations/translations_sk.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Výber rozsahu rokov
 coreMultiComboBox.multiComboBoxAriaLabel=Výklopný zoznam s viacerými hodnotami
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Vybrať všetko ({selectedItems} z {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Prejsť na predchádzajúcu položku
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Vybrať všetko ({selectedItems} z {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Prejsť na predchádzajúcu položku',
         rightNavigationBtnLabel: 'Prejsť na ďalšiu položku'
     },

--- a/libs/i18n/src/lib/translations/translations_sl.properties
+++ b/libs/i18n/src/lib/translations/translations_sl.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Izbirnik števila let
 coreMultiComboBox.multiComboBoxAriaLabel=Kombinirani seznam z več vrednostmi
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Izbira vseh ({selectedItems} od {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Premik na prejšnjo postavko
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Izbira vseh ({selectedItems} od {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Premik na prejšnjo postavko',
         rightNavigationBtnLabel: 'Premik na naslednjo postavko'
     },

--- a/libs/i18n/src/lib/translations/translations_sv.properties
+++ b/libs/i18n/src/lib/translations/translations_sv.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Årsintervallväljare
 coreMultiComboBox.multiComboBoxAriaLabel=Kombinationsruta med flera värden
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Välj alla ({selectedItems} av {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Gå till föregående artikel
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Välj alla ({selectedItems} av {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Gå till föregående artikel',
         rightNavigationBtnLabel: 'Gå till nästa artikel'
     },

--- a/libs/i18n/src/lib/translations/translations_th.properties
+++ b/libs/i18n/src/lib/translations/translations_th.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=ตัวเลือกช่ว
 coreMultiComboBox.multiComboBoxAriaLabel=คอมโบบ็อกซ์แบบหลายค่า
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=เลือกทั้งหมด ({selectedItems} จาก {totalItems}) รายการ
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=ไปยังไอเท็มก่อนหน้า
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'เลือกทั้งหมด ({selectedItems} จาก {totalItems}) รายการ'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'ไปยังไอเท็มก่อนหน้า',
         rightNavigationBtnLabel: 'ไปยังไอเท็มถัดไป'
     },

--- a/libs/i18n/src/lib/translations/translations_tr.properties
+++ b/libs/i18n/src/lib/translations/translations_tr.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Yıl aralığı seçici
 coreMultiComboBox.multiComboBoxAriaLabel=Çoklu Değer Açılan Kutusu
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Tümünü seç ({selectedItems}/{totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Önceki öğeye git
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Tümünü seç ({selectedItems}/{totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Önceki öğeye git',
         rightNavigationBtnLabel: 'Sonraki öğeye git'
     },

--- a/libs/i18n/src/lib/translations/translations_uk.properties
+++ b/libs/i18n/src/lib/translations/translations_uk.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=Вибір діапазону р�
 coreMultiComboBox.multiComboBoxAriaLabel=Багатозначне поле зі списком
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=Вибрати всі ({selectedItems} з {totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=Перейти до попереднього елемента
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: 'Вибрати всі ({selectedItems} з {totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: 'Перейти до попереднього елемента',
         rightNavigationBtnLabel: 'Перейти до наступного елемента'
     },

--- a/libs/i18n/src/lib/translations/translations_zh_CN.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=年度范围选取器
 coreMultiComboBox.multiComboBoxAriaLabel=多值组合框
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=全选（已选 {selectedItems} 个，共 {totalItems} 个）
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=转到上一个项目
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: '全选（已选 {selectedItems} 个，共 {totalItems} 个）'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: '转到上一个项目',
         rightNavigationBtnLabel: '转到下一个项目'
     },

--- a/libs/i18n/src/lib/translations/translations_zh_TW.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.properties
@@ -40,6 +40,8 @@ coreCalendar.calendarYearsRangeViewDescription=年份範圍選擇器
 coreMultiComboBox.multiComboBoxAriaLabel=多重值下拉式清單方塊
 #XBUT: Button used to select every option in the dropdown on the multi-combobox.
 coreMultiComboBox.selectAllLabel=全選 ({selectedItems}/{totalItems})
+#XFLD: Label for the page indicator of the carousel.
+coreCarousel.pageIndicatorLabel = Item {itemNum} of {totalNum} displayed
 #XBUT: Button used to show previous item in the carousel.
 coreCarousel.leftNavigationBtnLabel=移至先前項目
 #XBUT: Button used to show next item in the carousel.

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -27,6 +27,7 @@ export default {
         selectAllLabel: '全選 ({selectedItems}/{totalItems})'
     },
     coreCarousel: {
+        pageIndicatorLabel: 'Item {itemNum} of {totalNum} displayed',
         leftNavigationBtnLabel: '移至先前項目',
         rightNavigationBtnLabel: '移至下一個項目'
     },


### PR DESCRIPTION
## Related Issue(s)
closes none

## Description
- parent element: markup update, role, added aria-roledescription and aria-activedescendant + JS logic
- carousel item: updated role, host binding classes, added a11y attributes: aria-setsize, aria-posinset, aria-selected, aria-hidden and the necessary JS logic to generate them.
- carousel page indicators: markup update, removed `attr.data-slide-to`, added aria-label and i18n for it