### PR TITLE
docs: make fundamental ngx appear first upon ui5 wrappers search

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@
 
 ## Packages
 
+### UI5 Web Components
+
+Angular wrappers for the [@ui5/webcomponents](https://sap.github.io/ui5-webcomponents) project, letting you use UI5 Web Components in Angular without needing [CUSTOM_ELEMENTS_SCHEMA](https://angular.io/api/core/CUSTOM_ELEMENTS_SCHEMA) or [NO_ERRORS_SCHEMA](https://angular.io/api/core/NO_ERRORS_SCHEMA). Provides full type safety and access to the underlying web components in a type-safe environment. Everything available on the [@ui5/webcomponents](https://sap.github.io/ui5-webcomponents) side is available here.
+
+| Package                                                                    | Description                               |
+| -------------------------------------------------------------------------- | ----------------------------------------- |
+| [`@fundamental-ngx/ui5-webcomponents`](libs/ui5-webcomponents)             | Angular wrappers for UI5 Web Components   |
+| [`@fundamental-ngx/ui5-webcomponents-fiori`](libs/ui5-webcomponents-fiori) | Angular wrappers for UI5 Fiori components |
+| [`@fundamental-ngx/ui5-webcomponents-ai`](libs/ui5-webcomponents-ai)       | Angular wrappers for UI5 AI components    |
+
 ### Core Libraries
 
 | Package                                      | Description                                                                  |

--- a/libs/docs/GETTING_STARTED.md
+++ b/libs/docs/GETTING_STARTED.md
@@ -4,7 +4,10 @@
 
 ## Overview
 
-Fundamental NGX is the SAP set of Angular component libraries implementing the SAP Design System. Build modern, enterprise-grade applications with the SAP look and feel.
+Fundamental NGX is the SAP set of Angular component libraries implementing the SAP Design System. Build modern, enterprise-grade applications with the SAP look and feel:
+
+- **Native Angular components** built on [Fundamental Library Styles](https://sap.github.io/fundamental-styles/), covering core UI, platform-level composites, BTP, and CX patterns.
+- **Angular wrappers for UI5 Web Components** — a wrapper around the [@ui5/webcomponents](https://sap.github.io/ui5-webcomponents) project to make it work with Angular without needing to use the [CUSTOM_ELEMENTS_SCHEMA](https://angular.io/api/core/CUSTOM_ELEMENTS_SCHEMA) or [NO_ERRORS_SCHEMA](https://angular.io/api/core/NO_ERRORS_SCHEMA) schemas, while providing full type safety and access to underlying web components in a type-safe environment. Everything that works and is available on the [@ui5/webcomponents](https://sap.github.io/ui5-webcomponents) side.
 
 ## Packages
 

--- a/libs/ui5-webcomponents-ai/package.json
+++ b/libs/ui5-webcomponents-ai/package.json
@@ -15,7 +15,12 @@
         "btp",
         "angular-components",
         "sap-fiori",
-        "fundamental"
+        "fundamental",
+        "angular-wrapper",
+        "angular-ui5",
+        "ui5-angular",
+        "webcomponents-angular",
+        "type-safe"
     ],
     "license": "Apache-2.0",
     "homepage": "https://sap.github.io/fundamental-ngx",

--- a/libs/ui5-webcomponents-base/package.json
+++ b/libs/ui5-webcomponents-base/package.json
@@ -15,7 +15,12 @@
         "btp",
         "angular-components",
         "sap-fiori",
-        "fundamental"
+        "fundamental",
+        "angular-wrapper",
+        "angular-ui5",
+        "ui5-angular",
+        "webcomponents-angular",
+        "type-safe"
     ],
     "license": "Apache-2.0",
     "homepage": "https://sap.github.io/fundamental-ngx",

--- a/libs/ui5-webcomponents-fiori/package.json
+++ b/libs/ui5-webcomponents-fiori/package.json
@@ -15,7 +15,12 @@
         "btp",
         "angular-components",
         "sap-fiori",
-        "fundamental"
+        "fundamental",
+        "angular-wrapper",
+        "angular-ui5",
+        "ui5-angular",
+        "webcomponents-angular",
+        "type-safe"
     ],
     "license": "Apache-2.0",
     "homepage": "https://sap.github.io/fundamental-ngx",

--- a/libs/ui5-webcomponents/package.json
+++ b/libs/ui5-webcomponents/package.json
@@ -15,7 +15,12 @@
         "btp",
         "angular-components",
         "sap-fiori",
-        "fundamental"
+        "fundamental",
+        "angular-wrapper",
+        "angular-ui5",
+        "ui5-angular",
+        "webcomponents-angular",
+        "type-safe"
     ],
     "license": "Apache-2.0",
     "homepage": "https://sap.github.io/fundamental-ngx",


### PR DESCRIPTION
## Related Issue(s)

part of https://github.com/SAP/fundamental-ngx/issues/14148

## Description

The project was still not surfacing well for searches like "ui5 wrappers for angular" hence the additional changes in this PR:
- `README.md` — added a **### UI5 Web Components** subsection at the top of **## Packages**, making it the first content visitors and crawlers see. Includes the value-prop description: no CUSTOM_ELEMENTS_SCHEMA/NO_ERRORS_SCHEMA needed, full type safety, **full parity with** `@ui5/webcomponents`.

- `libs/docs/GETTING_STARTED.md` — split the single-sentence overview into two bullet points, one for native Angular components and one for UI5 Web Component wrappers, using the same value-prop language.

- All 4 UI5 package.json files (ui5-webcomponents, ui5-webcomponents-fiori, ui5-webcomponents-ai, ui5-webcomponents-base) — added missing npm keywords: angular-wrapper, angular-ui5, ui5-angular, webcomponents-angular, type-safe. These are the exact phrases users search on npm when looking for this kind of library.
