### PR TITLE
fix(core): make Shellbar title heading one

### DIFF
--- a/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
+++ b/libs/core/src/lib/shellbar/product-menu/product-menu.component.html
@@ -1,4 +1,5 @@
 <ng-template [ngIf]="items && items.length > 0" [ngIfElse]="subHeader">
+    <h1 class="fd-sr-only">{{ control }}</h1>
     <button
         fd-button
         fdType="transparent"
@@ -34,7 +35,7 @@
 </ng-template>
 
 <ng-template #subHeader>
-    <span class="fd-shellbar__title fd-product-menu__title">
+    <h1 class="fd-shellbar__title fd-product-menu__title">
         {{ control }}
-    </span>
+    </h1>
 </ng-template>

--- a/libs/core/src/lib/shellbar/product-menu/product-menu.component.scss
+++ b/libs/core/src/lib/shellbar/product-menu/product-menu.component.scss
@@ -1,0 +1,11 @@
+.fd-sr-only {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    height: 1px;
+    width: 1px;
+    border: 0;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    white-space: nowrap;
+}

--- a/libs/core/src/lib/shellbar/product-menu/product-menu.component.ts
+++ b/libs/core/src/lib/shellbar/product-menu/product-menu.component.ts
@@ -16,6 +16,7 @@ import { Nullable } from '@fundamental-ngx/cdk/utils';
 @Component({
     selector: 'fd-product-menu',
     templateUrl: './product-menu.component.html',
+    styleUrls: ['./product-menu.component.scss'],
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/libs/core/src/lib/shellbar/shellbar-title/shellbar-title.component.html
+++ b/libs/core/src/lib/shellbar/shellbar-title/shellbar-title.component.html
@@ -1,3 +1,3 @@
-<span class="fd-shellbar__title">
+<h1 class="fd-shellbar__title">
     <ng-content></ng-content>
-</span>
+</h1>


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13492

## Description
downport the changes made in [this PR](https://github.com/SAP/fundamental-ngx/pull/11681) for Shellbar title, which should be a `h1` element, not a `span`.  For the case where the title is part of a product menu, a visually hidden heading 1 element is added as we can't place heading element inside a button. 

<img width="1843" height="835" alt="Screenshot 2025-09-15 at 10 14 11 AM" src="https://github.com/user-attachments/assets/5c9c204e-ceb7-4969-8a37-71ce06587cb4" />

When title is part of product menu:
<img width="1844" height="779" alt="Screenshot 2025-09-15 at 10 13 57 AM" src="https://github.com/user-attachments/assets/605697b4-6dce-493a-88a2-25e4444bbe83" />

