### PR TITLE
fix(core): add some a11y improvements to segmented button

### DIFF
--- a/libs/cdk/utils/directives/focusable-list/focusable-list.directive.ts
+++ b/libs/cdk/utils/directives/focusable-list/focusable-list.directive.ts
@@ -40,6 +40,7 @@ import { ScrollPosition, scrollIntoView } from './scroll';
 
 export interface FocusableListItemFocusedEvent {
     index: number;
+    id: string | null;
     total: number;
 }
 
@@ -364,7 +365,8 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
                     this._gridItemFocused$.next(directiveItem._position!);
                 }
 
-                this.itemFocused.next({ index, total: items.length });
+                const id = getItemElement(item)?.id ?? null;
+                this.itemFocused.next({ index, id, total: items.length });
                 this._focusableItems.forEach((i) => i.setTabbable(i === directiveItem));
                 this._keyManager?.setActiveItem(index);
             })

--- a/libs/cdk/utils/directives/focusable-list/focusable-list.directive.ts
+++ b/libs/cdk/utils/directives/focusable-list/focusable-list.directive.ts
@@ -366,7 +366,7 @@ export class FocusableListDirective implements OnChanges, AfterViewInit, OnDestr
                 }
 
                 const id = getItemElement(item)?.id ?? null;
-                this.itemFocused.next({ index, id, total: items.length });
+                this.itemFocused.next({ index, total: items.length, id });
                 this._focusableItems.forEach((i) => i.setTabbable(i === directiveItem));
                 this._keyManager?.setActiveItem(index);
             })

--- a/libs/cdk/utils/directives/focusable-list/focusable-list.directive.ts
+++ b/libs/cdk/utils/directives/focusable-list/focusable-list.directive.ts
@@ -40,8 +40,8 @@ import { ScrollPosition, scrollIntoView } from './scroll';
 
 export interface FocusableListItemFocusedEvent {
     index: number;
-    id: string | null;
     total: number;
+    id?: string | null;
 }
 
 export interface FocusableListKeydownEvent {

--- a/libs/core/button/base-button.ts
+++ b/libs/core/button/base-button.ts
@@ -34,9 +34,13 @@ export class BaseButton implements HasElementRef {
     /** Whether button is in toggled state. */
     @HostBinding('class.fd-button--toggled')
     @HostBinding('attr.aria-pressed')
-    @HostBinding('attr.aria-selected')
     @Input({ transform: booleanAttribute })
     toggled: BooleanInput;
+
+    /** Whether button is selected. */
+    @HostBinding('attr.aria-selected')
+    @Input({ transform: booleanAttribute })
+    selected: BooleanInput;
 
     /**
      * Native type of button element

--- a/libs/core/button/base-button.ts
+++ b/libs/core/button/base-button.ts
@@ -34,6 +34,7 @@ export class BaseButton implements HasElementRef {
     /** Whether button is in toggled state. */
     @HostBinding('class.fd-button--toggled')
     @HostBinding('attr.aria-pressed')
+    @HostBinding('attr.aria-selected')
     @Input({ transform: booleanAttribute })
     toggled: BooleanInput;
 

--- a/libs/core/button/button.component.spec.ts
+++ b/libs/core/button/button.component.spec.ts
@@ -31,25 +31,22 @@ export class DisabledTestComponent {}
 export class AriaDisabledTestComponent {}
 
 describe('ButtonComponent', () => {
-    let fixture: ComponentFixture<TestComponent>, debugElement: DebugElement;
-    let component, componentInstance: ButtonComponent;
+    let fixture: ComponentFixture<ButtonComponent>, componentInstance: ButtonComponent;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [ButtonModule, TestComponent]
+            imports: [ButtonComponent]
         }).compileComponents();
     }));
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(TestComponent);
-        debugElement = fixture.debugElement;
+        fixture = TestBed.createComponent(ButtonComponent);
         fixture.detectChanges();
-        component = debugElement.query(By.directive(ButtonComponent));
-        componentInstance = component.injector.get(ButtonComponent);
+        componentInstance = fixture.componentInstance;
     });
 
-    it('should create TestComponent', () => {
-        expect(component).toBeTruthy();
+    it('should create ButtonComponent', () => {
+        expect(componentInstance).toBeTruthy();
     });
 
     it('should add appropriate classes', () => {
@@ -66,6 +63,16 @@ describe('ButtonComponent', () => {
         jest.spyOn(componentInstance, 'buildComponentCssClass');
         componentInstance.ngOnInit();
         expect(componentInstance.buildComponentCssClass).toHaveBeenCalled();
+    });
+
+    it('should set a default id', () => {
+        expect(componentInstance.id()).toBe('fd-button-4');
+    });
+
+    it('should set a custom id if such is provided', () => {
+        fixture.componentRef.setInput('id', 'custom-id');
+        fixture.detectChanges();
+        expect(componentInstance.id()).toBe('custom-id');
     });
 });
 

--- a/libs/core/button/button.component.ts
+++ b/libs/core/button/button.component.ts
@@ -5,6 +5,7 @@ import {
     ElementRef,
     forwardRef,
     HostListener,
+    input,
     Input,
     OnChanges,
     OnDestroy,
@@ -18,6 +19,8 @@ import { BaseButton } from './base-button';
 
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { FD_BUTTON_COMPONENT } from './tokens';
+
+let buttonId = 0;
 
 /**
  * Button directive, used to enhance standard HTML buttons.
@@ -41,7 +44,8 @@ import { FD_BUTTON_COMPONENT } from './tokens';
         '[attr.type]': 'type',
         '[attr.disabled]': 'disabled || null',
         '[attr.aria-label]': 'buttonArialabel()',
-        '[attr.aria-description]': 'buttonAriaDescription()'
+        '[attr.aria-description]': 'buttonAriaDescription()',
+        '[attr.id]': 'id()'
     },
     providers: [
         contentDensityObserverProviders(),
@@ -59,6 +63,9 @@ export class ButtonComponent
     /** The property allows user to pass additional css classes. */
     @Input()
     class = '';
+
+    /** Button ID - default value is provided if not set  */
+    id = input(`fd-button-${++buttonId}`);
 
     /** @hidden */
     specialButtonType: Array<string> = ['emphasized', 'positive', 'negative', 'attention'];

--- a/libs/core/button/button.component.ts
+++ b/libs/core/button/button.component.ts
@@ -3,6 +3,7 @@ import {
     Component,
     computed,
     ElementRef,
+    forwardRef,
     HostListener,
     Input,
     OnChanges,
@@ -46,7 +47,7 @@ import { FD_BUTTON_COMPONENT } from './tokens';
         contentDensityObserverProviders(),
         {
             provide: FD_BUTTON_COMPONENT,
-            useExisting: ButtonComponent
+            useExisting: forwardRef(() => ButtonComponent)
         }
     ],
     imports: [IconComponent]

--- a/libs/core/button/button.component.ts
+++ b/libs/core/button/button.component.ts
@@ -3,7 +3,6 @@ import {
     Component,
     computed,
     ElementRef,
-    forwardRef,
     HostListener,
     input,
     Input,
@@ -51,7 +50,7 @@ let buttonId = 0;
         contentDensityObserverProviders(),
         {
             provide: FD_BUTTON_COMPONENT,
-            useExisting: forwardRef(() => ButtonComponent)
+            useExisting: ButtonComponent
         }
     ],
     imports: [IconComponent]

--- a/libs/core/segmented-button/segmented-button.component.scss
+++ b/libs/core/segmented-button/segmented-button.component.scss
@@ -1,8 +1,11 @@
 @import 'fundamental-styles/dist/segmented-button.css';
 
-.fd-button.fd-button--toggled.is-active,
-.fd-button.fd-button--toggled.is-selected,
-.fd-button.fd-button--toggled:active,
-.fd-button.fd-button--toggled[aria-selected='true'] {
+.fd-button.is-disabled.is-selected,
+.fd-button.is-disabled[aria-selected='true'],
+.fd-button:disabled.is-selected,
+.fd-button:disabled[aria-selected='true'],
+.fd-button[aria-disabled='true'].is-selected,
+.fd-button[aria-disabled='true'][aria-selected='true'] {
     --fdButtonBorderColor: var(--sapButton_Selected_BorderColor);
+    --fdButtonBackgroundColor: var(--sapButton_Selected_Background);
 }

--- a/libs/core/segmented-button/segmented-button.component.scss
+++ b/libs/core/segmented-button/segmented-button.component.scss
@@ -1,1 +1,8 @@
 @import 'fundamental-styles/dist/segmented-button.css';
+
+.fd-button.fd-button--toggled.is-active,
+.fd-button.fd-button--toggled.is-selected,
+.fd-button.fd-button--toggled:active,
+.fd-button.fd-button--toggled[aria-selected='true'] {
+    --fdButtonBorderColor: var(--sapButton_Selected_BorderColor);
+}

--- a/libs/core/segmented-button/segmented-button.component.spec.ts
+++ b/libs/core/segmented-button/segmented-button.component.spec.ts
@@ -6,8 +6,6 @@ import { runValueAccessorTests } from 'ngx-cva-test-suite';
 import { SegmentedButtonComponent } from './segmented-button.component';
 import { SegmentedButtonModule } from './segmented-button.module';
 
-const isSelectedClass = 'fd-button--toggled';
-
 @Component({
     selector: 'fd-test-component',
     template: `
@@ -84,12 +82,12 @@ describe('SegmentedButtonComponent', () => {
     it('should correctly select and deselect single value in non-toggle mode', () => {
         component.segmentedButton.writeValue('second');
         fixture.detectChanges();
-        expect(component.secondButton.elementRef.nativeElement.classList.contains(isSelectedClass)).toBe(true);
+        expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-selected')).toBe('true');
 
         component.segmentedButton.writeValue('first');
         fixture.detectChanges();
-        expect(component.firstButton.nativeElement.classList.contains(isSelectedClass)).toBe(true);
-        expect(component.secondButton.elementRef.nativeElement.classList.contains(isSelectedClass)).toBe(false);
+        expect(component.firstButton.nativeElement.getAttribute('aria-selected')).toBe('true');
+        expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-selected')).toBe('false');
     });
 
     // Toggle Example
@@ -99,31 +97,31 @@ describe('SegmentedButtonComponent', () => {
 
         component.firstButton.nativeElement.dispatchEvent(new MouseEvent('click'));
         fixture.detectChanges();
-        expect(component.firstButton.nativeElement.classList.contains(isSelectedClass)).toBe(true);
+        expect(component.firstButton.nativeElement.getAttribute('aria-selected')).toBe('true');
 
         component.secondButton.elementRef.nativeElement.dispatchEvent(new MouseEvent('click'));
         fixture.detectChanges();
-        expect(component.secondButton.elementRef.nativeElement.classList.contains(isSelectedClass)).toBe(true);
+        expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-selected')).toBe('true');
 
         component.thirdButton.nativeElement.dispatchEvent(new MouseEvent('click'));
         fixture.detectChanges();
-        expect(component.thirdButton.nativeElement.classList.contains(isSelectedClass)).toBe(true);
+        expect(component.thirdButton.nativeElement.getAttribute('aria-selected')).toBe('true');
 
         // Deselect
         component.firstButton.nativeElement.dispatchEvent(new MouseEvent('click'));
         fixture.detectChanges();
-        expect(component.firstButton.nativeElement.classList.contains(isSelectedClass)).toBe(false);
+        expect(component.firstButton.nativeElement.getAttribute('aria-selected')).toBe('false');
     });
 
     // Form Example
     it('should update form value correctly', () => {
         component.segmentedButton.writeValue('first');
         fixture.detectChanges();
-        expect(component.firstButton.nativeElement.classList.contains(isSelectedClass)).toBe(true);
+        expect(component.firstButton.nativeElement.getAttribute('aria-selected')).toBe('true');
 
         component.segmentedButton.writeValue('second');
         fixture.detectChanges();
-        expect(component.secondButton.elementRef.nativeElement.classList.contains(isSelectedClass)).toBe(true);
+        expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-selected')).toBe('true');
     });
 
     // Disabled State Check
@@ -150,15 +148,15 @@ describe('SegmentedButtonComponent', () => {
 
         component.firstButton.nativeElement.dispatchEvent(new MouseEvent('click'));
         fixture.detectChanges();
-        expect(component.firstButton.nativeElement.classList.contains(isSelectedClass)).toBe(true);
+        expect(component.firstButton.nativeElement.getAttribute('aria-selected')).toBe('true');
 
         component.secondButton.elementRef.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
         fixture.detectChanges();
-        expect(component.secondButton.elementRef.nativeElement.classList.contains(isSelectedClass)).toBe(true);
+        expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-selected')).toBe('true');
 
         component.thirdButton.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
         fixture.detectChanges();
-        expect(component.thirdButton.nativeElement.classList.contains(isSelectedClass)).toBe(true);
+        expect(component.thirdButton.nativeElement.getAttribute('aria-selected')).toBe('true');
     });
 });
 

--- a/libs/core/segmented-button/segmented-button.component.spec.ts
+++ b/libs/core/segmented-button/segmented-button.component.spec.ts
@@ -50,6 +50,36 @@ describe('SegmentedButtonComponent', () => {
         expect(component).toBeTruthy();
     });
 
+    it('should set segmented button group classes and attributes correctly', () => {
+        const segmentedButtonElement = fixture.debugElement.nativeElement.querySelector('fd-segmented-button');
+        expect(segmentedButtonElement.classList).toContain('fd-segmented-button');
+        expect(segmentedButtonElement.classList).not.toContain('fd-segmented-button--vertical');
+
+        expect(segmentedButtonElement.getAttribute('role')).toBe('listbox');
+        expect(segmentedButtonElement.getAttribute('aria-multiselectable')).toBe('false');
+        expect(segmentedButtonElement.getAttribute('aria-orientation')).toBe('horizontal');
+        expect(segmentedButtonElement.getAttribute('aria-roledescription')).toBe('Segmented button group');
+    });
+
+    it('should set button attributes correctly', () => {
+        expect(component.firstButton.nativeElement.getAttribute('role')).toBe('option');
+        expect(component.firstButton.nativeElement.getAttribute('aria-roledescription')).toBe('Segmented button');
+        expect(component.firstButton.nativeElement.getAttribute('aria-posinset')).toBe('1');
+        expect(component.firstButton.nativeElement.getAttribute('aria-setsize')).toBe('3');
+
+        expect(component.secondButton.elementRef.nativeElement.getAttribute('role')).toBe('option');
+        expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-roledescription')).toBe(
+            'Segmented button'
+        );
+        expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-posinset')).toBe('2');
+        expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-setsize')).toBe('3');
+
+        expect(component.thirdButton.nativeElement.getAttribute('role')).toBe('option');
+        expect(component.thirdButton.nativeElement.getAttribute('aria-roledescription')).toBe('Segmented button');
+        expect(component.thirdButton.nativeElement.getAttribute('aria-posinset')).toBe('3');
+        expect(component.thirdButton.nativeElement.getAttribute('aria-setsize')).toBe('3');
+    });
+
     // Default Example
     it('should correctly select and deselect single value in non-toggle mode', () => {
         component.segmentedButton.writeValue('second');

--- a/libs/core/segmented-button/segmented-button.component.spec.ts
+++ b/libs/core/segmented-button/segmented-button.component.spec.ts
@@ -58,24 +58,24 @@ describe('SegmentedButtonComponent', () => {
         expect(segmentedButtonElement.getAttribute('role')).toBe('listbox');
         expect(segmentedButtonElement.getAttribute('aria-multiselectable')).toBe('false');
         expect(segmentedButtonElement.getAttribute('aria-orientation')).toBe('horizontal');
-        expect(segmentedButtonElement.getAttribute('aria-roledescription')).toBe('Segmented button group');
+        expect(segmentedButtonElement.getAttribute('aria-roledescription')).toBe('Segmented Button Group');
     });
 
     it('should set button attributes correctly', () => {
         expect(component.firstButton.nativeElement.getAttribute('role')).toBe('option');
-        expect(component.firstButton.nativeElement.getAttribute('aria-roledescription')).toBe('Segmented button');
+        expect(component.firstButton.nativeElement.getAttribute('aria-roledescription')).toBe('Segmented Button');
         expect(component.firstButton.nativeElement.getAttribute('aria-posinset')).toBe('1');
         expect(component.firstButton.nativeElement.getAttribute('aria-setsize')).toBe('3');
 
         expect(component.secondButton.elementRef.nativeElement.getAttribute('role')).toBe('option');
         expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-roledescription')).toBe(
-            'Segmented button'
+            'Segmented Button'
         );
         expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-posinset')).toBe('2');
         expect(component.secondButton.elementRef.nativeElement.getAttribute('aria-setsize')).toBe('3');
 
         expect(component.thirdButton.nativeElement.getAttribute('role')).toBe('option');
-        expect(component.thirdButton.nativeElement.getAttribute('aria-roledescription')).toBe('Segmented button');
+        expect(component.thirdButton.nativeElement.getAttribute('aria-roledescription')).toBe('Segmented Button');
         expect(component.thirdButton.nativeElement.getAttribute('aria-posinset')).toBe('3');
         expect(component.thirdButton.nativeElement.getAttribute('aria-setsize')).toBe('3');
     });

--- a/libs/core/segmented-button/segmented-button.component.ts
+++ b/libs/core/segmented-button/segmented-button.component.ts
@@ -248,10 +248,6 @@ export class SegmentedButtonComponent implements AfterViewInit, ControlValueAcce
         buttonComponent.elementRef.nativeElement.setAttribute('aria-roledescription', 'Segmented button');
         buttonComponent.elementRef.nativeElement.setAttribute('aria-posinset', String(index + 1));
         buttonComponent.elementRef.nativeElement.setAttribute('aria-setsize', String(this._buttons.length));
-        buttonComponent.elementRef.nativeElement.setAttribute(
-            'aria-selected',
-            String(this._isButtonSelected(buttonComponent))
-        );
     }
 
     /** @hidden */

--- a/libs/core/segmented-button/segmented-button.component.ts
+++ b/libs/core/segmented-button/segmented-button.component.ts
@@ -54,7 +54,10 @@ export type SegmentedButtonValue = string | (string | null)[] | null;
     host: {
         role: 'listbox',
         '[class.fd-segmented-button]': 'true',
-        '[class.fd-segmented-button--vertical]': 'vertical'
+        '[class.fd-segmented-button--vertical]': 'vertical',
+        '[attr.aria-multiselectable]': 'toggle',
+        '[attr.aria-orientation]': 'vertical ? "vertical" : "horizontal"',
+        '[attr.aria-roledescription]': '"Segmented button group"'
     },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -212,8 +215,8 @@ export class SegmentedButtonComponent implements AfterViewInit, ControlValueAcce
 
                 this._toggleDisableButtons(this._isDisabled);
                 this._pickButtonsByValues(this._currentValue);
-                this._buttons.forEach((button) => {
-                    button.elementRef.nativeElement.role = 'option';
+                this._buttons.forEach((button, index) => {
+                    this._setButtonAttributes(button, index);
                     this._listenToTriggerEvents(button);
                 });
             });
@@ -237,6 +240,18 @@ export class SegmentedButtonComponent implements AfterViewInit, ControlValueAcce
         );
 
         triggerEvents$.pipe(takeUntil(refresh$)).subscribe(() => this._handleTriggerOnButton(buttonComponent));
+    }
+
+    /** @hidden */
+    private _setButtonAttributes(buttonComponent: ButtonComponent, index: number): void {
+        buttonComponent.elementRef.nativeElement.setAttribute('role', 'option');
+        buttonComponent.elementRef.nativeElement.setAttribute('aria-roledescription', 'Segmented button');
+        buttonComponent.elementRef.nativeElement.setAttribute('aria-posinset', String(index + 1));
+        buttonComponent.elementRef.nativeElement.setAttribute('aria-setsize', String(this._buttons.length));
+        buttonComponent.elementRef.nativeElement.setAttribute(
+            'aria-selected',
+            String(this._isButtonSelected(buttonComponent))
+        );
     }
 
     /** @hidden */

--- a/libs/core/segmented-button/segmented-button.component.ts
+++ b/libs/core/segmented-button/segmented-button.component.ts
@@ -125,7 +125,7 @@ export class SegmentedButtonComponent implements OnInit, AfterViewInit, ControlV
     private _translationResolver = inject(TranslationResolver);
 
     /** @hidden */
-    private _focusedItemId = signal<string | null>(null);
+    private _focusedItemId = signal<string | null | undefined>(null);
 
     /** @hidden */
     private renderer = inject(Renderer2);

--- a/libs/docs/core/segmented-button/examples/segmented-button-default-example.component.html
+++ b/libs/docs/core/segmented-button/examples/segmented-button-default-example.component.html
@@ -7,16 +7,30 @@
 
 <fd-text text="example with icon buttons"></fd-text>
 <fd-segmented-button [(ngModel)]="value">
-    <button fd-button fdkFocusableItem glyph="cart" value="first"></button>
-    <button fd-button fdkFocusableItem glyph="action" value="second"></button>
-    <button fd-button fdkFocusableItem glyph="activities" value="third"></button>
+    <button fd-button fdkFocusableItem glyph="cart" title="Add to cart" ariaLabel="Add to cart" value="first"></button>
+    <button fd-button fdkFocusableItem glyph="action" title="Action" ariaLabel="Action" value="second"></button>
+    <button
+        fd-button
+        fdkFocusableItem
+        glyph="activities"
+        title="Activities"
+        ariaLabel="Activities"
+        value="third"
+    ></button>
 </fd-segmented-button>
 
 <fd-text text="example with Vertical alignment"></fd-text>
 <fd-segmented-button [(ngModel)]="value" vertical>
-    <button fd-button fdkFocusableItem glyph="cart" value="first"></button>
-    <button fd-button fdkFocusableItem glyph="action" value="second"></button>
-    <button fd-button fdkFocusableItem glyph="activities" value="third"></button>
+    <button fd-button fdkFocusableItem glyph="cart" title="Add to cart" ariaLabel="Add to cart" value="first"></button>
+    <button fd-button fdkFocusableItem glyph="action" title="Action" ariaLabel="Action" value="second"></button>
+    <button
+        fd-button
+        fdkFocusableItem
+        glyph="activities"
+        title="Activities"
+        ariaLabel="Activities"
+        value="third"
+    ></button>
 </fd-segmented-button>
 
 <br />

--- a/libs/docs/core/segmented-button/segmented-button-docs.component.html
+++ b/libs/docs/core/segmented-button/segmented-button-docs.component.html
@@ -9,10 +9,10 @@
 <code-example [exampleFiles]="defaultSizeHtml"></code-example>
 <separator></separator>
 
-<fd-docs-section-title id="toggle" componentName="segmented-button"> Toggle </fd-docs-section-title>
+<fd-docs-section-title id="toggle" componentName="segmented-button"> Toggle / Multi-select </fd-docs-section-title>
 <description>
     With Toggle SegmentedButton you can communicate by <code>[(ngModel)]</code> with array of strings value. So more
-    than one button can be toggled at once.
+    than one button can be selected at once.
 </description>
 <component-example>
     <fd-segmented-button-toggle-example></fd-segmented-button-toggle-example>

--- a/libs/i18n/src/lib/models/fd-language-key-identifier.ts
+++ b/libs/i18n/src/lib/models/fd-language-key-identifier.ts
@@ -499,4 +499,6 @@ export type FdLanguageKeyIdentifier =
     | 'coreNotification.groupAriaDescriptionExpanded'
     | 'coreNotification.groupAriaDescriptionCollapsed'
     | 'coreNotification.triggerMoreLabel'
-    | 'coreNotification.triggerLessLabel';
+    | 'coreNotification.triggerLessLabel'
+    | 'segmentedButton.groupRoleDescription'
+    | 'segmentedButton.buttonRoleDescription';

--- a/libs/i18n/src/lib/models/fd-language.ts
+++ b/libs/i18n/src/lib/models/fd-language.ts
@@ -739,4 +739,8 @@ export interface FdLanguage {
         triggerMoreLabel: FdLanguageKey;
         triggerLessLabel: FdLanguageKey;
     };
+    segmentedButton: {
+        groupRoleDescription: FdLanguageKey;
+        buttonRoleDescription: FdLanguageKey;
+    };
 }

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -994,3 +994,9 @@ coreNotification.groupAriaDescriptionCollapsed = collapsed
 coreNotification.triggerMoreLabel = More
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel = Less
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations.properties instead
 export default {
     coreCalendar: {
@@ -610,5 +610,9 @@ export default {
         groupAriaDescriptionCollapsed: 'collapsed',
         triggerMoreLabel: 'More',
         triggerLessLabel: 'Less'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_ar.properties
+++ b/libs/i18n/src/lib/translations/translations_ar.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=تم طيه
 coreNotification.triggerMoreLabel=المزيد
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=أقل
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_ar.properties instead
 export default {
     coreCalendar: {
@@ -610,5 +610,9 @@ export default {
         groupAriaDescriptionCollapsed: 'تم طيه',
         triggerMoreLabel: 'المزيد',
         triggerLessLabel: 'أقل'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_ar.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_bg.properties
+++ b/libs/i18n/src/lib/translations/translations_bg.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=свито
 coreNotification.triggerMoreLabel=Повече
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=По-малко
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_bg.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'свито',
         triggerMoreLabel: 'Повече',
         triggerLessLabel: 'По-малко'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_bg.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_cs.properties
+++ b/libs/i18n/src/lib/translations/translations_cs.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=sbaleno
 coreNotification.triggerMoreLabel=Více
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Méně
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_cs.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_cs.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'sbaleno',
         triggerMoreLabel: 'Více',
         triggerLessLabel: 'Méně'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_da.properties
+++ b/libs/i18n/src/lib/translations/translations_da.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=minimeret
 coreNotification.triggerMoreLabel=Mere
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Mindre
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_da.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'minimeret',
         triggerMoreLabel: 'Mere',
         triggerLessLabel: 'Mindre'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_da.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_de.properties
+++ b/libs/i18n/src/lib/translations/translations_de.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=reduziert
 coreNotification.triggerMoreLabel=Mehr
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Weniger
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_de.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_de.properties instead
 export default {
     coreCalendar: {
@@ -612,5 +612,9 @@ export default {
         groupAriaDescriptionCollapsed: 'reduziert',
         triggerMoreLabel: 'Mehr',
         triggerLessLabel: 'Weniger'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_el.properties
+++ b/libs/i18n/src/lib/translations/translations_el.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=συμπτύχθηκε
 coreNotification.triggerMoreLabel=Περισσότερα
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Λιγότερα
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_el.properties instead
 export default {
     coreCalendar: {
@@ -612,5 +612,9 @@ export default {
         groupAriaDescriptionCollapsed: 'συμπτύχθηκε',
         triggerMoreLabel: 'Περισσότερα',
         triggerLessLabel: 'Λιγότερα'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_el.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=[[[ċŏĺĺąρşēƌ∙∙∙∙
 coreNotification.triggerMoreLabel=[[[Μŏŗē]]]
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=[[[Ļēşş]]]
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_en_US_sappsd.properties instead
 export default {
     coreCalendar: {
@@ -618,5 +618,9 @@ export default {
         groupAriaDescriptionCollapsed: '[[[ċŏĺĺąρşēƌ∙∙∙∙∙]]]',
         triggerMoreLabel: '[[[Μŏŗē]]]',
         triggerLessLabel: '[[[Ļēşş]]]'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_en_US_sappsd.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_es.properties
+++ b/libs/i18n/src/lib/translations/translations_es.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=contraído
 coreNotification.triggerMoreLabel=Más
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Menos
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_es.properties instead
 export default {
     coreCalendar: {
@@ -612,5 +612,9 @@ export default {
         groupAriaDescriptionCollapsed: 'contraído',
         triggerMoreLabel: 'Más',
         triggerLessLabel: 'Menos'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_es.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_fi.properties
+++ b/libs/i18n/src/lib/translations/translations_fi.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=tiivistetty
 coreNotification.triggerMoreLabel=Lisää
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Vähemmän
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_fi.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'tiivistetty',
         triggerMoreLabel: 'Lisää',
         triggerLessLabel: 'Vähemmän'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_fi.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_fr.properties
+++ b/libs/i18n/src/lib/translations/translations_fr.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=réduit
 coreNotification.triggerMoreLabel=Plus
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Moins
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_fr.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_fr.properties instead
 export default {
     coreCalendar: {
@@ -613,5 +613,9 @@ export default {
         groupAriaDescriptionCollapsed: 'réduit',
         triggerMoreLabel: 'Plus',
         triggerLessLabel: 'Moins'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_he.properties
+++ b/libs/i18n/src/lib/translations/translations_he.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=מצומצם
 coreNotification.triggerMoreLabel=יותר
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=פחות
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_he.properties instead
 export default {
     coreCalendar: {
@@ -609,5 +609,9 @@ export default {
         groupAriaDescriptionCollapsed: 'מצומצם',
         triggerMoreLabel: 'יותר',
         triggerLessLabel: 'פחות'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_he.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_hi.properties
+++ b/libs/i18n/src/lib/translations/translations_hi.properties
@@ -478,3 +478,7 @@ btpToolHeader.menuButtonAriaLabel = मेनू बटन
 coreNotification.triggerMoreLabel = More
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel = Less
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_hi.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_hi.properties instead
 export default {
     coreCalendar: {
@@ -587,5 +587,9 @@ export default {
     coreNotification: {
         triggerMoreLabel: 'More',
         triggerLessLabel: 'Less'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_hr.properties
+++ b/libs/i18n/src/lib/translations/translations_hr.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=sažeto
 coreNotification.triggerMoreLabel=Više
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Manje
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_hr.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_hr.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'sažeto',
         triggerMoreLabel: 'Više',
         triggerLessLabel: 'Manje'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_hu.properties
+++ b/libs/i18n/src/lib/translations/translations_hu.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=visszazárva
 coreNotification.triggerMoreLabel=Több
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Kevesebb
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_hu.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_hu.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'visszazárva',
         triggerMoreLabel: 'Több',
         triggerLessLabel: 'Kevesebb'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_it.properties
+++ b/libs/i18n/src/lib/translations/translations_it.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=compresso
 coreNotification.triggerMoreLabel=Espandi
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Comprimi
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_it.properties instead
 export default {
     coreCalendar: {
@@ -612,5 +612,9 @@ export default {
         groupAriaDescriptionCollapsed: 'compresso',
         triggerMoreLabel: 'Espandi',
         triggerLessLabel: 'Comprimi'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_it.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_ja.properties
+++ b/libs/i18n/src/lib/translations/translations_ja.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=非表示
 coreNotification.triggerMoreLabel=表示を増やす
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=表示を減らす
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_ja.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_ja.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: '非表示',
         triggerMoreLabel: '表示を増やす',
         triggerLessLabel: '表示を減らす'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ka.properties
+++ b/libs/i18n/src/lib/translations/translations_ka.properties
@@ -478,3 +478,7 @@ btpToolHeader.menuButtonAriaLabel = მენიუს ღილაკი
 coreNotification.triggerMoreLabel = More
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel = Less
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_ka.properties instead
 export default {
     coreCalendar: {
@@ -587,5 +587,9 @@ export default {
     coreNotification: {
         triggerMoreLabel: 'More',
         triggerLessLabel: 'Less'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_ka.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_kk.properties
+++ b/libs/i18n/src/lib/translations/translations_kk.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=жиылған
 coreNotification.triggerMoreLabel=Көбірек
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Азырақ
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_kk.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'жиылған',
         triggerMoreLabel: 'Көбірек',
         triggerLessLabel: 'Азырақ'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_kk.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_ko.properties
+++ b/libs/i18n/src/lib/translations/translations_ko.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=접힌 상태
 coreNotification.triggerMoreLabel=자세히
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=간단히
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_ko.properties instead
 export default {
     coreCalendar: {
@@ -609,5 +609,9 @@ export default {
         groupAriaDescriptionCollapsed: '접힌 상태',
         triggerMoreLabel: '자세히',
         triggerLessLabel: '간단히'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_ko.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_ms.properties
+++ b/libs/i18n/src/lib/translations/translations_ms.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=diruntuhkan
 coreNotification.triggerMoreLabel=Selanjutnya
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Kurang
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_ms.properties instead
 export default {
     coreCalendar: {
@@ -610,5 +610,9 @@ export default {
         groupAriaDescriptionCollapsed: 'diruntuhkan',
         triggerMoreLabel: 'Selanjutnya',
         triggerLessLabel: 'Kurang'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_ms.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_nl.properties
+++ b/libs/i18n/src/lib/translations/translations_nl.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=samengevouwen
 coreNotification.triggerMoreLabel=Meer
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Minder
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_nl.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_nl.properties instead
 export default {
     coreCalendar: {
@@ -612,5 +612,9 @@ export default {
         groupAriaDescriptionCollapsed: 'samengevouwen',
         triggerMoreLabel: 'Meer',
         triggerLessLabel: 'Minder'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_no.properties
+++ b/libs/i18n/src/lib/translations/translations_no.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=komprimert
 coreNotification.triggerMoreLabel=Mer
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Mindre
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_no.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_no.properties instead
 export default {
     coreCalendar: {
@@ -612,5 +612,9 @@ export default {
         groupAriaDescriptionCollapsed: 'komprimert',
         triggerMoreLabel: 'Mer',
         triggerLessLabel: 'Mindre'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_pl.properties
+++ b/libs/i18n/src/lib/translations/translations_pl.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=zwinięte
 coreNotification.triggerMoreLabel=Więcej
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Mniej
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_pl.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'zwinięte',
         triggerMoreLabel: 'Więcej',
         triggerLessLabel: 'Mniej'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_pl.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_pt.properties
+++ b/libs/i18n/src/lib/translations/translations_pt.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=recolhido
 coreNotification.triggerMoreLabel=Mais
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Menos
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_pt.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_pt.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'recolhido',
         triggerMoreLabel: 'Mais',
         triggerLessLabel: 'Menos'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ro.properties
+++ b/libs/i18n/src/lib/translations/translations_ro.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=restrâns
 coreNotification.triggerMoreLabel=Mai mult
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Mai puțin
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_ro.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_ro.properties instead
 export default {
     coreCalendar: {
@@ -612,5 +612,9 @@ export default {
         groupAriaDescriptionCollapsed: 'restrâns',
         triggerMoreLabel: 'Mai mult',
         triggerLessLabel: 'Mai puțin'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ru.properties
+++ b/libs/i18n/src/lib/translations/translations_ru.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=свернуто
 coreNotification.triggerMoreLabel=Больше
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Меньше
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_ru.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'свернуто',
         triggerMoreLabel: 'Больше',
         triggerLessLabel: 'Меньше'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_ru.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_sh.properties
+++ b/libs/i18n/src/lib/translations/translations_sh.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=sažeto
 coreNotification.triggerMoreLabel=Više
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Manje
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_sh.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'sažeto',
         triggerMoreLabel: 'Više',
         triggerLessLabel: 'Manje'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_sh.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_sk.properties
+++ b/libs/i18n/src/lib/translations/translations_sk.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=zbalené
 coreNotification.triggerMoreLabel=Viac
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Menej
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_sk.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'zbalené',
         triggerMoreLabel: 'Viac',
         triggerLessLabel: 'Menej'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_sk.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_sl.properties
+++ b/libs/i18n/src/lib/translations/translations_sl.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=strnjeno
 coreNotification.triggerMoreLabel=Več
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Manj
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_sl.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_sl.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'strnjeno',
         triggerMoreLabel: 'Več',
         triggerLessLabel: 'Manj'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_sq.properties
+++ b/libs/i18n/src/lib/translations/translations_sq.properties
@@ -474,3 +474,6 @@ btpSearchField.searchInputAriaLabel = Kërko
 btpToolHeader.menuButtonAriaLabel = Butoni i menysë
 coreNotification.triggerMoreLabel = More
 coreNotification.triggerLessLabel = Less
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_sq.ts
+++ b/libs/i18n/src/lib/translations/translations_sq.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_sq.properties instead
 export default {
     coreCalendar: {
@@ -588,5 +588,9 @@ export default {
     coreNotification: {
         triggerMoreLabel: 'More',
         triggerLessLabel: 'Less'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_sq.ts
+++ b/libs/i18n/src/lib/translations/translations_sq.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_sq.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_sv.properties
+++ b/libs/i18n/src/lib/translations/translations_sv.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=komprimera
 coreNotification.triggerMoreLabel=Mer
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Mindre
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_sv.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_sv.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'komprimera',
         triggerMoreLabel: 'Mer',
         triggerLessLabel: 'Mindre'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_th.properties
+++ b/libs/i18n/src/lib/translations/translations_th.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=ยุบรวม
 coreNotification.triggerMoreLabel=เพิ่มเติม
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=น้อยลง
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_th.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_th.properties instead
 export default {
     coreCalendar: {
@@ -611,5 +611,9 @@ export default {
         groupAriaDescriptionCollapsed: 'ยุบรวม',
         triggerMoreLabel: 'เพิ่มเติม',
         triggerLessLabel: 'น้อยลง'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_tr.properties
+++ b/libs/i18n/src/lib/translations/translations_tr.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=daraltıldı
 coreNotification.triggerMoreLabel=Daha Fazla
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Daha Az
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_tr.properties instead
 export default {
     coreCalendar: {
@@ -612,5 +612,9 @@ export default {
         groupAriaDescriptionCollapsed: 'daraltıldı',
         triggerMoreLabel: 'Daha Fazla',
         triggerLessLabel: 'Daha Az'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_tr.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_uk.properties
+++ b/libs/i18n/src/lib/translations/translations_uk.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=згорнуто
 coreNotification.triggerMoreLabel=Більше
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=Менше
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_uk.properties instead
 export default {
     coreCalendar: {
@@ -612,5 +612,9 @@ export default {
         groupAriaDescriptionCollapsed: 'згорнуто',
         triggerMoreLabel: 'Більше',
         triggerLessLabel: 'Менше'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_uk.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_zh_CN.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=已折叠
 coreNotification.triggerMoreLabel=更多
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=更少
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_zh_CN.properties instead
 export default {
     coreCalendar: {
@@ -608,5 +608,9 @@ export default {
         groupAriaDescriptionCollapsed: '已折叠',
         triggerMoreLabel: '更多',
         triggerLessLabel: '更少'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_zh_CN.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_zh_TW.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.properties
@@ -992,3 +992,7 @@ coreNotification.groupAriaDescriptionCollapsed=已摺疊
 coreNotification.triggerMoreLabel=更多
 #XACT Text for the trigger for collapse state, show less
 coreNotification.triggerLessLabel=較少
+#XACT Aria role description for Segmented Button Group
+segmentedButton.groupRoleDescription = Segmented Button Group
+#XACT Aria role description for Segmented Button
+segmentedButton.buttonRoleDescription = Segmented Button

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -1,4 +1,3 @@
- 
 // Do not modify, it's automatically created. Modify translations_zh_TW.properties instead
 export default {
     coreCalendar: {

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 // Do not modify, it's automatically created. Modify translations_zh_TW.properties instead
 export default {
     coreCalendar: {
@@ -608,5 +608,9 @@ export default {
         groupAriaDescriptionCollapsed: '已摺疊',
         triggerMoreLabel: '更多',
         triggerLessLabel: '較少'
+    },
+    segmentedButton: {
+        groupRoleDescription: 'Segmented Button Group',
+        buttonRoleDescription: 'Segmented Button'
     }
 };

--- a/libs/platform/button/button.component.spec.ts
+++ b/libs/platform/button/button.component.spec.ts
@@ -32,7 +32,7 @@ describe('ButtonComponent', () => {
         const element = fixture.debugElement.nativeElement.querySelector('button') as HTMLButtonElement;
         component.ariaSelected = false;
         fixture.detectChanges();
-        expect(element.getAttribute('aria-selected')).toBe(null);
+        expect(element.getAttribute('aria-selected')).toBe('false');
     });
 
     it('should have a content disabled button', () => {

--- a/libs/platform/button/button.component.spec.ts
+++ b/libs/platform/button/button.component.spec.ts
@@ -32,7 +32,7 @@ describe('ButtonComponent', () => {
         const element = fixture.debugElement.nativeElement.querySelector('button') as HTMLButtonElement;
         component.ariaSelected = false;
         fixture.detectChanges();
-        expect(element.getAttribute('aria-selected')).toBe('false');
+        expect(element.getAttribute('aria-selected')).toBe(null);
     });
 
     it('should have a content disabled button', () => {


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11092

## Description

1. Adds some missing a11y attributes as follow:
- to the segmented button listbox - `aria-multiselectable`, `aria-orientation`, `aria-roledescription`, `aria-activedescendant`
- to each of the options in the listbox - `aria-roledescription`, `aria-posinset`, `aria-setsize`, `aria-selected`

2. Removes `aria-pressed` attribute from the options in segmented button listbox as this attribute should only be present on elements with role `button` while the elements here have role `option`.

3. Adds an `id` input with a default value to `ButtonComponent`.

4. Updates `FocusableListDirective` to emit the `id` of the focused element which is used when setting `aria-activedescendant` on the segmented button listbox.

5. Adds translations of the `aria-roledescription` attributes on the segmented button listbox and on each individual option.

## Screenshots

<img width="2260" height="702" alt="Screenshot 2025-09-29 at 15 30 44" src="https://github.com/user-attachments/assets/a72c7453-b466-476c-97db-c359de16be2c" />


