### PR TITLE
fix(core): generic tag cut inside dynamic page title content

### DIFF
--- a/libs/core/dynamic-page/dynamic-page-header/actions/dynamic-page-title-content.component.ts
+++ b/libs/core/dynamic-page/dynamic-page-header/actions/dynamic-page-title-content.component.ts
@@ -30,6 +30,14 @@ import { DynamicPageResponsiveSize } from '../../constants';
             <ng-content></ng-content>
         </ng-template>
     `,
+    // TO BE REMOVED WITH THE LATEST VERSION OF FUNDAMENTAL STYLES
+    styles: [
+        `
+            .fd-dynamic-page__title-content {
+                padding-inline: 1rem 0.2rem;
+            }
+        `
+    ],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     providers: [contentDensityObserverProviders()],

--- a/libs/docs/core/dynamic-page/examples/dynamic-page-example.component.html
+++ b/libs/docs/core/dynamic-page/examples/dynamic-page-example.component.html
@@ -24,7 +24,9 @@
                         </fd-breadcrumb-item>
                     </fd-breadcrumb>
                 </fd-dynamic-page-breadcrumb>
-                <fd-dynamic-page-title-content> Key Info </fd-dynamic-page-title-content>
+                <fd-dynamic-page-title-content>
+                    <div fd-generic-tag name="Key Info" value="Lorem Ipsum"></div>
+                </fd-dynamic-page-title-content>
                 <fd-dynamic-page-global-actions>
                     <fd-toolbar fdType="transparent" [clearBorder]="true">
                         <button

--- a/libs/docs/core/dynamic-page/examples/dynamic-page-example.component.ts
+++ b/libs/docs/core/dynamic-page/examples/dynamic-page-example.component.ts
@@ -6,6 +6,7 @@ import { BreadcrumbModule } from '@fundamental-ngx/core/breadcrumb';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { ContentDensityDirective } from '@fundamental-ngx/core/content-density';
 import { DynamicPageModule } from '@fundamental-ngx/core/dynamic-page';
+import { GenericTagComponent } from '@fundamental-ngx/core/generic-tag';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { InlineHelpModule } from '@fundamental-ngx/core/inline-help';
 import { LinkComponent } from '@fundamental-ngx/core/link';
@@ -42,6 +43,7 @@ import { ToolbarComponent, ToolbarItemDirective, ToolbarSeparatorComponent } fro
         ToolbarSeparatorComponent,
         CdkScrollable,
         IconComponent,
+        GenericTagComponent,
         InlineHelpModule,
         BarModule,
         MessageToastModule


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/11440

## Description
 
- Gives a little bit of padding to the right of dynamic page title content so that generic tag does not get cut when used inside.
- Updates one of the examples to reproduce the issue.

Corresponding PR in **fundamental-styles** - https://github.com/SAP/fundamental-styles/pull/6235

## Screenshots

Before:
<img width="704" height="231" alt="Screenshot 2026-02-10 at 10 34 03" src="https://github.com/user-attachments/assets/da278670-322f-4fd1-b4e2-a91e7f23e48a" />


After:
<img width="686" height="243" alt="Screenshot 2026-02-10 at 10 32 59" src="https://github.com/user-attachments/assets/c2f9f1ff-0c05-4b56-a72f-267bb9873af4" />

