### PR TITLE
fix(btp): center vertically the Side Nav icons with nav button in Overlay Mode

### DIFF
--- a/libs/btp/navigation/components/navigation/navigation.component.scss
+++ b/libs/btp/navigation/components/navigation/navigation.component.scss
@@ -261,3 +261,12 @@ $block: fd-navigation;
 .fd-navigation.fd-navigation--snapped .fd-navigation__list-container {
     display: flex;
 }
+
+.fd-popover__body.fd-popover__body--left:has(.fd-navigation) {
+    margin-inline-start: -0.875rem;
+
+    &::after,
+    &::before {
+        margin-inline-start: 0.875rem;
+    }
+}


### PR DESCRIPTION
## Related Issue(s)

related to FIORITECHP1-35344 

## Description

Side navigation menu icons should be centre aligned with the hamburger icon in the shell bar


## Screenshots
### Before:
<img width="1082" height="1060" alt="Screenshot 2026-05-11 at 11 40 45 AM" src="https://github.com/user-attachments/assets/b0cc0218-d07b-4998-8dd9-d4881edecd8b" />

### After:
<img width="1207" height="1154" alt="Screenshot 2026-05-11 at 11 35 34 AM" src="https://github.com/user-attachments/assets/afcc1dec-aafb-496f-9927-6b0fd2faabe8" />
<img width="1211" height="1160" alt="Screenshot 2026-05-11 at 11 35 23 AM" src="https://github.com/user-attachments/assets/f6c19623-e148-484f-8e68-cd9fdb1bf3b7" />
