### PR TITLE
chore(ci):  use npx to upgrade npm avoiding self-corruption bug in npm 10.9.7

### DIFF
--- a/.github/actions/nodejs/action.yml
+++ b/.github/actions/nodejs/action.yml
@@ -10,10 +10,6 @@ inputs:
         description: Install dependencies from lock file
         required: false
         default: 'true'
-    registry-url:
-        description: npm registry URL (set for publishing with OIDC trusted publishing)
-        required: false
-        default: ''
 
 runs:
     using: composite
@@ -22,7 +18,6 @@ runs:
           uses: actions/setup-node@v4.3.0
           with:
               node-version: ${{ inputs.node-version }}
-              registry-url: ${{ inputs.registry-url }}
 
         - name: Get Yarn path from .yarnrc.yml
           id: yarn-path

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -59,13 +59,20 @@ jobs:
               uses: ./.github/actions/nodejs
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  registry-url: 'https://registry.npmjs.org'
 
             - name: Setup git user
               uses: ./.github/actions/set-up-git
               with:
                   name: ${{ secrets.GH_NAME }}
                   email: ${{ secrets.GH_EMAIL }}
+
+            # npm 11.5.0+ auto-detects OIDC in GitHub Actions and handles trusted publishing.
+            # The bundled npm 10.x doesn't support this, so we upgrade.
+            # We cannot run `npm install -g npm@latest` directly because npm 10.9.7
+            # crashes with MODULE_NOT_FOUND when replacing its own files mid-execution.
+            # Instead, we use npx to run a fresh copy of npm@latest for the upgrade.
+            - name: Upgrade npm for OIDC trusted publishing
+              run: npx --yes npm@latest install -g npm@latest
 
             - name: Initialize the Nx Cloud distributed CI run
               run: npx nx-cloud start-ci-run
@@ -133,10 +140,11 @@ jobs:
             - name: Reset dependency placeholders after pack
               run: node scripts/reset-placeholders.js
 
+            - name: Configure npm for trusted publishing
+              run: npm config delete //registry.npmjs.org/:_authToken || true
+
             # Use NX Release to publish all packages at once
-            # Authentication is handled via OIDC trusted publishing (id-token: write permission)
-            # setup-node with registry-url configures .npmrc for OIDC token exchange
-            # NPM_CONFIG_PROVENANCE generates signed provenance attestations
+            # Authentication is handled via npm 11.5.0+ auto-OIDC (detects GitHub Actions + id-token: write)
             # NX Release publishes from dist/libs/{projectName} as configured in nx.json
             # NPM tag is determined by release-tags action:
             # - prerelease: for RC versions (e.g., 0.58.0-rc.19)
@@ -149,7 +157,6 @@ jobs:
                   npx nx release publish --tag="${{ steps.releaseTags.outputs.npm }}" --registry=https://registry.npmjs.org/
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
-                  NPM_CONFIG_PROVENANCE: true
 
             # Create git commit and tag after successful build and publish
             # We do this here instead of during 'nx release version' to ensure we only commit


### PR DESCRIPTION
use npx to upgrade npm avoiding self-corruption bug in npm 10.9.7