### PR TITLE
fix: update default dayjs parse rule, doc improvements 

### DIFF
--- a/libs/datetime-adapter/src/lib/dayjs-datetime-formats.ts
+++ b/libs/datetime-adapter/src/lib/dayjs-datetime-formats.ts
@@ -3,8 +3,8 @@ import { DateTimeFormats } from '@fundamental-ngx/core/datetime';
 export const DAYJS_DATETIME_FORMATS: DateTimeFormats = {
     parse: {
         dateInput: 'l',
-        timeInput: 'h:mm A',
-        dateTimeInput: 'l h:mm A'
+        timeInput: 'h:mm',
+        dateTimeInput: 'l h:mm'
     },
     display: {
         dateInput: 'l',

--- a/libs/docs/core/datetime-picker/datetime-picker-docs.component.html
+++ b/libs/docs/core/datetime-picker/datetime-picker-docs.component.html
@@ -82,7 +82,7 @@
 
 <separator></separator>
 
-<fd-docs-section-title id="complex-i18n" componentName="datetime-picker"> i18n example. </fd-docs-section-title>
+<fd-docs-section-title id="complex-i18n" componentName="datetime-picker"> Internationalization </fd-docs-section-title>
 <description>
     <fd-datetime-important componentName="DatetimePicker"></fd-datetime-important>
     <p>
@@ -91,6 +91,12 @@
         labels) will need to be translated via the <code>fundamental-ngx/i18n</code> module. This is because the
         <code>CalendarComponent</code> utilizes different localization strategies than the other components of the
         library. Note the <code>TypeScript</code> example code below to see how this is done.
+    </p>
+    <p>
+        Also, due to the limitations of <code>FdDatetimeAdapter</code> which is built upon the JavaScript native
+        <code>Date</code>, it is advised to use the <code>Day.js</code> adapter for parsing of dates of various locales.
+        See the example below, as well as <a [routerLink]="['/core/dayjs-datetime-adapter']">this page</a> for more
+        information.
     </p>
 </description>
 <component-example>

--- a/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
+++ b/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.html
@@ -6,9 +6,11 @@
         [(value)]="locale"
         ariaLabelledBy="lang-select"
     >
-        <li fd-option *ngFor="let option of ['en-ca', 'fr', 'bg', 'pl', 'zh']" [value]="option">
-            {{ option }}
-        </li>
+        @for (option of ['en-us', 'en-gb', 'fr', 'bg', 'pl', 'zh']; track option) {
+            <li fd-option [value]="option">
+                {{ option }}
+            </li>
+        }
     </fd-select>
 </div>
 

--- a/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
+++ b/libs/docs/core/datetime-picker/examples/datetime-picker-complex-i18n-example/datetime-picker-complex-i18n-example.component.ts
@@ -1,12 +1,11 @@
 import { Component, Inject, LOCALE_ID, ViewChild } from '@angular/core';
-import {
-    DATE_TIME_FORMATS,
-    DatetimeAdapter,
-    FD_DATETIME_FORMATS,
-    FdDate,
-    FdDatetimeAdapter
-} from '@fundamental-ngx/core/datetime';
+import { FormsModule } from '@angular/forms';
+import { DatePickerComponent } from '@fundamental-ngx/core/date-picker';
+import { DATE_TIME_FORMATS, DatetimeAdapter } from '@fundamental-ngx/core/datetime';
 import { DatetimePickerComponent } from '@fundamental-ngx/core/datetime-picker';
+import { FormLabelComponent } from '@fundamental-ngx/core/form';
+import { SelectModule } from '@fundamental-ngx/core/select';
+import { DAYJS_DATETIME_FORMATS, DayjsDatetimeAdapter } from '@fundamental-ngx/datetime-adapter';
 import {
     FD_LANGUAGE,
     FD_LANGUAGE_BULGARIAN,
@@ -16,13 +15,18 @@ import {
     FD_LANGUAGE_POLISH,
     FdLanguage
 } from '@fundamental-ngx/i18n';
+import dayjs, { Dayjs } from 'dayjs';
+import 'dayjs/locale/en-gb';
+import 'dayjs/locale/pl';
+import 'dayjs/locale/zh';
 import { BehaviorSubject } from 'rxjs';
 
 const placeholders = new Map([
-    ['en-ca', 'mm/dd/yyyy, hh:mm a'],
-    ['fr', 'dd/mm/yyyy  hh:mm'],
-    ['bg', 'дд.мм.гг чч:мм'],
-    ['pl', 'dd.mm.yyyy, hh:mm']
+    ['en-us', 'mm/dd/yyyy, hh:mm a'],
+    ['en-gb', 'dd/mm/yyyy, hh:mm a'],
+    ['fr', 'dd/mm/yyyy  hh:mm a'],
+    ['bg', 'дд.мм.гг чч:мм a'],
+    ['pl', 'dd.mm.yyyy, hh:mm a']
 ]);
 
 @Component({
@@ -34,29 +38,32 @@ const placeholders = new Map([
         // Due to the limit of this example we must provide it on this level.
         {
             provide: LOCALE_ID,
-            useValue: 'en-ca'
-        },
-        {
-            provide: DatetimeAdapter,
-            useClass: FdDatetimeAdapter
+            useValue: 'en-us'
         },
         {
             provide: DATE_TIME_FORMATS,
-            useValue: FD_DATETIME_FORMATS
+            useValue: DAYJS_DATETIME_FORMATS
+        },
+        {
+            provide: DatetimeAdapter,
+            useClass: DayjsDatetimeAdapter
         }
-    ]
+    ],
+    imports: [FormLabelComponent, SelectModule, DatetimePickerComponent, DatePickerComponent, FormsModule]
 })
 export class DatetimePickerComplexI18nExampleComponent {
-    locale = 'en-ca';
+    @ViewChild(DatetimePickerComponent) datetimePickerComponent: DatetimePickerComponent<Dayjs>;
 
-    date = FdDate.getNow();
+    locale = 'en-us';
+
+    date: Dayjs = dayjs();
 
     placeholder = placeholders.get(this.locale) as string;
 
     @ViewChild(DatetimePickerComponent) datetimePickerComponent: DatetimePickerComponent<FdDate>;
 
     constructor(
-        private datetimeAdapter: DatetimeAdapter<FdDate>,
+        private datetimeAdapter: DatetimeAdapter<Dayjs>,
         @Inject(FD_LANGUAGE) private langSubject$: BehaviorSubject<FdLanguage>
     ) {}
 
@@ -64,7 +71,7 @@ export class DatetimePickerComplexI18nExampleComponent {
         this.locale = locale;
         this.datetimeAdapter.setLocale(locale);
         this.placeholder = placeholders.get(this.locale) as string;
-        if (locale === 'en-ca') {
+        if (locale === 'en-us' || locale === 'en-gb') {
             this.langSubject$.next(FD_LANGUAGE_ENGLISH);
         } else if (locale === 'fr') {
             this.langSubject$.next(FD_LANGUAGE_FRENCH);

--- a/libs/docs/core/dayjs-datetime-adapter/examples/date-picker-dayjs-adapter-example.component.ts
+++ b/libs/docs/core/dayjs-datetime-adapter/examples/date-picker-dayjs-adapter-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, LOCALE_ID, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, inject, LOCALE_ID, ViewChild } from '@angular/core';
 import { DatePickerComponent } from '@fundamental-ngx/core/date-picker';
 import { DATE_TIME_FORMATS, DatetimeAdapter } from '@fundamental-ngx/core/datetime';
 import dayjs, { Dayjs } from 'dayjs';
@@ -27,11 +27,13 @@ import { DAYJS_DATETIME_FORMATS, DayjsDatetimeAdapter } from '@fundamental-ngx/d
         }
     ]
 })
-export class DatePickerDayjsAdapterExampleComponent {
+export class DatePickerDayjsAdapterExampleComponent implements AfterViewInit {
     @ViewChild(DatePickerComponent) datePicker: DatePickerComponent<Dayjs>;
 
     actualLocale: string;
     date: Dayjs = dayjs();
+
+    locale = inject(LOCALE_ID);
 
     readonly localeOptions = [
         { value: 'en', label: 'English' },
@@ -41,10 +43,12 @@ export class DatePickerDayjsAdapterExampleComponent {
         { value: 'ar', label: 'Arabic' }
     ];
 
-    constructor(@Inject(LOCALE_ID) locale: string, private datetimeAdapter: DatetimeAdapter<Dayjs>) {
+    constructor(private datetimeAdapter: DatetimeAdapter<Dayjs>) {}
+
+    ngAfterViewInit(): void {
         // since datetimeAdapter instance is shared globally,
         // once loaded, we need to update value in it with LOCALE_ID provided for this component
-        this.setLocale(locale);
+        this.setLocale(this.locale);
     }
 
     setLocale(locale: string): void {


### PR DESCRIPTION
## Related Issue(s)

(#13326 )
fix PR #13344 

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes

## Description

<!-- Enter short description of the change -->
When the locale is not en or zh, manually deleting the time portion and keeping only the date causes the displayed date to become inconsistent with the original selection.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->
