### PR TITLE
fix(core): Combobox inside a Dialog - Not able navigate through the invoked drop-down values using keyboard

### DIFF
--- a/libs/core/combobox/combobox.component.spec.ts
+++ b/libs/core/combobox/combobox.component.spec.ts
@@ -399,4 +399,15 @@ describe('ComboboxComponent', () => {
             expect(component.onChange).toHaveBeenCalledWith('');
         });
     });
+
+    it('should pause and unpause focus trap when open changes', () => {
+        jest.spyOn((<any>component)._focusTrapService, 'pauseCurrentFocusTrap');
+        jest.spyOn((<any>component)._focusTrapService, 'unpauseCurrentFocusTrap');
+
+        component.isOpenChangeHandle(true);
+        expect((<any>component)._focusTrapService.pauseCurrentFocusTrap).toHaveBeenCalled();
+
+        component.isOpenChangeHandle(false);
+        expect((<any>component)._focusTrapService.unpauseCurrentFocusTrap).toHaveBeenCalled();
+    });
 });

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -41,6 +41,7 @@ import {
     AutoCompleteEvent,
     DynamicComponentService,
     FocusEscapeDirection,
+    FocusTrapService,
     KeyUtil,
     Nullable,
     TruncatedTitleDirective
@@ -467,6 +468,7 @@ export class ComboboxComponent<T = any>
         private readonly _injector: Injector,
         private readonly _viewContainerRef: ViewContainerRef,
         private readonly _dynamicComponentService: DynamicComponentService,
+        private readonly _focusTrapService: FocusTrapService,
         readonly _contentDensityObserver: ContentDensityObserver
     ) {
         this._repositionScrollStrategy = this._overlay.scrollStrategies.reposition({ autoClose: true });
@@ -681,6 +683,13 @@ export class ComboboxComponent<T = any>
         if (this.open !== isOpen) {
             this.open = isOpen;
             this.openChange.emit(isOpen);
+
+            /** Allow combobox up and down arrows to work properly when combobox is inside a dialog */
+            if (this.open) {
+                this._focusTrapService.pauseCurrentFocusTrap();
+            } else {
+                this._focusTrapService.unpauseCurrentFocusTrap();
+            }
         }
 
         if (!this.open && !this.mobile) {

--- a/libs/docs/core/combobox/combobox-docs.component.html
+++ b/libs/docs/core/combobox/combobox-docs.component.html
@@ -215,3 +215,17 @@
     <fd-combobox-byline-example></fd-combobox-byline-example>
 </component-example>
 <code-example [exampleFiles]="comboboxBylineExample"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="standard" componentName="combobox"> Combobox inside a Dialog </fd-docs-section-title>
+<description>
+    <p>
+        The standard version of the combobox component used inside a <code>dialog</code> with a trapped focus
+        <code>focusTrapped: true</code>.
+    </p>
+</description>
+<component-example>
+    <fd-combobox-inside-dialog-example></fd-combobox-inside-dialog-example>
+</component-example>
+<code-example [exampleFiles]="comboboxInsideDialogExample"></code-example>

--- a/libs/docs/core/combobox/combobox-docs.component.html
+++ b/libs/docs/core/combobox/combobox-docs.component.html
@@ -220,10 +220,8 @@
 
 <fd-docs-section-title id="standard" componentName="combobox"> Combobox inside a Dialog </fd-docs-section-title>
 <description>
-    <p>
-        The standard version of the combobox component used inside a <code>dialog</code> with a trapped focus
-        <code>focusTrapped: true</code>.
-    </p>
+    The standard version of the combobox component used inside a <code>dialog</code> with a trapped focus
+    <code>focusTrapped: true</code>.
 </description>
 <component-example>
     <fd-combobox-inside-dialog-example></fd-combobox-inside-dialog-example>

--- a/libs/docs/core/combobox/combobox-docs.component.ts
+++ b/libs/docs/core/combobox/combobox-docs.component.ts
@@ -21,6 +21,7 @@ import { ComboboxFormsExampleComponent } from './examples/combobox-forms-example
 import { ComboboxGroupExampleComponent } from './examples/combobox-group-example.component';
 import { ComboboxHeightExampleComponent } from './examples/combobox-height-example.component';
 import { ComboboxIncludesExampleComponent } from './examples/combobox-includes-example.component';
+import { ComboboxInsideDialogExampleComponent } from './examples/combobox-inside-dialog-example.component';
 import { ComboboxMobileExampleComponent } from './examples/combobox-mobile/combobox-mobile-example.component';
 import { ComboboxOpenControlExampleComponent } from './examples/combobox-open-control-example.component';
 import { ComboboxSearchFieldExampleComponent } from './examples/combobox-search-field-example.component';
@@ -63,6 +64,9 @@ const comboboxSearchFieldTSSrc = 'combobox-search-field-example.component.ts';
 const comboboxBylineHtml = 'combobox-byline-example.component.html';
 const comboboxBylineTs = 'combobox-byline-example.component.ts';
 
+const comboboxInsideDialogH = 'combobox-inside-dialog-example.component.html';
+const comboboxInsideDialogT = 'combobox-inside-dialog-example.component.ts';
+
 @Component({
     selector: 'fd-combobox-docs',
     templateUrl: './combobox-docs.component.html',
@@ -88,7 +92,8 @@ const comboboxBylineTs = 'combobox-byline-example.component.ts';
         ComboboxIncludesExampleComponent,
         ComboboxFormsExampleComponent,
         ComboboxDisabledExampleComponent,
-        ComboboxBylineExampleComponent
+        ComboboxBylineExampleComponent,
+        ComboboxInsideDialogExampleComponent
     ]
 })
 export class ComboboxDocsComponent {
@@ -314,6 +319,20 @@ export class ComboboxDocsComponent {
             component: 'ComboboxBylineExampleComponent',
             code: getAssetFromModuleAssets(comboboxBylineTs),
             fileName: 'combobox-byline-example'
+        }
+    ];
+
+    comboboxInsideDialogExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(comboboxInsideDialogH),
+            fileName: 'combobox-inside-dialog-example'
+        },
+        {
+            language: 'typescript',
+            component: 'ComboboxInsideDialogExampleComponent',
+            code: getAssetFromModuleAssets(comboboxInsideDialogT),
+            fileName: 'combobox-inside-dialog-example'
         }
     ];
 }

--- a/libs/docs/core/combobox/examples/combobox-inside-dialog-example.component.html
+++ b/libs/docs/core/combobox/examples/combobox-inside-dialog-example.component.html
@@ -1,0 +1,38 @@
+<ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #confirmationDialog>
+    <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
+        <fd-dialog-header>
+            <h1 id="fd-dialog-header-10" fd-title>Combobox inside a dialog</h1>
+        </fd-dialog-header>
+
+        <fd-dialog-body>
+            <div fd-form-item>
+                <fd-combobox
+                    inputId="comboboxId"
+                    ariaLabel="Standard"
+                    maxHeight="250px"
+                    width="300px"
+                    placeholder="Type some text..."
+                    [dropdownValues]="fruits"
+                    [(ngModel)]="searchTerm"
+                >
+                </fd-combobox>
+            </div>
+            <small>Search Term: {{ searchTerm }}</small>
+        </fd-dialog-body>
+
+        <fd-dialog-footer>
+            <fd-button-bar
+                fdType="emphasized"
+                label="OK"
+                (click)="dialog.close('Continue')"
+                ariaLabel="OK Emphasized"
+            ></fd-button-bar>
+
+            <fd-button-bar label="Cancel" (click)="dialog.dismiss('Cancel')" ariaLabel="Cancel"></fd-button-bar>
+        </fd-dialog-footer>
+    </fd-dialog>
+</ng-template>
+
+<button fd-button label="Open from Template" (click)="openDialog(confirmationDialog)"></button>
+<br />
+<small>{{ confirmationReason }}</small>

--- a/libs/docs/core/combobox/examples/combobox-inside-dialog-example.component.ts
+++ b/libs/docs/core/combobox/examples/combobox-inside-dialog-example.component.ts
@@ -1,0 +1,59 @@
+import { ChangeDetectorRef, Component, TemplateRef } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ButtonBarComponent } from '@fundamental-ngx/core/bar';
+import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { ComboboxComponent } from '@fundamental-ngx/core/combobox';
+import {
+    DialogBodyComponent,
+    DialogComponent,
+    DialogFooterComponent,
+    DialogHeaderComponent,
+    DialogService,
+    DialogTemplateDirective
+} from '@fundamental-ngx/core/dialog';
+import { TitleComponent } from '@fundamental-ngx/core/title';
+
+@Component({
+    selector: 'fd-combobox-inside-dialog-example',
+    templateUrl: './combobox-inside-dialog-example.component.html',
+    imports: [
+        ComboboxComponent,
+        TitleComponent,
+        DialogTemplateDirective,
+        DialogFooterComponent,
+        ButtonComponent,
+        DialogComponent,
+        ButtonBarComponent,
+        DialogBodyComponent,
+        DialogHeaderComponent,
+        FormsModule
+    ]
+})
+export class ComboboxInsideDialogExampleComponent {
+    confirmationReason: string;
+    searchTerm = '';
+    fruits = ['Apple', 'Pineapple', 'Banana', 'Kiwi', 'Strawberry'];
+
+    constructor(
+        private _dialogService: DialogService,
+        private _cdr: ChangeDetectorRef
+    ) {}
+
+    openDialog(dialog: TemplateRef<any>): void {
+        const dialogRef = this._dialogService.open(dialog, {
+            responsivePadding: true,
+            focusTrapped: true
+        });
+
+        dialogRef.afterClosed.subscribe(
+            (result) => {
+                this.confirmationReason = 'Dialog closed with result: ' + result;
+                this._cdr.detectChanges();
+            },
+            (error) => {
+                this.confirmationReason = 'Dialog dismissed with result: ' + error;
+                this._cdr.detectChanges();
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/12669#issue-2621028090

## Description

Problem:

When combobox is used within a dialog, when the dialog is created with `focusTrapped: true`, user is not able to navigate up and down the dropdown options. The reason is that focus is trapped on the popup and its child components, but the combobox dropdown is not a child component of the popup, it is positioned within a separate overlay. 

Solution:

Pausing and unpausing the focus trapped logic upon opening and closing the dropdown allows the user to interact with the combobox dropdown. When the dropdown is open, we pause current focus trap and arrow keys work as expected within the combobox. When the dropdown is closed, focus trap is unpaused again and focus is back on the dialog.

## Screenshots


https://github.com/user-attachments/assets/32096adf-9e10-42e8-9f39-9bd5f9b74070


