### PR TITLE
fix(platform): multi-input popover width default to 0 bug

### DIFF
--- a/libs/platform/form/multi-input/multi-input.component.html
+++ b/libs/platform/form/multi-input/multi-input.component.html
@@ -10,7 +10,6 @@
         [focusTrapped]="true"
         [triggers]="triggers"
         [disabled]="disabled || readonly"
-        [maxWidth]="(!autoResize && minWidth) || 0"
         [closeOnOutsideClick]="closeOnOutsideClick"
     >
         <fd-popover-control>


### PR DESCRIPTION
fixes #14002 

before:
<img width="843" height="325" alt="Screenshot 2026-03-19 at 5 56 03 PM" src="https://github.com/user-attachments/assets/312c98a7-7cfe-48fc-9fe4-74642eb62a35" />

after:
<img width="1119" height="403" alt="Screenshot 2026-03-19 at 5 58 09 PM" src="https://github.com/user-attachments/assets/10b83753-02c8-48e9-bf6a-8ec27c0291ba" />
