### PR TITLE
fix(core): convert carousel item _visibility to signal for zoneless compatibility

### DIFF
--- a/libs/core/carousel/carousel-item/carousel-item.component.ts
+++ b/libs/core/carousel/carousel-item/carousel-item.component.ts
@@ -32,6 +32,7 @@ let carouselItemCounter = 0;
     host: {
         role: 'option',
         class: 'fd-carousel__item fd-carousel__item--active',
+        '[style.visibility]': '_visibility()',
         '[attr.aria-setsize]': 'ariaSetsize()',
         '[attr.aria-posinset]': 'ariaPosinset()',
         '[attr.aria-selected]': 'ariaSelected()',
@@ -86,8 +87,7 @@ export class CarouselItemComponent<T = any> implements CarouselItemInterface {
     value: T;
 
     /** @hidden Hide/show slide, useful for managing tab order */
-    @HostBinding('style.visibility')
-    _visibility: Visibility = 'visible';
+    _visibility = signal<Visibility>('visible');
 
     /** @hidden value for aria-setsize attribute */
     ariaSetsize = signal<number>(0);
@@ -103,11 +103,11 @@ export class CarouselItemComponent<T = any> implements CarouselItemInterface {
 
     /** @hidden */
     set visibility(visibility: Visibility) {
-        this._visibility = visibility;
+        this._visibility.set(visibility);
     }
 
     get visibility(): Visibility {
-        return this._visibility;
+        return this._visibility();
     }
 
     /** @hidden */


### PR DESCRIPTION
## Summary
- Convert `CarouselItemComponent._visibility` from `@HostBinding('style.visibility')` plain property to a `signal<Visibility>` with `host: { '[style.visibility]': '_visibility()' }`
- Update the `visibility` getter/setter to use `.set()` and signal read
- Parent carousel's `markForCheck()` doesn't dirty the child component's `@HostBinding` in zoneless mode — signals are auto-tracked

Closes #14037 (carousel item)

## Test plan
- [x] All 21 existing carousel tests pass (`nx run core:test --testFile=carousel.component.spec.ts`)
- [x] Tests cover: initial visibility, DOM style.visibility assertion, visibility after navigation, aria attributes, multi-slide visibility range