### PR TITLE
fix(btp): remove NgZone usage from navigation-content-start for zoneless compatibility

### DIFF
--- a/libs/btp/navigation/components/navigation-start/navigation-content-start.component.spec.ts
+++ b/libs/btp/navigation/components/navigation-start/navigation-content-start.component.spec.ts
@@ -1,4 +1,4 @@
-import { signal } from '@angular/core';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { FdbNavigationListItem } from '../../models/navigation-list-item.class';
@@ -83,5 +83,52 @@ describe('NavigationContentStartComponent', () => {
     it('should filter list items based on navigation state', () => {
         const items = component.listItems$();
         expect(Array.isArray(items)).toBe(true);
+    });
+});
+
+describe('NavigationContentStartComponent (zoneless)', () => {
+    let component: NavigationContentStartComponent;
+    let fixture: ComponentFixture<NavigationContentStartComponent>;
+    let navigationMock: NavigationComponentMock;
+
+    beforeEach(async () => {
+        navigationMock = new NavigationComponentMock();
+        await TestBed.configureTestingModule({
+            imports: [NavigationContentStartComponent],
+            providers: [
+                provideZonelessChangeDetection(),
+                {
+                    provide: FdbNavigation,
+                    useValue: navigationMock
+                }
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(NavigationContentStartComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create without NgZone dependency', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should run overflow calculation when isSnapped changes in zoneless mode', async () => {
+        // This is the bug that this migration fixes: in zoneless mode, NgZone.onStable never emits,
+        // so _calculateVisibleItems never ran. The fix replaces onStable with animationFrames().
+        // We spy on the private method because without real DOM dimensions (jsdom has 0 for all
+        // layout properties), the method produces no observable state change from its default values.
+        const spy = jest.spyOn(component as any, '_calculateVisibleItems');
+
+        navigationMock.isSnapped$.set(true);
+
+        // toObservable uses effect() internally, which needs a CD pass in zoneless mode.
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        // animationFrames() resolves via requestAnimationFrame (shimmed as setTimeout in jsdom).
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+
+        expect(spy).toHaveBeenCalled();
     });
 });

--- a/libs/btp/navigation/components/navigation-start/navigation-content-start.component.ts
+++ b/libs/btp/navigation/components/navigation-start/navigation-content-start.component.ts
@@ -7,7 +7,6 @@ import {
     ContentChildren,
     ElementRef,
     Input,
-    NgZone,
     QueryList,
     ViewChild,
     ViewEncapsulation,
@@ -18,7 +17,17 @@ import {
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { Nullable, resizeObservable } from '@fundamental-ngx/cdk';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
-import { asyncScheduler, debounceTime, filter, merge, observeOn, startWith, switchMap, take } from 'rxjs';
+import {
+    animationFrames,
+    asyncScheduler,
+    debounceTime,
+    filter,
+    merge,
+    observeOn,
+    startWith,
+    switchMap,
+    take
+} from 'rxjs';
 import { FdbNavigationContentContainer } from '../../models/navigation-content-container.class';
 import { FdbNavigationListItem } from '../../models/navigation-list-item.class';
 import { FdbNavigation } from '../../models/navigation.class';
@@ -118,9 +127,6 @@ export class NavigationContentStartComponent extends FdbNavigationContentContain
     private readonly _cdr = inject(ChangeDetectorRef);
 
     /** @hidden */
-    private readonly _zone = inject(NgZone);
-
-    /** @hidden */
     ngAfterContentInit(): void {
         this._listItems.changes
             .pipe(
@@ -136,7 +142,10 @@ export class NavigationContentStartComponent extends FdbNavigationContentContain
         const resize = resizeObservable(this._elementRef.nativeElement).pipe(debounceTime(30));
 
         merge(this._isSnappedObservable, this._listItemsObservable, resize)
-            .pipe(switchMap(() => this._zone.onStable.pipe(startWith(this._zone.isStable), take(1))))
+            .pipe(
+                switchMap(() => animationFrames().pipe(take(1))),
+                takeUntilDestroyed(this._destroyRef)
+            )
             .subscribe(() => {
                 this._calculateVisibleItems();
             });


### PR DESCRIPTION
remove NgZone usage from navigation-content-start for zoneless compatibility

part of #14035 item 12