### PR TITLE
fix(core,platform): remove aria-haspopup attribute from button

### DIFF
--- a/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
+++ b/libs/core/dynamic-page/dynamic-page-header/subheader/dynamic-page-subheader.component.html
@@ -16,7 +16,6 @@
                 <button
                     fd-button
                     class="fd-dynamic-page__collapse-button"
-                    aria-haspopup="true"
                     [ariaLabel]="_toggleButtonAriaLabel"
                     [attr.title]="_toggleButtonAriaLabel"
                     [attr.aria-expanded]="!_dynamicPageService.collapsed()"


### PR DESCRIPTION
## Related Issue(s)

fixes https://github.com/SAP/fundamental-ngx/issues/12614

## Description

Dynamic page collapse button was incorrectly given an `aria-haspopup` attribute which causes JAWS to read it as `Collapse Header button menu`. After removing the attribute the reader now reads it as `Collapse Header button`.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->
