### PR TITLE
fix(core,platform,btp,cx): migrate remaining Default strategy components to OnPush

### DIFF
--- a/libs/btp/navigation-menu/src/lib/navigation-menu-item.component.ts
+++ b/libs/btp/navigation-menu/src/lib/navigation-menu-item.component.ts
@@ -1,4 +1,12 @@
-import { Component, ElementRef, HostBinding, inject, Input } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    HostBinding,
+    inject,
+    Input
+} from '@angular/core';
 import {
     FDK_FOCUSABLE_ITEM_DIRECTIVE,
     FocusableItem,
@@ -38,7 +46,8 @@ import { fromEvent, Observable } from 'rxjs';
     ],
     host: {
         class: 'fd-navigation-menu__item'
-    }
+    },
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NavigationMenuItemComponent implements FocusableItem, HasElementRef {
     /**
@@ -71,6 +80,9 @@ export class NavigationMenuItemComponent implements FocusableItem, HasElementRef
     keydown: Observable<KeyboardEvent> = fromEvent<KeyboardEvent>(this.elementRef.nativeElement, 'keydown');
 
     /** @hidden */
+    private readonly _cdr = inject(ChangeDetectorRef);
+
+    /** @hidden */
     element = (): HTMLElement => this.elementRef.nativeElement;
 
     /** @hidden */
@@ -79,6 +91,7 @@ export class NavigationMenuItemComponent implements FocusableItem, HasElementRef
     /** @hidden */
     setTabbable(tabbable: boolean): void {
         this.tabindex = tabbable ? 0 : -1;
+        this._cdr.markForCheck();
     }
 
     /** @hidden */

--- a/libs/btp/navigation-menu/src/lib/navigation-menu-popover.component.ts
+++ b/libs/btp/navigation-menu/src/lib/navigation-menu-popover.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, ContentChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, ViewEncapsulation } from '@angular/core';
 import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
 import { NavigationMenuPopoverControlDirective } from './navigation-menu-popover-control.directive';
 
@@ -17,7 +17,8 @@ import { NavigationMenuPopoverControlDirective } from './navigation-menu-popover
     `,
     styleUrls: ['./navigation-menu-popover.component.scss'],
     imports: [PopoverComponent, PopoverControlComponent, PopoverBodyComponent, NgTemplateOutlet],
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NavigationMenuPopoverComponent {
     /** @hidden */

--- a/libs/btp/search-field/src/search-field.component.ts
+++ b/libs/btp/search-field/src/search-field.component.ts
@@ -1,5 +1,7 @@
 import {
     AfterViewInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     DestroyRef,
     ElementRef,
@@ -28,7 +30,8 @@ import { of, tap } from 'rxjs';
     hostDirectives: [CvaDirective],
     providers: [CvaControl],
     imports: [IconComponent, FormsModule, FdTranslatePipe, ButtonComponent, NestedButtonDirective],
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SearchFieldComponent implements AfterViewInit, HasElementRef {
     /** Placeholder for the input field. */
@@ -60,6 +63,9 @@ export class SearchFieldComponent implements AfterViewInit, HasElementRef {
     private _destroyRef = inject(DestroyRef);
 
     /** @hidden */
+    private _cdr = inject(ChangeDetectorRef);
+
+    /** @hidden */
     focus(): void {
         this._searchInputField?.nativeElement.focus();
     }
@@ -68,7 +74,10 @@ export class SearchFieldComponent implements AfterViewInit, HasElementRef {
         this._cvaControl.listenToChanges();
         (this._cvaControl.cvaDirective?.ngControl?.valueChanges || of(undefined))
             .pipe(
-                tap((value: string) => (this._value = value)),
+                tap((value: string) => {
+                    this._value = value;
+                    this._cdr.markForCheck();
+                }),
                 takeUntilDestroyed(this._destroyRef)
             )
             .subscribe();

--- a/libs/btp/tool-header/src/components/tool-header-action-separator.component.ts
+++ b/libs/btp/tool-header/src/components/tool-header-action-separator.component.ts
@@ -1,4 +1,4 @@
-import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, TemplateRef, ViewChild } from '@angular/core';
 import { ToolHeaderActionClass } from '../tool-header-action.class';
 
 @Component({
@@ -14,7 +14,7 @@ import { ToolHeaderActionClass } from '../tool-header-action.class';
             useExisting: ToolHeaderActionSeparatorComponent
         }
     ],
-    standalone: true
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ToolHeaderActionSeparatorComponent extends ToolHeaderActionClass {
     /** @hidden */

--- a/libs/btp/tool-header/src/components/tool-header-product-switch.component.ts
+++ b/libs/btp/tool-header/src/components/tool-header-product-switch.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, model, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, model, output } from '@angular/core';
 import { ToolHeaderButtonDirective } from '@fundamental-ngx/btp/button';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { TriggerConfig } from '@fundamental-ngx/core/popover';
@@ -51,7 +51,8 @@ import { FdTranslatePipe } from '@fundamental-ngx/i18n';
     ],
     host: {
         '[class.fd-popover-custom--disabled]': 'disabled()'
-    }
+    },
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ToolHeaderProductSwitchComponent {
     /** Placement of a popover. */

--- a/libs/cdk/utils/components/dynamic-portal/dynamic-portal.component.ts
+++ b/libs/cdk/utils/components/dynamic-portal/dynamic-portal.component.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/cdk/portal';
 import {
     AfterViewInit,
+    ChangeDetectionStrategy,
     Component,
     ComponentRef,
     DestroyRef,
@@ -34,6 +35,7 @@ import { BehaviorSubject, filter, map, tap } from 'rxjs';
 @Component({
     selector: 'fdk-dynamic-portal',
     imports: [PortalModule],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     template: ` <ng-template cdkPortalOutlet></ng-template>`
 })
 export class DynamicPortalComponent implements AfterViewInit {

--- a/libs/core/bar/button-bar/button-bar.component.ts
+++ b/libs/core/bar/button-bar/button-bar.component.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, input, viewChild } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, input, viewChild } from '@angular/core';
 import { BaseButton, ButtonComponent, ButtonType } from '@fundamental-ngx/core/button';
 import { FD_BUTTON_BAR_COMPONENT } from '../tokens';
 
@@ -31,6 +31,7 @@ let randomButtonBarId = 0;
         }
     ],
     imports: [ButtonComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         class: 'fd-bar__element',
         '[class.fd-bar__element--full-width]': 'fullWidth()',

--- a/libs/core/card/header-elements/card-indicator.component.ts
+++ b/libs/core/card/header-elements/card-indicator.component.ts
@@ -1,10 +1,10 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
     selector: 'fd-card-indicator',
     template: `<ng-content select="[fd-card-indicator-title]"></ng-content>
         <ng-content select="[fd-card-indicator-value]"></ng-content>`,
-    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         class: 'fd-card__indicator'
     }

--- a/libs/core/card/header-elements/card-numeric-container.component.ts
+++ b/libs/core/card/header-elements/card-numeric-container.component.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
     selector: 'fd-card-numeric-container',
     templateUrl: './card-numeric-container.component.html',
-    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         class: 'fd-card__numeric-container'
     }

--- a/libs/core/dialog/dialog-container/dialog-container.component.ts
+++ b/libs/core/dialog/dialog-container/dialog-container.component.ts
@@ -1,5 +1,6 @@
 import {
     AfterViewInit,
+    ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
     ComponentRef,
@@ -34,6 +35,7 @@ import { DialogRef } from '../utils/dialog-ref.class';
     template: '<ng-template (attached)="_attached($event)" cdkPortalOutlet></ng-template>',
     styleUrls: ['./dialog-container.component.scss'],
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [PortalModule],
     host: {
         style: 'opacity: 0; position: relative; z-index: 999'

--- a/libs/core/feed-list-item/components/feed-list-action/feed-list-action.component.ts
+++ b/libs/core/feed-list-item/components/feed-list-action/feed-list-action.component.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
     selector: 'fd-feed-list-action',
     template: '<ng-content></ng-content>',
     host: { class: 'fd-feed-list__actions' },
-    standalone: true
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FeedListActionComponent {}

--- a/libs/core/feed-list-item/components/feed-list-avatar/feed-list-avatar.component.ts
+++ b/libs/core/feed-list-item/components/feed-list-avatar/feed-list-avatar.component.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
     selector: 'fd-feed-list-avatar',
     template: '<ng-content></ng-content>',
     host: { class: 'fd-feed-list__thumb' },
-    standalone: true
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FeedListAvatarComponent {}

--- a/libs/core/feed-list-item/components/feed-list-footer/feed-list-footer.component.ts
+++ b/libs/core/feed-list-item/components/feed-list-footer/feed-list-footer.component.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
     selector: 'fd-feed-list-footer',
     template: '<ng-content></ng-content>',
     host: { class: 'fd-feed-list__footer' },
-    standalone: true
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FeedListFooterComponent {}

--- a/libs/core/list/list-navigation-item/list-navigation-item.component.ts
+++ b/libs/core/list/list-navigation-item/list-navigation-item.component.ts
@@ -4,6 +4,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
     AfterContentInit,
     AfterViewInit,
+    ChangeDetectionStrategy,
     Component,
     ContentChild,
     ContentChildren,
@@ -32,6 +33,7 @@ import { FD_LIST_COMPONENT } from '../tokens';
     selector: '[fd-list-navigation-item], [fdListNavigaitonItem]',
     templateUrl: './list-navigation-item.component.html',
     styleUrl: './list-navigation-item.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         role: 'treeitem'
     },

--- a/libs/core/menu/menu-interactive.component.ts
+++ b/libs/core/menu/menu-interactive.component.ts
@@ -1,5 +1,15 @@
 import { CdkPortalOutlet, ComponentPortal, PortalModule } from '@angular/cdk/portal';
-import { Component, ContentChild, ElementRef, HostBinding, HostListener, ViewChild, inject } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    ContentChild,
+    ElementRef,
+    HostBinding,
+    HostListener,
+    ViewChild,
+    inject
+} from '@angular/core';
 import { HasElementRef, Nullable } from '@fundamental-ngx/cdk/utils';
 import { MenuAddonDirective } from './directives/menu-addon.directive';
 import { MenuItemInputDirective } from './directives/menu-item-input.directive';
@@ -14,6 +24,7 @@ import { MenuItemInputDirective } from './directives/menu-item-input.directive';
     host: {
         role: 'menuitem'
     },
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [PortalModule]
 })
 export class MenuInteractiveComponent implements HasElementRef {
@@ -71,6 +82,9 @@ export class MenuInteractiveComponent implements HasElementRef {
     readonly elementRef: ElementRef = inject(ElementRef);
 
     /** @hidden */
+    private readonly _cdr = inject(ChangeDetectorRef);
+
+    /** @hidden */
     private _startAddonInstance: MenuAddonDirective;
 
     /** @hidden */
@@ -100,18 +114,21 @@ export class MenuInteractiveComponent implements HasElementRef {
         if (this.ariaHaspopup || this._fromSplitButton) {
             this.ariaExpanded = isSelected;
         }
+        this._cdr.markForCheck();
     }
 
     /** @hidden */
     setDisabled(isDisabled: boolean): void {
         this.disabled = isDisabled;
         this.tabindex = isDisabled ? -1 : 0;
+        this._cdr.markForCheck();
     }
 
     /** @hidden */
     setSubmenu(hasSubmenu: boolean, itemId?: string): void {
         this.ariaHaspopup = hasSubmenu;
         this.ariaControls = hasSubmenu ? itemId || this.ariaControls : null;
+        this._cdr.markForCheck();
     }
 }
 

--- a/libs/core/message-box/message-box-body/message-box-body.component.ts
+++ b/libs/core/message-box/message-box-body/message-box-body.component.ts
@@ -1,4 +1,4 @@
-import { Component, Optional } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Optional } from '@angular/core';
 import { MessageBoxConfig, MessageBoxHost } from '../utils/message-box-config.class';
 
 /**
@@ -13,11 +13,11 @@ import { MessageBoxConfig, MessageBoxHost } from '../utils/message-box-config.cl
     template: `<section>
         <ng-content></ng-content>
     </section>`,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         '[class.fd-message-box__body]': 'true',
         '[class.fd-message-box__body--no-vertical-padding]': '!messageBoxConfig.verticalPadding'
-    },
-    standalone: true
+    }
 })
 export class MessageBoxBodyComponent {
     /** @hidden */

--- a/libs/core/message-box/message-box-container/message-box-container.component.ts
+++ b/libs/core/message-box/message-box-container/message-box-container.component.ts
@@ -1,6 +1,7 @@
 import { CdkPortalOutlet, CdkPortalOutletAttachedRef, PortalModule } from '@angular/cdk/portal';
 import {
     AfterViewInit,
+    ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
     ComponentRef,
@@ -28,6 +29,7 @@ import { MessageBoxRef } from '../utils/message-box-ref.class';
 @Component({
     selector: 'fd-message-box-container',
     template: '<ng-template (attached)="_attached($event)" cdkPortalOutlet></ng-template>',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [PortalModule],
     host: {
         style: 'opacity: 0; position: relative; z-index: 999'

--- a/libs/core/message-box/message-box-footer/message-box-footer.component.spec.ts
+++ b/libs/core/message-box/message-box-footer/message-box-footer.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Type, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, Type, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { TemplateDirective } from '@fundamental-ngx/cdk/utils';
@@ -17,7 +17,6 @@ import { MessageBoxButtonClass, MessageBoxFooterComponent } from './message-box-
             </ng-template>
         </fd-message-box-footer>
     `,
-    standalone: true,
     imports: [MessageBoxFooterComponent, BarMiddleDirective, TemplateDirective]
 })
 class CustomFooterTestComponent {
@@ -30,7 +29,6 @@ class CustomFooterTestComponent {
             <fd-button-bar label="Default button">Default button</fd-button-bar>
         </fd-message-box-footer>
     `,
-    standalone: true,
     imports: [MessageBoxFooterComponent, ButtonBarComponent]
 })
 class DefaultFooterTestComponent {
@@ -68,6 +66,8 @@ describe('MessageBoxFooterComponent', () => {
 
         component.messageBoxFooter.messageBoxConfig.mobile = true;
 
+        const cdr = fixture.debugElement.children[0].injector.get(ChangeDetectorRef);
+        cdr.markForCheck();
         await whenStable(fixture);
         const footerEl = fixture.nativeElement.querySelector('footer');
 

--- a/libs/core/message-box/message-box-footer/message-box-footer.component.ts
+++ b/libs/core/message-box/message-box-footer/message-box-footer.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, Component, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { BarComponent, BarRightDirective } from '@fundamental-ngx/core/bar';
 import { ContentDensityDirective } from '@fundamental-ngx/core/content-density';
 import { DialogFooterBase } from '@fundamental-ngx/core/dialog';
@@ -22,6 +22,7 @@ export const MessageBoxButtonClass = 'fd-message-box__decisive-button';
 @Component({
     selector: 'fd-message-box-footer',
     templateUrl: './message-box-footer.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [BarComponent, ContentDensityDirective, NgTemplateOutlet, BarRightDirective]
 })
 export class MessageBoxFooterComponent extends DialogFooterBase implements AfterViewInit {

--- a/libs/core/message-box/message-box-header/message-box-header.component.ts
+++ b/libs/core/message-box/message-box-header/message-box-header.component.ts
@@ -1,6 +1,7 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
     AfterViewInit,
+    ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
     ContentChild,
@@ -33,6 +34,7 @@ import { MessageBoxConfig, MessageBoxHost } from '../utils/message-box-config.cl
 @Component({
     selector: 'fd-message-box-header',
     templateUrl: './message-box-header.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [
         BarComponent,
         ContentDensityDirective,

--- a/libs/core/message-box/message-box.component.ts
+++ b/libs/core/message-box/message-box.component.ts
@@ -1,5 +1,6 @@
 import {
     AfterViewInit,
+    ChangeDetectionStrategy,
     Component,
     ElementRef,
     Input,
@@ -37,8 +38,8 @@ import { MessageBoxRef } from './utils/message-box-ref.class';
         tabindex: '-1'
     },
     encapsulation: ViewEncapsulation.None,
-    providers: [{ provide: MessageBoxHost, useExisting: MessageBoxComponent }],
-    standalone: true
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [{ provide: MessageBoxHost, useExisting: MessageBoxComponent }]
 })
 export class MessageBoxComponent
     extends DialogBase

--- a/libs/core/message-strip/alert/message-strip-alert-container-footer/message-strip-alert-container-footer.component.ts
+++ b/libs/core/message-strip/alert/message-strip-alert-container-footer/message-strip-alert-container-footer.component.ts
@@ -1,5 +1,5 @@
 import { ComponentPortal, PortalModule } from '@angular/cdk/portal';
-import { Component, DestroyRef, effect, inject, Injector, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, Injector, input, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { Observable } from 'rxjs';
@@ -24,6 +24,7 @@ import { MessageStripAlertContainerAlertRefs, MessageStripAlertContainerPosition
             }
         `
     ],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [PortalModule]
 })
 export class MessageStripAlertContainerFooterComponent {

--- a/libs/core/message-strip/alert/message-strip-alert-container/message-strip-alert-container.component.ts
+++ b/libs/core/message-strip/alert/message-strip-alert-container/message-strip-alert-container.component.ts
@@ -1,5 +1,13 @@
 import { CdkPortalOutlet, ComponentPortal, PortalModule } from '@angular/cdk/portal';
-import { Component, ComponentRef, computed, signal, viewChildren, ViewEncapsulation } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    ComponentRef,
+    computed,
+    signal,
+    viewChildren,
+    ViewEncapsulation
+} from '@angular/core';
 import { ScrollbarDirective } from '@fundamental-ngx/core/scrollbar';
 import { MessageStripAlertContainerFooterComponent } from '../message-strip-alert-container-footer/message-strip-alert-container-footer.component';
 import { MessageStripAlertComponent } from '../message-strip-alert/message-strip-alert.component';
@@ -22,6 +30,7 @@ import { MessageStripAlert } from '../message-strip-alert/message-strip-alert.in
     `,
     styleUrl: './message-strip-alert-container.component.scss',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [PortalModule, ScrollbarDirective, MessageStripAlertContainerFooterComponent]
 })
 export class MessageStripAlertContainerComponent {

--- a/libs/core/message-strip/alert/message-strip-alert/message-strip-alert.component.ts
+++ b/libs/core/message-strip/alert/message-strip-alert/message-strip-alert.component.ts
@@ -1,6 +1,7 @@
 import { ComponentPortal, DomPortal, Portal, PortalModule, TemplatePortal } from '@angular/cdk/portal';
 import {
     afterNextRender,
+    ChangeDetectionStrategy,
     Component,
     DestroyRef,
     inject,
@@ -33,6 +34,7 @@ export type MessageStripAlertPortalType<ComponentType> =
  */
 @Component({
     templateUrl: `./message-strip-alert.component.html`,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [MessageStripComponent, PortalModule, AutoDismissMessageStripDirective]
 })
 export class MessageStripAlertComponent<ComponentType = unknown> implements MessageStripAlert {

--- a/libs/core/multi-combobox/mobile/mobile-multi-combobox.component.ts
+++ b/libs/core/multi-combobox/mobile/mobile-multi-combobox.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, Inject, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SelectableOptionItem } from '@fundamental-ngx/cdk/forms';
 import { Nullable, TemplateDirective } from '@fundamental-ngx/cdk/utils';
@@ -22,6 +22,7 @@ import { MULTI_COMBOBOX_COMPONENT } from '../multi-combobox.token';
     selector: 'fd-mobile-multi-combobox',
     templateUrl: './mobile-multi-combobox.component.html',
     styleUrl: './mobile-multi-combobox.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [
         BarMiddleDirective,
         BarElementDirective,

--- a/libs/core/notification/notification-group-growing-item/notification-group-growing-item.component.ts
+++ b/libs/core/notification/notification-group-growing-item/notification-group-growing-item.component.ts
@@ -1,8 +1,8 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
     selector: 'fd-notification-group-growing-item',
-    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     template: `<ng-content select="[fd-notification-group-growing-item-title]"></ng-content> <ng-content></ng-content>`,
     host: {
         class: 'fd-notification-group__growing-item',

--- a/libs/core/notification/notification-group/notification-group.component.ts
+++ b/libs/core/notification/notification-group/notification-group.component.ts
@@ -1,4 +1,14 @@
-import { AfterViewInit, Component, computed, contentChild, effect, inject, input, signal } from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    Component,
+    computed,
+    contentChild,
+    effect,
+    inject,
+    input,
+    signal
+} from '@angular/core';
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { FD_LANGUAGE_SIGNAL, TranslationResolver } from '@fundamental-ngx/i18n';
 import { NotificationGroupHeaderTitleDirective } from '../directives/notification-group-header-title.directive';
@@ -8,7 +18,7 @@ import { FD_NOTIFICATION_GROUP_HEADER, FD_NOTIFICATION_GROUP_HEADER_TITLE, FD_NO
 
 @Component({
     selector: 'fd-notification-group',
-    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     template: `<div class="fd-notification-group__wrapper">
         <ng-content select="fd-notification-group-header"></ng-content>
         @if (isExpanded()) {

--- a/libs/core/notification/notification-link/notification-link.component.ts
+++ b/libs/core/notification/notification-link/notification-link.component.ts
@@ -1,8 +1,8 @@
-import { Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 
 @Component({
     selector: 'fd-notification-link',
-    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     template: `<span class="fd-link__content">{{ showMore() ? 'Less' : 'More' }}</span>`,
     host: {
         class: 'fd-link fd-notification__link',

--- a/libs/core/side-navigation/side-navigation.component.ts
+++ b/libs/core/side-navigation/side-navigation.component.ts
@@ -1,16 +1,21 @@
 import {
     AfterContentInit,
     AfterViewInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     ContentChild,
+    DestroyRef,
     HostBinding,
     HostListener,
+    inject,
     Input,
     OnInit,
     QueryList,
     ViewChildren,
     ViewEncapsulation
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Nullable, warnOnce } from '@fundamental-ngx/cdk/utils';
 import { MenuKeyboardService } from '@fundamental-ngx/core/menu';
 import {
@@ -34,6 +39,7 @@ import { SideNavigationInterface } from './side-navigation.interface';
     selector: 'fd-side-nav',
     styleUrl: './side-navigation.component.scss',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [MenuKeyboardService, NestedListKeyboardService, NestedListStateService],
     imports: [SideNavigationMainDirective, PreparedNestedListComponent, SideNavigationUtilityDirective]
 })
@@ -77,11 +83,17 @@ export class SideNavigationComponent implements AfterContentInit, AfterViewInit,
     additionalShellbarCssClass = 'fd-shellbar--side-nav';
 
     /** @hidden */
+    private readonly _cdr = inject(ChangeDetectorRef);
+
+    /** @hidden */
+    private readonly _destroyRef = inject(DestroyRef);
+
+    /** @hidden */
     constructor(
         private keyboardService: NestedListKeyboardService,
         private nestedListState: NestedListStateService
     ) {
-        this.keyboardService.refresh$.subscribe(() => {
+        this.keyboardService.refresh$.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
             /** Refresh list of elements, that are being supported by keyboard */
             this.keyboardService.refreshItems(this.getLists());
         });
@@ -98,6 +110,7 @@ export class SideNavigationComponent implements AfterContentInit, AfterViewInit,
         if (this.collapseWidth) {
             this.condensed = window.innerWidth <= this.collapseWidth;
         }
+        this._cdr.markForCheck();
     }
 
     /** @hidden */

--- a/libs/core/tree/tree.component.ts
+++ b/libs/core/tree/tree.component.ts
@@ -3,6 +3,7 @@ import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, UP_ARROW } from '@angular/cdk/keyc
 import { NgTemplateOutlet } from '@angular/common';
 import {
     AfterViewInit,
+    ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
     ContentChild,
@@ -55,6 +56,7 @@ import { TreeService } from './tree.service';
     selector: 'fd-tree',
     templateUrl: './tree.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     styleUrl: './tree.component.scss',
     hostDirectives: [
         {
@@ -289,7 +291,7 @@ export class TreeComponent<P extends FdTreeAcceptableDataSource, T extends TreeI
         this.buildComponentCssClass();
 
         this._treeService.detectChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
-            this._cdr.detectChanges();
+            this._cdr.markForCheck();
         });
 
         if (this.selection !== 'none') {
@@ -340,6 +342,7 @@ export class TreeComponent<P extends FdTreeAcceptableDataSource, T extends TreeI
         }
 
         this._focusKeyManager.setActiveItem(focusedIndex);
+        this._cdr.markForCheck();
     }
 
     /** @hidden */
@@ -402,7 +405,7 @@ export class TreeComponent<P extends FdTreeAcceptableDataSource, T extends TreeI
         }
 
         treeItem.expanded = true;
-        this._cdr.detectChanges();
+        this._cdr.markForCheck();
     }
 
     /** @hidden */
@@ -416,7 +419,7 @@ export class TreeComponent<P extends FdTreeAcceptableDataSource, T extends TreeI
             }
         }
         treeItem.expanded = false;
-        this._cdr.detectChanges();
+        this._cdr.markForCheck();
     }
 
     /** @hidden */

--- a/libs/core/upload-collection/upload-collection-form-item/upload-collection-form-item.component.ts
+++ b/libs/core/upload-collection/upload-collection-form-item/upload-collection-form-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, FormsModule } from '@angular/forms';
 import { FormControlComponent } from '@fundamental-ngx/core/form';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
@@ -8,6 +8,7 @@ import { FdTranslatePipe } from '@fundamental-ngx/i18n';
     host: { class: 'fd-upload-collection__form-item' },
     templateUrl: './upload-collection-form-item.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [FormControlComponent, FormsModule, FdTranslatePipe]
 })
 export class UploadCollectionFormItemComponent implements ControlValueAccessor {

--- a/libs/cx/nested-list/nested-item/nested-item.component.ts
+++ b/libs/cx/nested-list/nested-item/nested-item.component.ts
@@ -1,5 +1,7 @@
 import {
     AfterContentInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     ContentChild,
     DestroyRef,
@@ -32,7 +34,7 @@ let sideNavigationItemUniqueId = 0;
     selector: '[cxNestedItem], [fdx-nested-list-item], li[fdx-nested-list-item]',
     template: ` <ng-content></ng-content> `,
     providers: [NestedItemService],
-    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         role: 'treeitem'
     }
@@ -149,6 +151,9 @@ export class NestedItemComponent implements AfterContentInit, NestedItemInterfac
 
     /** @hidden */
     private readonly _destroyRef = inject(DestroyRef);
+
+    /** @hidden */
+    private readonly _cdr = inject(ChangeDetectorRef);
 
     /** Unique element ID */
     private readonly _elementId: string = 'fdNestedItem' + sideNavigationItemUniqueId++;
@@ -278,6 +283,7 @@ export class NestedItemComponent implements AfterContentInit, NestedItemInterfac
         }
 
         this.expandedChange.emit(open);
+        this._cdr.markForCheck();
     }
 
     /** @hidden */
@@ -320,7 +326,7 @@ export class NestedItemComponent implements AfterContentInit, NestedItemInterfac
         if (this.contentItem && this.hasChildren) {
             this._ariaExpanded = false;
             this.contentItem.hasChildren = true;
-            this.contentItem.changeDetRef.detectChanges();
+            this.contentItem.changeDetRef.markForCheck();
         }
     }
 
@@ -341,5 +347,6 @@ export class NestedItemComponent implements AfterContentInit, NestedItemInterfac
         } else if (this.linkItem) {
             this.linkItem.changeSelected(selected);
         }
+        this._cdr.markForCheck();
     }
 }

--- a/libs/cx/nested-list/nested-link/nested-link.component.ts
+++ b/libs/cx/nested-list/nested-link/nested-link.component.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
+    ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
     ContentChild,
@@ -39,7 +40,7 @@ import {
         </ng-template>
     `,
     imports: [NgTemplateOutlet],
-    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     selector:
         // eslint-disable-next-line @angular-eslint/component-selector
         '[fdx-nested-list-link], button[fdx-nested-list-link], a[fdx-nested-list-link], div[fdx-nested-list-link]',
@@ -136,6 +137,7 @@ export class NestedLinkComponent {
     changeSelected(selected: boolean): void {
         this.selected = selected;
         this.selectedChange.emit(selected);
+        this.changeDetRef.markForCheck();
     }
 
     /** Set focus on the element. */

--- a/libs/cx/side-navigation/side-navigation.component.ts
+++ b/libs/cx/side-navigation/side-navigation.component.ts
@@ -2,6 +2,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import {
     AfterContentInit,
     AfterViewInit,
+    ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
     ContentChild,
@@ -46,6 +47,7 @@ import { SideNavigationUtilityDirective } from './side-navigation-utility.direct
     templateUrl: './side-navigation.component.html',
     styleUrl: 'side-navigation.component.scss',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [
         FdTranslatePipe,
         NgTemplateOutlet,
@@ -55,7 +57,6 @@ import { SideNavigationUtilityDirective } from './side-navigation-utility.direct
         SideNavigationUtilityDirective,
         SideNavigationButtonDirective
     ],
-    standalone: true,
     providers: [MenuKeyboardService, NestedListKeyboardService, NestedListStateService]
 })
 export class SideNavigationComponent
@@ -169,6 +170,7 @@ export class SideNavigationComponent
         if (this.collapseWidth) {
             this._condensed = window.innerWidth <= this.collapseWidth;
         }
+        this._cdRef.markForCheck();
     }
 
     /** @hidden */
@@ -230,7 +232,7 @@ export class SideNavigationComponent
                     item._narrow = false;
                 });
             }
-            this._cdRef.detectChanges();
+            this._cdRef.markForCheck();
         });
     }
 

--- a/libs/platform/button/button.component.ts
+++ b/libs/platform/button/button.component.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { Component, booleanAttribute, computed, effect, input, output } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, effect, input, output } from '@angular/core';
 
 import { ModuleDeprecation, warnOnce } from '@fundamental-ngx/cdk/utils';
 import { ButtonType, ButtonComponent as CoreButtonComponent, GlyphPosition } from '@fundamental-ngx/core/button';
@@ -24,6 +24,7 @@ let platformButtonId = 0;
         }
     ],
     imports: [CoreButtonComponent],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         role: 'button',
         '[attr.tabindex]': '-1'

--- a/libs/platform/form/form-generator/form-generator-field/form-generator-field.component.ts
+++ b/libs/platform/form/form-generator/form-generator-field/form-generator-field.component.ts
@@ -1,5 +1,5 @@
 import {
-    ChangeDetectorRef,
+    ChangeDetectionStrategy,
     Component,
     forwardRef,
     Input,
@@ -37,6 +37,7 @@ const formGroupChildProvider: Provider = {
     templateUrl: './form-generator-field.component.html',
     providers: [formFieldProvider, formGroupChildProvider],
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [FdpFormGroupModule, FormsModule, ReactiveFormsModule, DynamicFormControlDirective]
 })
 export class FormGeneratorFieldComponent implements OnInit {
@@ -104,15 +105,11 @@ export class FormGeneratorFieldComponent implements OnInit {
     _errorModels: { type: string; value: any }[] = [];
 
     /** @hidden */
-    constructor(
-        private _fgService: FormGeneratorService,
-        private _cdr: ChangeDetectorRef
-    ) {}
+    constructor(private _fgService: FormGeneratorService) {}
 
     /** @hidden */
     ngOnInit(): void {
         this._errorModels = this._getErrors();
-        this._cdr.detectChanges();
     }
 
     /** @hidden */

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-base.class.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-base.class.ts
@@ -1,10 +1,12 @@
 import {
+    afterNextRender,
     AfterViewInit,
     ChangeDetectorRef,
     Directive,
     ElementRef,
     EventEmitter,
     inject,
+    Injector,
     input,
     Input,
     isDevMode,
@@ -120,6 +122,9 @@ export abstract class IconTabBarBase implements OnInit, OnChanges, AfterViewInit
 
     /** @hidden */
     protected _destroyed = false;
+
+    /** @hidden */
+    protected readonly _injector = inject(Injector);
 
     /** @hidden */
     private _tabs: IconTabBarItem[] = [];
@@ -262,7 +267,7 @@ export abstract class IconTabBarBase implements OnInit, OnChanges, AfterViewInit
         this._resetAndHideExtraTabs(tabs, extraTabs);
 
         this._extraTabs$.set(extraTabs);
-        this._cd.detectChanges();
+        this._cd.markForCheck();
     }
 
     /**
@@ -286,13 +291,16 @@ export abstract class IconTabBarBase implements OnInit, OnChanges, AfterViewInit
      * @description trigger recalculation items, need to do it asynchronously after dom was rerendered
      */
     protected _triggerRecalculationVisibleItems(): void {
-        queueMicrotask(() => {
-            if (this.overflowDirective && !this._destroyed) {
-                const extra = this.overflowDirective.getAmountOfExtraItems();
-                this._recalculateVisibleItems(extra);
-                this._cd.detectChanges();
-            }
-        });
+        afterNextRender(
+            () => {
+                if (this.overflowDirective && !this._destroyed) {
+                    const extra = this.overflowDirective.getAmountOfExtraItems();
+                    this._recalculateVisibleItems(extra);
+                    this._cd.markForCheck();
+                }
+            },
+            { injector: this._injector }
+        );
     }
 
     /**

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-filter-type/icon-tab-bar-filter-type.component.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-filter-type/icon-tab-bar-filter-type.component.ts
@@ -1,5 +1,13 @@
 import { NgTemplateOutlet, SlicePipe } from '@angular/common';
-import { Component, ElementRef, Input, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    Input,
+    QueryList,
+    ViewChild,
+    ViewChildren
+} from '@angular/core';
 import { AsyncOrSyncPipe, OverflowListDirective, OverflowListItemDirective } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { IconComponent } from '@fundamental-ngx/core/icon';
@@ -11,6 +19,7 @@ import { IconTabBarPopoverComponent } from '../popovers/icon-tab-bar-popover/ico
 @Component({
     selector: 'fdp-icon-tab-bar-filter-type',
     templateUrl: './icon-tab-bar-filter-type.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
         {
             provide: IconTabBarBase,

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-icon-type/icon-tab-bar-icon-type.component.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-icon-type/icon-tab-bar-icon-type.component.ts
@@ -1,5 +1,13 @@
 import { NgClass, NgTemplateOutlet } from '@angular/common';
-import { Component, ElementRef, Input, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    Input,
+    QueryList,
+    ViewChild,
+    ViewChildren
+} from '@angular/core';
 import { AsyncOrSyncPipe, OverflowListDirective, OverflowListItemDirective } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { FD_DEFAULT_ICON_FONT_FAMILY, IconComponent } from '@fundamental-ngx/core/icon';
@@ -10,6 +18,7 @@ import { IconTabBarPopoverComponent } from '../popovers/icon-tab-bar-popover/ico
 @Component({
     selector: 'fdp-icon-tab-bar-icon-type',
     templateUrl: './icon-tab-bar-icon-type.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
         {
             provide: IconTabBarBase,

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-process-type/icon-tab-bar-process-type.component.spec.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-process-type/icon-tab-bar-process-type.component.spec.ts
@@ -61,7 +61,6 @@ describe('IconTabBarProcessTypeComponent', () => {
     beforeEach(fakeAsync(() => {
         fixture = TestBed.createComponent(IconTabBarProcessTypeComponent);
         component = fixture.componentInstance;
-        (component as any)['_cd'] = fakeCdr as any;
 
         component.tabs = _generateTabBarItems(generateTestConfig(100));
         fixture.detectChanges();
@@ -188,9 +187,4 @@ describe('IconTabBarProcessTypeComponent', () => {
 
 const fakeOverflowDirective = {
     getAmountOfExtraItems: () => AMOUNT_OF_EXTRA_TABS
-};
-
-const fakeCdr = {
-    detectChanges: () => null,
-    markForCheck: () => null
 };

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-process-type/icon-tab-bar-process-type.component.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-process-type/icon-tab-bar-process-type.component.ts
@@ -1,4 +1,12 @@
-import { Component, ElementRef, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import {
+    afterNextRender,
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    QueryList,
+    ViewChild,
+    ViewChildren
+} from '@angular/core';
 
 import { NgTemplateOutlet } from '@angular/common';
 import { AsyncOrSyncPipe, OverflowListDirective, OverflowListItemDirective } from '@fundamental-ngx/cdk/utils';
@@ -13,6 +21,7 @@ import { IconTabBarPopoverComponent } from '../popovers/icon-tab-bar-popover/ico
 @Component({
     selector: 'fdp-icon-tab-bar-process-type',
     templateUrl: './icon-tab-bar-process-type.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
         {
             provide: IconTabBarBase,
@@ -103,15 +112,18 @@ export class IconTabBarProcessTypeComponent extends ClosableIconTabBar {
         }
         this._selectItem(selectedItem);
 
-        queueMicrotask(() => {
-            if (this.overflowDirective && !this._destroyed) {
-                const extra = this.overflowDirective.getAmountOfExtraItems();
-                isPreviousStepsStrategy
-                    ? this.recalculateItemsByPrevArr(extra, amountOfPreviousSteps)
-                    : this._recalculateItemsByNextArr(extra, amountOfNextSteps);
-                this._cd.detectChanges();
-            }
-        });
+        afterNextRender(
+            () => {
+                if (this.overflowDirective && !this._destroyed) {
+                    const extra = this.overflowDirective.getAmountOfExtraItems();
+                    isPreviousStepsStrategy
+                        ? this.recalculateItemsByPrevArr(extra, amountOfPreviousSteps)
+                        : this._recalculateItemsByNextArr(extra, amountOfNextSteps);
+                    this._cd.markForCheck();
+                }
+            },
+            { injector: this._injector }
+        );
     }
 
     /**
@@ -122,6 +134,7 @@ export class IconTabBarProcessTypeComponent extends ClosableIconTabBar {
     _recalculateVisibleItems(extraItems: number): void {
         const amountOfPrevSteps = this._currentStepIndex > extraItems ? extraItems : this._currentStepIndex;
         this.recalculateItemsByPrevArr(extraItems, amountOfPrevSteps);
+        this._cd.markForCheck();
     }
 
     /** @hidden */
@@ -178,7 +191,7 @@ export class IconTabBarProcessTypeComponent extends ClosableIconTabBar {
             : this._prevSteps.length + visibleAmountOfItems - 1;
 
         this._showLeftBtn = !!this._prevSteps.length;
-        this._cd.detectChanges();
+        this._cd.markForCheck();
     }
 
     /**
@@ -227,6 +240,6 @@ export class IconTabBarProcessTypeComponent extends ClosableIconTabBar {
 
         this._showRightBtn = !!this._nextSteps.length;
         this._offsetOverflowDirective = this._nextSteps.length ? 70 : 0;
-        this._cd.detectChanges();
+        this._cd.markForCheck();
     }
 }

--- a/libs/platform/icon-tab-bar/components/icon-tab-bar-text-type/icon-tab-bar-text-type.component.ts
+++ b/libs/platform/icon-tab-bar/components/icon-tab-bar-text-type/icon-tab-bar-text-type.component.ts
@@ -1,5 +1,15 @@
 import { NgClass } from '@angular/common';
-import { Component, ElementRef, EventEmitter, Input, Output, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    ElementRef,
+    EventEmitter,
+    Input,
+    Output,
+    QueryList,
+    ViewChild,
+    ViewChildren
+} from '@angular/core';
 import { Nullable, OverflowListDirective, OverflowListItemDirective } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { IconComponent } from '@fundamental-ngx/core/icon';
@@ -26,6 +36,7 @@ type TabItem = ElementRef<HTMLElement> | TextTypePopoverComponent;
 @Component({
     selector: 'fdp-icon-tab-bar-text-type',
     templateUrl: './icon-tab-bar-text-type.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [
         {
             provide: IconTabBarBase,

--- a/libs/platform/icon-tab-bar/components/popovers/icon-tab-bar-popover/icon-tab-bar-popover.component.ts
+++ b/libs/platform/icon-tab-bar/components/popovers/icon-tab-bar-popover/icon-tab-bar-popover.component.ts
@@ -1,5 +1,5 @@
 import { NgClass } from '@angular/common';
-import { Component, ElementRef, Input, QueryList, ViewChildren } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, QueryList, ViewChildren } from '@angular/core';
 import { AsyncOrSyncPipe } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { IconComponent } from '@fundamental-ngx/core/icon';
@@ -10,6 +10,7 @@ import { IconTabBarPopoverBase } from '../icon-tab-bar-popover-base.class';
 @Component({
     selector: 'fdp-icon-tab-bar-popover',
     templateUrl: './icon-tab-bar-popover.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [
         PopoverComponent,
         PopoverControlComponent,

--- a/libs/platform/list/list-group-footer.component.ts
+++ b/libs/platform/list/list-group-footer.component.ts
@@ -1,11 +1,11 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { BaseComponent } from '@fundamental-ngx/platform/shared';
 import { LIST_ITEM_TYPE } from './base-list-item';
 
 @Component({
     selector: 'fdp-list-footer',
     template: `<div #listFooter class="fd-list__footer" [attr.id]="id" role="option"><ng-content></ng-content></div>`,
-    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         role: 'none'
     }

--- a/libs/platform/list/list-group-header.component.ts
+++ b/libs/platform/list/list-group-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, OnInit } from '@angular/core';
 import { ListGroupHeaderDirective, ListTitleDirective } from '@fundamental-ngx/core/list';
 import { BaseListItem, LIST_ITEM_TYPE } from './base-list-item';
 
@@ -19,6 +19,7 @@ let nextListGrpHeaderId = 0;
         <ng-content></ng-content>
     </div>`,
     providers: [{ provide: BaseListItem, useExisting: forwardRef(() => ListGroupHeaderComponent) }],
+    changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         role: 'none'
     },

--- a/libs/platform/object-marker/object-marker.component.ts
+++ b/libs/platform/object-marker/object-marker.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 import { Nullable, warnOnce } from '@fundamental-ngx/cdk/utils';
 import { FD_DEFAULT_ICON_FONT_FAMILY, IconFont } from '@fundamental-ngx/core/icon';
@@ -11,6 +11,7 @@ import { ObjectMarkerComponent } from '@fundamental-ngx/core/object-marker';
 @Component({
     selector: 'fdp-object-marker',
     templateUrl: './object-marker.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [ObjectMarkerComponent]
 })
 export class PlatformObjectMarkerComponent {

--- a/libs/platform/page-footer/page-footer.component.ts
+++ b/libs/platform/page-footer/page-footer.component.ts
@@ -1,5 +1,14 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, HostListener, Input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    HostListener,
+    inject,
+    Input,
+    TemplateRef,
+    ViewEncapsulation
+} from '@angular/core';
 import { warnOnce } from '@fundamental-ngx/cdk/utils';
 
 export type footerSize = 'sm' | 'md' | 'lg' | 'xl';
@@ -13,6 +22,7 @@ export type footerSize = 'sm' | 'md' | 'lg' | 'xl';
     templateUrl: './page-footer.component.html',
     styleUrl: './page-footer.component.scss',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [NgTemplateOutlet]
 })
 export class PlatformFooterComponent {
@@ -32,6 +42,9 @@ export class PlatformFooterComponent {
     public screenHeight: any;
 
     /** @hidden */
+    private readonly _cdr = inject(ChangeDetectorRef);
+
+    /** @hidden */
     constructor() {
         warnOnce('PlatformFooterComponent component is deprecated since version 0.40.0');
     }
@@ -49,5 +62,6 @@ export class PlatformFooterComponent {
         } else {
             this.size = 'xl';
         }
+        this._cdr.markForCheck();
     }
 }

--- a/libs/platform/smart-filter-bar/components/smart-filter-bar-condition-field/smart-filter-bar-condition-field.component.ts
+++ b/libs/platform/smart-filter-bar/components/smart-filter-bar-condition-field/smart-filter-bar-condition-field.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { PlatformMultiInputComponent } from '@fundamental-ngx/platform/form';
@@ -8,6 +8,7 @@ import { BaseSmartFilterBarConditionField } from './base-smart-filter-bar-condit
     selector: 'fdp-smart-filter-bar-condition-field',
     templateUrl: './smart-filter-bar-condition-field.component.html',
     encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [FormsModule, ReactiveFormsModule, PlatformMultiInputComponent, FdTranslatePipe]
 })
 export class SmartFilterBarConditionFieldComponent extends BaseSmartFilterBarConditionField {}

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filter-custom.component.spec.ts
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filter-custom.component.spec.ts
@@ -1,0 +1,339 @@
+import { Component, TemplateRef, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ContentDensityMode, ContentDensityObserver } from '@fundamental-ngx/core/content-density';
+import { whenStable } from '@fundamental-ngx/core/tests';
+import { CollectionFilter, FILTER_STRATEGY } from '@fundamental-ngx/platform/table-helpers';
+import { TableViewSettingsFilterComponent } from '../table-view-settings-filter.component';
+import { FilterCustomComponent } from './filter-custom.component';
+
+/**
+ * Test host that provides a custom filter template simulating a real use case:
+ * a user form that directly mutates the model object (the `$implicit` context).
+ */
+@Component({
+    template: `
+        <ng-template #customFilterTpl let-model>
+            <label>Price range</label>
+            <input class="min-input" [value]="model.min ?? ''" (input)="model.min = +$event.target.value" />
+            <input class="max-input" [value]="model.max ?? ''" (input)="model.max = +$event.target.value" />
+        </ng-template>
+    `
+})
+class FilterCustomTestHostComponent {
+    @ViewChild('customFilterTpl', { static: true })
+    customFilterTpl: TemplateRef<any>;
+}
+
+describe('FilterCustomComponent', () => {
+    let fixture: ComponentFixture<FilterCustomComponent>;
+    let component: FilterCustomComponent;
+    let hostFixture: ComponentFixture<FilterCustomTestHostComponent>;
+    let host: FilterCustomTestHostComponent;
+
+    /** Helper to build a mock TableViewSettingsFilterComponent with the host's template */
+    function buildMockFilter(tpl: TemplateRef<any>): TableViewSettingsFilterComponent {
+        return {
+            customFilterTemplate: tpl,
+            column: 'price',
+            label: 'Price',
+            type: 'custom'
+        } as any;
+    }
+
+    /** Helper to build a CollectionFilter with custom object value */
+    function buildCollectionFilter(value: Record<string, any>): CollectionFilter {
+        return {
+            field: 'price',
+            value,
+            strategy: FILTER_STRATEGY.EQ,
+            exclude: false
+        } as CollectionFilter;
+    }
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [FilterCustomComponent, FilterCustomTestHostComponent],
+            providers: [
+                {
+                    provide: ContentDensityObserver,
+                    useValue: { value: ContentDensityMode.COZY } as Partial<ContentDensityObserver>
+                }
+            ]
+        }).compileComponents();
+
+        hostFixture = TestBed.createComponent(FilterCustomTestHostComponent);
+        host = hostFixture.componentInstance;
+        hostFixture.detectChanges();
+
+        fixture = TestBed.createComponent(FilterCustomComponent);
+        component = fixture.componentInstance;
+    });
+
+    describe('initialization and filterBy input', () => {
+        it('should create', () => {
+            expect(component).toBeTruthy();
+        });
+
+        it('should initialize _value to empty object when filterBy is undefined', () => {
+            component.filterBy = undefined;
+            expect(component._value).toEqual({});
+        });
+
+        it('should initialize _value to empty object when filterBy has a non-object value (string)', () => {
+            const filter = {
+                field: 'name',
+                value: 'some string',
+                strategy: FILTER_STRATEGY.EQ,
+                exclude: false
+            } as CollectionFilter;
+            component.filterBy = filter;
+            expect(component._value).toEqual({});
+        });
+
+        it('should initialize _value to empty object when filterBy has a null value', () => {
+            const filter = {
+                field: 'price',
+                value: null,
+                strategy: FILTER_STRATEGY.EQ,
+                exclude: false
+            } as any;
+            component.filterBy = filter;
+            expect(component._value).toEqual({});
+        });
+
+        it('should initialize _value to empty object when filterBy has an array value', () => {
+            const filter = {
+                field: 'tags',
+                value: ['a', 'b'],
+                strategy: FILTER_STRATEGY.EQ,
+                exclude: false
+            } as any;
+            component.filterBy = filter;
+            expect(component._value).toEqual({});
+        });
+
+        it('should clone the object value from filterBy', () => {
+            const originalValue = { min: 10, max: 100 };
+            component.filterBy = buildCollectionFilter(originalValue);
+            expect(component._value).toEqual({ min: 10, max: 100 });
+            // Must be a clone, not the same reference
+            expect(component._value).not.toBe(originalValue);
+        });
+
+        it('should reset _valueLastEmitted to match _value on filterBy set', () => {
+            component.filterBy = buildCollectionFilter({ min: 5, max: 50 });
+            expect(component._valueLastEmitted).toEqual({ min: 5, max: 50 });
+        });
+    });
+
+    describe('mutation detection', () => {
+        beforeEach(() => {
+            component.filterBy = buildCollectionFilter({ min: 0, max: 100 });
+        });
+
+        it('should not emit valueChange when _value has not changed', () => {
+            const spy = jest.fn();
+            component.valueChange.subscribe(spy);
+
+            component._checkValueChanges();
+
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('should emit valueChange when a property on _value is mutated', () => {
+            const spy = jest.fn();
+            component.valueChange.subscribe(spy);
+
+            // Simulate what a custom template does: directly mutate the object
+            component._value.min = 25;
+            component._checkValueChanges();
+
+            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledWith({ min: 25, max: 100 });
+        });
+
+        it('should emit valueChange when a new property is added to _value', () => {
+            const spy = jest.fn();
+            component.valueChange.subscribe(spy);
+
+            component._value.currency = 'EUR';
+            component._checkValueChanges();
+
+            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledWith({ min: 0, max: 100, currency: 'EUR' });
+        });
+
+        it('should emit valueChange when a property is deleted from _value', () => {
+            const spy = jest.fn();
+            component.valueChange.subscribe(spy);
+
+            delete component._value.max;
+            component._checkValueChanges();
+
+            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledWith({ min: 0 });
+        });
+
+        it('should not emit again on subsequent check if no further mutations', () => {
+            const spy = jest.fn();
+            component.valueChange.subscribe(spy);
+
+            component._value.min = 25;
+            component._checkValueChanges();
+            expect(spy).toHaveBeenCalledTimes(1);
+
+            // No further mutation
+            component._checkValueChanges();
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should emit for each distinct mutation across multiple check cycles', () => {
+            const emitted: any[] = [];
+            component.valueChange.subscribe((v) => emitted.push({ ...v }));
+
+            component._value.min = 10;
+            component._checkValueChanges();
+
+            component._value.max = 200;
+            component._checkValueChanges();
+
+            component._value.min = 50;
+            component._value.max = 300;
+            component._checkValueChanges();
+
+            expect(emitted).toEqual([
+                { min: 10, max: 100 },
+                { min: 10, max: 200 },
+                { min: 50, max: 300 }
+            ]);
+        });
+
+        it('should update _valueLastEmitted after emitting', () => {
+            component._value.min = 42;
+            component._checkValueChanges();
+
+            expect(component._valueLastEmitted).toEqual({ min: 42, max: 100 });
+            // Must be a clone, not the same reference
+            expect(component._valueLastEmitted).not.toBe(component._value);
+        });
+    });
+
+    describe('circular reference handling', () => {
+        it('should silently catch JSON.stringify errors and not emit', () => {
+            component.filterBy = buildCollectionFilter({ name: 'test' });
+            const spy = jest.fn();
+            component.valueChange.subscribe(spy);
+
+            // Create a circular reference that will cause JSON.stringify to throw
+            const circular: any = { ref: null };
+            circular.ref = circular;
+            component._value = circular;
+
+            // Should not throw
+            expect(() => component._checkValueChanges()).not.toThrow();
+            // Should not emit since try/catch swallows the error
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('filterBy reset behavior', () => {
+        it('should stop emitting old mutations after filterBy is reassigned', () => {
+            component.filterBy = buildCollectionFilter({ min: 0, max: 100 });
+
+            const spy = jest.fn();
+            component.valueChange.subscribe(spy);
+
+            // Mutate and detect
+            component._value.min = 50;
+            component._checkValueChanges();
+            expect(spy).toHaveBeenCalledTimes(1);
+
+            // Re-assign filterBy with a new value (simulates user resetting the filter)
+            component.filterBy = buildCollectionFilter({ min: 0, max: 500 });
+
+            // No mutation on the new value yet
+            component._checkValueChanges();
+            expect(spy).toHaveBeenCalledTimes(1);
+
+            // Mutate the new value
+            component._value.min = 100;
+            component._checkValueChanges();
+            expect(spy).toHaveBeenCalledTimes(2);
+            expect(spy).toHaveBeenLastCalledWith({ min: 100, max: 500 });
+        });
+    });
+
+    describe('template rendering with custom filter', () => {
+        it('should render the custom filter template and pass the value as context', async () => {
+            component.filter = buildMockFilter(host.customFilterTpl);
+            component.filterBy = buildCollectionFilter({ min: 10, max: 200 });
+            fixture.detectChanges();
+            await whenStable(fixture);
+
+            const minInput = fixture.nativeElement.querySelector('.min-input') as HTMLInputElement;
+            const maxInput = fixture.nativeElement.querySelector('.max-input') as HTMLInputElement;
+
+            expect(minInput).toBeTruthy();
+            expect(maxInput).toBeTruthy();
+            expect(minInput.value).toBe('10');
+            expect(maxInput.value).toBe('200');
+        });
+
+        it('should detect value changes when user types in the custom template', async () => {
+            component.filter = buildMockFilter(host.customFilterTpl);
+            component.filterBy = buildCollectionFilter({ min: 0, max: 100 });
+            fixture.detectChanges();
+            await whenStable(fixture);
+
+            const spy = jest.fn();
+            component.valueChange.subscribe(spy);
+
+            // Simulate user changing the min input
+            const minInput = fixture.nativeElement.querySelector('.min-input') as HTMLInputElement;
+            minInput.value = '25';
+            minInput.dispatchEvent(new Event('input'));
+            fixture.detectChanges();
+            component._checkValueChanges();
+
+            // afterEveryRender detects the mutation after each render cycle
+            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledWith(expect.objectContaining({ min: 25, max: 100 }));
+        });
+
+        it('should detect multiple sequential user inputs', async () => {
+            component.filter = buildMockFilter(host.customFilterTpl);
+            component.filterBy = buildCollectionFilter({ min: 0, max: 100 });
+            fixture.detectChanges();
+            await whenStable(fixture);
+
+            const emitted: any[] = [];
+            component.valueChange.subscribe((v) => emitted.push({ ...(v as object) }));
+
+            const minInput = fixture.nativeElement.querySelector('.min-input') as HTMLInputElement;
+            const maxInput = fixture.nativeElement.querySelector('.max-input') as HTMLInputElement;
+
+            // User changes min
+            minInput.value = '10';
+            minInput.dispatchEvent(new Event('input'));
+            fixture.detectChanges();
+            component._checkValueChanges();
+
+            // User changes max
+            maxInput.value = '500';
+            maxInput.dispatchEvent(new Event('input'));
+            fixture.detectChanges();
+            component._checkValueChanges();
+
+            expect(emitted.length).toBe(2);
+            expect(emitted[0]).toEqual(expect.objectContaining({ min: 10, max: 100 }));
+            expect(emitted[1]).toEqual(expect.objectContaining({ min: 10, max: 500 }));
+        });
+    });
+
+    describe('contentDensity', () => {
+        it('should expose the content density from ContentDensityObserver', () => {
+            expect(component.contentDensity).toBe(ContentDensityMode.COZY);
+        });
+    });
+});

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filter-custom.component.ts
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filter-custom.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, DoCheck, EventEmitter, Input, Output } from '@angular/core';
+import {
+    afterEveryRender,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    EventEmitter,
+    inject,
+    Input,
+    Output
+} from '@angular/core';
 import { CollectionFilter } from '@fundamental-ngx/platform/table-helpers';
 
 import { NgTemplateOutlet } from '@angular/common';
@@ -19,12 +28,12 @@ import { TableViewSettingsFilterComponent } from '../table-view-settings-filter.
 @Component({
     selector: 'fdp-filter-custom',
     templateUrl: './filter-custom.component.html',
-    // Keep it "Default" intentionally to run ngDoCheck when child template emits changes
-    changeDetection: ChangeDetectionStrategy.Default,
+    // afterEveryRender is used to detect mutations on the _value object after each render cycle.
+    changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [contentDensityObserverProviders()],
     imports: [NgTemplateOutlet]
 })
-export class FilterCustomComponent implements DoCheck {
+export class FilterCustomComponent {
     /** ViewSettingsFilter options the filter is created from */
     @Input()
     filter: TableViewSettingsFilterComponent;
@@ -63,12 +72,16 @@ export class FilterCustomComponent implements DoCheck {
     _valueLastEmitted: Record<string, any>;
 
     /** @hidden */
-    constructor(private contentDensityObserver: ContentDensityObserver) {}
+    private readonly _cdr = inject(ChangeDetectorRef);
 
     /** @hidden */
-    ngDoCheck(): void {
+    constructor(private contentDensityObserver: ContentDensityObserver) {
+        afterEveryRender(() => this._checkValueChanges());
+    }
+
+    /** @hidden */
+    _checkValueChanges(): void {
         try {
-            // Didn't find a better way to catch changes in the custom template
             if (JSON.stringify(this._value) === JSON.stringify(this._valueLastEmitted)) {
                 return;
             }
@@ -76,6 +89,7 @@ export class FilterCustomComponent implements DoCheck {
             this._valueLastEmitted = { ...this._value };
 
             this.valueChange.emit(this._value);
+            this._cdr.markForCheck();
         } catch {}
     }
 }

--- a/libs/platform/value-help-dialog/components/base-tab/vhd-base-tab.component.ts
+++ b/libs/platform/value-help-dialog/components/base-tab/vhd-base-tab.component.ts
@@ -1,12 +1,11 @@
-import { ChangeDetectorRef, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
 
 import { VhdTab } from '../../models';
 
 @Component({
     template: '',
-    standalone: true
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
-// eslint-disable-next-line @angular-eslint/component-class-suffix
 export class VhdBaseTab {
     /** Tab Title */
     @Input()


### PR DESCRIPTION
migrate remaining Default strategy components to OnPush

fixes #14039

Summary

  Audit and migrate all remaining ChangeDetectionStrategy.Default components to OnPush for zoneless
  compatibility (#14039).

  Changes across 52 files (48 components, 3 specs, 1 base class):

  Core changes (applied to all 48 components):
  - Add ChangeDetectionStrategy.OnPush
  - Replace detectChanges() with markForCheck()
  - Remove standalone: true (default since Angular 19)

  FilterCustomComponent (libs/platform/table/.../filter-custom.component.ts):
  - Migrate from ngDoCheck polling to afterEveryRender — the only component that needed special handling
  because it detects mutations on a plain object passed by reference into a user template
  - Add markForCheck() after emission for OnPush parent notification
  - New spec file with 20 tests covering mutation detection, circular references, filterBy reset, template
  integration, and content density

  Icon Tab Bar (libs/platform/icon-tab-bar/):
  - Remove NgZone.onMicrotaskEmpty dependency from base class and process-type component
  - Replace with afterNextRender for zoneless compatibility
  - Preserve async _selectExtraItem(): Promise<void> signature (no breaking change)

  Affected libraries: core, platform, cdk, btp, cx

  Out of scope (intentionally not changed):

  - setTimeout() → afterNextRender() replacement (tracked in #14037)
  - @HostBinding / @HostListener → host: {} migration (future ticket)
### Review findings addressed

  | Concern | Analysis |
  |---------|----------|
  | OnPush on dialog/message-box containers may regress #12521 (dynamic content not updating) | Low risk. `_attached()` now calls `markForCheck()` on portal content. Child internal state changes are governed by the child's own CD, not the container's. |
  | Redundant `markForCheck()` after `signal.set()` on `@HostBinding` | Not redundant. `@HostBinding` getter is not a signal-reactive context — `markForCheck()` is needed. The CLAUDE.md rule applies to `host: {}` and template bindings only. |
  | Missing `markForCheck()` in `list-navigation-item` after mutating `@HostBinding` props | Not needed. `_handleExpandedChanges()` is only called from `@HostListener` handlers — DOM events automatically trigger CD on OnPush components. |
  | `afterEveryRender` detects mutations one frame later than `ngDoCheck` | Valid but inconsequential. Filter dialog requires user to click "OK" to apply — one-frame delay is imperceptible. |
