### PR TITLE
docs: add a skills page to documentation

### DIFF
--- a/apps/docs/src/app.config.ts
+++ b/apps/docs/src/app.config.ts
@@ -50,6 +50,7 @@ export const appConfig: ApplicationConfig = {
                 cx: () => import('@fundamental-ngx/docs/cx').then((m) => m.DOCS_DATA),
                 i18n: () => import('@fundamental-ngx/docs/i18n').then((m) => m.DOCS_DATA),
                 mcp: () => import('@fundamental-ngx/docs/mcp-server').then((m) => m.DOCS_DATA),
+                skills: () => import('@fundamental-ngx/docs/skills').then((m) => m.DOCS_DATA),
                 'ui5-webcomponents': () => import('@fundamental-ngx/docs/ui5-webcomponents').then((m) => m.DOCS_DATA),
                 'ui5-webcomponents-ai': () =>
                     import('@fundamental-ngx/docs/ui5-webcomponents-ai').then((m) => m.DOCS_DATA),

--- a/apps/docs/src/assets/skills/README.md
+++ b/apps/docs/src/assets/skills/README.md
@@ -1,0 +1,189 @@
+# Skills
+
+Agent Skills for **@fundamental-ngx** provide AI assistants with step-by-step guidance for building, testing, migrating, and reviewing Angular components with this library. These skills help AI agents (like Claude Code) complete complex multi-step tasks accurately without hallucinating APIs.
+
+## What are Skills?
+
+Skills are markdown-based task playbooks specifically designed for AI assistants. Each skill contains:
+
+- **Phased workflows** — Step-by-step instructions that guide the AI from discovery through implementation
+- **API lookup patterns** — How to query the MCP server for accurate, up-to-date component APIs before writing code
+- **Project conventions** — Enforced Angular 21+ patterns, NX workspace commands, and library-specific rules
+- **Validation steps** — How to verify the output compiles and behaves correctly
+
+## Available Skills
+
+fundamental-ngx provides **14 skills** organized by purpose:
+
+### Building & Setup (5 skills)
+
+Create new Angular projects and generate component implementations from scratch:
+
+- **setup-project** — Scaffold a new Angular app with `@fundamental-ngx` installed, a theme applied, and a working first component
+- **scaffold** — Generate a component using established fundamental-ngx patterns: dialog, table, card, form, shell, or layout-grid
+- **build-form** — Build a reactive form using `fdp-form-group` and `fdp-form-field` with field validation and error states
+- **build-table** — Build a `fdp-table` data table with `FdpTableDataSource`, sorting, filtering, pagination, and row selection
+- **build-page-layout** — Build a page layout using `fd-dynamic-page` or `fdp-dynamic-page` with collapsing header, subheader, tabs, and footer
+
+### Code Quality & Review (5 skills)
+
+Verify and improve the quality of existing code:
+
+- **best-practices** — Audit any component or folder against Angular 21+ conventions and project-specific rules
+- **review-pr** — Review a pull request, reporting blocking issues, suggestions, and nits grouped by severity
+- **create-test** — Generate or update unit tests for a component following project testing conventions
+- **a11y-audit** — Audit a component for WCAG AA accessibility compliance across semantic HTML, ARIA, keyboard, and focus
+- **preflight** — Run all local quality gates (format, lint, build, test) before opening a PR
+
+### Migration & Maintenance (4 skills)
+
+Keep the codebase up to date with evolving standards and dependencies:
+
+- **migrate** — Migrate a component or directive from decorator-based patterns to Angular 21+ signal-based patterns
+- **update-docs** — Verify that documentation examples are in sync with a component's current public API and fix any drift
+- **adopt-styles** — Apply breaking changes from `fundamental-styles` into the Angular component templates and class bindings
+- **i18n-manage** — Add, rename, or remove i18n translation keys across `FdLanguage`, `.properties` files, and generated types
+
+## Installation
+
+Skills are included automatically when you work in the fundamental-ngx repository. The `.claude/skills/` directory is checked in alongside the source code.
+
+To install the skills into any external project:
+
+```bash
+# Install at project level (only available in this project)
+npx skills add SAP/fundamental-ngx
+
+# Or install globally (available across all your projects)
+npx skills add SAP/fundamental-ngx -g
+```
+
+### Browse Available Skills
+
+Before installing, preview what skills are available:
+
+```bash
+npx skills add SAP/fundamental-ngx -l
+```
+
+### Install Individual Skills
+
+If you only need specific skills:
+
+```bash
+# Install only the scaffold skill
+npx skills add SAP/fundamental-ngx -s scaffold
+
+# Install only migration and best-practices
+npx skills add SAP/fundamental-ngx -s migrate,best-practices
+
+# Install all building skills
+npx skills add SAP/fundamental-ngx -s setup-project,scaffold,build-form,build-table,build-page-layout
+```
+
+Available skill IDs:
+
+```
+setup-project
+scaffold
+build-form
+build-table
+build-page-layout
+best-practices
+review-pr
+create-test
+a11y-audit
+preflight
+migrate
+update-docs
+adopt-styles
+i18n-manage
+```
+
+### Verify Installation
+
+After installing, verify that skills are available:
+
+```bash
+# List installed skills
+npx skills list
+
+# Or list global skills
+npx skills list -g
+```
+
+In Claude Code, test by typing a skill command:
+
+```
+/scaffold
+/build-form
+/migrate
+```
+
+The skill content should load immediately. If skills don't appear, try restarting Claude Code.
+
+## Skills vs MCP Tools
+
+fundamental-ngx provides two complementary ways to access information:
+
+| Feature        | Skills                                           | MCP Tools                                       |
+| -------------- | ------------------------------------------------ | ----------------------------------------------- |
+| **Purpose**    | Multi-step task execution                        | Quick API lookups & code generation             |
+| **Content**    | Phased workflows, conventions, validation steps  | Component APIs, HTML examples, usage guides     |
+| **Activation** | Type `/skill-name` or AI auto-loads              | Call tool functions (e.g., `get_component_api`) |
+| **Length**     | Detailed step-by-step playbooks                  | Focused, concise responses                      |
+| **Best For**   | Building features end-to-end, migrations, audits | Looking up an input, getting an HTML snippet    |
+
+### When to Use Each
+
+Use **Skills** for:
+
+- Building a feature end-to-end (new form, table, page layout)
+- Migrating existing code to Angular 21+ signal patterns
+- Reviewing a PR or auditing a component for quality
+- Running pre-PR quality checks
+- Managing i18n keys or adopting style library changes
+
+Use **MCP Tools** for:
+
+- Getting a component's current input/output API
+- Fetching a working HTML example to reference
+- Looking up usage guides mid-implementation
+
+## How AI Agents Use Skills
+
+### Explicit Activation (Recommended)
+
+Type the skill name as a slash command:
+
+```
+/scaffold dialog
+→ Generates a dialog component using the correct fd-dialog pattern
+
+/build-form UserProfile id:number name:string email:string role:select
+→ Builds a reactive form with those fields, validation, and error states
+
+/migrate libs/core/button
+→ Migrates button component to signal-based inputs and outputs
+
+/review-pr 1234
+→ Reviews PR #1234 and reports blocking/suggestion/nit findings
+```
+
+### Automatic Activation (Smart Detection)
+
+AI assistants like Claude Code will automatically load relevant skills based on your request:
+
+```
+You: "Create a data table for displaying orders"
+→ AI loads: build-table skill
+→ Follows: FdpTableDataSource setup, column definition, sorting/pagination wiring
+
+You: "Migrate this component to use signals"
+→ AI loads: migrate skill
+→ Follows: @Input → input(), @Output → output(), @HostBinding → host: {} migration phases
+
+You: "Run quality checks before I open a PR"
+→ AI loads: preflight skill
+→ Runs: format, lint, build, test in the correct order for affected libraries
+```

--- a/apps/docs/src/environments/app.routes.ts
+++ b/apps/docs/src/environments/app.routes.ts
@@ -151,6 +151,20 @@ export const ROUTES: Routes = [
                     })
             },
             {
+                path: 'skills',
+                loadChildren: () =>
+                    import('@fundamental-ngx/docs/skills').then((m) => {
+                        const route = m.default[0];
+                        return [
+                            {
+                                path: '',
+                                providers: route.providers || [],
+                                children: route.children
+                            }
+                        ];
+                    })
+            },
+            {
                 path: 'home',
                 loadComponent: () =>
                     import('@fundamental-ngx/docs/shared-pages').then((m) => m.UnifiedHomePageComponent)

--- a/libs/docs/shared-pages/index.ts
+++ b/libs/docs/shared-pages/index.ts
@@ -2,5 +2,6 @@ export * from './library-doc-shell-page.component';
 export * from './library-readme-page.component';
 export * from './mcp-server-page.component';
 export * from './new-component-page.component';
+export * from './skills-page.component';
 export * from './unified-docs-shell-page.component';
 export * from './unified-home-page.component';

--- a/libs/docs/shared-pages/skills-page.component.ts
+++ b/libs/docs/shared-pages/skills-page.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { MarkdownModule } from 'ngx-markdown';
+
+@Component({
+    template: `
+        <markdown
+            class="fd-docs-playground--markdown"
+            src="assets/skills/README.md"
+            (load)="onLoad()"
+            (error)="onError()"
+        ></markdown>
+    `,
+    imports: [MarkdownModule]
+})
+export class SkillsPageComponent {
+    onLoad(): void {}
+    onError(): void {}
+}

--- a/libs/docs/shared/src/lib/services/docs-packages.config.ts
+++ b/libs/docs/shared/src/lib/services/docs-packages.config.ts
@@ -52,7 +52,8 @@ export const DOCS_PACKAGES_META: DocsPackageMeta[] = [
     { id: 'cdk', name: 'CDK' },
     { id: 'i18n', name: 'i18n' },
     { id: 'cx', name: 'CX' },
-    { id: 'mcp', name: 'MCP Server' }
+    { id: 'mcp', name: 'MCP Server' },
+    { id: 'skills', name: 'Skills' }
 ];
 
 /**

--- a/libs/docs/skills/docs-data.json
+++ b/libs/docs/skills/docs-data.json
@@ -1,0 +1,8 @@
+{
+    "guides": [
+        {
+            "name": "Overview",
+            "url": "skills/overview"
+        }
+    ]
+}

--- a/libs/docs/skills/docs-routes.ts
+++ b/libs/docs/skills/docs-routes.ts
@@ -1,0 +1,26 @@
+import { Routes } from '@angular/router';
+import { CURRENT_LIB, StackblitzService } from '@fundamental-ngx/docs/shared';
+import { guides } from './docs-data.json';
+
+export const ROUTES: Routes = [
+    {
+        path: '',
+        loadComponent: () => import('@fundamental-ngx/docs/shared-pages').then((m) => m.LibraryDocShellPageComponent),
+        data: {
+            sections: [
+                {
+                    header: 'Guides',
+                    content: guides
+                }
+            ]
+        },
+        providers: [StackblitzService, { provide: CURRENT_LIB, useValue: 'skills' }],
+        children: [
+            { path: '', redirectTo: 'overview', pathMatch: 'full' },
+            {
+                path: 'overview',
+                loadComponent: () => import('@fundamental-ngx/docs/shared-pages').then((m) => m.SkillsPageComponent)
+            }
+        ]
+    }
+];

--- a/libs/docs/skills/index.ts
+++ b/libs/docs/skills/index.ts
@@ -1,0 +1,3 @@
+import { ROUTES } from './docs-routes';
+export default ROUTES;
+export { default as DOCS_DATA } from './docs-data.json';

--- a/libs/docs/skills/project.json
+++ b/libs/docs/skills/project.json
@@ -1,0 +1,10 @@
+{
+    "name": "docs-skills",
+    "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+    "projectType": "library",
+    "sourceRoot": "libs/docs/skills",
+    "prefix": "fundamental-ngx",
+    "tags": ["type:lib", "scope:docs"],
+    "// targets": "to see all targets run: nx show project docs-skills --web",
+    "targets": {}
+}

--- a/libs/mcp-server/README.md
+++ b/libs/mcp-server/README.md
@@ -1,66 +1,27 @@
 # @fundamental-ngx/mcp
 
-MCP (Model Context Protocol) server that exposes the entire Fundamental NGX component catalog to AI coding assistants.
-
-## What It Does
-
-AI coding assistants (Claude Code, Cursor, VS Code Copilot, Windsurf, etc.) can connect to this MCP server and get structured access to:
-
-- **1000+ components** across 8 libraries (core, platform, btp, cx, cdk, ui5-webcomponents, ui5-webcomponents-fiori, ui5-webcomponents-ai)
-- **Full API metadata** — inputs, outputs, slots, methods, enum values, CSS properties
-- **Component recommendations** — describe what you want to build and get matching components
-- **Design tokens** — SAP theming CSS custom properties and utility classes
-- **Migration guidance** — breaking changes and upgrade paths from changelogs
-- **Accessibility guidance** — ARIA inputs, keyboard handling, and a11y examples
-- **Component comparison** — side-by-side comparison of alternative components
-- **Usage guides** — decision trees and composition patterns for complex components (dialog, table, card, etc.)
-- **Selector classification** — whether a component is an element, attribute directive, or both, with correct template usage
-- **Companion skills** — installable Claude Code skills for project setup, form generation, table scaffolding, and page layout (`/setup-project`, `/build-form`, `/build-table`, `/build-page-layout`, and more)
-
-This eliminates hallucinated APIs and outdated documentation — the assistant works from the actual component metadata.
+MCP (Model Context Protocol) server that exposes the [Fundamental NGX](https://github.com/SAP/fundamental-ngx) component catalog to AI coding assistants.
 
 ## Quick Start
 
-### VS Code / Cursor
+### With Claude Code
 
-Create or edit `.vscode/mcp.json` in your project root:
-
-```json
-{
-    "servers": {
-        "fundamental-ngx": {
-            "command": "npx",
-            "args": ["-y", "@fundamental-ngx/mcp"]
-        }
-    }
-}
-```
-
-### Claude Code
-
-Run this command in your terminal to register the server for the current project:
+**Option 1: Using claude mcp add (Recommended)**
 
 ```bash
+# Install latest version
 claude mcp add fundamental-ngx -- npx -y @fundamental-ngx/mcp
+
+# Or install a specific version
+claude mcp add fundamental-ngx -- npx -y @fundamental-ngx/mcp@0.62.4
 ```
 
-Or to make it available across all your projects:
+This command automatically adds the MCP server to your `.claude/mcp.json` configuration.
 
-```bash
-claude mcp add --scope user fundamental-ngx -- npx -y @fundamental-ngx/mcp
-```
-
-You can verify it was added with:
-
-```bash
-claude mcp list
-```
-
-### Windsurf
-
-Add to `~/.codeium/windsurf/mcp_config.json`:
+**Option 2: Manual configuration**
 
 ```json
+// .claude/mcp.json
 {
     "mcpServers": {
         "fundamental-ngx": {
@@ -71,9 +32,59 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
-That's it — your AI assistant now has full access to the Fundamental NGX component catalog.
+### With Cursor
 
-## Available Tools
+```json
+// .cursor/mcp.json
+{
+    "mcpServers": {
+        "fundamental-ngx": {
+            "command": "npx",
+            "args": ["-y", "@fundamental-ngx/mcp"]
+        }
+    }
+}
+```
+
+### With VS Code (Copilot)
+
+```json
+// .vscode/mcp.json
+{
+    "servers": {
+        "fundamental-ngx": {
+            "command": "npx",
+            "args": ["-y", "@fundamental-ngx/mcp"],
+            "type": "stdio"
+        }
+    }
+}
+```
+
+### How it works
+
+`npx -y @fundamental-ngx/mcp` starts a Node.js process that listens on **stdio** for JSON-RPC messages following the [Model Context Protocol](https://modelcontextprotocol.io/). Running it directly in a terminal will appear to hang — that is intentional. The process is idle, waiting for a client to send tool requests over stdin. It is designed to be launched and managed by an MCP client (Claude Code, Cursor, VS Code Copilot), not run interactively.
+
+To explore the server's tools from a browser UI, use the MCP Inspector instead (see below).
+
+**Debugging with MCP Inspector:**
+
+The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) is a web UI for testing MCP servers interactively:
+
+```bash
+npx @modelcontextprotocol/inspector npx -y @fundamental-ngx/mcp
+```
+
+This opens a browser UI where you can:
+
+- Browse all 10 available tools
+- Send test requests with custom parameters
+- View formatted JSON responses
+- Debug tool behavior without an AI client
+
+The server communicates over **stdio** using the MCP JSON-RPC protocol.
+
+## Tools
 
 | Tool                      | Purpose                                                          | Example Query                                                  |
 | ------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------- |
@@ -88,82 +99,78 @@ That's it — your AI assistant now has full access to the Fundamental NGX compo
 | `compare_components`      | Side-by-side comparison of two components                        | `{ "component_a": "fd-button", "component_b": "ui5-button" }`  |
 | `get_usage_guide`         | Decision tree and composition patterns for a component           | `{ "component": "dialog" }`                                    |
 
-## Metadata Schema
+## Example Queries
 
-Each component in the catalog follows this structure:
+```
+"What components are available in the core library?"
+  → list_components with library "core"
 
-```typescript
-interface ComponentMetadata {
-    name: string; // "ButtonComponent"
-    selector: string; // "fd-button" or "ui5-button"
-    selectorType: 'element' | 'attribute' | 'both'; // how to use in templates
-    templateUsage: string; // "<button fd-button>...</button>"
-    library: Library; // "@fundamental-ngx/core"
-    category: string; // "Actions", "Form", "Layout"
-    description: string;
-    deprecated?: string; // deprecation message
-    inputs: InputMetadata[];
-    outputs: OutputMetadata[];
-    slots: SlotMetadata[]; // UI5 components
-    methods: MethodMetadata[];
-    cssProperties: CssPropertyMetadata[];
-    keyboardHandling?: string; // keyboard interaction notes (UI5 components)
-    source: 'cem' | 'typedoc';
-}
+"Find a component for selecting a date range"
+  → search_components with query "date range"
+
+"What inputs does fd-button accept?"
+  → get_component_api with name "fd-button"
+
+"Show me HTML examples for fd-dialog"
+  → get_component_examples with name "fd-dialog"
+
+"I need to build a filterable data table with pagination"
+  → recommend_components with description "filterable data table with pagination"
+
+"What broke between 0.60.0 and 0.62.0?"
+  → get_migration_guide with from_version "0.60.0", to_version "0.62.0"
+
+"What SAP design tokens are available for background colors?"
+  → get_design_tokens with query "background color", category "color"
+
+"How do I handle keyboard navigation in fd-menu?"
+  → get_accessibility_guide with name "fd-menu"
+
+"What is the difference between fd-table and fdp-table?"
+  → compare_components with component_a "fd-table", component_b "fdp-table"
+
+"Which dialog API should I use?"
+  → get_usage_guide with component "dialog"
 ```
 
-See `src/types/component-metadata.ts` for full type definitions.
+## Contributing
 
-## AI Onboarding
+### Prerequisites
 
-The MCP server is designed as the primary AI-assisted onboarding path for Fundamental NGX. Here's the recommended workflow:
+- Node.js 18+
+- Yarn 4.x (the monorepo uses Yarn workspaces)
 
-1. **Discover** — Use `recommend_components` to find the right components for your UI
-2. **Decide** — Use `get_usage_guide` to choose the right variant (e.g., which dialog API surface)
-3. **Learn** — Use `get_component_api` and `get_component_examples` for API details and working code
-4. **Build** — Use `get_design_tokens` and `get_accessibility_guide` while implementing
-5. **Compare** — Use `compare_components` when choosing between alternatives (e.g., `fd-table` vs `fdp-table`)
-
-### Usage Guides
-
-The `get_usage_guide` tool provides structured decision trees for components with multiple API surfaces or variants:
-
-- **Dialog** — template-based vs component-based vs object-based; fd-dialog vs ui5-dialog vs fd-message-box
-- **Table** — fd-table (core, lightweight) vs fdp-table (platform, feature-rich) vs ui5-table (Web Components)
-- **Button** — standard vs split-button vs segmented-button
-- **Card** — fd-card (core) vs ui5-card (Web Components)
-- **Layout Grid** — fd-layout-grid vs fd-flexible-column-layout
-
-### Selector Classification
-
-Each component now includes `selectorType` and `templateUsage` fields to prevent incorrect template usage:
-
-| selectorType | Meaning                               | Example                          |
-| ------------ | ------------------------------------- | -------------------------------- |
-| `element`    | Use as an HTML element                | `<fd-card>...</fd-card>`         |
-| `attribute`  | Use as an attribute on a host element | `<h2 fd-title>...</h2>`          |
-| `both`       | Element + attribute combined          | `<button fd-button>...</button>` |
-
-## Complementary Skills
-
-The MCP server answers _what_ Fundamental NGX components exist and _how_ their APIs work. For the procedural _how do I compose these together_ knowledge, a set of installable Claude Code skills is available in the repository.
-
-Install them with:
+### Setup
 
 ```bash
-npx skills add sap/fundamental-ngx
+# From the repo root
+yarn install
 ```
 
-Or copy the skills directory into your project's `.claude/skills/` folder.
+### Build
 
-| Skill               | Invocation                                                 | What It Does                                                                                                                                |
-| ------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `setup-project`     | `/setup-project my-app horizon`                            | Creates a new Angular app, installs `@fundamental-ngx/core`, applies a SAP Fiori theme, and verifies the setup with a smoke-test component  |
-| `build-form`        | `/build-form UserProfile firstName:text role:select`       | Generates a reactive form with `FormGroup` wiring, `fdp-form-field` composition, typed interface, and automatic error message setup         |
-| `build-table`       | `/build-table Orders sort filter paginate select=multiple` | Generates a platform data table with `FdpTableDataSource`, column definitions, sort/filter directives, pagination, and row selection        |
-| `build-page-layout` | `/build-page-layout ProductDetail subheader footer`        | Generates an `fd-dynamic-page` with collapsing header, subheader, scrollable content, floating footer, and optional tabs or FCL integration |
-| `scaffold`          | `/scaffold dialog component-ref`                           | Generates a working component for any supported pattern (dialog, table, card, form, shell, layout-grid) using live MCP data                 |
-| `migrate`           | `/migrate src/app/my-component`                            | Migrates a component to Angular 21+ signal-based patterns (`@Input→input()`, `@HostBinding→host`, `*ngIf→@if`, `BehaviorSubject→signal()`)  |
-| `a11y-audit`        | `/a11y-audit fd-menu`                                      | Audits a component for WCAG AA compliance — semantic HTML, ARIA, keyboard navigation, focus management                                      |
+```bash
+npx nx build mcp-server
+```
 
-The skills call back into the MCP server (`get_usage_guide`, `get_component_api`, `get_component_examples`) so the procedural guidance is always backed by up-to-date component metadata.
+This compiles TypeScript and copies data assets (JSON files) into `dist/libs/mcp-server/`.
+
+### Extract metadata
+
+The server's component catalog is generated from the built library artifacts. Re-run this after changing component source files:
+
+```bash
+npx nx run mcp-server:extract-metadata
+```
+
+Use `--dry-run` to validate without writing:
+
+```bash
+npx nx run mcp-server:check-metadata
+```
+
+### Test
+
+```bash
+npx nx test mcp-server
+```

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -50,6 +50,7 @@
             "@fundamental-ngx/docs/cx/*": ["libs/docs/cx/*/index.ts", "libs/docs/cx/*/src/index.ts"],
             "@fundamental-ngx/docs/i18n": ["libs/docs/i18n/index.ts"],
             "@fundamental-ngx/docs/mcp-server": ["libs/docs/mcp-server/index.ts"],
+            "@fundamental-ngx/docs/skills": ["libs/docs/skills/index.ts"],
             "@fundamental-ngx/docs/platform": ["libs/docs/platform/index.ts"],
             "@fundamental-ngx/docs/platform/*": ["libs/docs/platform/*/index.ts", "libs/docs/platform/*/src/index.ts"],
             "@fundamental-ngx/docs/schema": ["libs/docs/schema/src/index.ts"],


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

This PR consists of two main changes:

1. Adds a new `Skills` page to the documentation website. The `Skills` page now appears in the sidebar as "Skills" and navigates to `/skills/overview`, showing all 14 skills categorized as `Building & Setup`, `Code Quality & Review`, and `Migration & Maintenance`.
2. Updates the `MCP` page on the documentation website so that it resembles the one that we have in fundamental-styles. Also adds information how to use the `modelcontextprotocol` inspector if a user wants to play with the MCP manually and provides some example queries.