### PR TITLE
fix(cdk, platform): provide fix for max call stack size exceeded

### DIFF
--- a/libs/cdk/utils/functions/lodash-utils.spec.ts
+++ b/libs/cdk/utils/functions/lodash-utils.spec.ts
@@ -124,10 +124,38 @@ describe('lodash-utils', () => {
         });
 
         it('should handle circular references gracefully', () => {
-            const obj: any = { a: 1 };
+            const obj: any = { a: 1, b: { c: 2 } };
             obj.self = obj;
-            // This will cause infinite recursion, but we're testing it doesn't crash immediately
-            expect(() => cloneDeep(obj)).toBeDefined();
+            obj.b.parent = obj;
+            
+            const cloned = cloneDeep(obj);
+            
+            // Should successfully clone without stack overflow
+            expect(cloned).toBeDefined();
+            expect(cloned.a).toBe(1);
+            expect(cloned.b.c).toBe(2);
+            
+            // Circular references should be preserved
+            expect(cloned.self).toBe(cloned);
+            expect(cloned.b.parent).toBe(cloned);
+            
+            // But the cloned object should not be the same as the original
+            expect(cloned).not.toBe(obj);
+            expect(cloned.b).not.toBe(obj.b);
+        });
+
+        it('should handle circular references in arrays', () => {
+            const arr: any[] = [1, 2, 3];
+            arr.push(arr);
+            
+            const cloned = cloneDeep(arr);
+            
+            expect(cloned).toBeDefined();
+            expect(cloned[0]).toBe(1);
+            expect(cloned[1]).toBe(2);
+            expect(cloned[2]).toBe(3);
+            expect(cloned[3]).toBe(cloned);
+            expect(cloned).not.toBe(arr);
         });
     });
 

--- a/libs/platform/form/form-generator/form-generator.service.ts
+++ b/libs/platform/form/form-generator/form-generator.service.ts
@@ -210,7 +210,7 @@ export class FormGeneratorService {
     ): Promise<DynamicFormValue> {
         await this._triggerFieldsOnchange(form);
 
-        const formValue = structuredClone(form.value);
+        const formValue = cloneDeep(form.value);
 
         for (const [i, control] of Object.entries(form.controls)) {
             const formItem = control.formItem;
@@ -285,7 +285,7 @@ export class FormGeneratorService {
      * @returns `Set` where key is item name, and boolean value if field needs to be shown.
      */
     async checkVisibleFormItems(form: DynamicFormGroup): Promise<{ [key: string]: boolean }> {
-        const formValue = this._getFormValueWithoutUngrouped(structuredClone(form.value));
+        const formValue = this._getFormValueWithoutUngrouped(cloneDeep(form.value));
         return await this._checkFormControlsVisibility(form, formValue);
     }
 
@@ -493,6 +493,12 @@ export class FormGeneratorService {
         );
 
         if (!defaultChoices) {
+            return [];
+        }
+
+        // Defensive check: ensure defaultChoices is an array
+        if (!Array.isArray(defaultChoices)) {
+            console.warn('Expected defaultChoices to be an array, got:', typeof defaultChoices, defaultChoices);
             return [];
         }
 


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13895

## Description
**Problem:**
Stack overflow error (RangeError: Maximum call stack size exceeded) caused by `cloneDeep` function not handling circular references. When objects contained self-references or circular dependencies, the function would recurse infinitely. Additionally, `structuredClone` usage in form-generator service failed when cloning objects containing functions or RxJS observables.

**Solution:**

Added circular reference detection to `cloneDeep` using WeakMap to track visited objects
Replaced `structuredClone` with `cloneDeep` in form-generator service (lines 213, 288) to properly handle functions and complex objects
Added edge case handling for DOM elements, Error objects, and defensive array validation

**Changes:**

- `lodash-utils.ts`: Enhanced cloneDeep with circular reference tracking and edge case handling
- `form-generator.service.ts`: Replaced structuredClone with cloneDeep
- Updated tests to verify circular reference handling