### PR TITLE
fix(core): add arrow for User Menu popover

### DIFF
--- a/libs/core/user-menu/user-menu.component.html
+++ b/libs/core/user-menu/user-menu.component.html
@@ -6,6 +6,7 @@
         [restoreFocusOnClose]="true"
         [focusTrapped]="true"
         [disableScrollbar]="true"
+        [noArrow]="false"
     >
         <fd-popover-control>
             <ng-container *ngTemplateOutlet="control"></ng-container>


### PR DESCRIPTION
## Related Issue(s)

closes none, reported by  Sheffer, Dganit via email

## Description
The popover body now shows arrow for User Menu

## Screenshots
<img width="815" height="843" alt="Screenshot 2025-11-27 at 11 12 07 AM" src="https://github.com/user-attachments/assets/2af9fa7b-4aec-4f95-8dea-9a3bfb85bee9" />
