### PR TITLE
fix(core): restore ngModelChange emission in combobox communicateByObject mode

### DIFF
--- a/libs/core/combobox/combobox.component.spec.ts
+++ b/libs/core/combobox/combobox.component.spec.ts
@@ -90,7 +90,7 @@ describe('ComboboxComponent', () => {
         expect(component.onChange).toHaveBeenCalledWith('otherDisplayedValue');
     });
 
-    it('should not call onChange when using wrong input entry on dropdown mode with communicateByObject', () => {
+    it('should call onChange with null when using non-matching input in communicateByObject mode', () => {
         jest.spyOn(component, 'onChange');
         component.communicateByObject = true;
         component.displayFn = (item: any): string => {
@@ -101,7 +101,7 @@ describe('ComboboxComponent', () => {
             }
         };
         component.inputText = 'otherDisplayedValue';
-        expect(component.onChange).not.toHaveBeenCalled();
+        expect(component.onChange).toHaveBeenCalledWith(null);
     });
 
     it('should handle write value from outside on dropdown mode', () => {
@@ -411,6 +411,113 @@ describe('ComboboxComponent', () => {
             component.inputText = '';
 
             expect(component.onChange).toHaveBeenCalledWith('');
+        });
+    });
+
+    describe('communicateByObject propagateChange edge cases', () => {
+        interface Item {
+            displayedValue: string;
+            value: string;
+        }
+
+        let items: Item[];
+
+        beforeEach(() => {
+            fixture = TestBed.createComponent(ComboboxComponent<Item>);
+            component = fixture.componentInstance;
+            items = [
+                { displayedValue: 'Apple', value: 'apple-val' },
+                { displayedValue: 'Banana', value: 'banana-val' },
+                { displayedValue: 'Cherry', value: 'cherry-val' }
+            ];
+            component.dropdownValues = items;
+            component.communicateByObject = true;
+            component.displayFn = (item: Item): string => item?.displayedValue ?? '';
+            component.searchFn = () => {};
+            fixture.detectChanges();
+        });
+
+        it('should emit null when clearing input to empty string', () => {
+            jest.spyOn(component, 'onChange');
+            component.onMenuClickHandler(items[0]);
+            expect(component.onChange).toHaveBeenCalledWith(items[0]);
+
+            (component.onChange as jest.Mock).mockClear();
+            component.inputText = '';
+            expect(component.onChange).toHaveBeenCalledWith(null);
+        });
+
+        it('should emit the full object when input matches an item exactly', () => {
+            jest.spyOn(component, 'onChange');
+            component.inputText = 'Banana';
+            expect(component.onChange).toHaveBeenCalledWith(items[1]);
+        });
+
+        it('should emit null when switching from valid selection to non-matching text', () => {
+            jest.spyOn(component, 'onChange');
+            component.onMenuClickHandler(items[2]);
+            expect(component.onChange).toHaveBeenCalledWith(items[2]);
+
+            (component.onChange as jest.Mock).mockClear();
+            component.inputText = 'NonExistent';
+            expect(component.onChange).toHaveBeenCalledWith(null);
+        });
+
+        it('should not emit stale object when multiple items share the same display value', () => {
+            const duplicates: Item[] = [
+                { displayedValue: 'Apple', value: 'apple-1' },
+                { displayedValue: 'Apple', value: 'apple-2' },
+                { displayedValue: 'Banana', value: 'banana-val' }
+            ];
+            component.dropdownValues = duplicates;
+            jest.spyOn(component, 'onChange');
+
+            component.inputText = 'Apple';
+            // Multiple matches → should NOT emit a single item, should emit current getValue()
+            // The key assertion: onChange IS called (contract fulfilled) but NOT with a single stale object
+            expect(component.onChange).toHaveBeenCalled();
+            const emittedValue = (component.onChange as jest.Mock).mock.calls[0][0];
+            // With multiple matches, it should not prematurely pick one item
+            expect(emittedValue).not.toEqual(duplicates[0]);
+            expect(emittedValue).not.toEqual(duplicates[1]);
+        });
+
+        it('should emit extracted property value when valueProperty is set and input matches', () => {
+            jest.spyOn(component, 'onChange');
+            fixture.componentRef.setInput('valueProperty', 'value');
+            fixture.detectChanges();
+
+            component.inputText = 'Cherry';
+            expect(component.onChange).toHaveBeenCalledWith('cherry-val');
+        });
+
+        it('should emit null when valueProperty is set and input does not match', () => {
+            jest.spyOn(component, 'onChange');
+            fixture.componentRef.setInput('valueProperty', 'value');
+            fixture.detectChanges();
+
+            component.inputText = 'Grape';
+            expect(component.onChange).toHaveBeenCalledWith(null);
+        });
+
+        it('should not duplicate emissions when setting inputText to the same non-matching value', () => {
+            jest.spyOn(component, 'onChange');
+            component.inputText = 'xyz';
+            expect(component.onChange).toHaveBeenCalledTimes(1);
+            expect(component.onChange).toHaveBeenCalledWith(null);
+        });
+
+        it('should emit null via _handleClearSearchTerm when used as search field', () => {
+            jest.spyOn(component, 'onChange');
+            component.onMenuClickHandler(items[0]);
+            (component.onChange as jest.Mock).mockClear();
+
+            component.isSearch = true;
+            component.mobile = false;
+            fixture.detectChanges();
+
+            (component as any)._handleClearSearchTerm();
+            expect(component.onChange).toHaveBeenCalledWith(null);
         });
     });
 

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -885,18 +885,12 @@ export class ComboboxComponent<T = any>
     private _propagateChange(): void {
         if (this.communicateByObject) {
             const values = this._getOptionObjectByDisplayedValue(this.inputText);
-            // Do not set new value if theres multiple items that have same label.
             if (values.length === 1 && this.displayFn(values[0]) !== this.displayFn(this.getValue())) {
                 this.setValue(values[0]);
             } else if (values.length === 0) {
-                this.setValue(this.inputText);
+                this.setValue(null);
             }
-            const thisValue = this.getValue();
-            // If valueProperty is not specified and value is an object, emit the object
-            // If valueProperty is specified, the extracted value is already set by setValue
-            if (typeof thisValue === 'object' || this.valueProperty()) {
-                this.onChange(thisValue);
-            }
+            this.onChange(this.getValue());
         } else {
             this.onChange(this.inputText);
         }


### PR DESCRIPTION
closes https://github.com/SAP/fundamental-ngx/issues/13526

## What changed

When `communicateByObject = true`, `_propagateChange()` had a guard (`typeof thisValue === 'object'`) that silently skipped calling `onChange()` for non-matching input. This broke the ControlValueAccessor contract — `ngModelChange` / `formControl.valueChanges` never fired when the user typed text that didn't match a dropdown item.

**Fix:** Always call `onChange()` in `communicateByObject` mode. Non-matching input now emits `null` instead of a raw string, preserving type safety (`T | null`).

## How to test

**Component:** Combobox (`fd-combobox`)
**Page:** Docs app → Core → Combobox → "Combobox with object communicate" example

### Steps

1. Open the combobox with `communicateByObject` enabled (bound via `ngModel` or `formControl`)
2. Select an item from the dropdown → verify `ngModelChange` fires with the full object
3. Clear the input and type text that does NOT match any item (e.g. "xyz") → verify `ngModelChange` fires with `null`
4. Type text that exactly matches an item's display value → verify `ngModelChange` fires with that object
5. Select an item, then overwrite it with non-matching text → verify value changes from object to `null`

### Edge cases

- Empty input after a previous selection → should emit `null`
- Multiple dropdown items with the same display label → should NOT prematurely pick one; `onChange` fires but value stays as-is
- `valueProperty` set (e.g. `[valueProperty]="'id'"`) + matching input → should emit the extracted property value (e.g. the `id` string)
- `valueProperty` set + non-matching input → should emit `null`
- Clear button (search mode) → should emit `null`
