### PR TITLE
fix(core): remove NgZone usage from menu segmented-button-option directive for zoneless compatibility

### DIFF
--- a/libs/core/menu/directives/segmented-button/segmented-button-option.directive.spec.ts
+++ b/libs/core/menu/directives/segmented-button/segmented-button-option.directive.spec.ts
@@ -1,0 +1,151 @@
+import { Component, QueryList, ViewChildren } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { whenStable } from '@fundamental-ngx/core/tests';
+import { MenuInteractiveComponent } from '../../menu-interactive.component';
+import { MenuItemComponent } from '../../menu-item/menu-item.component';
+import { MenuComponent } from '../../menu.component';
+import { MenuAddonDirective } from '../menu-addon.directive';
+import { MenuTitleDirective } from '../menu-title.directive';
+import { SegmentedButtonHeaderDirective } from './segmented-button-header.directive';
+import { SegmentedButtonOptionDirective } from './segmented-button-option.directive';
+
+@Component({
+    template: `
+        <fd-menu>
+            <li fd-menu-item fdMenuSegmentedButtonHeader [(ngModel)]="sortValue">
+                <button fd-menu-interactive>
+                    <fd-menu-addon position="before" glyph="sort"></fd-menu-addon>
+                    <span fd-menu-title>Sort</span>
+                </button>
+            </li>
+            <li fd-menu-item fdMenuSegmentedButtonOption value="asc">
+                <button fd-menu-interactive>
+                    <fd-menu-addon position="before" glyph="sort"></fd-menu-addon>
+                    <span fd-menu-title>Ascending</span>
+                </button>
+            </li>
+            <li fd-menu-item fdMenuSegmentedButtonOption value="desc">
+                <button fd-menu-interactive>
+                    <fd-menu-addon position="before" glyph="sort"></fd-menu-addon>
+                    <span fd-menu-title>Descending</span>
+                </button>
+            </li>
+        </fd-menu>
+    `,
+    imports: [
+        MenuComponent,
+        MenuItemComponent,
+        MenuInteractiveComponent,
+        MenuAddonDirective,
+        MenuTitleDirective,
+        SegmentedButtonHeaderDirective,
+        SegmentedButtonOptionDirective,
+        FormsModule
+    ]
+})
+class SegmentedButtonOptionTestComponent {
+    @ViewChildren(SegmentedButtonOptionDirective) options: QueryList<SegmentedButtonOptionDirective<string>>;
+
+    sortValue: string | null = null;
+}
+
+describe('SegmentedButtonOptionDirective', () => {
+    let fixture: ComponentFixture<SegmentedButtonOptionTestComponent>;
+    let component: SegmentedButtonOptionTestComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [SegmentedButtonOptionTestComponent]
+        }).compileComponents();
+    }));
+
+    async function setup(): Promise<void> {
+        fixture = TestBed.createComponent(SegmentedButtonOptionTestComponent);
+        component = fixture.componentInstance;
+
+        await whenStable(fixture);
+        fixture.detectChanges();
+        await whenStable(fixture);
+
+        // Allow delay(0) in the directive to fire
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        fixture.detectChanges();
+        await whenStable(fixture);
+    }
+
+    function getOptionElements(): HTMLElement[] {
+        return component.options.toArray().map((opt) => opt.elementRef.nativeElement);
+    }
+
+    it('should create the directives', async () => {
+        await setup();
+        expect(component.options.length).toBe(2);
+    });
+
+    it('should emit clicked when option is clicked', async () => {
+        await setup();
+        const spy = jest.fn();
+        const optionDirective = component.options.first;
+        optionDirective.clicked.subscribe(spy);
+
+        getOptionElements()[0].click();
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('should create dot element after view init', async () => {
+        await setup();
+        const dot = getOptionElements()[0].querySelector('.fd-menu__active-dot');
+        expect(dot).toBeTruthy();
+    });
+
+    it('should hide dot when option is not selected', async () => {
+        await setup();
+        const dot = getOptionElements()[0].querySelector('.fd-menu__active-dot') as HTMLElement;
+        expect(dot.style.display).toBe('none');
+    });
+
+    it('should show dot when option is selected', async () => {
+        await setup();
+        component.sortValue = 'asc';
+        fixture.detectChanges();
+        await whenStable(fixture);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        fixture.detectChanges();
+        await whenStable(fixture);
+
+        const dot = getOptionElements()[0].querySelector('.fd-menu__active-dot') as HTMLElement;
+        expect(dot.style.display).toBe('inline-block');
+    });
+
+    it('should toggle dot visibility when selection changes', async () => {
+        await setup();
+
+        // Select first option
+        component.sortValue = 'asc';
+        fixture.detectChanges();
+        await whenStable(fixture);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        fixture.detectChanges();
+        await whenStable(fixture);
+
+        const elements = getOptionElements();
+        const ascDot = elements[0].querySelector('.fd-menu__active-dot') as HTMLElement;
+        const descDot = elements[1].querySelector('.fd-menu__active-dot') as HTMLElement;
+
+        expect(ascDot.style.display).toBe('inline-block');
+        expect(descDot.style.display).toBe('none');
+
+        // Switch to second option
+        component.sortValue = 'desc';
+        fixture.detectChanges();
+        await whenStable(fixture);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        fixture.detectChanges();
+        await whenStable(fixture);
+
+        expect(ascDot.style.display).toBe('none');
+        expect(descDot.style.display).toBe('inline-block');
+    });
+});

--- a/libs/core/menu/directives/segmented-button/segmented-button-option.directive.ts
+++ b/libs/core/menu/directives/segmented-button/segmented-button-option.directive.ts
@@ -1,24 +1,18 @@
 import { DomPortal } from '@angular/cdk/portal';
-import {
-    AfterViewInit,
-    DestroyRef,
-    Directive,
-    ElementRef,
-    HostListener,
-    inject,
-    Input,
-    NgZone,
-    Renderer2
-} from '@angular/core';
+import { AfterViewInit, DestroyRef, Directive, ElementRef, inject, Input, Renderer2 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { HasElementRef } from '@fundamental-ngx/cdk/utils';
-import { BehaviorSubject, combineLatest, delayWhen, Observable, Subject, tap } from 'rxjs';
+import { BehaviorSubject, combineLatest, delay, Observable, Subject, tap } from 'rxjs';
 import { MenuItemComponent } from '../../menu-item/menu-item.component';
 import { FD_MENU_ITEM_COMPONENT } from '../../menu.tokens';
 
 @Directive({
     selector: 'li[fd-menu-item][fdMenuSegmentedButtonOption]',
-    standalone: true
+    host: {
+        '(click)': '_onClick($event)',
+        '(keydown.enter)': '_onClick($event)',
+        '(keydown.space)': '_onClick($event)'
+    }
 })
 export class SegmentedButtonOptionDirective<T> implements AfterViewInit, HasElementRef {
     /** @hidden */
@@ -54,8 +48,7 @@ export class SegmentedButtonOptionDirective<T> implements AfterViewInit, HasElem
     /** @hidden */
     constructor() {
         this.clicked = this._clicked.asObservable();
-        const ngZone = inject(NgZone);
-        combineLatest([this._viewInit$.pipe(delayWhen(() => ngZone.onStable.asObservable())), this._selected$])
+        combineLatest([this._viewInit$.pipe(delay(0)), this._selected$])
             .pipe(
                 tap(() => {
                     if (!this._dotElement) {
@@ -71,9 +64,6 @@ export class SegmentedButtonOptionDirective<T> implements AfterViewInit, HasElem
     }
 
     /** @hidden */
-    @HostListener('click', ['$event'])
-    @HostListener('keydown.enter', ['$event'])
-    @HostListener('keydown.space', ['$event'])
     _onClick($event: Event): void {
         $event.preventDefault();
         this._clicked.next();


### PR DESCRIPTION
remove NgZone usage from menu segmented-button-option directive for zoneless compatibility

part of #14035 9

Menu -> Extended Menu Items
Before:
<img width="243" height="361" alt="Screenshot 2026-03-26 at 12 03 49" src="https://github.com/user-attachments/assets/0edaa957-844e-4bde-9ff5-a283fd6e2f2e" />

After 
<img width="242" height="343" alt="Screenshot 2026-03-26 at 12 03 44" src="https://github.com/user-attachments/assets/c1391756-1e0f-4a99-a785-de00cb025dd4" />
