### PR TITLE
fix(core): datetime picker jumps on hover

### DIFF
--- a/libs/core/datetime-picker/datetime-picker.component.spec.ts
+++ b/libs/core/datetime-picker/datetime-picker.component.spec.ts
@@ -304,6 +304,24 @@ describe('DatetimePickerComponent', () => {
             expect(component.onChange).toHaveBeenCalled();
             expect(component.date).toBeDefined();
         });
+
+        it('should update _calendarPendingDate on submit so reopening shows the selected month', () => {
+            // Simulate: picker opened with June date, user navigates to August and selects Aug 15
+            const juneDate = new FdDate(2024, 6, 5);
+            const augustDate = new FdDate(2024, 8, 15);
+
+            component.date = juneDate;
+            component._tempDate = augustDate;
+            component._tempTime = augustDate;
+
+            component.submit();
+
+            // _calendarPendingDate must reflect the newly submitted date so that
+            // when the ViewChild setter calls setCurrentlyDisplayed(_calendarPendingDate)
+            // after reopening, it shows August, not June.
+            expect((component as any)._calendarPendingDate?.month).toBe(augustDate.month);
+            expect((component as any)._calendarPendingDate?.day).toBe(augustDate.day);
+        });
     });
 
     describe('Validation', () => {

--- a/libs/core/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/datetime-picker/datetime-picker.component.ts
@@ -733,6 +733,7 @@ export class DatetimePickerComponent<D>
                 this._dateTimeAdapter.getMinutes(currentTime),
                 this._dateTimeAdapter.getSeconds(currentTime)
             );
+            this._refreshCurrentlyDisplayedCalendarDate(this.date);
         } catch {
             this.date = null;
         }


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14242

## Description

The `submit()` method of `DatetimePickerComponent` didn't update `_calendarPendingDate`, so reopening the picker called `setCurrentlyDisplayed` with the stale pre-selection date, jumping the calendar back to the previously displayed month.

## Screenshots

Before:

https://github.com/user-attachments/assets/f76114d7-7ec9-4087-aacf-a7225dd4f60d


After:

https://github.com/user-attachments/assets/5096e760-7577-4091-8dc5-10c805136f8a