### PR TITLE
fix(core): forward scrollStrategy through fd-menu and fd-inline-help

### DIFF
--- a/libs/core/inline-help/inline-help.directive.spec.ts
+++ b/libs/core/inline-help/inline-help.directive.spec.ts
@@ -1,3 +1,4 @@
+import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -32,6 +33,7 @@ class InlineHelpDefaultTestComponent {
             [fixedPosition]="fixedPosition"
             [maxWidth]="maxWidth"
             [appendTo]="appendTo"
+            [scrollStrategy]="scrollStrategy"
         ></div>
     `,
     imports: [InlineHelpModule]
@@ -47,6 +49,7 @@ class InlineHelpInputsTestComponent {
     fixedPosition = false;
     maxWidth: number | null = null;
     appendTo: Element | null = null;
+    scrollStrategy: ScrollStrategy | null = null;
 }
 
 describe('InlineHelpDirective', () => {
@@ -183,6 +186,15 @@ describe('InlineHelpDirective popover inputs', () => {
         fixture.detectChanges();
         expect(popoverService.appendTo()).toBe(container);
         document.body.removeChild(container);
+    });
+
+    it('should pass scrollStrategy to popover service (regression #14210)', () => {
+        const overlay = TestBed.inject(Overlay);
+        expect(popoverService.scrollStrategy()).toBeNull();
+        const closeStrategy = overlay.scrollStrategies.close();
+        component.scrollStrategy = closeStrategy;
+        fixture.detectChanges();
+        expect(popoverService.scrollStrategy()).toBe(closeStrategy);
     });
 
     it('should close on escape key when closeOnEscapeKey is true (focus on trigger)', fakeAsync(() => {

--- a/libs/core/inline-help/inline-help.directive.ts
+++ b/libs/core/inline-help/inline-help.directive.ts
@@ -1,3 +1,4 @@
+import { ScrollStrategy } from '@angular/cdk/overlay';
 import {
     booleanAttribute,
     computed,
@@ -92,6 +93,9 @@ export class InlineHelpDirective {
     /** Maximum width of popover body in px. */
     readonly maxWidth = input<number | null | undefined>(null);
 
+    /** CDK scroll strategy applied to the inline help overlay. */
+    readonly scrollStrategy = input<ScrollStrategy | null>(null);
+
     /** @hidden Combined internal + user-provided body classes. */
     readonly combinedBodyClass = computed(() => {
         const parts = [this._additionalBodyClass];
@@ -114,6 +118,7 @@ export class InlineHelpDirective {
         appendTo: this.appendTo,
         fixedPosition: this.fixedPosition,
         maxWidth: this.maxWidth,
+        scrollStrategy: this.scrollStrategy,
         additionalBodyClass: this.combinedBodyClass,
         disabled: this.disabled,
         bodyRole: this.bodyRole,

--- a/libs/core/menu/menu.component.spec.ts
+++ b/libs/core/menu/menu.component.spec.ts
@@ -1,6 +1,9 @@
 import { ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync } from '@angular/core/testing';
 
+import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
 import { Component, ElementRef, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { PopoverService } from '@fundamental-ngx/core/popover';
 import { MenuTitleDirective } from './directives/menu-title.directive';
 import { MenuTriggerDirective } from './directives/menu-trigger.directive';
 import { MenuInteractiveComponent } from './menu-interactive.component';
@@ -568,5 +571,75 @@ describe('MenuComponent advanced options', () => {
             expect(menu.appendTo()).toBeTruthy();
             expect(menu.appendTo()).toBe(testComponent.appendTarget.nativeElement);
         });
+    });
+});
+
+describe('MenuComponent scrollStrategy (regression #14210)', () => {
+    @Component({
+        selector: 'fd-menu-scroll-strategy-test',
+        template: `
+            <fd-menu #menu [config]="menuConfig" [scrollStrategy]="directScrollStrategy">
+                <li fd-menu-item>
+                    <a href="#" fd-menu-interactive>
+                        <span fd-menu-title>Option 1</span>
+                    </a>
+                </li>
+            </fd-menu>
+            <button #trigger [fdMenuTrigger]="menu">Open Menu</button>
+        `,
+        imports: [MenuComponent, MenuItemComponent, MenuInteractiveComponent, MenuTitleDirective, MenuTriggerDirective]
+    })
+    class TestMenuScrollStrategyComponent {
+        @ViewChild(MenuComponent) menu: MenuComponent;
+
+        menuConfig: { scrollStrategy?: ScrollStrategy | null } = {};
+        directScrollStrategy: ScrollStrategy | null = null;
+    }
+
+    let fixture: ComponentFixture<TestMenuScrollStrategyComponent>;
+    let testComponent: TestMenuScrollStrategyComponent;
+    let popoverService: PopoverService;
+    let overlay: Overlay;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [TestMenuScrollStrategyComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestMenuScrollStrategyComponent);
+        testComponent = fixture.componentInstance;
+        fixture.detectChanges();
+
+        const menuDebugEl = fixture.debugElement.query(By.directive(MenuComponent));
+        popoverService = menuDebugEl.injector.get(PopoverService);
+        overlay = TestBed.inject(Overlay);
+    });
+
+    it('should forward config.scrollStrategy to the popover service', () => {
+        const closeStrategy = overlay.scrollStrategies.close();
+        testComponent.menuConfig = { scrollStrategy: closeStrategy };
+        fixture.detectChanges();
+
+        expect(popoverService.scrollStrategy()).toBe(closeStrategy);
+    });
+
+    it('should forward direct [scrollStrategy] input to the popover service', () => {
+        const closeStrategy = overlay.scrollStrategies.close();
+        testComponent.directScrollStrategy = closeStrategy;
+        fixture.detectChanges();
+
+        expect(popoverService.scrollStrategy()).toBe(closeStrategy);
+    });
+
+    it('should let the direct [scrollStrategy] input win over config.scrollStrategy', () => {
+        const configStrategy = overlay.scrollStrategies.noop();
+        const directStrategy = overlay.scrollStrategies.close();
+        testComponent.menuConfig = { scrollStrategy: configStrategy };
+        testComponent.directScrollStrategy = directStrategy;
+        fixture.detectChanges();
+
+        expect(popoverService.scrollStrategy()).toBe(directStrategy);
     });
 });

--- a/libs/core/menu/menu.component.ts
+++ b/libs/core/menu/menu.component.ts
@@ -1,3 +1,4 @@
+import { ScrollStrategy } from '@angular/cdk/overlay';
 import {
     AfterContentInit,
     afterNextRender,
@@ -148,6 +149,9 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     /** Whether position shouldn't change when the menu approaches the corner of the page */
     readonly fixedPosition = input(false, { transform: booleanAttribute });
 
+    /** CDK scroll strategy applied to the menu overlay. */
+    readonly scrollStrategy = input<ScrollStrategy | null>(null);
+
     /** Two-way binding for menu open state */
     readonly isOpen = model(false);
 
@@ -271,6 +275,7 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
             this._popoverService.restoreFocusOnClose.set(this.restoreFocusOnClose() ?? cfg.restoreFocusOnClose ?? true);
             this._popoverService.appendTo.set(this.appendTo() ?? cfg.appendTo ?? null);
             this._popoverService.fixedPosition.set(this.fixedPosition() ?? cfg.fixedPosition ?? false);
+            this._popoverService.scrollStrategy.set(this.scrollStrategy() ?? cfg.scrollStrategy ?? null);
 
             const bodyClass = this.additionalBodyClass() ?? cfg.additionalBodyClass ?? '';
             this._popoverService.additionalBodyClass.set(bodyClass + ' fd-popover--menu');
@@ -537,6 +542,7 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
                 restoreFocusOnClose: this.restoreFocusOnClose() ?? cfg.restoreFocusOnClose,
                 appendTo: this.appendTo() ?? cfg.appendTo,
                 fixedPosition: this.fixedPosition() ?? cfg.fixedPosition,
+                scrollStrategy: this.scrollStrategy() ?? cfg.scrollStrategy,
                 additionalBodyClass: (
                     (this.additionalBodyClass() ?? cfg.additionalBodyClass ?? '') + ' fd-popover--menu'
                 ).trim()

--- a/libs/docs/core/inline-help/examples/inline-help-trigger-example.component.html
+++ b/libs/docs/core/inline-help/examples/inline-help-trigger-example.component.html
@@ -7,3 +7,23 @@
 >
     Click on me, to display inline help
 </button>
+
+<div class="sap-margin-top-medium">
+    <p class="fd-margin-bottom--xs">
+        <strong>Scroll Strategy:</strong> open the help, then scroll the box below — the overlay closes because
+        <code>[scrollStrategy]</code> is bound to <code>closeOnScroll</code>.
+    </p>
+    <div style="height: 120px; overflow: auto; border: 1px solid var(--sapList_BorderColor); padding: 1rem">
+        <div style="height: 400px">
+            <button
+                role="button"
+                fd-button
+                fd-inline-help="Closes when you scroll this container"
+                [triggers]="['click']"
+                [scrollStrategy]="closeOnScroll"
+            >
+                Open me, then scroll
+            </button>
+        </div>
+    </div>
+</div>

--- a/libs/docs/core/inline-help/examples/inline-help-trigger-example.component.ts
+++ b/libs/docs/core/inline-help/examples/inline-help-trigger-example.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
+import { Component, inject } from '@angular/core';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { InlineHelpModule } from '@fundamental-ngx/core/inline-help';
 
@@ -7,4 +8,7 @@ import { InlineHelpModule } from '@fundamental-ngx/core/inline-help';
     templateUrl: './inline-help-trigger-example.component.html',
     imports: [ButtonComponent, InlineHelpModule]
 })
-export class InlineHelpTriggerExampleComponent {}
+export class InlineHelpTriggerExampleComponent {
+    /** CDK scroll strategy that closes the overlay when an ancestor scrolls. */
+    readonly closeOnScroll: ScrollStrategy = inject(Overlay).scrollStrategies.close();
+}

--- a/libs/docs/core/inline-help/inline-help-docs.component.html
+++ b/libs/docs/core/inline-help/inline-help-docs.component.html
@@ -16,7 +16,9 @@
     Inline Help with Changed Trigger Event
 </fd-docs-section-title>
 <description>
-    To change trigger event, same as in popover component, you need to pass events to <code>[triggers]</code> input.
+    To change trigger event, same as in popover component, you need to pass events to <code>[triggers]</code> input. Use
+    <code>[scrollStrategy]</code> to control how the overlay reacts when an ancestor scrolls — typical CDK strategies
+    are <code>reposition()</code> (default), <code>close()</code>, <code>block()</code>, and <code>noop()</code>.
 </description>
 <component-example>
     <p class="fd-docs-centered-content">

--- a/libs/docs/core/inline-help/inline-help-docs.component.ts
+++ b/libs/docs/core/inline-help/inline-help-docs.component.ts
@@ -17,6 +17,7 @@ import { InlineHelpTriggerExampleComponent } from './examples/inline-help-trigge
 const inlineHelpTs = 'inline-help-example.component.ts';
 const inlineHelpSrc = 'inline-help-example.component.html';
 const inlineHelpTriggerHtml = 'inline-help-trigger-example.component.html';
+const inlineHelpTriggerTs = 'inline-help-trigger-example.component.ts';
 const inlineHelpStylesTs = 'inline-help-styled-example.component.ts';
 const inlineHelpStylesHtml = 'inline-help-styled-example.component.html';
 const inlineHelpTemplateHtml = 'inline-help-template-example/inline-help-template-example.component.html';
@@ -56,6 +57,12 @@ export class InlineHelpDocsComponent {
             language: 'html',
             code: getAssetFromModuleAssets(inlineHelpTriggerHtml),
             fileName: 'inline-help-trigger-example'
+        },
+        {
+            language: 'typescript',
+            code: getAssetFromModuleAssets(inlineHelpTriggerTs),
+            fileName: 'inline-help-trigger-example',
+            component: 'InlineHelpTriggerExampleComponent'
         }
     ];
 

--- a/libs/docs/core/menu/examples/menu-placement-example.component.ts
+++ b/libs/docs/core/menu/examples/menu-placement-example.component.ts
@@ -1,4 +1,5 @@
-import { Component, signal } from '@angular/core';
+import { Overlay, ScrollStrategy } from '@angular/cdk/overlay';
+import { Component, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
@@ -12,6 +13,8 @@ import {
 } from '@fundamental-ngx/core/menu';
 import { SelectModule } from '@fundamental-ngx/core/select';
 import { PopoverFillMode } from '@fundamental-ngx/core/shared';
+
+type ScrollStrategyOption = 'reposition' | 'close' | 'noop';
 
 type PlacementOption =
     | 'top'
@@ -49,6 +52,14 @@ type PlacementOption =
                 </fd-select>
             </div>
             <fd-checkbox label="fixedPosition" [(ngModel)]="fixedPosition"></fd-checkbox>
+            <div>
+                <label fd-form-label for="scrollStrategy">Scroll Strategy:</label>
+                <fd-select id="scrollStrategy" [(ngModel)]="scrollStrategyOption" style="width: 10rem;">
+                    @for (option of scrollStrategyOptions; track option) {
+                        <fd-option [value]="option">{{ option }}</fd-option>
+                    }
+                </fd-select>
+            </div>
         </div>
 
         <div class="sap-flex sap-flex--justify-center sap-padding-x-large sap-margin-y-large">
@@ -59,6 +70,7 @@ type PlacementOption =
                 [placement]="placement()"
                 [fillControlMode]="fillMode()"
                 [fixedPosition]="fixedPosition"
+                [scrollStrategy]="scrollStrategy()"
             >
                 <li fd-menu-item>
                     <a href="#" fd-menu-interactive>
@@ -152,4 +164,26 @@ export class MenuPlacementExampleComponent {
 
     /** Whether to prevent position flipping at viewport edges */
     fixedPosition = false;
+
+    /** Available CDK scroll strategies */
+    readonly scrollStrategyOptions: ScrollStrategyOption[] = ['reposition', 'close', 'noop'];
+
+    /** Current scroll strategy selection */
+    scrollStrategyOption = signal<ScrollStrategyOption>('reposition');
+
+    /** CDK ScrollStrategy resolved from the selected option */
+    readonly scrollStrategy = computed<ScrollStrategy>(() => {
+        const strategies = this._overlay.scrollStrategies;
+        switch (this.scrollStrategyOption()) {
+            case 'close':
+                return strategies.close();
+            case 'noop':
+                return strategies.noop();
+            case 'reposition':
+            default:
+                return strategies.reposition();
+        }
+    });
+
+    private readonly _overlay = inject(Overlay);
 }

--- a/libs/docs/core/menu/menu-docs.component.html
+++ b/libs/docs/core/menu/menu-docs.component.html
@@ -241,6 +241,11 @@
         position when it reaches the edge of the viewport. By default, the menu automatically repositions to stay
         visible.
     </p>
+    <p>
+        <strong>Scroll strategy:</strong> Use <code>[scrollStrategy]</code> to control how the overlay reacts when an
+        ancestor scrolls. Pass any CDK <code>ScrollStrategy</code> obtained from <code>Overlay.scrollStrategies</code> —
+        typical choices are <code>reposition()</code> (default), <code>close()</code>, and <code>noop()</code>.
+    </p>
 </description>
 <component-example>
     <fd-menu-placement-example></fd-menu-placement-example>


### PR DESCRIPTION
forward scrollStrategy through fd-menu and fd-inline-help

fixes #14210

[config].scrollStrategy on <fd-menu> was silently dropped, and fd-inline-help had no scrollStrategy input at all. Wire both through to PopoverService so the CDK ScrollStrategy reaches OverlayConfig. Adds regression tests covering config + direct-input precedence on the menu and direct-input forwarding on inline-help. Adds a scrollStrategy selector to the menu placement docs example and a closeScrollStrategy demo to the inline-help trigger example.