### PR TITLE
fix: migrate RtlService usage to Angular 21 signal patterns

### DIFF
--- a/libs/btp/navigation/components/navigation-item/navigation-list-item.component.html
+++ b/libs/btp/navigation/components/navigation-item/navigation-list-item.component.html
@@ -61,7 +61,7 @@
             [focusAutoCapture]="true"
             [restoreFocusOnClose]="false"
             [focusTrapped]="true"
-            [placement]="_popoverPlacement$()"
+            [placement]="popoverPlacement()"
             [disableScrollbar]="true"
         >
             <fd-popover-body [ngClass]="navigation.classList$()">

--- a/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
+++ b/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
@@ -202,14 +202,6 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
     /** Type of the list item. Whether its a standard item or a "show more" button container. */
     readonly type: 'item' | 'showMore' = 'item';
 
-    /** @hidden */
-    readonly _toggleIcon$ = computed(() => {
-        if (this.expandedAttr$()) {
-            return 'slim-arrow-down';
-        }
-        return this._rtl$() ? 'slim-arrow-left' : 'slim-arrow-right';
-    });
-
     /** List item placement container. */
     readonly placementContainer =
         inject(FdbNavigationContentContainer, {
@@ -425,12 +417,6 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
     /** @hidden */
     readonly quickCreate$ = signal(false);
 
-    /**
-     * @hidden
-     * Popover position. Changes based on rtl value.
-     */
-    readonly _popoverPlacement$ = computed<Placement>(() => (this._rtl$() ? 'left-start' : 'right-start'));
-
     /** @hidden */
     readonly _moreButtonRef$ = computed(() => this._parentNavigationList?.moreButtonRef || null);
 
@@ -446,6 +432,12 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
             this._parentNavigationListItemDirective?.parentNavListItemDirective?._item || this.parentListItemComponent
         );
     }
+
+    /**
+     * @hidden
+     * Popover position. Changes based on rtl value.
+     */
+    protected readonly popoverPlacement = computed<Placement>(() => (this._isRtl() ? 'left-start' : 'right-start'));
 
     /** @hidden */
     private readonly _home$ = signal(false);
@@ -498,12 +490,10 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
         { initialValue: 'expand/collapse sub-items' }
     );
 
-    private readonly _rtlService = inject(RtlService, {
-        optional: true
-    });
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /** @hidden */
-    private readonly _rtl$ = computed<boolean>(() => !!this._rtlService?.rtlSignal());
+    private readonly _isRtl = computed(() => this._rtlService?.rtl() ?? false);
 
     /**
      * @hidden
@@ -666,7 +656,7 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
             return;
         }
 
-        const isGoBack = KeyUtil.isKeyCode(event, this._rtl$() ? LEFT_ARROW : RIGHT_ARROW);
+        const isGoBack = KeyUtil.isKeyCode(event, this._isRtl() ? LEFT_ARROW : RIGHT_ARROW);
 
         if (!isGoBack) {
             return;

--- a/libs/btp/navigation/components/navigation-link/navigation-link.component.ts
+++ b/libs/btp/navigation/components/navigation-link/navigation-link.component.ts
@@ -247,7 +247,7 @@ export class NavigationLinkComponent extends FdbNavigationItemLink implements On
             return;
         }
 
-        const expansionKey = this._rtl?.rtl.value ? LEFT_ARROW : RIGHT_ARROW;
+        const expansionKey = this._rtl?.rtl() ? LEFT_ARROW : RIGHT_ARROW;
 
         this._listItemComponent?.keyboardExpanded(KeyUtil.isKeyCode(keyboardEvent, expansionKey));
     }

--- a/libs/btp/navigation/components/navigation-list/navigation-list.component.ts
+++ b/libs/btp/navigation/components/navigation-list/navigation-list.component.ts
@@ -190,7 +190,7 @@ export class NavigationListComponent implements OnChanges, AfterViewInit, OnDest
     });
 
     /** @hidden */
-    private readonly _rtl = inject(RtlService, {
+    private readonly _rtlService = inject(RtlService, {
         optional: true
     });
 
@@ -257,7 +257,7 @@ export class NavigationListComponent implements OnChanges, AfterViewInit, OnDest
 
         // All navigation lists use the same swapped arrow logic:
         // RIGHT arrow = expand action, LEFT arrow = collapse/go back action
-        const isExpandAction = KeyUtil.isKeyCode(event, this._rtl?.rtl.value ? LEFT_ARROW : RIGHT_ARROW);
+        const isExpandAction = KeyUtil.isKeyCode(event, this._rtlService?.rtl() ? LEFT_ARROW : RIGHT_ARROW);
 
         if (!isExpandAction) {
             if (this.moreButtonRef) {

--- a/libs/btp/navigation/components/navigation-more-button/navigation-more-button.component.html
+++ b/libs/btp/navigation/components/navigation-more-button/navigation-more-button.component.html
@@ -17,7 +17,7 @@
         (isOpenChange)="_onPopoverOpenChange($event)"
         [focusTrapped]="true"
         additionalBodyClass="fd-navigation__list-container fd-navigation__list-container--menu"
-        [placement]="_popoverPlacement$()"
+        [placement]="popoverPlacement()"
     >
         <fd-popover-body [ngClass]="_navigation.classList$()" role="menu">
             <ul

--- a/libs/btp/navigation/components/navigation-more-button/navigation-more-button.component.ts
+++ b/libs/btp/navigation/components/navigation-more-button/navigation-more-button.component.ts
@@ -107,21 +107,19 @@ export class NavigationMoreButtonComponent {
      * @hidden
      * Popover position. Changes based on rtl value.
      */
-    readonly _popoverPlacement$ = computed<Placement>(() => (this._rtl$() ? 'left-start' : 'right-start'));
+    protected readonly popoverPlacement = computed<Placement>(() => (this._isRtl() ? 'left-start' : 'right-start'));
 
     /** @hidden */
     private _popoverClicked = false;
 
     /** @hidden */
-    private readonly _rtlService = inject(RtlService, {
-        optional: true
-    });
-
-    /** @hidden */
     private readonly elementRef = inject(ElementRef);
 
     /** @hidden */
-    private readonly _rtl$ = computed<boolean>(() => !!this._rtlService?.rtlSignal());
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
+    private readonly _isRtl = computed(() => this._rtlService?.rtl() ?? false);
 
     /** @hidden */
     private readonly _lang$ = inject(FD_LANGUAGE);
@@ -251,7 +249,7 @@ export class NavigationMoreButtonComponent {
             return;
         }
 
-        const isRtl = this._rtl$() || false;
+        const isRtl = this._isRtl();
 
         if (KeyUtil.isKeyCode(event, isRtl ? LEFT_ARROW : RIGHT_ARROW)) {
             // Open popover only if not already open

--- a/libs/btp/splitter/splitter-pane-container/splitter-pane-container.component.ts
+++ b/libs/btp/splitter/splitter-pane-container/splitter-pane-container.component.ts
@@ -12,10 +12,8 @@ import {
     inject,
     Input,
     OnDestroy,
-    Optional,
     Output,
     QueryList,
-    SkipSelf,
     ViewEncapsulation
 } from '@angular/core';
 import { Subscription } from 'rxjs';
@@ -176,18 +174,20 @@ export class SplitterPaneContainerComponent
     }
 
     /** @hidden */
-    private get _isRtl(): boolean {
-        return this._rtlService?.rtl.getValue();
-    }
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
+    private readonly _parentSplitterPaneContainer = inject(SplitterPaneContainerComponent, {
+        optional: true,
+        skipSelf: true
+    });
 
     /** @hidden */
     constructor(
         private readonly _cdr: ChangeDetectorRef,
         private readonly _elementRef: ElementRef,
         private readonly _splitter: SplitterComponent,
-        private readonly _viewportRuler: ViewportRuler,
-        @Optional() private readonly _rtlService: RtlService,
-        @Optional() @SkipSelf() private readonly _parentSplitterPaneContainer: SplitterPaneContainerComponent
+        private readonly _viewportRuler: ViewportRuler
     ) {}
 
     /** @hidden */
@@ -273,7 +273,8 @@ export class SplitterPaneContainerComponent
             return;
         }
 
-        diff *= this._isRtl && this.orientation === SplitterPaneContainerOrientation.vertical ? -1 : 1;
+        const isRtl = this._rtlService?.rtl() ?? false;
+        diff *= isRtl && this.orientation === SplitterPaneContainerOrientation.vertical ? -1 : 1;
 
         const resizedPaneIndex =
             this._panesInRightOrderForResize.findIndex((pane) => pane.id === paneId) + (diff < 0 ? 1 : 0);

--- a/libs/btp/tool-header/src/components/tool-header/tool-header.component.ts
+++ b/libs/btp/tool-header/src/components/tool-header/tool-header.component.ts
@@ -254,7 +254,7 @@ export class ToolHeaderComponent extends ToolHeaderComponentClass implements OnD
 
     /** @hidden */
     protected _handleMenuLeftArrowKey(): void {
-        if (this._rtl()) {
+        if (this.rtl()) {
             this.menuExpand.emit();
         } else {
             this.menuCollapse.emit();
@@ -263,7 +263,7 @@ export class ToolHeaderComponent extends ToolHeaderComponentClass implements OnD
 
     /** @hidden */
     protected _handleMenuRightArrowKey(): void {
-        if (this._rtl()) {
+        if (this.rtl()) {
             this.menuCollapse.emit();
         } else {
             this.menuExpand.emit();

--- a/libs/btp/tool-header/src/tool-header-component.class.ts
+++ b/libs/btp/tool-header/src/tool-header-component.class.ts
@@ -88,7 +88,7 @@ export abstract class ToolHeaderComponentClass {
      * RTL signal
      * @hidden
      */
-    protected _rtl = computed<boolean>(() => !!this._rtlService?.rtlSignal());
+    protected rtl = computed<boolean>(() => this._rtlService?.rtl() ?? false);
 
     /** @hidden */
     private readonly _rtlService = inject(RtlService, { optional: true });

--- a/libs/cdk/utils/directives/resize/resize.directive.ts
+++ b/libs/cdk/utils/directives/resize/resize.directive.ts
@@ -7,10 +7,9 @@ import {
     Input,
     OnChanges,
     OnDestroy,
-    Optional,
     Output,
     SimpleChanges,
-    computed
+    inject
 } from '@angular/core';
 import { Observable, Subscription, fromEvent, merge } from 'rxjs';
 import { filter, map, pairwise, takeUntil, tap } from 'rxjs/operators';
@@ -33,7 +32,7 @@ export class ResizeDirective implements OnChanges, AfterViewInit, OnDestroy {
     @Input('fdkResizeBoundary') resizeBoundary: string | HTMLElement = 'body';
 
     /** Whether resizable behaviour should be disabled */
-    // eslint-disable-next-line @angular-eslint/no-input-rename
+
     @Input('fdkResizeDisabled') disabled = false;
 
     /** Additional class to be applied to the Element ref during resize. */
@@ -83,13 +82,10 @@ export class ResizeDirective implements OnChanges, AfterViewInit, OnDestroy {
     private _resizeSubscriptions = new Subscription();
 
     /** @hidden */
-    private readonly _direction$ = computed(() => (this._rtlService?.rtlSignal() ? -1 : 1));
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /** @hidden */
-    constructor(
-        private _elementRef: ElementRef<HTMLElement>,
-        @Optional() private _rtlService: RtlService
-    ) {}
+    constructor(private _elementRef: ElementRef<HTMLElement>) {}
 
     /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
@@ -200,7 +196,8 @@ export class ResizeDirective implements OnChanges, AfterViewInit, OnDestroy {
         }
 
         return (event1: MouseEvent, event2: MouseEvent) => {
-            const x = (event2.screenX - event1.screenX) * this._direction$();
+            const direction = this._rtlService?.rtl() ? -1 : 1;
+            const x = (event2.screenX - event1.screenX) * direction;
             const y = event2.screenY - event1.screenY;
 
             return {

--- a/libs/cdk/utils/drag-and-drop/dnd-keyboard-group/dnd-keyboard-group.directive.ts
+++ b/libs/cdk/utils/drag-and-drop/dnd-keyboard-group/dnd-keyboard-group.directive.ts
@@ -1,6 +1,6 @@
 import { moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
 import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
-import { ChangeDetectorRef, Directive, Input, Optional } from '@angular/core';
+import { ChangeDetectorRef, Directive, inject, Input } from '@angular/core';
 import { Subject } from 'rxjs';
 import { KeyUtil } from '../../functions';
 import { RtlService } from '../../services/rtl.service';
@@ -29,10 +29,10 @@ export class DndKeyboardGroupDirective {
     _onDndItemFocus$ = new Subject<[number, number]>();
 
     /** @hidden */
-    constructor(
-        private readonly _cdr: ChangeDetectorRef,
-        @Optional() private readonly _rtlService: RtlService
-    ) {}
+    private readonly _cdr = inject(ChangeDetectorRef);
+
+    /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /** Custom function to call when moving item inside the group */
     @Input()
@@ -50,7 +50,7 @@ export class DndKeyboardGroupDirective {
             return;
         }
 
-        const isRtl = this._rtlService.rtl.value;
+        const isRtl = this._rtlService?.rtl() ?? false;
 
         const group = this.groups[groupIndex];
         const indexInNextGroup = this.orientation === 'vertical' ? 0 : itemIndex;

--- a/libs/cdk/utils/services/rtl.service.spec.ts
+++ b/libs/cdk/utils/services/rtl.service.spec.ts
@@ -1,0 +1,162 @@
+import { computed, effect, Injector, runInInjectionContext } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { RTL_LANGUAGE, RtlService } from './rtl.service';
+
+describe('RtlService', () => {
+    let service: RtlService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [RtlService]
+        });
+        service = TestBed.inject(RtlService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    describe('signal operations', () => {
+        it('should allow setting RTL value via set()', () => {
+            service.rtl.set(true);
+            expect(service.rtl()).toBe(true);
+
+            service.rtl.set(false);
+            expect(service.rtl()).toBe(false);
+        });
+
+        it('should allow updating RTL value via update()', () => {
+            service.rtl.set(false);
+            service.rtl.update((current) => !current);
+            expect(service.rtl()).toBe(true);
+
+            service.rtl.update((current) => !current);
+            expect(service.rtl()).toBe(false);
+        });
+
+        it('should work with computed signals', () => {
+            const injector = TestBed.inject(Injector);
+
+            runInInjectionContext(injector, () => {
+                const direction = computed(() => (service.rtl() ? 'rtl' : 'ltr'));
+
+                service.rtl.set(false);
+                expect(direction()).toBe('ltr');
+
+                service.rtl.set(true);
+                expect(direction()).toBe('rtl');
+            });
+        });
+
+        it('should trigger effects when value changes', () => {
+            const injector = TestBed.inject(Injector);
+            const values: boolean[] = [];
+
+            runInInjectionContext(injector, () => {
+                effect(() => {
+                    values.push(service.rtl());
+                });
+
+                // Initial value captured
+                TestBed.tick();
+                expect(values.length).toBe(1);
+
+                // Change value
+                service.rtl.set(!service.rtl());
+                TestBed.tick();
+                expect(values.length).toBe(2);
+            });
+        });
+    });
+
+    describe('deprecated rtlSignal getter', () => {
+        it('should return the same signal as rtl', () => {
+            expect(service.rtlSignal).toBe(service.rtl);
+        });
+    });
+
+    describe('RTL_LANGUAGE injection token', () => {
+        it('should use custom RTL languages when token is provided', () => {
+            // Mock navigator.language to return a custom RTL language
+            const originalLanguage = navigator.language;
+            Object.defineProperty(navigator, 'language', {
+                value: 'custom-rtl',
+                configurable: true
+            });
+
+            TestBed.resetTestingModule();
+            TestBed.configureTestingModule({
+                providers: [RtlService, { provide: RTL_LANGUAGE, useValue: ['custom-rtl'] }]
+            });
+
+            const customService = TestBed.inject(RtlService);
+            expect(customService.rtl()).toBe(true);
+
+            // Restore original language
+            Object.defineProperty(navigator, 'language', {
+                value: originalLanguage,
+                configurable: true
+            });
+        });
+
+        it('should detect Arabic language as RTL', () => {
+            const originalLanguage = navigator.language;
+            Object.defineProperty(navigator, 'language', {
+                value: 'ar-SA',
+                configurable: true
+            });
+
+            TestBed.resetTestingModule();
+            TestBed.configureTestingModule({
+                providers: [RtlService]
+            });
+
+            const arabicService = TestBed.inject(RtlService);
+            expect(arabicService.rtl()).toBe(true);
+
+            Object.defineProperty(navigator, 'language', {
+                value: originalLanguage,
+                configurable: true
+            });
+        });
+
+        it('should detect English language as LTR', () => {
+            const originalLanguage = navigator.language;
+            Object.defineProperty(navigator, 'language', {
+                value: 'en-US',
+                configurable: true
+            });
+
+            TestBed.resetTestingModule();
+            TestBed.configureTestingModule({
+                providers: [RtlService]
+            });
+
+            const englishService = TestBed.inject(RtlService);
+            expect(englishService.rtl()).toBe(false);
+
+            Object.defineProperty(navigator, 'language', {
+                value: originalLanguage,
+                configurable: true
+            });
+        });
+    });
+
+    describe('integration patterns', () => {
+        it('should support arrow key swapping pattern', () => {
+            const LEFT_ARROW = 37;
+            const RIGHT_ARROW = 39;
+
+            const getExpandKey = (): number => (service.rtl() ? LEFT_ARROW : RIGHT_ARROW);
+            const getCollapseKey = (): number => (service.rtl() ? RIGHT_ARROW : LEFT_ARROW);
+
+            service.rtl.set(false);
+            expect(getExpandKey()).toBe(RIGHT_ARROW);
+            expect(getCollapseKey()).toBe(LEFT_ARROW);
+
+            service.rtl.set(true);
+            expect(getExpandKey()).toBe(LEFT_ARROW);
+            expect(getCollapseKey()).toBe(RIGHT_ARROW);
+        });
+    });
+});

--- a/libs/cdk/utils/services/rtl.service.ts
+++ b/libs/cdk/utils/services/rtl.service.ts
@@ -1,32 +1,79 @@
-import { Inject, Injectable, InjectionToken, Optional, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { BehaviorSubject } from 'rxjs';
+import { inject, Injectable, InjectionToken, signal, WritableSignal } from '@angular/core';
 
-/** Default RTL languages */
-const DefaultRtlLanguages = ['ar', 'arc', 'dv', 'fa', 'ha', 'he', 'khw', 'ks', 'ku', 'ps', 'ur', 'yi'];
+/**
+ * Default RTL (Right-to-Left) language codes.
+ *
+ * Note: For Kurdish, we use 'ckb' (Central Kurdish/Sorani) which uses Arabic script.
+ * The generic 'ku' code is not included as Kurmanji Kurdish uses Latin script (LTR).
+ */
+const DefaultRtlLanguages = [
+    'ar', // Arabic
+    'arc', // Aramaic
+    'azb', // South Azerbaijani
+    'bal', // Balochi
+    'ckb', // Central Kurdish (Sorani)
+    'dv', // Divehi (Maldivian)
+    'fa', // Persian (Farsi)
+    'glk', // Gilaki
+    'he', // Hebrew
+    'khw', // Khowar
+    'ks', // Kashmiri
+    'mzn', // Mazanderani
+    'nqo', // N'Ko
+    'pnb', // Western Punjabi (Shahmukhi)
+    'ps', // Pashto
+    'sd', // Sindhi
+    'syr', // Syriac
+    'ug', // Uyghur
+    'ur', // Urdu
+    'yi' // Yiddish
+];
+
+/** Injection token for overriding RTL languages. */
 export const RTL_LANGUAGE = new InjectionToken<string[]>('RtlLanguage');
 
-@Injectable()
 /**
- * Service taking care of RTL trough behavior subject
- * language list is used to determine if rtl should be enabled at start
- * user can overwrite default languages by using injection token RtlLanguageToken
+ * Service for managing RTL (Right-to-Left) state.
+ *
+ * Uses signals for reactive state management and is fully compatible with zoneless change detection.
+ * The language list is used to determine if RTL should be enabled at startup based on the browser's language.
+ * Users can override the default RTL languages by providing the `RTL_LANGUAGE` injection token.
+ *
+ * @example
+ * ```typescript
+ * // Reading RTL state
+ * readonly isRtl = computed(() => this._rtlService.rtl());
+ *
+ * // Updating RTL state
+ * this._rtlService.rtl.set(true);
+ * ```
  */
+@Injectable()
 export class RtlService {
-    /** RTL value */
-    rtl: BehaviorSubject<boolean>;
+    /**
+     * Writable signal for RTL state.
+     *
+     * Read the current value: `rtl()`
+     * Set a new value: `rtl.set(value)`
+     * Update based on current value: `rtl.update(current => !current)`
+     */
+    readonly rtl: WritableSignal<boolean>;
 
-    /** Signal wrapper for RTL value. */
-    rtlSignal: Signal<boolean>;
+    /**
+     * Signal for RTL value.
+     * @deprecated Use `rtl()` instead. This alias will be removed in a future version.
+     */
+    get rtlSignal(): WritableSignal<boolean> {
+        return this.rtl;
+    }
 
     /** @hidden */
-    constructor(@Optional() @Inject(RTL_LANGUAGE) injectedRtlLanguages: string[]) {
-        injectedRtlLanguages = injectedRtlLanguages || DefaultRtlLanguages;
+    private readonly _injectedRtlLanguages = inject(RTL_LANGUAGE, { optional: true });
 
-        const filtered = injectedRtlLanguages.filter((language) => navigator.language.includes(language));
+    constructor() {
+        const rtlLanguages = this._injectedRtlLanguages || DefaultRtlLanguages;
+        const isRtlLanguage = rtlLanguages.some((language) => navigator.language.includes(language));
 
-        this.rtl = new BehaviorSubject(filtered.length > 0);
-
-        this.rtlSignal = toSignal(this.rtl, { requireSync: true });
+        this.rtl = signal(isRtlLanguage);
     }
 }

--- a/libs/core/avatar-group/avatar-group.component.html
+++ b/libs/core/avatar-group/avatar-group.component.html
@@ -7,7 +7,7 @@
         [orientation]="orientation"
         fdkResizeObserver
         fdkFocusableList
-        [contentDirection]="_contentDirection$()"
+        [contentDirection]="contentDirection()"
         [wrap]="true"
         [navigationDirection]="orientation"
         [items]="_avatars"

--- a/libs/core/avatar-group/avatar-group.component.ts
+++ b/libs/core/avatar-group/avatar-group.component.ts
@@ -56,8 +56,7 @@ import { AvatarGroupHostConfig } from './types';
         DefaultAvatarGroupOverflowBodyComponent,
         AvatarGroupInternalOverflowButtonDirective,
         ResizeObserverDirective
-    ],
-    standalone: true
+    ]
 })
 export class AvatarGroupComponent implements AvatarGroupHostConfig {
     /**
@@ -111,7 +110,7 @@ export class AvatarGroupComponent implements AvatarGroupHostConfig {
     _avatarGroupPopoverBody: AvatarGroupOverflowBodyDirective;
 
     /** @hidden */
-    _contentDirection$ = computed<Direction>(() => (this._rtlService?.rtlSignal() ? 'rtl' : 'ltr'));
+    protected readonly contentDirection = computed<Direction>(() => (this._rtlService?.rtl() ? 'rtl' : 'ltr'));
 
     /** @hidden */
     private readonly _cdr = inject(ChangeDetectorRef);

--- a/libs/core/avatar-group/components/default-avatar-group-overflow-body/default-avatar-group-overflow-body.component.html
+++ b/libs/core/avatar-group/components/default-avatar-group-overflow-body/default-avatar-group-overflow-body.component.html
@@ -3,8 +3,8 @@
         <div fd-bar-left>
             @if (_isDetailStage) {
                 <fd-button-bar
-                    (click)="_openOverflowMain()"
-                    [glyph]="isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'"
+                    (click)="openOverflowMain()"
+                    [glyph]="navigationArrow()"
                     fdType="transparent"
                     aria-label="Back"
                     title="Back"

--- a/libs/core/avatar-group/components/default-avatar-group-overflow-body/default-avatar-group-overflow-body.component.ts
+++ b/libs/core/avatar-group/components/default-avatar-group-overflow-body/default-avatar-group-overflow-body.component.ts
@@ -11,6 +11,7 @@ import {
     Renderer2,
     ViewChildren,
     ViewEncapsulation,
+    computed,
     inject
 } from '@angular/core';
 import { FocusableListDirective, RtlService, elementClick$ } from '@fundamental-ngx/cdk/utils';
@@ -72,9 +73,10 @@ export class DefaultAvatarGroupOverflowBodyComponent implements AfterViewInit, O
     }
 
     /** @hidden */
-    get isRtl(): boolean {
-        return !!this._rtlService?.rtl.value;
-    }
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    );
+
     /** @hidden */
     private _itemClickSubscription: Subscription;
 
@@ -121,7 +123,7 @@ export class DefaultAvatarGroupOverflowBodyComponent implements AfterViewInit, O
     }
 
     /** @hidden */
-    _openOverflowMain(): void {
+    protected openOverflowMain(): void {
         this._overflowPopoverStage = 'main';
         this._changeDetectorRef.detectChanges();
     }

--- a/libs/core/breadcrumb/breadcrumb.component.html
+++ b/libs/core/breadcrumb/breadcrumb.component.html
@@ -16,7 +16,7 @@
         </div>
     }
     <ng-container *fdOverflowExpand="let breadcrumbs; items: _items$()">
-        <fd-menu #menu [closeOnEscapeKey]="true" [focusAutoCapture]="true" [placement]="_placement$()">
+        <fd-menu #menu [closeOnEscapeKey]="true" [focusAutoCapture]="true" [placement]="placement()">
             @for (breadcrumbItem of breadcrumbs; track breadcrumbItem) {
                 <li
                     fd-menu-item

--- a/libs/core/breadcrumb/breadcrumb.component.ts
+++ b/libs/core/breadcrumb/breadcrumb.component.ts
@@ -146,10 +146,10 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit, HasElementRef
     _items$ = signal<BreadcrumbItemComponent[]>([]);
 
     /** @hidden */
-    _placement$ = computed<Placement>(() => (this._rtl$() ? 'bottom-end' : 'bottom-start'));
-
-    /** Element reference. */
     readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+    /** @hidden */
+    protected readonly placement = computed<Placement>(() => (this._rtlService?.rtl() ? 'bottom-end' : 'bottom-start'));
 
     /** @hidden */
     protected readonly _cssClass = computed(() => {
@@ -165,9 +165,6 @@ export class BreadcrumbComponent implements OnInit, AfterViewInit, HasElementRef
     private readonly _rtlService = inject(RtlService, {
         optional: true
     });
-
-    /** @hidden */
-    private readonly _rtl$ = computed<boolean>(() => !!this._rtlService?.rtlSignal());
 
     /** @hidden */
     private readonly _lang$ = inject(FD_LANGUAGE);

--- a/libs/core/calendar/calendar.service.ts
+++ b/libs/core/calendar/calendar.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optional } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { RtlService } from '@fundamental-ngx/cdk/utils';
@@ -34,7 +34,7 @@ export class CalendarService {
     focusEscapeFunction: EscapeFocusFunction;
 
     /** @hidden */
-    constructor(@Optional() private _rtlService: RtlService) {}
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /**
      * Standardized method to calculate grid [x][y] to index number
@@ -51,7 +51,7 @@ export class CalendarService {
      * @param index which is number (0 - (rowAmount * colAmount))
      */
     onKeydownHandler(event: KeyboardEvent, index: number): void {
-        const rtl = !!this._rtlService?.rtlSignal();
+        const rtl = this._rtlService?.rtl() ?? false;
 
         switch (event.key) {
             case 'Spacebar':

--- a/libs/core/carousel/carousel.component.html
+++ b/libs/core/carousel/carousel.component.html
@@ -4,7 +4,7 @@
     tabindex="0"
     [style.height]="height"
     [style.width]="width"
-    [attr.dir]="_dir$()"
+    [attr.dir]="dir()"
     role="listbox"
     aria-roledescription="Carousel"
     [attr.aria-activedescendant]="ariaActivedescendant"
@@ -63,7 +63,7 @@
         </div>
     }
     @if (!numericIndicator && _showNavigationButtonInPageIndicatorContainer) {
-        <div class="fd-carousel__page-indicators" [attr.dir]="_dir$()">
+        <div class="fd-carousel__page-indicators" [attr.dir]="dir()">
             @if (pageIndicator) {
                 @for (item of pageIndicatorsCountArray; track item; let i = $index) {
                     <span

--- a/libs/core/carousel/carousel.component.ts
+++ b/libs/core/carousel/carousel.component.ts
@@ -208,9 +208,6 @@ export class CarouselComponent implements AfterContentInit, AfterViewInit, After
     /** @hidden the total number of slides in the carousel */
     totalSlides = 0;
 
-    /** @hidden handles rtl service */
-    readonly _dir$ = computed<Direction>(() => (this._rtl$() ? 'rtl' : 'ltr'));
-
     /** @hidden Make left navigation button disabled */
     leftButtonDisabled = false;
 
@@ -230,6 +227,9 @@ export class CarouselComponent implements AfterContentInit, AfterViewInit, After
     get _contentSizePx(): string {
         return this._slidesWrapperSize ? `${this._slidesWrapperSize}px` : this.width;
     }
+
+    /** @hidden handles rtl service */
+    protected readonly dir = computed<Direction>(() => (this._isRtl() ? 'rtl' : 'ltr'));
 
     /** @hidden */
     private _visibleSlidesCount: number | 'auto' = 1;
@@ -261,7 +261,7 @@ export class CarouselComponent implements AfterContentInit, AfterViewInit, After
     });
 
     /** @hidden */
-    private readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
+    private readonly _isRtl = computed(() => this._rtlService?.rtl() ?? false);
 
     /** @hidden */
     constructor(
@@ -272,7 +272,7 @@ export class CarouselComponent implements AfterContentInit, AfterViewInit, After
         private readonly _zone: NgZone
     ) {
         effect(() => {
-            const isRtl = this._rtl$();
+            const isRtl = this._isRtl();
             this._carouselService.isRtl = isRtl;
             if (this._carouselService.items && this._carouselService.active) {
                 this._carouselService.goToItem(this._carouselService.active, false);
@@ -290,10 +290,10 @@ export class CarouselComponent implements AfterContentInit, AfterViewInit, After
             event.preventDefault();
 
             if (KeyUtil.isKeyCode(event, LEFT_ARROW)) {
-                this._rtl$() ? this.next() : this.previous();
+                this._isRtl() ? this.next() : this.previous();
             }
             if (KeyUtil.isKeyCode(event, RIGHT_ARROW)) {
-                this._rtl$() ? this.previous() : this.next();
+                this._isRtl() ? this.previous() : this.next();
             }
             if (KeyUtil.isKeyCode(event, UP_ARROW)) {
                 this.previous();
@@ -586,8 +586,8 @@ export class CarouselComponent implements AfterContentInit, AfterViewInit, After
     private _getStepTaken(event: PanEndOutput, actualActiveSlideIndex: number): number {
         let stepsCalculated: number;
         if (
-            (!this._rtl$() && event.after) ||
-            (this._rtl$() && !event.after && !this.vertical) ||
+            (!this._isRtl() && event.after) ||
+            (this._isRtl() && !event.after && !this.vertical) ||
             (this.vertical && event.after)
         ) {
             if (actualActiveSlideIndex === 0 && this.currentActiveSlidesStartIndex === 0) {
@@ -672,7 +672,7 @@ export class CarouselComponent implements AfterContentInit, AfterViewInit, After
         const stepTaken = this._getStepTaken(event, actualActiveSlideIndex);
         if (stepTaken > 0) {
             let slideDirection: SlideDirection;
-            if (!this._rtl$()) {
+            if (!this._isRtl()) {
                 slideDirection = event.after ? SlideDirection.NEXT : SlideDirection.PREVIOUS;
             } else {
                 // vertical carousel slide direction is same in ltr and rtl

--- a/libs/core/fixed-card-layout/fixed-card-layout.component.html
+++ b/libs/core/fixed-card-layout/fixed-card-layout.component.html
@@ -10,7 +10,7 @@
     [customTransferFn]="_customTransferFn"
     [disableKeyboardDragDrop]="disableDragDrop"
     [cdkDropListGroupDisabled]="disableDragDrop"
-    [attr.dir]="_dir$()"
+    [attr.dir]="dir()"
 >
     @for (card of _cardsArray; track card; let cardIndex = $index) {
         <div

--- a/libs/core/fixed-card-layout/fixed-card-layout.component.ts
+++ b/libs/core/fixed-card-layout/fixed-card-layout.component.ts
@@ -23,7 +23,6 @@ import {
     Input,
     OnChanges,
     OnDestroy,
-    Optional,
     Output,
     QueryList,
     SimpleChanges,
@@ -196,7 +195,7 @@ export class FixedCardLayoutComponent implements AfterViewInit, OnChanges, OnDes
     _containerHeight = 0;
 
     /** @hidden handles rtl service */
-    _dir$ = computed<Direction>(() => (this._rtlService?.rtlSignal() ? 'rtl' : 'ltr'));
+    readonly dir = computed<Direction>(() => (this._rtlService?.rtl() ? 'rtl' : 'ltr'));
 
     /** @hidden first number is the CardDefinition rank, i.e. id */
     _groupIndexes = new Map<number, number>();
@@ -237,10 +236,10 @@ export class FixedCardLayoutComponent implements AfterViewInit, OnChanges, OnDes
     private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
-    constructor(
-        private readonly _changeDetector: ChangeDetectorRef,
-        @Optional() private readonly _rtlService: RtlService
-    ) {}
+    private readonly _changeDetector = inject(ChangeDetectorRef);
+
+    /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /** @hidden */
     @HostListener('keydown', ['$event'])

--- a/libs/core/grid-list/components/grid-list/grid-list.component.ts
+++ b/libs/core/grid-list/components/grid-list/grid-list.component.ts
@@ -117,18 +117,21 @@ export class GridListComponent<T> extends GridList<T> implements OnChanges, Afte
     private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
+    private readonly _cd = inject(ChangeDetectorRef);
+
+    /** @hidden */
+    private readonly _elRef = inject(ElementRef);
+
+    /** @hidden */
     private readonly _rtlService = inject(RtlService, {
         optional: true
     });
 
     /** @hidden */
-    private readonly _rtl$ = computed<boolean>(() => !!this._rtlService?.rtlSignal());
+    private readonly _isRtl = computed<boolean>(() => this._rtlService?.rtl() ?? false);
 
     /** @hidden */
-    constructor(
-        private readonly _cd: ChangeDetectorRef,
-        private _elRef: ElementRef
-    ) {
+    constructor() {
         super();
         this._selectedItems$ = this._selectedItemsSubject$.asObservable();
         const selectedItemsSub = this._selectedItems$
@@ -367,9 +370,9 @@ export class GridListComponent<T> extends GridList<T> implements OnChanges, Afte
         const itemsPerRow = this._getItemsPerRow(
             this._gridListItems.toArray()[currentItemIndex]._gridListItem.nativeElement
         );
-        if (KeyUtil.isKeyCode(event, LEFT_ARROW) || (this._rtl$() && KeyUtil.isKeyCode(event, [RIGHT_ARROW]))) {
+        if (KeyUtil.isKeyCode(event, LEFT_ARROW) || (this._isRtl() && KeyUtil.isKeyCode(event, [RIGHT_ARROW]))) {
             return currentItemIndex - 1;
-        } else if (KeyUtil.isKeyCode(event, RIGHT_ARROW) || (this._rtl$() && KeyUtil.isKeyCode(event, [LEFT_ARROW]))) {
+        } else if (KeyUtil.isKeyCode(event, RIGHT_ARROW) || (this._isRtl() && KeyUtil.isKeyCode(event, [LEFT_ARROW]))) {
             return currentItemIndex + 1;
         } else if (KeyUtil.isKeyCode(event, UP_ARROW)) {
             return currentItemIndex - itemsPerRow;

--- a/libs/core/list/list-navigation-item/list-navigation-item.component.ts
+++ b/libs/core/list/list-navigation-item/list-navigation-item.component.ts
@@ -11,7 +11,6 @@ import {
     HostBinding,
     HostListener,
     Input,
-    Optional,
     QueryList,
     Renderer2,
     computed,
@@ -114,16 +113,19 @@ export class ListNavigationItemComponent implements AfterContentInit, AfterViewI
     _isItemVisible = true;
 
     /** @hidden handles rtl service */
-    private readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
+    private readonly _isRtl = computed(() => this._rtlService?.rtl() ?? false);
 
     /** @hidden */
     private readonly _renderer2 = inject(Renderer2);
 
     /** @hidden */
-    constructor(
-        private _elementRef: ElementRef,
-        @Optional() private _rtlService: RtlService
-    ) {
+    private readonly _elementRef = inject(ElementRef);
+
+    /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
+    constructor() {
         effect(() => {
             if (this._condensed()) {
                 this._renderer2.addClass(this._elementRef.nativeElement, 'fd-list__navigation-item--condensed');
@@ -145,11 +147,11 @@ export class ListNavigationItemComponent implements AfterContentInit, AfterViewI
     keyDownHandler(event: KeyboardEvent): void {
         if (KeyUtil.isKeyCode(event, [RIGHT_ARROW])) {
             event.preventDefault();
-            this._handleExpandedChanges(!this._rtl$());
+            this._handleExpandedChanges(!this._isRtl());
         }
         if (KeyUtil.isKeyCode(event, [LEFT_ARROW])) {
             event.preventDefault();
-            this._handleExpandedChanges(this._rtl$());
+            this._handleExpandedChanges(this._isRtl());
         }
         if (KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
             event.preventDefault();

--- a/libs/core/menu/menu-mobile/menu-mobile.component.html
+++ b/libs/core/menu/menu-mobile/menu-mobile.component.html
@@ -11,7 +11,7 @@
                                 id="menu-mobile-navigate-back"
                                 fdCozy
                                 [attr.aria-label]="'Go to previous menu level: ' + title$()"
-                                [glyph]="navigationIcon$()"
+                                [glyph]="navigationIcon()"
                                 (click)="backToParentLevel()"
                             ></button>
                         </fd-bar-element>

--- a/libs/core/menu/menu-mobile/menu-mobile.component.ts
+++ b/libs/core/menu/menu-mobile/menu-mobile.component.ts
@@ -5,11 +5,11 @@ import {
     Inject,
     NgZone,
     OnInit,
-    Optional,
     TemplateRef,
     ViewChild,
     ViewEncapsulation,
     computed,
+    inject,
     signal
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -81,8 +81,8 @@ export class MenuMobileComponent extends MobileModeBase<MenuInterface> implement
     view$ = signal<TemplateRef<any> | null>(null);
 
     /** @hidden Navigation icon name based on RTL */
-    navigationIcon$ = computed(() =>
-        this._rtlService?.rtlSignal() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    protected readonly navigationIcon = computed(() =>
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
     );
 
     /** @hidden */
@@ -94,12 +94,16 @@ export class MenuMobileComponent extends MobileModeBase<MenuInterface> implement
     }
 
     /** @hidden */
-    constructor(
-        private _menuService: MenuService,
-        private _ngZone: NgZone,
-        @Optional() private _rtlService: RtlService,
-        @Inject(MENU_COMPONENT) menuComponent: MenuInterface
-    ) {
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
+    private readonly _menuService = inject(MenuService);
+
+    /** @hidden */
+    private readonly _ngZone = inject(NgZone);
+
+    /** @hidden */
+    constructor(@Inject(MENU_COMPONENT) menuComponent: MenuInterface) {
         super(menuComponent, MobileModeControl.MENU);
     }
 

--- a/libs/core/menu/services/menu.service.ts
+++ b/libs/core/menu/services/menu.service.ts
@@ -1,5 +1,5 @@
 import { DOWN_ARROW, ENTER, ESCAPE, LEFT_ARROW, RIGHT_ARROW, SPACE, UP_ARROW } from '@angular/cdk/keycodes';
-import { ElementRef, Injectable, OnDestroy, Optional, Renderer2 } from '@angular/core';
+import { ElementRef, inject, Injectable, OnDestroy, Renderer2 } from '@angular/core';
 import { KeyUtil, RtlService } from '@fundamental-ngx/cdk/utils';
 import { Observable, Subject } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
@@ -36,15 +36,15 @@ export class MenuService implements OnDestroy {
     private _destroyKeyboardHandlerListener: () => void;
 
     /** @hidden */
-    get _isRtl(): boolean {
-        return this._rtlService?.rtl.value;
-    }
+    private readonly _renderer = inject(Renderer2);
 
     /** @hidden */
-    constructor(
-        private _renderer: Renderer2,
-        @Optional() private readonly _rtlService: RtlService
-    ) {}
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
+    get _isRtl(): boolean {
+        return this._rtlService?.rtl() ?? false;
+    }
 
     /** Reference to menu component */
     get menuComponent(): MenuComponent {

--- a/libs/core/nested-list/nested-content/nested-list-content.directive.spec.ts
+++ b/libs/core/nested-list/nested-content/nested-list-content.directive.spec.ts
@@ -62,9 +62,9 @@ describe('NestedContentDirective', () => {
     });
 
     it('Should propagate expanded state to icon', () => {
-        expect(iconElement.expanded).toBeFalsy();
+        expect(iconElement.expanded()).toBeFalsy();
         directiveElement.changeExpandedState(true);
         fixture.detectChanges();
-        expect(iconElement.expanded).toBeTruthy();
+        expect(iconElement.expanded()).toBeTruthy();
     });
 });

--- a/libs/core/nested-list/nested-list-directives.spec.ts
+++ b/libs/core/nested-list/nested-list-directives.spec.ts
@@ -55,7 +55,7 @@ describe('NestedListDirectives', () => {
     });
 
     it('Expand Icon Element should have good classes and react on click', () => {
-        expect(expandIconElement.expanded).toBeFalsy();
+        expect(expandIconElement.expanded()).toBeFalsy();
 
         const spy = jest.spyOn((<any>expandIconElement)._itemService.toggle, 'next');
 
@@ -64,7 +64,7 @@ describe('NestedListDirectives', () => {
         fixture.detectChanges();
 
         expect(spy).toHaveBeenCalled();
-        expect(expandIconElement.expanded).toBeTruthy();
+        expect(expandIconElement.expanded()).toBeTruthy();
     });
 
     it('Title should give valid title string', () => {

--- a/libs/core/nested-list/nested-list-popover/nested-list-popover.component.html
+++ b/libs/core/nested-list/nested-list-popover/nested-list-popover.component.html
@@ -1,5 +1,5 @@
 <fd-popover
-    [placement]="placement$()"
+    [placement]="placement()"
     [triggers]="['click']"
     [noArrow]="false"
     [isOpen]="open"

--- a/libs/core/nested-list/nested-list-popover/nested-list-popover.component.ts
+++ b/libs/core/nested-list/nested-list-popover/nested-list-popover.component.ts
@@ -2,13 +2,12 @@ import {
     AfterContentInit,
     ChangeDetectionStrategy,
     Component,
+    computed,
     ContentChild,
-    HostBinding,
+    inject,
     Input,
-    Optional,
     ViewChild,
-    ViewEncapsulation,
-    computed
+    ViewEncapsulation
 } from '@angular/core';
 
 import { RtlService } from '@fundamental-ngx/cdk/utils';
@@ -28,6 +27,9 @@ import { NestedListPopoverInterface } from './nested-list-popover.interface';
     styleUrl: './nested-list-popover.component.scss',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        class: 'fd-nested-list__popover'
+    },
     imports: [
         PopoverComponent,
         PopoverControlComponent,
@@ -48,10 +50,6 @@ export class NestedListPopoverComponent implements NestedListPopoverInterface, A
     popoverComponent: PopoverComponent;
 
     /** @hidden */
-    @HostBinding('class.fd-nested-list__popover')
-    popoverClass = true;
-
-    /** @hidden */
     @ContentChild(NestedLinkDirective)
     linkDirective: NestedLinkDirective;
 
@@ -66,17 +64,22 @@ export class NestedListPopoverComponent implements NestedListPopoverInterface, A
     parentItemElement: NestedItemInterface;
 
     /** @hidden */
-    placement$ = computed<Placement>(() => (this._rtlService?.rtlSignal() ? 'left-start' : 'right-start'));
-
-    /** @hidden */
     open = false;
 
     /** @hidden */
-    constructor(
-        private _keyboardNestService: NestedListKeyboardService,
-        @Optional() private _itemService: NestedItemService,
-        @Optional() private _rtlService: RtlService
-    ) {
+    protected readonly placement = computed<Placement>(() => (this._rtlService?.rtl() ? 'left-start' : 'right-start'));
+
+    /** @hidden */
+    private readonly _keyboardNestService = inject(NestedListKeyboardService);
+
+    /** @hidden */
+    private readonly _itemService = inject(NestedItemService, { optional: true });
+
+    /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
+    constructor() {
         this._listenOnKeyboardRefresh();
         if (this._itemService) {
             this._itemService.popover = this;

--- a/libs/core/notification/notification-group-header/notification-group-header.component.ts
+++ b/libs/core/notification/notification-group-header/notification-group-header.component.ts
@@ -20,7 +20,7 @@ import { FD_NOTIFICATION_GROUP_HEADER } from '../token';
     selector: 'fd-notification-group-header',
     template: `
         <span class="fd-notification-group__header-arrow">
-            <fd-icon [glyph]="_buttonIcon$()"></fd-icon>
+            <fd-icon [glyph]="_buttonIcon()"></fd-icon>
         </span>
         <ng-content select="fd-notification-group-header-title"></ng-content>
         <ng-content></ng-content>
@@ -61,8 +61,8 @@ export class NotificationGroupHeaderComponent extends NotificationGroupBaseDirec
     expanded = signal(false);
 
     /** @hidden */
-    readonly _buttonIcon$ = computed(() =>
-        this.expanded() ? 'slim-arrow-down' : this._rtlService?.rtlSignal() ? 'slim-arrow-left' : 'slim-arrow-right'
+    protected readonly _buttonIcon = computed(() =>
+        this.expanded() ? 'slim-arrow-down' : this._rtlService?.rtl() ? 'slim-arrow-left' : 'slim-arrow-right'
     );
 
     /** @hidden */

--- a/libs/core/notification/notification/notification.component.ts
+++ b/libs/core/notification/notification/notification.component.ts
@@ -10,7 +10,6 @@ import {
     ComponentRef,
     DestroyRef,
     EmbeddedViewRef,
-    HostListener,
     OnDestroy,
     OnInit,
     TemplateRef,
@@ -50,10 +49,11 @@ import { FD_NOTIFICATION, FD_NOTIFICATION_FOOTER, FD_NOTIFICATION_PARAGRAPH, FD_
         '[attr.aria-label]': 'ariaLabel',
         '[attr.aria-level]': 'ariaLevel()',
         '[attr.role]': 'role()',
-        '[attr.dir]': '_dir$()',
+        '[attr.dir]': '_dir()',
         '[attr.id]': 'id',
         '[tabindex]': '0',
-        '[style.width]': 'width'
+        '[style.width]': 'width',
+        '(window:keyup)': '_closeNotificationEsc($event)'
     },
     providers: [
         {
@@ -61,8 +61,7 @@ import { FD_NOTIFICATION, FD_NOTIFICATION_FOOTER, FD_NOTIFICATION_PARAGRAPH, FD_
             useExisting: NotificationComponent
         }
     ],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: true
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NotificationComponent extends AbstractFdNgxClass implements OnInit, AfterViewInit, OnDestroy {
     /** @hidden */
@@ -75,7 +74,7 @@ export class NotificationComponent extends AbstractFdNgxClass implements OnInit,
     mobile = input(false);
 
     /** @hidden */
-    _dir$ = computed<Direction>(() => (this._rtlService?.rtlSignal() ? 'rtl' : 'ltr'));
+    _dir = computed<Direction>(() => (this._rtlService?.rtl() ? 'rtl' : 'ltr'));
 
     /** ID of the notification */
     id: string;
@@ -188,7 +187,6 @@ export class NotificationComponent extends AbstractFdNgxClass implements OnInit,
     }
 
     /** @hidden Listen and close notification on Escape key */
-    @HostListener('window:keyup', ['$event'])
     _closeNotificationEsc(event: KeyboardEvent): void {
         if (this.escKeyCloseable && KeyUtil.isKeyCode(event, ESCAPE) && this._notificationRef) {
             this._notificationRef.dismiss('escape');

--- a/libs/core/overflow-layout/directives/overflow-layout-popover-content.directive.ts
+++ b/libs/core/overflow-layout/directives/overflow-layout-popover-content.directive.ts
@@ -7,9 +7,9 @@ import {
     Inject,
     Input,
     OnDestroy,
-    Optional,
     computed,
-    effect
+    effect,
+    inject
 } from '@angular/core';
 import { KeyUtil, Nullable, RtlService } from '@fundamental-ngx/cdk/utils';
 import { OverflowContainer } from '../interfaces/overflow-container.interface';
@@ -42,7 +42,7 @@ export class OverflowLayoutPopoverContentDirective implements OverflowPopoverCon
                     .map((item) => item.overflowItem.focusableItem)
             )
                 .withWrap()
-                .withHorizontalOrientation(this._dir$());
+                .withHorizontalOrientation(this._dir());
         });
     }
 
@@ -57,17 +57,17 @@ export class OverflowLayoutPopoverContentDirective implements OverflowPopoverCon
     private _items: OverflowItemRef[];
 
     /** @hidden */
-    private readonly _dir$ = computed<'ltr' | 'rtl'>(() => (this._rtl?.rtlSignal() ? 'rtl' : 'ltr'));
+    private readonly _dir = computed<'ltr' | 'rtl'>(() => (this._rtlService?.rtl() ? 'rtl' : 'ltr'));
 
     /** @hidden */
-    constructor(
-        @Inject(FD_OVERFLOW_CONTAINER) private _overflowContainer: OverflowContainer,
-        @Optional() private _rtl: RtlService
-    ) {
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
+    constructor(@Inject(FD_OVERFLOW_CONTAINER) private _overflowContainer: OverflowContainer) {
         this._overflowContainer?.registerPopoverContent(this);
 
         effect(() => {
-            this._keyboardEventsManager = this._keyboardEventsManager?.withHorizontalOrientation(this._dir$());
+            this._keyboardEventsManager = this._keyboardEventsManager?.withHorizontalOrientation(this._dir());
         });
     }
 

--- a/libs/core/pagination/pagination.component.ts
+++ b/libs/core/pagination/pagination.component.ts
@@ -11,8 +11,6 @@ import {
     Input,
     OnChanges,
     OnDestroy,
-    OnInit,
-    Optional,
     Output,
     QueryList,
     SimpleChanges,
@@ -20,7 +18,9 @@ import {
     ViewChild,
     ViewChildren,
     ViewEncapsulation,
-    booleanAttribute
+    booleanAttribute,
+    effect,
+    inject
 } from '@angular/core';
 import { FormsModule, NgModel } from '@angular/forms';
 import { Observable, Subscription, firstValueFrom } from 'rxjs';
@@ -85,7 +85,7 @@ let paginationUniqueId = 0;
         FdTranslatePipe
     ]
 })
-export class PaginationComponent implements OnChanges, OnInit, AfterViewInit, OnDestroy {
+export class PaginationComponent implements OnChanges, AfterViewInit, OnDestroy {
     /** @hidden */
     @ViewChild(FocusKeyManagerListDirective)
     readonly _focusKeyManagerList: FocusKeyManagerListDirective;
@@ -254,14 +254,22 @@ export class PaginationComponent implements OnChanges, OnInit, AfterViewInit, On
     private _translationResolver = new TranslationResolver();
 
     /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
     constructor(
         private readonly paginationService: PaginationService,
         private readonly _cdr: ChangeDetectorRef,
         private readonly _liveAnnouncer: LiveAnnouncer,
         @Inject(FD_LANGUAGE) private readonly _language: Observable<FdLanguage>,
-        @Optional() private readonly _rtlService: RtlService,
         readonly _contentDensityObserver: ContentDensityObserver
-    ) {}
+    ) {
+        // React to RTL changes
+        effect(() => {
+            this._rtlService?.rtl();
+            this._refreshPages();
+        });
+    }
 
     /** @hidden */
     ngOnChanges(changes: SimpleChanges): void {
@@ -277,11 +285,6 @@ export class PaginationComponent implements OnChanges, OnInit, AfterViewInit, On
             }
         }
         this._refreshPages();
-    }
-
-    /** @hidden */
-    ngOnInit(): void {
-        this._subscriptions.add(this._rtlService?.rtl.subscribe(() => this._refreshPages()));
     }
 
     /** @hidden */

--- a/libs/core/panel/panel.component.html
+++ b/libs/core/panel/panel.component.html
@@ -12,7 +12,7 @@
                     fd-button
                     fdType="transparent"
                     class="fd-panel__button"
-                    [glyph]="_buttonIcon$()"
+                    [glyph]="buttonIcon()"
                     [id]="expandId"
                     [class.is-expanded]="expanded"
                     [attr.aria-expanded]="expanded"

--- a/libs/core/panel/panel.component.ts
+++ b/libs/core/panel/panel.component.ts
@@ -66,10 +66,10 @@ export class PanelComponent {
     /** Whether the Panel Content is expanded */
     @Input()
     set expanded(value: boolean) {
-        this._expanded$.set(value);
+        this._expanded.set(value);
     }
     get expanded(): boolean {
-        return this._expanded$();
+        return this._expanded();
     }
 
     /** Output event triggered when the Expand button is clicked */
@@ -87,20 +87,17 @@ export class PanelComponent {
     noRadius = input(false, { transform: booleanAttribute });
 
     /** @hidden */
-    _buttonIcon$ = computed(() =>
-        this._expanded$() ? 'slim-arrow-down' : this._rtl$() ? 'slim-arrow-left' : 'slim-arrow-right'
+    protected readonly buttonIcon = computed(() =>
+        this._expanded() ? 'slim-arrow-down' : this._rtlService?.rtl() ? 'slim-arrow-left' : 'slim-arrow-right'
     );
 
     /** @hidden */
-    private readonly _expanded$ = signal(false);
+    private readonly _expanded = signal(false);
 
     /** @hidden */
     private readonly _rtlService = inject(RtlService, {
         optional: true
     });
-
-    /** @hidden */
-    private readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
 
     /** @hidden */
     constructor(
@@ -110,7 +107,7 @@ export class PanelComponent {
 
     /** Methods that toggles the Panel Content */
     toggleExpand(): void {
-        this._expanded$.update((expanded) => !expanded);
+        this._expanded.update((expanded) => !expanded);
         this.expandedChange.emit(this.expanded);
     }
 }

--- a/libs/core/popover/popover-service/popover.service.ts
+++ b/libs/core/popover/popover-service/popover.service.ts
@@ -13,7 +13,6 @@ import {
     ElementRef,
     Injectable,
     Injector,
-    Optional,
     Renderer2,
     TemplateRef,
     ViewContainerRef,
@@ -98,6 +97,12 @@ export class PopoverService extends BasePopoverClass {
     private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
+    private readonly _popoverContainer = inject(PopoverContainerDirective, { optional: true });
+
+    /** @hidden */
     private get _triggerHtmlElement(): HTMLElement {
         return this._triggerElement instanceof ElementRef ? this._triggerElement.nativeElement : this._triggerElement;
     }
@@ -107,9 +112,7 @@ export class PopoverService extends BasePopoverClass {
         private _overlay: Overlay,
         private _renderer: Renderer2,
         private _viewportRuler: ViewportRuler,
-        private _injector: Injector,
-        @Optional() private _rtlService: RtlService,
-        @Optional() private readonly _popoverContainer: PopoverContainerDirective
+        private _injector: Injector
     ) {
         super();
 
@@ -401,11 +404,7 @@ export class PopoverService extends BasePopoverClass {
 
     /** @hidden */
     private _getDirection(): 'rtl' | 'ltr' {
-        if (!this._rtlService) {
-            return 'ltr';
-        }
-
-        return this._rtlService.rtl.getValue() ? 'rtl' : 'ltr';
+        return this._rtlService?.rtl() ? 'rtl' : 'ltr';
     }
 
     /** @hidden */

--- a/libs/core/product-switch/product-switch-body/product-switch-body.component.ts
+++ b/libs/core/product-switch/product-switch-body/product-switch-body.component.ts
@@ -5,10 +5,10 @@ import {
     ChangeDetectorRef,
     Component,
     EventEmitter,
+    inject,
     Input,
     OnDestroy,
     OnInit,
-    Optional,
     Output,
     ViewEncapsulation
 } from '@angular/core';
@@ -63,9 +63,11 @@ export class ProductSwitchBodyComponent implements OnInit, OnDestroy {
     private _subscriptions = new Subscription();
 
     /** @hidden */
+    private _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
     constructor(
         private _viewportRuler: ViewportRuler,
-        @Optional() private readonly _rtlService: RtlService,
         private readonly _cdr: ChangeDetectorRef
     ) {}
 
@@ -149,8 +151,7 @@ export class ProductSwitchBodyComponent implements OnInit, OnDestroy {
 
         if (
             i === this.products.length - 1 &&
-            (KeyUtil.isKeyCode(event, RIGHT_ARROW) ||
-                (KeyUtil.isKeyCode(event, LEFT_ARROW) && this._rtlService?.rtlSignal()))
+            (KeyUtil.isKeyCode(event, RIGHT_ARROW) || (KeyUtil.isKeyCode(event, LEFT_ARROW) && this._rtlService?.rtl()))
         ) {
             while (<HTMLElement>target.previousElementSibling) {
                 target = <HTMLElement>target.previousElementSibling;
@@ -159,9 +160,9 @@ export class ProductSwitchBodyComponent implements OnInit, OnDestroy {
         }
 
         if (KeyUtil.isKeyCode(event, LEFT_ARROW)) {
-            this._rtlService?.rtlSignal() ? nextElementSibling?.focus() : previousElementSibling?.focus();
+            this._rtlService?.rtl() ? nextElementSibling?.focus() : previousElementSibling?.focus();
         } else if (KeyUtil.isKeyCode(event, RIGHT_ARROW)) {
-            this._rtlService?.rtlSignal() ? previousElementSibling?.focus() : nextElementSibling?.focus();
+            this._rtlService?.rtl() ? previousElementSibling?.focus() : nextElementSibling?.focus();
         } else if (KeyUtil.isKeyCode(event, [DOWN_ARROW, UP_ARROW])) {
             if (this.products.length >= 7) {
                 this._handleNoListMoreThanSeven(event, target, i);

--- a/libs/core/resizable-card-layout/resizable-card-layout/resizable-card-item/resizable-card-item.component.ts
+++ b/libs/core/resizable-card-layout/resizable-card-layout/resizable-card-item/resizable-card-item.component.ts
@@ -8,9 +8,9 @@ import {
     EventEmitter,
     HostBinding,
     HostListener,
+    inject,
     Input,
     OnDestroy,
-    Optional,
     Output,
     ViewEncapsulation
 } from '@angular/core';
@@ -272,10 +272,12 @@ export class ResizableCardItemComponent implements FocusableOption, OnDestroy {
     private _subscriptions = new Subscription();
 
     /** @hidden */
+    private _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
     constructor(
         private readonly _cd: ChangeDetectorRef,
-        public readonly elementRef: ElementRef,
-        @Optional() private readonly _rtlService: RtlService
+        public readonly elementRef: ElementRef
     ) {}
 
     /**
@@ -574,12 +576,12 @@ export class ResizableCardItemComponent implements FocusableOption, OnDestroy {
      */
     private _horizontalResizing(xPosition: number): void {
         const difference = this._prevX - xPosition;
-        this.cardWidth = this._rtlService?.rtlSignal() ? this.cardWidth + difference : this.cardWidth - difference;
+        this.cardWidth = this._rtlService?.rtl() ? this.cardWidth + difference : this.cardWidth - difference;
 
         const totalIndentation = (this._maxColumn - 1) * gap;
         const maxCardWidtWithoutIndentation = this._maxColumn * horizontalResizeStep;
 
-        const maxCardWidth = this._rtlService?.rtlSignal()
+        const maxCardWidth = this._rtlService?.rtl()
             ? maxCardWidtWithoutIndentation - totalIndentation
             : maxCardWidtWithoutIndentation + totalIndentation;
 

--- a/libs/core/resizable-card-layout/resizable-card-layout/resizable-card-layout.component.ts
+++ b/libs/core/resizable-card-layout/resizable-card-layout/resizable-card-layout.component.ts
@@ -13,7 +13,6 @@ import {
     Input,
     OnDestroy,
     OnInit,
-    Optional,
     Output,
     QueryList,
     ViewEncapsulation,
@@ -108,13 +107,15 @@ export class ResizableCardLayoutComponent implements OnInit, AfterViewInit, Afte
     private _layoutShifted = false;
 
     /** @hidden */
-    private _directionPosition$ = computed<'left' | 'right'>(() => (this._rtlService?.rtlSignal() ? 'right' : 'left'));
+    private _directionPosition = computed<'left' | 'right'>(() => (this._rtlService?.rtl() ? 'right' : 'left'));
+
+    /** @hidden */
+    private _rtlService = inject(RtlService, { optional: true });
 
     /** @hidden */
     constructor(
         private readonly _cd: ChangeDetectorRef,
-        public readonly elementRef: ElementRef,
-        @Optional() private readonly _rtlService: RtlService
+        public readonly elementRef: ElementRef
     ) {}
 
     /** @hidden handles keyboard accessibility */
@@ -470,7 +471,7 @@ export class ResizableCardLayoutComponent implements OnInit, AfterViewInit, Afte
      * @param card {ResizableCardItemComponent}
      */
     private _updateColumnsHeight(card: ResizableCardItemComponent): void {
-        const directionPosition = this._directionPosition$();
+        const directionPosition = this._directionPosition();
         const columnsStart =
             card[directionPosition] != null ? Math.floor(card[directionPosition]! / horizontalResizeStep) : 0;
 
@@ -500,7 +501,7 @@ export class ResizableCardLayoutComponent implements OnInit, AfterViewInit, Afte
      * @param index value of card in array of ResizableCardItemComponent
      */
     private _setCardPositionValues(card: ResizableCardItemComponent, index: number): void {
-        const directionPosition = this._directionPosition$();
+        const directionPosition = this._directionPosition();
         if (index === 0) {
             card[directionPosition] = Number(this._paddingLeft);
             card.top = 0;
@@ -523,7 +524,7 @@ export class ResizableCardLayoutComponent implements OnInit, AfterViewInit, Afte
      * @returns It returns true when card position id found otherwise it returns false.
      */
     private _isPositionSetSuccess(height: number, card: ResizableCardItemComponent): boolean {
-        const directionPosition = this._directionPosition$();
+        const directionPosition = this._directionPosition();
         const columnPositions: number[] = [];
         let index = 0;
         for (const columnHeight of this._columnsHeight) {

--- a/libs/core/segmented-button/segmented-button.component.ts
+++ b/libs/core/segmented-button/segmented-button.component.ts
@@ -14,7 +14,6 @@ import {
     OnChanges,
     OnDestroy,
     OnInit,
-    Optional,
     QueryList,
     Renderer2,
     SimpleChanges,
@@ -74,7 +73,6 @@ export type SegmentedButtonValue = string | (string | null)[] | null;
             multi: true
         }
     ],
-    standalone: true,
     hostDirectives: [FocusableListDirective]
 })
 export class SegmentedButtonComponent implements OnInit, AfterViewInit, ControlValueAccessor, OnDestroy, OnChanges {
@@ -131,17 +129,19 @@ export class SegmentedButtonComponent implements OnInit, AfterViewInit, ControlV
     private renderer = inject(Renderer2);
 
     /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
     constructor(
         private readonly _changeDetRef: ChangeDetectorRef,
         private readonly _elementRef: ElementRef,
         private readonly _destroyRef: DestroyRef,
         private readonly _ngZone: NgZone,
-        @Optional() @Host() private _focusableList: FocusableListDirective,
-        @Optional() private _rtlService: RtlService
+        @Host() private _focusableList: FocusableListDirective
     ) {
         this._focusableList.navigationDirection = this.vertical ? 'vertical' : 'horizontal';
         effect(() => {
-            this._focusableList.contentDirection = this._rtlService?.rtlSignal() ? 'rtl' : 'ltr';
+            this._focusableList.contentDirection = this._rtlService?.rtl() ? 'rtl' : 'ltr';
         });
         this._focusableList.itemFocused.pipe(takeUntil(this._onDestroy$)).subscribe((item) => {
             this._focusedItemId.set(item.id);

--- a/libs/core/select/select-key-manager.service.ts
+++ b/libs/core/select/select-key-manager.service.ts
@@ -23,7 +23,7 @@ export class SelectKeyManagerService {
         this._keyManager = new ActiveDescendantKeyManager<OptionsInterface>(this._component._options)
             .withTypeAhead(this._component.typeaheadDebounceInterval)
             .withVerticalOrientation()
-            .withHorizontalOrientation(this._component.rtl$() ? 'rtl' : 'ltr')
+            .withHorizontalOrientation(this._component.isRtl() ? 'rtl' : 'ltr')
             .withAllowedModifierKeys(['shiftKey']);
 
         this._keyManager.tabOut.pipe(takeUntilDestroyed(this._component._destroy)).subscribe(() => {

--- a/libs/core/select/select.component.ts
+++ b/libs/core/select/select.component.ts
@@ -338,9 +338,6 @@ export class SelectComponent<T = any>
     _calculatedMaxHeight: number;
 
     /** @hidden */
-    _rtl = false;
-
-    /** @hidden */
     _selectionModel: SelectionModel<OptionComponent>;
 
     /** @hidden */
@@ -447,8 +444,8 @@ export class SelectComponent<T = any>
     get calculatedMaxHeight(): number {
         return this._maxHeight || this._calculatedMaxHeight;
     }
-    /** @hidden */
-    readonly rtl$ = computed(() => !!this._rtlService?.rtlSignal());
+    /** Whether the component is in RTL mode */
+    readonly isRtl = computed(() => this._rtlService?.rtl() ?? false);
 
     private readonly _rtlService = inject(RtlService, {
         optional: true
@@ -586,7 +583,7 @@ export class SelectComponent<T = any>
                 this._keyManagerService._keyManager.activeItem?._selectViaInteraction();
             }
             this._isOpen = false;
-            this._keyManagerService._keyManager.withHorizontalOrientation(this.rtl$() ? 'rtl' : 'ltr');
+            this._keyManagerService._keyManager.withHorizontalOrientation(this.isRtl() ? 'rtl' : 'ltr');
             this._changeDetectorRef.markForCheck();
             this.onTouched();
 

--- a/libs/core/select/select.interface.ts
+++ b/libs/core/select/select.interface.ts
@@ -12,7 +12,8 @@ export const SELECT_COMPONENT = new InjectionToken<SelectInterface>('SelectInter
  */
 export interface SelectInterface<TOption = any> extends MobileMode {
     typeaheadDebounceInterval: number;
-    rtl$: Signal<boolean>;
+    /** Whether the component is in RTL mode */
+    isRtl: Signal<boolean>;
     selected: OptionComponent;
     mobileConfig: MobileModeConfig;
     _options: QueryList<TOption>;

--- a/libs/core/settings/settings-container/settings-container.component.html
+++ b/libs/core/settings/settings-container/settings-container.component.html
@@ -12,7 +12,7 @@
                             fd-settings-header-button
                             fdkInitialFocus
                             fdType="transparent"
-                            [glyph]="navigationArrow$ | async"
+                            [glyph]="navigationArrow()"
                             [ariaLabel]="backBtnAriaLabel()"
                             [title]="backBtnAriaLabel()"
                             (click)="onHeaderBackClick()"

--- a/libs/core/settings/settings-container/settings-container.component.ts
+++ b/libs/core/settings/settings-container/settings-container.component.ts
@@ -1,14 +1,13 @@
-import { AsyncPipe } from '@angular/common';
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
     Component,
+    computed,
     contentChildren,
     HostListener,
     inject,
     input,
     OnDestroy,
-    OnInit,
     Renderer2,
     signal,
     viewChild,
@@ -20,7 +19,6 @@ import { BarComponent, BarElementDirective, BarLeftDirective } from '@fundamenta
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ListItemComponent } from '@fundamental-ngx/core/list';
 import { TitleComponent } from '@fundamental-ngx/core/title';
-import { map, Observable } from 'rxjs';
 import { SettingsDetailAreaDirective } from '../settings-detail-area/settings-detail-area.directive';
 import { SettingsHeaderButtonDirective } from '../settings-header-button/settings-header-button.directive';
 import { SettingsHeaderDirective } from '../settings-header/settings-header.directive';
@@ -44,9 +42,7 @@ export enum VIEW_MODE {
     },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: true,
     imports: [
-        AsyncPipe,
         BarComponent,
         BarElementDirective,
         BarLeftDirective,
@@ -58,7 +54,7 @@ export enum VIEW_MODE {
         InitialFocusDirective
     ]
 })
-export class SettingsContainerComponent implements OnInit, OnDestroy, AfterViewInit {
+export class SettingsContainerComponent implements OnDestroy, AfterViewInit {
     /**
      * Heading level for the title in the Details Area
      * Default value is 2
@@ -77,11 +73,6 @@ export class SettingsContainerComponent implements OnInit, OnDestroy, AfterViewI
      * aria-label and title value for the back button
      */
     readonly backBtnAriaLabel = input<string>('');
-
-    /**
-     * Handle the navigation icon (arrow) of the Back button in RTL mode
-     */
-    navigationArrow$: Observable<string>;
 
     /** @hidden */
     readonly viewContainer = viewChild('container', { read: ViewContainerRef });
@@ -107,11 +98,18 @@ export class SettingsContainerComponent implements OnInit, OnDestroy, AfterViewI
     /** @hidden */
     readonly activeTitle = signal<string>('');
 
+    /**
+     * Handle the navigation icon (arrow) of the Back button in RTL mode
+     */
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    );
+
     /** @hidden */
     private _eventUnlisteners: (() => void)[] = [];
 
     /** @hidden */
-    private _rtlService = inject(RtlService);
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /** @hidden */
     private _renderer = inject(Renderer2);
@@ -126,13 +124,6 @@ export class SettingsContainerComponent implements OnInit, OnDestroy, AfterViewI
     onWindowResize(): void {
         this.screenWidth.set(window.innerWidth);
         this._updateViewMode();
-    }
-
-    /** @hidden */
-    ngOnInit(): void {
-        this.navigationArrow$ = this._rtlService.rtl.pipe(
-            map((isRtl) => (isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'))
-        );
     }
 
     /** @hidden */

--- a/libs/core/shellbar/shellbar.component.html
+++ b/libs/core/shellbar/shellbar.component.html
@@ -33,7 +33,7 @@
                     class="fd-shellbar__button"
                     fd-button
                     fdType="transparent"
-                    [glyph]="_rtl$() ? 'slim-arrow-right' : 'nav-back'"
+                    [glyph]="navigationIcon()"
                     (fdkClicked)="_backClicked($event)"
                     [attr.title]="backButtonLabel || ('coreShellbar.backButtonLabel' | fdTranslate)"
                     [attr.aria-label]="backButtonLabel || ('coreShellbar.backButtonLabel' | fdTranslate)"

--- a/libs/core/shellbar/shellbar.component.ts
+++ b/libs/core/shellbar/shellbar.component.ts
@@ -169,8 +169,10 @@ export class ShellbarComponent implements AfterContentInit, AfterViewInit, OnDes
     /** @hidden */
     _showMobileSearch = false;
 
+    protected readonly navigationIcon = computed<string>(() => (this.isRtl() ? 'slim-arrow-right' : 'nav-back'));
+
     /** @hidden */
-    readonly _rtl$ = computed<boolean>(() => !!this._rtlService?.rtlSignal());
+    private readonly isRtl = computed<boolean>(() => this._rtlService?.rtl() ?? false);
 
     /**
      * Search component placed inside the shellbar
@@ -344,9 +346,9 @@ export class ShellbarComponent implements AfterContentInit, AfterViewInit, OnDes
     /** @hidden */
     _getShellbarEnd(): number {
         const shellbarEl = this._shellbar.nativeElement;
-        const end = this._rtl$() ? shellbarEl.getBoundingClientRect().left : shellbarEl.getBoundingClientRect().right;
+        const end = this.isRtl() ? shellbarEl.getBoundingClientRect().left : shellbarEl.getBoundingClientRect().right;
         let shellbarPadding = parseInt(window.getComputedStyle(shellbarEl).paddingInline, 10);
-        if (this._rtl$()) {
+        if (this.isRtl()) {
             shellbarPadding = shellbarPadding * -1;
         }
         return end - shellbarPadding;
@@ -354,7 +356,7 @@ export class ShellbarComponent implements AfterContentInit, AfterViewInit, OnDes
 
     /** @hidden */
     _getActionsEnd(): number {
-        const end = this._rtl$()
+        const end = this.isRtl()
             ? this._actions?._elRef.nativeElement.getBoundingClientRect().left
             : this._actions?._elRef.nativeElement.getBoundingClientRect().right;
         return end;
@@ -362,7 +364,7 @@ export class ShellbarComponent implements AfterContentInit, AfterViewInit, OnDes
 
     /** @hidden */
     _actionsExceedShellbarWidth(): boolean {
-        return this._rtl$()
+        return this.isRtl()
             ? this._getActionsEnd() < this._getShellbarEnd()
             : this._getActionsEnd() > this._getShellbarEnd();
     }

--- a/libs/core/slider/slider-position.directive.ts
+++ b/libs/core/slider/slider-position.directive.ts
@@ -1,10 +1,9 @@
-import { Directive, ElementRef, Input, OnChanges, Optional, Renderer2, computed, effect } from '@angular/core';
+import { Directive, ElementRef, Input, OnChanges, Renderer2, computed, effect, inject } from '@angular/core';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 
 @Directive({
     // eslint-disable-next-line @angular-eslint/directive-selector
-    selector: '[fd-slider-position]',
-    standalone: true
+    selector: '[fd-slider-position]'
 })
 export class SliderPositionDirective implements OnChanges {
     /** Position of the slider */
@@ -15,16 +14,22 @@ export class SliderPositionDirective implements OnChanges {
     @Input()
     vertical = false;
 
-    private readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
+    /** @hidden */
+    private readonly _isRtl = computed(() => this._rtlService?.rtl() ?? false);
 
     /** @hidden */
-    constructor(
-        private readonly _elementRef: ElementRef<HTMLElement>,
-        private readonly _renderer: Renderer2,
-        @Optional() private readonly _rtlService: RtlService
-    ) {
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
+    private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+    /** @hidden */
+    private readonly _renderer = inject(Renderer2);
+
+    /** @hidden */
+    constructor() {
         effect(() => {
-            this._setPosition(this._rtl$());
+            this._setPosition(this._isRtl());
         });
     }
 
@@ -33,7 +38,7 @@ export class SliderPositionDirective implements OnChanges {
         this._setPosition();
     }
     /** @hidden */
-    private _setPosition(rtl = this._rtl$()): void {
+    private _setPosition(rtl = this._isRtl()): void {
         if (this.vertical) {
             this._renderer.setStyle(this._elementRef.nativeElement, 'bottom', `${this.position}%`);
             return;

--- a/libs/core/slider/slider.component.ts
+++ b/libs/core/slider/slider.component.ts
@@ -14,7 +14,6 @@ import {
     Input,
     OnChanges,
     OnInit,
-    Optional,
     QueryList,
     Renderer2,
     ViewChild,
@@ -345,7 +344,10 @@ export class SliderComponent
     readonly _popoverInputFieldHovered$ = new BehaviorSubject(false);
 
     /** @hidden */
-    private readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
+    private readonly _isRtl = computed(() => this._rtlService?.rtl() ?? false);
+
+    /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /** @hidden */
     constructor(
@@ -354,8 +356,6 @@ export class SliderComponent
         private readonly _renderer: Renderer2,
         private readonly _platform: Platform,
         private readonly _liveAnnouncer: LiveAnnouncer,
-        @Optional()
-        private readonly _rtlService: RtlService,
         readonly _contentDensityObserver: ContentDensityObserver
     ) {
         _contentDensityObserver.subscribe();
@@ -528,9 +528,8 @@ export class SliderComponent
             return;
         }
         event.preventDefault();
-        const upActionKey = KeyUtil.isKeyCode(event, [UP_ARROW, this._rtl$() ? LEFT_ARROW : RIGHT_ARROW]);
-        const downActionKey = KeyUtil.isKeyCode(event, [DOWN_ARROW, this._rtl$() ? RIGHT_ARROW : LEFT_ARROW]);
-
+        const upActionKey = KeyUtil.isKeyCode(event, [UP_ARROW, this._isRtl() ? LEFT_ARROW : RIGHT_ARROW]);
+        const downActionKey = KeyUtil.isKeyCode(event, [DOWN_ARROW, this._isRtl() ? RIGHT_ARROW : LEFT_ARROW]);
         if (!upActionKey && !downActionKey) {
             return;
         }
@@ -639,7 +638,7 @@ export class SliderComponent
         const { left, width, bottom, height } = this.trackEl.nativeElement.getBoundingClientRect();
         let percentage = this.vertical ? (bottom - coords.clientY) / height : (coords.clientX - left) / width;
 
-        if (this._rtl$()) {
+        if (this._isRtl()) {
             percentage = 1 - percentage;
         }
         const newValue = this.min + percentage * (this.max - this.min);
@@ -810,7 +809,7 @@ export class SliderComponent
     /** @hidden */
     private _calcProgress(value: number, skipRtl = false): number {
         let progress = ((value - this.min) / (this.max - this.min)) * 100;
-        if (!skipRtl && this._rtl$()) {
+        if (!skipRtl && this._isRtl()) {
             progress = 100 - progress;
         }
         if (progress > 100) {

--- a/libs/core/time/time.component.ts
+++ b/libs/core/time/time.component.ts
@@ -200,13 +200,15 @@ export class TimeComponent<D> implements OnInit, OnChanges, OnDestroy, AfterView
     private _subscriptions = new Subscription();
 
     /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
     constructor(
         private _changeDetectorRef: ChangeDetectorRef,
         private _elementRef: ElementRef,
         // Use @Optional to avoid angular injection error message and throw our own which is more precise one
         @Optional() private _dateTimeAdapter: DatetimeAdapter<D>,
-        readonly _contentDensityObserver: ContentDensityObserver,
-        @Optional() private _rtlService: RtlService
+        readonly _contentDensityObserver: ContentDensityObserver
     ) {
         if (!_dateTimeAdapter) {
             throw createMissingDateImplementationError('DateTimeAdapter');
@@ -414,7 +416,7 @@ export class TimeComponent<D> implements OnInit, OnChanges, OnDestroy, AfterView
      */
     private _getVisibleColumnsWithRtl(): FdTimeActiveView[] {
         const columns = this._getVisibleColumns();
-        return this._rtlService?.rtl.value ? columns.reverse() : columns;
+        return this._rtlService?.rtl() ? columns.reverse() : columns;
     }
 
     /** @hidden */

--- a/libs/core/token/tokenizer.component.ts
+++ b/libs/core/token/tokenizer.component.ts
@@ -18,7 +18,6 @@ import {
     OnChanges,
     OnDestroy,
     OnInit,
-    Optional,
     Output,
     QueryList,
     Renderer2,
@@ -204,6 +203,9 @@ export class TokenizerComponent implements AfterViewInit, OnDestroy, CssClassBui
     private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
     private readonly _eventListeners: (() => void)[] = [];
 
     /** @hidden */
@@ -223,7 +225,6 @@ export class TokenizerComponent implements AfterViewInit, OnDestroy, CssClassBui
         readonly _contentDensityObserver: ContentDensityObserver,
         public readonly elementRef: ElementRef,
         private _cdRef: ChangeDetectorRef,
-        @Optional() private _rtlService: RtlService,
         private _renderer: Renderer2,
         @Inject(DOCUMENT) private readonly _document: Document,
         private readonly _liveAnnouncer: LiveAnnouncer,
@@ -389,7 +390,7 @@ export class TokenizerComponent implements AfterViewInit, OnDestroy, CssClassBui
     /** @hidden */
     handleKeyDown(event: KeyboardEvent, fromIndex: number): void {
         let newIndex: number | undefined;
-        const rtl = !!this._rtlService?.rtlSignal();
+        const rtl = this._rtlService?.rtl() ?? false;
         if (KeyUtil.isKeyCode(event, SPACE) && !this._isInputFocused()) {
             const token = this.tokenList.find((_, index) => index === fromIndex);
             this.tokenList.forEach((shadowedToken) => {

--- a/libs/core/tree/tree.component.ts
+++ b/libs/core/tree/tree.component.ts
@@ -210,7 +210,7 @@ export class TreeComponent<P extends FdTreeAcceptableDataSource, T extends TreeI
     private readonly _selectionService = inject(SelectionService);
 
     /** @hidden */
-    private readonly _rtl = inject(RtlService, {
+    private readonly _rtlService = inject(RtlService, {
         optional: true
     });
 
@@ -352,7 +352,7 @@ export class TreeComponent<P extends FdTreeAcceptableDataSource, T extends TreeI
             return;
         }
 
-        const isRtl = !!this._rtl?.rtlSignal();
+        const isRtl = this._rtlService?.rtl() ?? false;
         const expandKey = isRtl ? LEFT_ARROW : RIGHT_ARROW;
         const collapseKey = isRtl ? RIGHT_ARROW : LEFT_ARROW;
 

--- a/libs/core/user-menu/components/user-menu-body.component.html
+++ b/libs/core/user-menu/components/user-menu-body.component.html
@@ -15,7 +15,7 @@
                     <fd-button-bar
                         fdkInitialFocus
                         ariaLabel="previous"
-                        [glyph]="navigationArrow$ | async"
+                        [glyph]="navigationArrow()"
                         (click)="clearSubmenu()"
                     >
                     </fd-button-bar>

--- a/libs/core/user-menu/components/user-menu-body.component.ts
+++ b/libs/core/user-menu/components/user-menu-body.component.ts
@@ -7,10 +7,10 @@ import {
     DestroyRef,
     ElementRef,
     HostListener,
-    OnInit,
     QueryList,
     TemplateRef,
     ViewEncapsulation,
+    computed,
     contentChild,
     inject,
     signal,
@@ -27,7 +27,7 @@ import {
 } from '@fundamental-ngx/core/bar';
 import { contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { TitleComponent } from '@fundamental-ngx/core/title';
-import { Observable, Subject, map, startWith } from 'rxjs';
+import { Subject, startWith } from 'rxjs';
 import { UserMenuUserNameDirective } from '../directives/user-menu-user-name.directive';
 import { UserMenuListItemComponent } from './user-menu-list-item.component';
 
@@ -51,15 +51,10 @@ import { UserMenuListItemComponent } from './user-menu-list-item.component';
     ],
     providers: [contentDensityObserverProviders()]
 })
-export class UserMenuBodyComponent implements OnInit, AfterViewInit {
+export class UserMenuBodyComponent implements AfterViewInit {
     /** @hidden */
     @ContentChildren(UserMenuListItemComponent, { descendants: true })
     readonly _listItems: QueryList<UserMenuListItemComponent>;
-
-    /**
-     * Handle the navigation icon (arrow) of the Back button in RTL mode
-     */
-    navigationArrow$: Observable<string>;
 
     /**
      * Template ref of the submenu
@@ -94,14 +89,21 @@ export class UserMenuBodyComponent implements OnInit, AfterViewInit {
      */
     readonly bodyHeader = viewChild<TemplateRef<any>>('bodyHeader');
 
+    /**
+     * Handle the navigation icon (arrow) of the Back button in RTL mode
+     */
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    );
+
     /** @hidden */
     protected readonly userNameEl = contentChild(UserMenuUserNameDirective, { read: ElementRef });
 
     /** @hidden */
-    private _rtlService = inject(RtlService);
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /** @hidden */
-    private _refresh$ = new Subject<void>();
+    private readonly _refresh$ = new Subject<void>();
 
     /** @hidden */
     private readonly _destroyRef = inject(DestroyRef);
@@ -110,13 +112,6 @@ export class UserMenuBodyComponent implements OnInit, AfterViewInit {
     @HostListener('click', ['$event'])
     onClick(event: MouseEvent): void {
         event.stopPropagation();
-    }
-
-    /** @hidden */
-    ngOnInit(): void {
-        this.navigationArrow$ = this._rtlService.rtl.pipe(
-            map((isRtl) => (isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'))
-        );
     }
 
     /** @hidden */

--- a/libs/core/user-menu/user-menu.component.ts
+++ b/libs/core/user-menu/user-menu.component.ts
@@ -5,6 +5,7 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
+    computed,
     contentChild,
     contentChildren,
     DestroyRef,
@@ -12,15 +13,12 @@ import {
     ElementRef,
     inject,
     input,
-    OnInit,
     output,
     Renderer2,
     signal,
     TemplateRef,
     ViewEncapsulation
 } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 import { KeyboardSupportService, RtlService, TemplateDirective } from '@fundamental-ngx/cdk/utils';
 import { ContentDensityMode, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
@@ -68,7 +66,7 @@ import { UserMenuUserNameDirective } from './directives/user-menu-user-name.dire
     ],
     providers: [KeyboardSupportService, contentDensityObserverProviders()]
 })
-export class UserMenuComponent implements OnInit, AfterViewInit {
+export class UserMenuComponent implements AfterViewInit {
     /** Event thrown, when the user menu is opened or closed */
     isOpenChange = output<boolean>();
 
@@ -110,27 +108,29 @@ export class UserMenuComponent implements OnInit, AfterViewInit {
     protected readonly userMenuBody = contentChild(UserMenuBodyComponent, { descendants: true });
 
     /** @hidden */
-    protected navigationArrow$: Observable<string>;
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    );
 
     /** @hidden */
-    private _listItems = contentChildren(UserMenuListItemComponent, { descendants: true });
+    private readonly _listItems = contentChildren(UserMenuListItemComponent, { descendants: true });
 
     /** @hidden */
-    private _rtlService = inject(RtlService);
+    private readonly _rtlService = inject(RtlService);
 
     /** @hidden */
-    private _dialogService = inject(DialogService);
+    private readonly _dialogService = inject(DialogService);
 
     /** @hidden */
-    private _changeDetectionRef = inject(ChangeDetectorRef);
+    private readonly _changeDetectionRef = inject(ChangeDetectorRef);
 
     /** @hidden */
-    private _renderer = inject(Renderer2);
+    private readonly _renderer = inject(Renderer2);
 
     /** @hidden */
     private _dialogRef: DialogRef | undefined;
 
-    private _destroyRef = inject(DestroyRef);
+    private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     constructor() {
@@ -138,13 +138,6 @@ export class UserMenuComponent implements OnInit, AfterViewInit {
             const isMobile = this.mobile();
             this._listItems()?.forEach((item) => item.mobile.set(isMobile));
         });
-    }
-
-    /** @hidden */
-    ngOnInit(): void {
-        this.navigationArrow$ = this._rtlService.rtl.pipe(
-            map((isRtl) => (isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'))
-        );
     }
 
     /** @hidden */

--- a/libs/core/wizard/wizard.service.ts
+++ b/libs/core/wizard/wizard.service.ts
@@ -11,7 +11,7 @@ export class WizardService {
 
     /** @hidden */
     progressBarKeyHandler(event: any, steps: QueryList<WizardStepComponent>, index: number): void {
-        const rtlDirection = this._rtlService?.rtlSignal();
+        const rtlDirection = this._rtlService?.rtl();
         if (KeyUtil.isKeyCode(event, LEFT_ARROW)) {
             if (
                 steps.get(index - 1)?.status === COMPLETED_STEP_STATUS ||

--- a/libs/cx/nested-list/nested-list-keyboard.service.spec.ts
+++ b/libs/cx/nested-list/nested-list-keyboard.service.spec.ts
@@ -1,3 +1,4 @@
+import { TestBed } from '@angular/core/testing';
 import { MenuKeyboardService } from '@fundamental-ngx/core/menu';
 import { Subject } from 'rxjs';
 import { NestedListKeyboardService } from './nested-list-keyboard.service';
@@ -48,7 +49,8 @@ describe('NestedListKeyboardSupportService', () => {
         object = {
             nestedItems: toArray()
         };
-        service = new NestedListKeyboardService(new MenuKeyboardService(), null);
+        TestBed.configureTestingModule({ providers: [NestedListKeyboardService, MenuKeyboardService] });
+        service = TestBed.inject(NestedListKeyboardService);
     });
 
     it('Should return all of the items', () => {

--- a/libs/cx/nested-list/nested-list-keyboard.service.ts
+++ b/libs/cx/nested-list/nested-list-keyboard.service.ts
@@ -1,5 +1,5 @@
 import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
-import { Inject, Injectable, Optional } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { KeyUtil, RtlService } from '@fundamental-ngx/cdk/utils';
 import { MenuKeyboardService } from '@fundamental-ngx/core/menu';
 import { Subject } from 'rxjs';
@@ -20,10 +20,10 @@ export class NestedListKeyboardService {
     readonly refresh$: Subject<void> = new Subject<void>();
 
     /** @hidden */
-    constructor(
-        @Inject(MenuKeyboardService) private keyboardService: MenuKeyboardService,
-        @Optional() private _rtlService: RtlService | null
-    ) {}
+    private readonly keyboardService = inject(MenuKeyboardService);
+
+    /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /**
      * Function called after refresh$ event is triggered.
@@ -75,7 +75,7 @@ export class NestedListKeyboardService {
      */
     private _handleKeyDown(keyboardEvent: KeyboardEvent, index: number, items: NestedItemInterface[]): void {
         const item: NestedItemInterface = items[index];
-        const isRtl = !!this._rtlService?.rtlSignal();
+        const isRtl = this._rtlService?.rtl() ?? false;
 
         if (
             (!isRtl && KeyUtil.isKeyCode(keyboardEvent, RIGHT_ARROW)) ||

--- a/libs/cx/nested-list/nested-list-popover/nested-list-popover.component.html
+++ b/libs/cx/nested-list/nested-list-popover/nested-list-popover.component.html
@@ -1,5 +1,5 @@
 <fd-popover
-    [placement]="placement$()"
+    [placement]="placement()"
     [triggers]="['click']"
     [noArrow]="false"
     [isOpen]="open"

--- a/libs/cx/nested-list/nested-list-popover/nested-list-popover.component.ts
+++ b/libs/cx/nested-list/nested-list-popover/nested-list-popover.component.ts
@@ -7,7 +7,8 @@ import {
     Optional,
     ViewChild,
     ViewEncapsulation,
-    computed
+    computed,
+    inject
 } from '@angular/core';
 
 import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
@@ -48,7 +49,7 @@ export class NestedListPopoverComponent implements NestedListPopoverInterface, O
     parentItemElement: NestedItemInterface;
 
     /** @hidden */
-    placement$ = computed(() => (this._rtlService?.rtlSignal() ? 'left-start' : 'right-start'));
+    placement = computed(() => (this._rtlService?.rtl() ? 'left-start' : 'right-start'));
 
     /** @hidden */
     open = false;
@@ -57,10 +58,12 @@ export class NestedListPopoverComponent implements NestedListPopoverInterface, O
     _closeScrollStrategy: ScrollStrategy;
 
     /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
     constructor(
         private _keyboardNestService: NestedListKeyboardService,
         @Optional() private _itemService: NestedItemService,
-        @Optional() private _rtlService: RtlService,
         private _overlay: Overlay
     ) {
         this._listenOnKeyboardRefresh();

--- a/libs/docs/cdk/rtl-service/examples/rtl-service-basic-example/rtl-service-basic-example.component.html
+++ b/libs/docs/cdk/rtl-service/examples/rtl-service-basic-example/rtl-service-basic-example.component.html
@@ -1,10 +1,10 @@
 <div id="exampleTextContainer">
-    <h3>Is <code>RTL</code>: {{ rtl$() }}</h3>
+    <h3>Is <code>RTL</code>: {{ isRtl() }}</h3>
     <h3>Whitespaces disabled</h3>
     <fd-text [text]="text"></fd-text>
 
     <h3>Whitespaces enabled</h3>
     <fd-text id="example-text" [text]="text" [whitespaces]="true"></fd-text>
     <br /><br />
-    <button fd-button (click)="simulateRTL()">Simulate {{ rtl$() ? 'LTR' : 'RTL' }}</button>
+    <button fd-button (click)="simulateRTL()">Simulate {{ isRtl() ? 'LTR' : 'RTL' }}</button>
 </div>

--- a/libs/docs/cdk/rtl-service/examples/rtl-service-basic-example/rtl-service-basic-example.component.ts
+++ b/libs/docs/cdk/rtl-service/examples/rtl-service-basic-example/rtl-service-basic-example.component.ts
@@ -1,12 +1,12 @@
 import { Direction } from '@angular/cdk/bidi';
 import { ChangeDetectionStrategy, Component, computed, effect, inject } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { ButtonComponent, FormLabelComponent, RtlService, SwitchComponent, TextComponent } from '@fundamental-ngx/core';
+import { RtlService } from '@fundamental-ngx/cdk/utils';
+import { ButtonComponent, TextComponent } from '@fundamental-ngx/core';
 
 @Component({
     selector: 'fd-rtl-service-basic-example',
     templateUrl: 'rtl-service-basic-example.component.html',
-    imports: [TextComponent, ButtonComponent, FormLabelComponent, SwitchComponent, FormsModule],
+    imports: [TextComponent, ButtonComponent],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RtlServiceBasicExampleComponent {
@@ -20,28 +20,24 @@ export class RtlServiceBasicExampleComponent {
     eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
     deserunt mollit anim id est laborum.`;
 
-    // Signal to track RTL state
-    rtl$ = computed(() => !!this._rtlService?.rtlSignal());
-    // Signal to track a direction
-    _dir$ = computed<Direction>(() => (this.rtl$() ? 'rtl' : 'ltr'));
+    protected readonly isRtl = computed(() => this._rtlService.rtl());
 
-    // Injecting the RtlService
-    private _rtlService = inject(RtlService);
+    protected readonly direction = computed<Direction>(() => (this.isRtl() ? 'rtl' : 'ltr'));
+
+    private readonly _rtlService = inject(RtlService);
 
     constructor() {
         effect(() => {
-            this._updateTextContainerDirection();
+            const dir = this.direction();
+            const labelElement = document.getElementById('exampleTextContainer');
+            if (labelElement) {
+                labelElement.dir = dir;
+            }
         });
     }
 
-    // Method to handle changes in RTL state
-    simulateRTL(): void {
-        this._rtlService.rtl.next(!this._rtlService.rtl.value);
-    }
-
-    // Method to update the direction of the text container
-    private _updateTextContainerDirection(): void {
-        const labelElement = document.getElementById('exampleTextContainer');
-        labelElement && (labelElement.dir = this._dir$());
+    // Method to toggle RTL state
+    protected simulateRTL(): void {
+        this._rtlService.rtl.update((current) => !current);
     }
 }

--- a/libs/docs/core/action-bar/examples/action-bar-back-example.component.ts
+++ b/libs/docs/core/action-bar/examples/action-bar-back-example.component.ts
@@ -1,5 +1,4 @@
 import { Component, computed, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import {
     ActionBarActionsDirective,
@@ -26,9 +25,8 @@ import { ButtonComponent } from '@fundamental-ngx/core/button';
 })
 export class ActionBarBackExampleComponent {
     protected readonly navigationArrow = computed(() =>
-        this._isRtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
     );
 
-    private readonly _rtlService = inject(RtlService);
-    private readonly _isRtl = toSignal(this._rtlService.rtl, { initialValue: false });
+    private readonly _rtlService = inject(RtlService, { optional: true });
 }

--- a/libs/docs/core/action-bar/examples/action-bar-long-string-title-truncation-example.component.ts
+++ b/libs/docs/core/action-bar/examples/action-bar-long-string-title-truncation-example.component.ts
@@ -1,5 +1,4 @@
 import { Component, computed, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import {
     ActionBarActionsDirective,
@@ -26,9 +25,8 @@ import { ButtonComponent } from '@fundamental-ngx/core/button';
 })
 export class ActionBarLongStringTitleTruncationExampleComponent {
     protected readonly navigationArrow = computed(() =>
-        this._isRtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+        this._rtlService.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
     );
 
     private readonly _rtlService = inject(RtlService);
-    private readonly _isRtl = toSignal(this._rtlService.rtl, { initialValue: false });
 }

--- a/libs/docs/core/action-bar/examples/action-bar-mobile-example.component.ts
+++ b/libs/docs/core/action-bar/examples/action-bar-mobile-example.component.ts
@@ -1,5 +1,4 @@
 import { Component, computed, inject, viewChild } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import {
     ActionBarActionsDirective,
@@ -42,11 +41,10 @@ export class ActionBarMobileExampleComponent {
     protected readonly menu = viewChild.required<MenuComponent>('menu');
 
     protected readonly navigationArrow = computed(() =>
-        this._isRtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
     );
 
-    private readonly _rtlService = inject(RtlService);
-    private readonly _isRtl = toSignal(this._rtlService.rtl, { initialValue: false });
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     protected closeMenu(): void {
         this.menu().close();

--- a/libs/docs/core/avatar-group-legacy/examples/avatar-group-legacy-group-type-example.component.html
+++ b/libs/docs/core/avatar-group-legacy/examples/avatar-group-legacy-group-type-example.component.html
@@ -70,7 +70,7 @@
                             @if (isDetailStage) {
                                 <fd-button-bar
                                     (click)="openOverflowMain()"
-                                    [glyph]="isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'"
+                                    [glyph]="isRtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'"
                                     fdType="transparent"
                                     aria-label="Back"
                                     title="Back"

--- a/libs/docs/core/avatar-group-legacy/examples/avatar-group-legacy-group-type-example.component.ts
+++ b/libs/docs/core/avatar-group-legacy/examples/avatar-group-legacy-group-type-example.component.ts
@@ -1,5 +1,5 @@
 import { ENTER, ESCAPE, SPACE, TAB } from '@angular/cdk/keycodes';
-import { Component, ViewChild } from '@angular/core';
+import { Component, computed, inject, ViewChild } from '@angular/core';
 
 import { KeyUtil, RtlService, Size } from '@fundamental-ngx/cdk/utils';
 import { AvatarComponent } from '@fundamental-ngx/core/avatar';
@@ -61,14 +61,11 @@ export class AvatarGroupLegacyGroupTypeExampleComponent {
         return this.overflowPopoverStage === 'detail';
     }
 
-    get isRtl(): boolean {
-        return this._rtlService.rtl.getValue();
-    }
+    protected readonly isRtl = computed(() => this._rtlService?.rtl ?? false);
 
-    constructor(
-        private readonly avatarGroupDataExampleService: AvatarGroupLegacyDataExampleService,
-        private _rtlService: RtlService
-    ) {
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    constructor(private readonly avatarGroupDataExampleService: AvatarGroupLegacyDataExampleService) {
         this.people = this.avatarGroupDataExampleService.generate();
     }
 

--- a/libs/docs/core/avatar-group-legacy/examples/avatar-group-legacy-individual-type-example.component.html
+++ b/libs/docs/core/avatar-group-legacy/examples/avatar-group-legacy-individual-type-example.component.html
@@ -161,7 +161,7 @@
                                 @if (isDetailStage) {
                                     <fd-button-bar
                                         (click)="openOverflowMain()"
-                                        [glyph]="isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'"
+                                        [glyph]="navigationArrow()"
                                         fdType="transparent"
                                         aria-label="Back"
                                         title="Back"

--- a/libs/docs/core/avatar-group-legacy/examples/avatar-group-legacy-individual-type-example.component.ts
+++ b/libs/docs/core/avatar-group-legacy/examples/avatar-group-legacy-individual-type-example.component.ts
@@ -1,5 +1,5 @@
 import { ENTER, ESCAPE, SPACE, TAB } from '@angular/cdk/keycodes';
-import { Component, ViewChild } from '@angular/core';
+import { Component, computed, inject, ViewChild } from '@angular/core';
 
 import { SlicePipe } from '@angular/common';
 import { KeyUtil, RtlService, Size } from '@fundamental-ngx/cdk/utils';
@@ -66,15 +66,14 @@ export class AvatarGroupLegacyIndividualTypeExampleComponent {
         return this.overflowPopoverStage === 'detail';
     }
 
-    constructor(
-        private readonly avatarGroupDataExampleService: AvatarGroupLegacyDataExampleService,
-        private _rtlService: RtlService
-    ) {
-        this.people = this.avatarGroupDataExampleService.generate();
-    }
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    );
 
-    get isRtl(): boolean {
-        return this._rtlService.rtl.getValue();
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    constructor(private readonly avatarGroupDataExampleService: AvatarGroupLegacyDataExampleService) {
+        this.people = this.avatarGroupDataExampleService.generate();
     }
 
     openOverflowDetails(idx: number): void {

--- a/libs/docs/core/avatar-group/examples/group-type/group-type-example.component.ts
+++ b/libs/docs/core/avatar-group/examples/group-type/group-type-example.component.ts
@@ -1,7 +1,7 @@
 import { ENTER, ESCAPE, SPACE, TAB } from '@angular/cdk/keycodes';
 
 import { Component, inject } from '@angular/core';
-import { KeyUtil, RtlService, Size } from '@fundamental-ngx/cdk/utils';
+import { KeyUtil, Size } from '@fundamental-ngx/cdk/utils';
 import { AvatarComponent } from '@fundamental-ngx/core/avatar';
 import { AvatarGroupComponent, AvatarGroupItemDirective } from '@fundamental-ngx/core/avatar-group';
 import { LinkComponent } from '@fundamental-ngx/core/link';
@@ -21,8 +21,6 @@ export class GroupTypeExampleComponent {
     personDetails: any = null;
     overflowPopoverStage: 'main' | 'detail' = 'main';
 
-    constructor(private _rtlService: RtlService) {}
-
     get isDetailStage(): boolean {
         return this.overflowPopoverStage === 'detail';
     }
@@ -35,10 +33,6 @@ export class GroupTypeExampleComponent {
             overflowItemsCount +
             ' avatars hidden, activate for complete list'
         );
-    }
-
-    get isRtl(): boolean {
-        return this._rtlService.rtl.getValue();
     }
 
     isOpenChanged(isOpened: boolean): void {

--- a/libs/docs/core/bar/examples/bar-default-example.component.html
+++ b/libs/docs/core/bar/examples/bar-default-example.component.html
@@ -1,6 +1,6 @@
 <div fd-bar aria-label="Default Bar">
     <div fd-bar-left>
-        <fd-button-bar ariaLabel="previous" [glyph]="navigationArrow$ | async"></fd-button-bar>
+        <fd-button-bar ariaLabel="previous" [glyph]="navigationArrow()"></fd-button-bar>
         <fd-bar-element> Left Section </fd-bar-element>
     </div>
     <div fd-bar-middle>

--- a/libs/docs/core/bar/examples/bar-default-example.component.ts
+++ b/libs/docs/core/bar/examples/bar-default-example.component.ts
@@ -1,24 +1,18 @@
-import { AsyncPipe } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { AvatarComponent } from '@fundamental-ngx/core/avatar';
 import { BarModule } from '@fundamental-ngx/core/bar';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 @Component({
     selector: 'fd-bar-default-example',
     templateUrl: './bar-default-example.component.html',
-    imports: [BarModule, AvatarComponent, AsyncPipe]
+    imports: [BarModule, AvatarComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BarDefaultExampleComponent implements OnInit {
-    navigationArrow$: Observable<string>;
+export class BarDefaultExampleComponent {
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    );
 
-    constructor(private _rtlService: RtlService) {}
-
-    ngOnInit(): void {
-        this.navigationArrow$ = this._rtlService.rtl.pipe(
-            map((isRtl) => (isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'))
-        );
-    }
+    private readonly _rtlService = inject(RtlService, { optional: true });
 }

--- a/libs/docs/core/bar/examples/bar-header-example.component.html
+++ b/libs/docs/core/bar/examples/bar-header-example.component.html
@@ -1,6 +1,6 @@
 <div fd-bar barDesign="header" aria-label="Bar Design Header">
     <div fd-bar-left>
-        <fd-button-bar ariaLabel="previous" [glyph]="navigationArrow$ | async"></fd-button-bar>
+        <fd-button-bar ariaLabel="previous" [glyph]="navigationArrow()"></fd-button-bar>
         <fd-bar-element> Left Section </fd-bar-element>
     </div>
     <div fd-bar-middle>

--- a/libs/docs/core/bar/examples/bar-header-example.component.ts
+++ b/libs/docs/core/bar/examples/bar-header-example.component.ts
@@ -1,24 +1,18 @@
-import { AsyncPipe } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { AvatarComponent } from '@fundamental-ngx/core/avatar';
 import { BarModule } from '@fundamental-ngx/core/bar';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 @Component({
     selector: 'fd-bar-header-example',
     templateUrl: './bar-header-example.component.html',
-    imports: [BarModule, AvatarComponent, AsyncPipe]
+    imports: [BarModule, AvatarComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BarHeaderExampleComponent implements OnInit {
-    navigationArrow$: Observable<string>;
+export class BarHeaderExampleComponent {
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    );
 
-    constructor(private _rtlService: RtlService) {}
-
-    ngOnInit(): void {
-        this.navigationArrow$ = this._rtlService.rtl.pipe(
-            map((isRtl) => (isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'))
-        );
-    }
+    private readonly _rtlService = inject(RtlService, { optional: true });
 }

--- a/libs/docs/core/bar/examples/bar-page-example.component.html
+++ b/libs/docs/core/bar/examples/bar-page-example.component.html
@@ -1,6 +1,6 @@
 <div fd-bar [inPage]="true" aria-label="Bar Design in Page">
     <div fd-bar-left>
-        <fd-button-bar ariaLabel="previous" [glyph]="navigationArrow$ | async"></fd-button-bar>
+        <fd-button-bar ariaLabel="previous" [glyph]="navigationArrow()"></fd-button-bar>
         <fd-bar-element> Left Section </fd-bar-element>
     </div>
     <div fd-bar-middle>

--- a/libs/docs/core/bar/examples/bar-page-example.component.ts
+++ b/libs/docs/core/bar/examples/bar-page-example.component.ts
@@ -1,24 +1,18 @@
-import { AsyncPipe } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { AvatarComponent } from '@fundamental-ngx/core/avatar';
 import { BarModule } from '@fundamental-ngx/core/bar';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 @Component({
     selector: 'fd-bar-page-example',
     templateUrl: './bar-page-example.component.html',
-    imports: [BarModule, AvatarComponent, AsyncPipe]
+    imports: [BarModule, AvatarComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BarPageExampleComponent implements OnInit {
-    navigationArrow$: Observable<string>;
+export class BarPageExampleComponent {
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    );
 
-    constructor(private _rtlService: RtlService) {}
-
-    ngOnInit(): void {
-        this.navigationArrow$ = this._rtlService.rtl.pipe(
-            map((isRtl) => (isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'))
-        );
-    }
+    private readonly _rtlService = inject(RtlService, { optional: true });
 }

--- a/libs/docs/core/bar/examples/bar-page-responsive-example.component.html
+++ b/libs/docs/core/bar/examples/bar-page-responsive-example.component.html
@@ -1,6 +1,6 @@
 <div fd-bar [inPage]="true" size="m_l" aria-label="Bar Design in Page Responsive Behaviour">
     <div fd-bar-left>
-        <fd-button-bar ariaLabel="previous" [glyph]="navigationArrow$ | async"></fd-button-bar>
+        <fd-button-bar ariaLabel="previous" [glyph]="navigationArrow()"></fd-button-bar>
         <fd-bar-element> Left Section </fd-bar-element>
     </div>
     <div fd-bar-middle>

--- a/libs/docs/core/bar/examples/bar-page-responsive-example.component.ts
+++ b/libs/docs/core/bar/examples/bar-page-responsive-example.component.ts
@@ -1,24 +1,18 @@
-import { AsyncPipe } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { AvatarComponent } from '@fundamental-ngx/core/avatar';
 import { BarModule } from '@fundamental-ngx/core/bar';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 @Component({
     selector: 'fd-bar-page-responsive-example',
     templateUrl: './bar-page-responsive-example.component.html',
-    imports: [BarModule, AvatarComponent, AsyncPipe]
+    imports: [BarModule, AvatarComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BarPageResponsiveExampleComponent implements OnInit {
-    navigationArrow$: Observable<string>;
+export class BarPageResponsiveExampleComponent {
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService?.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
+    );
 
-    constructor(private _rtlService: RtlService) {}
-
-    ngOnInit(): void {
-        this.navigationArrow$ = this._rtlService.rtl.pipe(
-            map((isRtl) => (isRtl ? 'navigation-right-arrow' : 'navigation-left-arrow'))
-        );
-    }
+    private readonly _rtlService = inject(RtlService, { optional: true });
 }

--- a/libs/docs/core/inline-help/examples/inline-help-example.component.html
+++ b/libs/docs/core/inline-help/examples/inline-help-example.component.html
@@ -32,7 +32,7 @@
     <input
         fd-form-control
         fd-inline-help="Inline Help Tooltip"
-        [placement]="rtlDirection$ | async"
+        [placement]="rtlDirection()"
         placeholder="Inline help inside input"
     />
 </div>

--- a/libs/docs/core/inline-help/examples/inline-help-example.component.ts
+++ b/libs/docs/core/inline-help/examples/inline-help-example.component.ts
@@ -1,12 +1,9 @@
-import { AsyncPipe } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { FormControlComponent } from '@fundamental-ngx/core/form';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { InlineHelpModule } from '@fundamental-ngx/core/inline-help';
 import { Placement } from '@fundamental-ngx/core/shared';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 @Component({
     selector: 'fd-inline-help-example',
@@ -24,12 +21,10 @@ import { map } from 'rxjs/operators';
             }
         `
     ],
-    imports: [IconComponent, InlineHelpModule, FormControlComponent, AsyncPipe]
+    imports: [IconComponent, InlineHelpModule, FormControlComponent]
 })
 export class InlineHelpExampleComponent {
-    rtlDirection$: Observable<Placement>;
+    protected readonly rtlDirection = computed<Placement>(() => (this._rtlService?.rtl() ? 'left' : 'right'));
 
-    constructor(private _rtlService: RtlService) {
-        this.rtlDirection$ = this._rtlService.rtl.pipe(map((isRtl) => (isRtl ? 'left' : 'right')));
-    }
+    private readonly _rtlService = inject(RtlService, { optional: true });
 }

--- a/libs/docs/core/link/examples/link-example.component.html
+++ b/libs/docs/core/link/examples/link-example.component.html
@@ -5,17 +5,17 @@
 <br /><br />
 <a [routerLink]="['./']" fd-link aria-label="Icon right">
     Icon Right Link
-    <fd-icon [glyph]="arrowRight$ | async"></fd-icon>
+    <fd-icon [glyph]="arrowRight()"></fd-icon>
 </a>
 <br /><br />
 <a [routerLink]="['./']" fd-link aria-label="Icon left">
-    <fd-icon [glyph]="arrowLeft$ | async"></fd-icon>
+    <fd-icon [glyph]="arrowLeft()"></fd-icon>
     Icon Left Link
 </a>
 <br /><br />
 
 <a fd-link [subtle]="true" aria-label="Standard">Subtle Link</a> <br /><br />
 
-<div [ngStyle]="{ 'background-color': 'var(--sapShellColor)', padding: '10px' }">
+<div [ngStyle]="{ 'background-color': 'var(--sapShellColor)', padding: '1rem' }">
     <a fd-link [routerLink]="['./']" fragment="inverted" aria-label="Inverted" [inverted]="true">Inverted Link</a>
 </div>

--- a/libs/docs/core/link/examples/link-example.component.ts
+++ b/libs/docs/core/link/examples/link-example.component.ts
@@ -1,26 +1,19 @@
-import { AsyncPipe, NgStyle } from '@angular/common';
-import { Component, inject } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NgStyle } from '@angular/common';
+import { Component, computed, inject } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { LinkComponent } from '@fundamental-ngx/core/link';
-import { BehaviorSubject, of } from 'rxjs';
 
 @Component({
     selector: 'fd-link-example',
     templateUrl: './link-example.component.html',
-    imports: [LinkComponent, RouterLink, IconComponent, AsyncPipe, NgStyle]
+    imports: [LinkComponent, RouterLink, IconComponent, NgStyle]
 })
 export class LinkExampleComponent {
-    arrowRight$: BehaviorSubject<string> = new BehaviorSubject<string>('slim-arrow-right');
-    arrowLeft$: BehaviorSubject<string> = new BehaviorSubject<string>('slim-arrow-left');
+    readonly arrowRight = computed(() => (this._rtlService?.rtl() ? 'slim-arrow-left' : 'slim-arrow-right'));
 
-    constructor() {
-        const { rtl: rtl$ } = inject(RtlService, { optional: true }) || { rtl: of(false) };
-        rtl$.pipe(takeUntilDestroyed()).subscribe((value) => {
-            this.arrowRight$.next(value ? 'slim-arrow-left' : 'slim-arrow-right');
-            this.arrowLeft$.next(value ? 'slim-arrow-right' : 'slim-arrow-left');
-        });
-    }
+    readonly arrowLeft = computed(() => (this._rtlService?.rtl() ? 'slim-arrow-right' : 'slim-arrow-left'));
+
+    private readonly _rtlService = inject(RtlService, { optional: true });
 }

--- a/libs/docs/core/table/examples/table-navigatable-row-example.component.html
+++ b/libs/docs/core/table/examples/table-navigatable-row-example.component.html
@@ -37,7 +37,7 @@
                         <i
                             title="Navigate"
                             fd-table-icon
-                            [glyph]="isRtl ? 'slim-arrow-left' : 'slim-arrow-right'"
+                            glyph="slim-arrow-right"
                             [navigation]="true"
                             role="presentation"
                         ></i>
@@ -82,7 +82,7 @@
                         routerLink="/core/home"
                         aria-label="navigation"
                     >
-                        <i [class]="isRtl ? 'sap-icon--navigation-left-arrow' : 'sap-icon--navigation-right-arrow'"></i>
+                        <i [class]="navigationArrow()"></i>
                     </button>
                 </td>
             </tr>
@@ -128,7 +128,7 @@
                             <i
                                 title="Navigate"
                                 fd-table-icon
-                                [glyph]="isRtl ? 'slim-arrow-left' : 'slim-arrow-right'"
+                                glyph="slim-arrow-right"
                                 [navigation]="true"
                                 role="presentation"
                             ></i>

--- a/libs/docs/core/table/examples/table-navigatable-row-example.component.ts
+++ b/libs/docs/core/table/examples/table-navigatable-row-example.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 
 import { RouterLink } from '@angular/router';
 import { FocusableGridDirective, RtlService } from '@fundamental-ngx/cdk/utils';
@@ -85,11 +85,11 @@ export class TableNavigatableRowExampleComponent {
         }
     ];
 
-    get isRtl(): boolean {
-        return this._rtlService.rtl.getValue();
-    }
+    protected readonly navigationArrow = computed(() =>
+        this._rtlService?.rtl() ? 'sap-icon--navigation-left-arrow' : 'sap-icon--navigation-right-arrow'
+    );
 
-    constructor(private _rtlService: RtlService) {}
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     alert(row: any): void {
         if (row.navigatable) {

--- a/libs/docs/core/table/examples/table-pagination-example.component.ts
+++ b/libs/docs/core/table/examples/table-pagination-example.component.ts
@@ -1,12 +1,11 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { FocusableGridDirective, RtlService } from '@fundamental-ngx/cdk/utils';
+import { FocusableGridDirective } from '@fundamental-ngx/cdk/utils';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { LinkComponent } from '@fundamental-ngx/core/link';
 import { MenuComponent } from '@fundamental-ngx/core/menu';
 import { PaginationModule } from '@fundamental-ngx/core/pagination';
 import { TableModule } from '@fundamental-ngx/core/table';
 import { ToolbarItemDirective } from '@fundamental-ngx/core/toolbar';
-import { Observable } from 'rxjs';
 
 @Component({
     selector: 'fd-table-pagination-example',
@@ -23,9 +22,6 @@ export class TablePaginationExampleComponent implements OnInit {
     itemsPerPage = 5;
     currentPage = 3;
     itemsPerPageOptions: number[] = [3, 5, 10];
-    rtl$: Observable<boolean>;
-
-    constructor(private _rtlService: RtlService) {}
 
     newPageClicked(pageNumber: number): void {
         this.currentPage = pageNumber;
@@ -42,7 +38,6 @@ export class TablePaginationExampleComponent implements OnInit {
     }
 
     ngOnInit(): void {
-        this.rtl$ = this._rtlService.rtl;
         this.tableRows = [
             {
                 column1: 'Row 1',

--- a/libs/docs/core/table/examples/table-popin-example/table-popin-example.component.html
+++ b/libs/docs/core/table/examples/table-popin-example/table-popin-example.component.html
@@ -26,9 +26,7 @@
                         {{ fruit.price }}
                     </td>
                     <td fd-table-cell [fitContent]="true" [noPadding]="true">
-                        @if (navigationArrow$ | async; as navigationArrow) {
-                            <i fd-table-icon [glyph]="navigationArrow" [navigation]="true" role="presentation"></i>
-                        }
+                        <i fd-table-icon glyph="slim-arrow-right" [navigation]="true" role="presentation"></i>
                     </td>
                 </tr>
                 <tr fd-table-row [secondary]="true">
@@ -87,9 +85,7 @@
                         {{ fruit.dateOfExpire }}
                     </td>
                     <td fd-table-cell [fitContent]="true" [noPadding]="true">
-                        @if (navigationArrow$ | async; as navigationArrow) {
-                            <i fd-table-icon [glyph]="navigationArrow" [navigation]="true" role="presentation"></i>
-                        }
+                        <i fd-table-icon glyph="slim-arrow-right" [navigation]="true" role="presentation"></i>
                     </td>
                 </tr>
                 <tr fd-table-row [secondary]="true">
@@ -140,9 +136,7 @@
                         {{ fruit.description }}
                     </td>
                     <td fd-table-cell [fitContent]="true" [noPadding]="true">
-                        @if (navigationArrow$ | async; as navigationArrow) {
-                            <i fd-table-icon [glyph]="navigationArrow" [navigation]="true" role="presentation"></i>
-                        }
+                        <i fd-table-icon glyph="slim-arrow-right" [navigation]="true" role="presentation"></i>
                     </td>
                 </tr>
             }
@@ -196,9 +190,7 @@
                         {{ fruit.price }}
                     </td>
                     <td fd-table-cell [fitContent]="true" [noPadding]="true">
-                        @if (navigationArrow$ | async; as navigationArrow) {
-                            <i fd-table-icon [glyph]="navigationArrow" [navigation]="true" role="presentation"></i>
-                        }
+                        <i fd-table-icon glyph="slim-arrow-right" [navigation]="true" role="presentation"></i>
                     </td>
                 </tr>
                 <tr fd-table-row [secondary]="true" [attr.aria-selected]="fruit.checked">

--- a/libs/docs/core/table/examples/table-popin-example/table-popin-example.component.ts
+++ b/libs/docs/core/table/examples/table-popin-example/table-popin-example.component.ts
@@ -1,13 +1,10 @@
-import { AsyncPipe } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { FocusableGridDirective, RtlService } from '@fundamental-ngx/cdk/utils';
+import { FocusableGridDirective } from '@fundamental-ngx/cdk/utils';
 import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
 import { FormLabelComponent } from '@fundamental-ngx/core/form';
 import { ObjectStatusComponent } from '@fundamental-ngx/core/object-status';
 import { TableModule } from '@fundamental-ngx/core/table';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 
 @Component({
     selector: 'fd-table-popin-example',
@@ -25,14 +22,11 @@ import { map } from 'rxjs/operators';
         FormLabelComponent,
         ObjectStatusComponent,
         CheckboxComponent,
-        FormsModule,
-        AsyncPipe
+        FormsModule
     ]
 })
-export class TablePopinExampleComponent implements OnInit {
+export class TablePopinExampleComponent {
     masterCheckbox: boolean | null = false;
-
-    navigationArrow$: Observable<string>;
 
     fruits: any[] = [
         {
@@ -81,7 +75,7 @@ export class TablePopinExampleComponent implements OnInit {
         }
     ];
 
-    constructor(private _rtlService: RtlService) {}
+    constructor() {}
 
     select(index: number, checked: boolean): void {
         this.fruits[index].checked = checked;
@@ -93,12 +87,6 @@ export class TablePopinExampleComponent implements OnInit {
         checked ? this._selectAll() : this._deselectAll();
 
         this._handleMasterCheckboxState();
-    }
-
-    ngOnInit(): void {
-        this.navigationArrow$ = this._rtlService.rtl.pipe(
-            map((isRtl) => (isRtl ? 'slim-arrow-left' : 'slim-arrow-right'))
-        );
     }
 
     private _handleMasterCheckboxState(): void {

--- a/libs/docs/shared/src/lib/core-helpers/directionality/directionality.component.ts
+++ b/libs/docs/shared/src/lib/core-helpers/directionality/directionality.component.ts
@@ -25,14 +25,14 @@ import { SwitchComponent } from '@fundamental-ngx/core/switch';
 export class DirectionalityComponent {
     readonly label = input<string>();
 
-    protected readonly isChecked = linkedSignal(() => this._rtlService.rtlSignal());
+    protected readonly isChecked = linkedSignal(() => this._rtlService?.rtl() ?? false);
 
     protected readonly id = computed(() => {
         const labelValue = this.label();
         return labelValue ? `${labelValue}${Date.now()}-rtl` : `${Date.now()}6`;
     });
 
-    private readonly _rtlService = inject(RtlService);
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     constructor() {
         effect(() => {
@@ -48,7 +48,6 @@ export class DirectionalityComponent {
     }
 
     protected onChange(checked: boolean): void {
-        this.isChecked.set(checked);
-        this._rtlService.rtl.next(checked);
+        this._rtlService?.rtl.set(checked);
     }
 }

--- a/libs/platform/approval-flow/approval-flow-node/approval-flow-node.component.ts
+++ b/libs/platform/approval-flow/approval-flow-node/approval-flow-node.component.ts
@@ -10,7 +10,6 @@ import {
     OnChanges,
     OnDestroy,
     OnInit,
-    Optional,
     Output,
     QueryList,
     TemplateRef,
@@ -20,7 +19,6 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { GridListItemComponent } from '@fundamental-ngx/core/grid-list';
 import { MenuComponent } from '@fundamental-ngx/core/menu';
 import { ObjectStatus } from '@fundamental-ngx/core/object-status';
@@ -268,8 +266,7 @@ export class ApprovalFlowNodeComponent implements OnInit, OnChanges, OnDestroy {
     /** @hidden */
     constructor(
         private readonly _elRef: ElementRef,
-        private readonly _cdr: ChangeDetectorRef,
-        @Optional() private readonly _rtlService: RtlService
+        private readonly _cdr: ChangeDetectorRef
     ) {}
 
     /** @hidden */
@@ -336,8 +333,6 @@ export class ApprovalFlowNodeComponent implements OnInit, OnChanges, OnDestroy {
     /** @hidden */
     ngOnInit(): void {
         this._checkNodeStatus();
-
-        this._subscriptions.add(this._rtlService?.rtl.subscribe(() => this._cdr.markForCheck()));
     }
 
     /** @hidden */

--- a/libs/platform/approval-flow/approval-flow.component.html
+++ b/libs/platform/approval-flow/approval-flow.component.html
@@ -74,7 +74,7 @@
                                     [attr.aria-label]="'platformApprovalFlow.prevButtonAriaLabel' | fdTranslate"
                                     (click)="nextSlide(-1)"
                                 >
-                                    <fd-icon [glyph]="'navigation-' + (_rtl ? 'right' : 'left') + '-arrow'"></fd-icon>
+                                    <fd-icon [glyph]="prevSlideArrowGlyph()"></fd-icon>
                                     {{ _carouselStepsLeft }}
                                 </button>
                             }
@@ -85,7 +85,7 @@
                                     (click)="nextSlide()"
                                 >
                                     {{ _carouselStepsRight }}
-                                    <fd-icon [glyph]="'navigation-' + (_rtl ? 'left' : 'right') + '-arrow'"></fd-icon>
+                                    <fd-icon [glyph]="nextSlideArrowGlyph()"></fd-icon>
                                 </button>
                             }
                         </div>

--- a/libs/platform/form/step-input/base.step-input.ts
+++ b/libs/platform/form/step-input/base.step-input.ts
@@ -169,7 +169,7 @@ export abstract class StepInputComponent extends BaseInput implements OnInit {
     readonly _textAlign$ = computed(() => {
         const align = this._align$();
 
-        const isRtl = !!this._rtlService?.rtlSignal();
+        const isRtl = this._rtlService?.rtl() ?? false;
 
         if (!ALIGN_INPUT_OPTIONS_LIST.includes(align!)) {
             return null;

--- a/libs/platform/icon-tab-bar/icon-tab-bar.component.html
+++ b/libs/platform/icon-tab-bar/icon-tab-bar.component.html
@@ -44,7 +44,7 @@
 <ng-template #processType>
     <fdp-icon-tab-bar-process-type
         [tabs]="_tabs$()"
-        [isRtl]="_rtl$()"
+        [isRtl]="isRtl()"
         [selectedUid]="_selectedUid()"
         (selectedUidChange)="_selectedUid.set($event)"
         [densityMode]="densityMode()"
@@ -57,7 +57,7 @@
     <fdp-icon-tab-bar-filter-type
         [tabs]="_tabs$()"
         [showTotalTab]="showTotalTab()"
-        [isRtl]="_rtl$()"
+        [isRtl]="isRtl()"
         [selectedUid]="_selectedUid()"
         (selectedUidChange)="_selectedUid.set($event)"
         [densityMode]="densityMode()"
@@ -70,7 +70,7 @@
     <fdp-icon-tab-bar-icon-type
         [showLabel]="iconTabType() === 'icon'"
         [tabs]="_tabs$()"
-        [isRtl]="_rtl$()"
+        [isRtl]="isRtl()"
         [selectedUid]="_selectedUid()"
         (selectedUidChange)="_selectedUid.set($event)"
         [densityMode]="densityMode()"
@@ -85,7 +85,7 @@
         [tabs]="_tabs$()"
         [multiClick]="multiClick()"
         [layoutMode]="layoutMode()"
-        [isRtl]="_rtl$()"
+        [isRtl]="isRtl()"
         [selectedUid]="_selectedUid()"
         (selectedUidChange)="_selectedUid.set($event)"
         [densityMode]="densityMode()"

--- a/libs/platform/icon-tab-bar/icon-tab-bar.component.ts
+++ b/libs/platform/icon-tab-bar/icon-tab-bar.component.ts
@@ -187,9 +187,6 @@ export class IconTabBarComponent implements OnInit, TabList {
     readonly _tabRenderer$ = signal<IconTabBarItem | null>(null);
 
     /** @hidden */
-    readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
-
-    /** @hidden */
     readonly _templateMap$ = computed(() =>
         // Access the template service signal to get all registered templates reactively
         this.templateService.getAllTemplatesSignal()()
@@ -216,6 +213,9 @@ export class IconTabBarComponent implements OnInit, TabList {
         return children.map((t) => this._generateTabConfig(t));
     });
 
+    /** @hidden */
+    protected readonly isRtl = computed(() => this._rtlService?.rtl() ?? false);
+
     /** @hidden Initialize active tab when tabs change */
     private readonly _initActiveTabEffect = effect(() => {
         const flatTabs = this._flatTabs$();
@@ -239,10 +239,12 @@ export class IconTabBarComponent implements OnInit, TabList {
     private readonly _iconTabBarCmp = viewChild<Nullable<IconTabBarBase>>(IconTabBarBase);
 
     /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
     constructor(
         private _cd: ChangeDetectorRef,
-        @Optional() private _contentDensityService: ContentDensityService,
-        @Optional() private _rtlService: RtlService
+        @Optional() private _contentDensityService: ContentDensityService
     ) {}
 
     /** @hidden */

--- a/libs/platform/menu/menu.component.html
+++ b/libs/platform/menu/menu.component.html
@@ -1,7 +1,7 @@
 <ng-template #menuTemplate>
     <nav
         [attr.id]="menuId"
-        [attr.dir]="direction"
+        [attr.dir]="direction()"
         class="fd-menu"
         [class.is-compact]="contentDensityObserver.isCompactSignal()"
         tabindex="0"

--- a/libs/platform/menu/menu.spec.ts
+++ b/libs/platform/menu/menu.spec.ts
@@ -1,8 +1,7 @@
 import { ENTER, ESCAPE, LEFT_ARROW, RIGHT_ARROW, TAB } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { Component, ElementRef, QueryList, ViewChild, ViewChildren } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, inject, tick, waitForAsync } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { Component, ElementRef, QueryList, signal, ViewChild, ViewChildren } from '@angular/core';
+import { ComponentFixture, fakeAsync, inject, TestBed, tick, waitForAsync } from '@angular/core/testing';
 
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { createKeyboardEvent, createMouseEvent } from '@fundamental-ngx/platform/shared';
@@ -813,7 +812,7 @@ describe('Cascading Menu - Position After, RTL', () => {
     let button: ElementRef<HTMLElement>;
 
     const dirProvider = {
-        rtl: of(true)
+        rtl: signal(true)
     };
 
     beforeEach(waitForAsync(() => {
@@ -943,7 +942,7 @@ describe('Cascading Menu - Position Before, RTL', () => {
     let button: ElementRef<HTMLElement>;
 
     const dirProvider = {
-        rtl: of(true)
+        rtl: signal(true)
     };
 
     beforeEach(waitForAsync(() => {
@@ -1064,7 +1063,7 @@ describe('Multiple triggers sharing same menu', () => {
     let overlayContainerEl: HTMLElement;
 
     const dirProvider = {
-        rtl: of(false)
+        rtl: signal(false)
     };
 
     beforeEach(waitForAsync(() => {

--- a/libs/platform/search-field/search-field.component.html
+++ b/libs/platform/search-field/search-field.component.html
@@ -156,7 +156,7 @@
 <ng-template #suggestionMenuTemplate>
     @if (_dropdownValues$ | async | suggestionMatches: inputText; as suggestions) {
         @if (suggestions?.length) {
-            <div class="fdp-search-field__suggestion-dropdown" [attr.dir]="_dir$()">
+            <div class="fdp-search-field__suggestion-dropdown" [attr.dir]="dir()">
                 <nav
                     class="fd-menu"
                     tabindex="-1"

--- a/libs/platform/search-field/search-field.component.ts
+++ b/libs/platform/search-field/search-field.component.ts
@@ -21,7 +21,6 @@ import {
     OnChanges,
     OnDestroy,
     OnInit,
-    Optional,
     Output,
     Pipe,
     PipeTransform,
@@ -328,9 +327,6 @@ export class SearchFieldComponent
     _clearId = '';
 
     /** @hidden */
-    readonly _dir$ = computed<Direction>(() => (this._rtl?.rtlSignal() ? 'rtl' : 'ltr'));
-
-    /** @hidden */
     isOpen = false;
 
     /** @hidden */
@@ -341,6 +337,9 @@ export class SearchFieldComponent
 
     /** @hidden */
     _isOpen$ = signal(false);
+
+    /** @hidden */
+    protected readonly dir = computed<Direction>(() => (this._rtlService?.rtl() ? 'rtl' : 'ltr'));
 
     /** @hidden */
     private _suggestions: SuggestionItem[] | Observable<SuggestionItem[]>;
@@ -369,12 +368,14 @@ export class SearchFieldComponent
     /** @hidden */
     private _appearance: Appearance;
 
+    /** hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
     /** @hidden */
     constructor(
         public elementRef: ElementRef<HTMLElement>,
         private readonly _viewContainerRef: ViewContainerRef,
         private readonly _injector: Injector,
-        @Optional() private readonly _rtl: RtlService,
         @Inject(DOCUMENT) private readonly _document: Document,
         private readonly _liveAnnouncer: LiveAnnouncer,
         readonly _dynamicComponentService: DynamicComponentService,

--- a/libs/platform/split-menu-button/split-menu-button.component.html
+++ b/libs/platform/split-menu-button/split-menu-button.component.html
@@ -3,7 +3,7 @@
     [class]="typeClass"
     role="group"
     aria-label="split-button"
-    [attr.dir]="dir$()"
+    [attr.dir]="dir()"
     [style.max-width]="splitButtonMaxWidth"
 >
     <button

--- a/libs/platform/split-menu-button/split-menu-button.component.ts
+++ b/libs/platform/split-menu-button/split-menu-button.component.ts
@@ -6,10 +6,10 @@ import {
     EventEmitter,
     Input,
     OnInit,
-    Optional,
     Output,
     ViewChild,
-    computed
+    computed,
+    inject
 } from '@angular/core';
 
 import { RtlService } from '@fundamental-ngx/cdk/utils';
@@ -83,10 +83,6 @@ export class SplitMenuButtonComponent extends BaseComponent implements OnInit, A
      */
     public secondaryId: string;
 
-    /** handles rtl service
-     * @hidden */
-    readonly dir$ = computed<'ltr' | 'rtl'>(() => (this._rtlService?.rtlSignal() ? 'rtl' : 'ltr'));
-
     /** @hidden */
     primaryButtonWidth: string;
     /** Defined max width of Split menu button */
@@ -96,10 +92,12 @@ export class SplitMenuButtonComponent extends BaseComponent implements OnInit, A
         return this.type ? `fd-button-split--${this.type}` : '';
     }
 
+    /** handles rtl service
+     * @hidden */
+    protected readonly dir = computed<'ltr' | 'rtl'>(() => (this._rtlService?.rtl() ? 'rtl' : 'ltr'));
+
     /** @hidden */
-    constructor(@Optional() private readonly _rtlService: RtlService) {
-        super();
-    }
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /** Tabindex for button. */
     get tabindex(): number {

--- a/libs/platform/table-helpers/directives/table-cell-resizable.directive.ts
+++ b/libs/platform/table-helpers/directives/table-cell-resizable.directive.ts
@@ -54,7 +54,7 @@ export class PlatformTableCellResizableDirective
     private _resizableSide: TableColumnResizableSide = 'both';
 
     /** @hidden */
-    private readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
+    private readonly _isRtl = computed(() => !!this._rtlService?.rtl());
 
     /** @hidden */
     private readonly _tableColumnResizeService = inject(TableColumnResizeService);
@@ -108,24 +108,24 @@ export class PlatformTableCellResizableDirective
             let resizerPosition: number | undefined;
             let resizedColumn: string | undefined;
 
-            const pointerOnLeft = this._rtl$()
+            const pointerOnLeft = this._isRtl()
                 ? elPosition.right - event.clientX < TABLE_CELL_RESIZABLE_THRESHOLD_PX
                 : event.clientX - elPosition.left < TABLE_CELL_RESIZABLE_THRESHOLD_PX;
 
             if (pointerOnLeft && this._resizableSide !== 'end') {
-                resizerPosition = this._rtl$()
+                resizerPosition = this._isRtl()
                     ? el.parentElement!.offsetWidth - (el.offsetLeft + el.offsetWidth)
                     : el.offsetLeft;
 
                 resizedColumn = this._tableColumnResizeService.getPreviousColumnName(this.columnName);
             }
 
-            const pointerOnRight = this._rtl$()
+            const pointerOnRight = this._isRtl()
                 ? event.clientX - elPosition.left < TABLE_CELL_RESIZABLE_THRESHOLD_PX
                 : elPosition.right - event.clientX < TABLE_CELL_RESIZABLE_THRESHOLD_PX;
 
             if (pointerOnRight && this._resizableSide !== 'start') {
-                resizerPosition = this._rtl$()
+                resizerPosition = this._isRtl()
                     ? el.parentElement!.offsetWidth - el.offsetLeft
                     : el.offsetLeft + el.offsetWidth;
 

--- a/libs/platform/table-helpers/directives/table-header-resizer.directive.ts
+++ b/libs/platform/table-helpers/directives/table-header-resizer.directive.ts
@@ -1,6 +1,6 @@
 import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 
-import { DOCUMENT, DestroyRef, Directive, ElementRef, NgZone, OnInit, inject } from '@angular/core';
+import { DOCUMENT, DestroyRef, Directive, ElementRef, NgZone, OnInit, computed, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
     FocusableCellPosition,
@@ -25,9 +25,12 @@ export class TableHeaderResizerDirective implements OnInit {
     private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
-    private readonly _rtl = inject(RtlService, {
+    private readonly _rtlService = inject(RtlService, {
         optional: true
     });
+
+    /** @hidden */
+    private readonly _isRtl = computed(() => this._rtlService?.rtl() ?? false);
 
     /** @hidden */
     private readonly _elmRef = inject(ElementRef);
@@ -59,7 +62,7 @@ export class TableHeaderResizerDirective implements OnInit {
                 .subscribe((event) => {
                     if (
                         (KeyUtil.isKeyCode(event, LEFT_ARROW) ||
-                            (this._rtl?.rtl.value && KeyUtil.isKeyCode(event, RIGHT_ARROW))) &&
+                            (this._isRtl() && KeyUtil.isKeyCode(event, RIGHT_ARROW))) &&
                         event.shiftKey &&
                         this._headerCellFocused
                     ) {
@@ -68,7 +71,7 @@ export class TableHeaderResizerDirective implements OnInit {
                         event.stopImmediatePropagation();
                     } else if (
                         (KeyUtil.isKeyCode(event, RIGHT_ARROW) ||
-                            (this._rtl?.rtl.value && KeyUtil.isKeyCode(event, LEFT_ARROW))) &&
+                            (this._isRtl() && KeyUtil.isKeyCode(event, LEFT_ARROW))) &&
                         event.shiftKey &&
                         this._headerCellFocused
                     ) {

--- a/libs/platform/table-helpers/services/table-column-resize.service.ts
+++ b/libs/platform/table-helpers/services/table-column-resize.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, ElementRef, Injectable, OnDestroy, Optional, computed, inject, signal } from '@angular/core';
+import { DestroyRef, ElementRef, Injectable, OnDestroy, computed, inject, signal } from '@angular/core';
 import { BehaviorSubject, Observable, Subject, Subscription, fromEvent } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
@@ -101,13 +101,15 @@ export class TableColumnResizeService implements OnDestroy {
     private _tableRef: Table;
 
     /** @hidden */
-    private readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
+    private readonly _isRtl = computed(() => this._rtlService?.rtl() ?? false);
 
     /** @hidden */
-    constructor(
-        private readonly _tableScrollDispatcherService: TableScrollDispatcherService,
-        @Optional() private readonly _rtlService: RtlService
-    ) {
+    private readonly _rtlService = inject(RtlService, {
+        optional: true
+    });
+
+    /** @hidden */
+    constructor(private readonly _tableScrollDispatcherService: TableScrollDispatcherService) {
         this._tableScrollDispatcherService
             ?.horizontallyScrolled()
             .pipe(takeUntilDestroyed(this._destroyed))
@@ -235,7 +237,7 @@ export class TableColumnResizeService implements OnDestroy {
         this.resizerPosition$.next(this.resizerPosition);
 
         if (resizerPosition != null) {
-            const scrollLeftOffset = this._scrollLeft * (this._rtl$() ? 1 : -1);
+            const scrollLeftOffset = this._scrollLeft * (this._isRtl() ? 1 : -1);
             this._resizerPosition = resizerPosition - TABLE_RESIZER_BORDER_WIDTH + scrollLeftOffset;
             this.resizerPosition$.next(this.resizerPosition);
         }
@@ -276,7 +278,7 @@ export class TableColumnResizeService implements OnDestroy {
 
         if (this._startX != null) {
             const clientStartX = this._clientStartX ?? 0;
-            const diffX = this._rtl$() ? clientStartX - event.clientX : event.clientX - clientStartX;
+            const diffX = this._isRtl() ? clientStartX - event.clientX : event.clientX - clientStartX;
 
             this._processResize(diffX);
         }
@@ -351,7 +353,7 @@ export class TableColumnResizeService implements OnDestroy {
             .pipe(debounceTime(10))
             .subscribe((event) => {
                 const clientStartX = this._clientStartX ?? 0;
-                const diffX = this._rtl$() ? clientStartX - event.clientX : event.clientX - clientStartX;
+                const diffX = this._isRtl() ? clientStartX - event.clientX : event.clientX - clientStartX;
 
                 this._resizerPosition = (this._startX ?? 0) + diffX;
                 this.resizerPosition$.next(this.resizerPosition);

--- a/libs/platform/table/components/table-column-resizer/table-column-resizer.component.ts
+++ b/libs/platform/table/components/table-column-resizer/table-column-resizer.component.ts
@@ -9,7 +9,6 @@ import {
     Inject,
     NgZone,
     OnInit,
-    Optional,
     Renderer2,
     ViewEncapsulation
 } from '@angular/core';
@@ -40,7 +39,10 @@ export class PlatformTableColumnResizerComponent implements OnInit {
     private _destroyRef = inject(DestroyRef);
 
     /** @hidden */
-    private readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
+    private readonly _isRtl = computed(() => this._rtlService?.rtl() ?? false);
+
+    /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
 
     /** @hidden */
     constructor(
@@ -48,8 +50,7 @@ export class PlatformTableColumnResizerComponent implements OnInit {
         private readonly _tableColumnResizeService: TableColumnResizeService,
         private readonly _renderer: Renderer2,
         private readonly _elmRef: ElementRef,
-        @Inject(DOCUMENT) private readonly _document: Document | null,
-        @Optional() private readonly _rtlService: RtlService
+        @Inject(DOCUMENT) private readonly _document: Document | null
     ) {}
 
     /** @hidden */
@@ -75,12 +76,12 @@ export class PlatformTableColumnResizerComponent implements OnInit {
                     this._renderer.setStyle(
                         this._elmRef.nativeElement,
                         'left',
-                        this._rtl$() ? 'auto' : `${position}px`
+                        this._isRtl() ? 'auto' : `${position}px`
                     );
                     this._renderer.setStyle(
                         this._elmRef.nativeElement,
                         'right',
-                        !this._rtl$() ? 'auto' : `${position}px`
+                        !this._isRtl() ? 'auto' : `${position}px`
                     );
                 });
 

--- a/libs/platform/table/components/table-header-row/table-header-row.component.html
+++ b/libs/platform/table/components/table-header-row/table-header-row.component.html
@@ -25,7 +25,7 @@
         class="fd-table__cell--checkbox"
         [style]="
             _contentDensityObserver.contentDensity$()
-                | selectionCellStyles: _rtl$() : _fdpTableService._semanticHighlightingColumnWidth$()
+                | selectionCellStyles: isRtl() : _fdpTableService._semanticHighlightingColumnWidth$()
         "
         (keydown.enter)="
             selectionMode === SELECTION_MODE.MULTIPLE && _tableRowService.toggleAllSelectableRows(!checkedState)
@@ -89,7 +89,7 @@
         [ngStyle]="
             column
                 | tableCellStyles
-                    : _rtl$()
+                    : isRtl()
                     : _fdpTableService._semanticHighlightingColumnWidth$()
                     : selectionColumnWidth
                     : column._freezed

--- a/libs/platform/table/components/table-header-row/table-header-row.component.ts
+++ b/libs/platform/table/components/table-header-row/table-header-row.component.ts
@@ -148,9 +148,6 @@ export class TableHeaderRowComponent extends TableRowDirective implements OnInit
     }
 
     /** @hidden */
-    readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
-
-    /** @hidden */
     readonly SELECTION_MODE = SelectionMode;
 
     /** @hidden */
@@ -167,6 +164,9 @@ export class TableHeaderRowComponent extends TableRowDirective implements OnInit
 
     /** @hidden */
     readonly _tableRowService = inject(TableRowService);
+
+    /** @hidden */
+    protected readonly isRtl = computed(() => this._rtlService?.rtl() ?? false);
 
     /** @hidden */
     private readonly _rtlService = inject(RtlService, {

--- a/libs/platform/table/components/table-row/table-row.component.html
+++ b/libs/platform/table/components/table-row/table-row.component.html
@@ -37,7 +37,7 @@
             [focusable]="true"
             [style]="
                 _contentDensityObserver.contentDensity$()
-                    | selectionCellStyles: _rtl$() : _fdpTableService._semanticHighlightingColumnWidth$()
+                    | selectionCellStyles: isRtl() : _fdpTableService._semanticHighlightingColumnWidth$()
             "
             [attr.aria-selected]="row.checked"
             [attr.aria-labelledby]="_rowSelectionHelperTextId"
@@ -74,7 +74,7 @@
             [attr.aria-selected]="row.checked"
             [style]="
                 _contentDensityObserver.contentDensity$()
-                    | selectionCellStyles: _rtl$() : _fdpTableService._semanticHighlightingColumnWidth$()
+                    | selectionCellStyles: isRtl() : _fdpTableService._semanticHighlightingColumnWidth$()
             "
         >
             <ng-template [ngTemplateOutlet]="selectionScreenReaderText"></ng-template>
@@ -126,7 +126,7 @@
         [ngStyle]="
             column
                 | tableCellStyles
-                    : _rtl$()
+                    : isRtl()
                     : _fdpTableService._semanticHighlightingColumnWidth$()
                     : selectionColumnWidth
                     : column._freezed
@@ -212,7 +212,7 @@
             <fd-icon
                 fd-table-icon
                 [navigation]="true"
-                [glyph]="_rtl$() ? 'slim-arrow-left' : 'slim-arrow-right'"
+                [glyph]="navigationIcon()"
                 class="fdp-table__navigation-indicator"
                 [attr.title]="'platformTable.rowNavigateButtonTitle' | fdTranslate"
             ></fd-icon>

--- a/libs/platform/table/components/table-row/table-row.component.ts
+++ b/libs/platform/table/components/table-row/table-row.component.ts
@@ -177,9 +177,6 @@ export class TableRowComponent<T> extends TableRowDirective implements OnInit, A
     _hasRowHeaderColumn$ = computed(() => this._fdpTableService.visibleColumns$().some((c) => c.role === 'rowheader'));
 
     /** @hidden */
-    readonly _rtl$ = computed(() => !!this._rtlService?.rtlSignal());
-
-    /** @hidden */
     _rowSelectionHelperTextId = `rowSelectionHelper-${uuidv4()}`;
 
     /** @hidden */
@@ -205,6 +202,12 @@ export class TableRowComponent<T> extends TableRowDirective implements OnInit, A
 
     /** @hidden */
     readonly _isTreeRow = isTreeRow;
+
+    /** @hidden */
+    protected readonly isRtl = computed(() => this._rtlService?.rtl() ?? false);
+
+    /** @hidden */
+    protected readonly navigationIcon = computed(() => (this.isRtl() ? 'slim-arrow-left' : 'slim-arrow-right'));
 
     /** @hidden */
     private readonly _refreshChildRows$ = new Subject<void>();

--- a/libs/platform/table/table.component.ts
+++ b/libs/platform/table/table.component.ts
@@ -21,7 +21,6 @@ import {
     OnChanges,
     OnDestroy,
     OnInit,
-    Optional,
     Output,
     QueryList,
     signal,
@@ -792,8 +791,6 @@ export class TableComponent<T = any>
     /** @hidden */
     _loadPreviousPages = false;
     /** @hidden */
-    _rtl = false;
-    /** @hidden */
     readonly _dataSourceDirective = inject<TableDataSourceDirective<T>>(TableDataSourceDirective);
     /** @hidden */
     readonly _tableRowService = inject(TableRowService);
@@ -875,13 +872,15 @@ export class TableComponent<T = any>
     private readonly _defaultTrackBy: TrackByFunction<number> = (index: number) => index;
 
     /** @hidden */
+    private readonly _rtlService = inject(RtlService, { optional: true });
+
+    /** @hidden */
     constructor(
         private readonly _ngZone: NgZone,
         private readonly _cdr: ChangeDetectorRef,
         readonly _tableService: TableService,
         private readonly _tableScrollDispatcher: TableScrollDispatcherService,
         public readonly _tableColumnResizeService: TableColumnResizeService,
-        @Optional() private readonly _rtlService: RtlService,
         readonly contentDensityObserver: ContentDensityObserver,
         readonly injector: Injector,
         private readonly _tabbableService: TabbableElementService
@@ -1481,7 +1480,7 @@ export class TableComponent<T = any>
     /** @hidden */
     _scrollToOverlappedCell(): void {
         this.tableScrollable.scrollToOverlappedCell(
-            !!this._rtlService?.rtlSignal(),
+            this._rtlService?.rtl() ?? false,
             this._freezableColumns.size,
             this._freezableEndColumns.size
         );

--- a/libs/platform/value-help-dialog/value-help-dialog/value-help-dialog.component.html
+++ b/libs/platform/value-help-dialog/value-help-dialog/value-help-dialog.component.html
@@ -1,11 +1,11 @@
 <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #container>
     <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">
-        <fd-dialog-header [attr.dir]="_dir$()">
+        <fd-dialog-header [attr.dir]="dir()">
             <ng-template fdkTemplate="header">
                 <ng-template [ngTemplateOutlet]="mobile ? mobileDialogTitle : desktopDialogTitle"></ng-template>
             </ng-template>
         </fd-dialog-header>
-        <fd-dialog-body [attr.dir]="_dir$()">
+        <fd-dialog-body [attr.dir]="dir()">
             @if (!mobile) {
                 <ng-template [ngTemplateOutlet]="advancedSearchContent"></ng-template>
             }
@@ -21,7 +21,7 @@
                 }
             </div>
         </fd-dialog-body>
-        <fd-dialog-footer [attr.dir]="_dir$()">
+        <fd-dialog-footer [attr.dir]="dir()">
             <ng-template fdkTemplate="footer">
                 @if (!isMobileAdvancedSearchActive) {
                     <div

--- a/libs/platform/value-help-dialog/value-help-dialog/value-help-dialog.component.ts
+++ b/libs/platform/value-help-dialog/value-help-dialog/value-help-dialog.component.ts
@@ -9,7 +9,6 @@ import {
     Input,
     OnChanges,
     OnDestroy,
-    Optional,
     Output,
     QueryList,
     SimpleChanges,
@@ -318,10 +317,6 @@ export class PlatformValueHelpDialogComponent<T = any> extends VhdComponent impl
     /** @hidden */
     _mainSearch = '';
 
-    /** handles rtl service
-     * @hidden */
-    _dir$ = computed<Direction>(() => (this._rtlService?.rtlSignal() ? 'rtl' : 'ltr'));
-
     /** @hidden */
     selectedTab: VhdTab | null = null;
 
@@ -337,6 +332,10 @@ export class PlatformValueHelpDialogComponent<T = any> extends VhdComponent impl
      * To differentiate between first loading when skeletons be shown and subsequent loadings when busy indicator be shown
      */
     _firstLoadingDone = false;
+
+    /** handles rtl service
+     * @hidden */
+    protected readonly dir = computed<Direction>(() => (this._rtlService?.rtl() ? 'rtl' : 'ltr'));
 
     /** @hidden */
     private _destroyed = inject(DestroyRef);
@@ -365,11 +364,15 @@ export class PlatformValueHelpDialogComponent<T = any> extends VhdComponent impl
     private readonly _onDestroy$ = new Subject<void>();
 
     /** @hidden */
+    private readonly _rtlService = inject(RtlService, {
+        optional: true
+    });
+
+    /** @hidden */
     constructor(
         public readonly elementRef: ElementRef,
         private readonly _changeDetectorRef: ChangeDetectorRef,
-        private readonly _dialogService: DialogService,
-        @Optional() private readonly _rtlService: RtlService
+        private readonly _dialogService: DialogService
     ) {
         super();
         /** Default display function for define conditions */


### PR DESCRIPTION
migrate RtlService usage to Angular 21 signal patterns

BREAKING CHANGE:
 in SelectComponent public API: Renamed `rtl$` to `isRtl` in SelectComponent and SelectComponentInterface