### PR TITLE
fix(core): match fundamental-styles combobox group styling

### DIFF
--- a/libs/core/combobox/combobox.component.html
+++ b/libs/core/combobox/combobox.component.html
@@ -117,59 +117,70 @@
     </div>
 </ng-template>
 <ng-template #listTemplate>
-    <ul
-        fd-list
-        class="fd-combobox-custom-list"
-        [dropdownMode]="true"
-        [id]="comboboxId + '-result'"
-        role="listbox"
-        [attr.aria-labelledby]="comboboxId + '-search'"
-        [style.maxHeight]="!mobile && maxHeight"
-        [hasMessage]="listMessages && listMessages.length > 0"
-        [byline]="byline"
-        [tabindex]="0"
-        (keydown.tab)="_close()"
-        (keydown.shift.tab)="_close()"
-        (focusEscapeList)="handleListFocusEscape($event)"
-    >
-        <ng-content></ng-content>
-        @if (groupFn) {
+    @if (groupFn) {
+        <div
+            class="fd-combobox-custom-list"
+            [style.maxHeight]="!mobile && maxHeight"
+            (keydown.tab)="_close()"
+            (keydown.shift.tab)="_close()"
+        >
+            <ng-content></ng-content>
             @for (group of displayedValues | listGroupPipe: groupFn; track group.key; let groupIndex = $index) {
-                <li
-                    fd-list-item
-                    fd-list-group-header
-                    ariaRole="group"
-                    [attr.aria-roledescription]="('coreMultiComboBox.listGroupHeader' | fdTranslate)()"
-                    [attr.aria-owns]="_getGroupItemIds(groupIndex)"
-                    [attr.aria-label]="group.key"
-                >
+                <label class="fd-list__group-header" [id]="comboboxId + '-group-header-' + groupIndex">
                     <span fd-list-title>{{ group.key }}</span>
-                </li>
-                @for (term of group.value; track $index; let index = $index) {
-                    <li
-                        fd-list-item
-                        #item="fdListItem"
-                        ariaRole="option"
-                        [attr.aria-placeholder]="group.key"
-                        [attr.aria-setsize]="group.value.length"
-                        [attr.aria-posinset]="index + 1"
-                        [attr.id-with-group-index]="item.id + '-group-' + groupIndex"
-                        class="fd-combobox-list-item"
-                        [selected]="isSelected(term)"
-                        [value]="term"
-                        (keydown)="onItemKeyDownHandler($event, term)"
-                        (mousedown)="_itemMousedown = true"
-                        (click)="onMenuClickHandler(term)"
-                        (focus)="onItemFocused(term)"
-                    >
-                        <ng-template
-                            [ngTemplateOutlet]="itemSource"
-                            [ngTemplateOutletContext]="{ term: term }"
-                        ></ng-template>
-                    </li>
-                }
+                </label>
+                <ul
+                    fd-list
+                    [dropdownMode]="true"
+                    [id]="comboboxId + '-result-' + groupIndex"
+                    role="listbox"
+                    [attr.aria-labelledby]="comboboxId + '-group-header-' + groupIndex"
+                    [hasMessage]="listMessages && listMessages.length > 0"
+                    [byline]="byline"
+                    [tabindex]="groupIndex === 0 ? 0 : -1"
+                    (focusEscapeList)="handleListFocusEscape($event)"
+                >
+                    @for (term of group.value; track $index; let index = $index) {
+                        <li
+                            fd-list-item
+                            ariaRole="option"
+                            [attr.aria-placeholder]="group.key"
+                            [attr.aria-setsize]="group.value.length"
+                            [attr.aria-posinset]="index + 1"
+                            class="fd-combobox-list-item"
+                            [selected]="isSelected(term)"
+                            [value]="term"
+                            (keydown)="onItemKeyDownHandler($event, term)"
+                            (mousedown)="_itemMousedown = true"
+                            (click)="onMenuClickHandler(term)"
+                            (focus)="onItemFocused(term)"
+                        >
+                            <ng-template
+                                [ngTemplateOutlet]="itemSource"
+                                [ngTemplateOutletContext]="{ term: term }"
+                            ></ng-template>
+                        </li>
+                    }
+                </ul>
             }
-        } @else {
+        </div>
+    } @else {
+        <ul
+            fd-list
+            class="fd-combobox-custom-list"
+            [dropdownMode]="true"
+            [id]="comboboxId + '-result'"
+            role="listbox"
+            [attr.aria-labelledby]="comboboxId + '-search'"
+            [style.maxHeight]="!mobile && maxHeight"
+            [hasMessage]="listMessages && listMessages.length > 0"
+            [byline]="byline"
+            [tabindex]="0"
+            (keydown.tab)="_close()"
+            (keydown.shift.tab)="_close()"
+            (focusEscapeList)="handleListFocusEscape($event)"
+        >
+            <ng-content></ng-content>
             @for (term of displayedValues; track $index) {
                 <li
                     fd-list-item
@@ -189,6 +200,6 @@
                     ></ng-template>
                 </li>
             }
-        }
-    </ul>
+        </ul>
+    }
 </ng-template>

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -30,7 +30,6 @@ import {
     SimpleChanges,
     TemplateRef,
     ViewChild,
-    ViewChildren,
     ViewContainerRef,
     ViewEncapsulation,
     forwardRef,
@@ -69,7 +68,6 @@ import { InputGroupComponent, InputGroupInputDirective } from '@fundamental-ngx/
 import {
     FD_LIST_MESSAGE_DIRECTIVE,
     ListComponent,
-    ListGroupHeaderDirective,
     ListItemComponent,
     ListMessageDirective,
     ListTitleDirective
@@ -132,7 +130,6 @@ let comboboxUniqueId = 0;
         ListComponent,
         ListItemComponent,
         ListTitleDirective,
-        ListGroupHeaderDirective,
         InputGroupComponent,
         InputGroupInputDirective,
         FormsModule,
@@ -411,10 +408,6 @@ export class ComboboxComponent<T = any>
     /** @hidden */
     @ContentChild(ComboboxItemDirective)
     private readonly _comboboxItemRenderer: ComboboxItemDirective;
-
-    /** @hidden */
-    @ViewChildren('item', { read: ElementRef })
-    private readonly items: QueryList<ElementRef>;
 
     /** When communicateByObject is true, specifies which property of the selected object
      * should be used as the form control value. If not specified, the entire object is returned.
@@ -806,23 +799,6 @@ export class ComboboxComponent<T = any>
     isSelected(term: any): boolean {
         const termValue = this.communicateByObject ? term : this.displayFn(term);
         return this.getValue() === termValue;
-    }
-
-    /** @hidden */
-    _getGroupItemIds(groupIndex: number): string {
-        if (!this.items?.length) {
-            return '';
-        }
-
-        const groupItemIds = this.items
-            .filter((el) => {
-                const idWithGroup = el.nativeElement.getAttribute('id-with-group-index');
-                const groupIdx = idWithGroup.split('-')[idWithGroup.split('-').length - 1];
-                return groupIdx === String(groupIndex);
-            })
-            .map((el) => el.nativeElement.getAttribute('id'));
-
-        return groupItemIds?.join(' ');
     }
 
     /** Method that picks other value moved from current one by offset, called only when combobox is closed */


### PR DESCRIPTION
## Related Issue(s)

Closes https://github.com/SAP/fundamental-ngx/issues/14010

## Description

The combobox with groups (`[groupFn]`) was rendering incorrect HTML — all group headers and items were placed inside a single flat `<ul role="listbox">`, which violated the fundamental-styles reference markup and produced invalid HTML (`<label>` and nested `<ul>` are not valid children of `<ul>`).

This PR restructures the grouped combobox dropdown to match the [fundamental-styles combobox grouped pattern](https://fundamental-styles.netlify.app/?path=/docs/sap-design-patterns-combobox-input--docs#two-items-and-items-grouping-1), where each group is a separate `<label>` + `<ul role="listbox">` pair inside a wrapper `<div>`.

### What changed

**Template (`combobox.component.html`):**

- **Separated grouped and ungrouped paths** — the `@if (groupFn)` / `@else` is now the top-level branch in `#listTemplate`, instead of being nested inside a single `<ul>`.
- **Grouped path** uses a `<div class="fd-combobox-custom-list">` wrapper containing per-group `<label class="fd-list__group-header">` + `<ul fd-list role="listbox">` pairs. This matches fundamental-styles reference HTML.
- **Ungrouped path** is unchanged — still a single `<ul fd-list role="listbox">`.
- Removed `fd-list-group-header` directive and `ariaRole="group"` / `aria-owns` / `aria-roledescription` from group headers — replaced by `<label id="...">` with `aria-labelledby` on each `<ul>`.
- Removed `#item="fdListItem"` template ref and `[attr.id-with-group-index]` from list items — no longer needed since `aria-owns` is removed.

**Component TS (`combobox.component.ts`):**

- Removed `_getGroupItemIds(groupIndex)` method — was building space-separated item IDs for `aria-owns`, no longer needed since items are now direct DOM children of their `<ul>`.
- Removed `@ViewChildren('item', { read: ElementRef })` — was only used by `_getGroupItemIds()`.
- Removed `ViewChildren` import from `@angular/core` (no longer used).
- Removed `ListGroupHeaderDirective` from imports (no longer used in template).

### Relationship to PR #13494

PR #13494 ("List: Group label not read") added a11y improvements for grouped combobox using the **SAPUI5 pattern**: a flat `<ul>` with `<li role="group" aria-owns="...">` group headers. This PR replaces that pattern with the **fundamental-styles pattern** for the combobox component only.

Every a11y goal from #13494 is preserved or achieved equivalently:

| #13494 feature | This PR | Notes |
|---|---|---|
| Group label read by screen readers | **Preserved** | `<label>` + `aria-labelledby` on `<ul>` — screen reader announces "Fruits, listbox" |
| `aria-setsize` / `aria-posinset` per group | **Preserved** | Still on each `<li role="option">` with correct per-group counts |
| `aria-placeholder` identifying group | **Preserved** | Still on each option |
| `role="group"` + `aria-owns` on header | **Replaced** | Not needed — items are direct DOM children of their `<ul role="listbox">` |
| `aria-roledescription` on header | **Removed** | Not needed — `<ul role="listbox" aria-labelledby>` is self-describing |
| `_getGroupItemIds()` + `ViewChildren` | **Removed** | Were only needed for `aria-owns` calculation |
| `id-with-group-index` attribute | **Removed** | Was only used by `_getGroupItemIds()` |
| `tabindex` on list level | **Preserved** | First `<ul>` gets `tabindex="0"`, rest get `tabindex="-1"` |
| `exportAs: 'fdListItem'` on ListItemComponent | **Untouched** | Still in `list-item.component.ts`, still used by `multi-combobox` |
| i18n key `coreMultiComboBox.listGroupHeader` | **Untouched** | Still used by `multi-combobox`, still in all translation files |

**`multi-combobox` is not affected** — it still uses the original UI5 pattern from #13494.

### Why `<div>` wrapper instead of `<ul>`

HTML spec requires `<ul>` to only contain `<li>` children. The grouped pattern needs `<label>` elements and nested `<ul>` elements as siblings, which is invalid inside a `<ul>`. A `<div>` wrapper is semantically correct and matches the fundamental-styles reference (`<div class="fd-popover__wrapper">`). The `fd-popover__wrapper` class is not added to this `<div>` because the `<fd-popover-body>` component already wraps projected content in `<div class="fd-popover__wrapper">`.

### Rendered a11y tree (verified in browser)

```
label "Fruits" (id: fd-combobox-19-group-header-0)
listbox "Fruits" (aria-labelledby → fd-combobox-19-group-header-0)
  option "Apple"   (aria-setsize=4, aria-posinset=1, aria-selected=false)
  option "Banana"  (aria-setsize=4, aria-posinset=2, aria-selected=false)
  option "Pineapple" (aria-setsize=4, aria-posinset=3, aria-selected=false)
  option "Strawberry" (aria-setsize=4, aria-posinset=4, aria-selected=false)
label "Vegetables" (id: fd-combobox-19-group-header-1)
listbox "Vegetables" (aria-labelledby → fd-combobox-19-group-header-1)
  option "Broccoli" (aria-setsize=4, aria-posinset=1, aria-selected=false)
  option "Carrot"   (aria-setsize=4, aria-posinset=2, aria-selected=false)
  option "Jalapeño" (aria-setsize=4, aria-posinset=3, aria-selected=false)
  option "Spinach"  (aria-setsize=4, aria-posinset=4, aria-selected=false)
```

### Pre-existing a11y issues (not introduced by this PR)

These affect all combobox variants and are out of scope:

1. **`aria-expanded` evaluates to item count** — `[attr.aria-expanded]="!mobile && open && displayedValues.length"` produces `aria-expanded="8"` instead of `"true"`. Should use `displayedValues.length > 0`.
2. **Live region lacks `aria-live`** — the result count `<div>` is linked via `aria-describedby` but has no `aria-live="polite"` for dynamic announcements.

## Screenshots

Before (flat `<ul>` with invalid nesting):
- Group headers rendered as `<li role="group">` inside single `<ul role="listbox">`
- `<label>` and nested `<ul>` would be invalid children

After (per-group `<label>` + `<ul>` pairs):
- Each group is a `<label class="fd-list__group-header">` followed by `<ul role="listbox" aria-labelledby="...">`
- Matches fundamental-styles reference markup exactly