### PR TITLE
docs: clarify resizable popover example

### DIFF
--- a/libs/docs/core/popover/examples/popover-resizable/popover-resizable-example.component.html
+++ b/libs/docs/core/popover/examples/popover-resizable/popover-resizable-example.component.html
@@ -1,130 +1,18 @@
-<div class="fd-docs-popover-container fd-docs-popover-container--horizontal">
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="top-start" [noArrow]="false" title="top-start" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-up-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="top" [noArrow]="false" title="top" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-up-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="top-end" [noArrow]="false" title="top-end" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-up-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-</div>
-<div class="fd-docs-popover-container">
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="left-start" [noArrow]="false" title="left-start" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-left-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="right-start" [noArrow]="false" title="right-start" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-right-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-</div>
-<div class="fd-docs-popover-container">
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="left" [noArrow]="false" title="left" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-left-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="right" [noArrow]="false" title="right" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-right-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-</div>
-<div class="fd-docs-popover-container">
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="left-end" [noArrow]="false" title="left-end" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-left-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="right-end" [noArrow]="false" title="right-end" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-right-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-</div>
-<div class="fd-docs-popover-container fd-docs-popover-container--horizontal">
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="bottom-start" [noArrow]="false" title="bottom-start" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-down-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="bottom" [noArrow]="false" title="bottom" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-down-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
-    <div class="fd-docs-popover-element">
-        <fd-popover placement="bottom-end" [noArrow]="false" title="bottom-end" [resizable]="true">
-            <fd-popover-control>
-                <button fd-button glyph="navigation-down-arrow"></button>
-            </fd-popover-control>
-            <fd-popover-body minWidth="9rem" minHeight="9rem">
-                <fd-avatar [circle]="true" [style.margin.rem]="1" size="xl" glyph="group"></fd-avatar>
-            </fd-popover-body>
-        </fd-popover>
-    </div>
+<div class="fd-docs-popover-resizable-example">
+    <fd-popover placement="bottom-start" title="Resizable popover" [resizable]="true">
+        <fd-popover-control>
+            <button fd-button label="Open resizable popover"></button>
+        </fd-popover-control>
+
+        <fd-popover-body minWidth="18rem" minHeight="10rem" maxWidth="32rem" maxHeight="24rem">
+            <div class="fd-docs-popover-resizable-example__content">
+                <h4 class="fd-docs-popover-resizable-example__title">Resizable content area</h4>
+                <p>
+                    Drag the resize handle to make room for longer content, tables, previews, or forms while keeping the
+                    popover within its configured limits.
+                </p>
+                <button fd-button label="Save changes" fdType="emphasized"></button>
+            </div>
+        </fd-popover-body>
+    </fd-popover>
 </div>

--- a/libs/docs/core/popover/examples/popover-resizable/popover-resizable-example.component.scss
+++ b/libs/docs/core/popover/examples/popover-resizable/popover-resizable-example.component.scss
@@ -1,16 +1,16 @@
 .fd-docs-popover-resizable-example {
-    padding: var(--sapContent_PaddingM, 1rem);
+    padding: var(--sapContent_PaddingM);
 }
 
 .fd-docs-popover-resizable-example__content {
     display: flex;
     flex-direction: column;
-    gap: var(--sapContent_PaddingS, 0.5rem);
-    padding: var(--sapContent_PaddingM, 1rem);
+    gap: var(--sapContent_PaddingS);
+    padding: var(--sapContent_PaddingM);
 }
 
 .fd-docs-popover-resizable-example__title {
     margin: 0;
-    font-size: var(--sapFontHeader5Size, 1rem);
-    font-weight: var(--sapFontHeaderWeight, 600);
+    font-size: var(--sapFontHeader5Size);
+    font-weight: var(--sapFontHeaderWeight);
 }

--- a/libs/docs/core/popover/examples/popover-resizable/popover-resizable-example.component.scss
+++ b/libs/docs/core/popover/examples/popover-resizable/popover-resizable-example.component.scss
@@ -1,16 +1,16 @@
-/* Using SAP CSS variables for theming consistency */
+.fd-docs-popover-resizable-example {
+    padding: var(--sapContent_PaddingM, 1rem);
+}
 
-.fd-docs-popover-container {
+.fd-docs-popover-resizable-example__content {
     display: flex;
-    max-width: 100%;
-    justify-content: space-between;
+    flex-direction: column;
+    gap: var(--sapContent_PaddingS, 0.5rem);
+    padding: var(--sapContent_PaddingM, 1rem);
 }
 
-.fd-docs-popover-container--horizontal {
-    justify-content: space-evenly;
-    margin: 0 var(--sapContent_PaddingXL, 5rem);
-}
-
-.fd-docs-popover-element {
-    margin: var(--sapContent_PaddingM, 1rem);
+.fd-docs-popover-resizable-example__title {
+    margin: 0;
+    font-size: var(--sapFontHeader5Size, 1rem);
+    font-weight: var(--sapFontHeaderWeight, 600);
 }

--- a/libs/docs/core/popover/examples/popover-resizable/popover-resizable-example.component.ts
+++ b/libs/docs/core/popover/examples/popover-resizable/popover-resizable-example.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { AvatarComponent } from '@fundamental-ngx/core/avatar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from '@fundamental-ngx/core/popover';
 
@@ -7,6 +6,6 @@ import { PopoverBodyComponent, PopoverComponent, PopoverControlComponent } from 
     selector: 'fd-popover-resizable-example',
     templateUrl: './popover-resizable-example.component.html',
     styleUrls: ['popover-resizable-example.component.scss'],
-    imports: [PopoverComponent, PopoverControlComponent, ButtonComponent, PopoverBodyComponent, AvatarComponent]
+    imports: [PopoverComponent, PopoverControlComponent, ButtonComponent, PopoverBodyComponent]
 })
 export class PopoverResizableExampleComponent {}

--- a/libs/docs/core/popover/popover-docs.component.ts
+++ b/libs/docs/core/popover/popover-docs.component.ts
@@ -379,6 +379,11 @@ export class PopoverDocsComponent {
             code: getAssetFromModuleAssets(resizablePopoverTsSrc),
             fileName: 'popover-resizable-example',
             scssFileCode: getAssetFromModuleAssets(resizablePopoverScss)
+        },
+        {
+            language: 'scss',
+            code: getAssetFromModuleAssets(resizablePopoverScss),
+            fileName: 'popover-resizable-example'
         }
     ];
 }

--- a/libs/docs/core/popover/popover-docs.component.ts
+++ b/libs/docs/core/popover/popover-docs.component.ts
@@ -377,8 +377,7 @@ export class PopoverDocsComponent {
             language: 'typescript',
             component: 'PopoverResizableExampleComponent',
             code: getAssetFromModuleAssets(resizablePopoverTsSrc),
-            fileName: 'popover-resizable-example',
-            scssFileCode: getAssetFromModuleAssets(resizablePopoverScss)
+            fileName: 'popover-resizable-example'
         },
         {
             language: 'scss',


### PR DESCRIPTION
Updates the resizable popover docs example so it no longer duplicates the placement example.
Closes #14011
Checks: yarn prettier 
check nx lint docs-core-popover- git diff --check