### PR TITLE
feat(core,platform,datetime-adapter,docs): add minuteStep input for time picker intervals

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,6 +118,62 @@ All components MUST:
 - Do NOT use `ngClass`; use `class` bindings instead
 - Do NOT use `ngStyle`; use `style` bindings instead
 
+#### Component Member Ordering
+
+Follow strict member ordering as enforced by `@typescript-eslint/member-ordering`:
+
+1. **Decorated properties** (in order):
+
+    - `@Input()` decorated properties
+    - `@Output()` decorated properties
+    - `@ViewChild()` / `@ViewChildren()` decorated properties
+    - Other decorated properties
+
+2. **Signal inputs and outputs**:
+
+    - `input()` signal inputs
+    - `output()` signal outputs
+
+3. **Other instance fields**:
+    - Public instance fields
+    - Protected instance fields
+    - Private instance fields
+
+**Important**: Signal inputs created with `input()` are treated as regular readonly field definitions by TypeScript/ESLint. They MUST be declared after all `@Input()`, `@Output()`, and `@ViewChild()` decorated properties to comply with member-ordering rules.
+
+**Example**:
+
+```typescript
+@Component({
+    /* ... */
+})
+export class MyComponent {
+    // 1. Decorated properties first
+    @Input()
+    displayValue = true;
+
+    @Input()
+    placeholder: string;
+
+    @Output()
+    valueChange = new EventEmitter<string>();
+
+    @ViewChild('template')
+    template: TemplateRef<any>;
+
+    // 2. Signal inputs/outputs after decorated properties
+    readonly minuteStep = input<number>(1);
+    readonly itemSelected = output<string>();
+
+    // 3. Other instance fields
+    activeView: string = 'default';
+
+    protected items: string[] = [];
+
+    private _cache: Map<string, any>;
+}
+```
+
 ### State Management
 
 - Use signals for local component state

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": true,
     "eslint.validate": ["json"]
 }

--- a/libs/core/datetime/datetime-adapter.ts
+++ b/libs/core/datetime/datetime-adapter.ts
@@ -130,9 +130,12 @@ export abstract class DatetimeAdapter<D> {
 
     /**
      * Gets a list of minute names.
-     * @returns An ordered list of all hours (0 - 24).
+     * @param options Configuration options for minute names
+     * @param options.twoDigit Whether to format minutes with two digits (e.g., '05' vs '5')
+     * @param options.minuteStep The interval between minutes (e.g., 1 for every minute, 5 for 5-minute intervals, 15 for 15-minute intervals). Defaults to 1.
+     * @returns An ordered list of minute names based on the step interval.
      */
-    abstract getMinuteNames(options: { twoDigit: boolean }): string[];
+    abstract getMinuteNames(options: { twoDigit: boolean; minuteStep?: number }): string[];
 
     /**
      * Gets a list of second names.

--- a/libs/core/datetime/fd-datetime-adapter.ts
+++ b/libs/core/datetime/fd-datetime-adapter.ts
@@ -135,8 +135,12 @@ export class FdDatetimeAdapter extends DatetimeAdapter<FdDate> {
     }
 
     /** Get minute names */
-    getMinuteNames({ twoDigit }: { twoDigit: boolean }): string[] {
-        return range(60, (minute) => minute.toLocaleString(this.locale, { minimumIntegerDigits: twoDigit ? 2 : 1 }));
+    getMinuteNames({ twoDigit, minuteStep = 1 }: { twoDigit: boolean; minuteStep?: number }): string[] {
+        const length = Math.ceil(60 / minuteStep);
+        return range(length, (index) => {
+            const minute = index * minuteStep;
+            return minute.toLocaleString(this.locale, { minimumIntegerDigits: twoDigit ? 2 : 1 });
+        });
     }
 
     /** Get second names */

--- a/libs/core/time-picker/time-picker.component.html
+++ b/libs/core/time-picker/time-picker.component.html
@@ -52,6 +52,7 @@
                 [displayHours]="_displayHours"
                 [displayMinutes]="_displayMinutes"
                 [displaySeconds]="_displaySeconds"
+                [minuteStep]="minuteStep()"
                 [spinnerButtons]="spinnerButtons"
             ></fd-time>
         }

--- a/libs/core/time-picker/time-picker.component.ts
+++ b/libs/core/time-picker/time-picker.component.ts
@@ -9,6 +9,7 @@ import {
     forwardRef,
     inject,
     Inject,
+    input,
     Input,
     OnChanges,
     OnDestroy,
@@ -296,6 +297,12 @@ export class TimePickerComponent<D>
     /** @hidden */
     @ViewChild('formMessageTemplate')
     private readonly _formMessageTemplate: TemplateRef<any>;
+
+    /**
+     * The interval between selectable minutes (e.g., 1 for every minute, 5 for 5-minute intervals, 15 for 15-minute intervals).
+     * Defaults to 1 (every minute).
+     */
+    readonly minuteStep = input<number>(1);
 
     /** @hidden */
     _message: string | null = null;

--- a/libs/core/time/time-column/time-column.component.ts
+++ b/libs/core/time/time-column/time-column.component.ts
@@ -232,7 +232,7 @@ export class TimeColumnComponent<K extends number, T extends SelectableViewItem<
                             this.items.toArray().reduce((acc, next) => acc + next.getHeight(), 0) / this.items.length;
                         this.wrapperHeight = averageHeight * elementsAtOnce;
                         const visibleButNotSelectedElements = Math.floor(elementsAtOnce / 2);
-                        if (offset === 0) {
+                        if (offset !== 3) {
                             this.items.first.element.style.marginTop = `${
                                 visibleButNotSelectedElements * averageHeight
                             }px`;
@@ -495,7 +495,7 @@ export class TimeColumnComponent<K extends number, T extends SelectableViewItem<
      * @hidden
      */
     private _getItem(_item: Nullable<T>): CarouselItemDirective<T> | undefined {
-        return this.items.find((item) => item.value === _item);
+        return this.items.find((item) => item.value?.value === _item?.value);
     }
 
     /** @hidden */
@@ -551,7 +551,9 @@ export class TimeColumnComponent<K extends number, T extends SelectableViewItem<
             elementsAtOnce: this._elementsAtOnce$.value,
             transition: '150ms'
         };
-        if (!this.meridian) {
+        // Enable infinite scrolling only if not meridian column and have enough items
+        // Need more items than elementsAtOnce for infinite scrolling to work
+        if (!this.meridian && this.rows.length > this._elementsAtOnce$.value) {
             config.infinite = true;
         }
         this.config = config;

--- a/libs/core/time/time.component.html
+++ b/libs/core/time/time.component.html
@@ -8,7 +8,7 @@
     <fd-time-column
         [active]="isActive('hour')"
         [rows]="hourViewItems"
-        [offset]="offset"
+        [offset]="offset()"
         [elementsAtOnce]="elementsAtOnce"
         [activeValue]="activeHourViewItem"
         columnTranslationsPreset="hours"
@@ -20,7 +20,7 @@
         <fd-time-column
             [active]="isActive('minute')"
             [rows]="minuteViewItems"
-            [offset]="offset"
+            [offset]="minuteOffset()"
             [elementsAtOnce]="elementsAtOnce"
             [activeValue]="activeMinuteViewItem"
             columnTranslationsPreset="minutes"
@@ -33,7 +33,7 @@
         <fd-time-column
             [active]="isActive('second')"
             [rows]="secondViewItems"
-            [offset]="offset"
+            [offset]="offset()"
             [elementsAtOnce]="elementsAtOnce"
             [activeValue]="activeSecondViewItem"
             columnTranslationsPreset="seconds"

--- a/libs/core/time/time.component.spec.ts
+++ b/libs/core/time/time.component.spec.ts
@@ -34,45 +34,45 @@ describe('TimeComponent', () => {
     });
 
     it('should construct hours view items', () => {
-        expect(component.hourViewItems.length).toBe(24);
-        expect(component.hourViewItems[0].value).toBe(0);
-        expect(component.hourViewItems[23].value).toBe(23);
+        expect((<any>component).hourViewItems.length).toBe(24);
+        expect((<any>component).hourViewItems[0].value).toBe(0);
+        expect((<any>component).hourViewItems[23].value).toBe(23);
     });
 
     it('should construct minutes view items', () => {
-        expect(component.minuteViewItems.length).toBe(60);
-        expect(component.minuteViewItems[0].value).toBe(0);
-        expect(component.minuteViewItems[59].value).toBe(59);
+        expect((<any>component).minuteViewItems.length).toBe(60);
+        expect((<any>component).minuteViewItems[0].value).toBe(0);
+        expect((<any>component).minuteViewItems[59].value).toBe(59);
     });
 
     it('should construct seconds view items', () => {
-        expect(component.secondViewItems.length).toBe(60);
-        expect(component.secondViewItems[0].value).toBe(0);
-        expect(component.secondViewItems[59].value).toBe(59);
+        expect((<any>component).secondViewItems.length).toBe(60);
+        expect((<any>component).secondViewItems[0].value).toBe(0);
+        expect((<any>component).secondViewItems[59].value).toBe(59);
     });
 
     it('should construct meridian view items', () => {
-        expect(component.meridianViewItems.length).toBe(2);
-        expect(component.meridianViewItems[0].value).toBe(Meridian.AM);
-        expect(component.meridianViewItems[1].value).toBe(Meridian.PM);
+        expect((<any>component).meridianViewItems.length).toBe(2);
+        expect((<any>component).meridianViewItems[0].value).toBe(Meridian.AM);
+        expect((<any>component).meridianViewItems[1].value).toBe(Meridian.PM);
     });
 
     it('should keep active view items up to date', () => {
         component.time = new FdDate().setTime(15, 30, 45);
         (<any>component)._setUpViewGrid();
-        expect(component.activeHourViewItem?.value).toBe(15);
-        expect(component.activeMinuteViewItem?.value).toBe(30);
-        expect(component.activeSecondViewItem?.value).toBe(45);
-        expect(component.activeMeridianViewItem?.value).toBe(Meridian.PM);
+        expect((<any>component).activeHourViewItem?.value).toBe(15);
+        expect((<any>component).activeMinuteViewItem?.value).toBe(30);
+        expect((<any>component).activeSecondViewItem?.value).toBe(45);
+        expect((<any>component).activeMeridianViewItem?.value).toBe(Meridian.PM);
     });
 
     it('should set period after hour change', () => {
         component.meridian = true;
         component.handleHourChange(0);
-        expect(component.activeMeridianViewItem?.value).toBe(Meridian.AM);
+        expect((<any>component).activeMeridianViewItem?.value).toBe(Meridian.AM);
 
         component.handleHourChange(12);
-        expect(component.activeMeridianViewItem?.value).toBe(Meridian.PM);
+        expect((<any>component).activeMeridianViewItem?.value).toBe(Meridian.PM);
     });
 
     it('should set hour after period change', () => {

--- a/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.ts
+++ b/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.ts
@@ -208,11 +208,15 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
     }
 
     /** Get minute names */
-    getMinuteNames({ twoDigit }: { twoDigit: boolean }): string[] {
+    getMinuteNames({ twoDigit, minuteStep = 1 }: { twoDigit: boolean; minuteStep?: number }): string[] {
         const format: string = twoDigit ? 'mm' : 'm';
         const dayjsDate = this._createDayjsDate();
+        const length = Math.ceil(60 / minuteStep);
 
-        return range(60, (i) => this.clone(dayjsDate).minute(i).format(format));
+        return range(length, (index) => {
+            const minute = index * minuteStep;
+            return this.clone(dayjsDate).minute(minute).format(format);
+        });
     }
 
     /** Get second names */

--- a/libs/docs/core/time-picker/examples/time-picker-minute-step-example.html
+++ b/libs/docs/core/time-picker/examples/time-picker-minute-step-example.html
@@ -1,0 +1,47 @@
+<style>
+    @import '@sap-ui/common-css/dist/sap-flex.css';
+    @import '@sap-ui/common-css/dist/sap-margin.css';
+    @import '@sap-ui/common-css/dist/sap-typography.css';
+</style>
+
+<div class="sap-flex sap-flex--column sap-flex--gap-small">
+    <div>
+        <label fd-form-label>Default (Every Minute):</label>
+        <fd-time-picker [(ngModel)]="timeEveryMinute" [minuteStep]="1"></fd-time-picker>
+        <div class="sap-margin-top-tiny sap-font-size-small">
+            Selected time: {{ timeEveryMinute.toDate() | date: 'HH:mm:ss' }}
+        </div>
+    </div>
+
+    <div>
+        <label fd-form-label>5-Minute Intervals:</label>
+        <fd-time-picker [(ngModel)]="time5Minutes" [minuteStep]="5"></fd-time-picker>
+        <div class="sap-margin-top-tiny sap-font-size-small">
+            Selected time: {{ time5Minutes.toDate() | date: 'HH:mm:ss' }}
+        </div>
+    </div>
+
+    <div>
+        <label fd-form-label>10-Minute Intervals:</label>
+        <fd-time-picker [(ngModel)]="time10Minutes" [minuteStep]="10"></fd-time-picker>
+        <div class="sap-margin-top-tiny sap-font-size-small">
+            Selected time: {{ time10Minutes.toDate() | date: 'HH:mm:ss' }}
+        </div>
+    </div>
+
+    <div>
+        <label fd-form-label>15-Minute Intervals:</label>
+        <fd-time-picker [(ngModel)]="time15Minutes" [minuteStep]="15"></fd-time-picker>
+        <div class="sap-margin-top-tiny sap-font-size-small">
+            Selected time: {{ time15Minutes.toDate() | date: 'HH:mm:ss' }}
+        </div>
+    </div>
+
+    <div>
+        <label fd-form-label>30-Minute Intervals:</label>
+        <fd-time-picker [(ngModel)]="time30Minutes" [minuteStep]="30"></fd-time-picker>
+        <div class="sap-margin-top-tiny sap-font-size-small">
+            Selected time: {{ time30Minutes.toDate() | date: 'HH:mm:ss' }}
+        </div>
+    </div>
+</div>

--- a/libs/docs/core/time-picker/examples/time-picker-minute-step-example.ts
+++ b/libs/docs/core/time-picker/examples/time-picker-minute-step-example.ts
@@ -1,0 +1,20 @@
+import { DatePipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { FdDate, provideDateTimeFormats } from '@fundamental-ngx/core/datetime';
+import { FormLabelComponent } from '@fundamental-ngx/core/form';
+import { TimePickerModule } from '@fundamental-ngx/core/time-picker';
+
+@Component({
+    selector: 'fd-time-picker-minute-step-example',
+    templateUrl: './time-picker-minute-step-example.html',
+    providers: [provideDateTimeFormats()],
+    imports: [FormLabelComponent, TimePickerModule, FormsModule, DatePipe]
+})
+export class TimePickerMinuteStepExample {
+    timeEveryMinute = new FdDate().setTime(12, 0, 0);
+    time5Minutes = new FdDate().setTime(12, 0, 0);
+    time10Minutes = new FdDate().setTime(12, 0, 0);
+    time15Minutes = new FdDate().setTime(12, 0, 0);
+    time30Minutes = new FdDate().setTime(12, 0, 0);
+}

--- a/libs/docs/core/time-picker/time-picker-docs.component.html
+++ b/libs/docs/core/time-picker/time-picker-docs.component.html
@@ -90,3 +90,16 @@
     <fd-time-picker-locale-example></fd-time-picker-locale-example>
 </component-example>
 <code-example [exampleFiles]="timePickerLocale"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="minute-step" componentName="time-picker"> Minute Step </fd-docs-section-title>
+<description>
+    The time-picker component allows you to set the interval for minute selection using the <code>[minuteStep]</code>
+    input. This input defines the increments in which minutes can be selected, making it easier to choose specific time
+    values.
+</description>
+<component-example>
+    <fd-time-picker-minute-step-example></fd-time-picker-minute-step-example>
+</component-example>
+<code-example [exampleFiles]="timePickerStep"></code-example>

--- a/libs/docs/core/time-picker/time-picker-docs.component.ts
+++ b/libs/docs/core/time-picker/time-picker-docs.component.ts
@@ -16,6 +16,7 @@ import { TimePickerExampleComponent } from './examples/time-picker-example.compo
 import { TimePickerFormExampleComponent } from './examples/time-picker-form-example.component';
 import { TimePickerFormatExampleComponent } from './examples/time-picker-format-example.component';
 import { TimePickerLocaleExampleComponent } from './examples/time-picker-locale-example/time-picker-locale-example.component';
+import { TimePickerMinuteStepExample } from './examples/time-picker-minute-step-example';
 
 const timePickerFormScssSrc = 'time-picker-form-example.component.scss';
 
@@ -33,6 +34,8 @@ const timePickerLocaleHtmlSrc = 'time-picker-locale-example/time-picker-locale-e
 const timePickerLocaleTsSrc = 'time-picker-locale-example/time-picker-locale-example.component.ts';
 const timePickerFormHtmlSrc = 'time-picker-form-example.component.html';
 const timePickerFormTsSrc = 'time-picker-form-example.component.ts';
+const timePickerMinuteStepSrc = 'time-picker-minute-step-example.ts';
+const timePickerMinuteStepHtmlSrc = 'time-picker-minute-step-example.html';
 
 @Component({
     selector: 'app-time-picker',
@@ -49,7 +52,8 @@ const timePickerFormTsSrc = 'time-picker-form-example.component.ts';
         TimePickerCompactExampleComponent,
         TimePickerAllowNullExampleComponent,
         TimePickerFormExampleComponent,
-        TimePickerLocaleExampleComponent
+        TimePickerLocaleExampleComponent,
+        TimePickerMinuteStepExample
     ]
 })
 export class TimePickerDocsComponent {
@@ -133,6 +137,20 @@ export class TimePickerDocsComponent {
             code: getAssetFromModuleAssets(timePickerLocaleTsSrc),
             fileName: 'time-picker-locale-example',
             component: 'TimePickerLocaleExampleComponent'
+        }
+    ];
+
+    timePickerStep: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(timePickerMinuteStepHtmlSrc),
+            fileName: 'time-picker-minute-step-example'
+        },
+        {
+            language: 'typescript',
+            code: getAssetFromModuleAssets(timePickerMinuteStepSrc),
+            fileName: 'time-picker-minute-step-example',
+            component: 'TimePickerMinuteStepExample'
         }
     ];
 }

--- a/libs/docs/core/time/examples/time-minute-steps.html
+++ b/libs/docs/core/time/examples/time-minute-steps.html
@@ -1,0 +1,19 @@
+<style>
+    @import '@sap-ui/common-css/dist/sap-flex.css';
+    @import '@sap-ui/common-css/dist/sap-margin.css';
+    @import '@sap-ui/common-css/dist/sap-text.css';
+    @import '@sap-ui/common-css/dist/sap-typography.css';
+</style>
+
+<div style="display: flex; gap: 2rem; flex-wrap: wrap">
+    @for (step of minuteSteps; track step.step) {
+    <section class="sap-flex sap-flex--column">
+        <h4 class="sap-margin-bottom-tiny sap-margin-top-none">{{ step.title }}</h4>
+        <p class="sap-margin-bottom-tiny sap-font-small-detail-text">
+            Step: {{ step.step }} {{ step.step === 1 ? 'minute' : 'minutes' }}
+        </p>
+        <fd-time [minuteStep]="step.step" [displaySeconds]="false" [(ngModel)]="step.time" [meridian]="true"></fd-time>
+        <p class="sap-margin-top-tiny sap-font-size-small">Selected: <strong>{{ formatTime(step.time) }}</strong></p>
+    </section>
+    }
+</div>

--- a/libs/docs/core/time/examples/time-minute-steps.ts
+++ b/libs/docs/core/time/examples/time-minute-steps.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { FdDate, provideDateTimeFormats } from '@fundamental-ngx/core/datetime';
+import { TimeComponent } from '@fundamental-ngx/core/time';
+
+@Component({
+    selector: 'fd-time-minute-steps',
+    templateUrl: './time-minute-steps.html',
+    providers: [provideDateTimeFormats()],
+    imports: [TimeComponent, FormsModule]
+})
+export class TimeMinuteSteps {
+    protected readonly minuteSteps = [
+        {
+            step: 1,
+            time: new FdDate().setTime(14, 23, 0),
+            title: 'Every Minute'
+        },
+        {
+            step: 5,
+            time: new FdDate().setTime(14, 25, 0),
+            title: '5-Minute Intervals'
+        },
+        {
+            step: 10,
+            time: new FdDate().setTime(14, 30, 0),
+            title: '10-Minute Intervals'
+        },
+        {
+            step: 15,
+            time: new FdDate().setTime(14, 30, 0),
+            title: '15-Minute Intervals'
+        },
+        {
+            step: 30,
+            time: new FdDate().setTime(14, 30, 0),
+            title: '30-Minute Intervals'
+        }
+    ];
+
+    protected formatTime(time: FdDate): string {
+        const hours = time.hour % 12 || 12;
+        const minutes = time.minute.toString().padStart(2, '0');
+        const period = time.hour >= 12 ? 'PM' : 'AM';
+        return `${hours}:${minutes} ${period}`;
+    }
+}

--- a/libs/docs/core/time/time-docs.component.html
+++ b/libs/docs/core/time/time-docs.component.html
@@ -107,3 +107,15 @@
     <fd-time-form-example></fd-time-form-example>
 </component-example>
 <code-example [exampleFiles]="timeForm"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="minute-steps" componentName="time"> Time with Minute Steps </fd-docs-section-title>
+<description>
+    You can set minute steps for the time component by passing <code>[minuteStep]="step"</code>. The step value
+    determines the interval between the available minutes in the minutes column.
+</description>
+<component-example>
+    <fd-time-minute-steps></fd-time-minute-steps>
+</component-example>
+<code-example [exampleFiles]="timeMinuteSteps"></code-example>

--- a/libs/docs/core/time/time-docs.component.ts
+++ b/libs/docs/core/time/time-docs.component.ts
@@ -13,6 +13,7 @@ import {
 import { Time12ExampleComponent } from './examples/time-12-example.component';
 import { TimeExampleComponent } from './examples/time-example.component';
 import { TimeFormExampleComponent } from './examples/time-form-example.component';
+import { TimeMinuteSteps } from './examples/time-minute-steps';
 import { TimeNoSecondsExampleComponent } from './examples/time-no-seconds-example.component';
 import { TimeNoSpinnersExampleComponent } from './examples/time-no-spinners-example/time-no-spinners-example.component';
 import { TimeOnlyHoursExampleComponent } from './examples/time-only-hours-example.component';
@@ -43,6 +44,8 @@ const timeTwoDigitsSrcH = 'time-two-digits-example/time-two-digits-example.compo
 
 const timeFormHtmlSrc = 'time-form-example.component.html';
 const timeFormTsSrc = 'time-form-example.component.ts';
+const timeMinuteStepTsSrc = 'time-minute-steps.ts';
+const timeMinuteStepHtmlSrc = 'time-minute-steps.html';
 
 @Component({
     selector: 'app-time',
@@ -61,7 +64,8 @@ const timeFormTsSrc = 'time-form-example.component.ts';
         TimeNoSecondsExampleComponent,
         TimeOnlyHoursExampleComponent,
         TimeTwoDigitsExampleComponent,
-        TimeFormExampleComponent
+        TimeFormExampleComponent,
+        TimeMinuteSteps
     ]
 })
 export class TimeDocsComponent {
@@ -167,6 +171,20 @@ export class TimeDocsComponent {
             code: getAssetFromModuleAssets(timeFormTsSrc),
             fileName: 'time-form-example',
             component: 'TimeFormExampleComponent'
+        }
+    ];
+
+    timeMinuteSteps: ExampleFile[] = [
+        {
+            language: 'typescript',
+            code: getAssetFromModuleAssets(timeMinuteStepTsSrc),
+            fileName: 'time-minute-steps',
+            component: 'TimeMinuteSteps'
+        },
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(timeMinuteStepHtmlSrc),
+            fileName: 'time-minute-steps'
         }
     ];
 

--- a/libs/moment-adapter/src/lib/moment-datetime-adapter.ts
+++ b/libs/moment-adapter/src/lib/moment-datetime-adapter.ts
@@ -21,7 +21,6 @@ export const MOMENT_DATE_TIME_ADAPTER_OPTIONS = new InjectionToken<MomentDatetim
     }
 );
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function MOMENT_DATE_TIME_ADAPTER_OPTIONS_FACTORY(): MomentDatetimeAdapterOptions {
     return {
         useUtc: false,
@@ -167,11 +166,15 @@ export class MomentDatetimeAdapter extends DatetimeAdapter<Moment> {
         return range(24, (i) => this.clone(momentDate).hour(i).format(format));
     }
 
-    getMinuteNames({ twoDigit }: { twoDigit: boolean }): string[] {
+    getMinuteNames({ twoDigit, minuteStep = 1 }: { twoDigit: boolean; minuteStep?: number }): string[] {
         const format: string = twoDigit ? 'mm' : 'm';
         const momentDate = this._createMomentDate();
+        const length = Math.ceil(60 / minuteStep);
 
-        return range(60, (i) => this.clone(momentDate).minute(i).format(format));
+        return range(length, (index) => {
+            const minute = index * minuteStep;
+            return this.clone(momentDate).minute(minute).format(format);
+        });
     }
 
     getSecondNames({ twoDigit }: { twoDigit: boolean }): string[] {

--- a/libs/platform/form/time-picker/time-picker.component.html
+++ b/libs/platform/form/time-picker/time-picker.component.html
@@ -12,6 +12,7 @@
     [displaySeconds]="displaySeconds"
     [displayMinutes]="displayMinutes"
     [displayHours]="displayHours"
+    [minuteStep]="minuteStep()"
     [placeholder]="placeholder"
     [timePickerInputLabel]="timePickerInputLabel"
     [allowNull]="allowNull"

--- a/libs/platform/form/time-picker/time-picker.component.ts
+++ b/libs/platform/form/time-picker/time-picker.component.ts
@@ -7,7 +7,8 @@ import {
     OnDestroy,
     OnInit,
     Output,
-    ViewChild
+    ViewChild,
+    input
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { FD_FORM_FIELD_CONTROL, FormStates } from '@fundamental-ngx/cdk/forms';
@@ -169,6 +170,12 @@ export class PlatformTimePickerComponent<D> extends BaseInput implements OnInit,
     /** @hidden */
     @ViewChild(TimePickerComponent)
     timePickerComponent: TimePickerComponent<D>;
+
+    /**
+     * The interval between selectable minutes (e.g., 1 for every minute, 5 for 5-minute intervals, 15 for 15-minute intervals).
+     * Defaults to 1 (every minute).
+     */
+    readonly minuteStep = input<number>(1);
 
     /** @hidden */
     private _meridian: boolean;


### PR DESCRIPTION
add minuteStep input for time picker intervals

Add optional minuteStep parameter to control minute intervals in time picker components (e.g., 5, 10, 15-minute steps). Includes adapter implementations, signal-based inputs, dynamic offset calculation, and example components.

## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes #[13108](https://github.com/SAP/fundamental-ngx/issues/13108)

