### PR TITLE
fix(core): fix the font-weight of emphasized button

### DIFF
--- a/libs/core/button/button.component.scss
+++ b/libs/core/button/button.component.scss
@@ -1,1 +1,5 @@
 @import 'fundamental-styles/dist/button.css';
+
+.fd-button.fd-button--emphasized {
+    font-weight: 400;
+}


### PR DESCRIPTION
## Related Issue(s)
closes none, reported by a user
 
## Description
Temporary solution until the latest version of fund-styles is adopted. Set the font-weight of the Emphasized button to normal and rely on the font-family for the boldness of the text.