### PR TITLE
fix(core): clear dialogRef after close in mobile menu to allow reopening

### DIFF
--- a/libs/core/menu/menu-mobile/menu-mobile.component.spec.ts
+++ b/libs/core/menu/menu-mobile/menu-mobile.component.spec.ts
@@ -246,4 +246,33 @@ describe('MenuMobileComponent', () => {
         expect(mobileElements.dialogCloseBtn).toBeFalsy();
         expect(mobileElements.footerButtons.length).toEqual(2);
     });
+
+    it('should reopen dialog after closing', async () => {
+        await setup({ title: MOBILE_CONFIG.title, hasCloseButton: true });
+
+        await whenStable(fixture);
+
+        // First open
+        menu.open();
+        const dialogAppeared = await waitForMobileDialog(fixture);
+        expect(dialogAppeared).toBe(true);
+        expect(document.querySelector('.fd-dialog')).toBeTruthy();
+
+        // Close via the mobile component
+        menu.close();
+        await whenStable(fixture);
+        fixture.detectChanges();
+        await whenStable(fixture);
+
+        // Wait for dialog to be removed from the DOM
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        fixture.detectChanges();
+        await whenStable(fixture);
+
+        // Second open — this is the bug: dialog should reopen
+        menu.open();
+        const dialogReappeared = await waitForMobileDialog(fixture);
+        expect(dialogReappeared).toBe(true);
+        expect(document.querySelector('.fd-dialog')).toBeTruthy();
+    });
 });

--- a/libs/core/menu/menu-mobile/menu-mobile.component.ts
+++ b/libs/core/menu/menu-mobile/menu-mobile.component.ts
@@ -121,6 +121,7 @@ export class MenuMobileComponent extends MobileModeBase<MenuInterface> implement
                 } else if (!isOpen && this.dialogRef) {
                     // Only close if currently open
                     this.dialogRef.close();
+                    this.dialogRef = null!;
                 }
             });
         });
@@ -134,7 +135,8 @@ export class MenuMobileComponent extends MobileModeBase<MenuInterface> implement
 
     /** Closes the Dialog and Menu component */
     close(): void {
-        this.dialogRef.close();
+        this.dialogRef?.close();
+        this.dialogRef = null!;
         this._component.close();
     }
 


### PR DESCRIPTION
clear dialogRef after close in mobile menu to allow reopening