### PR TITLE
fix(core): allow Select options dropdown to have the parent width

### DIFF
--- a/libs/core/select/select.component.html
+++ b/libs/core/select/select.component.html
@@ -11,7 +11,7 @@
         [scrollStrategy]="scrollStrategy"
         [closeOnEscapeKey]="true"
         [fillControlMode]="fillControlMode"
-        [maxWidth]="600"
+        [maxWidth]="fillControlMode !== 'equal' ? 600 : null"
         [closeOnOutsideClick]="closeOnOutsideClick"
         (isOpenChange)="_popoverOpenChangeHandle($event)"
     >

--- a/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
+++ b/libs/docs/core/select/examples/select-semantic-state-example/select-semantic-state-example.component.html
@@ -6,6 +6,7 @@
         stateMessage="Success message. This is a longer success message to provide more detailed feedback to the user about the successful state of the selection. Please ensure that you have selected the correct option and proceed with the next steps as required."
         [(value)]="selectedValue1"
         state="success"
+        fillControlMode="equal"
     >
         @for (option of options; track option) {
             <li fd-option [value]="option">{{ option }}</li>


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13814

## Description
When `fillControlMode` is set to `equal`, the popover body should be the same width as the popover control. 

## Screenshots
**with `fillControlMode = "equal"`:**

<img width="1077" height="942" alt="Screenshot 2026-02-02 at 2 35 07 PM" src="https://github.com/user-attachments/assets/6390e70d-00c8-4f40-b576-068877a125ad" />

**default:**
<img width="1055" height="926" alt="Screenshot 2026-02-02 at 2 35 13 PM" src="https://github.com/user-attachments/assets/6506b08b-e0b6-4f50-921b-74be986b2bfb" />
