### PR TITLE
fix(core): fix the problem with jumping Product Switch items

### DIFF
--- a/libs/core/product-switch/product-switch-body/product-switch-body.component.scss
+++ b/libs/core/product-switch/product-switch-body/product-switch-body.component.scss
@@ -77,6 +77,8 @@
 
 // TO DO: to be removed with the adoption of fundamental-styles v0.41.0+
 .fd-product-switch__item {
+    --fdProduct_Switch_Item_Border_Color: transparent;
+
     gap: 0.5rem;
 }
 


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description
The value for css variable `--fdProduct_Switch_Item_Border_Color` was not defined for default state which resulted in a "jump" of 2px when the value was defined for active state. 

Before:
<img width="1911" height="566" alt="Screenshot 2026-03-24 at 3 31 47 PM" src="https://github.com/user-attachments/assets/3b1a5ae4-9ce0-4d06-8d82-00e3236fdb26" />


After:
<img width="1886" height="514" alt="Screenshot 2026-03-24 at 3 31 15 PM" src="https://github.com/user-attachments/assets/aa3c7165-5b10-4907-8754-da68964f3c1d" />
