### PR TITLE
feat(core): add headingLevel support to grid-list title bar

### DIFF
--- a/libs/core/grid-list/components/grid-list-title-bar/grid-list-title-bar.component.html
+++ b/libs/core/grid-list/components/grid-list-title-bar/grid-list-title-bar.component.html
@@ -1,8 +1,8 @@
 <fd-toolbar fdType="solid">
-    <label fd-toolbar-label>
+    <span fd-toolbar-label role="heading" [attr.aria-level]="normalizedLevel()">
         {{ title }}
         <ng-content select="[fd-grid-list-title-bar-additional-title-item]"></ng-content>
-    </label>
+    </span>
 
     <ng-content></ng-content>
 </fd-toolbar>

--- a/libs/core/grid-list/components/grid-list-title-bar/grid-list-title-bar.component.spec.ts
+++ b/libs/core/grid-list/components/grid-list-title-bar/grid-list-title-bar.component.spec.ts
@@ -1,24 +1,174 @@
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { GridListModule } from '../../grid-list.module';
+import { By } from '@angular/platform-browser';
 import { GridListTitleBarComponent } from './grid-list-title-bar.component';
 
+@Component({
+    template: `<fd-grid-list-title-bar [title]="title"></fd-grid-list-title-bar>`,
+    imports: [GridListTitleBarComponent]
+})
+class GridListTitleBarDefaultTestComponent {
+    title = 'Products';
+}
+
+@Component({
+    template: `<fd-grid-list-title-bar [title]="title" [headingLevel]="headingLevel"></fd-grid-list-title-bar>`,
+    imports: [GridListTitleBarComponent]
+})
+class GridListTitleBarTestComponent {
+    title = 'Products';
+    headingLevel: any = 2;
+}
+
+@Component({
+    template: `
+        <fd-grid-list-title-bar [title]="'Products'" [headingLevel]="3">
+            <span fd-grid-list-title-bar-additional-title-item>Extra info</span>
+        </fd-grid-list-title-bar>
+    `,
+    imports: [GridListTitleBarComponent]
+})
+class GridListTitleBarWithProjectionTestComponent {}
+
 describe('GridListTitleBarComponent', () => {
-    let component: GridListTitleBarComponent;
-    let fixture: ComponentFixture<GridListTitleBarComponent>;
+    let fixture: ComponentFixture<GridListTitleBarTestComponent>;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [GridListModule]
+            imports: [GridListTitleBarTestComponent]
         }).compileComponents();
     }));
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(GridListTitleBarComponent);
-        component = fixture.componentInstance;
+        fixture = TestBed.createComponent(GridListTitleBarTestComponent);
         fixture.detectChanges();
     });
 
     it('should create', () => {
-        expect(component).toBeTruthy();
+        const titleBar = fixture.debugElement.query(By.directive(GridListTitleBarComponent));
+        expect(titleBar).toBeTruthy();
+    });
+
+    it('should render role="heading" on the title label', () => {
+        const label = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(label.nativeElement.getAttribute('role')).toBe('heading');
+    });
+
+    it('should update aria-level when explicitly set to 2', () => {
+        const label = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(label.nativeElement.getAttribute('aria-level')).toBe('2');
+    });
+
+    it('should update aria-level when headingLevel input changes', () => {
+        fixture.componentInstance.headingLevel = 3;
+        fixture.detectChanges();
+        const label = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(label.nativeElement.getAttribute('aria-level')).toBe('3');
+    });
+
+    it('should render the title in a span element, not a label', () => {
+        const el = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(el.nativeElement.tagName.toLowerCase()).toBe('span');
+    });
+
+    it('should normalize string heading level "h4" to numeric aria-level "4"', () => {
+        fixture.componentInstance.headingLevel = 'h4';
+        fixture.detectChanges();
+        const el = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(el.nativeElement.getAttribute('aria-level')).toBe('4');
+    });
+
+    it('should pass through numeric string "3" as aria-level "3"', () => {
+        fixture.componentInstance.headingLevel = '3';
+        fixture.detectChanges();
+        const el = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(el.nativeElement.getAttribute('aria-level')).toBe('3');
+    });
+
+    it('should fallback to aria-level "2" for invalid string input', () => {
+        fixture.componentInstance.headingLevel = 'invalid';
+        fixture.detectChanges();
+        const el = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(el.nativeElement.getAttribute('aria-level')).toBe('2');
+    });
+
+    it('should fallback to aria-level "2" for "h0" string input', () => {
+        fixture.componentInstance.headingLevel = 'h0';
+        fixture.detectChanges();
+        const el = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(el.nativeElement.getAttribute('aria-level')).toBe('2');
+    });
+
+    it('should parse "h7" string as aria-level "7"', () => {
+        fixture.componentInstance.headingLevel = 'h7';
+        fixture.detectChanges();
+        const el = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(el.nativeElement.getAttribute('aria-level')).toBe('7');
+    });
+
+    it('should accept level 1 and render aria-level "1"', () => {
+        fixture.componentInstance.headingLevel = 1;
+        fixture.detectChanges();
+        const el = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(el.nativeElement.getAttribute('aria-level')).toBe('1');
+    });
+
+    it('should accept level 6 and render aria-level "6"', () => {
+        fixture.componentInstance.headingLevel = 6;
+        fixture.detectChanges();
+        const el = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(el.nativeElement.getAttribute('aria-level')).toBe('6');
+    });
+});
+
+describe('GridListTitleBarComponent — default heading level', () => {
+    let fixture: ComponentFixture<GridListTitleBarDefaultTestComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [GridListTitleBarDefaultTestComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(GridListTitleBarDefaultTestComponent);
+        fixture.detectChanges();
+    });
+
+    it('should default to aria-level "2" when no headingLevel is provided', () => {
+        const label = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(label.nativeElement.getAttribute('aria-level')).toBe('2');
+    });
+
+    it('should render role="heading" when no headingLevel is provided', () => {
+        const label = fixture.debugElement.query(By.css('[fd-toolbar-label]'));
+        expect(label.nativeElement.getAttribute('role')).toBe('heading');
+    });
+});
+
+describe('GridListTitleBarComponent — content projection', () => {
+    let fixture: ComponentFixture<GridListTitleBarWithProjectionTestComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [GridListTitleBarWithProjectionTestComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(GridListTitleBarWithProjectionTestComponent);
+        fixture.detectChanges();
+    });
+
+    it('should project content inside the heading span', () => {
+        const projected = fixture.debugElement.query(By.css('[fd-grid-list-title-bar-additional-title-item]'));
+        expect(projected).toBeTruthy();
+        expect(projected.nativeElement.textContent).toContain('Extra info');
+    });
+
+    it('should keep projected content within the element that has role="heading"', () => {
+        const heading = fixture.debugElement.query(By.css('[role="heading"]'));
+        const projected = heading.nativeElement.querySelector('[fd-grid-list-title-bar-additional-title-item]');
+        expect(projected).toBeTruthy();
     });
 });

--- a/libs/core/grid-list/components/grid-list-title-bar/grid-list-title-bar.component.ts
+++ b/libs/core/grid-list/components/grid-list-title-bar/grid-list-title-bar.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, Input, input } from '@angular/core';
+import { HeadingLevel } from '@fundamental-ngx/core/shared';
 import { ToolbarComponent, ToolbarLabelDirective } from '@fundamental-ngx/core/toolbar';
 
 @Component({
@@ -14,4 +15,20 @@ export class GridListTitleBarComponent {
     /** Sets title of the Grid List */
     @Input()
     title: string;
+
+    /**
+     * Sets the semantic heading level for the title bar.
+     * Renders `role="heading"` with the corresponding `aria-level` attribute.
+     * Accepts values 1–6 (as numbers or strings).
+     * @default 2
+     */
+    readonly headingLevel = input<HeadingLevel>(2);
+
+    protected readonly normalizedLevel = computed(() => {
+        const level = this.headingLevel();
+        if (typeof level === 'string') {
+            return parseInt(level.replace(/^h/i, ''), 10) || 2;
+        }
+        return level;
+    });
 }

--- a/libs/docs/core/grid-list/examples/heading-level/grid-list-heading-level-example.component.html
+++ b/libs/docs/core/grid-list/examples/heading-level/grid-list-heading-level-example.component.html
@@ -1,0 +1,10 @@
+<fd-grid-list>
+    <fd-grid-list-title-bar title="Products (Heading Level 3)" [headingLevel]="3">
+        <span fd-grid-list-title-bar-additional-title-item>(5)</span>
+    </fd-grid-list-title-bar>
+    @for (item of list; track item) {
+        <fd-grid-list-item [title]="item.title" [description]="item.description">
+            <fd-avatar fd-grid-list-item-image image="https://picsum.photos/id/1062/300/200" size="s"></fd-avatar>
+        </fd-grid-list-item>
+    }
+</fd-grid-list>

--- a/libs/docs/core/grid-list/examples/heading-level/grid-list-heading-level-example.component.scss
+++ b/libs/docs/core/grid-list/examples/heading-level/grid-list-heading-level-example.component.scss
@@ -1,0 +1,1 @@
+@import '../grid-list.component.scss';

--- a/libs/docs/core/grid-list/examples/heading-level/grid-list-heading-level-example.component.ts
+++ b/libs/docs/core/grid-list/examples/heading-level/grid-list-heading-level-example.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { AvatarComponent } from '@fundamental-ngx/core/avatar';
+import { GridListModule } from '@fundamental-ngx/core/grid-list';
+
+@Component({
+    selector: 'fd-grid-list-heading-level-example',
+    templateUrl: './grid-list-heading-level-example.component.html',
+    styleUrls: ['./grid-list-heading-level-example.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [GridListModule, AvatarComponent]
+})
+export class GridListHeadingLevelExampleComponent {
+    list = Array(5).fill({
+        title: 'Title',
+        description: 'Description'
+    });
+}

--- a/libs/docs/core/grid-list/examples/index.ts
+++ b/libs/docs/core/grid-list/examples/index.ts
@@ -4,6 +4,7 @@ import { GridListDndExampleComponent } from './dnd/grid-list-dnd-example.compone
 import { GridListFocusingItemExampleComponent } from './focusing/grid-list-focusing-example.component';
 import { GridListFooterExampleComponent } from './footer/grid-list-footer-example.component';
 import { GridListGroupExampleComponent } from './group/grid-list-group-example.component';
+import { GridListHeadingLevelExampleComponent } from './heading-level/grid-list-heading-level-example.component';
 import { GridListLayoutExampleComponent } from './layout/grid-list-layout-example.component';
 import { GridListMoreExampleComponent } from './more/grid-list-more-example.component';
 import { GridListStatesExampleComponent } from './states/grid-list-states-example.component';
@@ -19,5 +20,6 @@ export const COMPONENTS = [
     GridListLayoutExampleComponent,
     GridListFocusingItemExampleComponent,
     GridListAutoHeightExampleComponent,
-    GridListComboSelectComponent
+    GridListComboSelectComponent,
+    GridListHeadingLevelExampleComponent
 ];

--- a/libs/docs/core/grid-list/grid-list-docs.component.html
+++ b/libs/docs/core/grid-list/grid-list-docs.component.html
@@ -96,6 +96,17 @@
 </component-example>
 <code-example [exampleFiles]="gridListFocusingExample"></code-example>
 
+<fd-docs-section-title id="heading-level" componentName="grid-list">Heading Level</fd-docs-section-title>
+<description>
+    Use the <code>[headingLevel]</code> property on <code>fd-grid-list-title-bar</code> to set the semantic heading
+    level of the title. This adds <code>role="heading"</code> and the corresponding <code>aria-level</code> attribute
+    for accessibility. The default heading level is <code>2</code>.
+</description>
+<component-example>
+    <fd-grid-list-heading-level-example></fd-grid-list-heading-level-example>
+</component-example>
+<code-example [exampleFiles]="gridListHeadingLevelExample"></code-example>
+
 <fd-docs-section-title id="auto-height" componentName="grid-list">Auto Height</fd-docs-section-title>
 <description>
     By default, items have equal height, determined by the tallest item in the row. To override this, set

--- a/libs/docs/core/grid-list/grid-list-docs.component.ts
+++ b/libs/docs/core/grid-list/grid-list-docs.component.ts
@@ -14,11 +14,14 @@ import { GridListDndExampleComponent } from './examples/dnd/grid-list-dnd-exampl
 import { GridListFocusingItemExampleComponent } from './examples/focusing/grid-list-focusing-example.component';
 import { GridListFooterExampleComponent } from './examples/footer/grid-list-footer-example.component';
 import { GridListGroupExampleComponent } from './examples/group/grid-list-group-example.component';
+import { GridListHeadingLevelExampleComponent } from './examples/heading-level/grid-list-heading-level-example.component';
 import { GridListLayoutExampleComponent } from './examples/layout/grid-list-layout-example.component';
 import { GridListMoreExampleComponent } from './examples/more/grid-list-more-example.component';
 import { GridListStatesExampleComponent } from './examples/states/grid-list-states-example.component';
 import { GridListStatusesExampleComponent } from './examples/statuses/grid-list-statuses-example.component';
 
+const gridListHeadingLevelTs = 'heading-level/grid-list-heading-level-example.component.ts';
+const gridListHeadingLevelHtml = 'heading-level/grid-list-heading-level-example.component.html';
 const gridListGroupTs = 'group/grid-list-group-example.component.ts';
 const gridListStatesTs = 'states/grid-list-states-example.component.ts';
 const gridListStatusesTs = 'statuses/grid-list-statuses-example.component.ts';
@@ -60,7 +63,8 @@ const gridListComboSelectHtml = 'combo-select/grid-list-combo-select-example.com
         GridListLayoutExampleComponent,
         GridListFocusingItemExampleComponent,
         GridListAutoHeightExampleComponent,
-        GridListComboSelectComponent
+        GridListComboSelectComponent,
+        GridListHeadingLevelExampleComponent
     ]
 })
 export class GridListDocsComponent {
@@ -221,6 +225,22 @@ export class GridListDocsComponent {
             code: getAssetFromModuleAssets(gridListAutoHeightTs),
             fileName: 'grid-list-auto-height-example',
             component: 'GridListAutoHeightExampleComponent',
+            scssFileCode: getAssetFromModuleAssets(scssFileCode)
+        }
+    ];
+
+    gridListHeadingLevelExample: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(gridListHeadingLevelHtml),
+            scssFileCode: this._scssFileCode,
+            fileName: 'grid-list-heading-level-example'
+        },
+        {
+            language: 'typescript',
+            code: getAssetFromModuleAssets(gridListHeadingLevelTs),
+            fileName: 'grid-list-heading-level-example',
+            component: 'GridListHeadingLevelExampleComponent',
             scssFileCode: getAssetFromModuleAssets(scssFileCode)
         }
     ];


### PR DESCRIPTION
closes https://github.com/SAP/fundamental-ngx/issues/13537

**Key files to review:**

1. **`grid-list-title-bar.component.ts`** — Core change. New `headingLevel` signal input + `normalizedLevel` computed that strips the `h` prefix (e.g. `'h4'` → `4`). Check that the default value (`2`) and normalization logic are correct.

2. **`grid-list-title-bar.component.html`** — `<label>` replaced with `<span>` + `role="heading"` + `[attr.aria-level]`. Verify the a11y semantics are correct (implicit heading via ARIA role instead of native `<h2>`–`<h6>`).

**How to verify:**

- Check the docs example at `/grid-list` → "Heading Level" tab (`yarn start` then navigate)
- Inspect the rendered DOM: the title `<span>` should have `role="heading"` and `aria-level="<N>"`