### PR TITLE
fix(core): datetime adapter _parseTimeString function incorrectly handling some locales, so default to en-GB

### DIFF
--- a/libs/core/datetime/fd-datetime-adapter.ts
+++ b/libs/core/datetime/fd-datetime-adapter.ts
@@ -518,7 +518,7 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
          * Date.parse('10:30 AM') doesn't work so we need do a trick
          * and prepend it by a date string.
          */
-        const dateStr = this.format(this.now(), { year: 'numeric', month: 'numeric', day: 'numeric' });
+        const dateStr = new Intl.DateTimeFormat('en-GB').format(new Date());
         const dateTimeString = `${dateStr} ${timeStr}`;
         return new Date(Date.parse(dateTimeString));
     }

--- a/libs/docs/core/time-picker/examples/time-picker-locale-example/time-picker-locale-example.component.html
+++ b/libs/docs/core/time-picker/examples/time-picker-locale-example/time-picker-locale-example.component.html
@@ -17,6 +17,6 @@
 </div>
 <br />
 Selected Time:
-@if (time) {
+@if (time && time.isDateValid()) {
     {{ time.toDate() | date: 'shortTime' }}
 }


### PR DESCRIPTION
fixes #13303 