### PR TITLE
fix(platform): improve a11y for Platform Table View Settings dialog

### DIFF
--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
@@ -5,27 +5,26 @@
 </ng-template>
 
 <ng-template #bodyTemplate>
-    <span
-        role="heading"
-        [attr.aria-level]="headingLevel + 1"
-        fd-list-group-header
-        id="platformTableInternalFilterListGroupHeader"
-    >
-        {{ ('platformTable.filterDialogFilterBy' | fdTranslate)() }}
-    </span>
-    <ul fd-list [navigationIndicator]="true" aria-labelledby="platformTableInternalFilterListGroupHeader">
-        @for (filter of filters; track filter) {
-            <li
-                fd-list-item
-                [interactive]="true"
-                (click)="selectFilter.emit(filter)"
-                (keydown.space)="selectFilter.emit(filter)"
-                (keydown.enter)="selectFilter.emit(filter)"
-            >
-                <a fd-list-link [navigationIndicator]="true">
-                    <span fd-list-title>{{ filter.label }}</span>
-                </a>
-            </li>
-        }
-    </ul>
+    <fieldset>
+        <legend fd-list-group-header>
+            <span fd-list-title id="platformTableInternalFilterListGroupHeader">
+                {{ ('platformTable.filterDialogFilterBy' | fdTranslate)() }}
+            </span>
+        </legend>
+        <ul fd-list aria-labelledby="platformTableInternalFilterListGroupHeader" [navigationIndicator]="true">
+            @for (filter of filters; track filter) {
+                <li
+                    fd-list-item
+                    [interactive]="true"
+                    (click)="selectFilter.emit(filter)"
+                    (keydown.space)="selectFilter.emit(filter)"
+                    (keydown.enter)="selectFilter.emit(filter)"
+                >
+                    <a fd-list-link [navigationIndicator]="true">
+                        <span fd-list-title>{{ filter.label }}</span>
+                    </a>
+                </li>
+            }
+        </ul>
+    </fieldset>
 </ng-template>

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
@@ -5,26 +5,24 @@
 </ng-template>
 
 <ng-template #bodyTemplate>
-    <fieldset>
-        <legend fd-list-group-header>
-            <span fd-list-title id="platformTableInternalFilterListGroupHeader">
-                {{ ('platformTable.filterDialogFilterBy' | fdTranslate)() }}
-            </span>
-        </legend>
-        <ul fd-list aria-labelledby="platformTableInternalFilterListGroupHeader" [navigationIndicator]="true">
-            @for (filter of filters; track filter) {
-                <li
-                    fd-list-item
-                    [interactive]="true"
-                    (click)="selectFilter.emit(filter)"
-                    (keydown.space)="selectFilter.emit(filter)"
-                    (keydown.enter)="selectFilter.emit(filter)"
-                >
-                    <a fd-list-link [navigationIndicator]="true">
-                        <span fd-list-title>{{ filter.label }}</span>
-                    </a>
-                </li>
-            }
-        </ul>
-    </fieldset>
+    <div fd-list-group-header>
+        <span fd-list-title id="platformTableInternalFilterListGroupHeader">
+            {{ ('platformTable.filterDialogFilterBy' | fdTranslate)() }}
+        </span>
+    </div>
+    <ul fd-list aria-labelledby="platformTableInternalFilterListGroupHeader" [navigationIndicator]="true">
+        @for (filter of filters; track filter) {
+            <li
+                fd-list-item
+                [interactive]="true"
+                (click)="selectFilter.emit(filter)"
+                (keydown.space)="selectFilter.emit(filter)"
+                (keydown.enter)="selectFilter.emit(filter)"
+            >
+                <a fd-list-link [navigationIndicator]="true">
+                    <span fd-list-title>{{ filter.label }}</span>
+                </a>
+            </li>
+        }
+    </ul>
 </ng-template>

--- a/libs/platform/table/components/table-view-settings-dialog/grouping/grouping.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/grouping/grouping.component.html
@@ -1,56 +1,61 @@
-<span role="heading" [attr.aria-level]="headingLevel() + 1" fd-list-group-header>
-    <span fd-list-title [attr.id]="groupOrderHeaderId">
-        {{ ('platformTable.groupDialogGroupOrderHeader' | fdTranslate)() }}
-    </span>
-</span>
-<ul fd-list [selection]="true">
-    <li fd-list-item [selected]="direction() === SORT_DIRECTION.ASC" [attr.aria-describedby]="groupOrderHeaderId">
-        <fd-radio-button
-            name="sort-order"
-            value="asc"
-            state="default"
-            [ngModel]="direction()"
-            (ngModelChange)="_groupOrderChange($event)"
-        ></fd-radio-button>
-        <span fd-list-title>{{ ('platformTable.groupDialogGroupOrderAsc' | fdTranslate)() }}</span>
-    </li>
-    <li fd-list-item [selected]="direction() === SORT_DIRECTION.DESC" [attr.aria-describedby]="groupOrderHeaderId">
-        <fd-radio-button
-            name="sort-order"
-            value="desc"
-            state="default"
-            [ngModel]="direction()"
-            (ngModelChange)="_groupOrderChange($event)"
-        ></fd-radio-button>
-        <span fd-list-title>{{ ('platformTable.groupDialogGroupOrderDesc' | fdTranslate)() }}</span>
-    </li>
-</ul>
-<span role="heading" [attr.aria-level]="headingLevel() + 1" fd-list-group-header>
-    <span fd-list-title [attr.id]="groupByHeaderId">
-        {{ ('platformTable.groupDialogGroupByHeader' | fdTranslate)() }}
-    </span>
-</span>
-<ul fd-list [selection]="true">
-    <li fd-list-item [selected]="NOT_GROUPED_OPTION_VALUE === field()" [attr.aria-describedby]="groupByHeaderId">
-        <fd-radio-button
-            name="sort-by"
-            [value]="NOT_GROUPED_OPTION_VALUE"
-            state="default"
-            [ngModel]="field()"
-            (ngModelChange)="_groupFieldChange($event)"
-        ></fd-radio-button>
-        <span fd-list-title>{{ ('platformTable.groupDialogNotGroupedLabel' | fdTranslate)() }}</span>
-    </li>
-    @for (column of columns(); track column) {
-        <li fd-list-item [selected]="column.key === field()" [attr.aria-describedby]="groupByHeaderId">
+<fieldset>
+    <legend fd-list-group-header>
+        <span fd-list-title [attr.id]="groupOrderHeaderId">
+            {{ ('platformTable.groupDialogGroupOrderHeader' | fdTranslate)() }}
+        </span>
+    </legend>
+    <ul fd-list [selection]="true">
+        <li fd-list-item [selected]="direction() === SORT_DIRECTION.ASC" [attr.aria-describedby]="groupOrderHeaderId">
+            <fd-radio-button
+                name="sort-order"
+                value="asc"
+                state="default"
+                [ngModel]="direction()"
+                (ngModelChange)="_groupOrderChange($event)"
+            ></fd-radio-button>
+            <span fd-list-title>{{ ('platformTable.groupDialogGroupOrderAsc' | fdTranslate)() }}</span>
+        </li>
+        <li fd-list-item [selected]="direction() === SORT_DIRECTION.DESC" [attr.aria-describedby]="groupOrderHeaderId">
+            <fd-radio-button
+                name="sort-order"
+                value="desc"
+                state="default"
+                [ngModel]="direction()"
+                (ngModelChange)="_groupOrderChange($event)"
+            ></fd-radio-button>
+            <span fd-list-title>{{ ('platformTable.groupDialogGroupOrderDesc' | fdTranslate)() }}</span>
+        </li>
+    </ul>
+</fieldset>
+
+<fieldset>
+    <legend fd-list-group-header>
+        <span fd-list-title [attr.id]="groupByHeaderId">
+            {{ ('platformTable.groupDialogGroupByHeader' | fdTranslate)() }}
+        </span>
+    </legend>
+    <ul fd-list [selection]="true">
+        <li fd-list-item [selected]="NOT_GROUPED_OPTION_VALUE === field()" [attr.aria-describedby]="groupByHeaderId">
             <fd-radio-button
                 name="sort-by"
-                [value]="column.key"
+                [value]="NOT_GROUPED_OPTION_VALUE"
                 state="default"
                 [ngModel]="field()"
                 (ngModelChange)="_groupFieldChange($event)"
             ></fd-radio-button>
-            <span fd-list-title>{{ column.label }}</span>
+            <span fd-list-title>{{ ('platformTable.groupDialogNotGroupedLabel' | fdTranslate)() }}</span>
         </li>
-    }
-</ul>
+        @for (column of columns(); track column) {
+            <li fd-list-item [selected]="column.key === field()" [attr.aria-describedby]="groupByHeaderId">
+                <fd-radio-button
+                    name="sort-by"
+                    [value]="column.key"
+                    state="default"
+                    [ngModel]="field()"
+                    (ngModelChange)="_groupFieldChange($event)"
+                ></fd-radio-button>
+                <span fd-list-title>{{ column.label }}</span>
+            </li>
+        }
+    </ul>
+</fieldset>

--- a/libs/platform/table/components/table-view-settings-dialog/grouping/grouping.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/grouping/grouping.component.html
@@ -4,8 +4,8 @@
             {{ ('platformTable.groupDialogGroupOrderHeader' | fdTranslate)() }}
         </span>
     </legend>
-    <ul fd-list [selection]="true">
-        <li fd-list-item [selected]="direction() === SORT_DIRECTION.ASC" [attr.aria-describedby]="groupOrderHeaderId">
+    <ul fd-list [selection]="true" [attr.aria-labelledby]="groupOrderHeaderId">
+        <li fd-list-item [selected]="direction() === SORT_DIRECTION.ASC">
             <fd-radio-button
                 name="sort-order"
                 value="asc"
@@ -15,7 +15,7 @@
             ></fd-radio-button>
             <span fd-list-title>{{ ('platformTable.groupDialogGroupOrderAsc' | fdTranslate)() }}</span>
         </li>
-        <li fd-list-item [selected]="direction() === SORT_DIRECTION.DESC" [attr.aria-describedby]="groupOrderHeaderId">
+        <li fd-list-item [selected]="direction() === SORT_DIRECTION.DESC">
             <fd-radio-button
                 name="sort-order"
                 value="desc"
@@ -34,8 +34,8 @@
             {{ ('platformTable.groupDialogGroupByHeader' | fdTranslate)() }}
         </span>
     </legend>
-    <ul fd-list [selection]="true">
-        <li fd-list-item [selected]="NOT_GROUPED_OPTION_VALUE === field()" [attr.aria-describedby]="groupByHeaderId">
+    <ul fd-list [selection]="true" [attr.aria-labelledby]="groupByHeaderId">
+        <li fd-list-item [selected]="NOT_GROUPED_OPTION_VALUE === field()">
             <fd-radio-button
                 name="sort-by"
                 [value]="NOT_GROUPED_OPTION_VALUE"
@@ -46,7 +46,7 @@
             <span fd-list-title>{{ ('platformTable.groupDialogNotGroupedLabel' | fdTranslate)() }}</span>
         </li>
         @for (column of columns(); track column) {
-            <li fd-list-item [selected]="column.key === field()" [attr.aria-describedby]="groupByHeaderId">
+            <li fd-list-item [selected]="column.key === field()">
                 <fd-radio-button
                     name="sort-by"
                     [value]="column.key"

--- a/libs/platform/table/components/table-view-settings-dialog/sorting/sorting.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/sorting/sorting.component.html
@@ -4,8 +4,8 @@
             {{ ('platformTable.sortDialogSortOrderHeader' | fdTranslate)() }}
         </span>
     </legend>
-    <ul fd-list [selection]="true">
-        <li fd-list-item [selected]="direction() === SORT_DIRECTION.ASC" [attr.aria-describedby]="sortOrderHeaderId">
+    <ul fd-list [selection]="true" [attr.aria-labelledby]="sortOrderHeaderId">
+        <li fd-list-item [selected]="direction() === SORT_DIRECTION.ASC">
             <fd-radio-button
                 name="sort-order"
                 value="asc"
@@ -15,7 +15,7 @@
             ></fd-radio-button>
             <span fd-list-title>{{ ('platformTable.sortDialogSortOrderAsc' | fdTranslate)() }}</span>
         </li>
-        <li fd-list-item [selected]="direction() === SORT_DIRECTION.DESC" [attr.aria-describedby]="sortOrderHeaderId">
+        <li fd-list-item [selected]="direction() === SORT_DIRECTION.DESC">
             <fd-radio-button
                 name="sort-order"
                 value="desc"
@@ -34,13 +34,9 @@
             {{ ('platformTable.sortDialogSortByHeader' | fdTranslate)() }}
         </span>
     </legend>
-    <ul fd-list [selection]="true">
+    <ul fd-list [selection]="true" [attr.aria-labelledby]="sortDialogSortByHeaderId">
         @if (allowDisablingSorting()) {
-            <li
-                fd-list-item
-                [selected]="field() === NOT_SORTED_OPTION_VALUE"
-                [attr.aria-describedby]="sortDialogSortByHeaderId"
-            >
+            <li fd-list-item [selected]="field() === NOT_SORTED_OPTION_VALUE">
                 <fd-radio-button
                     name="sort-by"
                     [value]="NOT_SORTED_OPTION_VALUE"
@@ -52,7 +48,7 @@
             </li>
         }
         @for (column of columns(); track column) {
-            <li fd-list-item [selected]="column.key === field()" [attr.aria-describedby]="sortDialogSortByHeaderId">
+            <li fd-list-item [selected]="column.key === field()">
                 <fd-radio-button
                     name="sort-by"
                     [value]="column.key"

--- a/libs/platform/table/components/table-view-settings-dialog/sorting/sorting.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/sorting/sorting.component.html
@@ -1,63 +1,67 @@
-<span role="heading" [attr.aria-level]="headingLevel() + 1" fd-list-group-header>
-    <span fd-list-title [attr.id]="sortOrderHeaderId">
-        {{ ('platformTable.sortDialogSortOrderHeader' | fdTranslate)() }}
-    </span>
-</span>
-<ul fd-list [selection]="true">
-    <li fd-list-item [selected]="direction() === SORT_DIRECTION.ASC" [attr.aria-describedby]="sortOrderHeaderId">
-        <fd-radio-button
-            name="sort-order"
-            value="asc"
-            state="default"
-            [ngModel]="direction()"
-            (ngModelChange)="_sortDirectionChange($event)"
-        ></fd-radio-button>
-        <span fd-list-title>{{ ('platformTable.sortDialogSortOrderAsc' | fdTranslate)() }}</span>
-    </li>
-    <li fd-list-item [selected]="direction() === SORT_DIRECTION.DESC" [attr.aria-describedby]="sortOrderHeaderId">
-        <fd-radio-button
-            name="sort-order"
-            value="desc"
-            state="default"
-            [ngModel]="direction()"
-            (ngModelChange)="_sortDirectionChange($event)"
-        ></fd-radio-button>
-        <span fd-list-title>{{ ('platformTable.sortDialogSortOrderDesc' | fdTranslate)() }}</span>
-    </li>
-</ul>
+<fieldset>
+    <legend fd-list-group-header>
+        <span fd-list-title [attr.id]="sortOrderHeaderId">
+            {{ ('platformTable.sortDialogSortOrderHeader' | fdTranslate)() }}
+        </span>
+    </legend>
+    <ul fd-list [selection]="true">
+        <li fd-list-item [selected]="direction() === SORT_DIRECTION.ASC" [attr.aria-describedby]="sortOrderHeaderId">
+            <fd-radio-button
+                name="sort-order"
+                value="asc"
+                state="default"
+                [ngModel]="direction()"
+                (ngModelChange)="_sortDirectionChange($event)"
+            ></fd-radio-button>
+            <span fd-list-title>{{ ('platformTable.sortDialogSortOrderAsc' | fdTranslate)() }}</span>
+        </li>
+        <li fd-list-item [selected]="direction() === SORT_DIRECTION.DESC" [attr.aria-describedby]="sortOrderHeaderId">
+            <fd-radio-button
+                name="sort-order"
+                value="desc"
+                state="default"
+                [ngModel]="direction()"
+                (ngModelChange)="_sortDirectionChange($event)"
+            ></fd-radio-button>
+            <span fd-list-title>{{ ('platformTable.sortDialogSortOrderDesc' | fdTranslate)() }}</span>
+        </li>
+    </ul>
+</fieldset>
 
-<span role="heading" [attr.aria-level]="headingLevel() + 1" fd-list-group-header>
-    <span fd-list-title [attr.id]="sortDialogSortByHeaderId">
-        {{ ('platformTable.sortDialogSortByHeader' | fdTranslate)() }}
-    </span>
-</span>
-<ul fd-list [selection]="true">
-    @if (allowDisablingSorting()) {
-        <li
-            fd-list-item
-            [selected]="field() === NOT_SORTED_OPTION_VALUE"
-            [attr.aria-describedby]="sortDialogSortByHeaderId"
-        >
-            <fd-radio-button
-                name="sort-by"
-                [value]="NOT_SORTED_OPTION_VALUE"
-                state="default"
-                [ngModel]="field()"
-                (ngModelChange)="_sortFieldChange($event)"
-            ></fd-radio-button>
-            <span fd-list-title>{{ ('platformTable.sortDialogNotSortedLabel' | fdTranslate)() }}</span>
-        </li>
-    }
-    @for (column of columns(); track column) {
-        <li fd-list-item [selected]="column.key === field()" [attr.aria-describedby]="sortDialogSortByHeaderId">
-            <fd-radio-button
-                name="sort-by"
-                [value]="column.key"
-                state="default"
-                [ngModel]="field()"
-                (ngModelChange)="_sortFieldChange($event)"
-            ></fd-radio-button>
-            <span fd-list-title>{{ column.label }}</span>
-        </li>
-    }
-</ul>
+<fieldset>
+    <legend fd-list-group-header>
+        <span fd-list-title [attr.id]="sortDialogSortByHeaderId">
+            {{ ('platformTable.sortDialogSortByHeader' | fdTranslate)() }}
+        </span>
+    </legend>
+    <ul fd-list [selection]="true">
+        @if (allowDisablingSorting()) {
+            <li
+                fd-list-item
+                [selected]="field() === NOT_SORTED_OPTION_VALUE"
+                [attr.aria-describedby]="sortDialogSortByHeaderId"
+            >
+                <fd-radio-button
+                    name="sort-by"
+                    [value]="NOT_SORTED_OPTION_VALUE"
+                    state="default"
+                    [ngModel]="field()"
+                    (ngModelChange)="_sortFieldChange($event)"
+                ></fd-radio-button>
+                <span fd-list-title>{{ ('platformTable.sortDialogNotSortedLabel' | fdTranslate)() }}</span>
+            </li>
+        }
+        @for (column of columns(); track column) {
+            <li fd-list-item [selected]="column.key === field()" [attr.aria-describedby]="sortDialogSortByHeaderId">
+                <fd-radio-button
+                    name="sort-by"
+                    [value]="column.key"
+                    state="default"
+                    [ngModel]="field()"
+                    (ngModelChange)="_sortFieldChange($event)"
+                ></fd-radio-button>
+                <span fd-list-title>{{ column.label }}</span>
+            </li>
+        }
+    </ul>
+</fieldset>

--- a/libs/platform/table/table.component.scss
+++ b/libs/platform/table/table.component.scss
@@ -699,3 +699,13 @@ th.fd-table__cell .fd-table__inner {
     display: flex;
     align-items: center;
 }
+
+fdp-settings-dialog-settings fieldset {
+    margin: 0;
+    padding: 0;
+    border: none;
+
+    legend {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Related Issue(s)

related to https://github.com/SAP/fundamental-ngx/issues/14020

## Description
### The user reported the following:
In the “Settings” and “Filter” dialogs, group labels such as “Sort Order”, “Sort by”, and “Filter By” are marked up as H3 headings, even though they function as form/group labels rather than true section headings. This creates an inaccurate heading structure for screen reader users.
Group labels inside dialogs should be implemented as proper group names/labels (e.g., using for grouped controls or role="group" with aria-labelledby) instead of headings. Headings (H1–H6) should be used only for actual section headings and must follow a logical hierarchy within the dialog/page.
Remove the heading level for “Sort Order”, “Sort by”, and “Filter By”

### The fix provided:
  Replaced `role="heading"` with semantic `<fieldset>` + `<legend>` for "Sort Order" and "Sort by"  groups in the table sorting dialog. Group labels were incorrectly marked as H3 headings, creating a false document structure for screen reader users.                             
                                                                                             
  Changes:                                                                                   
  - Use `<fieldset>` with `<legend>` for proper form control grouping
  - Remove `role="heading"` and `aria-level` attributes                                          
  - Remove unnecessary `aria-describedby` references (fieldset handles this natively)   
  - custom CSS to achieve the old look     
                                                                                             
  Accessibility improvements:                                                                
  - Correct semantic HTML for form grouping                                                  
  - No artificial heading hierarchy                                                          
  - Better screen reader announcements (group context provided by fieldset)  
  
## Screenshots
<img width="1825" height="1255" alt="Screenshot 2026-04-28 at 4 35 38 PM" src="https://github.com/user-attachments/assets/39e3e963-9f21-4ee8-8e2b-b950f95ce177" />
<img width="1826" height="1247" alt="Screenshot 2026-04-28 at 4 35 16 PM" src="https://github.com/user-attachments/assets/bbdf928d-1522-41a7-8071-2c19ebd2332f" />
<img width="1827" height="1170" alt="Screenshot 2026-04-28 at 4 34 36 PM" src="https://github.com/user-attachments/assets/5459c1eb-6f1e-44c7-b771-8c9fab29e17d" />
