### PR TITLE
chore(ci): configure OIDC trusted publishing for npm release

### DIFF
--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -10,6 +10,10 @@ inputs:
         description: Install dependencies from lock file
         required: false
         default: 'true'
+    registry-url:
+        description: npm registry URL (set for publishing with OIDC trusted publishing)
+        required: false
+        default: ''
 
 runs:
     using: composite
@@ -18,6 +22,7 @@ runs:
           uses: actions/setup-node@v4.3.0
           with:
               node-version: ${{ inputs.node-version }}
+              registry-url: ${{ inputs.registry-url }}
 
         - name: Get Yarn path from .yarnrc.yml
           id: yarn-path

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -59,6 +59,7 @@ jobs:
               uses: ./.github/actions/nodejs
               with:
                   node-version: ${{ env.NODE_VERSION }}
+                  registry-url: 'https://registry.npmjs.org'
 
             - name: Setup git user
               uses: ./.github/actions/set-up-git
@@ -132,11 +133,10 @@ jobs:
             - name: Reset dependency placeholders after pack
               run: node scripts/reset-placeholders.js
 
-            - name: Configure npm for trusted publishing
-              run: npm config delete //registry.npmjs.org/:_authToken || true
-
             # Use NX Release to publish all packages at once
-            # This replaces the manual loop and handles provenance automatically
+            # Authentication is handled via OIDC trusted publishing (id-token: write permission)
+            # setup-node with registry-url configures .npmrc for OIDC token exchange
+            # NPM_CONFIG_PROVENANCE generates signed provenance attestations
             # NX Release publishes from dist/libs/{projectName} as configured in nx.json
             # NPM tag is determined by release-tags action:
             # - prerelease: for RC versions (e.g., 0.58.0-rc.19)
@@ -149,6 +149,7 @@ jobs:
                   npx nx release publish --tag="${{ steps.releaseTags.outputs.npm }}" --registry=https://registry.npmjs.org/
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
+                  NPM_CONFIG_PROVENANCE: true
 
             # Create git commit and tag after successful build and publish
             # We do this here instead of during 'nx release version' to ensure we only commit


### PR DESCRIPTION
configure OIDC trusted publishing for npm release

  Node 22.22.2 broke `npm install -g npm@latest` (MODULE_NOT_FOUND).
  Replace with proper OIDC auth via setup-node registry-url and NPM_CONFIG_PROVENANCE.