### PR TITLE
fix(core): Prevent event propagation on <span> element with class 'fd-time__item--collapsed'

### DIFF
--- a/libs/core/time/time-column/time-column.component.ts
+++ b/libs/core/time/time-column/time-column.component.ts
@@ -253,8 +253,18 @@ export class TimeColumnComponent<K extends number, T extends SelectableViewItem<
     }
 
     /** @hidden */
-    @HostListener('click')
-    onItemClick(): void {
+    @HostListener('click', ['$event'])
+    onItemClick(event: MouseEvent): void {
+        const targetRef = event.target as HTMLElement;
+
+        // Check if the click happened on the collapsed time item span
+        if (
+            targetRef.classList.contains('fd-time__item--collapsed') ||
+            targetRef.closest('.fd-time__item--collapsed')
+        ) {
+            // Stop event propagation to prevent bubbling
+            event.stopPropagation();
+        }
         this.activeStateChange.emit();
     }
 


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

## Description

<!-- Enter short description of the change -->

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->
