### PR TITLE
fix(core): [Core] [fd-illustrated-message] fd-illustrated-message in fdp-icon-tab-bar cannot render properly 

### DIFF
--- a/libs/core/illustrated-message/illustrated-message.component.spec.ts
+++ b/libs/core/illustrated-message/illustrated-message.component.spec.ts
@@ -4,7 +4,26 @@ import { By } from '@angular/platform-browser';
 import { IllustratedMessageFigcaptionComponent } from './components/illustrated-message-figcaption/illustrated-message-figcaption.component';
 import { IllustratedMessageTextDirective } from './directives/illustrated-message-text/illustrated-message-text.directive';
 import { IllustratedMessageTitleDirective } from './directives/illustrated-message-title/illustrated-message-title.directive';
-import { IllustratedMessageComponent, IllustratedMessageType, SvgConfig } from './illustrated-message.component';
+import {
+    IllustratedMessageComponent,
+    IllustratedMessageType,
+    IllustratedMessageTypes,
+    SvgConfig
+} from './illustrated-message.component';
+
+@Component({
+    template: `<figure fd-illustrated-message [svgConfig]="svgConfig"></figure>`,
+    standalone: true,
+    imports: [IllustratedMessageComponent]
+})
+class HiddenContainerTestComponent {
+    readonly svgConfig: SvgConfig = {
+        large: { url: 'large-url', id: 'large-id' },
+        medium: { url: 'medium-url', id: 'medium-id' },
+        small: { url: 'small-url', id: 'small-id' },
+        xsmall: { url: 'xsmall-url', id: 'xsmall-id' }
+    };
+}
 
 /**
  * Mock component for testing illustrated message with signals
@@ -197,5 +216,77 @@ describe('IllustratedMessageComponent', () => {
         const inlineSvgDiv = container.querySelector('div[style*="display"]');
         expect(inlineSvgDiv).toBeTruthy();
         expect(inlineSvgDiv.innerHTML).toContain('circle');
+    }));
+});
+
+describe('IllustratedMessageComponent - hidden container (tab switch scenario)', () => {
+    let resizeCallback: ResizeObserverCallback;
+    let fixture: ComponentFixture<HiddenContainerTestComponent>;
+    let illustratedEl: HTMLElement;
+
+    beforeEach(waitForAsync(() => {
+        (window as any).ResizeObserver = jest.fn((cb: ResizeObserverCallback) => {
+            resizeCallback = cb;
+            return { observe: jest.fn(), disconnect: jest.fn() };
+        });
+
+        TestBed.configureTestingModule({
+            imports: [HiddenContainerTestComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(HiddenContainerTestComponent);
+        illustratedEl = fixture.debugElement.query(By.directive(IllustratedMessageComponent)).nativeElement;
+        Object.defineProperty(illustratedEl, 'offsetWidth', { get: () => 0, configurable: true });
+    });
+
+    afterEach(() => {
+        delete (window as any).ResizeObserver;
+    });
+
+    it('should render with base type when initially hidden (offsetWidth = 0)', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        expect(illustratedEl.classList.contains('fd-illustrated-message--base')).toBe(true);
+    }));
+
+    it('should update to the correct type when the element becomes visible', fakeAsync(() => {
+        fixture.detectChanges();
+        tick(); // flush afterNextRender — ResizeObserver.observe() is now called, resizeCallback is captured
+        fixture.detectChanges();
+
+        expect(illustratedEl.classList.contains('fd-illustrated-message--base')).toBe(true);
+
+        // Simulate tab becoming active: element now has a real width (>= 682px → large)
+        Object.defineProperty(illustratedEl, 'offsetWidth', { get: () => 700, configurable: true });
+        resizeCallback([], {} as ResizeObserver);
+        fixture.detectChanges();
+
+        expect(illustratedEl.classList.contains('fd-illustrated-message--large')).toBe(true);
+        expect(illustratedEl.classList.contains('fd-illustrated-message--base')).toBe(false);
+    }));
+
+    it('should select the correct breakpoint type based on element width when becoming visible', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+
+        const cases: Array<[number, IllustratedMessageType]> = [
+            [700, IllustratedMessageTypes.LARGE], // >= 682
+            [500, IllustratedMessageTypes.MEDIUM], // 361–681
+            [300, IllustratedMessageTypes.SMALL], // 261–360
+            [200, IllustratedMessageTypes.EXTRA_SMALL] // 161–260
+        ];
+
+        for (const [width, expectedType] of cases) {
+            Object.defineProperty(illustratedEl, 'offsetWidth', { get: () => width, configurable: true });
+            resizeCallback([], {} as ResizeObserver);
+            fixture.detectChanges();
+
+            expect(illustratedEl.classList.contains(`fd-illustrated-message--${expectedType}`)).toBe(true);
+        }
     }));
 });

--- a/libs/core/illustrated-message/illustrated-message.component.ts
+++ b/libs/core/illustrated-message/illustrated-message.component.ts
@@ -4,17 +4,15 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    effect,
+    DestroyRef,
     ElementRef,
     inject,
     input,
     signal,
     ViewEncapsulation
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { DomSanitizer } from '@angular/platform-browser';
 import { HasElementRef, RequireOnlyOne } from '@fundamental-ngx/cdk/utils';
-import { debounceTime, fromEvent } from 'rxjs';
 
 /**
  * Configuration for an SVG item in the illustrated message.
@@ -229,24 +227,16 @@ export class IllustratedMessageComponent implements HasElementRef {
     private readonly _sanitizer = inject(DomSanitizer);
 
     /** @hidden */
+    private readonly _destroyRef = inject(DestroyRef);
+
+    /** @hidden */
     constructor() {
-        // Setup resize listener for responsive behavior with automatic cleanup
-        const resize$ = toSignal(fromEvent(window, 'resize').pipe(debounceTime(200)));
-
-        // Measure container width after render
         afterNextRender(() => {
-            this._measureContainerWidth();
-        });
-
-        // React to resize events and input changes
-        effect(() => {
-            // Track resize events
-            resize$();
-            this.type();
-            this.svgConfig();
-
-            // Remeasure on changes
-            this._measureContainerWidth();
+            const observer = new ResizeObserver(() => {
+                this._measureContainerWidth();
+            });
+            observer.observe(this.elementRef.nativeElement);
+            this._destroyRef.onDestroy(() => observer.disconnect());
         });
     }
 


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14207

## Description

**The bug:** `IllustratedMessageComponent` uses `afterNextRender()` for an initial measurement of `offsetWidth`, then an `effect()` that only re-measures on `window resize` events. When the component lives inside a hidden `tab` (`display: none`), `offsetWidth` is `0` at first render. The window resize listener never fires on tab switch — so when the user navigates to that tab, `containerWidth` stays at `0` and the component remains stuck in base (smallest) mode.

**The fix:** Replace the `window resize + afterNextRender` approach with a `ResizeObserver`. `ResizeObserver` fires both on initial observation AND when the element transitions from a no-layout-box state (display: none) to a visible state.

## Screenshots

**Before:**

https://github.com/user-attachments/assets/cf82af70-14d7-49e2-89a8-6f398a72c581

**After:**

https://github.com/user-attachments/assets/1bf65fca-3b45-427d-98cb-b597c7f300ef

