### PR TITLE
fix(core): disable tab focus on disabled multi input

### DIFF
--- a/libs/core/multi-input/multi-input.component.spec.ts
+++ b/libs/core/multi-input/multi-input.component.spec.ts
@@ -251,6 +251,7 @@ describe('MultiInputComponent', () => {
         // displaying only those options that were "seen" as values
         expect(component.selected).toEqual(['foo1', 'baz']);
     });
+
     it('should selectAll values  selectAllItems call with true and deselect all items it call with false', async () => {
         await fixture.whenStable();
 
@@ -273,5 +274,25 @@ describe('MultiInputComponent', () => {
         component._addOnButtonClicked(new MouseEvent('click'));
         expect(buttonSpy).toHaveBeenCalled();
         expect(openSpy).not.toHaveBeenCalled();
+    });
+
+    it('should disable pointer events and prevent tab focus when disabled', () => {
+        const element = component.elementRef.nativeElement;
+
+        component.setDisabledState(true);
+        fixture.detectChanges();
+
+        expect(element.style.pointerEvents).toBe('none');
+        expect(element.tabIndex).toBe(-1);
+    });
+
+    it('should enable pointer events and allow tab focus when enabled', () => {
+        const element = component.elementRef.nativeElement;
+
+        component.setDisabledState(false);
+        fixture.detectChanges();
+
+        expect(element.style.pointerEvents).toBe('auto');
+        expect(element.tabIndex).toBe(0);
     });
 });

--- a/libs/core/multi-input/multi-input.component.ts
+++ b/libs/core/multi-input/multi-input.component.ts
@@ -568,8 +568,10 @@ export class MultiInputComponent<ItemType = any, ValueType = any>
         this.disabled = isDisabled;
         if (isDisabled) {
             this.elementRef.nativeElement.style.pointerEvents = 'none';
+            this.elementRef.nativeElement.tabIndex = -1; // prevent focus
         } else {
             this.elementRef.nativeElement.style.pointerEvents = 'auto';
+            this.elementRef.nativeElement.tabIndex = 0; // allow focus
         }
 
         this._changeDetRef.detectChanges();


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13052

## Description

When a user navigates through multi inputs using the tab button, focus now skips disabled inputs and only goes to enabled ones.

## Screenshots

https://github.com/user-attachments/assets/f73dd8f9-f213-4fe6-be3d-e16393eeba11


