### PR TITLE
fix(platform): add fix for Form Field Group layout

### DIFF
--- a/libs/platform/form/form-group/form-group.component.html
+++ b/libs/platform/form/form-group/form-group.component.html
@@ -23,16 +23,17 @@
         @for (column of formRows | keyvalue; track $index) {
             <div class="fd-row">
                 @for (fields of column | fieldGroupRowValue | keyvalue; track $index) {
-                    <div class="fd-col fd-form-group" [class]="xlCol">
-                        @if ($fieldGroup(column.value); as value) {
-                            @if (value.label) {
-                                <div class="fd-row">
-                                    <div class="fd-col">
-                                        <div fdp-form-group-header [fieldGroup]="$index === 0 ? value : null"></div>
-                                    </div>
+                    @if ($fieldGroup(column.value); as value) {
+                        @if (value.label && $index === 0) {
+                            <div class="fd-row fd-form-item">
+                                <div class="fd-col" [class]="xlCol">
+                                    <div fdp-form-group-header [fieldGroup]="$index === 0 ? value : null"></div>
                                 </div>
-                            }
+                            </div>
                         }
+                    }
+
+                    <div class="fd-col fd-form-group" [class]="xlCol">
                         @for (field of fields.value; track trackByFieldName($index, field)) {
                             <div class="fd-row fd-form-item">
                                 <div class="fd-col" [class]="_inlineColumnLayoutClass" [style.order]="field.rank">

--- a/libs/platform/form/form-group/form-group.component.scss
+++ b/libs/platform/form/form-group/form-group.component.scss
@@ -6,6 +6,28 @@
 fdp-form-group {
     // resize observer won't work with inline elements
     display: block;
+
+    .fd-form-group {
+        display: block;
+    }
+
+    .fd-form-group.fd-form-group--inline {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+
+    .fd-form-group__header {
+        padding-inline: 1rem;
+    }
+
+    .fd-row:empty {
+        display: none;
+    }
+
+    .fd-form-group__header {
+        margin-block-start: 1rem;
+    }
 }
 
 // revert core styles overriding the form label styles


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13362

## Description
- add CSS to display the missing elements from the form (need display: block)
- changed a bit the internal markup to not render empty form header

## Screenshots
Before:
![Screenshot 2025-06-25 at 11 42 30 AM](https://github.com/user-attachments/assets/7e47fc76-5a44-43a0-b3d8-91e30e4f0859)


After:
![Screenshot 2025-06-25 at 11 42 40 AM](https://github.com/user-attachments/assets/3f949747-a86b-4ffb-aaa6-5be961a95cd4)

Before:

![Screenshot 2025-06-25 at 11 41 51 AM](https://github.com/user-attachments/assets/c4481206-5834-45a7-9697-a9a9f3f05d19)

After:
![Screenshot 2025-06-25 at 11 42 12 AM](https://github.com/user-attachments/assets/1b0bf6aa-b36a-4633-94fc-3bdf558e984a)

Before:
![Screenshot 2025-06-25 at 11 43 38 AM](https://github.com/user-attachments/assets/b6f37e00-d51d-4cfc-8aef-b4fecfb45cd5)

After: 
removed the empty element