### PR TITLE
fix(core): remove NgZone usage from Segmented Button

### DIFF
--- a/libs/core/segmented-button/segmented-button.component.ts
+++ b/libs/core/segmented-button/segmented-button.component.ts
@@ -10,7 +10,6 @@ import {
     Host,
     HostListener,
     Input,
-    NgZone,
     OnChanges,
     OnDestroy,
     QueryList,
@@ -134,7 +133,6 @@ export class SegmentedButtonComponent implements AfterViewInit, ControlValueAcce
         private readonly _changeDetRef: ChangeDetectorRef,
         private readonly _elementRef: ElementRef,
         private readonly _destroyRef: DestroyRef,
-        private readonly _ngZone: NgZone,
         @Host() private _focusableList: FocusableListDirective
     ) {
         this._focusableList.navigationDirection.set(this.vertical ? 'vertical' : 'horizontal');
@@ -230,12 +228,10 @@ export class SegmentedButtonComponent implements AfterViewInit, ControlValueAcce
         this._onRefresh$.next();
 
         if (!isDisabled) {
-            this._ngZone.run(() => {
-                if (this._buttons) {
-                    this._listenToButtonChanges();
-                    this._pickButtonsByValues(this._currentValue);
-                }
-            });
+            if (this._buttons) {
+                this._listenToButtonChanges();
+                this._pickButtonsByValues(this._currentValue);
+            }
         }
         this._changeDetRef.detectChanges();
     }


### PR DESCRIPTION
## Related Issue(s)

part of https://github.com/SAP/fundamental-ngx/issues/14035

## Description
`setDisabledState` is called by Angular's reactive forms infrastructure (via ControlValueAccessor), which already executes inside the zone. The `_ngZone.run()` wrapper was redundant — the code was never running outside the zone to begin with. Additionally, `detectChanges()` is called immediately after, which explicitly triggers change detection regardless of zone context. In zoneless mode (Angular 21 default), `NgZone.run()` is a no-op anyway since there's no zone to re-enter.