### PR TITLE
fix(core): guard tokenList.changes with takeUntilDestroyed

### DIFF
--- a/libs/core/token/tokenizer.component.ts
+++ b/libs/core/token/tokenizer.component.ts
@@ -295,7 +295,7 @@ export class TokenizerComponent implements AfterViewInit, OnDestroy, CssClassBui
         }
 
         // watch for changes to the tokenList and attempt to expand/collapse tokens as needed
-        this.tokenList.changes.pipe(startWith(null)).subscribe(() => {
+        this.tokenList.changes.pipe(startWith(null), takeUntilDestroyed(this._destroyRef)).subscribe(() => {
             this.tokenListChangesSubscription?.unsubscribe();
             this.tokenListChangesSubscription = new Subscription();
             this._unsubscribeTokenOutputs();


### PR DESCRIPTION
## Summary
  - Fixes NG0953 errors reported in Sentry after upgrading to the latest version. `TokenizerComponent` subscribed to `tokenList.changes` without a destroy guard, allowing `_resetTokens()` to fire during teardown and call `.subscribe()` on `output()` emitters of already-destroyed `TokenComponent` instances.
  - One operator added: `takeUntilDestroyed(this._destroyRef)` on the `tokenList.changes` pipe. `DestroyRef` was already injected.
  - The race only manifests in the browser when Angular destroys content children before the parent (not reproducible in jsdom).
  - Closes #14248.

  ## Test plan
  - [ ] Open a page that uses `fd-tokenizer` (e.g. multi-input example in the docs app), add several tokens, then navigate away. Confirm no NG0953 in the browser console.
