### PR TITLE
fix(platform): allow Hungarian special alphabet characters in Combobox input

### DIFF
--- a/libs/platform/form/combobox/commons/base-combobox.ts
+++ b/libs/platform/form/combobox/commons/base-combobox.ts
@@ -1,6 +1,5 @@
 import {
     ALT,
-    BACKSPACE,
     CONTROL,
     DOWN_ARROW,
     ENTER,
@@ -18,7 +17,6 @@ import {
     NUMPAD_ZERO,
     RIGHT_ARROW,
     SHIFT,
-    SPACE,
     TAB,
     UP_ARROW
 } from '@angular/cdk/keycodes';
@@ -483,17 +481,6 @@ export abstract class BaseCombobox
         } else if (!event.ctrlKey && !KeyUtil.isKeyCode(event, this._nonOpeningKeys)) {
             if (!KeyUtil.isKeyCode(event, this._numberPadNumberKeys)) {
                 this.isOpenChangeHandle(true);
-            }
-            const acceptedKeys =
-                !KeyUtil.isKeyCode(event, BACKSPACE) &&
-                !KeyUtil.isKeyCode(event, SPACE) &&
-                !KeyUtil.isKeyType(event, 'alphabetical') &&
-                !KeyUtil.isKeyType(event, 'numeric') &&
-                !KeyUtil.isKeyType(event, 'ime') &&
-                !KeyUtil.isKeyCode(event, this._numberPadNumberKeys);
-
-            if (this.isEmptyValue && acceptedKeys) {
-                this.listComponent?.setItemActive(0);
             }
         }
     }


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13475

## Description
Hungarian alphabet characters (such as á, é, í, ó, ö, ő, ú, ü, ű) were not appearing in the Combobox input. This happened because their key codes overlap with special characters on the English keyboard, and our input handling logic was blocking them.

This change removes the restrictive checks so that all valid characters, including those from the Hungarian alphabet and other international keyboards, can be entered into the Combobox input field.