### PR TITLE
fix(core): prevent list item selection when radio and checkbox are disabled

### DIFF
--- a/libs/core/list/list-item/list-item.component.ts
+++ b/libs/core/list/list-item/list-item.component.ts
@@ -210,10 +210,10 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
     @HostListener('keydown', ['$event'])
     keydownHandler(event: KeyboardEvent): void {
         if (KeyUtil.isKeyCode(event, [ENTER, SPACE])) {
-            if (this.checkbox) {
+            if (this.checkbox && !this.checkbox.disabled) {
                 this.checkbox.nextValue();
                 this._muteEvent(event);
-            } else if (this.radio) {
+            } else if (this.radio && !this.radio.disabled) {
                 this.radio.labelClicked(event, false);
                 this._muteEvent(event);
             } else if (this.interactive) {
@@ -244,14 +244,14 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
     onClick(event: MouseEvent): void {
         if (!this.preventClick) {
             this._clicked$.next(event);
-            if (this.checkbox && !this.link) {
+            if (this.checkbox && !this.checkbox.disabled && !this.link) {
                 if (!this.checkbox.elementRef.nativeElement.contains(event.target as Node)) {
                     // clicking on the checkbox is not suppressed
                     // so we should only process clicks if clicked on the list-item, not checkbox itself
                     this.checkbox.nextValue();
                 }
             }
-            if (this.radio && !this.link) {
+            if (this.radio && !this.radio.disabled && !this.link) {
                 this.radio.labelClicked(event, false);
             }
         }

--- a/libs/core/list/list.component.scss
+++ b/libs/core/list/list.component.scss
@@ -14,3 +14,8 @@
     height: var(--sapElement_LineHeight);
     max-height: var(--sapElement_LineHeight);
 }
+
+.fd-list.fd-list--selection .fd-radio.is-focus + .fd-radio__label,
+.fd-list.fd-list--selection .fd-radio:focus + .fd-radio__label {
+    outline: none;
+}

--- a/libs/docs/core/list/examples/list-selection-example/list-selection-example.component.html
+++ b/libs/docs/core/list/examples/list-selection-example/list-selection-example.component.html
@@ -9,6 +9,17 @@
         </li>
     }
 </ul>
+<h3>Cozy multi-selection list with disabled checkboxes</h3>
+<ul fd-list [selection]="true">
+    @for (item of cozyObjectCheckboxDisabled; track item) {
+        <li fd-list-item [selected]="item.selected">
+            <fd-checkbox [(ngModel)]="item.selected" [disabled]="true"></fd-checkbox>
+            <span fd-list-title>
+                {{ item.label }}
+            </span>
+        </li>
+    }
+</ul>
 <h3>Compact multi-selection list</h3>
 <ul fd-list fdCompact [selection]="true">
     @for (item of compactObject; track item) {
@@ -20,6 +31,7 @@
         </li>
     }
 </ul>
+
 <h3 id="cozy-single-selection-list">Cozy single-selection list</h3>
 <ul fd-list [selection]="true">
     <li fd-list-item [selected]="selectionValue === 'radio1'">
@@ -53,6 +65,7 @@
         <span fd-list-title> List item 3 </span>
     </li>
 </ul>
+
 <h3 id="compact-single-selection-list">Compact single-selection list</h3>
 <ul fd-list [selection]="true" fdCompact>
     <li fd-list-item [selected]="selectionValueTwo === 'radio1'">
@@ -85,6 +98,46 @@
             fdCompact
             [(ngModel)]="selectionValueTwo"
             aria-labelledby="radio32 compact-single-selection-list"
+        ></fd-radio-button>
+        <span fd-list-title> List item 3 </span>
+    </li>
+</ul>
+
+<h3 id="compact-single-selection-list">Compact single-selection list with disabled radios</h3>
+<ul fd-list [selection]="true" fdCompact>
+    <li fd-list-item [selected]="selectionValueTwo === 'radio1di'">
+        <fd-radio-button
+            name="radio2di"
+            id="radio12di"
+            value="radio1di"
+            fdCompact
+            [disabled]="true"
+            [(ngModel)]="selectionValueTwo"
+            aria-labelledby="radio12di compact-single-selection-list"
+        ></fd-radio-button>
+        <span fd-list-title> List item 1 </span>
+    </li>
+    <li fd-list-item [selected]="selectionValueTwo === 'radio2di'">
+        <fd-radio-button
+            name="radio2di"
+            id="radio22di"
+            value="radio2di"
+            fdCompact
+            [disabled]="true"
+            [(ngModel)]="selectionValueTwo"
+            aria-labelledby="radio22di compact-single-selection-list"
+        ></fd-radio-button>
+        <span fd-list-title> List item 2 </span>
+    </li>
+    <li fd-list-item [selected]="selectionValueTwo === 'radio3di'">
+        <fd-radio-button
+            name="radio2di"
+            id="radio32di"
+            value="radio3di"
+            fdCompact
+            [disabled]="true"
+            [(ngModel)]="selectionValueTwo"
+            aria-labelledby="radio32di compact-single-selection-list"
         ></fd-radio-button>
         <span fd-list-title> List item 3 </span>
     </li>

--- a/libs/docs/core/list/examples/list-selection-example/list-selection-example.component.ts
+++ b/libs/docs/core/list/examples/list-selection-example/list-selection-example.component.ts
@@ -30,6 +30,21 @@ export class ListSelectionExampleComponent {
         }
     ];
 
+    cozyObjectCheckboxDisabled = [
+        {
+            selected: false,
+            label: 'List item 1'
+        },
+        {
+            selected: false,
+            label: 'List item 2'
+        },
+        {
+            selected: false,
+            label: 'List item 3'
+        }
+    ];
+
     compactObject = [
         {
             selected: false,


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13450

## Description
- check if radio btn and checkbox are disabled before triggering event (selection doesn't happen if radio btn and checkbox are disabled)
- updated documentation to illustrate the case
- removed redundant outline around radio button on press