### PR TITLE
fix(core): adopt a11y breaking changes for Textarea and Input states

### DIFF
--- a/libs/core/form/form-control/form-control.component.scss
+++ b/libs/core/form/form-control/form-control.component.scss
@@ -25,3 +25,17 @@
 .fd-input[readonly]:focus {
     z-index: 1 !important;
 }
+
+.fd-value-state-message__sr-only {
+    position: absolute;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    width: 1px;
+    border: 0;
+    margin-inline: -1px;
+    margin-block: -1px;
+    padding-inline: 0;
+    padding-block: 0;
+    overflow: hidden;
+    white-space: nowrap;
+}

--- a/libs/core/form/form-control/form-control.component.ts
+++ b/libs/core/form/form-control/form-control.component.ts
@@ -1,85 +1,177 @@
 import {
-    Attribute,
     ChangeDetectionStrategy,
     Component,
+    computed,
+    effect,
     ElementRef,
-    HostBinding,
+    inject,
+    input,
     Input,
     OnChanges,
     OnDestroy,
     OnInit,
+    Renderer2,
+    signal,
     ViewEncapsulation
 } from '@angular/core';
 import { FormStates } from '@fundamental-ngx/cdk/forms';
-import { CssClassBuilder, Nullable, applyCssClass } from '@fundamental-ngx/cdk/utils';
+import { applyCssClass, CssClassBuilder, Nullable } from '@fundamental-ngx/cdk/utils';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
+import { ValueStateAriaMessageService } from '@fundamental-ngx/core/shared';
 import { Subscription } from 'rxjs';
 import { FormItemControl, registerFormItemControl } from '../form-item-control/form-item-control';
 
-/**
- * Directive intended for use on form controls.
- *
- * ```html
- * <input type="text" fd-form-control />
- * ```
- */
+let formControlId = 0;
+
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
     selector: 'input[fd-form-control], textarea[fd-form-control]',
-    template: ` <ng-content></ng-content>`,
+    template: `<ng-content></ng-content>`,
     styleUrl: './form-control.component.scss',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [registerFormItemControl(FormControlComponent), contentDensityObserverProviders()]
+    providers: [registerFormItemControl(FormControlComponent), contentDensityObserverProviders()],
+    host: {
+        '[attr.type]': 'type()',
+        '[attr.aria-label]': 'ariaLabel',
+        '[attr.aria-labelledby]': 'ariaLabelledBy',
+        '[attr.aria-describedby]': 'combinedAriaDescribedBy()'
+    }
 })
 export class FormControlComponent implements CssClassBuilder, OnInit, OnChanges, OnDestroy, FormItemControl {
-    /**
-     *  The state of the form control - applies css classes.
-     *  Can be `success`, `error`, `warning`, `information` or blank for default.
-     */
+    /** aria-label for form-control. */
     @Input()
-    state: FormStates | null = null;
-
-    /** Type of the form control. */
-    @HostBinding('attr.type')
-    @Input()
-    type: string;
-
-    /** user's custom classes */
-    @Input()
-    class: string;
+    ariaLabelledBy: Nullable<string>;
 
     /** aria-label for form-control. */
     @Input()
     ariaLabel: Nullable<string>;
 
-    /** aria-label for form-control. */
-    @Input()
-    ariaLabelledBy: Nullable<string>;
+    /**
+     *  The state of the form control - applies css classes.
+     *  Can be `success`, `error`, `warning`, `information` or blank for default.
+     */
+    state = input<FormStates | null>(null);
+
+    /** Type of the form control. */
+    type = input<string>();
+
+    /** User's custom classes */
+    class = input<string>();
+
+    /** Default ARIA message text for the "success" value state. */
+    valueStateSuccessMessage = input<string>(inject(ValueStateAriaMessageService).success);
+
+    /** Default ARIA message text for the "information" value state. */
+    valueStateInformationMessage = input<string>(inject(ValueStateAriaMessageService).information);
+
+    /** Default ARIA message text for the "warning" value state. */
+    valueStateWarningMessage = input<string>(inject(ValueStateAriaMessageService).warning);
+
+    /** Default ARIA message text for the "error" value state. */
+    valueStateErrorMessage = input<string>(inject(ValueStateAriaMessageService).error);
+
+    /**
+     * @hidden
+     * Stores the value of the `aria-describedby` attribute set by the enclosing Form Item component.
+     */
+    formItemAriaDescribedBy = signal<Nullable<string>>(null);
+
+    /**
+     * @hidden
+     * Computes the full list of element IDs that should be referenced by `aria-describedby`.
+     *
+     * The final string may include:
+     * - The generated ID of the visually hidden span for value state messages (success, error, warning, info).
+     * - Any user-provided IDs from a native `aria-describedby` attribute.
+     * - Any user-provided IDs from a native `aria-errormessage` attribute.
+     * - Any IDs set by the parent Form Item via `formItemAriaDescribedBy`.
+     *
+     * All IDs are concatenated with spaces, and `null` is returned if none exist.
+     */
+
+    combinedAriaDescribedBy = computed(() => {
+        const userAriaDescribedByID = this._userAriaDescribedBy();
+        const userAriaErrorMessageID = this._userAriaErrorMessage();
+        const valueStateId = this.state() ? this._valueStateMessageId : null;
+
+        // Include formItemAriaDescribedBy only if no user-provided IDs exist
+        const formItemAriaDescribedById =
+            !userAriaDescribedByID && !userAriaErrorMessageID ? this.formItemAriaDescribedBy() : null;
+
+        return (
+            [valueStateId, userAriaDescribedByID, userAriaErrorMessageID, formItemAriaDescribedById]
+                .filter(Boolean)
+                .join(' ') || null
+        );
+    });
 
     /** @hidden */
-    @HostBinding('attr.aria-label')
-    private get ariaLabelBinding(): string {
-        return this.ariaLabelAttr || this.ariaLabel || '';
-    }
+    public elementRef = inject(ElementRef);
 
     /** @hidden */
-    @HostBinding('attr.aria-labelledby')
-    private get ariaLabelledByBinding(): string {
-        return this.ariaLabelledByAttr || this.ariaLabelledBy || '';
-    }
+    private contentDensityObserver = inject(ContentDensityObserver);
+
+    /** @hidden */
+    private renderer = inject(Renderer2);
 
     /** @hidden */
     private _subscriptions = new Subscription();
 
+    /**
+     * @hidden
+     * Unique ID assigned to the hidden value state message <span>,
+     * used to link it with `aria-describedby`.
+     */
+    private _valueStateMessageId = `fd-form-control-value-state-${++formControlId}`;
+
+    /**
+     * @hidden
+     * Reference to the hidden <span> element that holds the value state message for screen readers.
+     * Created dynamically when the control has a state.
+     */
+    private _valueStateSpan: HTMLElement | null = null;
+
+    /**
+     * @hidden
+     * Stores the value of the user-defined `aria-describedby` attribute (if present on the host element).
+     */
+    private _userAriaDescribedBy = signal<Nullable<string>>(null);
+
+    /**
+     * @hidden
+     * Stores the value of the user-defined `aria-errormessage` attribute (if present on the host element).
+     */
+    private _userAriaErrorMessage = signal<Nullable<string>>(null);
+
     /** @hidden */
-    constructor(
-        public elementRef: ElementRef<HTMLInputElement | HTMLTextAreaElement>,
-        _contentDensityObserver: ContentDensityObserver,
-        @Attribute('aria-label') private ariaLabelAttr: string,
-        @Attribute('aria-labelledby') private ariaLabelledByAttr: string
-    ) {
-        _contentDensityObserver.subscribe();
+    private _valueStateMessages = {
+        success: this.valueStateSuccessMessage,
+        information: this.valueStateInformationMessage,
+        warning: this.valueStateWarningMessage,
+        error: this.valueStateErrorMessage
+    } as const;
+
+    /** @hidden */
+    private _currentValueStateMessage = computed(() => {
+        const st = this.state();
+        const signalMsg = st ? this._valueStateMessages[st] : null;
+        return signalMsg ? signalMsg() : '';
+    });
+
+    /** @hidden */
+    constructor() {
+        this._subscriptions.add(this.contentDensityObserver.subscribe());
+
+        // Update the hidden span’s text whenever the value state message changes
+        effect(() => {
+            if (!this._valueStateSpan) {
+                return;
+            }
+
+            const msg = this._currentValueStateMessage();
+            this._valueStateSpan.textContent = msg ?? '';
+        });
     }
 
     /**
@@ -92,15 +184,38 @@ export class FormControlComponent implements CssClassBuilder, OnInit, OnChanges,
     buildComponentCssClass(): string[] {
         const tagName = this.elementRef.nativeElement.tagName.toLowerCase();
         return [
-            this.state ? 'is-' + this.state : '',
-            this.class,
-            tagName === 'textarea' ? 'fd-textarea' : tagName === 'input' ? 'fd-input' : ''
-        ];
+            tagName === 'textarea' ? 'fd-textarea' : tagName === 'input' ? 'fd-input' : '',
+            this.state() ? `is-${this.state()}` : '',
+            this.class()
+        ].filter(Boolean) as string[];
     }
 
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
+
+        // Capture user-defined aria-describedby (if present on host element)
+        const userAriaDescribedByValue = this.elementRef.nativeElement.getAttribute('aria-describedby');
+        if (userAriaDescribedByValue) {
+            this._userAriaDescribedBy.set(userAriaDescribedByValue);
+        }
+
+        // Capture user-defined aria-errormessage (if present on host element)
+        const userAriaErrorMessageValue = this.elementRef.nativeElement.getAttribute('aria-errormessage');
+        if (userAriaErrorMessageValue) {
+            this._userAriaErrorMessage.set(userAriaErrorMessageValue);
+        }
+
+        // If the control has a state, create a hidden <span> for the value state message
+        if (this.state()) {
+            this._valueStateSpan = this.renderer.createElement('span');
+            this.renderer.setAttribute(this._valueStateSpan, 'id', this._valueStateMessageId);
+            this.renderer.addClass(this._valueStateSpan, 'fd-value-state-message__sr-only');
+
+            // Insert hidden span right after the input/textarea
+            const parent = this.elementRef.nativeElement.parentNode;
+            this.renderer.insertBefore(parent, this._valueStateSpan, this.elementRef.nativeElement.nextSibling);
+        }
     }
 
     /** @hidden */
@@ -110,6 +225,11 @@ export class FormControlComponent implements CssClassBuilder, OnInit, OnChanges,
 
     /** @hidden */
     ngOnDestroy(): void {
+        if (this._valueStateSpan) {
+            this.renderer.removeChild(this.elementRef.nativeElement.parentNode, this._valueStateSpan);
+            this._valueStateSpan = null;
+        }
+
         this._subscriptions.unsubscribe();
     }
 }

--- a/libs/core/form/form-item-control/form-item-control.ts
+++ b/libs/core/form/form-item-control/form-item-control.ts
@@ -1,4 +1,4 @@
-import { ElementRef, InjectionToken, Provider, Type } from '@angular/core';
+import { ElementRef, InjectionToken, Provider, Type, WritableSignal } from '@angular/core';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 
 /** An injection token, that should be used with all controls, that can be put inside `fd-form-item` */
@@ -17,4 +17,5 @@ export function registerFormItemControl(control: Type<FormItemControl>): Provide
 export interface FormItemControl {
     ariaLabelledBy: Nullable<string>;
     elmRef?: ElementRef;
+    formItemAriaDescribedBy?: WritableSignal<Nullable<string>>;
 }

--- a/libs/core/form/form-item/form-item.component.scss
+++ b/libs/core/form/form-item/form-item.component.scss
@@ -21,3 +21,9 @@ $form-label-margin: 0.5rem;
         }
     }
 }
+
+/* Disable label pointer events if the same form-item contains a disabled input/textarea */
+.fd-form-item:has(input[disabled], textarea[disabled], input.is-disabled, textarea.is-disabled)
+    .fd-form-label__wrapper {
+    pointer-events: none;
+}

--- a/libs/core/form/form-item/form-item.component.ts
+++ b/libs/core/form/form-item/form-item.component.ts
@@ -2,69 +2,53 @@ import {
     AfterViewInit,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    HostBinding,
-    Input,
-    NgZone,
+    contentChild,
+    input,
     ViewEncapsulation
 } from '@angular/core';
-import { first } from 'rxjs';
 import { FORM_ITEM_CONTROL, FormItemControl } from '../form-item-control/form-item-control';
 import { FormLabelComponent } from '../form-label/form-label.component';
+import { FormMessageComponent } from '../form-message/form-message.component';
 
-/**
- * Directive to be applied to the parent of a form control.
- *
- * ```html
- * <div fd-form-item>
- *     <input fd-form-control type="text" />
- * </div>
- * ```
- */
 @Component({
-    // TODO to be discussed
     // eslint-disable-next-line @angular-eslint/component-selector
     selector: '[fd-form-item]',
     template: `<ng-content></ng-content>`,
     styleUrl: './form-item.component.scss',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: true
+    standalone: true,
+    host: {
+        class: 'fd-form-item',
+        '[class.fd-form-item--inline]': 'isInline()',
+        '[class.fd-form-item--horizontal]': 'horizontal()'
+    }
 })
 export class FormItemComponent implements AfterViewInit {
     /** Whether the form item is inline. */
-    @Input()
-    @HostBinding('class.fd-form-item--inline')
-    isInline = false;
+    isInline = input(false);
 
     /** Whether the form item is horizontal. */
-    @Input()
-    @HostBinding('class.fd-form-item--horizontal')
-    horizontal = false;
+    horizontal = input(false);
 
     /** @hidden */
-    @HostBinding('class.fd-form-item')
-    fdFormItemClass = true;
+    formLabel = contentChild(FormLabelComponent);
 
     /** @hidden */
-    @ContentChild(FormLabelComponent)
-    formLabel?: FormLabelComponent;
+    formMessage = contentChild(FormMessageComponent);
 
     /** @hidden */
-    @ContentChild(FORM_ITEM_CONTROL)
-    formItemControl?: FormItemControl;
-
-    /** @hidden */
-    constructor(private ngZone: NgZone) {}
+    formItemControl = contentChild<FormItemControl>(FORM_ITEM_CONTROL);
 
     /** @hidden */
     ngAfterViewInit(): void {
-        if (this.formLabel && this.formItemControl && !this.formItemControl.ariaLabelledBy) {
-            this.ngZone.onStable.pipe(first()).subscribe(() => {
-                if (this.formLabel && this.formItemControl) {
-                    this.formItemControl.ariaLabelledBy = this.formLabel.formLabelId;
-                }
-            });
+        if (this.formLabel() && this.formItemControl && !this.formItemControl()?.ariaLabelledBy) {
+            const formItemControl = this.formItemControl();
+
+            if (formItemControl) {
+                formItemControl.ariaLabelledBy = this.formLabel()?.id();
+                formItemControl.formItemAriaDescribedBy?.set(this.formMessage()?.id());
+            }
         }
     }
 }

--- a/libs/core/form/form-label/form-label.component.html
+++ b/libs/core/form/form-label/form-label.component.html
@@ -1,30 +1,30 @@
 <ng-template #inlineHelpRef>
     <span fd-link [undecorated]="true" class="fd-form-label__inline-help">
-        @if (inlineHelpContent) {
+        @if (inlineHelpContent()) {
             <fd-icon
                 class="fd-form-label__help"
-                [class.fd-form-label__help--after]="inlineHelpPlacement === 'after'"
-                [glyph]="inlineHelpGlyph"
-                [triggers]="inlineHelpTriggers"
-                [fd-inline-help]="inlineHelpContent"
-                [ariaLabel]="inlineHelpLabel"
-                [placement]="inlineHelpBodyPlacement"
+                [class.fd-form-label__help--after]="inlineHelpPlacement() === 'after'"
+                [glyph]="inlineHelpGlyph()"
+                [triggers]="inlineHelpTriggers()"
+                [fd-inline-help]="inlineHelpContent()"
+                [ariaLabel]="computedInlineHelpLabel()"
+                [placement]="inlineHelpBodyPlacement()"
                 tabindex="0"
             ></fd-icon>
         }
     </span>
 </ng-template>
-@if (inlineHelpPlacement === 'before' && inlineHelpContent) {
+@if (inlineHelpPlacement() === 'before' && inlineHelpContent()) {
     <ng-template [ngTemplateOutlet]="inlineHelpRef"></ng-template>
 }
 <span
     class="fd-form-label"
-    [class.fd-form-label--allow-wrap]="allowWrap"
-    [class.fd-form-label--required]="required"
-    [class.fd-form-label--colon]="colon"
+    [class.fd-form-label--allow-wrap]="allowWrap()"
+    [class.fd-form-label--required]="required()"
+    [class.fd-form-label--colon]="colon()"
 >
     <ng-content></ng-content>
 </span>
-@if (inlineHelpPlacement === 'after' && inlineHelpContent) {
+@if (inlineHelpPlacement() === 'after' && inlineHelpContent()) {
     <ng-template [ngTemplateOutlet]="inlineHelpRef"></ng-template>
 }

--- a/libs/core/form/form-label/form-label.component.scss
+++ b/libs/core/form/form-label/form-label.component.scss
@@ -27,7 +27,6 @@ $form-label-bottom-spacing: 0.125rem;
 
     &__inline-help {
         position: relative;
-        top: 0.125rem;
     }
 
     &--allow-wrap {
@@ -65,6 +64,12 @@ $form-label-bottom-spacing: 0.125rem;
                 padding-right: 0;
                 padding-left: $form-label-inline-help-placement-space;
             }
+        }
+    }
+
+    &:has(.fd-form-label__inline-help) {
+        .fd-form-label {
+            margin-inline-end: 0;
         }
     }
 }

--- a/libs/core/form/form-label/form-label.component.ts
+++ b/libs/core/form/form-label/form-label.component.ts
@@ -1,13 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import {
-    ChangeDetectionStrategy,
-    Component,
-    HostBinding,
-    Input,
-    OnChanges,
-    TemplateRef,
-    ViewEncapsulation
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { InlineHelpDirective } from '@fundamental-ngx/core/inline-help';
@@ -34,39 +26,40 @@ let formLabelIdCount = 0;
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
+    host: {
+        '[attr.id]': 'id()',
+        class: 'fd-form-label__wrapper',
+        '[class.fd-form-label__wrapper--align-end]': 'alignLabelEnd()',
+        '[class.fd-form-label__wrapper--inline-help]': '!!inlineHelpContent()',
+        '[class.fd-form-label__wrapper--inline-help--after]':
+            '!!inlineHelpContent() && inlineHelpPlacement() === "after"'
+    },
     imports: [LinkComponent, IconComponent, InlineHelpDirective, NgTemplateOutlet]
 })
-export class FormLabelComponent implements OnChanges {
+export class FormLabelComponent {
     /** Whether form is required. */
-    @Input()
-    required = false;
+    required = input(false);
 
     /** Whether label text should be appended with colon. */
-    @Input()
-    colon = false;
+    colon = input(false);
 
     /** Align label on end. */
-    @Input()
-    @HostBinding('class.fd-form-label__wrapper--align-end')
-    alignLabelEnd = false;
+    alignLabelEnd = input(false);
 
     /** Inline help content. Could be just a string or complex template */
-    @Input()
-    inlineHelpContent: Nullable<string | TemplateRef<any>> = null;
+    inlineHelpContent = input<string | TemplateRef<any>>('');
 
     /** Glyph of icon triggering inline help. */
-    @Input()
-    inlineHelpGlyph = 'question-mark';
+    inlineHelpGlyph = input('question-mark');
 
     /** Trigger event names for the inline help. */
-    @Input()
-    inlineHelpTriggers: (string | TriggerConfig)[] = [
+    inlineHelpTriggers = input<(string | TriggerConfig)[]>([
         'mouseenter',
         'mouseleave',
         'focusin',
         'focusout',
         { trigger: 'click', openAction: true, closeAction: true }
-    ];
+    ]);
 
     /**
      * The placement of the inline help.
@@ -74,61 +67,31 @@ export class FormLabelComponent implements OnChanges {
      * top, top-start, top-end, bottom, bottom-start, bottom-end,
      * right, right-start, right-end, left, left-start, left-end.
      */
-    @Input()
-    inlineHelpBodyPlacement: Placement;
+    inlineHelpBodyPlacement = input<Placement>('bottom-start');
 
     /** If inline help trigger icon should be placed after, or before text. */
-    @Input()
-    inlineHelpPlacement: InlineHelpFormPlacement = 'after';
+    inlineHelpPlacement = input<InlineHelpFormPlacement>('after');
 
     /** Whether to allow the text of the form label to wrap. */
-    @Input()
-    allowWrap = false;
+    allowWrap = input(false);
 
-    /** Inline help label. */
-    @Input()
-    set inlineHelpLabel(label: string) {
-        this._inlineHelpLabel = label;
+    /** ID of the label. A default value is provided if not set. */
+    id = input(`fd-form-label-${++formLabelIdCount}`);
+
+    /** Inline help label */
+    inlineHelpLabel = input<Nullable<string>>(null);
+
+    get inlineHelpContentValue(): string | TemplateRef<any> {
+        return this.inlineHelpContent();
     }
-    get inlineHelpLabel(): string {
-        if (this._inlineHelpLabel) {
-            return this._inlineHelpLabel;
+
+    /** Computed inline help label */
+    computedInlineHelpLabel = computed(() => {
+        const label = this.inlineHelpLabel();
+        if (label) {
+            return label;
         }
-        return typeof this.inlineHelpContent === 'string' ? this.inlineHelpContent : '';
-    }
-
-    /** @hidden */
-    @HostBinding('class.fd-form-label__wrapper')
-    defaultClass = true;
-
-    /** @hidden */
-    @HostBinding('class.fd-form-label__wrapper--inline-help')
-    inlineHelpClass = true;
-
-    /** @hidden */
-    @HostBinding('class.fd-form-label__wrapper--inline-help--after')
-    inlineHelpAfter = true;
-
-    /** @hidden */
-    // eslint-disable-next-line @angular-eslint/no-input-rename
-    @Input('id')
-    @HostBinding('id')
-    set formLabelId(value: Nullable<string>) {
-        this._formLabelId = value || this._formLabelId;
-    }
-    get formLabelId(): string {
-        return this._formLabelId;
-    }
-
-    /** @hidden */
-    private _formLabelId = `fd-form-label-${++formLabelIdCount}`;
-
-    /** @hidden */
-    private _inlineHelpLabel?: string;
-
-    /** @hidden */
-    ngOnChanges(): void {
-        this.inlineHelpClass = !!this.inlineHelpContent;
-        this.inlineHelpAfter = !!this.inlineHelpContent && this.inlineHelpPlacement === 'after';
-    }
+        const content = this.inlineHelpContent();
+        return typeof content === 'string' ? content : '';
+    });
 }

--- a/libs/core/form/form-message/form-message.component.scss
+++ b/libs/core/form/form-message/form-message.component.scss
@@ -1,1 +1,15 @@
 @import 'fundamental-styles/dist/form-message.css';
+
+.fd-form-message__sr-only {
+    position: absolute;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    width: 1px;
+    border: 0;
+    margin-inline: -1px;
+    margin-block: -1px;
+    padding-inline: 0;
+    padding-block: 0;
+    overflow: hidden;
+    white-space: nowrap;
+}

--- a/libs/core/form/form-message/form-message.component.ts
+++ b/libs/core/form/form-message/form-message.component.ts
@@ -10,15 +10,13 @@ import {
 } from '@angular/core';
 import { FormStates } from '@fundamental-ngx/cdk/forms';
 import { applyCssClass, CssClassBuilder, DynamicComponentService } from '@fundamental-ngx/cdk/utils';
-import { ValueStateAriaMessageService } from '@fundamental-ngx/core/shared';
 import { CSS_CLASS_NAME, getTypeClassName } from './constants';
 
 let formMessageId = 0;
 
 @Component({
     selector: 'fd-form-message',
-    template: `<span class="fd-form-message__sr-only"> {{ valueStateMessages[type()]?.() }} </span
-        ><ng-content></ng-content>`,
+    template: `<ng-content></ng-content>`,
     styleUrl: './form-message.component.scss',
     host: {
         'aria-live': 'assertive',
@@ -46,37 +44,9 @@ export class FormMessageComponent implements CssClassBuilder, OnInit, OnChanges 
     /** User's custom classes */
     class = input<string>();
 
-    /**
-     * Value state "success" message.
-     */
-    valueStateSuccessMessage = input<string>(inject(ValueStateAriaMessageService).success);
-
-    /**
-     * Value state "information" message.
-     */
-    valueStateInformationMessage = input<string>(inject(ValueStateAriaMessageService).information);
-
-    /**
-     * Value state "warning" message.
-     */
-    valueStateWarningMessage = input<string>(inject(ValueStateAriaMessageService).warning);
-
-    /**
-     * Value state "error" message.
-     */
-    valueStateErrorMessage = input<string>(inject(ValueStateAriaMessageService).error);
-
     /** Form Message Text ID
      *  Default value is provided if not set  */
-    id = input('fd-form-message-' + ++formMessageId);
-
-    /** @hidden */
-    valueStateMessages = {
-        success: this.valueStateSuccessMessage,
-        information: this.valueStateInformationMessage,
-        warning: this.valueStateWarningMessage,
-        error: this.valueStateErrorMessage
-    } as const;
+    id = input(`fd-form-message-${++formMessageId}`);
 
     /** @hidden */
     elementRef: ElementRef<HTMLElement> = inject(ElementRef);

--- a/libs/core/illustrated-message/components/illustrated-message-section/illustrated-message-section.component.spec.ts
+++ b/libs/core/illustrated-message/components/illustrated-message-section/illustrated-message-section.component.spec.ts
@@ -4,14 +4,11 @@ import { IllustratedMessageSectionComponent } from './illustrated-message-sectio
 
 // Mock component for testing
 @Component({
-    template: `
-        <section fd-illustrated-message-section [responsive]="responsive">Test content</section>
-    `,
+    template: ` <section fd-illustrated-message-section [responsive]="responsive">Test content</section> `,
     standalone: true,
     imports: [IllustratedMessageSectionComponent]
 })
 class TestIllustratedMessageSectionComponent {
-    
     @ViewChild(IllustratedMessageSectionComponent, { static: true, read: ElementRef })
     illustratedMessageSectionElementRef: ElementRef;
 
@@ -39,6 +36,10 @@ describe('IllustratedMessageSectionComponent', () => {
     it('Should have assigned class when responsive is set to true', () => {
         testComponent.responsive = true;
         fixture.detectChanges();
-        expect(illustratedMessageSectionElementRef.nativeElement.classList.contains('fd-illustrated-message-responsive-container')).toBe(true);
+        expect(
+            illustratedMessageSectionElementRef.nativeElement.classList.contains(
+                'fd-illustrated-message-responsive-container'
+            )
+        ).toBe(true);
     });
 });

--- a/libs/core/quick-view/quick-view-group-item-label/quick-view-group-item-label.component.spec.ts
+++ b/libs/core/quick-view/quick-view-group-item-label/quick-view-group-item-label.component.spec.ts
@@ -35,7 +35,5 @@ describe('QuickViewGroupItemLabelComponent', () => {
         const quickViewContainer = fixture.debugElement.query(By.css('label[fd-form-label]'));
 
         expect(quickViewContainer.nativeElement.classList).toContain('fd-form-label__wrapper');
-        expect(quickViewContainer.nativeElement.classList).toContain('fd-form-label__wrapper--inline-help');
-        expect(quickViewContainer.nativeElement.classList).toContain('fd-form-label__wrapper--inline-help--after');
     });
 });

--- a/libs/docs/core/input/examples/input-state-example.component.html
+++ b/libs/docs/core/input/examples/input-state-example.component.html
@@ -1,19 +1,9 @@
 <div fd-form-item>
     <label fd-form-label for="input-52"> Valid(Success) Input </label>
-    <fd-form-input-message-group>
-        <input
-            fd-form-control
-            type="text"
-            id="input-52"
-            placeholder="Field placeholder text"
-            state="success"
-            aria-describedby="input-state-form-message-52"
-        />
-        <fd-form-message type="success" id="input-state-form-message-52">
-            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
-        </fd-form-message>
-    </fd-form-input-message-group>
+    <input fd-form-control type="text" id="input-52" placeholder="Field placeholder text" state="success" />
 </div>
+
+<br /><br />
 
 <div fd-form-item>
     <label fd-form-label for="input-53"> Invalid(Error) Input - Message appears on hover </label>
@@ -28,10 +18,12 @@
             aria-errormessage="input-state-form-message-53"
         />
         <fd-form-message type="error" id="input-state-form-message-53">
-            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+            Username must be at least 6 characters.
         </fd-form-message>
     </fd-form-input-message-group>
 </div>
+
+<br /><br />
 
 <div fd-form-item>
     <label fd-form-label for="input-54"> Warning Input - Example of message triggered only on focus/blur </label>
@@ -49,10 +41,12 @@
             aria-describedby="input-state-form-message-54"
         />
         <fd-form-message type="warning" id="input-state-form-message-54">
-            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+            Make sure this is easy for you to remember.
         </fd-form-message>
     </fd-form-input-message-group>
 </div>
+
+<br /><br />
 
 <div fd-form-item>
     <label fd-form-label for="input-55"> Information Input </label>
@@ -63,18 +57,21 @@
             id="input-55"
             placeholder="Field placeholder text"
             state="information"
-            aria-describedby="input-state-form-message-55"
+            valueStateInformationMessage="Custom Value State Information Message"
         />
-        <fd-form-message type="information" id="input-state-form-message-55">
-            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
-        </fd-form-message>
+        <fd-form-message type="information"> You can leave this blank if not applicable. </fd-form-message>
     </fd-form-input-message-group>
 </div>
+
+<br /><br />
 
 <div fd-form-item>
     <label fd-form-label for="input-56"> Disabled Input </label>
     <input fd-form-control type="text" id="input-56" placeholder="Field placeholder text" disabled />
 </div>
+
+<br /><br />
+
 <div fd-form-item>
     <label fd-form-label for="input-57"> Readonly Input </label>
     <input fd-form-control type="text" id="input-57" placeholder="Field placeholder text" readonly />

--- a/libs/docs/core/textarea/examples/textarea-state-example.component.html
+++ b/libs/docs/core/textarea/examples/textarea-state-example.component.html
@@ -1,74 +1,84 @@
 <div fd-form-item>
-    <label fd-form-label [colon]="true" for="textarea-52">Textarea State: Success</label>
+    <label fd-form-label for="textarea-52">Customer Feedback</label>
     <fd-form-input-message-group>
         <textarea
             fd-form-control
             id="textarea-52"
-            placeholder="Field placeholder text"
+            placeholder="Share your experience with our service"
             state="success"
             aria-describedby="form-message-52"
         ></textarea>
         <fd-form-message type="success" id="form-message-52">
-            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+            Thank you! Your feedback has been saved successfully.
         </fd-form-message>
     </fd-form-input-message-group>
 </div>
 
+<br /><br /><br />
+
 <div fd-form-item>
-    <label fd-form-label [colon]="true" for="textarea-53">Textarea State: Error</label>
+    <label fd-form-label for="textarea-53">Billing Address</label>
     <fd-form-input-message-group>
         <textarea
             fd-form-control
             id="textarea-53"
-            aria-errormessage="form-message-53"
+            aria-describedby="form-message-53"
             aria-invalid="true"
-            placeholder="Field placeholder text"
+            placeholder="Enter your full billing address"
             state="error"
         ></textarea>
         <fd-form-message type="error" id="form-message-53">
-            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+            Address is required. Please provide your billing details.
         </fd-form-message>
     </fd-form-input-message-group>
 </div>
 
+<br /><br /><br />
+
 <div fd-form-item>
-    <label fd-form-label [colon]="true" for="textarea-54">Textarea State: Warning</label>
+    <label fd-form-label for="textarea-54">Delivery Instructions</label>
     <fd-form-input-message-group>
         <textarea
             fd-form-control
             id="textarea-54"
-            placeholder="Field placeholder text"
+            placeholder="Add optional notes for the delivery driver"
             state="warning"
             aria-describedby="form-message-54"
         ></textarea>
         <fd-form-message type="warning" id="form-message-54">
-            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+            Keep instructions under 250 characters to avoid truncation.
         </fd-form-message>
     </fd-form-input-message-group>
 </div>
 
+<br /><br /><br />
+
 <div fd-form-item>
-    <label fd-form-label [colon]="true" for="textarea-55">Textarea State: Information</label>
+    <label fd-form-label for="textarea-55">Support Request</label>
     <fd-form-input-message-group>
         <textarea
             fd-form-control
             id="textarea-55"
-            placeholder="Field placeholder text"
+            placeholder="Describe the issue you are experiencing"
             state="information"
             aria-describedby="form-message-55"
         ></textarea>
         <fd-form-message type="information" id="form-message-55">
-            Pellentesque metus lacus commodo eget justo ut rutrum varius nunc
+            Your request will be reviewed by our support team within 24 hours.
         </fd-form-message>
     </fd-form-input-message-group>
 </div>
 
+<br /><br /><br />
+
 <div fd-form-item>
-    <label fd-form-label [colon]="true" for="textarea-56">Textarea State: Disabled</label>
+    <label fd-form-label for="textarea-56">Textarea State: Disabled</label>
     <textarea fd-form-control id="textarea-56" placeholder="Field placeholder text" disabled></textarea>
 </div>
 
+<br /><br /><br />
+
 <div fd-form-item>
-    <label fd-form-label [colon]="true" for="textarea-57">Textarea State: Readonly</label>
+    <label fd-form-label for="textarea-57">Textarea State: Readonly</label>
     <textarea fd-form-control id="textarea-57" placeholder="Field placeholder text" readonly></textarea>
 </div>


### PR DESCRIPTION
## Related Issue(s)

part of https://github.com/SAP/fundamental-ngx/issues/13490

## Description
This changes concern ONLY textarea and input with directive `fd-form-control` (input[fd-form-control], textarea[fd-form-control])
Combobox, DatePicker, etc. belong to Input Group and there the logic for handling states will be different. 