### PR TITLE
fix(core): combobox group header missing bottom border

### DIFF
--- a/libs/core/combobox/combobox.component.scss
+++ b/libs/core/combobox/combobox.component.scss
@@ -6,6 +6,10 @@
     }
 }
 
+.fd-combobox-custom-list.fd-list--dropdown .fd-list__item.fd-list__group-header {
+    border-bottom: var(--sapList_BorderWidth) solid var(--sapList_GroupHeaderBorderColor);
+}
+
 .fd-list__item.fd-combobox-list-item {
     cursor: pointer;
 }


### PR DESCRIPTION
before:
<img width="286" height="327" alt="Screenshot 2026-03-24 at 1 09 05 PM" src="https://github.com/user-attachments/assets/98c7730a-7117-4b8d-88d1-6f27c231c2e0" />

after:
<img width="254" height="281" alt="Screenshot 2026-03-24 at 1 08 45 PM" src="https://github.com/user-attachments/assets/3d4c1b54-4f15-4211-ab5e-7f43f23b5507" />
