### PR TITLE
[WIP]fix(core): handle locale-specific decimal separators in input-group

### DIFF
--- a/libs/cdk/forms/cva/cva.directive.ts
+++ b/libs/cdk/forms/cva/cva.directive.ts
@@ -401,7 +401,14 @@ export class CvaDirective<T = any>
         let coercedValue: any = value;
 
         if (this.type === 'number') {
-            coercedValue = value === '' || value === null || value === undefined ? null : Number(value);
+            if (value === '' || value === null || value === undefined) {
+                coercedValue = null;
+            } else {
+                // Keep as string to preserve user input format (e.g., "1e2" instead of converting to 100)
+                // This prevents the input from changing unexpectedly while typing
+                // The actual number conversion will happen when the form is submitted
+                coercedValue = value;
+            }
         }
 
         if (coercedValue !== this.value) {

--- a/libs/core/input-group/input-group.component.html
+++ b/libs/core/input-group/input-group.component.html
@@ -74,12 +74,14 @@
         [attr.aria-labelledby]="ariaLabel ? null : _inputAriaLabelledBy"
         [class.fd-shellbar__input-group-input]="inShellbar"
         fd-input-group-input
-        [type]="type"
+        [type]="type === 'number' ? 'text' : type"
+        [attr.inputmode]="type === 'number' ? 'decimal' : null"
         [class.is-disabled]="!!_cvaControl.cvaDirective?.disabled"
         [disabled]="!!_cvaControl.cvaDirective?.disabled"
         [readonly]="_cvaControl.cvaDirective?.readonly"
         [attr.placeholder]="_cvaControl.cvaDirective?.placeholder || null"
         [attr.aria-required]="required"
+        (input)="_onInput($event)"
         (search)="_onSearchEvent($event)"
     />
 </ng-template>

--- a/libs/core/input-group/input-group.component.spec.ts
+++ b/libs/core/input-group/input-group.component.spec.ts
@@ -44,6 +44,73 @@ describe('InputGroupComponent', () => {
         });
         component._buttonClicked({} as any);
     });
+
+    it('should normalize comma to period for number inputs', () => {
+        component.type = 'number';
+        fixture.detectChanges();
+
+        const mockEvent = {
+            target: {
+                value: '123,45',
+                selectionStart: 6,
+                setSelectionRange: jest.fn()
+            }
+        } as any;
+
+        component._onInput(mockEvent);
+
+        expect(mockEvent.target.value).toBe('123.45');
+    });
+
+    it('should remove invalid characters from number input', () => {
+        component.type = 'number';
+        fixture.detectChanges();
+
+        const mockEvent = {
+            target: {
+                value: '12a3.4b5',
+                selectionStart: 8,
+                setSelectionRange: jest.fn()
+            }
+        } as any;
+
+        component._onInput(mockEvent);
+
+        expect(mockEvent.target.value).toBe('123.45');
+    });
+
+    it('should allow only one decimal point', () => {
+        component.type = 'number';
+        fixture.detectChanges();
+
+        const mockEvent = {
+            target: {
+                value: '123.45.67',
+                selectionStart: 9,
+                setSelectionRange: jest.fn()
+            }
+        } as any;
+
+        component._onInput(mockEvent);
+
+        expect(mockEvent.target.value).toBe('123.4567');
+    });
+
+    it('should not modify non-number inputs', () => {
+        component.type = 'text';
+        fixture.detectChanges();
+
+        const mockEvent = {
+            target: {
+                value: '123,abc',
+                selectionStart: 7
+            }
+        } as any;
+
+        component._onInput(mockEvent);
+
+        expect(mockEvent.target.value).toBe('123,abc');
+    });
 });
 
 describe('InputGroup component CVA', () => {
@@ -59,6 +126,7 @@ describe('InputGroup component CVA', () => {
         },
         hostTemplate: {
             hostComponent: InputGroupComponent,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             getTestingComponent: (fixture) => fixture.componentInstance._cvaControl.cvaDirective!
         },
         /** Whether component is able to track "onBlur" events separately */

--- a/libs/docs/core/input-group/examples/input-group-text-example.component.html
+++ b/libs/docs/core/input-group/examples/input-group-text-example.component.html
@@ -2,9 +2,16 @@
 <br />
 <div fd-form-item>
     <label fd-form-label [required]="true" for="fd-input-group-text-1" id="fd-input-group-label-1"
-        >Left Aligned Text Add-on</label
+        >Left Aligned Text Add-on (input type number)</label
     >
-    <fd-input-group id="fd-input-group-text-1" addOnText="$" placement="before" [required]="true" placeholder="Amount">
+    <fd-input-group
+        id="fd-input-group-text-1"
+        type="number"
+        addOnText="$"
+        placement="before"
+        [required]="true"
+        placeholder="Amount"
+    >
     </fd-input-group>
 </div>
 

--- a/libs/docs/core/input/examples/input-example.component.html
+++ b/libs/docs/core/input/examples/input-example.component.html
@@ -9,6 +9,10 @@
     <input fd-form-control type="text" id="input-2" placeholder="Field placeholder text" aria-required="true" />
 </div>
 <div fd-form-item>
+    <label fd-form-label for="input-num" [colon]="true">Number input</label>
+    <input fd-form-control type="number" id="input-num" placeholder="Field placeholder text" />
+</div>
+<div fd-form-item>
     <label fd-form-label for="input-3">Password</label>
     <input fd-form-control type="password" id="input-3" placeholder="Field placeholder text" aria-required="true" />
 </div>


### PR DESCRIPTION
## Related Issue(s)

related to https://github.com/SAP/fundamental-ngx/issues/13778
(to be closed with the downport issue)

## Description
**Problem:**
In some locales (for example Bulgarian, German) typing a period in number inputs caused the field to clear due to browser locale validation.

**Changes:**
- Changed input-group to use type="text" with inputmode="decimal" for number inputs
- Added custom validation to normalize comma/period to locale separator
- Support for scientific notation (e.g., 1e10, 1.5e-3)
- Updated CvaDirective to preserve string values during input
- Locale-aware display: comma in comma-locales, period in period-locales
- Updated input and input-group examples to show input fields of type number


https://github.com/user-attachments/assets/0866cfec-5fb7-4521-9995-10270cfb8684



