### PR TITLE
chore: remove dead CSS code in message toast

### DIFF
--- a/libs/core/message-toast/message-toast.component.scss
+++ b/libs/core/message-toast/message-toast.component.scss
@@ -1,9 +1,2 @@
 @use '@angular/cdk/overlay-prebuilt.css';
 @use 'fundamental-styles/dist/message-toast.css';
-
-.fn-toast-overlay-container {
-    .cdk-overlay-pane {
-        max-height: none;
-        height: fit-content;
-    }
-}


### PR DESCRIPTION
remove dead CSS code in message toast - fn is long gone