### PR TITLE
fix(core): Input Group of type number should have value of type number

### DIFF
--- a/libs/cdk/forms/cva/cva.directive.ts
+++ b/libs/cdk/forms/cva/cva.directive.ts
@@ -38,6 +38,10 @@ export class CvaDirective<T = any>
     @Input()
     placeholder: string;
 
+    /** Input type */
+    @Input()
+    type: string;
+
     /**
      *  The state of the form control - applies css classes.
      *  Can be 'success', 'error', 'warning', 'default', 'information'.
@@ -394,10 +398,16 @@ export class CvaDirective<T = any>
      * Should be "false", if the change is made programmatically (internally) by the control, "true" otherwise
      */
     setValue(value: T, emitOnChange = true): void {
-        if (value !== this.value) {
-            this.writeValue(value);
+        let coercedValue: any = value;
+
+        if (this.type === 'number') {
+            coercedValue = value === '' || value === null || value === undefined ? null : Number(value);
+        }
+
+        if (coercedValue !== this.value) {
+            this.writeValue(coercedValue);
             if (emitOnChange) {
-                this.onChange(value);
+                this.onChange(coercedValue);
             }
             this._markForCheck();
         }

--- a/libs/core/input-group/input-group.component.ts
+++ b/libs/core/input-group/input-group.component.ts
@@ -54,7 +54,7 @@ let addOnInputRandomId = 0;
     hostDirectives: [
         {
             directive: CvaDirective,
-            inputs: ['placeholder', 'disabled', 'readonly', 'state', 'name', 'stateMessage']
+            inputs: ['placeholder', 'disabled', 'readonly', 'state', 'name', 'stateMessage', 'type']
         }
     ],
     providers: [

--- a/libs/docs/core/input-group/examples/input-group-form-example/input-group-form-example.component.html
+++ b/libs/docs/core/input-group/examples/input-group-form-example/input-group-form-example.component.html
@@ -13,16 +13,46 @@
             </fd-input-group>
         </div>
         <small>Disabled Input Value: {{ customForm.controls.disabledInput.value }}</small>
+
+        <!-- Input with Type Text  -->
         <div fd-form-item [style.margin-top.rem]="1">
-            <label fd-form-label for="fd-input-group-form-2" id="fd-input-group-form-label-2">Enabled Input</label>
-            <fd-input-group formControlName="enabledInput" ariaLabelledBy="fd-input-group-form-label-2">
+            <label fd-form-label for="fd-input-group-form-2" id="fd-input-group-form-label-2"
+                >Enabled Input (Type Text)</label
+            >
+            <fd-input-group
+                formControlName="enabledInputText"
+                ariaLabelledBy="fd-input-group-form-label-2"
+                placeholder="Enter text"
+            >
             </fd-input-group>
         </div>
         <small>
-            Enabled Input Form Control Value: {{ customForm.controls.enabledInput.value }}<br />
-            Enabled Input Form Control Touched: {{ customForm.controls.enabledInput.touched }}<br />
-            Enabled Input Form Control Dirty: {{ customForm.controls.enabledInput.dirty }}<br />
-            Enabled Input Form Control Valid: {{ customForm.controls.enabledInput.valid }}
+            Enabled Input Form Control Value: {{ customForm.controls.enabledInputText.value }}<br />
+            Enabled Input Form Control Value Type: {{ typeof customForm.controls.enabledInputText.value }}<br />
+            Enabled Input Form Control Touched: {{ customForm.controls.enabledInputText.touched }}<br />
+            Enabled Input Form Control Dirty: {{ customForm.controls.enabledInputText.dirty }}<br />
+            Enabled Input Form Control Valid: {{ customForm.controls.enabledInputText.valid }}
+        </small>
+
+        <!-- Input with Type Number  -->
+        <div fd-form-item [style.margin-top.rem]="1">
+            <label fd-form-label for="fd-input-group-form-3" id="fd-input-group-form-label-3"
+                >Enabled Input (Type Number)</label
+            >
+            <fd-input-group
+                formControlName="enabledInputNumber"
+                ariaLabelledBy="fd-input-group-form-label-3"
+                placeholder="Enter a number"
+                type="number"
+            >
+            </fd-input-group>
+        </div>
+        <small>
+            Enabled Input Form Control Value: {{ customForm.controls.enabledInputNumber.value }}<br />
+            Enabled Input Form Control Value Type: {{ typeof customForm.controls.enabledInputNumber.value }}<br />
+            Enabled Input Form Control Touched: {{ customForm.controls.enabledInputNumber.touched }}<br />
+            Enabled Input Form Control Dirty: {{ customForm.controls.enabledInputNumber.dirty }}<br />
+            Enabled Input Form Control Valid: {{ customForm.controls.enabledInputNumber.valid }}
         </small>
     </fieldset>
 </form>

--- a/libs/docs/core/input-group/examples/input-group-form-example/input-group-form-example.component.ts
+++ b/libs/docs/core/input-group/examples/input-group-form-example/input-group-form-example.component.ts
@@ -18,6 +18,7 @@ import { InputGroupModule } from '@fundamental-ngx/core/input-group';
 export class InputGroupFormExampleComponent {
     customForm = new FormGroup({
         disabledInput: new FormControl({ value: 'Disabled Value', disabled: true }),
-        enabledInput: new FormControl({ value: '123', disabled: false })
+        enabledInputNumber: new FormControl({ value: 123, disabled: false }),
+        enabledInputText: new FormControl({ value: '', disabled: false })
     });
 }


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13382

## Description
When the type of Input Group is set to "number", the value of the input should be also of type number. Before the fix the value was string.