### PR TITLE
fix(core): apply correct class to back and hamburger buttons in ShellBar

### DIFF
--- a/libs/core/shellbar/shellbar.component.html
+++ b/libs/core/shellbar/shellbar.component.html
@@ -13,7 +13,7 @@
         >
             @if (showNavigationButton && !_showMobileSearch) {
                 <button
-                    class="fd-shellbar__action"
+                    class="fd-shellbar__button"
                     fd-button
                     fdType="transparent"
                     glyph="menu2"
@@ -24,7 +24,7 @@
             }
             @if (showBackButton && !_showMobileSearch) {
                 <button
-                    class="fd-shellbar__action"
+                    class="fd-shellbar__button"
                     fd-button
                     fdType="transparent"
                     [glyph]="_rtl$() ? 'slim-arrow-right' : 'nav-back'"


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13332
 
## Description
The incorrect hover style of the back and hamburger buttons was caused by an incorrect CSS class being applied. 
