### PR TITLE
fix(core): add fix for clean btn not working in Combobox in Core

### DIFF
--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -646,6 +646,7 @@ export class ComboboxComponent<T = any>
         this.inputTextValue = '';
         this.inputTextChange.emit('');
         this.displayedValues = this.dropdownValues || [];
+        this.searchInputElement.nativeElement.value = '';
         this.searchInputElement.nativeElement.focus();
         if (!this.mobile) {
             this._propagateChange();


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13900

## Description
The clear button stopped working after [this PR](https://github.com/SAP/fundamental-ngx/pull/13647), which added `_setupValueSynchronization()` to sync DOM values back to the model on focus events. When the clear button was clicked:
1. `_handleClearSearchTerm()` set `inputTextValue = ''`
2. Then it called `focus()` on the input element
3. The focus event triggered `_syncDomValueToModel()`
4. `_syncDomValueToModel()` read the DOM value (which was still the old value) and restored it back to the model
5. The clear appeared to not work because the value was immediately restored

Fix: explicitly clear the DOM input value before calling `focus()`. This ensures that when the focus event triggers `_syncDomValueToModel()`, it reads an empty string from the DOM and keeps the input cleared.
