### PR TITLE
fix(core): add option to customize Combobox dropdown width

### DIFF
--- a/libs/core/combobox/combobox.component.html
+++ b/libs/core/combobox/combobox.component.html
@@ -10,7 +10,7 @@
         [focusTrapped]="true"
         [triggers]="triggers"
         [disabled]="disabled || readOnly"
-        [maxWidth]="640"
+        [maxWidth]="!mobile && noDropDownMaxWidth ? null : dropDownMaxWidthPx"
         [style.width]="width && '100%'"
         [closeOnOutsideClick]="closeOnOutsideClick"
     >

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -253,6 +253,17 @@ export class ComboboxComponent<T = any>
     @Input()
     maxHeight = '50vh';
 
+    /** Max width of the dropdown in pixels. Default is 640px (40rem). */
+    @Input()
+    dropDownMaxWidthPx = 640;
+
+    /**
+     * Whether the dropdown should have max width.
+     * Set to true if you want the dropdown to take the width of the control.
+     * Default is false */
+    @Input()
+    noDropDownMaxWidth = false;
+
     /** Custom width of the control. */
     @Input()
     width: Nullable<string>;

--- a/libs/docs/core/combobox/examples/combobox-search-field-example.component.html
+++ b/libs/docs/core/combobox/examples/combobox-search-field-example.component.html
@@ -10,6 +10,8 @@
     </fd-combobox>
 </div>
 <small>Search Term: {{ searchTerm }}</small>
+
+<br /><br />
 <div fd-form-item>
     <label fd-form-label>Combobox</label>
     <fd-combobox
@@ -22,3 +24,35 @@
     </fd-combobox>
 </div>
 <small>Combobox Term: {{ searchTerm2 }}</small>
+
+<br /><br />
+
+<div fd-form-item>
+    <label fd-form-label>Combobox with custom dropdown width</label>
+    <fd-combobox
+        maxHeight="250px"
+        placeholder="Type some text..."
+        [showClearButton]="true"
+        [dropDownMaxWidthPx]="992"
+        [dropdownValues]="fruits"
+        [(ngModel)]="searchTerm3"
+    >
+    </fd-combobox>
+</div>
+<small>Combobox Term: {{ searchTerm3 }}</small>
+
+<br /><br />
+
+<div fd-form-item>
+    <label fd-form-label>Combobox with full dropdown width</label>
+    <fd-combobox
+        maxHeight="250px"
+        placeholder="Type some text..."
+        [showClearButton]="true"
+        [noDropDownMaxWidth]="true"
+        [dropdownValues]="fruits"
+        [(ngModel)]="searchTerm4"
+    >
+    </fd-combobox>
+</div>
+<small>Combobox Term: {{ searchTerm4 }}</small>

--- a/libs/docs/core/combobox/examples/combobox-search-field-example.component.ts
+++ b/libs/docs/core/combobox/examples/combobox-search-field-example.component.ts
@@ -11,6 +11,8 @@ import { FormItemComponent, FormLabelComponent } from '@fundamental-ngx/core/for
 export class ComboboxSearchFieldExampleComponent {
     searchTerm = '';
     searchTerm2 = '';
+    searchTerm3 = '';
+    searchTerm4 = '';
     fruits = [
         'Apple',
         'Pineapple',


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13360

## Description
- added option to set the max width of the dropdown via `dropDownMaxWidthPx` input property
- added option to remove the max-width of the dropdown via  `noDropDownMaxWidth` property. This way the dropdown will take the width of the input element.

## Screenshots
**Custom max-width. In this case 992px:**
![Screenshot 2025-06-25 at 1 58 42 PM](https://github.com/user-attachments/assets/74bdb32e-d644-44fd-b440-2b2861479b2f)

**No max-width:**
![Screenshot 2025-06-25 at 1 58 35 PM](https://github.com/user-attachments/assets/3f30b8d0-2229-406d-aee9-8f9e90f1d567)
