### PR TITLE
docs(cx, core): add deprecation message for Side nav components in Core and CX 

### DIFF
--- a/libs/docs/core/side-navigation/side-navigation-header/side-navigation-header.component.html
+++ b/libs/docs/core/side-navigation/side-navigation-header/side-navigation-header.component.html
@@ -1,7 +1,23 @@
 <fd-doc-page>
     <header>Side Navigation</header>
-    <description
-        >The left navigation can always display or expand/collapse using the menu icon within the global navigation.<br /><br />
+    <description>
+        <fd-message-strip type="warning" [dismissible]="false">
+            <b>Important</b>: The Side Navigation component is now <b>deprecated</b>. It will be removed in the upcoming
+            release (v0.59.0). To ensure consistency with current UXC standards, use the
+            <a
+                target="_blank"
+                href="https://fundamental-ngx.netlify.app/#/btp/navigation"
+                fd-link
+                [emphasized]="true"
+                aria-label="BTP Vertical Navigation"
+                >BTP Vertical Navigation</a
+            >
+            component instead.
+        </fd-message-strip>
+
+        <br /><br />
+
+        The left navigation can always display or expand/collapse using the menu icon within the global navigation.<br /><br />
         Side navigation anchors are keyboard navigated, it can be achieved by <code>ArrowDown</code>,
         <code>ArrowUp</code>, and basic <code>Tab</code>. Sub-levels of tiered side navigation can be opened with the
         space bar, enter key or right arrow.<br /><br />

--- a/libs/docs/core/side-navigation/side-navigation-header/side-navigation-header.component.ts
+++ b/libs/docs/core/side-navigation/side-navigation-header/side-navigation-header.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
 import { LinkComponent } from '@fundamental-ngx/core/link';
 import { MessageStripComponent } from '@fundamental-ngx/core/message-strip';
 import {
@@ -21,8 +20,8 @@ import {
         ImportComponent,
         HeaderTabsComponent,
         MessageStripComponent,
-        RouterLink,
-        LinkComponent
+        LinkComponent,
+        MessageStripComponent
     ]
 })
 export class SideNavigationHeaderComponent {}

--- a/libs/docs/cx/side-navigation/side-navigation-header/side-navigation-header.component.html
+++ b/libs/docs/cx/side-navigation/side-navigation-header/side-navigation-header.component.html
@@ -2,6 +2,22 @@
     <header>Side Navigation</header>
 
     <description>
+        <fd-message-strip type="warning" [dismissible]="false">
+            <b>Important</b>: The Side Navigation component is now <b>deprecated</b>. It will be removed in the upcoming
+            release (v0.59.0). To ensure consistency with current UXC standards, use the
+            <a
+                target="_blank"
+                href="https://fundamental-ngx.netlify.app/#/btp/navigation"
+                fd-link
+                [emphasized]="true"
+                aria-label="BTP Vertical Navigation"
+                >BTP Vertical Navigation</a
+            >
+            component instead.
+        </fd-message-strip>
+
+        <br /><br />
+
         The Side Navigation can display structures of up to three levels.
 
         <h2>In the Wide variant:</h2>

--- a/libs/docs/cx/side-navigation/side-navigation-header/side-navigation-header.component.ts
+++ b/libs/docs/cx/side-navigation/side-navigation-header/side-navigation-header.component.ts
@@ -1,4 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { LinkComponent } from '@fundamental-ngx/core/link';
+import { MessageStripComponent } from '@fundamental-ngx/core/message-strip';
 import {
     DescriptionComponent,
     DocPageComponent,
@@ -11,6 +13,14 @@ import {
     selector: 'app-side-navigation-header',
     templateUrl: './side-navigation-header.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [DocPageComponent, HeaderComponent, DescriptionComponent, ImportComponent, HeaderTabsComponent]
+    imports: [
+        DocPageComponent,
+        HeaderComponent,
+        DescriptionComponent,
+        ImportComponent,
+        HeaderTabsComponent,
+        MessageStripComponent,
+        LinkComponent
+    ]
 })
 export class SideNavigationHeaderComponent {}


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13609

## Description

add deprecation message for Side nav components in Core and CX 
## Screenshots
Core Side Navigation
<img width="1629" height="393" alt="Screenshot 2025-11-25 at 1 04 22 PM" src="https://github.com/user-attachments/assets/ea442b06-42e0-426f-9115-2e81fc8bccbe" />

CX Side Navigation
<img width="1656" height="529" alt="Screenshot 2025-11-25 at 1 04 33 PM" src="https://github.com/user-attachments/assets/c849bf52-7152-4807-91d1-f765e1c19b7f" />

