### PR TITLE
fix(core): add correct icons for form messages

### DIFF
--- a/libs/core/form/form-message/form-message.component.scss
+++ b/libs/core/form/form-message/form-message.component.scss
@@ -1,1 +1,18 @@
 @import 'fundamental-styles/dist/form-message.css';
+
+// Temporary CSS for the correct icons until we adopt the latest version of Fundamental Styles
+.fd-form-message--error::before {
+    content: '\e1ec';
+}
+
+.fd-form-message--warning::before {
+    content: '\e053';
+}
+
+.fd-form-message--success::before {
+    content: '\e1c1';
+}
+
+.fd-form-message--information::before {
+    content: '\e289';
+}


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13567
 
## Description
A temp fix bringing the correct icon codes for form messages. To be deleted after we adopt the latest version of fund-styles.