### PR TITLE
ci(release): build only release packages, drop --all

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -126,7 +126,7 @@ jobs:
               with:
                   parallel-commands: |
                       npx nx run-many --target=lint --skip-nx-cache --projects=${{ env.RELEASE_PACKAGES }} --parallel=3
-                      npx nx run-many --target=build --all --parallel=1
+                      npx nx run-many --target=build --projects=${{ env.RELEASE_PACKAGES }} --parallel=1
 
             - name: Extract Angular version
               id: angularVersion


### PR DESCRIPTION
nx run-many --target=build --all dragged e2e-harness into the
  release build, which fails on Nx Cloud DTE because its ui5
  generated sources aren't available on sibling agents. Build only
  the publishable RELEASE_PACKAGES — e2e-harness and docs were never
  intended to ship from the release workflow.