### PR TITLE
fix(platform): lookupKey now correctly matches complex objects in fdp-select

### DIFF
--- a/libs/docs/platform/select/examples/platform-select-lookup-key/platform-select-lookup-key-example.component.html
+++ b/libs/docs/platform/select/examples/platform-select-lookup-key/platform-select-lookup-key-example.component.html
@@ -1,0 +1,13 @@
+<fdp-form-group [noLabelLayout]="false" [formGroup]="form">
+    <fdp-form-field id="country" label="Country" [rank]="4">
+        <fdp-select
+            name="country"
+            placeholder="Select a country"
+            [list]="countries"
+            displayKey="name"
+            lookupKey="id"
+            formControlName="country"
+        ></fdp-select>
+    </fdp-form-field>
+</fdp-form-group>
+<p>Form value: {{ form.get('country')?.value | json }}</p>

--- a/libs/docs/platform/select/examples/platform-select-lookup-key/platform-select-lookup-key-example.component.ts
+++ b/libs/docs/platform/select/examples/platform-select-lookup-key/platform-select-lookup-key-example.component.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+
+import { JsonPipe } from '@angular/common';
+import { FdpFormGroupModule, PlatformSelectModule } from '@fundamental-ngx/platform/form';
+
+interface Country {
+    id: number;
+    name: string;
+    region: string;
+}
+
+@Component({
+    selector: 'fdp-platform-select-lookup-key-example',
+    templateUrl: './platform-select-lookup-key-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [FdpFormGroupModule, ReactiveFormsModule, PlatformSelectModule, JsonPipe]
+})
+export class PlatformSelectLookupKeyExampleComponent {
+    countries: Country[] = [
+        { id: 1, name: 'Germany', region: 'Europe' },
+        { id: 2, name: 'France', region: 'Europe' },
+        { id: 3, name: 'Japan', region: 'Asia' },
+        { id: 4, name: 'Brazil', region: 'Americas' }
+    ];
+
+    form = new FormGroup({
+        country: new FormControl<Country | null>({ id: 2, name: 'France', region: 'Europe' })
+    });
+}

--- a/libs/docs/platform/select/platform-select-docs.component.html
+++ b/libs/docs/platform/select/platform-select-docs.component.html
@@ -116,3 +116,19 @@
     <fdp-platform-select-forms></fdp-platform-select-forms>
 </component-example>
 <code-example [exampleFiles]="selectForm"></code-example>
+
+<separator></separator>
+
+<fd-docs-section-title id="lookup-key" componentName="select"> Select With Lookup Key</fd-docs-section-title>
+<description>
+    Imagine you load a user's saved country from an API and pass it to the form. The object looks identical to one in
+    your list (<code>{{ '{' }} id: 2, name: "France" {{ '}' }}</code
+    >), but JavaScript treats them as different because they are two separate objects in memory. Without
+    <code>[lookupKey]</code>, the select cannot find a match and shows nothing. Setting
+    <code>lookupKey="id"</code> tells the select to compare items by their <code>id</code> property instead. Now it sees
+    that both objects have <code>id: 2</code> and correctly shows "France" as selected.
+</description>
+<component-example>
+    <fdp-platform-select-lookup-key-example></fdp-platform-select-lookup-key-example>
+</component-example>
+<code-example [exampleFiles]="selectLookupKey"></code-example>

--- a/libs/docs/platform/select/platform-select-docs.component.ts
+++ b/libs/docs/platform/select/platform-select-docs.component.ts
@@ -13,6 +13,7 @@ import { PlatformSelectColumnsExampleComponent } from './examples/platform-selec
 import { PlatformSelectCustomTriggerComponent } from './examples/platform-select-custom-trigger/platform-select-custom-trigger.component';
 import { PlatformSelectFormsComponent } from './examples/platform-select-forms/platform-select-forms.component';
 import { PlatformSelectMaxHeightExampleComponent } from './examples/platform-select-height/platform-select-max-height-example.component';
+import { PlatformSelectLookupKeyExampleComponent } from './examples/platform-select-lookup-key/platform-select-lookup-key-example.component';
 import { PlatformSelectMobileExampleComponent } from './examples/platform-select-mobile-example/platform-select-mobile-example.component';
 import { PlatformSelectModeExampleComponent } from './examples/platform-select-mode-example/platform-select-mode-example.component';
 import { PlatformSelectNoneExampleComponent } from './examples/platform-select-none/platform-select-none-example.component';
@@ -48,6 +49,9 @@ const selectNoneTs = 'platform-select-none/platform-select-none-example.componen
 const selectNoWrapHtml = 'platform-select-nowrap/platform-select-nowrap-example.component.html';
 const selectNoWrapTs = 'platform-select-nowrap/platform-select-nowrap-example.component.ts';
 
+const selectLookupKeyHtml = 'platform-select-lookup-key/platform-select-lookup-key-example.component.html';
+const selectLookupKeyTs = 'platform-select-lookup-key/platform-select-lookup-key-example.component.ts';
+
 @Component({
     selector: 'fdp-select-docs',
     templateUrl: './platform-select-docs.component.html',
@@ -73,6 +77,7 @@ const selectNoWrapTs = 'platform-select-nowrap/platform-select-nowrap-example.co
         PlatformSelectMaxHeightExampleComponent,
         PlatformSelectNoneExampleComponent,
         PlatformSelectNoWrapExampleComponent,
+        PlatformSelectLookupKeyExampleComponent,
         PlatformSelectFormsComponent
     ]
 })
@@ -158,6 +163,20 @@ export class PlatformSelectDocsComponent {
             component: 'PlatformSelectFormsComponent',
             code: getAssetFromModuleAssets(selectFormTs),
             fileName: 'platform-select-forms'
+        }
+    ];
+
+    selectLookupKey: ExampleFile[] = [
+        {
+            language: 'html',
+            code: getAssetFromModuleAssets(selectLookupKeyHtml),
+            fileName: 'platform-select-lookup-key-example'
+        },
+        {
+            language: 'typescript',
+            component: 'PlatformSelectLookupKeyExampleComponent',
+            code: getAssetFromModuleAssets(selectLookupKeyTs),
+            fileName: 'platform-select-lookup-key-example'
         }
     ];
 

--- a/libs/platform/form/select/select/select.component.html
+++ b/libs/platform/form/select/select/select.component.html
@@ -10,6 +10,7 @@
     [appendTo]="appendTo"
     [fillControlMode]="fillControlMode"
     [maxHeight]="maxHeight"
+    [compareWith]="compareOptionValues"
     [attr.aria-disabled]="disabled || readonly"
     [attr.aria-labelledby]="ariaLabelledBy"
     [attr.tooltip]="value"

--- a/libs/platform/form/select/select/select.component.spec.ts
+++ b/libs/platform/form/select/select/select.component.spec.ts
@@ -228,6 +228,87 @@ describe('Select component Reactive Form Test', () => {
     });
 });
 
+interface Country {
+    id: number;
+    name: string;
+    region: string;
+}
+
+@Component({
+    selector: 'fdp-select-lookup-key-test',
+    template: `
+        <fdp-form-group [noLabelLayout]="false">
+            <fdp-form-field id="country" label="Country" rank="4">
+                <fdp-select
+                    name="country"
+                    placeholder="Select a country"
+                    [list]="countries"
+                    displayKey="name"
+                    lookupKey="id"
+                    [(ngModel)]="selectedCountry"
+                ></fdp-select>
+            </fdp-form-field>
+        </fdp-form-group>
+    `,
+    standalone: true,
+    imports: [FormsModule, FdpFormGroupModule, FormModule, PlatformSelectModule]
+})
+class SelectLookupKeyTestComponent {
+    @ViewChild(SelectComponent)
+    select: SelectComponent;
+
+    countries: Country[] = [
+        { id: 1, name: 'Germany', region: 'Europe' },
+        { id: 2, name: 'France', region: 'Europe' },
+        { id: 3, name: 'Japan', region: 'Asia' },
+        { id: 4, name: 'Brazil', region: 'Americas' }
+    ];
+
+    selectedCountry: Country | null = null;
+}
+
+describe('Select Component with lookupKey', () => {
+    let component: SelectLookupKeyTestComponent;
+    let fixture: ComponentFixture<SelectLookupKeyTestComponent>;
+    let select: SelectComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [SelectLookupKeyTestComponent],
+            providers: [DynamicComponentService, MenuKeyboardService]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SelectLookupKeyTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        select = component.select;
+    });
+
+    it('should identify selected item when ngModel is set to a separate object reference with same lookupKey value', async () => {
+        // Set ngModel to a DIFFERENT object reference that has the same id
+        component.selectedCountry = { id: 2, name: 'France', region: 'Europe' };
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        // The option item for France (id=2) should be recognized as selected
+        const franceOptionItem = select._optionItems[1]; // { label: 'France', value: {id:2, ...} }
+        expect(select._isSelectedOptionItem(franceOptionItem)).toBe(true);
+    });
+
+    it('should not identify non-matching item as selected when using lookupKey', async () => {
+        component.selectedCountry = { id: 2, name: 'France', region: 'Europe' };
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const germanyOptionItem = select._optionItems[0]; // { label: 'Germany', value: {id:1, ...} }
+        expect(select._isSelectedOptionItem(germanyOptionItem)).toBe(false);
+    });
+});
+
 const SELECT_IDENTIFIER = 'platform-select-unit-test';
 
 runValueAccessorTests({

--- a/libs/platform/form/select/select/select.component.spec.ts
+++ b/libs/platform/form/select/select/select.component.spec.ts
@@ -309,6 +309,320 @@ describe('Select Component with lookupKey', () => {
     });
 });
 
+@Component({
+    selector: 'fdp-select-lookup-key-reactive-test',
+    template: `
+        <fdp-form-group [noLabelLayout]="false">
+            <fdp-form-field id="country" label="Country" rank="4">
+                <fdp-select
+                    name="country"
+                    placeholder="Select a country"
+                    [list]="countries"
+                    displayKey="name"
+                    lookupKey="id"
+                    [formControl]="countryControl"
+                ></fdp-select>
+            </fdp-form-field>
+        </fdp-form-group>
+    `,
+    standalone: true,
+    imports: [ReactiveFormsModule, FdpFormGroupModule, FormModule, PlatformSelectModule]
+})
+class SelectLookupKeyReactiveTestComponent {
+    @ViewChild(SelectComponent)
+    select: SelectComponent;
+
+    countries: Country[] = [
+        { id: 1, name: 'Germany', region: 'Europe' },
+        { id: 2, name: 'France', region: 'Europe' },
+        { id: 3, name: 'Japan', region: 'Asia' },
+        { id: 4, name: 'Brazil', region: 'Americas' }
+    ];
+
+    countryControl = new FormControl<Country | null>(null);
+}
+
+describe('Select Component with lookupKey and reactive forms', () => {
+    let component: SelectLookupKeyReactiveTestComponent;
+    let fixture: ComponentFixture<SelectLookupKeyReactiveTestComponent>;
+    let select: SelectComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [SelectLookupKeyReactiveTestComponent],
+            providers: [DynamicComponentService, MenuKeyboardService]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SelectLookupKeyReactiveTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        select = component.select;
+    });
+
+    it('should display selected option when FormControl is set to a different object reference with matching lookupKey', async () => {
+        component.countryControl.setValue({ id: 3, name: 'Japan', region: 'Asia' });
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Japan');
+    });
+
+    it('should update displayed value when FormControl value changes', async () => {
+        component.countryControl.setValue({ id: 1, name: 'Germany', region: 'Europe' });
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        let triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Germany');
+
+        component.countryControl.setValue({ id: 4, name: 'Brazil', region: 'Americas' });
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Brazil');
+    });
+
+    it('should show placeholder when FormControl value is null', async () => {
+        component.countryControl.setValue(null);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Select a country');
+    });
+});
+
+@Component({
+    selector: 'fdp-select-lookup-key-secondary-test',
+    template: `
+        <fdp-form-group [noLabelLayout]="false">
+            <fdp-form-field id="country" label="Country" rank="4">
+                <fdp-select
+                    name="country"
+                    placeholder="Select a country"
+                    [list]="countries"
+                    displayKey="name"
+                    secondaryKey="region"
+                    showSecondaryText="true"
+                    lookupKey="id"
+                    [(ngModel)]="selectedCountry"
+                ></fdp-select>
+            </fdp-form-field>
+        </fdp-form-group>
+    `,
+    standalone: true,
+    imports: [FormsModule, FdpFormGroupModule, FormModule, PlatformSelectModule]
+})
+class SelectLookupKeySecondaryTextTestComponent {
+    @ViewChild(SelectComponent)
+    select: SelectComponent;
+
+    countries: Country[] = [
+        { id: 1, name: 'Germany', region: 'Europe' },
+        { id: 2, name: 'France', region: 'Europe' },
+        { id: 3, name: 'Japan', region: 'Asia' },
+        { id: 4, name: 'Brazil', region: 'Americas' }
+    ];
+
+    selectedCountry: Country | null = null;
+}
+
+describe('Select Component with lookupKey and showSecondaryText', () => {
+    let component: SelectLookupKeySecondaryTextTestComponent;
+    let fixture: ComponentFixture<SelectLookupKeySecondaryTextTestComponent>;
+    let select: SelectComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [SelectLookupKeySecondaryTextTestComponent],
+            providers: [DynamicComponentService, MenuKeyboardService]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SelectLookupKeySecondaryTextTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        select = component.select;
+    });
+
+    it('should build option items with secondary text', () => {
+        expect(select._optionItems.length).toBe(4);
+        expect(select._optionItems[0].label).toBe('Germany');
+        expect(select._optionItems[0].secondaryText).toBe('Europe');
+    });
+
+    it('should extract lookupKey value into option item value when showSecondaryText is true', () => {
+        expect(select._optionItems[0].value).toBe(1);
+        expect(select._optionItems[2].value).toBe(3);
+    });
+
+    it('should not break when lookupKey is used with showSecondaryText (known limitation)', async () => {
+        // When showSecondaryText=true, option values are pre-extracted to the lookupKey value (e.g., id: 2 → value: 2).
+        // The compareOptionValues fallback handles this by falling back to === when lookupValue returns null.
+        // Full lookupKey matching with showSecondaryText is a separate issue.
+        component.selectedCountry = { id: 2, name: 'France', region: 'Europe' };
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        // Verify no errors thrown and component is stable
+        expect(select._optionItems.length).toBe(4);
+    });
+});
+
+@Component({
+    selector: 'fdp-select-simple-values-test',
+    template: `
+        <fdp-form-group [noLabelLayout]="false">
+            <fdp-form-field id="fruit" label="Fruit" rank="4">
+                <fdp-select
+                    name="fruit"
+                    placeholder="Select a fruit"
+                    [list]="fruits"
+                    [(ngModel)]="selectedFruit"
+                ></fdp-select>
+            </fdp-form-field>
+        </fdp-form-group>
+    `,
+    standalone: true,
+    imports: [FormsModule, FdpFormGroupModule, FormModule, PlatformSelectModule]
+})
+class SelectSimpleValuesTestComponent {
+    @ViewChild(SelectComponent)
+    select: SelectComponent;
+
+    fruits: string[] = ['Apple', 'Banana', 'Cherry', 'Date'];
+
+    selectedFruit: string | null = null;
+}
+
+describe('Select Component with simple string values (no lookupKey)', () => {
+    let component: SelectSimpleValuesTestComponent;
+    let fixture: ComponentFixture<SelectSimpleValuesTestComponent>;
+    let select: SelectComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [SelectSimpleValuesTestComponent],
+            providers: [DynamicComponentService, MenuKeyboardService]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SelectSimpleValuesTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        select = component.select;
+    });
+
+    it('should convert string items to OptionItems', () => {
+        expect(select._optionItems.length).toBe(4);
+        expect(select._optionItems[0].label).toBe('Apple');
+        expect(select._optionItems[0].value).toBe('Apple');
+    });
+
+    it('should display selected string value in trigger', async () => {
+        component.selectedFruit = 'Cherry';
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Cherry');
+    });
+
+    it('should update trigger when selection changes between string values', async () => {
+        component.selectedFruit = 'Apple';
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        let triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Apple');
+
+        component.selectedFruit = 'Date';
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Date');
+    });
+});
+
+describe('Select Component with lookupKey — selection changes', () => {
+    let component: SelectLookupKeyTestComponent;
+    let fixture: ComponentFixture<SelectLookupKeyTestComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [SelectLookupKeyTestComponent],
+            providers: [DynamicComponentService, MenuKeyboardService]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SelectLookupKeyTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should display correct country when ngModel changes from one to another', async () => {
+        component.selectedCountry = { id: 1, name: 'Germany', region: 'Europe' };
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        let triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Germany');
+
+        component.selectedCountry = { id: 3, name: 'Japan', region: 'Asia' };
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Japan');
+    });
+
+    it('should clear displayed value when ngModel is set to null', async () => {
+        component.selectedCountry = { id: 2, name: 'France', region: 'Europe' };
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        let triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('France');
+
+        component.selectedCountry = null;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Select a country');
+    });
+
+    it('should display correct value when ngModel is set before first detection cycle', async () => {
+        component.selectedCountry = { id: 4, name: 'Brazil', region: 'Americas' };
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const triggerText = fixture.nativeElement.querySelector('.fd-select__text-content')?.textContent?.trim();
+        expect(triggerText).toBe('Brazil');
+    });
+});
+
 const SELECT_IDENTIFIER = 'platform-select-unit-test';
 
 runValueAccessorTests({

--- a/libs/platform/form/select/select/select.component.ts
+++ b/libs/platform/form/select/select/select.component.ts
@@ -93,7 +93,7 @@ export class SelectComponent extends BaseSelect implements AfterViewInit, AfterV
      * @hidden
      */
     _isSelectedOptionItem(selectedItem: any): boolean {
-        return this.value === this.lookupValue(selectedItem);
+        return this.lookupValue(this.value) === this.lookupValue(selectedItem);
     }
 
     /** @hidden */
@@ -108,6 +108,18 @@ export class SelectComponent extends BaseSelect implements AfterViewInit, AfterV
         }
         this.formMessage?._popover?.setIgnoreTriggers(isOpen);
     }
+
+    /** @hidden */
+    protected compareOptionValues = (o1: any, o2: any): boolean => {
+        if (this.lookupKey) {
+            const v1 = this.lookupValue(o1);
+            const v2 = this.lookupValue(o2);
+            if (v1 != null && v2 != null) {
+                return v1 === v2;
+            }
+        }
+        return o1 === o2;
+    };
 
     /** @hidden */
     private _setColumnsRatio(firstColumnRatio: number, secondColumnRatio: number): void {


### PR DESCRIPTION
closes https://github.com/SAP/fundamental-ngx/issues/13533

### Summary

The `lookupKey` input on `<fdp-select>` was declared and documented but had no effect. When a form control was set to an object fetched from an API (a different JS reference than the one in the `[list]`), the select could not find a match and displayed nothing — even when the objects were semantically identical.

**Root cause:** `_isSelectedOptionItem()` compared the raw stored value against the extracted key from the option item, mixing comparison types. Additionally, the inner `fd-select` used default `===` reference equality with no awareness of `lookupKey`.

**Fix:** Apply `lookupValue()` to both sides of the comparison in `_isSelectedOptionItem()`, and pass a `compareWith` function to the core `fd-select` that compares by `lookupKey` property when set (falling back to `===` when not).

### Changes

**Implementation:**
- `libs/platform/form/select/select/select.component.ts` — fixed `_isSelectedOptionItem` to extract lookup key from both sides; added `compareOptionValues` comparator with null-guard fallback
- `libs/platform/form/select/select/select.component.html` — wired `[compareWith]="compareOptionValues"` to inner `fd-select`
