### PR TITLE
fix(btp): add fix for unreachable menu items in BTP vertical navigation

### DIFF
--- a/libs/btp/navigation/components/navigation-item/navigation-list-item.component.html
+++ b/libs/btp/navigation/components/navigation-item/navigation-list-item.component.html
@@ -24,6 +24,7 @@
             (focusin)="_focusInHandler()"
             (click)="handleItemClick()"
             (keydown)="handleItemKeydown($event)"
+            (mouseenter)="onOverflowItemMouseEnter()"
             fdbNavigationListItemMarker
             #itemContainer
         >
@@ -106,7 +107,11 @@
 </ng-template>
 <!-- Template used for rendering sublist of items for the list item that is currently in overflow menu. -->
 <ng-template #overflowItemListRenderer>
-    <div class="fd-navigation__list-container fd-navigation__list-container--submenu fd-menu__sublist">
+    <div
+        #overflowSubmenuContainer
+        class="fd-navigation__list-container fd-navigation__list-container--submenu fd-menu__sublist"
+        [style.max-height]="overflowSubmenuMaxHeight()"
+    >
         <ng-template [ngTemplateOutlet]="wrapperRenderer" [ngTemplateOutletContext]="{ $implicit: true }"></ng-template>
     </div>
 </ng-template>

--- a/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
+++ b/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
@@ -440,6 +440,9 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
      */
     protected readonly popoverPlacement = computed<Placement>(() => (this._isRtl() ? 'left-start' : 'right-start'));
 
+    /** @hidden Max-height for the overflow submenu, computed dynamically based on viewport position. */
+    protected readonly overflowSubmenuMaxHeight = signal<string | null>(null);
+
     /** @hidden */
     private readonly _home$ = signal(false);
 
@@ -519,6 +522,9 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
 
     /** @hidden */
     private readonly _itemContainer = viewChild<ElementRef>('itemContainer');
+
+    /** @hidden */
+    private readonly _overflowSubmenuContainer = viewChild<ElementRef>('overflowSubmenuContainer');
 
     /** @hidden */
     constructor() {
@@ -855,6 +861,36 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
 
         // All other items (leaf items and items with both links and children) can be selected
         return true;
+    }
+
+    /**
+     * @hidden
+     * Handles mouseenter on overflow items to dynamically adjust the submenu max-height.
+     * Uses requestAnimationFrame to ensure the browser has laid out the submenu
+     * (which transitions from display:none to display:block via CSS :hover)
+     * before measuring its viewport position.
+     */
+    onOverflowItemMouseEnter(): void {
+        if (!this.isOverflow$() || !this.hasChildren$()) {
+            return;
+        }
+
+        const submenuEl = this._overflowSubmenuContainer()?.nativeElement;
+        if (!submenuEl) {
+            return;
+        }
+
+        // Wait for the browser to complete layout after CSS :hover makes the submenu visible
+        requestAnimationFrame(() => {
+            const rect = submenuEl.getBoundingClientRect();
+            const viewportHeight = window.innerHeight;
+            const margin = 16; // 1rem safety margin from viewport edge
+            const availableHeight = viewportHeight - rect.top - margin;
+
+            if (availableHeight > 0) {
+                this.overflowSubmenuMaxHeight.set(`${availableHeight}px`);
+            }
+        });
     }
 
     private _focusPopoverLink(): void {

--- a/libs/btp/navigation/components/navigation/navigation.component.scss
+++ b/libs/btp/navigation/components/navigation/navigation.component.scss
@@ -1,4 +1,5 @@
 @import 'fundamental-styles/dist/navigation.css';
+@import 'fundamental-styles/dist/menu.css';
 
 $block: fd-navigation;
 
@@ -118,6 +119,9 @@ $block: fd-navigation;
             }
 
             .#{$block}__list-container--submenu {
+                overflow-x: hidden;
+                overflow-y: auto;
+
                 &::before {
                     content: '';
                     position: absolute;

--- a/libs/docs/btp/navigation/examples/parent-item-link/navigation-parent-item-link.component.html
+++ b/libs/docs/btp/navigation/examples/parent-item-link/navigation-parent-item-link.component.html
@@ -121,6 +121,104 @@
         <fdb-navigation-list-item>
             <a fdb-navigation-link *fdbNavigationLinkRef glyph="task">Task Manager</a>
         </fdb-navigation-list-item>
+
+        <fdb-navigation-list-item group>
+            <a fdb-navigation-link *fdbNavigationLinkRef>Product Catalog</a>
+
+            <fdb-navigation-list-item>
+                <a fdb-navigation-link *fdbNavigationLinkRef glyph="product">Products</a>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Active Products</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Archived Products</a>
+                </fdb-navigation-list-item>
+            </fdb-navigation-list-item>
+
+            <fdb-navigation-list-item>
+                <a fdb-navigation-link *fdbNavigationLinkRef glyph="cart">Orders</a>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Open Orders</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Completed Orders</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Cancelled Orders</a>
+                </fdb-navigation-list-item>
+            </fdb-navigation-list-item>
+
+            <fdb-navigation-list-item>
+                <a fdb-navigation-link *fdbNavigationLinkRef glyph="inventory">Inventory</a>
+            </fdb-navigation-list-item>
+        </fdb-navigation-list-item>
+        <fdb-navigation-list-item separator />
+
+        <fdb-navigation-list-item group>
+            <a fdb-navigation-link *fdbNavigationLinkRef>Service Operations</a>
+
+            <fdb-navigation-list-item>
+                <a fdb-navigation-link *fdbNavigationLinkRef glyph="workflow-tasks">Service Tickets</a>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Open Tickets</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>In Progress</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Resolved Tickets</a>
+                </fdb-navigation-list-item>
+            </fdb-navigation-list-item>
+
+            <fdb-navigation-list-item>
+                <a fdb-navigation-link *fdbNavigationLinkRef glyph="calendar">Scheduling</a>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Team Schedule</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Availability</a>
+                </fdb-navigation-list-item>
+            </fdb-navigation-list-item>
+        </fdb-navigation-list-item>
+        <fdb-navigation-list-item separator />
+
+        <fdb-navigation-list-item group>
+            <a fdb-navigation-link *fdbNavigationLinkRef>Administration</a>
+
+            <fdb-navigation-list-item>
+                <a fdb-navigation-link *fdbNavigationLinkRef glyph="settings">Settings</a>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>General Settings</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Security Settings</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Email Configuration</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Integration Setup</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Workflow Automation</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>User Management</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Role Assignments</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Audit Log</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>Data Export</a>
+                </fdb-navigation-list-item>
+                <fdb-navigation-list-item>
+                    <a fdb-navigation-link *fdbNavigationLinkRef>System Health</a>
+                </fdb-navigation-list-item>
+            </fdb-navigation-list-item>
+        </fdb-navigation-list-item>
     </fdb-navigation-content-start>
     <fdb-navigation-content-end ariaLabel="Footer Navigation Menu" ariaRoleDescription="Navigation List Tree">
         <fdb-navigation-list-item quickCreate>


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13934

## Description

**Problem:** In snapped navigation, the overflow submenu (second-level popover) doesn't respect viewport boundaries — items at the bottom get clipped and are inaccessible.

**Root cause:** The parent overflow menu uses <fd-popover> (CDK overlay with viewport detection), but child submenus use plain CSS position: absolute with no boundary detection.

**Changes:**

- Dynamic max-height on overflow submenus: Added `onOverflowItemMouseEnter()` that calculates available viewport space and sets max-height via a signal + template binding, making the submenu scrollable when it would overflow.

- Added missing `menu.css` import: The `fd-menu__sublist` class was used in the template but its styles from `fundamental-styles/dist/menu.css` were never imported — it only worked when another component (e.g., user-menu) happened to load the stylesheet.

- Added test items to the parent-item-link example for easier overflow testing.

## Screenshots
<img width="627" height="856" alt="Screenshot 2026-03-06 at 12 35 45 PM" src="https://github.com/user-attachments/assets/e3f8fa32-b2b2-49e0-9cc5-a2f6e6a93826" />
<img width="568" height="633" alt="Screenshot 2026-03-06 at 12 35 36 PM" src="https://github.com/user-attachments/assets/f7698a44-6bfc-4b26-9e58-ac3a9e163dfe" />
