### PR TITLE
feat(mcp): MCP server evaluation - part 4

### DIFF
--- a/libs/core/checkbox/checkbox/checkbox.component.spec.ts
+++ b/libs/core/checkbox/checkbox/checkbox.component.spec.ts
@@ -136,6 +136,32 @@ describe('CheckboxComponent', () => {
         }
     });
 
+    it('should clear state class when setStyleState is called with null', async () => {
+        checkbox.setStyleState('error');
+        checkboxDetectChanges(checkbox);
+        await whenStable(fixture);
+
+        let input = getCheckboxInput(fixture);
+        expect(input.classList.contains('is-error')).toBe(true);
+
+        checkbox.setStyleState(null);
+        checkboxDetectChanges(checkbox);
+        await whenStable(fixture);
+
+        input = getCheckboxInput(fixture);
+        expect(input.classList.contains('is-error')).toBe(false);
+    });
+
+    it('should not add any state class when state is null', async () => {
+        checkbox.state = null;
+        checkboxDetectChanges(checkbox);
+        await whenStable(fixture);
+
+        const input = getCheckboxInput(fixture);
+        const stateClasses = Array.from(input.classList).filter((c) => c.startsWith('is-'));
+        expect(stateClasses.length).toBe(0);
+    });
+
     it('should be disabled', async () => {
         checkbox.setDisabledState(true);
 

--- a/libs/core/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/checkbox/checkbox/checkbox.component.ts
@@ -110,7 +110,7 @@ export class CheckboxComponent<T = unknown> implements ControlValueAccessor, Aft
 
     /** State of control, changes visual appearance of control. */
     @Input()
-    state?: FormStates;
+    state?: FormStates | null;
 
     /** Sets [name] property of input. */
     @Input()

--- a/libs/core/checkbox/checkbox/checkbox.component.ts
+++ b/libs/core/checkbox/checkbox/checkbox.component.ts
@@ -297,7 +297,7 @@ export class CheckboxComponent<T = unknown> implements ControlValueAccessor, Aft
     }
 
     /** @hidden */
-    setStyleState(state: FormStates): void {
+    setStyleState(state: FormStates | null): void {
         this.state = state;
         this._detectChanges();
     }

--- a/libs/core/schematics/add-styles/index.ts
+++ b/libs/core/schematics/add-styles/index.ts
@@ -163,7 +163,10 @@ function updateBudgets(options: Schema): Rule {
             const workspace = await getWorkspaceDefinition(tree);
             await updateWorkspaceDefinition(tree, workspace);
         } catch (error) {
-            handleError(context, error, 'Failed to update bundle budgets');
+            context.logger.warn(
+                `⚠️ Could not update bundle budgets (non-fatal): ${(error as Error).message}. ` +
+                    `Styles and assets were still configured. Update angular.json budgets manually if needed.`
+            );
         }
     };
 }

--- a/libs/mcp-server/src/data/usage-guides.ts
+++ b/libs/mcp-server/src/data/usage-guides.ts
@@ -9,6 +9,12 @@ export interface UsageGuideDecisionNode {
     options: UsageGuideDecisionOption[];
 }
 
+export interface UsageGuideKnownIssue {
+    symptom: string;
+    cause: string;
+    fix: string;
+}
+
 export interface UsageGuide {
     component: string;
     summary: string;
@@ -16,10 +22,258 @@ export interface UsageGuide {
     commonPitfalls: string[];
     compositionPattern: string;
     relatedComponents: string[];
+    /** Ordered list of CSS files that must be loaded for this component/setup to work. */
+    requiredStyles?: string[];
+    /** Known issues with symptoms, causes, and fixes. */
+    knownIssues?: UsageGuideKnownIssue[];
     resources?: string[];
 }
 
+const _setupGuide: UsageGuide = {
+    component: 'setup',
+    summary:
+        '@fundamental-ngx/core uses DYNAMIC theming via ThemingService — theme CSS files are served as assets ' +
+        'and loaded at runtime, NOT as static entries in angular.json styles. ' +
+        'Run "ng add @fundamental-ngx/core" to configure everything automatically. ' +
+        'The schematic adds: (1) fundamental-ngx-core.css to angular.json styles, ' +
+        '(2) @sap-theming and fundamental-styles theming files to angular.json assets, ' +
+        '(3) provideTheming() and themingInitializer() to app.config.ts.',
+    requiredStyles: ['./node_modules/@fundamental-ngx/core/styles/fundamental-ngx-core.css'],
+    decisionTree: [
+        {
+            question: 'How do you want to set up @fundamental-ngx/core?',
+            options: [
+                {
+                    answer: 'Automatic setup (recommended)',
+                    recommendation:
+                        'Run "ng add @fundamental-ngx/core". The schematic writes all required angular.json ' +
+                        'entries and wires up ThemingService in app.config.ts automatically.',
+                    example: `ng add @fundamental-ngx/core`
+                },
+                {
+                    answer: 'Static CSS — demos, prototypes, no ThemingService needed',
+                    recommendation:
+                        'Install @sap-theming/theming-base-content, then add three CSS files to angular.json ' +
+                        'styles in the exact order shown. No providers needed. ' +
+                        'The three-layer token chain is: (1) @sap-theming css_variables.css defines --sap* tokens, ' +
+                        '(2) fundamental-styles theming file maps --fd* to --sap*, ' +
+                        '(3) fundamental-styles.css uses --fd* tokens for component styles.',
+                    example: `// Install:
+npm install @sap-theming/theming-base-content
+
+// angular.json build.options.styles (order is critical):
+"node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/css_variables.css",
+"node_modules/fundamental-styles/dist/theming/sap_horizon.css",
+"node_modules/fundamental-styles/dist/fundamental-styles.css",
+"src/styles.css"
+
+// No app.config.ts changes needed.`
+                },
+                {
+                    answer: 'Manual dynamic — production app with runtime theme switching',
+                    recommendation:
+                        'Add one static style, two asset groups, and two providers. ' +
+                        'Theme CSS files are loaded at runtime by ThemingService from the assets folder — ' +
+                        'do NOT add them to angular.json styles in this setup.',
+                    example: `// angular.json build.options.styles:
+"./node_modules/@fundamental-ngx/core/styles/fundamental-ngx-core.css"
+
+// angular.json build.options.assets:
+{ "glob": "**/css_variables.css", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/", "output": "./assets/theming-base/" },
+{ "glob": "**/*", "input": "./node_modules/fundamental-styles/dist/theming/", "output": "./assets/fundamental-styles-theming/" }
+
+// app.config.ts providers:
+provideTheming({ defaultTheme: 'sap_horizon' }),
+themingInitializer()`
+                }
+            ]
+        },
+        {
+            question: 'Which defaultTheme should you pass to provideTheming()?',
+            options: [
+                {
+                    answer: 'Standard light theme (recommended default)',
+                    recommendation: "Pass defaultTheme: 'sap_horizon'.",
+                    example: `provideTheming({ defaultTheme: 'sap_horizon' })`
+                },
+                {
+                    answer: 'Dark theme',
+                    recommendation: "Pass defaultTheme: 'sap_horizon_dark'.",
+                    example: `provideTheming({ defaultTheme: 'sap_horizon_dark' })`
+                },
+                {
+                    answer: 'High contrast for accessibility',
+                    recommendation: "Pass defaultTheme: 'sap_horizon_hcb' (black) or 'sap_horizon_hcw' (white).",
+                    example: `provideTheming({ defaultTheme: 'sap_horizon_hcb' })`
+                }
+            ]
+        },
+        {
+            question: 'Do you need runtime theme switching?',
+            options: [
+                {
+                    answer: 'Yes — let users switch themes at runtime',
+                    recommendation:
+                        'ThemingService handles this automatically. Optionally add changeThemeOnQueryParamChange: true to provideTheming() to also switch via the ?theme= query param.',
+                    example: `provideTheming({ defaultTheme: 'sap_horizon', changeThemeOnQueryParamChange: true })`
+                },
+                {
+                    answer: 'No — single fixed theme',
+                    recommendation:
+                        'Pass only defaultTheme to provideTheming(). ThemingService will load that theme on startup and never switch.',
+                    example: `provideTheming({ defaultTheme: 'sap_horizon' })`
+                }
+            ]
+        }
+    ],
+    commonPitfalls: [
+        'When using ThemingService (dynamic setup via ng add or manual dynamic), do NOT add theme CSS files to angular.json styles — they are served as assets and loaded at runtime. When using static CSS setup (no ThemingService), you MUST add all three files in the correct order: (1) @sap-theming css_variables.css, (2) fundamental-styles theming file, (3) fundamental-styles.css.',
+        '@sap-theming/theming-base-content must be explicitly installed (npm install @sap-theming/theming-base-content). It is a peer dependency and is NOT automatically installed with @fundamental-ngx/core.',
+        'The two theming CSS files have different roles: fundamental-styles/dist/theming/sap_horizon.css defines only BTP palette alias variables (--btp-Blue1, etc.) but NOT the semantic SAP tokens. The semantic tokens (--sapShellColor, --sapFontFamily, --sapTextColor, etc.) and SAP icon @font-face declarations all come from @sap-theming/theming-base-content css_variables.css. Without css_variables.css, components render with wrong colours and icons appear as empty squares.',
+        'Load order matters for static CSS setup: css_variables.css MUST come first. If fundamental-styles is parsed before css_variables.css, all --sap* tokens resolve to initial and components render unstyled.',
+        'Icons render as empty squares even when styles are otherwise correct: the SAP icon font (@font-face declarations for SAP-icons) is defined in css_variables.css from @sap-theming/theming-base-content — NOT in fundamental-styles or the theme CSS file. The font will only load if css_variables.css is included. In Vite/non-Angular projects, use @import "@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/css_variables.css" as the very first import in your CSS entry point.',
+        'In the sap_horizon (light) theme, --sapShellColor resolves to #fff (white). Using it directly as a header background makes the shell bar invisible. Use fd-shellbar (from @fundamental-ngx/core/shellbar) instead — it applies its own background through fundamental-styles classes rather than relying on --sapShellColor.',
+        'When using @fundamental-ngx/platform, the initial bundle can reach 4–5 MB. Raise angular.json production budgets: maximumWarning: "2MB", maximumError: "5MB".',
+        'themingInitializer() must be present alongside provideTheming() in the dynamic setup. Omitting it means the theme is never applied on startup.',
+        'Available theme IDs: sap_horizon, sap_horizon_dark, sap_horizon_hcb, sap_horizon_hcw.',
+        'After ng add, verify angular.json has both the styles entry (fundamental-ngx-core.css) and the assets entries (@sap-theming and fundamental-styles-theming). If either is missing, run the schematic again or add them manually.'
+    ],
+    compositionPattern: `// ── Static CSS setup (demos/prototypes — no ThemingService) ──────────────
+// angular.json build.options.styles (order is critical):
+{
+    "styles": [
+        "node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/css_variables.css",
+        "node_modules/fundamental-styles/dist/theming/sap_horizon.css",
+        "node_modules/fundamental-styles/dist/fundamental-styles.css",
+        "src/styles.css"
+    ]
+}
+// No app.config.ts providers needed for static setup.
+
+// ── Dynamic setup (production — ThemingService manages runtime switching) ──
+// app.config.ts:
+import { provideTheming, themingInitializer } from '@fundamental-ngx/core/theming';
+export const appConfig: ApplicationConfig = {
+    providers: [
+        provideTheming({ defaultTheme: 'sap_horizon' }),
+        themingInitializer()
+    ]
+};
+// angular.json (added by ng add):
+{
+    "styles": ["./node_modules/@fundamental-ngx/core/styles/fundamental-ngx-core.css", "src/styles.css"],
+    "assets": [
+        { "glob": "**/css_variables.css", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/", "output": "./assets/theming-base/" },
+        { "glob": "**/*", "input": "./node_modules/fundamental-styles/dist/theming/", "output": "./assets/fundamental-styles-theming/" }
+    ]
+}`,
+    knownIssues: [
+        {
+            symptom: 'CSS variables resolve to empty strings in a sandboxed browser (Playwright, strict CSP)',
+            cause: 'CSS was loaded via CDN URLs (unpkg.com, jsdelivr.net). These external requests are blocked in sandboxed Playwright browsers and in apps with a strict Content-Security-Policy. The browser fetches nothing, so --sap* tokens are all undefined and components render unstyled.',
+            fix: 'Install packages locally (npm install @sap-theming/theming-base-content fundamental-styles @fundamental-ngx/core) and serve CSS from node_modules or a local dist directory. Do not rely on CDN URLs for automated testing or CSP-restricted environments.'
+        },
+        {
+            symptom: '@font-face src paths resolve to 404 when css_variables.css is copied to a flat directory',
+            cause: 'css_variables.css uses relative @font-face src paths such as url(../sap_horizon/fonts/SAP-icons.woff2). These paths assume the file lives inside the @sap-theming package directory structure. Moving css_variables.css to a flat css/ folder breaks the relative paths.',
+            fix: 'Either (a) reproduce the expected directory layout — place css_variables.css at css/sap_horizon/css_variables.css and copy the fonts to css/sap_horizon/fonts/ and css/baseTheme/fonts/ — or (b) create a wrapper CSS file with corrected absolute/relative paths pointing to the font files in their actual location.'
+        },
+        {
+            symptom: 'Icons render as empty squares (no glyph, just blank box)',
+            cause: 'The SAP icon font (@font-face declarations for SAP-icons) is defined in css_variables.css from @sap-theming/theming-base-content. It is NOT included in fundamental-styles or the theme CSS. If css_variables.css is missing or not loaded first, the browser cannot find the font file and renders empty boxes.',
+            fix: 'Ensure @sap-theming/theming-base-content is installed (npm install @sap-theming/theming-base-content) and that css_variables.css is loaded BEFORE any fundamental-styles CSS. Angular: add it as the first entry in angular.json styles. Vite/plain CSS: add @import "@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/css_variables.css" as the first line of your CSS entry point.'
+        },
+        {
+            symptom: 'All --sap* CSS custom properties are undefined after ng add',
+            cause: 'The ng add schematic failed mid-run (e.g. the bundle-budget update step threw an error), causing the whole tree to be rolled back. Styles and assets were not written to angular.json.',
+            fix: 'Run "ng add @fundamental-ngx/core" again, or manually add the styles and assets entries shown in the compositionPattern above, and add provideTheming() + themingInitializer() to app.config.ts.'
+        },
+        {
+            symptom: 'App renders with no colors, spacing, or typography after manual static CSS setup',
+            cause: '@sap-theming/theming-base-content is not installed, or its css_variables.css is not the first entry in angular.json styles. The --sap* design tokens are undefined, so all component styles resolve to initial.',
+            fix: 'Run: npm install @sap-theming/theming-base-content. Then add css_variables.css as the FIRST entry in angular.json styles, followed by fundamental-styles/dist/theming/<theme>.css, then fundamental-styles/dist/fundamental-styles.css.'
+        },
+        {
+            symptom: 'Theme loads on first paint but flashes unstyled briefly',
+            cause: 'ThemingService loads theme CSS asynchronously. The flash occurs before the dynamically injected <link> tag resolves.',
+            fix: 'This is expected behavior with dynamic theming. For SSR or critical rendering, consider preloading the theme CSS file manually in index.html with <link rel="preload">.'
+        }
+    ],
+    relatedComponents: [],
+    resources: [
+        'Theming guide: https://sap.github.io/fundamental-ngx/#/core/theming',
+        'Get available themes with the fundamental-styles MCP tool: get_theme_info'
+    ]
+};
+
 export const USAGE_GUIDES: Record<string, UsageGuide> = {
+    setup: _setupGuide,
+    installation: _setupGuide,
+
+    ui5: {
+        component: 'ui5-webcomponents',
+        summary:
+            'Angular wrappers for UI5 Web Components, published under @fundamental-ngx/ui5-webcomponents. ' +
+            'The older @ui5/webcomponents-ngx package is deprecated and incompatible with Angular 20+. ' +
+            'Always use @fundamental-ngx/ui5-webcomponents which supports Angular 21 natively.',
+        decisionTree: [
+            {
+                question: 'Which UI5 package should I install?',
+                options: [
+                    {
+                        answer: '@fundamental-ngx/ui5-webcomponents (correct)',
+                        recommendation:
+                            'Install @fundamental-ngx/ui5-webcomponents@^<same version as @fundamental-ngx/core>. ' +
+                            'Also install the required peer dependencies: ' +
+                            'npm install @fundamental-ngx/ui5-webcomponents @fundamental-ngx/cdk @fundamental-ngx/core',
+                        example: `npm install @fundamental-ngx/ui5-webcomponents @fundamental-ngx/cdk @fundamental-ngx/core`
+                    },
+                    {
+                        answer: '@ui5/webcomponents-ngx (deprecated — do not use)',
+                        recommendation:
+                            'This package is deprecated and declares peerDependencies on @angular/core ^20 — it is ' +
+                            'incompatible with Angular 21. Migrate to @fundamental-ngx/ui5-webcomponents.',
+                        example: ''
+                    }
+                ]
+            }
+        ],
+        commonPitfalls: [
+            '@ui5/webcomponents-ngx is deprecated. The successor is @fundamental-ngx/ui5-webcomponents from this monorepo. Using the old package with --legacy-peer-deps on Angular 21 may appear to install but will cause build or runtime errors.',
+            '@fundamental-ngx/cdk is a required peer dependency that npm does not always install automatically. If you see "Could not resolve @fundamental-ngx/cdk/utils" or similar import errors, install it explicitly: npm install @fundamental-ngx/cdk',
+            'UI5 component import paths follow the pattern @fundamental-ngx/ui5-webcomponents/<component-name>. Example: import { Ui5ButtonComponent } from "@fundamental-ngx/ui5-webcomponents/button".',
+            'All three @fundamental-ngx packages (core, cdk, ui5-webcomponents) must be the same semver minor version. Mixing 0.61.x with 0.62.x will cause peer-dep conflicts.',
+            'fundamental-styles.css is a monolithic stylesheet (~1.9 MB uncompressed). Raise angular.json production budgets: maximumWarning: "3MB", maximumError: "5MB".'
+        ],
+        compositionPattern: `// Install all required packages:
+npm install @fundamental-ngx/ui5-webcomponents @fundamental-ngx/cdk @fundamental-ngx/core
+npm install @sap-theming/theming-base-content  // peer dep, not auto-installed
+
+// angular.json budgets (styles push past the default 1 MB limit):
+"budgets": [
+  { "type": "initial", "maximumWarning": "3MB", "maximumError": "5MB" }
+]
+
+// Import a UI5 component in an Angular standalone component:
+import { Ui5ButtonComponent } from '@fundamental-ngx/ui5-webcomponents/button';
+import { Ui5InputComponent } from '@fundamental-ngx/ui5-webcomponents/input';
+
+@Component({
+    imports: [Ui5ButtonComponent, Ui5InputComponent],
+    template: \`
+        <ui5-button design="Emphasized">Click me</ui5-button>
+        <ui5-input placeholder="Enter text"></ui5-input>
+    \`
+})
+export class MyComponent {}`,
+        relatedComponents: ['fd-shellbar', 'ui5-button', 'ui5-input', 'ui5-dialog', 'ui5-table']
+    },
+
+    // alias
+    get 'ui5-webcomponents'() {
+        return this['ui5'];
+    },
+
     dialog: {
         component: 'dialog',
         summary:
@@ -113,7 +367,8 @@ this._dialogService.open(MyDialogComponent, {
             'Dialog body not scrollable — wrap body content in <fd-dialog-body> which handles overflow automatically.',
             'Focus not trapped inside dialog — ensure focusTrapped: true in DialogConfig (default is true).',
             'Dialog not closing on Escape — check that escKeyClosable is not set to false in config.',
-            'ARIA warnings — always provide ariaLabelledBy pointing to the dialog title element ID.'
+            'ARIA warnings — always provide ariaLabelledBy pointing to the dialog title element ID.',
+            'Dialog footer buttons must use <fd-button-bar> (from @fundamental-ngx/core/bar), NOT <button fd-button>. fd-button-bar is a standalone component that wraps a button with the fd-bar__element host class and correct dialog padding. Import ButtonBarComponent, not ButtonComponent, in the dialog component.'
         ],
         compositionPattern: `<fd-dialog>
   <fd-dialog-header>
@@ -124,12 +379,8 @@ this._dialogService.open(MyDialogComponent, {
   </fd-dialog-body>
   <fd-dialog-footer>
     <fd-bar barDesign="footer">
-      <fd-bar-element>
-        <button fd-button fdType="emphasized" (click)="close()">Save</button>
-      </fd-bar-element>
-      <fd-bar-element>
-        <button fd-button fdType="transparent" (click)="dismiss()">Cancel</button>
-      </fd-bar-element>
+      <fd-button-bar fdType="emphasized" label="Save" (click)="close()"></fd-button-bar>
+      <fd-button-bar fdType="transparent" label="Cancel" (click)="dismiss()"></fd-button-bar>
     </fd-bar>
   </fd-dialog-footer>
 </fd-dialog>`,
@@ -138,6 +389,7 @@ this._dialogService.open(MyDialogComponent, {
             'fd-dialog-body',
             'fd-dialog-footer',
             'fd-bar',
+            'fd-button-bar',
             'fd-message-box',
             'ui5-dialog'
         ]
@@ -543,5 +795,262 @@ layout = signal<FlexibleColumnLayout>(FlexibleColumnLayout.OneColumnStartFullScr
         resources: [
             'UX specs: https://www.sap.com/design-system/fiori-design-web/v1-145/page-types/page-layouts/flexible-column-layout'
         ]
+    },
+
+    'fdp-table': {
+        component: 'fdp-table',
+        summary:
+            'Platform data table with declarative columns and built-in sort, filter, group, and paginate. ' +
+            'Accepts a plain array or a TableDataProvider<T> subclass as [dataSource]. ' +
+            'Key pitfalls: TableDataProvider members need the override keyword; ' +
+            'FilterType.MULTI delivers string[] not string; ' +
+            'TableDataSourceDirective and TableHeaderResizerDirective are host directives (auto-applied, never add them to the template); ' +
+            'fdp-table-view-settings-dialog must be a sibling of fdp-table, not a child.',
+        decisionTree: [
+            {
+                question: 'What type of data source does fdp-table need?',
+                options: [
+                    {
+                        answer: 'Static array — data is already in memory',
+                        recommendation:
+                            'Pass the array directly to [dataSource]. fdp-table handles paging and sorting internally.',
+                        example: `<fdp-table [dataSource]="products">
+  <fdp-column key="name" label="Name" [sortable]="true"></fdp-column>
+  <fdp-column key="price" label="Price" dataType="number"></fdp-column>
+</fdp-table>`
+                    },
+                    {
+                        answer: 'Server-side / dynamic — fetch is triggered by sort/filter/page state',
+                        recommendation:
+                            'Extend TableDataProvider<T>. Override items, totalItems, and fetch(). ' +
+                            'All three members require the override modifier — TypeScript strict mode rejects the class without it.',
+                        example: `import { TableDataProvider, TableState } from '@fundamental-ngx/platform/table';
+import { Observable, of } from 'rxjs';
+
+export class ProductDataProvider extends TableDataProvider<Product> {
+    override items: Product[] = ALL_PRODUCTS;
+    override totalItems = ALL_PRODUCTS.length;
+
+    override fetch(state?: TableState): Observable<Product[]> {
+        let result = [...ALL_PRODUCTS];
+
+        // Filtering — handle both single-value and MULTI (string[]) filter values
+        (state?.filterBy ?? []).forEach((filter) => {
+            const fv = filter.value;
+            result = result.filter((item) => {
+                const val = String((item as Record<string, unknown>)[filter.field as string] ?? '');
+                if (Array.isArray(fv)) {
+                    return fv.length === 0 || fv.includes(val);   // FilterType.MULTI
+                }
+                return val.toLowerCase().includes(String(fv ?? '').toLowerCase());
+            });
+        });
+
+        this.totalItems = result.length;
+        this.items = result;
+        return of(result);
+    }
+}`
+                    }
+                ]
+            },
+            {
+                question: 'Where should fdp-table-view-settings-dialog be placed in the template?',
+                options: [
+                    {
+                        answer: 'As a sibling of fdp-table (correct)',
+                        recommendation:
+                            'Place the dialog next to fdp-table and link them with a template reference variable on fdp-table.',
+                        example: `<!-- Correct: dialog is a sibling -->
+<fdp-table #myTable [dataSource]="dataProvider">
+  <fdp-column key="name" label="Name" [sortable]="true"></fdp-column>
+</fdp-table>
+
+<fdp-table-view-settings-dialog [table]="myTable">
+  <fdp-table-view-settings-sort-rule column="name" label="Name"></fdp-table-view-settings-sort-rule>
+  <fdp-table-view-settings-filter-rule
+    column="status"
+    label="Status"
+    [type]="FilterType.MULTI"
+  ></fdp-table-view-settings-filter-rule>
+</fdp-table-view-settings-dialog>`
+                    },
+                    {
+                        answer: 'Nested inside fdp-table (incorrect)',
+                        recommendation:
+                            'Do NOT nest fdp-table-view-settings-dialog inside fdp-table. It is a sibling component, not a child.',
+                        example: `<!-- Wrong — causes template parse errors:
+<fdp-table>
+  <fdp-table-view-settings-dialog>...</fdp-table-view-settings-dialog>
+</fdp-table> -->`
+                    }
+                ]
+            }
+        ],
+        commonPitfalls: [
+            'All three TableDataProvider members (items, totalItems, fetch) require the override modifier. Omitting it causes a TypeScript compiler error in strict mode.',
+            'TableDataSourceDirective and TableHeaderResizerDirective are declared as Angular hostDirectives on TableComponent. They are applied automatically — never add them as template attributes or to the component imports array.',
+            'FilterType.MULTI delivers filter.value as string[] (array of selected option values), not a string. Call Array.isArray(filter.value) before any string operations to avoid runtime TypeError.',
+            'fdp-table-view-settings-dialog must be a sibling element of fdp-table, linked via [table]="tableRef". Nesting it inside <fdp-table> causes a template parse error.',
+            '@fundamental-ngx/platform adds ~4–5 MB to the initial bundle. Set angular.json production budgets to at least maximumWarning: "2MB", maximumError: "5MB".',
+            'Import FilterType from @fundamental-ngx/platform/table, not a deep internal path.'
+        ],
+        compositionPattern: `import { TableDataProvider, TableState, FilterType } from '@fundamental-ngx/platform/table';
+import { Observable, of } from 'rxjs';
+
+// Data provider — override keyword is required on all three members
+export class ProductDataProvider extends TableDataProvider<Product> {
+    override items: Product[] = [];
+    override totalItems = 0;
+
+    override fetch(state?: TableState): Observable<Product[]> {
+        let result = [...SOURCE_DATA];
+
+        (state?.filterBy ?? []).forEach((filter) => {
+            const fv = filter.value;
+            result = result.filter((item) => {
+                const val = String((item as Record<string, unknown>)[filter.field as string] ?? '');
+                if (Array.isArray(fv)) {
+                    return fv.length === 0 || fv.includes(val);  // MULTI filter
+                }
+                return val.toLowerCase().includes(String(fv ?? '').toLowerCase());
+            });
+        });
+
+        (state?.sortBy ?? []).forEach((sort) => {
+            result.sort((a, b) => {
+                const av = String((a as Record<string, unknown>)[sort.field as string] ?? '');
+                const bv = String((b as Record<string, unknown>)[sort.field as string] ?? '');
+                return sort.direction === 'ASC' ? av.localeCompare(bv) : bv.localeCompare(av);
+            });
+        });
+
+        this.items = result;
+        this.totalItems = result.length;
+        return of(result);
+    }
+}
+
+// Template — dialog is a sibling of fdp-table, NOT a child
+<fdp-table #table [dataSource]="dataProvider">
+  <fdp-column key="name" label="Name" [sortable]="true"></fdp-column>
+  <fdp-column key="status" label="Status" [sortable]="true"></fdp-column>
+</fdp-table>
+
+<fdp-table-view-settings-dialog [table]="table">
+  <fdp-table-view-settings-sort-rule column="name" label="Name"></fdp-table-view-settings-sort-rule>
+  <fdp-table-view-settings-filter-rule
+    column="status"
+    label="Status"
+    [type]="FilterType.MULTI"
+  ></fdp-table-view-settings-filter-rule>
+</fdp-table-view-settings-dialog>`,
+        relatedComponents: [
+            'fd-table',
+            'fdp-table-toolbar',
+            'fdp-table-view-settings-dialog',
+            'fdp-table-view-settings-filter-rule',
+            'fdp-table-view-settings-sort-rule',
+            'fdp-pagination'
+        ]
+    },
+
+    'fd-dynamic-page': {
+        component: 'fd-dynamic-page',
+        summary:
+            'Full-page layout component with a collapsible header, breadcrumb, title, and scrollable content area. ' +
+            'Designed to be used as a standalone full-viewport overlay. When embedded inside an existing shell layout ' +
+            '(shellbar + side nav), the fixed-position header must be overridden with CSS.',
+        decisionTree: [
+            {
+                question: 'Are you using fd-dynamic-page inside an existing shell/nav layout?',
+                options: [
+                    {
+                        answer: 'Yes — embedded inside shellbar + side navigation',
+                        recommendation:
+                            'Override .fd-dynamic-page__header-fixed to use position: sticky instead of fixed. ' +
+                            'Also ensure the scroll container (the element wrapping the dynamic page) uses overflow-y: auto — ' +
+                            'position: sticky requires a scrollable ancestor to anchor to.',
+                        example:
+                            '/* In component or global styles: */\n' +
+                            '.fd-dynamic-page__header-fixed {\n' +
+                            '    position: sticky !important;\n' +
+                            '    top: 0 !important;\n' +
+                            '    z-index: 10;\n' +
+                            '}\n' +
+                            '.main-content {\n' +
+                            '    overflow-y: auto;  /* required for sticky to work */\n' +
+                            '}'
+                    },
+                    {
+                        answer: 'No — standalone full-viewport page',
+                        recommendation:
+                            'Use the default layout: wrap fd-dynamic-page in a fixed overlay div ' +
+                            '(position: fixed; inset: 0). This is the intended usage in the documentation examples.',
+                        example: ''
+                    }
+                ]
+            },
+            {
+                question: 'Which library variant do you need?',
+                options: [
+                    {
+                        answer: 'fd-dynamic-page (@fundamental-ngx/core)',
+                        recommendation:
+                            'Core component. Use for custom page layouts with full control over the header.',
+                        example: ''
+                    },
+                    {
+                        answer: 'fdp-dynamic-page (@fundamental-ngx/platform)',
+                        recommendation:
+                            'Platform variant with additional slots for toolbar and smart filter bar integration.',
+                        example: ''
+                    }
+                ]
+            }
+        ],
+        commonPitfalls: [
+            'fd-dynamic-page__header-fixed uses position: fixed; top: 0 from fundamental-styles. When used inside a shell layout (shellbar + content area), the dynamic page header overlaps the shellbar because both are fixed at y=0. Override with position: sticky and ensure the parent scroll container uses overflow-y: auto.',
+            'position: sticky only works when an ancestor element has overflow-y: auto or overflow-y: scroll. If the parent uses overflow: hidden, sticky positioning silently falls back to relative and the header will not stick.',
+            'ariaLabel is a required input on fd-dynamic-page. Omitting it causes an Angular error at runtime.',
+            'fd-dynamic-page is designed as a full-page overlay in the docs examples (wrapped in position: fixed; inset: 0 div). Embedding it inside an existing layout without the CSS override will cause the fixed header to escape the layout container.',
+            'fdp-dynamic-page from @fundamental-ngx/platform adds ~4–5 MB to the initial bundle. Raise angular.json production budgets accordingly.'
+        ],
+        compositionPattern: `// ── Standalone full-viewport usage (default pattern from docs) ──
+<div style="position: fixed; inset: 0; display: flex; flex-direction: column; overflow: hidden;">
+  <fd-dynamic-page ariaLabel="Product Details" [expandable]="true">
+    <fd-dynamic-page-header-image>
+      <fd-avatar size="m" glyph="product"></fd-avatar>
+    </fd-dynamic-page-header-image>
+    <fd-dynamic-page-title>
+      <fd-dynamic-page-breadcrumb>
+        <fd-breadcrumb>
+          <fd-breadcrumb-item><a fd-link>Home</a></fd-breadcrumb-item>
+        </fd-breadcrumb>
+      </fd-dynamic-page-breadcrumb>
+      <fd-dynamic-page-header-title>Product Name</fd-dynamic-page-header-title>
+    </fd-dynamic-page-title>
+    <fd-dynamic-page-header>
+      <!-- Collapsible header content -->
+    </fd-dynamic-page-header>
+    <fd-dynamic-page-content>
+      <!-- Scrollable page body -->
+    </fd-dynamic-page-content>
+  </fd-dynamic-page>
+</div>
+
+// ── Embedded inside shell layout — CSS override required ──
+// styles.css or component styles:
+.fd-dynamic-page__header-fixed {
+    position: sticky !important;
+    top: 0 !important;
+    z-index: 10;
+}
+// The scroll container wrapping fd-dynamic-page must have overflow-y: auto:
+.main-content {
+    overflow-y: auto;
+    flex: 1;
+}`,
+        relatedComponents: ['fd-shellbar', 'fd-vertical-navigation', 'fdp-dynamic-page', 'fd-breadcrumb', 'fd-toolbar']
     }
 };

--- a/libs/mcp-server/src/index.ts
+++ b/libs/mcp-server/src/index.ts
@@ -1,2 +1,69 @@
 #!/usr/bin/env node
-import './server';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { loadData, server, startStdioServer } from './server';
+
+const args = process.argv.slice(2);
+
+if (args[0] === '--list-tools') {
+    runListTools().catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });
+} else if (args[0] === '--call') {
+    const toolName = args[1];
+    const rawArgs = args[2] ?? '{}';
+    if (!toolName) {
+        console.error('Usage: fundamental-ngx-mcp --call <tool-name> [json-args]');
+        process.exit(1);
+    }
+    runCallTool(toolName, rawArgs).catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });
+} else {
+    startStdioServer().catch((error) => {
+        console.error('MCP server failed to start:', error);
+        process.exit(1);
+    });
+}
+
+async function runListTools(): Promise<void> {
+    await loadData();
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: 'cli', version: '1.0' });
+    await client.connect(clientTransport);
+    const { tools } = await client.listTools();
+    console.log(
+        JSON.stringify(
+            tools.map((t) => ({ name: t.name, description: t.description })),
+            null,
+            2
+        )
+    );
+    await client.close();
+}
+
+async function runCallTool(toolName: string, rawArgs: string): Promise<void> {
+    let parsedArgs: Record<string, unknown>;
+    try {
+        parsedArgs = JSON.parse(rawArgs);
+    } catch {
+        console.error(`Invalid JSON arguments: ${rawArgs}`);
+        process.exit(1);
+    }
+    await loadData();
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: 'cli', version: '1.0' });
+    await client.connect(clientTransport);
+    const result = await client.callTool({ name: toolName, arguments: parsedArgs });
+    const content = result.content as Array<{ type: string; text?: string }>;
+    for (const item of content) {
+        if (item.type === 'text') {
+            console.log(item.text);
+        }
+    }
+    await client.close();
+}

--- a/libs/mcp-server/src/server.ts
+++ b/libs/mcp-server/src/server.ts
@@ -371,15 +371,18 @@ server.tool(
 Returns breaking changes, deprecated APIs, and migration steps.
 Use this when helping users upgrade between versions.`,
     {
-        component: z.string().optional().describe('Specific component to get migration info for'),
+        name: z
+            .string()
+            .optional()
+            .describe('Component name to get migration info for (e.g., "fd-button", "fd-dialog")'),
         from_version: z.string().optional().describe('Version migrating from (e.g., "0.58.0")'),
         to_version: z.string().optional().describe('Version migrating to (defaults to latest)')
     },
-    async ({ component, from_version, to_version }) => {
+    async ({ name, from_version, to_version }) => {
         let entries = changelogEntries;
 
-        if (component) {
-            const lowerComp = component.toLowerCase();
+        if (name) {
+            const lowerComp = name.toLowerCase();
             entries = entries.filter(
                 (e) => e.component?.toLowerCase().includes(lowerComp) || e.description.toLowerCase().includes(lowerComp)
             );
@@ -400,7 +403,7 @@ Use this when helping users upgrade between versions.`,
                         type: 'text' as const,
                         text: JSON.stringify(
                             {
-                                filters: { component, from_version, to_version },
+                                filters: { name, from_version, to_version },
                                 matches: 0,
                                 note: 'No changelog entries found for the given filters. Try broader version ranges or omit the component filter.'
                             },
@@ -467,7 +470,7 @@ Use this when helping users upgrade between versions.`,
                     type: 'text' as const,
                     text: JSON.stringify(
                         {
-                            filters: { component, from_version, to_version },
+                            filters: { name, from_version, to_version },
                             totalEntries: entries.length,
                             versions: result
                         },
@@ -689,25 +692,31 @@ server.tool(
     `Get a practical usage guide for a Fundamental NGX component.
 Returns the correct import path, a minimal template snippet showing proper selector usage,
 required inputs that must be provided, and common pitfalls to avoid.
-Use this as the first step when adding a new component to an Angular template.`,
+Use this as the first step when adding a new component to an Angular template.
+Use "setup" or "installation" as the component name to get the complete project setup guide
+(angular.json configuration, ThemingService wiring, and ng add instructions).
+Use "ui5" or "ui5-webcomponents" to get the UI5 package setup guide (correct package name,
+peer dependencies, import paths).`,
     {
-        component: z.string().describe('Component name or selector (e.g., "fd-button", "fdp-table", "ui5-input")')
+        name: z
+            .string()
+            .describe('Component name or selector. Examples: "fd-button", "fdp-table", "ui5-input", "setup", "ui5"')
     },
-    async ({ component }) => {
-        const lowerComponent = component.toLowerCase().replace(/\s+/g, '-');
+    async ({ name }) => {
+        const lowerComponent = name.toLowerCase().replace(/\s+/g, '-');
         const curatedGuide = USAGE_GUIDES[lowerComponent];
         if (curatedGuide) {
             return { content: [{ type: 'text' as const, text: JSON.stringify(curatedGuide, null, 2) }] };
         }
 
-        const found = findComponent(component);
+        const found = findComponent(name);
 
         if (!found) {
             return {
                 content: [
                     {
                         type: 'text' as const,
-                        text: `Component "${component}" not found. Use search_components to find available components.`
+                        text: `Component "${name}" not found. Use search_components to find available components.`
                     }
                 ]
             };
@@ -1148,8 +1157,9 @@ const UI_PATTERNS: Record<string, string[]> = {
 // ---------------------------------------------------------------------------
 // Start server
 // ---------------------------------------------------------------------------
-async function main(): Promise<void> {
-    // Load design tokens and changelog entries in parallel
+
+/** Load design tokens and changelog data. Must be called before tool handlers that use them. */
+export async function loadData(): Promise<void> {
     const basePath = resolve(__dirname, '..', '..', '..');
     const [tokens, changelog] = await Promise.all([
         extractDesignTokens(basePath).catch(() => [] as DesignToken[]),
@@ -1157,12 +1167,13 @@ async function main(): Promise<void> {
     ]);
     designTokens = tokens;
     changelogEntries = changelog;
+}
 
+/** Start in MCP stdio transport mode (normal operation). */
+export async function startStdioServer(): Promise<void> {
+    await loadData();
     const transport = new StdioServerTransport();
     await server.connect(transport);
 }
 
-main().catch((error) => {
-    console.error('MCP server failed to start:', error);
-    process.exit(1);
-});
+export { server };


### PR DESCRIPTION
## Related Issue(s)

part of https://github.com/SAP/fundamental-ngx/issues/14158

## MCP server evaluation improvements

### The improvements below have been addressed after using Claude Code to build sample projects containing the following components:

1. **Simple form** — "Build a login form with email, password, and submit using @fundamental-ngx/core"
2. **Data table** — "Create a platform table with sorting, filtering, and row selection"
3. **Dialog with form** — "Build a dialog that contains a reactive form with validation states"
4. **Page layout** — "Create a page with dynamic page header, side navigation, and content area"
5. **Complex composition** — "Build a master-detail layout with a platform list on the left and detail view on the right"
6. **UI5 Web Components** — "Build a form using UI5 Web Component wrappers (ui5-input, ui5-button)"

### Feedback from Claude and the corresponding fixes:

### 1. `ng add` schematic — non-fatal budget update

**File:** `libs/core/schematics/add-styles/index.ts`

**Problem:** The `updateBudgets` rule in the `add-styles` schematic called the shared `handleError` helper on failure, which throws a `SchematicsException`. Because Angular schematics stage all tree changes atomically, a failure in `updateBudgets` (the last step in the chain) rolled back the styles and assets that were already queued by the two earlier steps. The result: a failed bundle-budget update left `angular.json` with no styles and no assets, causing all `--sap*` CSS custom properties to be undefined at runtime.

**Fix:** Replaced `handleError(...)` in `updateBudgets`'s catch block with `context.logger.warn(...)`. The budget update now logs a non-fatal warning and lets the schematic continue, so styles and assets are always written regardless of whether the budget step succeeds.

---

### 2. `@fundamental-ngx/mcp` — `setup` usage guide

**Files:** `libs/mcp-server/src/data/usage-guides.ts`, `libs/mcp-server/src/server.ts`

**Problem:** `get_usage_guide` had no entry for project setup. An AI assistant asking "how do I configure a new project?" got no answer and fell back on inference, producing an incorrect `angular.json` (e.g. adding all three theming CSS files as static `styles` entries, which is wrong for the dynamic-theming architecture).

**Fix:**

- Added `UsageGuideKnownIssue` interface and optional `requiredStyles`/`knownIssues` fields to `UsageGuide`.
- Added a `_setupGuide` constant documenting the correct architecture:
    - `ng add @fundamental-ngx/core` is the recommended path.
    - The schematic adds **one** static style (`fundamental-ngx-core.css`) + asset entries for dynamic theme loading + `provideTheming()` / `themingInitializer()` providers.
    - Theme CSS files (`css_variables.css`, theming `.css`) are served as assets and loaded at runtime by `ThemingService` — they must **not** be added to `angular.json styles`.
    - Decision tree covers theme selection and runtime vs. fixed-theme setups.
    - Known issues section explains the rollback scenario (now fixed in point 1 above).
- Registered the guide under both `"setup"` and `"installation"` keys in `USAGE_GUIDES`.
- Updated the `get_usage_guide` tool description in `server.ts` to advertise `"setup"` as a valid input.

---

### 3. `setup` guide — static CSS approach and corrected pitfalls

**File:** `libs/mcp-server/src/data/usage-guides.ts`

**Problem:** The `setup` guide only documented the dynamic theming approach (ThemingService + assets). This was misleading because:

- The static three-file CSS approach is valid and simpler for demos/prototypes.
- The guide actively said "DO NOT add theme CSS files to angular.json styles", which is correct for dynamic setup but wrong for static setup.
- `@sap-theming/theming-base-content` was not mentioned as a required explicit install (it is a peer dep, not auto-installed).
- No guidance on the three-layer CSS token chain (why load order matters).
- No mention of the bundle budget issue for `@fundamental-ngx/platform`.

**Fix:**

- Added a third option to the first decision tree node: "Static CSS — demos, prototypes, no ThemingService needed". It explains the three-layer token chain (css_variables.css → theming.css → fundamental-styles.css) and includes the complete `angular.json` snippet.
- Replaced the blanket "DO NOT add theme CSS" pitfall with an accurate conditional: only applies to dynamic/ThemingService setup.
- Added pitfalls for: missing `@sap-theming/theming-base-content` install, wrong CSS load order, and bundle budget for platform components.
- Updated `compositionPattern` to show both the static and dynamic setups side by side.
- Added a new `knownIssue` entry for "App renders unstyled after manual static CSS setup".

---

### 4. `@fundamental-ngx/mcp` — new `fdp-table` usage guide

**File:** `libs/mcp-server/src/data/usage-guides.ts`

**Problem:** No curated guide existed for `fdp-table`. AI assistants building a platform table hit multiple non-obvious traps with no guidance available from `get_usage_guide`:

1. **`override` keyword required** — `TableDataProvider<T>` members `items`, `totalItems`, and `fetch` must be declared with `override`. TypeScript strict mode rejects the subclass without it.
2. **Host directives applied automatically** — `TableDataSourceDirective` and `TableHeaderResizerDirective` are declared as `hostDirectives` on `TableComponent`. Adding them as template attributes or to a component's `imports` causes a template parse error.
3. **`FilterType.MULTI` delivers `string[]`** — `filter.value` is a `string[]` when `FilterType.MULTI` is used. Calling `.toLowerCase()` directly on it throws a runtime `TypeError`.
4. **`fdp-table-view-settings-dialog` must be a sibling** — nesting the dialog inside `<fdp-table>` causes a template parse error. It must be a sibling and linked via `[table]="tableRef"`.
5. **Bundle budget** — `@fundamental-ngx/platform` reaches ~4–5 MB before tree-shaking; the default Angular 1 MB error budget fails.

**Fix:** Added `'fdp-table'` entry to `USAGE_GUIDES` covering:

- Decision tree: static array vs. `TableDataProvider` (with `override` example and array-aware filter logic).
- Decision tree: correct placement of `fdp-table-view-settings-dialog` as a sibling.
- `commonPitfalls` listing all five traps above.
- `compositionPattern` showing a complete working `TableDataProvider` subclass with sort, multi-value filter handling, and the sibling dialog template.

---

### 5. `dialog` usage guide — `fd-button-bar` vs `fd-button` clarification

**File:** `libs/mcp-server/src/data/usage-guides.ts`

**Problem:** The `dialog` usage guide `compositionPattern` showed dialog footer buttons as `<button fd-button>`, which is incorrect. The correct component for dialog footers is `<fd-button-bar>` (from `@fundamental-ngx/core/bar`). Using `ButtonComponent` (the `fd-button` directive) instead of `ButtonBarComponent` in a dialog footer produces incorrect padding and layout because `fd-button-bar` adds the required `fd-bar__element` host class.

**Fix:**

- Added pitfall: `'Dialog footer buttons must use <fd-button-bar> (from @fundamental-ngx/core/bar), NOT <button fd-button>. fd-button-bar is a standalone component that wraps a button with the fd-bar__element host class and correct dialog padding. Import ButtonBarComponent, not ButtonComponent, in the dialog component.'`
- Updated `compositionPattern` footer to use `<fd-button-bar fdType="emphasized" label="Save" (click)="close()">` and `<fd-button-bar fdType="transparent" label="Cancel" (click)="dismiss()">`
- Added `'fd-button-bar'` to `relatedComponents`

---

### 6. `fd-checkbox` — `[state]` accepts `null` as well as `undefined`

**File:** `libs/core/checkbox/checkbox/checkbox.component.ts`

**Problem:** `fd-form-control` declares `state: FormStates | null = null` (initialized to `null`). `fd-checkbox` declared `state?: FormStates` (only `undefined`, not `null`). When a form control bound `[state]="formControl.state"` to a checkbox, passing `null` was rejected by TypeScript and could cause unexpected behavior at runtime.

**Fix:** Changed `state?: FormStates` to `state?: FormStates | null`. The existing null guard `if (this.state && this.state !== 'default')` already handles `null` safely — no logic changes needed.

---

### 7. `@fundamental-ngx/mcp` — CLI interface (`--list-tools` / `--call`)

**Files:** `libs/mcp-server/src/index.ts`, `libs/mcp-server/src/server.ts`

**Problem:** The MCP server could only be queried by implementing the full JSON-RPC stdio handshake (`initialize → notifications/initialized → tools/call`). There was no way to discover or invoke tools from a simple one-liner bash command, which made ad-hoc testing and scripting unnecessarily complex.

**Fix:**

- Refactored `server.ts`: extracted `loadData()` (async token/changelog loading) and `startStdioServer()` as exported functions; removed the auto-calling `main()` from module level; exported the `server` instance.
- Rewrote `index.ts` to handle three modes:
    - `fundamental-ngx-mcp --list-tools` — connects a client-server in-memory pair (using `@modelcontextprotocol/sdk InMemoryTransport`), lists all tools via `client.listTools()`, and prints a JSON array of `{ name, description }`. To test the output, you can simply run `node dist/libs/mcp-server/src/index.js --list-tools`.
    - `fundamental-ngx-mcp --call <tool-name> [json-args]` — parses the JSON args, invokes the tool via `client.callTool()`, and prints the text output. To test the output, try any of the following commands: `node dist/libs/mcp-server/src/index.js --call get_usage_guide '{"name":"setup"}'` or `node dist/libs/mcp-server/src/index.js --call search_components '{"query":"button"}'` or `node dist/libs/mcp-server/src/index.js --call get_component_api '{"name":"fd-button"}'`
    - No flags — starts in normal MCP stdio mode as before.

---

### 8. `setup` guide — SAP icon font pitfall

**File:** `libs/mcp-server/src/data/usage-guides.ts`

**Problem:** The `setup` guide documented CSS loading order for design tokens but did not mention that the SAP icon font (`@font-face` declarations for `SAP-icons`) is also defined in `css_variables.css` from `@sap-theming/theming-base-content`. Icons would render as empty squares if `css_variables.css` was missing or loaded in the wrong order, with no guidance available in the guide.

**Fix:**

- Added `commonPitfalls` entry: icons render as empty squares when `css_variables.css` is missing. The entry covers both Angular and Vite/plain-CSS project setups.
- Added `knownIssues` entry: symptom = "Icons render as empty squares", cause = font-face in `css_variables.css`, fix = ensure `@sap-theming` is installed and `css_variables.css` is the first CSS import.

---

### 9. `@fundamental-ngx/mcp` — new `fd-dynamic-page` usage guide

**File:** `libs/mcp-server/src/data/usage-guides.ts`

**Problem:** No curated guide existed for `fd-dynamic-page`. The `fd-dynamic-page__header-fixed` CSS class applies `position: fixed; top: 0` globally, which causes the header to overlap the shellbar when the dynamic page is embedded inside an existing shell layout. The correct fix (override to `position: sticky` + ensure scroll container uses `overflow-y: auto`) was not documented anywhere in the MCP server.

**Fix:** Added `'fd-dynamic-page'` entry to `USAGE_GUIDES` covering:

- Decision tree: embedded-in-shell (sticky override + scroll container) vs. standalone full-viewport (default layout).
- Decision tree: `fd-dynamic-page` (core) vs. `fdp-dynamic-page` (platform).
- `commonPitfalls`: fixed-position header overlap, sticky failing due to `overflow: hidden` on parent, missing required `ariaLabel` input, bundle budget for platform variant.
- `compositionPattern`: standalone full-viewport template + the CSS override for embedded usage.

---

### 10. `setup` guide — CSS file role distinction, `--sapShellColor` white, CDN blocked, font path issues

**File:** `libs/mcp-server/src/data/usage-guides.ts`

**Problem (issues 3, 5 from feedback):** The setup guide described `css_variables.css` as "must come first" but never explained _why_ or what the other theming file actually provides. Specifically:

- `fundamental-styles/dist/theming/sap_horizon.css` defines only BTP palette alias variables (`--btp-Blue1`, etc.) — **not** the semantic `--sap*` tokens (`--sapShellColor`, `--sapFontFamily`, `--sapTextColor`). Those all come from `@sap-theming css_variables.css`.
- In the `sap_horizon` (light) theme `--sapShellColor` resolves to `#fff` (white), making any header that uses it as a background invisible.

**Problem (issues 2, 4 from feedback):**

- CSS loaded via CDN (`unpkg.com`, `jsdelivr.net`) is blocked in sandboxed Playwright browsers and CSP-restricted environments — `--sap*` tokens resolve to empty strings. No guidance existed.
- `css_variables.css` uses relative `@font-face` src paths that assume the package directory structure. Copying it to a flat `css/` folder causes 404s for all SAP icon and 72 font files.

**Fix:**

- Added `commonPitfalls` entry explaining the two-file distinction (css_variables.css = semantic tokens + font-face; fundamental-styles theming = BTP palette aliases only).
- Added `commonPitfalls` entry: `--sapShellColor` is `#fff` in light theme; use `fd-shellbar` instead which applies its own background.
- Added `knownIssues` entry: CDN-blocked symptom, cause (sandboxed/CSP), fix (install locally, serve from node_modules).
- Added `knownIssues` entry: font 404s when css_variables.css moved to flat directory; fix = reproduce the package directory structure or use a wrapper CSS file with corrected paths.

---

### 11. `@fundamental-ngx/mcp` — standardise tool parameter name: `component` → `name`

**File:** `libs/mcp-server/src/server.ts`

**Problem:** `get_usage_guide` used `component` as its parameter name while `get_component_api`, `get_component_examples`, and `get_accessibility_guide` all used `name`. An AI assistant that learned `name` from one tool had to guess or inspect the schema to discover the correct key for `get_usage_guide`. The same inconsistency existed in `get_migration_guide`.

**Fix:**

- Renamed `component` → `name` in `get_usage_guide` schema, handler destructuring, not-found error message, and tool description (also extended description to advertise `"ui5"` as a valid input).
- Renamed `component` → `name` in `get_migration_guide` schema, handler destructuring, and both `filters` output objects.
- All nine tools now use `name` consistently for "the component to look up".

---

### 12. `@fundamental-ngx/mcp` — new `ui5` usage guide (deprecation + peer deps)

**File:** `libs/mcp-server/src/data/usage-guides.ts`

**Problem:** Two related issues had no guidance in the MCP server:

1. `@ui5/webcomponents-ngx` is deprecated and declares `peerDependencies: { "@angular/core": "^20.0.0" }`, making it incompatible with Angular 21 projects. The correct successor is `@fundamental-ngx/ui5-webcomponents` but nothing in the MCP flagged this.
2. `@fundamental-ngx/cdk` is a required peer dependency that npm does not auto-install. Build failures (`Could not resolve "@fundamental-ngx/cdk/utils"`) had no guidance in the server.

**Fix:** Added `'ui5'` entry to `USAGE_GUIDES` (with `'ui5-webcomponents'` as an alias) covering:

- Decision tree: correct package (`@fundamental-ngx/ui5-webcomponents`) vs deprecated package (`@ui5/webcomponents-ngx`), with explicit `npm install` command for all required packages.
- `commonPitfalls`: deprecation warning, `@fundamental-ngx/cdk` must be installed explicitly, import path pattern, version-pinning rule (all three packages must share the same semver minor), bundle budget.
- `compositionPattern`: full install command + angular.json budget + standalone component example with UI5 imports.

--
