### PR TITLE
Fix/focus moves to unselected tab in Icon Tab Bar

### DIFF
--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-filter-type/icon-tab-bar-filter-type.component.html
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-filter-type/icon-tab-bar-filter-type.component.html
@@ -15,7 +15,7 @@
                 (keydown)="_keyDownHandler($event, _totalTab, 0)"
                 [attr.aria-selected]="_totalTab?.uId === selectedUid"
                 class="fd-icon-tab-bar__tab"
-                tabindex="0"
+                [tabindex]="selectedUid === '0' ? 0 : -1"
                 #tabItem
                 role="tab"
                 [attr.aria-level]="tabHeadingLevel()"
@@ -42,7 +42,7 @@
                 [attr.aria-selected]="item.uId === selectedUid"
                 class="fd-icon-tab-bar__tab"
                 #tabItem
-                [attr.tabindex]="showTotalTab ? -1 : idx > 0 ? -1 : 0"
+                [attr.tabindex]="item.uId === selectedUid ? 0 : -1"
                 (keydown)="_keyDownHandler($event, item, idx + (showTotalTab ? 1 : 0))"
                 role="tab"
                 [attr.aria-level]="tabHeadingLevel()"

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-icon-type/icon-tab-bar-icon-type.component.html
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-icon-type/icon-tab-bar-icon-type.component.html
@@ -21,7 +21,7 @@
                 class="fd-icon-tab-bar__tab"
                 #tabItem
                 role="tab"
-                [attr.tabindex]="idx === 0 ? 0 : -1"
+                [attr.tabindex]="item.uId === selectedUid ? 0 : -1"
                 [attr.aria-selected]="item.uId === selectedUid"
                 (click)="_selectItem(item)"
                 (keydown)="_keyDownHandler($event, item, idx)"

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-process-type/icon-tab-bar-process-type.component.html
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-process-type/icon-tab-bar-process-type.component.html
@@ -37,7 +37,7 @@
                 [attr.aria-selected]="item.uId === selectedUid"
                 class="fd-icon-tab-bar__tab"
                 #tabItem
-                [attr.tabindex]="idx === 0 ? 0 : -1"
+                [attr.tabindex]="item.uId === selectedUid ? 0 : -1"
                 role="tab"
                 [attr.aria-level]="tabHeadingLevel()"
             >

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-process-type/icon-tab-bar-process-type.component.spec.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-process-type/icon-tab-bar-process-type.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { By } from '@angular/platform-browser';
 import { OverflowListDirective } from '@fundamental-ngx/cdk/utils';
 import { of } from 'rxjs';
 import { IconTabBarComponent } from '../../icon-tab-bar.component';
@@ -9,6 +10,7 @@ import { IconTabBarProcessTypeComponent } from './icon-tab-bar-process-type.comp
 const AMOUNT_OF_EXTRA_TABS = 80;
 
 describe('IconTabBarProcessTypeComponent', () => {
+    const selectedTabIndex = 50;
     let component: IconTabBarProcessTypeComponent;
     let fixture: ComponentFixture<IconTabBarProcessTypeComponent>;
 
@@ -27,10 +29,11 @@ describe('IconTabBarProcessTypeComponent', () => {
 
         component.tabs = _generateTabBarItems(generateTestConfig(100));
         fixture.detectChanges();
-        component._selectItem(component.tabs[50]); // Select random item
+        component._selectItem(component.tabs[selectedTabIndex]); // Select random item
         component._lastVisibleTabIndex = 60; // Random big number
         component.overflowDirective = fakeOverflowDirective as OverflowListDirective;
         component._recalculateVisibleItems(AMOUNT_OF_EXTRA_TABS);
+        fixture.detectChanges();
     });
 
     it('should create', () => {
@@ -64,6 +67,17 @@ describe('IconTabBarProcessTypeComponent', () => {
 
         expect(component._prevSteps.length).toBeGreaterThan(previousLengthOfPrevSteps);
         expect(component._nextSteps.length).toBeLessThan(previousLengthOfNextSteps);
+    });
+
+    it('should set tabindex=0 to the selected tab', () => {
+        const tabElements = fixture.debugElement.queryAll(By.css('li a'));
+        tabElements.forEach((tabElement, index) => {
+            if (index === selectedTabIndex) {
+                expect(tabElement.nativeElement.getAttribute('tabindex')).toBe('0');
+            } else {
+                expect(tabElement.nativeElement.getAttribute('tabindex')).toBe('-1');
+            }
+        });
     });
 });
 

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-text-type/icon-tab-bar-text-type.component.html
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-text-type/icon-tab-bar-text-type.component.html
@@ -31,7 +31,7 @@
                         [item]="item"
                         [layoutMode]="layoutMode"
                         [colorAssociations]="colorAssociations()"
-                        [attr.tabindex]="idx === 0 ? 0 : -1"
+                        [attr.tabindex]="item.uId === selectedUid ? 0 : -1"
                         [attr.aria-selected]="item.uId === selectedUid"
                         (click)="_selectItem(item, $event)"
                         (keydown)="_keyDownHandler($event, item, idx)"
@@ -43,7 +43,7 @@
                     <fdp-text-type-popover
                         #tabItem
                         #itemPopover
-                        [tabindex]="idx === 0 ? 0 : -1"
+                        [tabindex]="item.uId === _getItemIdFromSubItemUid(selectedUid) ? 0 : -1"
                         [parentTab]="item"
                         [layoutMode]="layoutMode"
                         [multiClick]="multiClick"

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-text-type/icon-tab-bar-text-type.component.spec.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-text-type/icon-tab-bar-text-type.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { By } from '@angular/platform-browser';
 import { IconTabBarComponent } from '../../icon-tab-bar.component';
 import { _generateTabBarItems, generateTestConfig } from '../../tests-helper';
 import { IconTabBarTextTypeComponent } from './icon-tab-bar-text-type.component';
@@ -18,7 +19,7 @@ describe('IconTabBarTextTypeComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(IconTabBarTextTypeComponent);
         component = fixture.componentInstance;
-        component.tabs = _generateTabBarItems(generateTestConfig(10));
+        component.tabs = _generateTabBarItems(generateTestConfig(10, true)); // generate 10 tabs, the 6th of them with subitems
         fixture.detectChanges();
     });
 
@@ -72,5 +73,39 @@ describe('IconTabBarTextTypeComponent', () => {
 
         expect(component._extraTabs$().length).toBe(extraTabs);
         expect(visibleTabsLength).toBe(tabsLength - extraTabs);
+    });
+
+    describe('for items without subitems', () => {
+        it('should set tabindex=0 to the selected tab', () => {
+            const selectedTab = 2; // a tab without subitems
+
+            component.selectedUid = component.tabs[selectedTab].uId;
+            fixture.detectChanges();
+
+            const iconTabBarElements = fixture.debugElement.queryAll(By.css('[fdp-icon-tab-bar-text-type-tab-item]'));
+            iconTabBarElements.forEach((tabElement, index) => {
+                if (index === selectedTab) {
+                    expect(tabElement.nativeElement.getAttribute('tabindex')).toBe('0');
+                } else {
+                    expect(tabElement.nativeElement.getAttribute('tabindex')).toBe('-1');
+                }
+            });
+            const popoverTabBarElement = fixture.debugElement.query(By.css('fdp-text-type-popover'));
+            expect(popoverTabBarElement.componentInstance.tabindex).toBe(-1);
+        });
+    });
+
+    describe('for items with subitems', () => {
+        it('should set tabindex=0 to the selected tab', () => {
+            component.selectedUid = component.tabs[5].subItems![0].uId; // an id of a tab with subitems
+            fixture.detectChanges();
+
+            const iconTabBarElements = fixture.debugElement.queryAll(By.css('[fdp-icon-tab-bar-text-type-tab-item]'));
+            iconTabBarElements.forEach((tabElement) => {
+                expect(tabElement.nativeElement.getAttribute('tabindex')).toBe('-1');
+            });
+            const popoverTabBarElement = fixture.debugElement.query(By.css('fdp-text-type-popover'));
+            expect(popoverTabBarElement.componentInstance.tabindex).toBe(0);
+        });
     });
 });

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-text-type/icon-tab-bar-text-type.component.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-text-type/icon-tab-bar-text-type.component.ts
@@ -132,6 +132,15 @@ export class IconTabBarTextTypeComponent extends ClosableIconTabBar {
         this.reordered.emit(this.tabs);
     }
 
+    /**
+     * @hidden
+     * @param uid
+     * @description Get item id from sub item uid. Eg if sub item id is '6.2', then item id will be '6'. Defaults to '0'.
+     */
+    _getItemIdFromSubItemUid(uid: string | undefined): string {
+        return uid?.split(UNIQUE_KEY_SEPARATOR)[0] || '0';
+    }
+
     /** @hidden */
     protected _getTabUIElementFocusable(tabUIElement: Nullable<TabItem>): Nullable<HTMLElement> {
         if (!tabUIElement) {


### PR DESCRIPTION
## Related Issue(s)

fixes https://github.com/SAP/fundamental-ngx/issues/12732

## Description

When the user navigates using the tab button through [Icon Tab Bar](https://sap.github.io/fundamental-ngx/#/platform/icon-tab-bar), focus now correctly goes to the selected tab item, not always to the first item in the tab bar.

## Screenshots

Before:
<img width="1191" height="369" alt="before" src="https://github.com/user-attachments/assets/057108dd-615b-4a16-91e9-db6d0bd97815" />
After:
<img width="1349" height="350" alt="after" src="https://github.com/user-attachments/assets/238d13e9-1bbe-4979-8704-ed59d9ac7125" />
