### PR TITLE
fix(core): add fix for Inline Help focus outline

### DIFF
--- a/libs/core/icon/icon.component.scss
+++ b/libs/core/icon/icon.component.scss
@@ -1,6 +1,5 @@
 @import 'fundamental-styles/dist/icon.css';
 
 [class*='sap-icon'].fd-inline-help__trigger {
-    padding: 0 0.25rem;
-    outline-offset: -0.125rem;
+    margin-inline-start: 0.25rem;
 }


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/14019

## Description
CSS changes for the focus outline
In web components you cna check interactive icon: https://ui5.github.io/webcomponents/components/Icon/

## Screenshots
Before:
<img width="557" height="233" alt="Screenshot 2026-03-31 at 2 27 08 PM" src="https://github.com/user-attachments/assets/20d41007-71c3-4182-a03c-82002534c0bc" />
<img width="453" height="230" alt="Screenshot 2026-03-31 at 2 27 04 PM" src="https://github.com/user-attachments/assets/8b0df67e-4604-48e2-be0a-7cf8f4a3267b" />



After:
<img width="414" height="217" alt="Screenshot 2026-03-31 at 2 24 31 PM" src="https://github.com/user-attachments/assets/f5b825a1-f14b-4434-8168-494ad2b851c1" />
<img width="600" height="199" alt="Screenshot 2026-03-31 at 2 24 37 PM" src="https://github.com/user-attachments/assets/b7315213-681d-4ca0-94a1-b76acde4999e" />
