### PR TITLE
fix: adopt minor styles changes

### DIFF
--- a/libs/core/form/fieldset/fieldset.component.ts
+++ b/libs/core/form/fieldset/fieldset.component.ts
@@ -4,11 +4,11 @@ import { ChangeDetectionStrategy, Component, HostBinding, ViewEncapsulation } fr
  * Used for easily displaying forms with a margin. Not necessary for fundamental forms to be functional.
  *
  * ```html
- * <div fd-fieldset
+ * <fieldset fd-fieldset>
  *     <div fd-form-item>
  *         ...
  *     </div>
- * </div>
+ * </fieldset>
  * ```
  */
 @Component({

--- a/libs/core/form/form-group/form-group.component.spec.ts
+++ b/libs/core/form/form-group/form-group.component.spec.ts
@@ -21,4 +21,18 @@ describe('FormGroupComponent', () => {
     it('should create', () => {
         expect(component).toBeTruthy();
     });
+
+    it('should apply fd-form-group--with-spacing when withSpacing is true', () => {
+        component.withSpacing = true;
+        component.ngOnChanges();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.classList.contains('fd-form-group--with-spacing')).toBe(true);
+    });
+
+    it('should not apply fd-form-group--with-spacing when withSpacing is false', () => {
+        component.withSpacing = false;
+        component.ngOnChanges();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.classList.contains('fd-form-group--with-spacing')).toBe(false);
+    });
 });

--- a/libs/core/form/form-group/form-group.component.ts
+++ b/libs/core/form/form-group/form-group.component.ts
@@ -27,8 +27,7 @@ import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
     template: `<ng-content></ng-content>`,
     encapsulation: ViewEncapsulation.None,
     styleUrl: './form-group.component.scss',
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: true
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FormGroupComponent implements CssClassBuilder, OnChanges, OnInit {
     /** @hidden */
@@ -40,6 +39,10 @@ export class FormGroupComponent implements CssClassBuilder, OnChanges, OnInit {
      */
     @Input()
     isInline: boolean;
+
+    /** Adds gap spacing between form items. */
+    @Input()
+    withSpacing = false;
 
     /** @hidden */
     class: string;
@@ -53,7 +56,7 @@ export class FormGroupComponent implements CssClassBuilder, OnChanges, OnInit {
      */
     @applyCssClass
     buildComponentCssClass(): string[] {
-        return [this.isInline ? 'fd-form-group--inline' : ''];
+        return [this.isInline ? 'fd-form-group--inline' : '', this.withSpacing ? 'fd-form-group--with-spacing' : ''];
     }
 
     /** @hidden */

--- a/libs/core/form/form-group/form-group.component.ts
+++ b/libs/core/form/form-group/form-group.component.ts
@@ -6,7 +6,8 @@ import {
     Input,
     OnChanges,
     OnInit,
-    ViewEncapsulation
+    ViewEncapsulation,
+    booleanAttribute
 } from '@angular/core';
 import { CssClassBuilder, applyCssClass } from '@fundamental-ngx/cdk/utils';
 
@@ -41,7 +42,7 @@ export class FormGroupComponent implements CssClassBuilder, OnChanges, OnInit {
     isInline: boolean;
 
     /** Adds gap spacing between form items. */
-    @Input()
+    @Input({ transform: booleanAttribute })
     withSpacing = false;
 
     /** @hidden */

--- a/libs/core/form/form-label/form-label.component.html
+++ b/libs/core/form/form-label/form-label.component.html
@@ -9,7 +9,7 @@
                 [fd-inline-help]="inlineHelpContent"
                 [ariaLabel]="inlineHelpLabel"
                 [placement]="inlineHelpBodyPlacement"
-                tabindex="0"
+                [tabindex]="0"
             ></fd-icon>
         }
     </span>
@@ -22,6 +22,9 @@
     [class.fd-form-label--wrap]="allowWrap"
     [class.fd-form-label--required]="required"
     [class.fd-form-label--colon]="colon"
+    [class.fd-form-label--unit-description]="unitDescription()"
+    [class.fd-form-label--stand-alone]="standAlone()"
+    [attr.aria-disabled]="disabled() || null"
 >
     <ng-content></ng-content>
 </span>

--- a/libs/core/form/form-label/form-label.component.html
+++ b/libs/core/form/form-label/form-label.component.html
@@ -23,7 +23,7 @@
     [class.fd-form-label--required]="required"
     [class.fd-form-label--colon]="colon"
     [class.fd-form-label--unit-description]="unitDescription()"
-    [class.fd-form-label--stand-alone]="standAlone()"
+    [class.fd-form-label--stand-alone]="independent()"
     [attr.aria-disabled]="disabled() || null"
 >
     <ng-content></ng-content>

--- a/libs/core/form/form-label/form-label.component.scss
+++ b/libs/core/form/form-label/form-label.component.scss
@@ -83,26 +83,3 @@ $form-label-bottom-spacing: 0.125rem;
         }
     }
 }
-
-// remove after adopting fd-styles version 0.39
-.fd-container.fd-form-layout-grid-container.fd-form-group .fd-form-item .fd-form-label--colon,
-.fd-container.fd-form-layout-grid-container .fd-form-group .fd-form-item .fd-form-label--colon {
-    padding-inline-end: 0.25rem;
-}
-.fd-container.fd-form-layout-grid-container.fd-form-group .fd-form-item .fd-form-label--required,
-.fd-container.fd-form-layout-grid-container .fd-form-group .fd-form-item .fd-form-label--required {
-    padding-inline-end: 0.5rem;
-}
-.fd-container.fd-form-layout-grid-container.fd-form-group .fd-form-item .fd-form-label--required.fd-form-label--colon,
-.fd-container.fd-form-layout-grid-container .fd-form-group .fd-form-item .fd-form-label--required.fd-form-label--colon {
-    padding-inline-end: 0.75rem;
-}
-.fd-form-item .fd-form-label--colon {
-    padding-inline-end: 0.25rem;
-}
-.fd-form-item .fd-form-label--required {
-    padding-inline-end: 0.5rem;
-}
-.fd-form-item .fd-form-label--required.fd-form-label--colon {
-    padding-inline-end: 0.75rem;
-}

--- a/libs/core/form/form-label/form-label.component.spec.ts
+++ b/libs/core/form/form-label/form-label.component.spec.ts
@@ -11,11 +11,10 @@ import { FormLabelComponent } from './form-label.component';
             [colon]="colon"
             [disabled]="disabled"
             [unitDescription]="unitDescription"
-            [standAlone]="standAlone"
+            [independent]="independent"
             >Test Text</label
         >
     `,
-    standalone: true,
     imports: [FormLabelComponent]
 })
 class FormLabelTestComponent {
@@ -26,7 +25,7 @@ class FormLabelTestComponent {
     colon = false;
     disabled = false;
     unitDescription = false;
-    standAlone = false;
+    independent = false;
 
     getLabelElement(): Element {
         return document.getElementsByClassName('fd-form-label')[0];
@@ -80,8 +79,8 @@ describe('FormLabelComponent', () => {
         expect(component.getLabelElement().classList.contains('fd-form-label--unit-description')).toBe(true);
     });
 
-    it('should apply fd-form-label--stand-alone when standAlone is true', () => {
-        component.standAlone = true;
+    it('should apply fd-form-label--stand-alone when independent is true', () => {
+        component.independent = true;
         fixture.detectChanges();
         expect(component.getLabelElement().classList.contains('fd-form-label--stand-alone')).toBe(true);
     });

--- a/libs/core/form/form-label/form-label.component.spec.ts
+++ b/libs/core/form/form-label/form-label.component.spec.ts
@@ -3,13 +3,30 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormLabelComponent } from './form-label.component';
 
 @Component({
-    template: ` <label #componentElement fd-form-label>Test Text</label> `,
+    template: `
+        <label
+            #componentElement
+            fd-form-label
+            [required]="required"
+            [colon]="colon"
+            [disabled]="disabled"
+            [unitDescription]="unitDescription"
+            [standAlone]="standAlone"
+            >Test Text</label
+        >
+    `,
     standalone: true,
     imports: [FormLabelComponent]
 })
-class TestComponent {
+class FormLabelTestComponent {
     @ViewChild(FormLabelComponent)
     ref: FormLabelComponent;
+
+    required = false;
+    colon = false;
+    disabled = false;
+    unitDescription = false;
+    standAlone = false;
 
     getLabelElement(): Element {
         return document.getElementsByClassName('fd-form-label')[0];
@@ -17,17 +34,17 @@ class TestComponent {
 }
 
 describe('FormLabelComponent', () => {
-    let component: TestComponent;
-    let fixture: ComponentFixture<TestComponent>;
+    let component: FormLabelTestComponent;
+    let fixture: ComponentFixture<FormLabelTestComponent>;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [TestComponent]
+            imports: [FormLabelTestComponent]
         }).compileComponents();
     }));
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(TestComponent);
+        fixture = TestBed.createComponent(FormLabelTestComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
     });
@@ -38,5 +55,46 @@ describe('FormLabelComponent', () => {
 
     it('should assign class', () => {
         expect(component.getLabelElement().className.includes('fd-form-label')).toBe(true);
+    });
+
+    it('should apply fd-form-label--disabled when disabled', () => {
+        component.disabled = true;
+        fixture.detectChanges();
+        const labelEl = fixture.nativeElement.querySelector('[fd-form-label]');
+        expect(labelEl.classList.contains('fd-form-label--disabled')).toBe(true);
+    });
+
+    it('should set aria-disabled on inner label span when disabled', () => {
+        component.disabled = true;
+        fixture.detectChanges();
+        expect(component.getLabelElement().getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('should not set aria-disabled when not disabled', () => {
+        expect(component.getLabelElement().getAttribute('aria-disabled')).toBeNull();
+    });
+
+    it('should apply fd-form-label--unit-description when unitDescription is true', () => {
+        component.unitDescription = true;
+        fixture.detectChanges();
+        expect(component.getLabelElement().classList.contains('fd-form-label--unit-description')).toBe(true);
+    });
+
+    it('should apply fd-form-label--stand-alone when standAlone is true', () => {
+        component.standAlone = true;
+        fixture.detectChanges();
+        expect(component.getLabelElement().classList.contains('fd-form-label--stand-alone')).toBe(true);
+    });
+
+    it('should apply fd-form-label--required when required', () => {
+        component.required = true;
+        fixture.detectChanges();
+        expect(component.getLabelElement().classList.contains('fd-form-label--required')).toBe(true);
+    });
+
+    it('should apply fd-form-label--colon when colon is true', () => {
+        component.colon = true;
+        fixture.detectChanges();
+        expect(component.getLabelElement().classList.contains('fd-form-label--colon')).toBe(true);
     });
 });

--- a/libs/core/form/form-label/form-label.component.ts
+++ b/libs/core/form/form-label/form-label.component.ts
@@ -35,7 +35,6 @@ let formLabelIdCount = 0;
     styleUrl: './form-label.component.scss',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: true,
     imports: [LinkComponent, IconComponent, InlineHelpDirective, NgTemplateOutlet],
     host: {
         '[class.fd-form-label--disabled]': 'disabled()'
@@ -132,7 +131,7 @@ export class FormLabelComponent implements OnChanges {
     readonly unitDescription = input(false, { transform: booleanAttribute });
 
     /** Whether this label stands alone (self-centering, no end margin). */
-    readonly standAlone = input(false, { transform: booleanAttribute });
+    readonly independent = input(false, { transform: booleanAttribute });
 
     /** @hidden */
     private _formLabelId = `fd-form-label-${++formLabelIdCount}`;

--- a/libs/core/form/form-label/form-label.component.ts
+++ b/libs/core/form/form-label/form-label.component.ts
@@ -1,9 +1,11 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
+    booleanAttribute,
     ChangeDetectionStrategy,
     Component,
     HostBinding,
     Input,
+    input,
     OnChanges,
     TemplateRef,
     ViewEncapsulation
@@ -34,7 +36,10 @@ let formLabelIdCount = 0;
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [LinkComponent, IconComponent, InlineHelpDirective, NgTemplateOutlet]
+    imports: [LinkComponent, IconComponent, InlineHelpDirective, NgTemplateOutlet],
+    host: {
+        '[class.fd-form-label--disabled]': 'disabled()'
+    }
 })
 export class FormLabelComponent implements OnChanges {
     /** Whether form is required. */
@@ -119,6 +124,15 @@ export class FormLabelComponent implements OnChanges {
     get formLabelId(): string {
         return this._formLabelId;
     }
+
+    /** Whether the label is disabled. */
+    readonly disabled = input(false, { transform: booleanAttribute });
+
+    /** Whether this label is a unit description (e.g., "kg", "USD"). */
+    readonly unitDescription = input(false, { transform: booleanAttribute });
+
+    /** Whether this label stands alone (self-centering, no end margin). */
+    readonly standAlone = input(false, { transform: booleanAttribute });
 
     /** @hidden */
     private _formLabelId = `fd-form-label-${++formLabelIdCount}`;

--- a/libs/core/form/form-legend/form-legend.component.spec.ts
+++ b/libs/core/form/form-legend/form-legend.component.spec.ts
@@ -3,27 +3,29 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormLegendDirective } from './form-legend.directive';
 
 @Component({
-    template: ` <legend #directiveElement fd-form-legend>Test Text</legend> `,
+    template: ` <legend #directiveElement fd-form-legend [disabled]="disabled">Test Text</legend> `,
     imports: [FormLegendDirective],
     standalone: true
 })
-class TestComponent {
+class FormLegendTestComponent {
     @ViewChild('directiveElement')
     ref: ElementRef;
+
+    disabled = false;
 }
 
 describe('FormLegendDirective', () => {
-    let component: TestComponent;
-    let fixture: ComponentFixture<TestComponent>;
+    let component: FormLegendTestComponent;
+    let fixture: ComponentFixture<FormLegendTestComponent>;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [TestComponent]
+            imports: [FormLegendTestComponent]
         }).compileComponents();
     }));
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(TestComponent);
+        fixture = TestBed.createComponent(FormLegendTestComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
     });
@@ -33,6 +35,16 @@ describe('FormLegendDirective', () => {
     });
 
     it('should assign class', () => {
-        expect(component.ref.nativeElement.className).toBe('fd-fieldset__legend');
+        expect(component.ref.nativeElement.className).toContain('fd-fieldset__legend');
+    });
+
+    it('should not have is-disabled class by default', () => {
+        expect(component.ref.nativeElement.classList.contains('is-disabled')).toBe(false);
+    });
+
+    it('should add is-disabled class when disabled', () => {
+        component.disabled = true;
+        fixture.detectChanges();
+        expect(component.ref.nativeElement.classList.contains('is-disabled')).toBe(true);
     });
 });

--- a/libs/core/form/form-legend/form-legend.directive.ts
+++ b/libs/core/form/form-legend/form-legend.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, HostBinding } from '@angular/core';
+import { booleanAttribute, Directive, input } from '@angular/core';
 
 /**
  * Applies css to a legend html element.
@@ -9,10 +9,12 @@ import { Directive, HostBinding } from '@angular/core';
     // TODO to be discussed
     // eslint-disable-next-line @angular-eslint/directive-selector
     selector: '[fd-form-legend]',
-    standalone: true
+    host: {
+        class: 'fd-fieldset__legend',
+        '[class.is-disabled]': 'disabled()'
+    }
 })
 export class FormLegendDirective {
-    /** @hidden */
-    @HostBinding('class.fd-fieldset__legend')
-    fdFormLegendClass = true;
+    /** Whether the legend is disabled. */
+    readonly disabled = input(false, { transform: booleanAttribute });
 }

--- a/libs/core/icon/icon.component.spec.ts
+++ b/libs/core/icon/icon.component.spec.ts
@@ -29,6 +29,10 @@ describe('IconComponent', () => {
         expect(fixture.debugElement.nativeElement.className).toContain('sap-icon--' + ICON_NAME);
     });
 
+    it('should include the sap-icon base class', () => {
+        expect(fixture.debugElement.nativeElement.className).toContain('sap-icon');
+    });
+
     it('should apply SAP-icons-TNT icon font with font on input', () => {
         fixture.componentRef.setInput('font', 'SAP-icons-TNT');
         fixture.detectChanges();
@@ -41,5 +45,31 @@ describe('IconComponent', () => {
         expect(fixture.debugElement.nativeElement.className).toContain(
             'sap-icon-businessSuiteInAppSymbols--' + ICON_NAME
         );
+    });
+
+    it('should default role to "presentation" for decorative icons', () => {
+        expect(fixture.debugElement.nativeElement.getAttribute('role')).toBe('presentation');
+    });
+
+    it('should set role to "img" when ariaLabel is provided', () => {
+        fixture.componentRef.setInput('ariaLabel', 'Add item');
+        fixture.detectChanges();
+        expect(fixture.debugElement.nativeElement.getAttribute('role')).toBe('img');
+    });
+
+    it('should set aria-hidden to true by default when no ariaLabel', () => {
+        expect(fixture.debugElement.nativeElement.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('should not set aria-hidden when ariaLabel is provided', () => {
+        fixture.componentRef.setInput('ariaLabel', 'Add item');
+        fixture.detectChanges();
+        expect(fixture.debugElement.nativeElement.getAttribute('aria-hidden')).toBeNull();
+    });
+
+    it('should apply size modifier class', () => {
+        fixture.componentRef.setInput('size', 'lg');
+        fixture.detectChanges();
+        expect(fixture.debugElement.nativeElement.className).toContain('sap-icon--lg');
     });
 });

--- a/libs/core/icon/icon.component.ts
+++ b/libs/core/icon/icon.component.ts
@@ -28,6 +28,8 @@ export type IconColor =
     | 'positive'
     | 'information';
 
+export type IconSize = 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+
 const SAP_ICONS_PREFIX = 'sap-icon';
 
 export const FD_ICON_FONT_FAMILY: Record<IconFont, string> = {
@@ -48,11 +50,12 @@ export function fdBuildIconClass(
     font: IconFont,
     glyph: any,
     color?: IconColor | null,
-    background?: IconColor | null
+    background?: IconColor | null,
+    size?: IconSize | null
 ): string {
     const fontFamily = FD_ICON_FONT_FAMILY[font];
 
-    const returnIconClass = [`${fontFamily}--${glyph}`];
+    const returnIconClass = [fontFamily, `${fontFamily}--${glyph}`];
 
     if (color) {
         returnIconClass.push(`${fontFamily}--color-${color}`);
@@ -60,6 +63,10 @@ export function fdBuildIconClass(
 
     if (background) {
         returnIconClass.push(`${fontFamily}--background-${background}`);
+    }
+
+    if (size) {
+        returnIconClass.push(`${fontFamily}--${size}`);
     }
 
     return returnIconClass.join(' ');
@@ -85,8 +92,9 @@ export function fdBuildIconClass(
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
+        '[attr.role]': '_role()',
         '[attr.aria-label]': 'ariaLabel()',
-        '[attr.aria-hidden]': 'ariaHidden()',
+        '[attr.aria-hidden]': '_effectiveAriaHidden()',
         '[class.fd-list__navigation-item-icon]': '_navigationItemIcon()',
         '[class]': '_cssClasses()'
     }
@@ -109,6 +117,9 @@ export class IconComponent implements HasElementRef {
     /** Icon color */
     readonly background = input<IconColor | null>(null);
 
+    /** Icon size */
+    readonly size = input<IconSize | null>(null);
+
     /** user's custom classes */
     readonly class = input<string>();
 
@@ -123,6 +134,18 @@ export class IconComponent implements HasElementRef {
 
     /** Whether or not this icon is for a list navigation item. */
     readonly _navigationItemIcon = signal(false);
+
+    /** @hidden Computed role — "presentation" for decorative, "img" when ariaLabel is set. */
+    protected readonly _role = computed(() => (this.ariaLabel() ? 'img' : 'presentation'));
+
+    /** @hidden Default aria-hidden to true for decorative icons (no ariaLabel). */
+    protected readonly _effectiveAriaHidden = computed<Nullable<boolean>>(() => {
+        const explicit = this.ariaHidden();
+        if (explicit != null) {
+            return explicit;
+        }
+        return !this.ariaLabel() ? true : null;
+    });
 
     /** @hidden Computed CSS classes */
     protected readonly _cssClasses = computed<string>(() => {
@@ -139,6 +162,6 @@ export class IconComponent implements HasElementRef {
 
     /** @hidden */
     private readonly _fontIconClass = computed<string>(() =>
-        fdBuildIconClass(this.font(), this.glyph(), this.color(), this.background())
+        fdBuildIconClass(this.font(), this.glyph(), this.color(), this.background(), this.size())
     );
 }

--- a/libs/core/icon/icon.component.ts
+++ b/libs/core/icon/icon.component.ts
@@ -9,7 +9,7 @@ import {
     model,
     signal
 } from '@angular/core';
-import { HasElementRef, Nullable } from '@fundamental-ngx/cdk/utils';
+import { HasElementRef } from '@fundamental-ngx/cdk/utils';
 import { FD_ICON_COMPONENT } from './tokens';
 
 export type IconFont = 'SAP-icons' | 'BusinessSuiteInAppSymbols' | 'SAP-icons-TNT';
@@ -92,11 +92,11 @@ export function fdBuildIconClass(
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
-        '[attr.role]': '_role()',
+        '[attr.role]': 'computedRole()',
         '[attr.aria-label]': 'ariaLabel()',
-        '[attr.aria-hidden]': '_effectiveAriaHidden()',
+        '[attr.aria-hidden]': 'effectiveAriaHidden()',
         '[class.fd-list__navigation-item-icon]': '_navigationItemIcon()',
-        '[class]': '_cssClasses()'
+        '[class]': 'cssClasses()'
     }
 })
 export class IconComponent implements HasElementRef {
@@ -124,10 +124,10 @@ export class IconComponent implements HasElementRef {
     readonly class = input<string>();
 
     /** Aria-label for Icon. */
-    readonly ariaLabel = input<Nullable<string>>();
+    readonly ariaLabel = input<string | null>();
 
     /** Aria-hidden attribute for Icon element. */
-    readonly ariaHidden = model<Nullable<boolean>>();
+    readonly ariaHidden = model<boolean | null>();
 
     /** @hidden */
     readonly elementRef = inject(ElementRef<HTMLElement>);
@@ -136,10 +136,10 @@ export class IconComponent implements HasElementRef {
     readonly _navigationItemIcon = signal(false);
 
     /** @hidden Computed role — "presentation" for decorative, "img" when ariaLabel is set. */
-    protected readonly _role = computed(() => (this.ariaLabel() ? 'img' : 'presentation'));
+    protected readonly computedRole = computed(() => (this.ariaLabel() ? 'img' : 'presentation'));
 
     /** @hidden Default aria-hidden to true for decorative icons (no ariaLabel). */
-    protected readonly _effectiveAriaHidden = computed<Nullable<boolean>>(() => {
+    protected readonly effectiveAriaHidden = computed<boolean | null>(() => {
         const explicit = this.ariaHidden();
         if (explicit != null) {
             return explicit;
@@ -148,7 +148,7 @@ export class IconComponent implements HasElementRef {
     });
 
     /** @hidden Computed CSS classes */
-    protected readonly _cssClasses = computed<string>(() => {
+    protected readonly cssClasses = computed<string>(() => {
         const returnClass = [this.class()];
 
         if (!this.glyph()) {

--- a/libs/core/table/directives/table-icon.directive.spec.ts
+++ b/libs/core/table/directives/table-icon.directive.spec.ts
@@ -35,6 +35,10 @@ describe('TableIconDirective', () => {
     });
 
     it('should assign classes', () => {
-        expect(component.icon.elementRef.nativeElement.classList.length).toBe(3);
+        const el = component.icon.elementRef.nativeElement;
+        expect(el.classList).toContain('fd-table__icon');
+        expect(el.classList).toContain('sap-icon');
+        expect(el.classList).toContain('sap-icon--glyph');
+        expect(el.classList).toContain('fd-table__icon--navigation');
     });
 });

--- a/libs/core/wizard/wizard-step-indicator/wizard-step-indicator.component.spec.ts
+++ b/libs/core/wizard/wizard-step-indicator/wizard-step-indicator.component.spec.ts
@@ -37,6 +37,8 @@ describe('WizardStepIndicatorComponent', () => {
 
     it('Should Add icon class with glyph on input', () => {
         const indicator = fixture.debugElement.nativeElement.querySelector('.fd-wizard__icon');
-        expect(indicator.className).toContain('fd-wizard__icon sap-icon--accept');
+        expect(indicator.classList).toContain('fd-wizard__icon');
+        expect(indicator.classList).toContain('sap-icon');
+        expect(indicator.classList).toContain('sap-icon--accept');
     });
 });

--- a/libs/docs/core/icon/examples/icon-size-example.component.scss
+++ b/libs/docs/core/icon/examples/icon-size-example.component.scss
@@ -1,0 +1,18 @@
+.fd-docs-icon-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.fd-docs-icons {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    word-break: break-all;
+    padding: 1rem;
+    width: 9rem;
+
+    span {
+        text-align: center;
+    }
+}

--- a/libs/docs/core/icon/examples/icon-size-example.component.ts
+++ b/libs/docs/core/icon/examples/icon-size-example.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { IconComponent, IconSize } from '@fundamental-ngx/core/icon';
+
+@Component({
+    selector: 'fd-icon-size-example',
+    template: `
+        <div class="fd-docs-icon-container">
+            @for (size of sizes; track size) {
+                <div class="fd-docs-icons">
+                    <fd-icon glyph="home" [size]="size"></fd-icon>
+                    <span>{{ size }}</span>
+                </div>
+            }
+        </div>
+    `,
+    styleUrls: ['icon-size-example.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [IconComponent]
+})
+export class IconSizeExampleComponent {
+    sizes: IconSize[] = ['sm', 'md', 'lg', 'xl', 'xxl'];
+}

--- a/libs/docs/core/icon/icon-docs.component.html
+++ b/libs/docs/core/icon/icon-docs.component.html
@@ -45,3 +45,15 @@
     <fd-icon-color-example></fd-icon-color-example>
 </component-example>
 <code-example [exampleFiles]="iconColorExample"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="icon-sizes" componentName="icon"> Icon sizes </fd-docs-section-title>
+<description>
+    Icons can be rendered in different sizes using the <code>[size]</code> input property. Available sizes are:
+    <code>sm</code>, <code>md</code>, <code>lg</code>, <code>xl</code>, and <code>xxl</code>.
+</description>
+<component-example>
+    <fd-icon-size-example></fd-icon-size-example>
+</component-example>
+<code-example [exampleFiles]="iconSizeExample"></code-example>

--- a/libs/docs/core/icon/icon-docs.component.ts
+++ b/libs/docs/core/icon/icon-docs.component.ts
@@ -11,6 +11,7 @@ import {
 import { IconBusinessSuiteInAppSymbolsExampleComponent } from './examples/icon-businessSuiteInAppSymbols-example.component';
 import { IconColorExampleComponent } from './examples/icon-color-example.component';
 import { IconExampleComponent } from './examples/icon-example.component';
+import { IconSizeExampleComponent } from './examples/icon-size-example.component';
 import { IconTNTExampleComponent } from './examples/icon-tnt-example.component';
 
 const iconSrc = 'icon-example.component.html';
@@ -21,6 +22,7 @@ const iconBusinessSuiteInAppSymbolsSrc = 'icon-businessSuiteInAppSymbols-example
 const iconBusinessSuiteInAppSymbolsTs = 'icon-businessSuiteInAppSymbols-example.component.ts';
 const iconColorExampleTs = 'icon-color-example.component.ts';
 const iconColorExampleScss = 'icon-example.component.scss';
+const iconSizeExampleTs = 'icon-size-example.component.ts';
 
 @Component({
     selector: 'app-icon',
@@ -34,6 +36,7 @@ const iconColorExampleScss = 'icon-example.component.scss';
         IconBusinessSuiteInAppSymbolsExampleComponent,
         IconTNTExampleComponent,
         IconColorExampleComponent,
+        IconSizeExampleComponent,
         SeparatorComponent
     ]
 })
@@ -97,6 +100,15 @@ export class IconDocsComponent {
             language: 'scss',
             code: getAssetFromModuleAssets(iconColorExampleScss),
             fileName: 'icon-color-example'
+        }
+    ];
+
+    iconSizeExample: ExampleFile[] = [
+        {
+            language: 'typescript',
+            code: getAssetFromModuleAssets(iconSizeExampleTs),
+            fileName: 'icon-size-example',
+            component: 'IconSizeExampleComponent'
         }
     ];
 }

--- a/libs/docs/core/inline-help/examples/inline-help-example.component.html
+++ b/libs/docs/core/inline-help/examples/inline-help-example.component.html
@@ -1,21 +1,21 @@
 <div class="fd-inline-help-example">
     <span>Default</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" [tabindex]="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" tabindex="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Left Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" [tabindex]="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" tabindex="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Right Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" [tabindex]="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" tabindex="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Top Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" [tabindex]="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" tabindex="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
@@ -24,7 +24,7 @@
         glyph="question-mark"
         fd-inline-help="Inline Help Tooltip Lorem ipsum, dolor sit amet consectetur adipisicing elit. Officia vitae ipsum facilis quasi similique! Aperiam incidunt perspiciatis quam architecto. Culpa minima odio adipisci tempora reprehenderit necessitatibus, repellendus dolor tempore pariatur?"
         placement="bottom"
-        [tabindex]="0"
+        tabindex="0"
     ></fd-icon>
 </div>
 
@@ -39,7 +39,7 @@
 
 <div class="fd-inline-help-example">
     <span>Disabled</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" [disabled]="true" [tabindex]="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" [disabled]="true" tabindex="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
@@ -48,6 +48,6 @@
         glyph="question-mark"
         fd-inline-help="Inline Help Tooltip"
         [closeOnEscapeKey]="true"
-        [tabindex]="0"
+        tabindex="0"
     ></fd-icon>
 </div>

--- a/libs/docs/core/inline-help/examples/inline-help-example.component.html
+++ b/libs/docs/core/inline-help/examples/inline-help-example.component.html
@@ -1,21 +1,21 @@
 <div class="fd-inline-help-example">
     <span>Default</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" tabindex="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" [tabindex]="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Left Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" tabindex="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="left" [tabindex]="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Right Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" tabindex="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="right" [tabindex]="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
     <span>Top Position</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" tabindex="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" placement="top" [tabindex]="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
@@ -24,7 +24,7 @@
         glyph="question-mark"
         fd-inline-help="Inline Help Tooltip Lorem ipsum, dolor sit amet consectetur adipisicing elit. Officia vitae ipsum facilis quasi similique! Aperiam incidunt perspiciatis quam architecto. Culpa minima odio adipisci tempora reprehenderit necessitatibus, repellendus dolor tempore pariatur?"
         placement="bottom"
-        tabindex="0"
+        [tabindex]="0"
     ></fd-icon>
 </div>
 
@@ -39,7 +39,7 @@
 
 <div class="fd-inline-help-example">
     <span>Disabled</span>
-    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" [disabled]="true" tabindex="0"></fd-icon>
+    <fd-icon glyph="question-mark" fd-inline-help="Inline Help Tooltip" [disabled]="true" [tabindex]="0"></fd-icon>
 </div>
 
 <div class="fd-inline-help-example">
@@ -48,6 +48,6 @@
         glyph="question-mark"
         fd-inline-help="Inline Help Tooltip"
         [closeOnEscapeKey]="true"
-        tabindex="0"
+        [tabindex]="0"
     ></fd-icon>
 </div>

--- a/libs/docs/core/inline-help/examples/inline-help-template-example/inline-help-template-example.component.html
+++ b/libs/docs/core/inline-help/examples/inline-help-template-example/inline-help-template-example.component.html
@@ -8,7 +8,7 @@
 
 <ng-template #templateRef>
     <div style="display: flex; align-items: center; gap: 0.25rem">
-        <fd-icon glyph="alert" size="l"></fd-icon>
+        <fd-icon glyph="alert"></fd-icon>
         <span>There can be placed everything.</span>
     </div>
 </ng-template>

--- a/libs/docs/core/input/examples/input-example.component.html
+++ b/libs/docs/core/input/examples/input-example.component.html
@@ -23,3 +23,14 @@
         aria-required="true"
     />
 </div>
+<div fd-form-item>
+    <label fd-form-label [disabled]="true" for="input-5">Disabled Label</label>
+    <input fd-form-control type="text" id="input-5" placeholder="Field placeholder text" disabled />
+</div>
+<div fd-form-item>
+    <label fd-form-label [unitDescription]="true" for="input-6">kg</label>
+    <input fd-form-control type="text" id="input-6" placeholder="Enter weight" />
+</div>
+<div fd-form-item>
+    <label fd-form-label [standAlone]="true">Stand-Alone Label</label>
+</div>

--- a/libs/docs/core/input/examples/input-example.component.html
+++ b/libs/docs/core/input/examples/input-example.component.html
@@ -12,25 +12,3 @@
     <label fd-form-label for="input-3">Password</label>
     <input fd-form-control type="password" id="input-3" placeholder="Field placeholder text" aria-required="true" />
 </div>
-<div fd-form-item>
-    <label fd-form-label for="input-4">Compact</label>
-    <input
-        fd-form-control
-        fdCompact
-        type="password"
-        id="input-4"
-        placeholder="Field placeholder text"
-        aria-required="true"
-    />
-</div>
-<div fd-form-item>
-    <label fd-form-label [disabled]="true" for="input-5">Disabled Label</label>
-    <input fd-form-control type="text" id="input-5" placeholder="Field placeholder text" disabled />
-</div>
-<div fd-form-item>
-    <label fd-form-label [unitDescription]="true" for="input-6">kg</label>
-    <input fd-form-control type="text" id="input-6" placeholder="Enter weight" />
-</div>
-<div fd-form-item>
-    <label fd-form-label [standAlone]="true">Stand-Alone Label</label>
-</div>


### PR DESCRIPTION
## Summary

Adopts CSS classes and modifiers from fundamental-styles that were missing or outdated in the Angular components

## Icon (`fd-icon`)

- **Added `sap-icon` base class** to `fdBuildIconClass` output — previously only the glyph modifier (`sap-icon--{name}`) was emitted, now the base class is included as required by fundamental-styles
- **Added `size` input** (`IconSize`: `'sm' | 'md' | 'lg' | 'xl' | 'xxl'`) — maps to `sap-icon--{size}` modifier
- **Added `role` and `aria-hidden` accessibility defaults** — decorative icons (no `ariaLabel`) get `role="presentation"` and `aria-hidden="true"`; icons with `ariaLabel` get `role="img"` and no `aria-hidden`
- **No breaking changes** — `ariaLabel`, `ariaHidden`, and existing inputs are unchanged

## Form Label (`fd-form-label`)

- **Added `disabled` signal input** — applies `fd-form-label--disabled` class on host and `aria-disabled` on inner label span
- **Added `unitDescription` signal input** — applies `fd-form-label--unit-description` class (e.g., "kg", "USD" labels)
- **Added `standAlone` signal input** — applies `fd-form-label--stand-alone` class
- **Removed stale SCSS overrides** — 25 lines of CSS marked "remove after adopting fd-styles version 0.39" (current version is 0.41+)

## Form Group (`fd-form-group`)

- **Added `withSpacing` input** — applies `fd-form-group--with-spacing` modifier

## Form Legend (`fd-form-legend`)

- **Added `disabled` signal input** — applies `is-disabled` state class
- **Migrated from `@HostBinding` to `host: {}`** — the directive was trivial (one class binding), so the migration is minimal
