### PR TITLE
chore(ci): add explicit permissions to workflows for GITHUB_TOKEN read-only default

### DIFF
--- a/.github/workflows/i18n-auto-generate.test.yml
+++ b/.github/workflows/i18n-auto-generate.test.yml
@@ -18,10 +18,15 @@ on:
 env:
     NODE_VERSION: '22.x'
 
+permissions:
+    contents: read
+
 jobs:
     test_generation:
         name: Test TypeScript file generation
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - name: Checkout
               uses: actions/checkout@v4.2.2

--- a/.github/workflows/i18n-auto-generate.yml
+++ b/.github/workflows/i18n-auto-generate.yml
@@ -12,6 +12,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     auto_generate:
         name: Generate TypeScript files from .properties changes

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -16,11 +16,16 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     nx_agents:
         name: Nx Cloud Agent ${{ matrix.agent }}
         runs-on: ubuntu-latest
         timeout-minutes: 60
+        permissions:
+            contents: read
         strategy:
             matrix:
                 agent: [1, 2, 3]
@@ -43,6 +48,9 @@ jobs:
     build_test:
         runs-on: ubuntu-latest
         name: Run affected Build, Lint and test commands
+        permissions:
+            contents: read
+            pull-requests: read
         defaults:
             run:
                 working-directory: ${{ github.workspace }}
@@ -146,6 +154,8 @@ jobs:
             # - e2e_test
         name: Nx Cloud - Stop Agents
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - uses: actions/checkout@v4.2.2
               with:


### PR DESCRIPTION
Add explicit `permissions:` blocks so workflows continue to work after the flip.

  - on-pull-request.yml: contents: read at workflow level; build_test adds
    pull-requests: read for commitlint-github-action
  - i18n-auto-generate.test.yml: contents: read (manual read-only test)
  - i18n-auto-generate.yml: contents: read at workflow level for consistency
    (auto_generate job already had contents: write + pull-requests: write)