### PR TITLE
fix(core): resolve ExpressionChangedAfterItHasBeenCheckedError in message strip alerts

### DIFF
--- a/libs/core/message-strip/alert/message-strip-alert.service.ts
+++ b/libs/core/message-strip/alert/message-strip-alert.service.ts
@@ -191,8 +191,7 @@ export class MessageStripAlertService {
                             topSectionIsOpened = topSectionIsOpened || position.startsWith('top');
                             bottomSectionIsOpened = bottomSectionIsOpened || position.startsWith('bottom');
                             const { containerRef } = this.getOverlayRef(position);
-                            containerRef.instance.attachedElements = portals;
-                            containerRef.changeDetectorRef.detectChanges();
+                            containerRef.instance.attachedElements.set(portals);
                         });
                         this.syncExistingOverlays(messageAlertsByPosition, bottomSectionIsOpened, topSectionIsOpened);
                     }
@@ -208,11 +207,15 @@ export class MessageStripAlertService {
         topSectionIsOpened: boolean
     ): void {
         (Object.keys(this._overlayRefs) as MessageStripAlertPosition[]).forEach((position) => {
+            const overlayRef = this._overlayRefs[position];
+            if (!overlayRef) {
+                return;
+            }
             if (!messageAlertsByPosition[position]) {
-                this._overlayRefs[position]!.ref.dispose();
+                overlayRef.ref.dispose();
                 delete this._overlayRefs[position];
             } else {
-                const ref = this._overlayRefs[position]!.ref;
+                const ref = overlayRef.ref;
                 if (position.startsWith('top')) {
                     if (bottomSectionIsOpened) {
                         ref.overlayElement.classList.add('fd-message-strip-alert-overlay--bottom-opened');
@@ -256,6 +259,7 @@ export class MessageStripAlertService {
             );
             this._overlayRefs[position] = { ref: overlayRef, containerRef };
         }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return this._overlayRefs[position]!;
     }
 

--- a/libs/core/message-strip/auto-dismiss-message-strip.directive.ts
+++ b/libs/core/message-strip/auto-dismiss-message-strip.directive.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, DestroyRef, Directive, ElementRef, inject, Input, isDevMode } from '@angular/core';
+import { booleanAttribute, DestroyRef, Directive, ElementRef, inject, Input, isDevMode, signal } from '@angular/core';
 import { destroyObservable } from '@fundamental-ngx/cdk/utils';
 import { fromEvent, map, merge, Observable, of, startWith, takeUntil } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
@@ -11,7 +11,7 @@ import { MessageStripComponent } from './message-strip.component';
     exportAs: 'fdAutoDismissMessageStrip',
     standalone: true,
     host: {
-        '[style.display]': '!opened ? "none" : null'
+        '[style.display]': '!_opened() ? "none" : null'
     }
 })
 export class AutoDismissMessageStripDirective {
@@ -30,8 +30,11 @@ export class AutoDismissMessageStripDirective {
     @Input({ transform: booleanAttribute })
     mousePersist: BooleanInput = false;
 
-    /** Whether the message strip is currently opened. */
-    opened = false;
+    /**
+     * Whether the message strip is currently opened.
+     * @hidden
+     */
+    protected readonly _opened = signal(false);
 
     /** @hidden */
     private messageStripComponent = inject(MessageStripComponent, { optional: false, host: true });
@@ -54,7 +57,7 @@ export class AutoDismissMessageStripDirective {
 
     /** @hidden */
     open(): void {
-        this.opened = true;
+        this._opened.set(true);
         this.elementRef.nativeElement.classList.remove('fd-has-display-block');
         this.elementRef.nativeElement.classList.remove('fd-has-display-none');
         this.stopAutoDismiss();


### PR DESCRIPTION


## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13802

## Description
**Problem:**
- Direct property mutations during change detection caused expression changed errors
- Manual detectChanges() calls triggered updates in the same cycle
- Observable-based alertRefs$ emitted synchronously during change detection

**Updates:**
- Migrated to signal-based reactive patterns 
- Converted attachedElements and opened properties to signals
- Replaced @ViewChildren with viewChildren() signal query
- Converted alertRefs$ Observable to computed() signal
- Removed manual change detection calls