### PR TITLE
fix(core): add role heading to title element in Toolbar

### DIFF
--- a/libs/core/toolbar/toolbar.component.html
+++ b/libs/core/toolbar/toolbar.component.html
@@ -1,7 +1,15 @@
 @if (title) {
-    <span [attr.aria-level]="_headingLevel" fd-title class="fd-toolbar__title" [id]="titleId" #titleElement>{{
-        title
-    }}</span>
+    <span
+        fd-title
+        role="heading"
+        [headerSize]="4"
+        [attr.aria-level]="_headingLevel"
+        class="fd-toolbar__title"
+        [id]="titleId"
+        #titleElement
+    >
+        {{ title }}
+    </span>
 }
 <ng-content></ng-content>
 @if (overflownItems.length > 0) {

--- a/libs/core/toolbar/toolbar.component.ts
+++ b/libs/core/toolbar/toolbar.component.ts
@@ -56,6 +56,8 @@ const MAX_CONTENT_SIZE = 99999999;
 
 export type ToolbarType = 'solid' | 'transparent' | 'auto' | 'info';
 
+let toolbarTitleId = 0;
+
 export const enum OverflowPriorityEnum {
     ALWAYS = 'always',
     NEVER = 'never',
@@ -93,7 +95,7 @@ export class ToolbarComponent implements AfterViewInit, AfterViewChecked, CssCla
      * The ID of the toolbar title
      * */
     @Input()
-    titleId: string;
+    titleId = `fd-toolbar-title-${toolbarTitleId++}`;
 
     /** Property allows user to pass additional class
      */

--- a/libs/docs/core/toolbar/examples/toolbar-title-example.component.html
+++ b/libs/docs/core/toolbar/examples/toolbar-title-example.component.html
@@ -1,6 +1,13 @@
 <h5 fd-title>Title via Input Property</h5>
 <fd-toolbar title="H4 sized text"></fd-toolbar>
-<br />
+
+<br /><br />
+
+<h5 fd-title>Title via Input Property and Heading Level</h5>
+<fd-toolbar title="heading 2 title" [headingLevel]="2"></fd-toolbar>
+
+<br /><br />
+
 <h5 fd-title>Title via ng-content</h5>
 <fd-toolbar>
     <h4 fd-title>H4 sized text with Icon</h4>


### PR DESCRIPTION
## Related Issue(s)
closes none

## Description
The title element inside the Toolbar previously had an `aria-level` attribute set without the required `role="heading"`. This PR adds the missing role to ensure proper accessibility.

Additionally, the `headerSize` input property is now explicitly set to 4 for the Toolbar Title. Without this, the compiled CSS classes included `fd-title--hP`, which is invalid. The font size continues to be controlled by the `fd-toolbar__title` class.

Lastly, the title id was previously rendered as "undefined" when not provided by the user. A default id is now generated if none is specified. 

Before:
<img width="723" height="49" alt="Screenshot 2025-09-08 at 3 53 07 PM" src="https://github.com/user-attachments/assets/ae3657e0-769c-4f24-abe7-148d36811cd2" />

Now:

<img width="911" height="61" alt="Screenshot 2025-09-08 at 3 56 25 PM" src="https://github.com/user-attachments/assets/efc307bd-002e-440a-925e-57a3452f572d" />
