### PR TITLE
fix(platform): do not start table column resize when right mouse button clicked

### DIFF
--- a/libs/platform/table-helpers/directives/table-cell-resizable.directive.ts
+++ b/libs/platform/table-helpers/directives/table-cell-resizable.directive.ts
@@ -3,9 +3,8 @@ import { AfterViewInit, computed, Directive, inject, Input, OnDestroy, OnInit } 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FDK_FOCUSABLE_ITEM_DIRECTIVE, FocusableItemDirective, RtlService } from '@fundamental-ngx/cdk/utils';
 import { TableCellDirective } from '@fundamental-ngx/core/table';
-import equal from 'fast-deep-equal';
 import { fromEvent } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
+import { debounceTime, filter, map } from 'rxjs/operators';
 import { TableColumnResizeService } from '../services/table-column-resize.service';
 
 export type TableColumnResizableSide = 'start' | 'end' | 'both';
@@ -73,7 +72,6 @@ export class PlatformTableCellResizableDirective
                     filter(() => this._tableColumnResizeService?.resizeInProgress !== true),
                     debounceTime(5),
                     map((event) => this._getResizer(event) || { resizerPosition: 0, resizedColumn: this.columnName }),
-                    distinctUntilChanged((prev, curr) => equal(prev, curr)),
                     takeUntilDestroyed(this._destroyRef)
                 )
                 .subscribe((data) => {

--- a/libs/platform/table/components/table-column-resizer/table-column-resizer.component.scss
+++ b/libs/platform/table/components/table-column-resizer/table-column-resizer.component.scss
@@ -11,6 +11,7 @@
     border-left: 3px solid var(--sapContent_DragAndDropActiveColor, #0854a0);
     border-right: 3px solid var(--sapContent_DragAndDropActiveColor, #0854a0);
     user-select: none;
+    height: 100%;
 
     &--active {
         opacity: 1;

--- a/libs/platform/table/components/table-column-resizer/table-column-resizer.component.ts
+++ b/libs/platform/table/components/table-column-resizer/table-column-resizer.component.ts
@@ -58,9 +58,11 @@ export class PlatformTableColumnResizerComponent implements OnInit {
             fromEvent<MouseEvent>(this._elmRef.nativeElement, 'mousedown')
                 .pipe(takeUntilDestroyed(this._destroyRef))
                 .subscribe((evt) => {
-                    this._tableColumnResizeService.startResize(evt);
+                    if (evt.button === 0 && !evt.ctrlKey) {
+                        this._tableColumnResizeService.startResize(evt);
 
-                    this._listenForMouseUp();
+                        this._listenForMouseUp();
+                    }
                 });
 
             this._tableColumnResizeService.resizerPosition$


### PR DESCRIPTION
fixes #13334 

Fixes an issue where, if you right-click a vertical border to drag it rather than left-click, the logic to hide the resizing border would break. Also fixes an issue where the resize border would not occupy 100% height