### PR TITLE
docs(ui5): make webcomponents wrappers more visible in google

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
 </a>
 
-Angular component library implementing the SAP Design System. Ships 1000+ components across 14 packages, targeting Angular 21+.
+**The official SAP-maintained Angular library for UI5 Web Components and the SAP design system.** Ships 1000+ components across 14 packages, targeting Angular 21+.
 
 [Documentation](https://sap.github.io/fundamental-ngx) | [Component Playground](https://sap.github.io/fundamental-ngx)
 

--- a/apps/docs/src/index.html
+++ b/apps/docs/src/index.html
@@ -2,13 +2,51 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <meta name="description" content="Fundamental Library for Angular - SAP Design System Components for Angular" />
-        <title>Fundamental Library for Angular</title>
+        <title>SAP UI5 Angular Components – Fundamental Library for Angular</title>
+        <meta
+            name="description"
+            content="The official SAP Angular library for UI5 Web Components. 1000+ Fiori components for Angular 21+, maintained by SAP. Includes button, dialog, table, calendar, and more."
+        />
+        <meta
+            name="keywords"
+            content="angular, ui5, ui5-webcomponents, web-components, sap, fiori, ngx, design-system, btp, sap-fiori"
+        />
         <base href="" />
 
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#354a5f" />
+
+        <!-- Open Graph -->
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://sap.github.io/fundamental-ngx" />
+        <meta property="og:title" content="SAP UI5 Angular Components – Fundamental Library for Angular" />
+        <meta
+            property="og:description"
+            content="The official SAP Angular library for UI5 Web Components. 1000+ Fiori components for Angular 21+, maintained by SAP."
+        />
+        <meta property="og:image" content="https://sap.github.io/fundamental-ngx/assets/og-image.png" />
+
+        <!-- Structured data -->
+        <script type="application/ld+json">
+            {
+                "@context": "https://schema.org",
+                "@type": "SoftwareSourceCode",
+                "name": "Fundamental Library for Angular",
+                "alternateName": "fundamental-ngx",
+                "description": "The official SAP Angular library for UI5 Web Components. 1000+ Fiori components for Angular 21+.",
+                "url": "https://sap.github.io/fundamental-ngx",
+                "codeRepository": "https://github.com/SAP/fundamental-ngx",
+                "programmingLanguage": "TypeScript",
+                "runtimePlatform": "Angular",
+                "license": "https://www.apache.org/licenses/LICENSE-2.0",
+                "author": {
+                    "@type": "Organization",
+                    "name": "SAP",
+                    "url": "https://www.sap.com"
+                }
+            }
+        </script>
         <link rel="icon" type="image/x-icon" href="favicon.ico" />
 
         <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/libs/ui5-webcomponents-ai/package.json
+++ b/libs/ui5-webcomponents-ai/package.json
@@ -2,7 +2,21 @@
     "name": "@fundamental-ngx/ui5-webcomponents-ai",
     "version": "0.62.0-rc.95",
     "schematics": "./schematics/collection.json",
-    "description": "Fundamental Library for Angular - UI5 Webcomponents AI",
+    "description": "Official SAP Angular wrappers for UI5 AI Web Components – part of the Fundamental Library for Angular.",
+    "keywords": [
+        "angular",
+        "ui5",
+        "ui5-webcomponents",
+        "web-components",
+        "sap",
+        "fiori",
+        "ngx",
+        "design-system",
+        "btp",
+        "angular-components",
+        "sap-fiori",
+        "fundamental"
+    ],
     "license": "Apache-2.0",
     "homepage": "https://sap.github.io/fundamental-ngx",
     "repository": {

--- a/libs/ui5-webcomponents-base/package.json
+++ b/libs/ui5-webcomponents-base/package.json
@@ -2,7 +2,21 @@
     "name": "@fundamental-ngx/ui5-webcomponents-base",
     "version": "0.62.0-rc.95",
     "schematics": "./schematics/collection.json",
-    "description": "Fundamental Library for Angular - UI5 Webcomponents Base",
+    "description": "Official SAP Angular base library for UI5 Web Component wrappers – part of the Fundamental Library for Angular.",
+    "keywords": [
+        "angular",
+        "ui5",
+        "ui5-webcomponents",
+        "web-components",
+        "sap",
+        "fiori",
+        "ngx",
+        "design-system",
+        "btp",
+        "angular-components",
+        "sap-fiori",
+        "fundamental"
+    ],
     "license": "Apache-2.0",
     "homepage": "https://sap.github.io/fundamental-ngx",
     "repository": {

--- a/libs/ui5-webcomponents-fiori/package.json
+++ b/libs/ui5-webcomponents-fiori/package.json
@@ -2,7 +2,21 @@
     "name": "@fundamental-ngx/ui5-webcomponents-fiori",
     "version": "0.62.0-rc.95",
     "schematics": "./schematics/collection.json",
-    "description": "Fundamental Library for Angular - UI5 Webcomponents Fiori",
+    "description": "Official SAP Angular wrappers for UI5 Fiori Web Components – part of the Fundamental Library for Angular.",
+    "keywords": [
+        "angular",
+        "ui5",
+        "ui5-webcomponents",
+        "web-components",
+        "sap",
+        "fiori",
+        "ngx",
+        "design-system",
+        "btp",
+        "angular-components",
+        "sap-fiori",
+        "fundamental"
+    ],
     "license": "Apache-2.0",
     "homepage": "https://sap.github.io/fundamental-ngx",
     "repository": {

--- a/libs/ui5-webcomponents/package.json
+++ b/libs/ui5-webcomponents/package.json
@@ -2,7 +2,21 @@
     "name": "@fundamental-ngx/ui5-webcomponents",
     "version": "0.62.0-rc.95",
     "schematics": "./schematics/collection.json",
-    "description": "Fundamental Library for Angular - UI5 Webcomponents Base",
+    "description": "Official SAP Angular wrappers for UI5 Web Components – part of the Fundamental Library for Angular.",
+    "keywords": [
+        "angular",
+        "ui5",
+        "ui5-webcomponents",
+        "web-components",
+        "sap",
+        "fiori",
+        "ngx",
+        "design-system",
+        "btp",
+        "angular-components",
+        "sap-fiori",
+        "fundamental"
+    ],
     "license": "Apache-2.0",
     "homepage": "https://sap.github.io/fundamental-ngx",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,21 @@
     "private": true,
     "license": "Apache-2.0",
     "main": "dist/libs/core/index.js",
-    "description": "Fundamental Library for Angular is a themeable Fiori Angular component library.",
+    "description": "The official SAP Angular library for UI5 Web Components and Fiori design system. 1000+ components for Angular 21+.",
+    "keywords": [
+        "angular",
+        "ui5",
+        "ui5-webcomponents",
+        "web-components",
+        "sap",
+        "fiori",
+        "ngx",
+        "design-system",
+        "btp",
+        "angular-components",
+        "sap-fiori",
+        "fundamental"
+    ],
     "homepage": "https://sap.github.io/fundamental-ngx",
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Related Issue(s)

part of https://github.com/SAP/fundamental-ngx/issues/14148

## Description


- Adds keywords to package.json and the individual @fundamental-ngx/ui5-webcomponents package.json-s:

```
"keywords": ["angular", "ui5", "web-components", "sap", "fiori", "ngx", "design-system", "ui5-webcomponents"]
```

- Updates apps/docs/src/index.html:
```
Title: SAP UI5 Angular Components – Fundamental Library for Angular
Meta description: "The official SAP Angular library for UI5 Web Components. 1000+ Fiori components for Angular 21+, maintained by SAP."
Add OG tags and a JSON-LD SoftwareApplication schema block.
```

- Updates the README hero text to lead with "Official SAP Angular library for UI5 Web Components" before any other description.

