### PR TITLE
feat(core): pass a value in combobox set by application

### DIFF
--- a/libs/docs/core/combobox/combobox-docs.component.html
+++ b/libs/docs/core/combobox/combobox-docs.component.html
@@ -200,6 +200,25 @@
 
 <separator></separator>
 
+<fd-docs-section-title id="value-property" componentName="combobox">
+    Reactive Form with Value Property
+</fd-docs-section-title>
+<description>
+    When using <code>[communicateByObject]="true"</code> with custom objects, you can use the
+    <code>[valueProperty]</code>
+    input to specify which property of the selected object should be used as the form control value.
+</description>
+<description>
+    By default, the entire object is passed to the form control. With <code>[valueProperty]="'propertyName'"</code>,
+    only the specified property value is passed, making it easier to work with APIs and form submissions.
+</description>
+<component-example>
+    <fd-combobox-value-property-example></fd-combobox-value-property-example>
+</component-example>
+<code-example [exampleFiles]="comboboxValuePropertyExample"></code-example>
+
+<separator></separator>
+
 <fd-docs-section-title id="disabled" componentName="combobox"> Disabled Combobox </fd-docs-section-title>
 <description> This example shows how to use a disabled combobox in a reactive form. </description>
 <component-example>

--- a/libs/docs/core/combobox/combobox-docs.component.ts
+++ b/libs/docs/core/combobox/combobox-docs.component.ts
@@ -27,6 +27,7 @@ import { ComboboxOpenControlExampleComponent } from './examples/combobox-open-co
 import { ComboboxSearchFieldExampleComponent } from './examples/combobox-search-field-example.component';
 import { ComboboxSearchFunctionExampleComponent } from './examples/combobox-search-function-example.component';
 import { ComboboxTemplateExampleComponent } from './examples/combobox-template-example.component';
+import { ComboboxValuePropertyExampleComponent } from './examples/combobox-value-property-example.component';
 
 const comboboxScss = 'combobox-example.component.scss';
 
@@ -66,6 +67,8 @@ const comboboxBylineTs = 'combobox-byline-example.component.ts';
 
 const comboboxInsideDialogH = 'combobox-inside-dialog-example.component.html';
 const comboboxInsideDialogT = 'combobox-inside-dialog-example.component.ts';
+const comboboxValuePropertyH = 'combobox-value-property-example.component.html';
+const comboboxValuePropertyT = 'combobox-value-property-example.component.ts';
 
 @Component({
     selector: 'fd-combobox-docs',
@@ -93,7 +96,8 @@ const comboboxInsideDialogT = 'combobox-inside-dialog-example.component.ts';
         ComboboxFormsExampleComponent,
         ComboboxDisabledExampleComponent,
         ComboboxBylineExampleComponent,
-        ComboboxInsideDialogExampleComponent
+        ComboboxInsideDialogExampleComponent,
+        ComboboxValuePropertyExampleComponent
     ]
 })
 export class ComboboxDocsComponent {
@@ -333,6 +337,20 @@ export class ComboboxDocsComponent {
             component: 'ComboboxInsideDialogExampleComponent',
             code: getAssetFromModuleAssets(comboboxInsideDialogT),
             fileName: 'combobox-inside-dialog-example'
+        }
+    ];
+
+    comboboxValuePropertyExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(comboboxValuePropertyH),
+            fileName: 'combobox-value-property-example'
+        },
+        {
+            language: 'typescript',
+            component: 'ComboboxValuePropertyExampleComponent',
+            code: getAssetFromModuleAssets(comboboxValuePropertyT),
+            fileName: 'combobox-value-property-example'
         }
     ];
 }

--- a/libs/docs/core/combobox/examples/combobox-value-property-example.component.html
+++ b/libs/docs/core/combobox/examples/combobox-value-property-example.component.html
@@ -1,0 +1,50 @@
+<form [formGroup]="comparisonForm">
+    <div class="sap-margin-bottom-medium">
+        <h3>Without valueProperty (entire object as value)</h3>
+        <div fd-form-item>
+            <label fd-form-label>Select Fruit:</label>
+            <fd-combobox
+                placeholder="Select a fruit..."
+                [communicateByObject]="true"
+                [dropdownValues]="fruits"
+                [displayFn]="displayFn"
+                formControlName="fruitWithoutValueProperty"
+            >
+            </fd-combobox>
+            <small class="sap-margin-top-tiny sap-display-block">
+                Form value will contain entire object:
+                <code>{{ comparisonForm.get('fruitWithoutValueProperty')?.value | json }}</code>
+            </small>
+        </div>
+    </div>
+
+    <div class="sap-margin-bottom-medium">
+        <h3>With valueProperty="code" (only code property as value)</h3>
+        <div fd-form-item>
+            <label fd-form-label>Select Fruit:</label>
+            <fd-combobox
+                placeholder="Select a fruit..."
+                [communicateByObject]="true"
+                [dropdownValues]="fruits"
+                [displayFn]="displayFn"
+                [valueProperty]="'code'"
+                formControlName="fruitWithValueProperty"
+            >
+            </fd-combobox>
+            <small class="sap-margin-top-tiny sap-display-block">
+                Form value will contain only the code:
+                <code>{{ comparisonForm.get('fruitWithValueProperty')?.value }}</code>
+            </small>
+        </div>
+    </div>
+
+    <div class="sap-margin-bottom-medium">
+        <button fd-button label="Select Apple (A1)" (click)="selectAppleWithCode()"></button>
+        <button fd-button label="Reset Form" (click)="resetForm()"></button>
+    </div>
+
+    <div>
+        <h4>Complete Form Value:</h4>
+        <pre>{{ comparisonForm.value | json }}</pre>
+    </div>
+</form>

--- a/libs/docs/core/combobox/examples/combobox-value-property-example.component.ts
+++ b/libs/docs/core/combobox/examples/combobox-value-property-example.component.ts
@@ -1,0 +1,71 @@
+import { JsonPipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { ComboboxComponent } from '@fundamental-ngx/core/combobox';
+
+/**
+ * Example demonstrating the [valueProperty] input when using [communicateByObject]="true"
+ * with Reactive Forms.
+ *
+ * The [valueProperty] input specifies which property of the selected object should be
+ * used as the form control value. This is useful when working with object arrays where
+ * you only want to submit a single property (like an ID or code) to the form, instead of
+ * the entire object.
+ */
+
+interface Product {
+    displayedValue: string;
+    code: string;
+}
+
+@Component({
+    selector: 'fd-combobox-value-property-example',
+    templateUrl: './combobox-value-property-example.component.html',
+    imports: [ReactiveFormsModule, ComboboxComponent, ButtonComponent, JsonPipe]
+})
+export class ComboboxValuePropertyExampleComponent {
+    /**
+     * Form demonstrating the difference between:
+     * 1. Without valueProperty - entire object is set to formControl value
+     * 2. With valueProperty - only the specified property is set to formControl value
+     */
+    comparisonForm = new FormGroup({
+        fruitWithoutValueProperty: new FormControl<Product | null>(null),
+        fruitWithValueProperty: new FormControl<string | null>(null)
+    });
+
+    /**
+     * Array of product objects with multiple properties
+     */
+    fruits: Product[] = [
+        { displayedValue: 'Apple', code: 'A1' },
+        { displayedValue: 'Banana', code: 'B1' },
+        { displayedValue: 'Orange', code: 'O1' },
+        { displayedValue: 'Strawberry', code: 'S1' },
+        { displayedValue: 'Tomato', code: 'T1' }
+    ];
+
+    /**
+     * Display function to show the displayedValue property in the dropdown
+     */
+    protected displayFn(item: Product | null): string {
+        return item?.displayedValue ?? '';
+    }
+
+    /**
+     * Programmatically set form values to demonstrate two-way binding
+     */
+    protected selectAppleWithCode(): void {
+        // When valueProperty is used, setting the form value to just the code
+        // will find the matching object and display it correctly
+        this.comparisonForm.patchValue({ fruitWithValueProperty: 'A1' });
+    }
+
+    /**
+     * Reset form values
+     */
+    protected resetForm(): void {
+        this.comparisonForm.reset();
+    }
+}

--- a/libs/docs/core/combobox/examples/index.ts
+++ b/libs/docs/core/combobox/examples/index.ts
@@ -13,6 +13,7 @@ import { ComboboxOpenControlExampleComponent } from './combobox-open-control-exa
 import { ComboboxSearchFieldExampleComponent } from './combobox-search-field-example.component';
 import { ComboboxSearchFunctionExampleComponent } from './combobox-search-function-example.component';
 import { ComboboxTemplateExampleComponent } from './combobox-template-example.component';
+import { ComboboxValuePropertyExampleComponent } from './combobox-value-property-example.component';
 
 export * from './combobox-async-example.component';
 export * from './combobox-columns-example.component';
@@ -28,6 +29,7 @@ export * from './combobox-open-control-example.component';
 export * from './combobox-search-field-example.component';
 export * from './combobox-search-function-example.component';
 export * from './combobox-template-example.component';
+export * from './combobox-value-property-example.component';
 
 export const examples = [
     ComboboxMobileExampleComponent,
@@ -44,5 +46,6 @@ export const examples = [
     ComboboxSearchFunctionExampleComponent,
     ComboboxTemplateExampleComponent,
     ComboboxIncludesExampleComponent,
-    ComboboxSearchFieldExampleComponent
+    ComboboxSearchFieldExampleComponent,
+    ComboboxValuePropertyExampleComponent
 ];


### PR DESCRIPTION
fixes #13436
When using `[communicateByObject]="true"` with custom objects, you can use the `[valueProperty]` input to specify which property of the selected object should be used as the form control value.