### PR TITLE
fix(core): remove the max-height for Object Status

### DIFF
--- a/libs/core/object-status/object-status.component.scss
+++ b/libs/core/object-status/object-status.component.scss
@@ -1,1 +1,11 @@
 @import 'fundamental-styles/dist/object-status.css';
+
+// TO BE REMOVED AFTER ADOPTION OF FUNDAMENTAL STYLES V.0.41.0
+
+.fd-object-status {
+    align-self: center;
+    height: auto;
+    max-height: none;
+    min-height: var(--fdObjectStatus_Height);
+    min-width: 1.5rem;
+}


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13596

## Description

The fix is also implemented in Fundamental-styles: https://github.com/SAP/fundamental-styles/pull/6210
Removed the max-height for Object Status which was causing the hidden text on 200% zoom

## Screenshots
**Before:**
<img width="1191" height="1015" alt="Screenshot 2025-11-27 at 3 02 09 PM" src="https://github.com/user-attachments/assets/8845a9c4-0e9e-4a20-b323-a38b2cd97826" />


**After:**
<img width="1271" height="1031" alt="Screenshot 2025-11-27 at 2 58 21 PM" src="https://github.com/user-attachments/assets/957ab5d7-4905-452a-8727-2824a46a5607" />


