### PR TITLE
fix(platform): show Toolbar separator in custom Toolbar inside Platform Table

### DIFF
--- a/libs/docs/platform/table/examples/platform-table-custom-title-example.component.html
+++ b/libs/docs/platform/table/examples/platform-table-custom-title-example.component.html
@@ -7,6 +7,7 @@
         </fdp-table-toolbar-left-actions>
         <fdp-table-toolbar-actions>
             <fdp-button label="Action One" (click)="alert('Action One')"></fdp-button>
+            <fd-toolbar-separator></fd-toolbar-separator>
             <fdp-button label="Action Two" (click)="alert('Action Two')"></fdp-button>
         </fdp-table-toolbar-actions>
     </fdp-table-toolbar>

--- a/libs/platform/table/components/table-toolbar/table-toolbar.component.html
+++ b/libs/platform/table/components/table-toolbar/table-toolbar.component.html
@@ -17,12 +17,12 @@
         [headingLevel]="headingLevel"
     >
         @if (_tableToolbarLeftActionsComponent) {
-            <span fd-toolbar-item>
+            <div fd-toolbar-item class="fd-toolbar__group">
                 @if (!!title || !hideItemCount) {
                     <fd-toolbar-separator></fd-toolbar-separator>
                 }
                 <ng-template [ngTemplateOutlet]="_tableToolbarLeftActionsComponent._contentTemplateRef"></ng-template>
-            </span>
+            </div>
         }
         <fd-toolbar-spacer></fd-toolbar-spacer>
         @if (!hideSearchInput) {

--- a/libs/platform/table/table.component.scss
+++ b/libs/platform/table/table.component.scss
@@ -100,14 +100,9 @@ $fd-table-scrollbar-width-with-border: calc(#{$fd-table-scrollbar-width} + var(-
 /** When actions are collapsed */
 fdk-dynamic-portal {
     .fdp-table-toolbar-actions {
+        gap: 0.5rem;
         display: flex;
         flex-direction: column;
-
-        > *:not(:last-of-type) {
-            margin-left: 0;
-            margin-right: 0;
-            margin-bottom: 0.25rem;
-        }
     }
 }
 
@@ -128,15 +123,9 @@ fdk-dynamic-portal {
 
     /** When actions are not collapsed */
     .fdp-table-toolbar-actions {
-        margin: 0;
-
-        > *:not(:first-of-type) {
-            margin-left: 0.5rem;
-            @include fd-rtl() {
-                margin-left: 0;
-                margin-right: 0.5rem;
-            }
-        }
+        gap: 0.5rem;
+        display: flex;
+        align-items: center;
     }
 
     .fdp-table__applied-filters-toolbar {
@@ -673,4 +662,10 @@ th.fd-table__cell .fd-table__inner {
 
 .fdp-table__body--disable-scroll {
     overflow: hidden !important;
+}
+
+.fd-toolbar__group {
+    gap: 0.5rem;
+    display: flex;
+    align-items: center;
 }


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13213

## Description
Left and right actions inside Table toolbar can be customized and should show a separator if needed. The reason the separator wasn't showing in the example is because the elements were projected inside a span element. To fix this:
1. changed the container of the projected elements to a `div`, 
2. added a class `fd-toolbar__group` that is a flex container which has a gap 0.5rem between the elements and aligns them vertically. 

Additionally, for the container of the right actions, some CSS code improvements were added: now the spacing between the elements is achieved with flex gap and there's no need of RTL handling.

## Screenshots
<img width="1193" alt="Screenshot 2025-06-26 at 2 06 23 PM" src="https://github.com/user-attachments/assets/fa8c9bd4-bca3-495b-8098-69ca8a625173" />

