### PR TITLE
chore: update doc text colors in the Shell and side nav

### DIFF
--- a/.github/actions/generate-conventional-release-notes/index.spec.js
+++ b/.github/actions/generate-conventional-release-notes/index.spec.js
@@ -22,7 +22,9 @@ describe('index.js - run()', () => {
         const stream = new PassThrough();
         conventionalChangelog.mockReturnValue(stream);
         process.nextTick(() => {
-            if (content) {stream.push(content);}
+            if (content) {
+                stream.push(content);
+            }
             stream.end();
         });
     }

--- a/libs/docs/shared/src/lib/core-helpers/sections-toolbar/sections-toolbar.component.scss
+++ b/libs/docs/shared/src/lib/core-helpers/sections-toolbar/sections-toolbar.component.scss
@@ -372,7 +372,7 @@
 
     &:hover {
         background: color-mix(in srgb, var(--sapList_Hover_Background) 70%, var(--sapGroup_ContentBorderColor));
-        color: var(--sapList_Active_TextColor);
+        color: var(--sapTextColor);
     }
 
     &:focus-visible {

--- a/libs/docs/shared/src/lib/core-helpers/toolbar/toolbar.component.scss
+++ b/libs/docs/shared/src/lib/core-helpers/toolbar/toolbar.component.scss
@@ -32,7 +32,7 @@
         font-family: var(--sapFontFamily);
         font-size: var(--sapFontHeader4Size);
         font-weight: 700;
-        color: var(--sapShell_TextColor);
+        color: var(--sapButton_TextColor);
         text-decoration: none;
         white-space: nowrap;
         transition: opacity 200ms ease;
@@ -67,7 +67,7 @@
         border-radius: 1.125rem;
         border: 0.0625rem solid transparent;
         background: transparent;
-        color: var(--sapShell_TextColor);
+        color: var(--sapButton_TextColor);
         font-family: var(--sapFontFamily);
         font-size: var(--sapFontLargeSize);
         line-height: 1;
@@ -80,12 +80,12 @@
             box-shadow 200ms ease;
 
         &:hover {
-            background: color-mix(in srgb, var(--sapShell_TextColor) 10%, transparent);
-            border-color: color-mix(in srgb, var(--sapShell_TextColor) 18%, transparent);
+            background: color-mix(in srgb, var(--sapButton_TextColor) 10%, transparent);
+            border-color: color-mix(in srgb, var(--sapButton_TextColor) 18%, transparent);
         }
 
         &:active {
-            background: color-mix(in srgb, var(--sapShell_TextColor) 16%, transparent);
+            background: color-mix(in srgb, var(--sapButton_TextColor) 16%, transparent);
         }
 
         &:focus-visible {
@@ -127,8 +127,8 @@
         // ── GitHub variant ─────────────────────────────────────
         &--github {
             &:hover {
-                background: color-mix(in srgb, var(--sapShell_TextColor) 10%, transparent);
-                border-color: color-mix(in srgb, var(--sapShell_TextColor) 18%, transparent);
+                background: color-mix(in srgb, var(--sapButton_TextColor) 10%, transparent);
+                border-color: color-mix(in srgb, var(--sapButton_TextColor) 18%, transparent);
             }
         }
     }
@@ -145,7 +145,7 @@
         display: block;
         width: 0.0625rem;
         height: 1.25rem;
-        background: color-mix(in srgb, var(--sapShell_TextColor) 20%, transparent);
+        background: color-mix(in srgb, var(--sapButton_TextColor) 20%, transparent);
         margin: 0 0.25rem;
         flex-shrink: 0;
     }


### PR DESCRIPTION
## Related Issue(s)
closes none

## Description
In Quartz light the text didn't have enough contrast ration against the background in the Shell and in the Side nav items on hover. 
Before:
<img width="1365" height="94" alt="Screenshot 2026-05-08 at 10 58 39 AM" src="https://github.com/user-attachments/assets/87ccc80a-beba-4940-9b19-98b983496a4a" />
<img width="282" height="453" alt="Screenshot 2026-05-08 at 11 38 52 AM" src="https://github.com/user-attachments/assets/2fd4e717-3b46-4294-9cc9-1a9b9a16e859" />


Now:
<img width="1044" height="598" alt="Screenshot 2026-05-08 at 11 39 26 AM" src="https://github.com/user-attachments/assets/533c41c6-9bb2-4f95-a9a5-466b01974e7d" />
