### PR TITLE
fix(core): add missing CSS for byline wrapping

### DIFF
--- a/libs/core/list/directives/byline/list-byline-left.directive.ts
+++ b/libs/core/list/directives/byline/list-byline-left.directive.ts
@@ -1,16 +1,13 @@
-import { Directive, HostBinding, Input } from '@angular/core';
+import { booleanAttribute, Directive, input } from '@angular/core';
 
 @Directive({
     selector: '[fdListBylineLeft], [fd-list-byline-left]',
-    standalone: true
+    host: {
+        class: 'fd-list__byline-left',
+        '[class.fd-list__byline-left--wrap]': 'wrap()'
+    }
 })
 export class ListBylineLeftDirective {
-    /** @hidden */
-    @HostBinding('class.fd-list__byline-left')
-    fdListBylineLeftClass = true;
-
     /** Whether or not this should be wrapped, when too much text. */
-    @Input()
-    @HostBinding('class.fd-list__byline-left--wrap')
-    wrap = false;
+    readonly wrap = input(false, { transform: booleanAttribute });
 }

--- a/libs/core/list/directives/byline/list-byline-right.directive.ts
+++ b/libs/core/list/directives/byline/list-byline-right.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input } from '@angular/core';
+import { booleanAttribute, Directive, input } from '@angular/core';
 
 export type ListBylineStatus = 'neutral' | 'positive' | 'negative' | 'critical' | 'informative';
 
@@ -6,24 +6,21 @@ export type ListBylineStatus = 'neutral' | 'positive' | 'negative' | 'critical' 
     selector: '[fdListBylineRight], [fd-list-byline-right]',
     host: {
         class: 'fd-list__byline-right',
-        '[class.fd-list__byline-right--neutral]': 'status === "neutral"',
-        '[class.fd-list__byline-right--positive]': 'status === "positive"',
-        '[class.fd-list__byline-right--negative]': 'status === "negative"',
-        '[class.fd-list__byline-right--critical]': 'status === "critical"',
-        '[class.fd-list__byline-right--informative]': 'status === "informative"',
-        '[class.fd-list__byline-right--wrap]': 'wrap'
-    },
-    standalone: true
+        '[class.fd-list__byline-right--neutral]': 'status() === "neutral"',
+        '[class.fd-list__byline-right--positive]': 'status() === "positive"',
+        '[class.fd-list__byline-right--negative]': 'status() === "negative"',
+        '[class.fd-list__byline-right--critical]': 'status() === "critical"',
+        '[class.fd-list__byline-right--informative]': 'status() === "informative"',
+        '[class.fd-list__byline-right--wrap]': 'wrap()'
+    }
 })
 export class ListBylineRightDirective {
     /** Semantic status of byline
      *  Possible options are:
      * 'neutral' | 'positive' | 'negative' | 'critical' | 'informative'
      */
-    @Input()
-    status: ListBylineStatus;
+    readonly status = input<ListBylineStatus>();
 
     /** Whether or not this should be wrapped, when too much text. */
-    @Input()
-    wrap = false;
+    readonly wrap = input(false, { transform: booleanAttribute });
 }

--- a/libs/core/list/directives/byline/list-byline.directive.ts
+++ b/libs/core/list/directives/byline/list-byline.directive.ts
@@ -1,20 +1,17 @@
-import { Directive, Input } from '@angular/core';
+import { booleanAttribute, Directive, input } from '@angular/core';
 
 @Directive({
     selector: '[fdListByline], [fd-list-byline]',
     host: {
         class: 'fd-list__byline',
-        '[class.fd-list__byline--2-col]': 'twoCol',
-        '[class.fd-list__byline--wrap]': 'wrap'
-    },
-    standalone: true
+        '[class.fd-list__byline--2-col]': 'twoCol()',
+        '[class.fd-list__byline--wrap]': 'wrap()'
+    }
 })
 export class ListBylineDirective {
     /** Whether or not this is a 2-column byline. */
-    @Input()
-    twoCol = false;
+    readonly twoCol = input(false, { transform: booleanAttribute });
 
     /** Whether or not this should be wrapped, when too much text. */
-    @Input()
-    wrap = false;
+    readonly wrap = input(false, { transform: booleanAttribute });
 }

--- a/libs/core/list/directives/list-title.directive.ts
+++ b/libs/core/list/directives/list-title.directive.ts
@@ -1,25 +1,22 @@
-import { booleanAttribute, Directive, ElementRef, input, OnInit } from '@angular/core';
+import { booleanAttribute, Directive, ElementRef, inject, input, OnInit } from '@angular/core';
 
 @Directive({
     selector: '[fd-list-title], [fdListTitle]',
-    standalone: true,
     host: {
         class: 'fd-list__title',
-        '[class.fd-list__title--truncate]': 'truncate()'
+        '[class.fd-list__title--truncate]': 'truncate()',
+        '[class.fd-list__title--wrap]': 'wrap()'
     }
 })
 export class ListTitleDirective implements OnInit {
-    /**
-     * @deprecated
-     * Whether or not this should be wrapped, when too much text.
-     */
-    wrap = input(false, { transform: booleanAttribute });
+    /** Whether or not this should be wrapped, when too much text. */
+    readonly wrap = input(false, { transform: booleanAttribute });
 
     /** Whether the text should truncate with ellipsis. */
-    truncate = input(false, { transform: booleanAttribute });
+    readonly truncate = input(false, { transform: booleanAttribute });
 
     /** @hidden */
-    constructor(public elRef: ElementRef) {}
+    readonly elRef = inject(ElementRef);
 
     /** @hidden */
     ngOnInit(): void {

--- a/libs/core/list/list.component.scss
+++ b/libs/core/list/list.component.scss
@@ -85,3 +85,11 @@
         white-space: normal;
     }
 }
+
+.fd-list--byline {
+    .fd-list__title.fd-list__title--wrap,
+    .fd-list__byline-left.fd-list__byline-left--wrap,
+    .fd-list__byline-right.fd-list__byline-right--wrap {
+        white-space: normal;
+    }
+}


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13718

## Description
- brings the CSS that allows text wrapping
- adds missing property binding for title
- refactor the affected directives to use signals
- remove the default standalone prop in the decorator


## Screenshots
Before:
<img width="776" height="504" alt="Screenshot 2026-01-19 at 11 39 47 AM" src="https://github.com/user-attachments/assets/77f8530d-8e7a-42bd-8278-9ea34768d179" />

After:
<img width="778" height="751" alt="Screenshot 2026-01-19 at 11 39 12 AM" src="https://github.com/user-attachments/assets/c71e90ba-b636-4839-91bb-fc9616d92475" />
