### PR TITLE
fix(core): apply autocomplete logic on keydown instead of keyup

### DIFF
--- a/libs/cdk/utils/directives/auto-complete/auto-complete.directive.ts
+++ b/libs/cdk/utils/directives/auto-complete/auto-complete.directive.ts
@@ -66,7 +66,7 @@ export class AutoCompleteDirective {
     private readonly _zone = inject(NgZone);
 
     /** @hidden */
-     
+    // eslint-disable-next-line @typescript-eslint/member-ordering
     constructor() {
         /**
          * Fixes #10710


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13384

## Description

When the user deletes a few chars from their inital selection and presses tab, now the input is correctly populated with the option that matches the string left in the input.

## Screenshots

https://github.com/user-attachments/assets/4ebf197d-3c25-462b-a378-3e917514abe3



