### PR TITLE
 docs(core): update aria attr for Breadcrumb

### DIFF
--- a/libs/docs/core/breadcrumb/examples/breadcrumb-href-example.component.html
+++ b/libs/docs/core/breadcrumb/examples/breadcrumb-href-example.component.html
@@ -1,16 +1,16 @@
 <fd-breadcrumb>
     <fd-breadcrumb-item>
-        <a fd-link (click)="onClick('Breadcrumb Level 1 clicked')">
+        <a fd-link (click)="onClick('Breadcrumb Level 1 clicked')" aria-current="false" aria-label="Root Page 1 of 4">
             Breadcrumb Level <span [style.font-weight]="'bold'">1</span>
         </a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
-        <a fd-link href="/#/core/breadcrumb">Breadcrumb Level 2</a>
+        <a fd-link href="/#/core/breadcrumb" aria-current="false" aria-label="Parent Page 2 of 4">Breadcrumb Level 2</a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
-        <a fd-link href="/#/core/breadcrumb">Breadcrumb Level 3</a>
+        <a fd-link href="/#/core/breadcrumb" aria-current="false" aria-label="Parent Page 3 of 4">Breadcrumb Level 3</a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
-        <span aria-current="page">Breadcrumb Level 4</span>
+        <span aria-current="page" aria-current="page" aria-label="Current Page 4 of 4">Breadcrumb Level 4</span>
     </fd-breadcrumb-item>
 </fd-breadcrumb>

--- a/libs/docs/core/breadcrumb/examples/breadcrumb-routerLink-example.component.html
+++ b/libs/docs/core/breadcrumb/examples/breadcrumb-routerLink-example.component.html
@@ -1,14 +1,18 @@
 <fd-breadcrumb>
     <fd-breadcrumb-item>
-        <a fd-link routerLink="/core/avatar"> Breadcrumb Level <span [style.font-weight]="'bold'">1</span> </a>
+        <a fd-link routerLink="/core/avatar" aria-current="false" aria-label="Root Page 1 of 4">
+            Breadcrumb Level <span [style.font-weight]="'bold'">1</span>
+        </a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
-        <a fd-link routerLink="/core/message-strip">Breadcrumb Level 2</a>
+        <a fd-link routerLink="/core/message-strip" aria-current="false" aria-label="Parent Page 2 of 4">
+            Breadcrumb Level 2
+        </a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
-        <a fd-link routerLink="/core/bar">Breadcrumb Level 3</a>
+        <a fd-link routerLink="/core/bar" aria-current="false" aria-label="Parent Page 3 of 4"> Breadcrumb Level 3 </a>
     </fd-breadcrumb-item>
     <fd-breadcrumb-item>
-        <span aria-current="page">Breadcrumb Level 4</span>
+        <span role="link" aria-current="page" aria-label="Current Page 4 of 4"> Breadcrumb Level 4 </span>
     </fd-breadcrumb-item>
 </fd-breadcrumb>


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description
the links inside the Breadcrumbs should have aria-current and aria-label