### PR TITLE
fix(core): fix Message Strip btn misalignment

### DIFF
--- a/libs/core/message-strip/message-strip.component.html
+++ b/libs/core/message-strip/message-strip.component.html
@@ -13,11 +13,10 @@
 </p>
 @if (dismissible()) {
     <button
-        class="fd-message-strip__close"
+        class="fd-message-strip__close fd-button--compact"
         fd-button
         glyph="decline"
         fdType="transparent"
-        fdCompact
         (click)="dismiss()"
         [attr.aria-controls]="id()"
         [ariaLabel]="dismissBtnTitle() || defaultDismissButtonText()"


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description
The dismiss btn inside Message strip should always be in its compact state.

## Screenshots
Before:

<img width="1132" height="504" alt="Screenshot 2026-06-09 at 3 54 00 PM" src="https://github.com/user-attachments/assets/a96a9d9b-c020-4ca6-850b-d203aa82ce61" />

After:
<img width="1200" height="480" alt="Screenshot 2026-06-09 at 3 52 00 PM" src="https://github.com/user-attachments/assets/fc9dc9f4-d122-4386-9a99-81297c529fce" />
