### PR TITLE
fix(core): not reset Dynamic Page Header paddings when Message strip is used

### DIFF
--- a/libs/core/dynamic-page/dynamic-page.component.scss
+++ b/libs/core/dynamic-page/dynamic-page.component.scss
@@ -93,7 +93,7 @@
     padding: 0 !important;
 }
 
-.fd-dynamic-page__collapsible-header:has(.fd-has-display-none) {
+.fd-dynamic-page__collapsible-header:has(.fd-has-display-none):not(:has(.fd-message-strip.fd-has-display-none)) {
     padding-block: 0;
     padding-inline: 0;
 }


### PR DESCRIPTION

## Related Issue(s)
reported in Slack

## Description
When dismissible Message strip is used in Dynamic Page Subheader, and the message strip is set to dismiss in several seconds, the Dynamic Page Subheader loses its paddings.