### PR TITLE
fix(core): update Avatar

### DIFF
--- a/libs/core/avatar/avatar.component.html
+++ b/libs/core/avatar/avatar.component.html
@@ -1,21 +1,21 @@
-@if (abbreviate) {
-    {{ abbreviate }}
+@if (abbreviate()) {
+    {{ abbreviate() }}
 }
-@if (zoomGlyph || valueState) {
+@if (zoomGlyph() || valueState()) {
     <i
         role="presentation"
         class="fd-avatar__zoom-icon"
-        [class]="valueState | fdAvatarIcon: zoomGlyph"
+        [class]="valueState() | fdAvatarIcon: zoomGlyph()"
         (mousedown)="zoomClicked($event)"
     >
     </i>
 }
-@if (glyph || showDefault) {
+@if (glyph() || showDefault()) {
     <fd-icon
         class="fd-avatar__icon"
         role="presentation"
-        [font]="font"
-        [glyph]="glyph || 'person-placeholder'"
+        [font]="font()"
+        [glyph]="glyph() || 'person-placeholder'"
     ></fd-icon>
 }
 <div #content [style.display]="'none'">

--- a/libs/core/avatar/avatar.component.spec.ts
+++ b/libs/core/avatar/avatar.component.spec.ts
@@ -180,11 +180,11 @@ describe('AvatarComponent', () => {
         component.label = 'Jane Doe';
         fixture.detectChanges();
         await fixture.whenRenderingDone();
-        expect(component.avatarComponent.abbreviate).toEqual('JD');
+        expect(component.avatarComponent.abbreviate()).toEqual('JD');
 
         component.label = 'Marjolein van Veen';
         fixture.detectChanges();
-        expect(component.avatarComponent.abbreviate).toEqual('MvV');
+        expect(component.avatarComponent.abbreviate()).toEqual('MvV');
     });
 
     it('should add respective Value State Icons', () => {

--- a/libs/core/avatar/avatar.component.ts
+++ b/libs/core/avatar/avatar.component.ts
@@ -1,30 +1,36 @@
 import {
     Attribute,
+    booleanAttribute,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    computed,
+    DestroyRef,
+    effect,
     ElementRef,
-    EventEmitter,
-    HostBinding,
     HostListener,
-    Input,
+    inject,
+    input,
     OnChanges,
     OnInit,
-    Output,
+    output,
     Renderer2,
-    ViewChild,
+    signal,
+    viewChild,
     ViewEncapsulation
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
     ANY_LANGUAGE_LETTERS_REGEX,
+    applyCssClass,
     ColorAccent,
     CssClassBuilder,
+    getRandomColorAccent,
     Nullable,
-    Size,
-    applyCssClass,
-    getRandomColorAccent
+    Size
 } from '@fundamental-ngx/cdk/utils';
 import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent } from '@fundamental-ngx/core/icon';
+import { FD_LANGUAGE, FdLanguage, TranslationResolver } from '@fundamental-ngx/i18n';
 import { AvatarIconPipe } from './avatar-icon.pipe';
 import { AvatarValueStates } from './avatar-value-states.type';
 import { FD_AVATAR_COMPONENT } from './tokens';
@@ -53,183 +59,179 @@ export type IndicationColor = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
         }
     ],
     host: {
-        '[attr.tabindex]': '_tabindex'
+        '[attr.id]': 'id()',
+        '[attr.alt]': 'alt()',
+        '[attr.tabindex]': 'tabindex()',
+        '[attr.role]': 'zoomGlyph() ? "button" : "img"',
+        '[attr.aria-label]': 'computedAriaLabel()',
+        '[attr.aria-labelledby]': 'ariaLabelledby()'
     },
     imports: [AvatarIconPipe, IconComponent]
 })
 export class AvatarComponent implements OnChanges, OnInit, CssClassBuilder, OnChanges {
     /** User's custom classes */
-    @Input()
-    class: string;
+    readonly class = input<string>();
 
     /** Id of the Avatar. */
-    @Input()
-    @HostBinding('attr.id')
-    id = `fd-avatar-${avatarUniqueId++}`;
+    readonly id = input(`fd-avatar-${++avatarUniqueId}`);
+
+    /** Alt attr for Avatar. */
+    readonly alt = input<Nullable<string>>(null);
 
     /** Aria-label for Avatar. */
-    @Input()
-    @HostBinding('attr.aria-label')
-    @HostBinding('attr.alt')
-    ariaLabel: Nullable<string> = null;
+    readonly ariaLabel = input<Nullable<string>>(null);
 
     /** Aria-Labelledby for element describing Avatar. */
-    @Input()
-    @HostBinding('attr.aria-labelledby')
-    ariaLabelledby: Nullable<string> = null;
+    readonly ariaLabelledby = input<Nullable<string>>(null);
 
     /** Localized text for label */
-    @Input()
-    set label(value: Nullable<string>) {
-        this.ariaLabel = value || null;
-        this.abbreviate = this._getAbbreviate(value);
-    }
+    readonly label = input<Nullable<string>>(null);
 
     /** The size of the Avatar. Options include: *xs*, *s*, *m*, *l* and *xl*. */
-    @Input() size: Size = 'l';
+    readonly size = input<Size>('l');
 
     /** Font family of the icon. */
-    @Input()
-    font: IconComponent['font'] = FD_DEFAULT_ICON_FONT_FAMILY;
+    readonly font = input<IconComponent['font']>(FD_DEFAULT_ICON_FONT_FAMILY);
 
     /** The glyph name. */
-    @Input() glyph: Nullable<string> = null;
+    readonly glyph = input<Nullable<string>>(null);
 
     /** The glyph name for zoom icon. */
-    @Input() zoomGlyph: Nullable<string> = null;
+    readonly zoomGlyph = input<Nullable<string>>(null);
 
     /** Whether to apply a circle style to the Avatar. */
-    @Input() circle = false;
+    readonly circle = input(false, { transform: booleanAttribute });
 
     /** Whether the Avatar should be interactive. */
-    @Input() interactive = false;
+    readonly interactive = input(false, { transform: booleanAttribute });
 
     /** Whether to apply a transparent style to the Avatar. */
-    @Input() transparent = false;
+    readonly transparent = input(false, { transform: booleanAttribute });
 
     /** Whether to apply background size contain style to the Avatar */
-    @Input() contain = false;
+    readonly contain = input(false, { transform: booleanAttribute });
 
     /** Whether to apply a placeholder background style to the Avatar. */
-    @Input() placeholder = false;
+    readonly placeholder = input(false, { transform: booleanAttribute });
 
     /** Whether to apply a tile background style to the Avatar. */
-    @Input() tile = false;
+    readonly tile = input(false, { transform: booleanAttribute });
 
     /** Whether to apply a border to the Avatar. */
-    @Input() border = false;
+    readonly border = input(false, { transform: booleanAttribute });
 
     /** A number from 1 to 10 representing the background color of the Avatar.
      * This property will override the colorIndication property.
      */
-    @Input() colorAccent: Nullable<ColorAccent> = null;
+    readonly colorAccent = input<Nullable<ColorAccent>>(null);
 
     /** A number from 1 to 10 representing the background color of the Avatar using the Indication Colors. */
-    @Input() colorIndication: Nullable<IndicationColor> = null;
+    readonly colorIndication = input<Nullable<IndicationColor>>(null);
 
     /** Whether to apply random background color to the Avatar. */
-    @Input() random = false;
+    readonly random = input(false, { transform: booleanAttribute });
 
     /** Whether component should be focusable & clicable */
-    @Input() clickable = false;
+    readonly clickable = input(false, { transform: booleanAttribute });
 
     /** Value state of the Avatar. */
-    @Input()
-    valueState: Nullable<AvatarValueStates>;
+    readonly valueState = input<Nullable<AvatarValueStates>>(null);
 
     /** Background image resource: url or base64. */
-    @Input()
-    set image(value: Nullable<string>) {
-        this._setImage(value);
-    }
-    get image(): Nullable<string> {
-        return this._image;
-    }
+    readonly image = input<Nullable<string>>(null);
 
     /** Backup options to use when image hasn't been loaded successfully.
      * Options separated with "|" symbol.
      * Possible options: content, alt, backup, default-icon
      */
-    @Input()
-    set alterIcon(value: Nullable<string>) {
-        this._alterIcon = value;
-    }
-    get alterIcon(): Nullable<string> {
-        return this._alterIcon;
-    }
+    readonly alterIcon = input<Nullable<string>>(null);
 
     /** Backup image to load when image hasn't been loaded successfully.
      * Only applicable when using alterIcon input property.
      */
-    @Input()
-    set backupImage(value: Nullable<string>) {
-        this._backupImage = value;
-    }
-    get backupImage(): Nullable<string> {
-        return this._backupImage;
-    }
+    readonly backupImage = input<Nullable<string>>(null);
 
     /** Event emitted when avatar clicked. Only fires if clickable input property set to true. */
-    @Output() avatarClicked = new EventEmitter<Event>();
+    readonly avatarClicked = output<Event>();
 
     /** Event emitted when zoom icon clicked. Only fires if zoomGlyph input property is set. */
-    @Output() zoomGlyphClicked = new EventEmitter<void>();
-
-    /**
-     * @hidden
-     */
-    set bgImage(image: Nullable<string>) {
-        this._bgImage = image;
-
-        this._renderer.setStyle(this.elementRef.nativeElement, 'background-image', image);
-    }
-
-    get bgImage(): Nullable<string> {
-        return this._bgImage;
-    }
+    readonly zoomGlyphClicked = output<void>();
 
     /** @hidden */
-    @HostBinding('attr.role')
-    get role(): string {
-        return this.zoomGlyph ? 'button' : 'img';
-    }
+    readonly abbreviate = signal<string | null>(null);
+
+    /** If a default placeholder should be displayed */
+    protected showDefault = computed(() => !this.abbreviate() && !this._image() && !this.glyph());
 
     /** @hidden */
-    @ViewChild('content')
-    set content(value: ElementRef) {
-        this._content = value;
-    }
+    protected computedAriaLabel = computed(() => {
+        const ariaLabel = this.ariaLabel(); // user defined aria-label
+        const label = this.label(); // user defined label
+        const alt = this.alt(); // user defined alt attr
+        const defaultLabel = this._defaultAriaLabel(); // default label
+
+        if (ariaLabel) {
+            // If user explicitly sets ariaLabel, use it as-is
+            return ariaLabel;
+        }
+
+        if (label) {
+            // If user provides label, prepend the default aria-label ('Avatar')
+            return `${defaultLabel ?? ''} ${label}`.trim();
+        }
+
+        if (alt) {
+            // If user provides alt, prepend the default aria-label ('Avatar')
+            return `${defaultLabel ?? ''} ${alt}`.trim();
+        }
+
+        // Otherwise fallback to default label only
+        return defaultLabel;
+    });
 
     /** @hidden */
-    abbreviate: Nullable<string> = null;
-
-    /** @hidden */
-    private _image: Nullable<string> = null;
-
-    /** @hidden */
-    private _alterIcon: Nullable<string> = null;
-
-    /** @hidden */
-    private _content: Nullable<ElementRef> = null;
-
-    /** @hidden */
-    private _backupImage: Nullable<string> = null;
-
-    /** @hidden */
-    private _bgImage: Nullable<string> = null;
-
-    /** @hidden */
-    get _tabindex(): number | null {
+    protected tabindex = computed((): number | null => {
         if (this.hostTabindex != null) {
             return this.hostTabindex;
         }
-        return this.clickable ? 0 : null;
-    }
+        return this._clickable() ? 0 : null;
+    });
 
-    /** If a default placeholder should be displayed */
-    get showDefault(): boolean {
-        return !this.abbreviate && !this._image && !this.glyph;
-    }
+    /** @hidden */
+    private _contentRef = viewChild<ElementRef>('content');
+
+    /** @hidden */
+    private _glyph = signal<Nullable<string>>(null);
+
+    /** @hidden */
+    private _clickable = signal<Nullable<boolean>>(null);
+
+    /** @hidden */
+    private _image = signal<Nullable<string>>(null);
+
+    /** @hidden */
+    private _alterIcon = signal<Nullable<string>>(null);
+
+    /** @hidden */
+    private _content = signal<Nullable<ElementRef>>(null);
+
+    /** @hidden */
+    private _backupImage = signal<Nullable<string>>(null);
+
+    /** @hidden */
+    private _bgImage = signal<Nullable<string>>(null);
+
+    /** @hidden */
+    private _defaultAriaLabel = signal<Nullable<string>>(null);
+
+    /** @hidden */
+    private readonly _destroyRef = inject(DestroyRef);
+
+    /** @hidden */
+    private readonly _lang$ = inject(FD_LANGUAGE);
+
+    /** @hidden */
+    private _translationResolver = new TranslationResolver();
 
     /** @hidden */
     constructor(
@@ -237,7 +239,18 @@ export class AvatarComponent implements OnChanges, OnInit, CssClassBuilder, OnCh
         private readonly _cdr: ChangeDetectorRef,
         private readonly _renderer: Renderer2,
         @Attribute('tabindex') private hostTabindex: number | null
-    ) {}
+    ) {
+        effect(() => {
+            this._glyph.set(this.glyph());
+            this._clickable.set(this.clickable());
+            this._alterIcon.set(this.alterIcon());
+            this._backupImage.set(this.backupImage());
+            this._content.set(this._contentRef());
+            this._setImage(this.image());
+            this._renderer.setStyle(this.elementRef.nativeElement, 'background-image', this._bgImage());
+            this.abbreviate.set(this._getAbbreviate(this.label()));
+        });
+    }
 
     /** @hidden
      * CssClassBuilder interface implementation
@@ -248,21 +261,21 @@ export class AvatarComponent implements OnChanges, OnInit, CssClassBuilder, OnCh
     buildComponentCssClass(): string[] {
         return [
             'fd-avatar',
-            this.size ? `fd-avatar--${this.size}` : '',
-            this.colorAccent && !this.random ? `fd-avatar--accent-color-${this.colorAccent}` : '',
-            this.random ? `fd-avatar--accent-color-${getRandomColorAccent()}` : '',
-            this.colorIndication && this.colorAccent === null && !this.random
-                ? `fd-avatar--indication-color-${this.colorIndication}`
+            this.size() ? `fd-avatar--${this.size()}` : '',
+            this.colorAccent() && !this.random() ? `fd-avatar--accent-color-${this.colorAccent()}` : '',
+            this.random() ? `fd-avatar--accent-color-${getRandomColorAccent()}` : '',
+            this.colorIndication() && this.colorAccent() === null && !this.random()
+                ? `fd-avatar--indication-color-${this.colorIndication()}`
                 : '',
-            this.circle ? 'fd-avatar--circle' : '',
-            this.border ? 'fd-avatar--border' : '',
-            this.interactive ? 'fd-avatar--interactive' : '',
-            this.transparent ? 'fd-avatar--transparent' : '',
-            this.contain ? 'fd-avatar--background-contain' : '',
-            this.placeholder ? 'fd-avatar--placeholder' : '',
-            this.tile ? 'fd-avatar--tile' : '',
-            this.class
-        ];
+            this.circle() ? 'fd-avatar--circle' : '',
+            this.border() ? 'fd-avatar--border' : '',
+            this.interactive() ? 'fd-avatar--interactive' : '',
+            this.transparent() ? 'fd-avatar--transparent' : '',
+            this.contain() ? 'fd-avatar--background-contain' : '',
+            this.placeholder() ? 'fd-avatar--placeholder' : '',
+            this.tile() ? 'fd-avatar--tile' : '',
+            this.class()
+        ].filter(Boolean) as string[];
     }
 
     /** @hidden */
@@ -270,39 +283,42 @@ export class AvatarComponent implements OnChanges, OnInit, CssClassBuilder, OnCh
     @HostListener('keydown.enter', ['$event'])
     @HostListener('keydown.space', ['$event'])
     _onClick(event: Event): void {
-        if (!this.clickable) {
+        if (!this._clickable()) {
             return;
         }
         event.preventDefault();
         this.avatarClicked.emit(event);
-        if (this.zoomGlyph) {
-            this.zoomGlyphClicked.next();
+        if (this.zoomGlyph()) {
+            this.zoomGlyphClicked.emit();
         }
     }
 
     /** @hidden */
     ngOnInit(): void {
         this.buildComponentCssClass();
+        this._lang$.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((lang: FdLanguage) => {
+            this._defaultAriaLabel.set(this._translationResolver.resolve(lang, 'coreAvatar.defaultLabel'));
+        });
     }
 
     /** @hidden */
     ngOnChanges(): void {
-        if (this.zoomGlyph) {
-            this.clickable = true;
+        if (this.zoomGlyph()) {
+            this._clickable.set(true);
         }
         this.buildComponentCssClass();
     }
 
     /** @hidden */
-    zoomClicked(event: Event): void {
+    protected zoomClicked(event: Event): void {
         event.preventDefault();
         this.elementRef.nativeElement.focus();
-        this.zoomGlyphClicked.next();
+        this.zoomGlyphClicked.emit();
     }
 
     /** @hidden Get an abbreviate from the label or return null if not fit requirements */
     private _getAbbreviate(label: Nullable<string>): string | null {
-        if (!label || this._image) {
+        if (!label || this._image()) {
             return null;
         }
 
@@ -327,97 +343,94 @@ export class AvatarComponent implements OnChanges, OnInit, CssClassBuilder, OnCh
 
     /** @hidden */
     private _setImage(value: Nullable<string>): void {
-        this._image = value;
+        this._image.set(value);
 
         if (value) {
             this._verifyImageUrl(value, (): void => {}, this._onErrorCallback);
         } else {
-            this.bgImage = null;
+            this._bgImage.set(null);
         }
     }
 
     /** @hidden */
     private _verifyImageUrl(srcValue: string, onLoadCallback: () => void, onErrorCallback: () => void): void {
-        // Don't load the same image all the time check happens
-        if (srcValue === this.bgImage) {
+        if (srcValue === this._bgImage()) {
             return;
         }
         const img = new Image();
-        img.onload = onLoadCallback.bind(this);
+        img.onload = () => {
+            this._assignBgImage(srcValue);
+            onLoadCallback.call(this);
+        };
         img.onerror = onErrorCallback.bind(this);
         img.src = srcValue;
-        this._assignBgImage(srcValue);
     }
 
     /** @hidden */
     private _assignBgImage(srcValue: Nullable<string>): void {
-        this.bgImage = srcValue ? `url(${srcValue})` : null;
+        this._bgImage.set(srcValue ? `url(${srcValue})` : null);
     }
 
     /** @hidden */
     private _onErrorCallback(): void {
-        if (!this._alterIcon) {
+        if (!this._alterIcon()) {
             this._showDefaultIcon();
             return;
         }
 
-        const options = this._alterIcon.split('|');
-        for (let i = 0; i < options.length; i++) {
-            const option = options[i];
+        const options = this._alterIcon()?.split('|');
 
-            if (option === ALTER_ICON_OPTIONS.CONTENT) {
-                const contentValue = this._content?.nativeElement.textContent;
-                if (contentValue) {
-                    this.abbreviate = this._generateAbbreviation(contentValue);
+        if (options) {
+            for (let i = 0; i < options.length; i++) {
+                const option = options[i];
+
+                if (option === ALTER_ICON_OPTIONS.CONTENT) {
+                    const contentValue = this._content()?.nativeElement.textContent;
+                    if (contentValue) {
+                        this.abbreviate.set(this._generateAbbreviation(contentValue));
+                        break;
+                    }
+
+                    continue;
+                }
+
+                if (option === ALTER_ICON_OPTIONS.ALT) {
+                    if (this.alt()) {
+                        this.abbreviate.set(this._generateAbbreviation(this.alt()));
+                        break;
+                    }
+
+                    continue;
+                }
+
+                if (option === ALTER_ICON_OPTIONS.BACKUP) {
+                    const backup = this._backupImage();
+                    if (backup && backup !== '') {
+                        this._verifyImageUrl(
+                            backup,
+                            () => this._assignBgImage(backup),
+                            () => this._showDefaultIcon()
+                        );
+                        break;
+                    }
+                    continue;
+                }
+
+                if (option === ALTER_ICON_OPTIONS.DEFAULT_ICON) {
+                    this._showDefaultIcon();
                     break;
                 }
 
-                continue;
-            }
-
-            if (option === ALTER_ICON_OPTIONS.ALT) {
-                const altValue = this.elementRef.nativeElement.getAttribute('alt');
-                if (altValue) {
-                    this.abbreviate = this._generateAbbreviation(altValue);
-                    break;
-                }
-
-                continue;
-            }
-
-            if (option === ALTER_ICON_OPTIONS.BACKUP) {
-                if (this._backupImage && this._backupImage !== '') {
-                    // Check if backupImage can be loaded successfully
-                    // If not, set default user icon
-                    this._verifyImageUrl(
-                        this._backupImage,
-                        () => {
-                            this._assignBgImage(this._backupImage);
-                        },
-                        () => {
-                            this._showDefaultIcon();
-                        }
-                    );
-                    break;
-                }
-
-                continue;
-            }
-
-            if (option === ALTER_ICON_OPTIONS.DEFAULT_ICON) {
                 this._showDefaultIcon();
-                break;
             }
-
-            this._showDefaultIcon();
         }
     }
 
     /** @hidden */
     private _showDefaultIcon(): void {
-        this.abbreviate = null;
-        this._image = null;
-        this.glyph = null;
+        this.abbreviate.set(null);
+        this._image.set(null);
+        this._glyph.set(null);
         this._cdr.markForCheck();
     }
 }

--- a/libs/docs/core/avatar/avatar-docs.component.html
+++ b/libs/docs/core/avatar/avatar-docs.component.html
@@ -134,7 +134,7 @@
     Alternative options can be passed the following way <code>alterIcon="content|alt|backup|default-icon"</code>
 </description>
 <component-example>
-    <fd-avatar-default-image-with-alternative-options-example></fd-avatar-default-image-with-alternative-options-example>
+    <fd-avatar-default-image-with-alternative-options-example />
 </component-example>
 <code-example [exampleFiles]="avatarBackgroundImageWithAlterOptions"></code-example>
 

--- a/libs/docs/core/avatar/examples/avatar-default-image-with-alternative-options-example.component.html
+++ b/libs/docs/core/avatar/examples/avatar-default-image-with-alternative-options-example.component.html
@@ -1,6 +1,7 @@
 <!-- should display "JD" from content -->
 <fd-avatar
     size="xs"
+    clickable
     image="http://example.com/1.jpeg"
     alterIcon="content|alt|backup|default-icon"
     backupImage="https://picsum.photos/id/1018/400"
@@ -11,6 +12,7 @@
 <!-- should display "JD" from alt -->
 <fd-avatar
     size="s"
+    clickable
     image="http://example.com/2.jpeg"
     alterIcon="content|alt|backup|default-icon"
     backupImage="https://picsum.photos/id/1018/400"
@@ -21,22 +23,31 @@
 <!-- should display backupImage -->
 <fd-avatar
     size="m"
+    clickable
     image="http://example.com/3.jpeg"
     alterIcon="content|alt|backup|default-icon"
-    backupImage="https://picsum.photos/200/300.jpg"
+    backupImage="https://picsum.photos/id/1018/400"
 >
 </fd-avatar>
 
 <!-- should display default icon, because there's no backupImage url provided -->
-<fd-avatar size="l" image="http://example.com/4.jpeg" alterIcon="alt|content|backup|default-icon"> </fd-avatar>
+<fd-avatar clickable size="l" image="http://example.com/4.jpeg" alterIcon="alt|content|backup|default-icon">
+</fd-avatar>
 
 <!-- should display default icon, because backupImage is not loadable -->
-<fd-avatar size="xl" image="http://example.com/5.jpeg" alterIcon="custom" backupImage="http://example.com/6.jpeg">
+<fd-avatar
+    clickable
+    size="xl"
+    image="http://example.com/5.jpeg"
+    alterIcon="custom"
+    backupImage="http://example.com/6.jpeg"
+>
 </fd-avatar>
 
 <!-- should load image -->
 <fd-avatar
     size="xl"
+    clickable
     [contain]="true"
     image="http://example.com/4.jpeg"
     alterIcon="alt|content|backup|default-icon"

--- a/libs/i18n/src/lib/models/fd-language-key-identifier.ts
+++ b/libs/i18n/src/lib/models/fd-language-key-identifier.ts
@@ -3,6 +3,7 @@
  * This type is generated automatically. Please, do not change it manually.
  **/
 export type FdLanguageKeyIdentifier =
+    | 'coreAvatar.defaultLabel'
     | 'coreCalendar.yearSelectionLabel'
     | 'coreCalendar.yearsRangeSelectionLabel'
     | 'coreCalendar.monthSelectionLabel'

--- a/libs/i18n/src/lib/models/fd-language.ts
+++ b/libs/i18n/src/lib/models/fd-language.ts
@@ -4,6 +4,10 @@ import { FdLanguageKey } from './fd-language-key';
  * Representation of the dictionary per UI component
  */
 export interface FdLanguage {
+    coreAvatar: {
+        /**  Default label for the Avatar. */
+        defaultLabel: FdLanguageKey;
+    };
     coreCalendar: {
         /** Year selection aria label. Used on the button to navigate to the years view. */
         yearSelectionLabel: FdLanguageKey;

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel = Select year
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Select year',
         yearsRangeSelectionLabel: 'Select years range',

--- a/libs/i18n/src/lib/translations/translations_ar.properties
+++ b/libs/i18n/src/lib/translations/translations_ar.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=تحديد السنة
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ar.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'تحديد السنة',
         yearsRangeSelectionLabel: 'تحديد نطاق السنوات',

--- a/libs/i18n/src/lib/translations/translations_bg.properties
+++ b/libs/i18n/src/lib/translations/translations_bg.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Избор на година
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_bg.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Избор на година',
         yearsRangeSelectionLabel: 'Избор на диапазон от години',

--- a/libs/i18n/src/lib/translations/translations_cs.properties
+++ b/libs/i18n/src/lib/translations/translations_cs.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Vybrat rok
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_cs.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Vybrat rok',
         yearsRangeSelectionLabel: 'Vybrat rozsah let',

--- a/libs/i18n/src/lib/translations/translations_da.properties
+++ b/libs/i18n/src/lib/translations/translations_da.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Vælg år
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_da.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Vælg år',
         yearsRangeSelectionLabel: 'Vælg årsinterval',

--- a/libs/i18n/src/lib/translations/translations_de.properties
+++ b/libs/i18n/src/lib/translations/translations_de.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Jahr auswählen
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_de.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Jahr auswählen',
         yearsRangeSelectionLabel: 'Jahresbereich auswählen',

--- a/libs/i18n/src/lib/translations/translations_el.properties
+++ b/libs/i18n/src/lib/translations/translations_el.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Επιλογή έτους
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_el.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Επιλογή έτους',
         yearsRangeSelectionLabel: 'Επιλογή εύρους ετών',

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=[[[Ŝēĺēċţ ŷēąŗ∙∙∙∙∙∙∙∙]]]
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_en_US_sappsd.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: '[[[Ŝēĺēċţ ŷēąŗ∙∙∙∙∙∙∙∙]]]',
         yearsRangeSelectionLabel: '[[[Ŝēĺēċţ ŷēąŗş ŗąŋğē∙∙∙∙∙∙]]]',

--- a/libs/i18n/src/lib/translations/translations_es.properties
+++ b/libs/i18n/src/lib/translations/translations_es.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Seleccionar año
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_es.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Seleccionar año',
         yearsRangeSelectionLabel: 'Seleccionar rango de años',

--- a/libs/i18n/src/lib/translations/translations_fi.properties
+++ b/libs/i18n/src/lib/translations/translations_fi.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Valitse vuosi
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_fi.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Valitse vuosi',
         yearsRangeSelectionLabel: 'Valitse vuosialue',

--- a/libs/i18n/src/lib/translations/translations_fr.properties
+++ b/libs/i18n/src/lib/translations/translations_fr.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Sélectionner une année
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_fr.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Sélectionner une année',
         yearsRangeSelectionLabel: "Sélectionner une plage d'années",

--- a/libs/i18n/src/lib/translations/translations_he.properties
+++ b/libs/i18n/src/lib/translations/translations_he.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=בחר שנה
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_he.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'בחר שנה',
         yearsRangeSelectionLabel: 'בחר טווחי שנים',

--- a/libs/i18n/src/lib/translations/translations_hi.properties
+++ b/libs/i18n/src/lib/translations/translations_hi.properties
@@ -1,4 +1,5 @@
-
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 coreCalendar.yearSelectionLabel = वर्ष चुनें
 coreCalendar.yearsRangeSelectionLabel = वर्षों की सीमा चुनें
 coreCalendar.monthSelectionLabel = महीना चुनें

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_hi.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'वर्ष चुनें',
         yearsRangeSelectionLabel: 'वर्षों की सीमा चुनें',

--- a/libs/i18n/src/lib/translations/translations_hr.properties
+++ b/libs/i18n/src/lib/translations/translations_hr.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Odaberi godinu
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_hr.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Odaberi godinu',
         yearsRangeSelectionLabel: 'Odaberi raspon godina',

--- a/libs/i18n/src/lib/translations/translations_hu.properties
+++ b/libs/i18n/src/lib/translations/translations_hu.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Év kiválasztása
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_hu.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Év kiválasztása',
         yearsRangeSelectionLabel: 'Évtartomány kiválasztása',

--- a/libs/i18n/src/lib/translations/translations_it.properties
+++ b/libs/i18n/src/lib/translations/translations_it.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Seleziona anno
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_it.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Seleziona anno',
         yearsRangeSelectionLabel: 'Seleziona intervallo anni',

--- a/libs/i18n/src/lib/translations/translations_ja.properties
+++ b/libs/i18n/src/lib/translations/translations_ja.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=年を選択
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ja.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: '年を選択',
         yearsRangeSelectionLabel: '年範囲を選択',

--- a/libs/i18n/src/lib/translations/translations_ka.properties
+++ b/libs/i18n/src/lib/translations/translations_ka.properties
@@ -1,4 +1,5 @@
-
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 coreCalendar.yearSelectionLabel = წელის არჩევა
 coreCalendar.yearsRangeSelectionLabel = წელთა შუალედის არჩევა
 coreCalendar.monthSelectionLabel = თვის არჩევა

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ka.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'წელის არჩევა',
         yearsRangeSelectionLabel: 'წელთა შუალედის არჩევა',

--- a/libs/i18n/src/lib/translations/translations_kk.properties
+++ b/libs/i18n/src/lib/translations/translations_kk.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Жылды таңдау
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_kk.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Жылды таңдау',
         yearsRangeSelectionLabel: 'Жылдар ауқымын таңдау',

--- a/libs/i18n/src/lib/translations/translations_ko.properties
+++ b/libs/i18n/src/lib/translations/translations_ko.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=연도 선택
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ko.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: '연도 선택',
         yearsRangeSelectionLabel: '연도 범위 선택',

--- a/libs/i18n/src/lib/translations/translations_ms.properties
+++ b/libs/i18n/src/lib/translations/translations_ms.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Pilih tahun
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ms.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Pilih tahun',
         yearsRangeSelectionLabel: 'Pilih julat tahun',

--- a/libs/i18n/src/lib/translations/translations_nl.properties
+++ b/libs/i18n/src/lib/translations/translations_nl.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Jaar selecteren
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_nl.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Jaar selecteren',
         yearsRangeSelectionLabel: 'Bereik van jaren selecteren',

--- a/libs/i18n/src/lib/translations/translations_no.properties
+++ b/libs/i18n/src/lib/translations/translations_no.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Velg år
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_no.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Velg år',
         yearsRangeSelectionLabel: 'Velg årsintervall',

--- a/libs/i18n/src/lib/translations/translations_pl.properties
+++ b/libs/i18n/src/lib/translations/translations_pl.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Wybierz rok
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_pl.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Wybierz rok',
         yearsRangeSelectionLabel: 'Wybierz zakres lat',

--- a/libs/i18n/src/lib/translations/translations_pt.properties
+++ b/libs/i18n/src/lib/translations/translations_pt.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Selecionar ano
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_pt.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Selecionar ano',
         yearsRangeSelectionLabel: 'Selecionar intervalo de anos',

--- a/libs/i18n/src/lib/translations/translations_ro.properties
+++ b/libs/i18n/src/lib/translations/translations_ro.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Selectați anul
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ro.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Selectați anul',
         yearsRangeSelectionLabel: 'Selectați intervalul de ani',

--- a/libs/i18n/src/lib/translations/translations_ru.properties
+++ b/libs/i18n/src/lib/translations/translations_ru.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Выберите год
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_ru.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Выберите год',
         yearsRangeSelectionLabel: 'Выберите диапазон годов',

--- a/libs/i18n/src/lib/translations/translations_sh.properties
+++ b/libs/i18n/src/lib/translations/translations_sh.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Odaberi godinu
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_sh.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Odaberi godinu',
         yearsRangeSelectionLabel: 'Odaberi raspon godina',

--- a/libs/i18n/src/lib/translations/translations_sk.properties
+++ b/libs/i18n/src/lib/translations/translations_sk.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Vybrať rok
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_sk.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Vybrať rok',
         yearsRangeSelectionLabel: 'Vybrať rozsah rokov',

--- a/libs/i18n/src/lib/translations/translations_sl.properties
+++ b/libs/i18n/src/lib/translations/translations_sl.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Izbira leta
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_sl.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Izbira leta',
         yearsRangeSelectionLabel: 'Izbira obsega let',

--- a/libs/i18n/src/lib/translations/translations_sq.properties
+++ b/libs/i18n/src/lib/translations/translations_sq.properties
@@ -1,4 +1,5 @@
-
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 coreCalendar.yearSelectionLabel = Zgjidhni vitin
 coreCalendar.yearsRangeSelectionLabel = Zgjidhni shtrirjen e viteve
 coreCalendar.monthSelectionLabel = Zgjidhni muajin

--- a/libs/i18n/src/lib/translations/translations_sq.ts
+++ b/libs/i18n/src/lib/translations/translations_sq.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_sq.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Zgjidhni vitin',
         yearsRangeSelectionLabel: 'Zgjidhni shtrirjen e viteve',

--- a/libs/i18n/src/lib/translations/translations_sv.properties
+++ b/libs/i18n/src/lib/translations/translations_sv.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Välj år
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_sv.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Välj år',
         yearsRangeSelectionLabel: 'Välj årsintervall',

--- a/libs/i18n/src/lib/translations/translations_th.properties
+++ b/libs/i18n/src/lib/translations/translations_th.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=เลือกปี
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_th.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'เลือกปี',
         yearsRangeSelectionLabel: 'เลือกช่วงปี',

--- a/libs/i18n/src/lib/translations/translations_tr.properties
+++ b/libs/i18n/src/lib/translations/translations_tr.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Yıl seç
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_tr.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Yıl seç',
         yearsRangeSelectionLabel: 'Yıl aralığı seç',

--- a/libs/i18n/src/lib/translations/translations_uk.properties
+++ b/libs/i18n/src/lib/translations/translations_uk.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=Виберіть рік
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_uk.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: 'Виберіть рік',
         yearsRangeSelectionLabel: 'Виберіть діапазон років',

--- a/libs/i18n/src/lib/translations/translations_zh_CN.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=选择年度
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_zh_CN.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: '选择年度',
         yearsRangeSelectionLabel: '选择年度范围',

--- a/libs/i18n/src/lib/translations/translations_zh_TW.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.properties
@@ -1,3 +1,5 @@
+#XFLD: Default label for the Avatar.
+coreAvatar.defaultLabel = Avatar
 #XBUT: Button on the calendar, used to navigate to the year selection view.
 coreCalendar.yearSelectionLabel=選擇年份
 #XBUT: Button on the calendar, used to navigate to the year range selection view.

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 // Do not modify, it's automatically created. Modify translations_zh_TW.properties instead
 export default {
+    coreAvatar: {
+        defaultLabel: 'Avatar'
+    },
     coreCalendar: {
         yearSelectionLabel: '選擇年份',
         yearsRangeSelectionLabel: '選擇年份範圍',


### PR DESCRIPTION
## Related Issue(s)
part of https://github.com/SAP/fundamental-ngx/issues/13490

## Description
- adopt a11y changes from styles: there's a default aria-label, label and alt attr passed by the user are reflected in the aria-label
- migrate Avatar implementation to signals
- refactored the implementation for the alternative options. 
Before: 
a) content options was not rendered (first avatar) 
b) alt option was not rendered

<img width="1015" height="1192" alt="Screenshot 2025-10-08 at 11 16 09 AM" src="https://github.com/user-attachments/assets/82957364-f674-47b0-808d-a399069d3a9e" />

After:
<img width="675" height="135" alt="Screenshot 2025-10-08 at 11 15 48 AM" src="https://github.com/user-attachments/assets/ee30cba8-e40a-40af-bc9b-25e29a87eeb8" />
