### PR TITLE
fix(platform): add missing chevrons to filter dialog in table

### DIFF
--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.html
@@ -13,7 +13,7 @@
     >
         {{ ('platformTable.filterDialogFilterBy' | fdTranslate)() }}
     </span>
-    <ul fd-list aria-labelledby="platformTableInternalFilterListGroupHeader">
+    <ul fd-list [navigationIndicator]="true" aria-labelledby="platformTableInternalFilterListGroupHeader">
         @for (filter of filters; track filter) {
             <li
                 fd-list-item
@@ -22,7 +22,9 @@
                 (keydown.space)="selectFilter.emit(filter)"
                 (keydown.enter)="selectFilter.emit(filter)"
             >
-                <span fd-list-title>{{ filter.label }}</span>
+                <a fd-list-link [navigationIndicator]="true">
+                    <span fd-list-title>{{ filter.label }}</span>
+                </a>
             </li>
         }
     </ul>

--- a/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.ts
+++ b/libs/platform/table/components/table-view-settings-dialog/filtering/filters-list-step.component.ts
@@ -14,6 +14,7 @@ import {
     ListComponent,
     ListGroupHeaderDirective,
     ListItemComponent,
+    ListLinkDirective,
     ListTitleDirective
 } from '@fundamental-ngx/core/list';
 import { TitleComponent } from '@fundamental-ngx/core/title';
@@ -42,6 +43,7 @@ export interface SelectableFilter {
         ListComponent,
         ListGroupHeaderDirective,
         ListItemComponent,
+        ListLinkDirective,
         ListTitleDirective,
         FdTranslatePipe
     ]


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14169

## Description

 Adds missing chevrons to filter dialog in platform table to visually mark them as navigatable.

## Screenshots

<img width="548" height="317" alt="Screenshot 2026-04-30 at 10 59 09" src="https://github.com/user-attachments/assets/67e49814-55dd-4b25-99d7-184358a42796" />

