### PR TITLE
fix(core): add fix for Select keyboard navigation not working

### DIFF
--- a/libs/core/select/select.component.scss
+++ b/libs/core/select/select.component.scss
@@ -70,3 +70,7 @@ $block: fd-select;
         }
     }
 }
+
+.fd-select__control.is-expanded {
+    outline: none;
+}

--- a/libs/core/select/select.component.ts
+++ b/libs/core/select/select.component.ts
@@ -573,9 +573,9 @@ export class SelectComponent<T = any>
         );
 
         this._keyManagerService._keyManager.withHorizontalOrientation(null);
-
         this._highlightCorrectOption();
-
+        this._changeDetectorRef.markForCheck();
+        this._controlElementRef.nativeElement.focus();
         this.isOpenChange.emit(true);
     }
 
@@ -681,18 +681,11 @@ export class SelectComponent<T = any>
 
     /** @hidden */
     _highlightCorrectOption(): void {
-        let elToFocus;
         if (this._keyManagerService._keyManager && this._selectionModel.isEmpty()) {
             this._keyManagerService._keyManager.setFirstItemActive();
-            elToFocus = this._options.first._getHtmlElement();
         } else if (this._keyManagerService._keyManager && !this._selectionModel.isEmpty()) {
             this._keyManagerService._keyManager.setActiveItem(this.selected);
-            elToFocus = this.selected._getHtmlElement();
-        } else {
-            elToFocus = this._controlElementRef?.nativeElement as HTMLElement;
         }
-        this._changeDetectorRef.detectChanges();
-        elToFocus.focus();
     }
 
     /** @hidden */


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13361

## Description
The changes introduced in https://github.com/SAP/fundamental-ngx/pull/13232 broke the keyboard navigation of Select component. 
This PR reverts the changes and adds CSS to remove the visible focus of the trigger when the dropdown is open. This still fixes the issue reported in https://github.com/SAP/fundamental-ngx/issues/11295 and keeps the keyboard functionality intact. 

## Screenshots
Now:

https://github.com/user-attachments/assets/1cda835b-30fd-4e87-abe6-66552d4110f9


