### PR TITLE
fix(core): update Illustrated Message xsmall look

### DIFF
--- a/libs/core/illustrated-message/illustrated-message.component.scss
+++ b/libs/core/illustrated-message/illustrated-message.component.scss
@@ -304,21 +304,18 @@
 .fd-illustrated-message--dot,
 .fd-illustrated-message--xsmall {
     --illustratedMessagePadding: 0.25rem;
-    --containerFlexDirection: row;
-    --containerFlexAlignment: flex-start;
     --illustrationMinWidth: 2.8125rem;
     --illustrationMaxWidth: 2.8125rem;
     --illustrationMinHeight: 2.8125rem;
     --illustrationMaxHeight: 2.8125rem;
-    --illustrationMarginBlock: 0;
-    --illustrationMarginInlineEnd: 0.25rem;
+    --illustrationMarginBlock: 0 0.25rem;
+    --illustrationMarginInlineEnd: 0;
     --figcaptionMaxWidth: 12.6875rem;
     --titleMarginBottom: 0.25rem;
     --titleFontSize: var(--sapFontHeader5Size);
     --textMarginBottom: 0.313rem;
     --actionsMarginBlock: 0.25rem;
     --actionsMarginInline: auto;
-    --actionsPaddingInlineStart: var(--illustrationMaxWidth);
 }
 .fd-illustrated-message--base {
     --illustratedMessagePadding: 0.25rem;
@@ -362,21 +359,18 @@
 @container (width <= 260px) {
     .fd-illustrated-message {
         --illustratedMessagePadding: 0.25rem;
-        --containerFlexDirection: row;
-        --containerFlexAlignment: flex-start;
         --illustrationMinWidth: 2.8125rem;
         --illustrationMaxWidth: 2.8125rem;
         --illustrationMinHeight: 2.8125rem;
         --illustrationMaxHeight: 2.8125rem;
-        --illustrationMarginBlock: 0;
-        --illustrationMarginInlineEnd: 0.25rem;
+        --illustrationMarginBlock: 0 0.25rem;
+        --illustrationMarginInlineEnd: 0;
         --figcaptionMaxWidth: 12.6875rem;
         --titleMarginBottom: 0.25rem;
         --titleFontSize: var(--sapFontHeader5Size);
         --textMarginBottom: 0.313rem;
         --actionsMarginBlock: 0.25rem;
         --actionsMarginInline: auto;
-        --actionsPaddingInlineStart: var(--illustrationMaxWidth);
     }
 }
 @container (width <= 160px) {
@@ -392,9 +386,4 @@
         --actionsMarginInline: auto;
         --actionsPaddingInlineStart: 0;
     }
-}
-
-/* Specific for the implementation */
-.fd-illustrated-message__illustration {
-    width: 100%;
 }

--- a/libs/docs/core/illustrated-message/examples/illustrated-message-dot-example.component.html
+++ b/libs/docs/core/illustrated-message/examples/illustrated-message-dot-example.component.html
@@ -10,6 +10,9 @@
                         the way.
                     </p>
                 </figcaption>
+                <fd-illustrated-message-actions>
+                    <button fd-button fdType="emphasized" label="Contact Us"></button>
+                </fd-illustrated-message-actions>
             </figure>
         </fd-card-content>
     </fd-card>

--- a/libs/docs/core/illustrated-message/examples/illustrated-message-dot-example.component.ts
+++ b/libs/docs/core/illustrated-message/examples/illustrated-message-dot-example.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
+import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { CardModule } from '@fundamental-ngx/core/card';
 import { IllustratedMessageModule, SvgConfig } from '@fundamental-ngx/core/illustrated-message';
 
 @Component({
     selector: 'fd-illustrated-message-dot-example',
     templateUrl: './illustrated-message-dot-example.component.html',
-    imports: [CardModule, IllustratedMessageModule]
+    imports: [CardModule, IllustratedMessageModule, ButtonComponent]
 })
 export class IllustratedMessageDotExampleComponent {
     xsmallConfig: SvgConfig = {


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13677

## Description
As of Dec 2nd, 2025 there's a new design for Illustrated message xsmall size. 
This PR:
- fixes the issue https://github.com/SAP/fundamental-ngx/issues/13677 as the new design for xsmall has all elements centered vertically.
- brings the CSS from fundamental-styles (a separate PR is open in fund-styles: https://github.com/SAP/fundamental-styles/pull/6222. We need to temp bring the CSS until we fully adopt the latest version of fund-styles)
- updates the doc example for xsmall Illustrated message to also show a button

## Screenshots

Before:
<img width="378" height="320" alt="Screenshot 2025-12-16 at 11 57 20 AM" src="https://github.com/user-attachments/assets/844bb6de-10ea-47f0-bb94-e99b04d8db49" />


After:
<img width="376" height="427" alt="Screenshot 2025-12-16 at 11 57 13 AM" src="https://github.com/user-attachments/assets/de3522b8-5b48-4e53-9da1-0ca2298c19b5" />
