### PR TITLE
fix(core): add fix for flickering Inline Help

### DIFF
--- a/libs/core/inline-help/inline-help.directive.spec.ts
+++ b/libs/core/inline-help/inline-help.directive.spec.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 
 import { InlineHelpModule } from './inline-help.module';
 
@@ -38,14 +38,15 @@ describe('InlineHelpDirective', () => {
         expect(component).toBeTruthy();
     });
 
-    it('should show the inline help on hover', () => {
+    it('should show the inline help on hover', fakeAsync(() => {
         const selector = '.fd-popover__body.fd-inline-help__content';
         expect(document.body.querySelector(selector)).toBeFalsy();
         component.ref.nativeElement.dispatchEvent(new Event('mouseenter'));
         expect(document.body.querySelector(selector)).toBeTruthy();
         component.ref.nativeElement.dispatchEvent(new Event('mouseleave'));
+        tick(50);
         expect(document.body.querySelector(selector)).toBeFalsy();
-    });
+    }));
 
     it('should hide the inline help if host element is destroyed', () => {
         const selector = '.fd-popover__body.fd-inline-help__content';
@@ -70,10 +71,11 @@ describe('InlineHelpDirective', () => {
         expect(component.ref.nativeElement.classList.contains('fd-inline-help__trigger')).toBe(true);
     });
 
-    it('should apply inline help content class to popover body', () => {
+    it('should apply inline help content class to popover body', fakeAsync(() => {
         component.ref.nativeElement.dispatchEvent(new Event('mouseenter'));
         const popoverBody = document.body.querySelector('.fd-popover__body');
         expect(popoverBody?.classList.contains('fd-inline-help__content')).toBe(true);
         component.ref.nativeElement.dispatchEvent(new Event('mouseleave'));
-    });
+        tick(50);
+    }));
 });

--- a/libs/core/popover/popover-service/popover.service.ts
+++ b/libs/core/popover/popover-service/popover.service.ts
@@ -172,6 +172,12 @@ export class PopoverService {
     /** @hidden */
     private _ignoreTriggers = false;
 
+    /** @hidden Timer for delayed hover close, allows mouse to travel from trigger to overlay body. */
+    private _hoverCloseTimer: ReturnType<typeof setTimeout> | null = null;
+
+    /** @hidden Listeners for mouseenter/mouseleave on the overlay element. */
+    private _overlayHoverListeners: (() => void)[] = [];
+
     /** @hidden */
     private _modalBodyClass = 'fd-overlay-active';
 
@@ -263,6 +269,8 @@ export class PopoverService {
         });
 
         this._destroyRef.onDestroy(() => {
+            this._clearHoverCloseTimer();
+            this._removeOverlayHoverListeners();
             this._removeTriggerListeners();
             if (this._overlayRef) {
                 this._overlayRef.detach();
@@ -314,6 +322,9 @@ export class PopoverService {
 
     /** Closes the popover. */
     close(focusActiveElement = true): void {
+        this._clearHoverCloseTimer();
+        this._removeOverlayHoverListeners();
+
         if (this._overlayRef) {
             this._overlayRef.dispose();
         }
@@ -354,6 +365,7 @@ export class PopoverService {
 
             this._safeSetIsOpen(true);
 
+            this._setupOverlayHoverListeners();
             this._listenOnClose();
             this._focusFirstTabbableElement();
             this._onLoad.next(this._getPopoverBody()._elementRef);
@@ -542,15 +554,30 @@ export class PopoverService {
         this._removeTriggerListeners();
 
         if (this.triggers()?.length) {
+            const hasHoverTrigger = this._hasHoverTriggers();
+
             this._normalizeTriggers().forEach((trigger) => {
                 this._eventRef.push(
                     this._renderer.listen(this._triggerHtmlElement, trigger.trigger, (event: Event) => {
                         if (this._ignoreTriggers || this.disabled()) {
                             return;
                         }
+
                         const closeAction = !!trigger.closeAction;
                         const openAction = !!trigger.openAction;
-                        this.toggle(openAction, closeAction);
+
+                        // For hover triggers, use delayed close to prevent flickering
+                        // when the mouse travels between the trigger and the popover body.
+                        if (hasHoverTrigger && trigger.trigger === 'mouseenter' && openAction) {
+                            this._clearHoverCloseTimer();
+                            if (!this.isOpen()) {
+                                this.toggle(openAction, closeAction);
+                            }
+                        } else if (hasHoverTrigger && trigger.trigger === 'mouseleave' && closeAction) {
+                            this._scheduleHoverClose();
+                        } else {
+                            this.toggle(openAction, closeAction);
+                        }
 
                         if (trigger.stopPropagation) {
                             event.stopImmediatePropagation();
@@ -593,6 +620,60 @@ export class PopoverService {
                 throw e;
             }
         }
+    }
+
+    /** @hidden Whether the current triggers include mouseenter or mouseleave. */
+    private _hasHoverTriggers(): boolean {
+        return this.triggers().some((t) => {
+            const name = typeof t === 'string' ? t : t.trigger;
+            return name === 'mouseenter' || name === 'mouseleave';
+        });
+    }
+
+    /** @hidden Clears any pending delayed hover close. */
+    private _clearHoverCloseTimer(): void {
+        if (this._hoverCloseTimer !== null) {
+            clearTimeout(this._hoverCloseTimer);
+            this._hoverCloseTimer = null;
+        }
+    }
+
+    /** @hidden Schedules a delayed close to allow mouse to travel from trigger to overlay body. */
+    private _scheduleHoverClose(): void {
+        this._clearHoverCloseTimer();
+        this._hoverCloseTimer = setTimeout(() => {
+            this._hoverCloseTimer = null;
+            this.close();
+        }, 50);
+    }
+
+    /** @hidden Adds mouseenter/mouseleave listeners on the overlay element when hover triggers are active. */
+    private _setupOverlayHoverListeners(): void {
+        this._removeOverlayHoverListeners();
+
+        if (!this._hasHoverTriggers() || !this._overlayRef) {
+            return;
+        }
+
+        const overlayElement = this._overlayRef.overlayElement;
+
+        this._overlayHoverListeners.push(
+            this._renderer.listen(overlayElement, 'mouseenter', () => {
+                this._clearHoverCloseTimer();
+            })
+        );
+
+        this._overlayHoverListeners.push(
+            this._renderer.listen(overlayElement, 'mouseleave', () => {
+                this._scheduleHoverClose();
+            })
+        );
+    }
+
+    /** @hidden Removes overlay hover listeners. */
+    private _removeOverlayHoverListeners(): void {
+        this._overlayHoverListeners.forEach((fn) => fn());
+        this._overlayHoverListeners = [];
     }
 
     /** @hidden */


### PR DESCRIPTION
## Description
**Problem**
When hovering near the edge of an inline-help trigger, the popover rapidly opens and closes (flickering). This happens because mouseleave fires on the trigger as the cursor moves into the popover body, causing an immediate close() → overlay disposed → cursor back over trigger → mouseenter → open() → loop. During this rapid cycle, the popover body also renders without its CSS classes (missing padding, arrow styles) because the CDK position change event never fires before the overlay is disposed.

https://github.com/user-attachments/assets/99e1070d-9aa4-4ffb-9d0d-86a5f1a94fe5




**Fix**

Introduced a 50ms delayed close for hover triggers (mouseenter/mouseleave), giving the cursor time to travel from the trigger into the popover body.
Added mouseenter/mouseleave listeners on the CDK overlay element itself — entering the overlay cancels the pending close, leaving it schedules a close.
All other trigger types (click, focusin/focusout, etc.) remain unaffected and continue to toggle immediately.