### PR TITLE
fix(platform): heading level for sort/filter table dialogs should be h2

### DIFF
--- a/libs/docs/platform/schema/schemas/table-schema.ts
+++ b/libs/docs/platform/schema/schemas/table-schema.ts
@@ -48,6 +48,9 @@ export const tableSchema = {
                 },
                 hideItemCount: {
                     type: 'boolean'
+                },
+                headingLevel: {
+                    type: 'string'
                 }
             }
         },

--- a/libs/docs/platform/table/examples/platform-table-default-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-default-example.component.html
@@ -1,5 +1,5 @@
 <fdp-table [dataSource]="source" [trackBy]="trackBy" emptyTableMessage="No data found">
-    <fdp-table-toolbar title="Order Line Items" [shouldOverflow]="true" [disableRefresh]="true">
+    <fdp-table-toolbar title="Order Line Items" [shouldOverflow]="true" [disableRefresh]="true" headingLevel="3">
         <fdp-table-toolbar-actions>
             <fdp-button label="Action One" (click)="alert('Action One')"></fdp-button>
             <fdp-button label="Action Two" (click)="alert('Action Two')"></fdp-button>

--- a/libs/docs/platform/table/platform-table-docs.component.html
+++ b/libs/docs/platform/table/platform-table-docs.component.html
@@ -6,6 +6,10 @@
         To do that, developers need to wrap needed content with <code>fdp-table-toolbar-left-actions</code> component.
     </p>
     <p>This example also shows the usage of the overflow functionality of the toolbar.</p>
+    <p>
+        By default, the heading level of the table toolbar will be <code>h2</code>. This can be configured via the
+        <code>headingLevel</code> input, as demonstrated in the example below.
+    </p>
 </description>
 <component-example>
     <fdp-platform-table-default-example></fdp-platform-table-default-example>
@@ -380,7 +384,11 @@
         (columnFreeze)="onFreezeChange($event)"
         (groupChange)="onGroupChange($event)"
     >
-        <fdp-table-toolbar [title]="data['table-toolbar'].title" [hideItemCount]="data['table-toolbar'].hideItemCount">
+        <fdp-table-toolbar
+            [title]="data['table-toolbar'].title"
+            [hideItemCount]="data['table-toolbar'].hideItemCount"
+            [headingLevel]="data['table-toolbar'].headingLevel"
+        >
             <fdp-table-toolbar-actions>
                 <fdp-button label="Action Button"></fdp-button>
             </fdp-table-toolbar-actions>

--- a/libs/docs/platform/table/platform-table-docs.component.ts
+++ b/libs/docs/platform/table/platform-table-docs.component.ts
@@ -149,7 +149,8 @@ export class PlatformTableDocsComponent {
         },
         'table-toolbar': {
             title: 'Order Line Items',
-            hideItemCount: false
+            hideItemCount: false,
+            headingLevel: 2
         },
         'first-column': {
             align: 'start',

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filter-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filter-step.component.html
@@ -7,9 +7,9 @@
         [ariaLabel]="'platformTable.filterDialogBackToColumns' | fdTranslate"
         (click)="back.emit()"
     ></button>
-    <h4 fd-title [headerSize]="4">
+    <h2 fd-title [headerSize]="4">
         {{ 'platformTable.filterDialogFilterByLabel' | fdTranslate: { filterLabel: filter.label } }}
-    </h4>
+    </h2>
 </ng-template>
 
 <ng-template #bodyTemplate>

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
@@ -1,5 +1,5 @@
 <ng-template #titleTemplate>
-    <h4 fd-title [headerSize]="4">{{ 'platformTable.filterDialogFilterTitle' | fdTranslate }}</h4>
+    <h2 fd-title [headerSize]="4">{{ 'platformTable.filterDialogFilterTitle' | fdTranslate }}</h2>
 </ng-template>
 
 <ng-template #bodyTemplate>

--- a/libs/platform/table/components/table-view-settings-dialog/settings-dialog/settings-dialog.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/settings-dialog/settings-dialog.component.html
@@ -4,7 +4,7 @@
             <div fd-bar-left>
                 @if (activeTab() !== 'filter') {
                     <fd-bar-element>
-                        <h4 fd-title [headerSize]="4">{{ 'platformTable.settingsDialogHeader' | fdTranslate }}</h4>
+                        <h2 fd-title [headerSize]="4">{{ 'platformTable.settingsDialogHeader' | fdTranslate }}</h2>
                     </fd-bar-element>
                 } @else {
                     <fd-bar-element>


### PR DESCRIPTION
fixes #12788 