### PR TITLE
fix(platform): Approval flow search issue when add

### DIFF
--- a/libs/platform/approval-flow/approval-flow-add-node/approval-flow-add-node.component.html
+++ b/libs/platform/approval-flow/approval-flow-add-node/approval-flow-add-node.component.html
@@ -24,6 +24,7 @@
                 <fdp-search-field
                     [placeholder]="'platformApprovalFlow.addNodeSearchPlaceholder' | fdTranslate"
                     [suggestions]="[]"
+                    [inputText]="_searchInput"
                     (inputChange)="_onSearchStringChange($event.text)"
                 ></fdp-search-field>
             }

--- a/libs/platform/approval-flow/approval-flow-add-node/approval-flow-add-node.component.ts
+++ b/libs/platform/approval-flow/approval-flow-add-node/approval-flow-add-node.component.ts
@@ -183,6 +183,9 @@ export class ApprovalFlowAddNodeComponent implements OnInit, OnDestroy {
     _addToNextSerial = false;
 
     /** @hidden */
+    _searchInput = '';
+
+    /** @hidden */
     private _viewChangeSub: Subscription;
 
     /** @hidden */
@@ -255,7 +258,6 @@ export class ApprovalFlowAddNodeComponent implements OnInit, OnDestroy {
         });
 
         this._viewChangeSub = this.viewService.onViewChange.subscribe(() => {
-            this._onSearchStringChange('');
             this._cdr.detectChanges();
         });
 
@@ -289,6 +291,8 @@ export class ApprovalFlowAddNodeComponent implements OnInit, OnDestroy {
 
     /** @hidden */
     _exitSelectMode(): void {
+        this._searchInput = '';
+        this._onSearchStringChange('');
         this._selectedApprovers = this._data.node?.approvers?.length ? [...this._data.node.approvers] : [];
 
         if (!this._data.isEdit && !this._data.node?.approvalTeamId) {
@@ -407,6 +411,7 @@ export class ApprovalFlowAddNodeComponent implements OnInit, OnDestroy {
 
     /** @hidden */
     _onSearchStringChange(searchString = ''): void {
+        this._searchInput = searchString;
         const params = new Map([['query', searchString]]);
 
         if (this.viewService.isSelectUserMode) {


### PR DESCRIPTION
## Related Issue(s)

When user is adding the user to the approval flow and going inside the details for the particular user within user search. After choosing a user from the search results and clicking the side arrow to view their details, closing the detail pane redirects the user back to the initial screen instead of returning to the previous search results.

closes  https://github.com/SAP/fundamental-ngx/issues/13546


## Description

Save input search result when use retrun to their detail than we send store search result to search input field.


## Screenshots

Before fix

https://github.com/user-attachments/assets/d1c2fdd6-163e-41ed-892d-1937736ec929


after fix

https://github.com/user-attachments/assets/a316ee12-6d2f-4b83-bf3b-e6a0a045d3f3
