### PR TITLE
fix(core): items in fd-menu should not be activated on key down

### DIFF
--- a/libs/core/menu/services/menu.service.spec.ts
+++ b/libs/core/menu/services/menu.service.spec.ts
@@ -150,109 +150,190 @@ describe('MenuService', () => {
         expect(siblings?.length).toEqual(3);
     });
 
-    it('should open submenu on arrow right', fakeAsync(() => {
-        const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
-        const activateSpy = jest.spyOn(menuItems.first, 'setSelected');
-        menuService.focusedNode = menuService.menuMap.get(menuItems.first);
+    describe('removeKeyboardSupport', () => {
+        it('should call the keydown destroy listener', () => {
+            const destroySpy = jest.fn();
+            menuService['_destroyKeyDownHandlerListener'] = destroySpy;
 
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+            menuService.removeKeyboardSupport();
 
-        tick();
+            expect(destroySpy).toHaveBeenCalledTimes(1);
+        });
 
-        expect(setFocusedSpy).toHaveBeenCalled();
-        expect(activateSpy).toHaveBeenCalledWith(true);
-        expect(menuService.activeNodePath[menuService.activeNodePath.length - 1].item).toBe(menuItems.first);
-    }));
+        it('should call the keyup destroy listener', () => {
+            const destroySpy = jest.fn();
+            menuService['_destroyKeyUpHandlerListener'] = destroySpy;
 
-    it('should open submenu on arrow right', fakeAsync(() => {
-        const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
-        const activateSpy = jest.spyOn(menuItems.first, 'setSelected');
-        menuService.focusedNode = menuService.menuMap.get(menuItems.first);
+            menuService.removeKeyboardSupport();
 
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+            expect(destroySpy).toHaveBeenCalledTimes(1);
+        });
 
-        tick();
+        it('should not throw when called before keyboard support is added', () => {
+            menuService['_destroyKeyDownHandlerListener'] = undefined as any;
+            menuService['_destroyKeyUpHandlerListener'] = undefined as any;
 
-        expect(setFocusedSpy).toHaveBeenCalled();
-        expect(activateSpy).toHaveBeenCalledWith(true);
-        expect(menuService.activeNodePath[menuService.activeNodePath.length - 1].item).toBe(menuItems.first);
-    }));
-
-    it('should open submenu on arrow left', () => {
-        const setActiveSpy = jest.spyOn(menuService, 'setActive');
-        const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
-
-        menuService.setActive(true, menuItems.first);
-        menuService.focusedNode = menuService.menuMap.get(nestedMenuItem);
-
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
-
-        expect(setActiveSpy).toHaveBeenCalledWith(false, menuItems.first);
-        expect(setFocusedSpy).toHaveBeenCalledWith(menuItems.first);
+            expect(() => menuService.removeKeyboardSupport()).not.toThrow();
+        });
     });
 
-    it('should focus next menu item on arrow down', () => {
-        const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+    describe('_handleKeydown', () => {
+        it('should open submenu on arrow right', fakeAsync(() => {
+            const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+            const activateSpy = jest.spyOn(menuItems.first, 'setSelected');
+            menuService.focusedNode = menuService.menuMap.get(menuItems.first);
 
-        menuService.focusedNode = menuService.menuMap.get(menuItems.first);
+            menuService['_handleKeydown'](new KeyboardEvent('keydown', { key: 'ArrowRight' }));
 
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            tick();
 
-        expect(setFocusedSpy).toHaveBeenCalledWith(menuItems.toArray()[1]);
+            expect(setFocusedSpy).toHaveBeenCalled();
+            expect(activateSpy).toHaveBeenCalledWith(true);
+            expect(menuService.activeNodePath[menuService.activeNodePath.length - 1].item).toBe(menuItems.first);
+        }));
+
+        it('should close submenu on arrow left', () => {
+            const setActiveSpy = jest.spyOn(menuService, 'setActive');
+            const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+
+            menuService.setActive(true, menuItems.first);
+            menuService.focusedNode = menuService.menuMap.get(nestedMenuItem);
+
+            menuService['_handleKeydown'](new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+
+            expect(setActiveSpy).toHaveBeenCalledWith(false, menuItems.first);
+            expect(setFocusedSpy).toHaveBeenCalledWith(menuItems.first);
+        });
+
+        it('should focus next menu item on arrow down', () => {
+            const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+
+            menuService.focusedNode = menuService.menuMap.get(menuItems.first);
+
+            menuService['_handleKeydown'](new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+
+            expect(setFocusedSpy).toHaveBeenCalledWith(menuItems.toArray()[1]);
+        });
+
+        it('should focus previous menu item on arrow up', () => {
+            const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+
+            menuService.focusedNode = menuService.menuMap.get(menuItems.toArray()[1]);
+
+            menuService['_handleKeydown'](new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+
+            expect(setFocusedSpy).toHaveBeenCalledWith(menuItems.first);
+        });
+
+        it('should not trigger click on Space/Enter', () => {
+            const clickSpy = jest.spyOn(menuItems.first, 'click');
+
+            menuService.focusedNode = menuService.menuMap.get(menuItems.first);
+
+            menuService['_handleKeydown'](new KeyboardEvent('keydown', { key: 'Enter' }));
+            menuService['_handleKeydown'](new KeyboardEvent('keydown', { key: ' ' }));
+
+            expect(clickSpy).not.toHaveBeenCalled();
+        });
+
+        it('should close menu on Escape', () => {
+            const closeSpy = jest.spyOn(menu, 'close');
+
+            menuService.focusedNode = menuService.menuMap.get(menuItems.first);
+
+            menuService['_handleKeydown'](new KeyboardEvent('keydown', { key: 'Escape' }));
+
+            expect(closeSpy).toHaveBeenCalled();
+        });
+
+        it('should skip disabled item on arrow up', () => {
+            fixture.componentInstance.disabled = true;
+            fixture.detectChanges();
+            const menuItemsArray = menuItems.toArray();
+            const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+
+            menuService.focusedNode = menuService.menuMap.get(menuItemsArray[2]);
+            menuService['_handleKeydown'](new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+
+            expect(setFocusedSpy).toHaveBeenCalledWith(menuItemsArray[0]);
+        });
+
+        it('should skip disabled item on arrow down', () => {
+            fixture.componentInstance.disabled = true;
+            fixture.detectChanges();
+            const menuItemsArray = menuItems.toArray();
+            const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+
+            menuService.focusedNode = menuService.menuMap.get(menuItemsArray[0]);
+            menuService['_handleKeydown'](new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+
+            expect(setFocusedSpy).toHaveBeenCalledWith(menuItemsArray[2]);
+        });
     });
 
-    it('should focus next menu item on arrow up', () => {
-        const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+    describe('_handleKeyup', () => {
+        it('should click focused item on Enter', () => {
+            const clickSpy = jest.spyOn(menuItems.first, 'click');
 
-        menuService.focusedNode = menuService.menuMap.get(menuItems.toArray()[1]);
+            menuService.focusedNode = menuService.menuMap.get(menuItems.first);
 
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+            menuService['_handleKeyup'](new KeyboardEvent('keyup', { key: 'Enter' }));
 
-        expect(setFocusedSpy).toHaveBeenCalledWith(menuItems.first);
-    });
+            expect(clickSpy).toHaveBeenCalledTimes(1);
+        });
 
-    it('should open submenu on space/enter', () => {
-        const clickSpy = jest.spyOn(menuItems.first, 'click');
+        it('should click focused item on Space', () => {
+            const clickSpy = jest.spyOn(menuItems.first, 'click');
 
-        menuService.focusedNode = menuService.menuMap.get(menuItems.first);
+            menuService.focusedNode = menuService.menuMap.get(menuItems.first);
 
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: 'Enter' }));
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: ' ' }));
+            menuService['_handleKeyup'](new KeyboardEvent('keyup', { key: ' ' }));
 
-        expect(clickSpy).toHaveBeenCalledTimes(2);
-    });
+            expect(clickSpy).toHaveBeenCalledTimes(1);
+        });
 
-    it('should close menu on Escape', () => {
-        const closeSpy = jest.spyOn(menu, 'close');
+        it('should set item active on Space/Enter', () => {
+            const setActiveSpy = jest.spyOn(menuService, 'setActive');
 
-        menuService.focusedNode = menuService.menuMap.get(menuItems.first);
+            menuService.focusedNode = menuService.menuMap.get(menuItems.first);
 
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: 'Escape' }));
+            menuService['_handleKeyup'](new KeyboardEvent('keyup', { key: 'Enter' }));
 
-        expect(closeSpy).toHaveBeenCalled();
-    });
+            expect(setActiveSpy).toHaveBeenCalledWith(true, menuItems.first);
+        });
 
-    it('should focus next available element on arrow up', () => {
-        fixture.componentInstance.disabled = true;
-        fixture.detectChanges();
-        const menuItemsArray = menuItems.toArray();
-        const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+        it('should focus first child on Space/Enter when item has submenu', fakeAsync(() => {
+            const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
 
-        menuService.focusedNode = menuService.menuMap.get(menuItemsArray[2]);
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+            menuService.focusedNode = menuService.menuMap.get(menuItems.first);
 
-        expect(setFocusedSpy).toHaveBeenCalledWith(menuItemsArray[0]);
-    });
+            menuService['_handleKeyup'](new KeyboardEvent('keyup', { key: 'Enter' }));
 
-    it('should focus next available element on arrow down', () => {
-        fixture.componentInstance.disabled = true;
-        fixture.detectChanges();
-        const menuItemsArray = menuItems.toArray();
-        const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+            tick();
 
-        menuService.focusedNode = menuService.menuMap.get(menuItemsArray[0]);
-        menuService['_handleKey'](new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+            expect(setFocusedSpy).toHaveBeenCalledWith(nestedMenuItem);
+        }));
 
-        expect(setFocusedSpy).toHaveBeenCalledWith(menuItemsArray[2]);
+        it('should not focus child on Space/Enter when item has no submenu', fakeAsync(() => {
+            const setFocusedSpy = jest.spyOn(menuService, 'setFocused');
+
+            menuService.focusedNode = menuService.menuMap.get(menuItems.last);
+
+            menuService['_handleKeyup'](new KeyboardEvent('keyup', { key: 'Enter' }));
+
+            tick();
+
+            expect(setFocusedSpy).not.toHaveBeenCalled();
+        }));
+
+        it('should do nothing when no item is focused', () => {
+            const clickSpy = jest.spyOn(menuItems.first, 'click');
+
+            menuService.focusedNode = undefined;
+
+            menuService['_handleKeyup'](new KeyboardEvent('keyup', { key: 'Enter' }));
+
+            expect(clickSpy).not.toHaveBeenCalled();
+        });
     });
 });

--- a/libs/core/menu/services/menu.service.ts
+++ b/libs/core/menu/services/menu.service.ts
@@ -33,7 +33,10 @@ export class MenuService implements OnDestroy {
     private _menuComponent: MenuComponent;
 
     /** @hidden */
-    private _destroyKeyboardHandlerListener: () => void;
+    private _destroyKeyDownHandlerListener: () => void;
+
+    /** @hidden */
+    private _destroyKeyUpHandlerListener: () => void;
 
     /** @hidden */
     private readonly _renderer = inject(Renderer2);
@@ -134,8 +137,11 @@ export class MenuService implements OnDestroy {
 
     /** Removes Menu keyboard support */
     removeKeyboardSupport(): void {
-        if (this._destroyKeyboardHandlerListener) {
-            this._destroyKeyboardHandlerListener();
+        if (this._destroyKeyDownHandlerListener) {
+            this._destroyKeyDownHandlerListener();
+        }
+        if (this._destroyKeyUpHandlerListener) {
+            this._destroyKeyUpHandlerListener();
         }
     }
 
@@ -235,20 +241,20 @@ export class MenuService implements OnDestroy {
 
     /** @hidden Adds keyboard support */
     private _setKeyboardSupport(elementRef: ElementRef): void {
-        this._destroyKeyboardHandlerListener = this._renderer.listen(
+        this._destroyKeyDownHandlerListener = this._renderer.listen(
             elementRef.nativeElement,
             'keydown',
-            (event: KeyboardEvent) => this._handleKey(event)
+            (event: KeyboardEvent) => this._handleKeydown(event)
+        );
+        this._destroyKeyUpHandlerListener = this._renderer.listen(
+            elementRef.nativeElement,
+            'keyup',
+            (event: KeyboardEvent) => this._handleKeyup(event)
         );
     }
 
-    /** @hidden */
-    private _handleKey(event: KeyboardEvent): void {
-        const focusRight = (node): void => {
-            setTimeout(() => this.setFocused(node.children[0].item));
-        };
-        let matched = true;
-
+    /** @hidden Handles keydown events: navigation and scroll prevention for Space/Enter */
+    private _handleKeydown(event: KeyboardEvent): void {
         if (!this.focusedNode) {
             return;
         }
@@ -259,7 +265,7 @@ export class MenuService implements OnDestroy {
         ) {
             if (this.focusedNode?.children.length) {
                 this.setActive(true, this.focusedNode.item);
-                focusRight(this.focusedNode);
+                setTimeout(() => this.setFocused(this.focusedNode!.children[0].item));
             }
         } else if (
             (KeyUtil.isKeyCode(event, LEFT_ARROW) && !this._isRtl) ||
@@ -279,20 +285,28 @@ export class MenuService implements OnDestroy {
             if (closest) {
                 this.setFocused(closest.item);
             }
-        } else if (KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
+        } else if (KeyUtil.isKeyCode(event, ESCAPE) && this.menuComponent.closeOnEscapeKey()) {
+            this.menuComponent.close();
+        } else if (!KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
+            return;
+        }
+
+        event.preventDefault();
+    }
+
+    /** @hidden Handles keyup events: activates focused item on Space/Enter (WCAG: activate on key release) */
+    private _handleKeyup(event: KeyboardEvent): void {
+        if (!this.focusedNode) {
+            return;
+        }
+
+        if (KeyUtil.isKeyCode(event, [SPACE, ENTER])) {
             const focusedNode = this.focusedNode;
             this.setActive(true, focusedNode?.item);
             focusedNode.item?.click();
-            if (focusedNode.children.length) {
-                focusRight(focusedNode);
+            if (focusedNode?.children.length) {
+                setTimeout(() => this.setFocused(focusedNode.children[0].item));
             }
-        } else if (KeyUtil.isKeyCode(event, ESCAPE) && this.menuComponent.closeOnEscapeKey()) {
-            this.menuComponent.close();
-        } else {
-            matched = false;
-        }
-
-        if (matched) {
             event.preventDefault();
         }
     }

--- a/libs/docs/core/menu/examples/menu-placement-example.component.ts
+++ b/libs/docs/core/menu/examples/menu-placement-example.component.ts
@@ -78,6 +78,27 @@ type PlacementOption =
             </fd-menu>
         </div>
 
+        <h4 class="fd-title fd-title--h5 fd-margin-top--md fd-margin-bottom--sm">Keyboard Activation (keyup fix)</h4>
+        <p class="fd-margin-bottom--sm">
+            Open the menu, navigate with arrow keys, then press <kbd>Space</kbd> or <kbd>Enter</kbd>. Activation should
+            fire on key <strong>release</strong>, not key press.
+        </p>
+        <div class="sap-flex sap-flex--gap-small sap-flex--align-items-center sap-margin-bottom-small">
+            <button fd-button label="Open (keyup test)" [fdMenuTrigger]="keyupTestMenu"></button>
+            <span style="font-size: 0.875rem; color: var(--sapContent_LabelColor)"
+                >Last event: <strong>{{ lastEvent() || '—' }}</strong></span
+            >
+        </div>
+        <fd-menu #keyupTestMenu>
+            @for (item of testItems; track item) {
+                <li fd-menu-item>
+                    <a (click)="onItemClick(item, $event)" fd-menu-interactive>
+                        <span fd-menu-title>{{ item }}</span>
+                    </a>
+                </li>
+            }
+        </fd-menu>
+
         <h4 class="fd-title fd-title--h5 fd-margin-top--md fd-margin-bottom--sm">Trigger Modes</h4>
         <p class="fd-margin-bottom--sm">
             The <code>[triggers]</code> input controls how the menu opens. Default is <code>['click']</code>.
@@ -152,4 +173,12 @@ export class MenuPlacementExampleComponent {
 
     /** Whether to prevent position flipping at viewport edges */
     fixedPosition = false;
+
+    readonly testItems = ['Alpha', 'Beta', 'Gamma'];
+
+    lastEvent = signal('');
+
+    onItemClick(item: string, event: MouseEvent): void {
+        this.lastEvent.set(`click on "${item}" (isTrusted: ${event.isTrusted})`);
+    }
 }


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14094

## Description

### Problem

Menu items in `fd-menu` were activated on `keydown` (Space/Enter), violating accessibility standard ACC-270.16 (Level A). This also caused a conflict when both `(click)` and `(keyup)` bindings were set on a menu item — the keyup handler would not fire as expected.

### Changes

**`MenuService`**

- Split the single `_handleKey` method into `_handleKeydown` and `_handleKeyup`.
- `_handleKeydown` now only calls `event.preventDefault()` for Space/Enter (to suppress page scroll), without activating the item.
- New `_handleKeyup` performs the actual activation — `setActive()` + `click()` + optional submenu focus — on key release, matching standard button behaviour and WCAG guidelines.
- Refactored the `matched` flag pattern to an early-return approach, removing the empty `else if` branch.
- Both listeners are registered and cleaned up correctly via `_destroyKeyDownHandlerListener` / `_destroyKeyUpHandlerListener`.

**Tests**

- Reorganised keyboard tests into `describe('_handleKeydown')` and `describe('_handleKeyup')` blocks.
- Added tests covering all `_handleKeyup` behaviours: Enter/Space activation, `setActive` call, submenu focus with `setTimeout`, no-op when unfocused, and no activation on keydown.
- Added `describe('removeKeyboardSupport')` tests: destroy listeners are called, safe to call before keyboard support is added.
- Removed a duplicate test that existed in the original spec.

**Docs example**

- Added a temporary "Keyboard Activation" section to `menu-placement-example` with a visible last-event display, to allow manual verification of the keyup fix. To be reverted before merge.

