### PR TITLE
fix(core): prevents esc key from propagating to the parent in nested popovers

### DIFF
--- a/libs/core/popover/popover-body/popover-body.component.ts
+++ b/libs/core/popover/popover-body/popover-body.component.ts
@@ -133,7 +133,7 @@ export class PopoverBodyComponent implements AfterViewInit {
     ) {}
 
     /** Handler escape keydown */
-    @HostListener('keyup', ['$event'])
+    @HostListener('keydown', ['$event'])
     bodyKeyupHandler(event: KeyboardEvent): void {
         if (KeyUtil.isKeyCode(event, ESCAPE) && this._closeOnEscapeKey) {
             // In case if popover belongs to the element inside dialog

--- a/libs/docs/core/popover/examples/popover-inside-popover/popover-inside-popover-example.component.html
+++ b/libs/docs/core/popover/examples/popover-inside-popover/popover-inside-popover-example.component.html
@@ -1,0 +1,25 @@
+<fd-popover title="money-bills" [focusAutoCapture]="true" [focusTrapped]="true">
+    <fd-popover-control>
+        <fd-avatar
+            size="s"
+            [circle]="true"
+            ariaLabel="photo 1 in circle"
+            image="https://picsum.photos/id/1018/400"
+        ></fd-avatar>
+    </fd-popover-control>
+    <fd-popover-body>
+        <div style="min-height: 20rem; padding: 1rem">
+            <h3 fd-title>Combobox control inside Popover</h3>
+            <br /><br />
+            <fd-combobox
+                inputId="comboboxID1"
+                ariaLabel="Standard"
+                maxHeight="250px"
+                width="300px"
+                placeholder="Type some text..."
+                [dropdownValues]="fruits"
+                [(ngModel)]="searchTermOne"
+            ></fd-combobox>
+        </div>
+    </fd-popover-body>
+</fd-popover>

--- a/libs/docs/core/popover/examples/popover-inside-popover/popover-inside-popover-example.component.ts
+++ b/libs/docs/core/popover/examples/popover-inside-popover/popover-inside-popover-example.component.ts
@@ -1,0 +1,34 @@
+import { CdkScrollable } from '@angular/cdk/overlay';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { InitialFocusDirective } from '@fundamental-ngx/cdk/utils';
+import { AvatarComponent } from '@fundamental-ngx/core/avatar';
+import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { ComboboxModule } from '@fundamental-ngx/core/combobox';
+import { MultiInputComponent } from '@fundamental-ngx/core/multi-input';
+import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
+import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
+import { TitleComponent } from '@fundamental-ngx/core/title';
+
+@Component({
+    selector: 'fd-popover-inside-popover-example',
+    templateUrl: './popover-inside-popover-example.component.html',
+    imports: [
+        ButtonComponent,
+        TitleComponent,
+        CdkScrollable,
+        ScrollbarDirective,
+        PopoverComponent,
+        PopoverControlComponent,
+        InitialFocusDirective,
+        PopoverBodyComponent,
+        MultiInputComponent,
+        AvatarComponent,
+        ComboboxModule,
+        FormsModule
+    ]
+})
+export class PopoverInsidePopoverExampleComponent {
+    searchTermOne = '';
+    fruits = ['Apple', 'Pineapple', 'Banana', 'Kiwi', 'Strawberry'];
+}

--- a/libs/docs/core/popover/popover-docs.component.html
+++ b/libs/docs/core/popover/popover-docs.component.html
@@ -86,6 +86,17 @@
 
 <separator></separator>
 
+<fd-docs-section-title id="popovers-inside-popover" componentName="popover">
+    Popover inside Popover
+</fd-docs-section-title>
+<description> </description>
+<component-example>
+    <fd-popover-inside-popover-example></fd-popover-inside-popover-example>
+</component-example>
+<code-example [exampleFiles]="popoverInsidePopoverExample"></code-example>
+
+<separator></separator>
+
 <fd-docs-section-title id="fill-control-width" componentName="popover"> Fill Control Width </fd-docs-section-title>
 <description>
     Use <code>fillControlMode</code> input property to control when popover should fill control width.

--- a/libs/docs/core/popover/popover-docs.component.ts
+++ b/libs/docs/core/popover/popover-docs.component.ts
@@ -19,6 +19,7 @@ import { PopoverDropdownExampleComponent } from './examples/popover-dropdown/pop
 import { PopoverDynamicContainerHeightExampleComponent } from './examples/popover-dynamic-container-height/popover-dynamic-container-height-example.component';
 import { PopoverDynamicExampleComponent } from './examples/popover-dynamic/popover-dynamic-example.component';
 import { PopoverFocusExampleComponent } from './examples/popover-focus-example/popover-focus-example.component';
+import { PopoverInsidePopoverExampleComponent } from './examples/popover-inside-popover/popover-inside-popover-example.component';
 import { PopoverLazyInitOfBodyExampleComponent } from './examples/popover-lazy-init-of-body/popover-lazy-init-of-body-example.component';
 import { PopoverMobileExampleComponent } from './examples/popover-mobile/popover-mobile-example.component';
 import { PopoverCdkPlacementExampleComponent } from './examples/popover-new-placement/popover-cdk-placement-example.component';
@@ -46,6 +47,8 @@ const popoverPlacementTsSrc = 'popover-placement/popover-placement-example.compo
 const popoverPlacementScss = 'popover-placement/popover-placement-example.component.scss';
 const popoverDialogHtmlSrc = 'popover-dialog/popover-dialog-example.component.html';
 const popoverDialogTsSrc = 'popover-dialog/popover-dialog-example.component.ts';
+const popoverInsidePopoverHtmlSrc = 'popover-inside-popover/popover-inside-popover-example.component.html';
+const popoverInsidePopoverTsSrc = 'popover-inside-popover/popover-inside-popover-example.component.ts';
 const popoverFillHSrc = 'popover-c-fill/popover-c-fill.component.html';
 const popoverFillSrcTs = 'popover-c-fill/popover-c-fill.component.ts';
 const popoverDynamicHSrc = 'popover-dynamic/popover-dynamic-example.component.html';
@@ -102,7 +105,8 @@ const dynamicContainerHeightTsSrc =
         PopoverMobileExampleComponent,
         PopoverDynamicContainerHeightExampleComponent,
         PopoverLazyInitOfBodyExampleComponent,
-        PopoverResizableExampleComponent
+        PopoverResizableExampleComponent,
+        PopoverInsidePopoverExampleComponent
     ]
 })
 export class PopoverDocsComponent {
@@ -254,6 +258,20 @@ export class PopoverDocsComponent {
             component: 'PopoverDialogExampleComponent',
             code: getAssetFromModuleAssets(popoverDialogTsSrc),
             fileName: 'popover-dialog-example'
+        }
+    ];
+
+    popoverInsidePopoverExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(popoverInsidePopoverHtmlSrc),
+            fileName: 'popover-dialog-example'
+        },
+        {
+            language: 'typescript',
+            component: 'PopoverInsidePopoverExampleComponent',
+            code: getAssetFromModuleAssets(popoverInsidePopoverTsSrc),
+            fileName: 'popover-inside-popover-example'
         }
     ];
 


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13449

## Description
Prevents the nested Popover esc event to bubble and close the parent Popover.
