### PR TITLE
fix(core): fix msg box focus trap

### DIFF
--- a/libs/core/message-box/message-box-default/message-box-default.component.html
+++ b/libs/core/message-box/message-box-default/message-box-default.component.html
@@ -18,6 +18,7 @@
                 @if (_messageBoxContent.approveButton) {
                     <fd-button-bar
                         fdkInitialFocus
+                        [enabled]="_messageBoxConfig.focusTrapped !== false"
                         fdType="emphasized"
                         [label]="_messageBoxContent.approveButton"
                         [ariaLabel]="_messageBoxContent.approveButtonAriaLabel"

--- a/libs/core/message-box/message-box-default/message-box-default.component.spec.ts
+++ b/libs/core/message-box/message-box-default/message-box-default.component.spec.ts
@@ -1,7 +1,11 @@
 import { ChangeDetectorRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FD_DIALOG_FOCUS_TRAP_ERROR } from '@fundamental-ngx/core/dialog';
 
 import { MessageBoxConfig } from '../utils/message-box-config.class';
 import { MessageBoxContent } from '../utils/message-box-content.class';
+import { MessageBoxRef } from '../utils/message-box-ref.class';
 import { MessageBoxDefaultComponent } from './message-box-default.component';
 
 describe('MessageBoxDefaultComponent', () => {
@@ -33,5 +37,75 @@ describe('MessageBoxDefaultComponent', () => {
 
         component._onApproveButton();
         expect(messageBoxContent.approveButtonCallback).toHaveBeenCalled();
+    });
+});
+
+function buildContent(): MessageBoxContent {
+    const c = new MessageBoxContent();
+    c.title = 'Test';
+    c.approveButton = 'Ok';
+    c.cancelButton = 'Cancel';
+    return c;
+}
+
+describe('MessageBoxDefaultComponent — focusTrapped: false', () => {
+    let fixture: ComponentFixture<MessageBoxDefaultComponent>;
+
+    beforeEach(async () => {
+        const cfg = new MessageBoxConfig();
+        cfg.focusTrapped = false;
+
+        await TestBed.configureTestingModule({
+            imports: [MessageBoxDefaultComponent, RouterTestingModule],
+            providers: [
+                { provide: MessageBoxConfig, useValue: cfg },
+                { provide: MessageBoxRef, useValue: new MessageBoxRef() },
+                { provide: FD_DIALOG_FOCUS_TRAP_ERROR, useValue: true }
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(MessageBoxDefaultComponent);
+        fixture.componentInstance._messageBoxContent = buildContent();
+        fixture.detectChanges();
+    });
+
+    it('should not move focus to the approve button when focusTrapped is false', async () => {
+        document.body.appendChild(fixture.nativeElement);
+        await fixture.whenStable();
+        const approveBtn = fixture.nativeElement.querySelector('fd-button-bar button');
+        expect(document.activeElement).not.toBe(approveBtn);
+        fixture.nativeElement.remove();
+    });
+});
+
+describe('MessageBoxDefaultComponent — focusTrapped: true', () => {
+    let fixture: ComponentFixture<MessageBoxDefaultComponent>;
+
+    beforeEach(async () => {
+        Object.defineProperty(global.window.HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 10 });
+
+        const cfg = new MessageBoxConfig();
+        cfg.focusTrapped = true;
+
+        await TestBed.configureTestingModule({
+            imports: [MessageBoxDefaultComponent, RouterTestingModule],
+            providers: [
+                { provide: MessageBoxConfig, useValue: cfg },
+                { provide: MessageBoxRef, useValue: new MessageBoxRef() },
+                { provide: FD_DIALOG_FOCUS_TRAP_ERROR, useValue: true }
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(MessageBoxDefaultComponent);
+        fixture.componentInstance._messageBoxContent = buildContent();
+    });
+
+    it('should move focus to the approve button when focusTrapped is true', async () => {
+        document.body.appendChild(fixture.nativeElement);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const approveBtn = fixture.nativeElement.querySelector('fd-button-bar button');
+        expect(document.activeElement).toBe(approveBtn);
+        fixture.nativeElement.remove();
     });
 });

--- a/libs/core/message-box/message-box-default/message-box-default.component.spec.ts
+++ b/libs/core/message-box/message-box-default/message-box-default.component.spec.ts
@@ -73,6 +73,8 @@ describe('MessageBoxDefaultComponent — focusTrapped: false', () => {
         document.body.appendChild(fixture.nativeElement);
         await fixture.whenStable();
         const approveBtn = fixture.nativeElement.querySelector('fd-button-bar button');
+        // Intentionally weak: we assert the button was not focused, not where focus landed.
+        // Asserting === document.body is fragile in jsdom when focus trap is suppressed.
         expect(document.activeElement).not.toBe(approveBtn);
         fixture.nativeElement.remove();
     });
@@ -98,6 +100,13 @@ describe('MessageBoxDefaultComponent — focusTrapped: true', () => {
 
         fixture = TestBed.createComponent(MessageBoxDefaultComponent);
         fixture.componentInstance._messageBoxContent = buildContent();
+    });
+
+    afterEach(() => {
+        Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+            configurable: true,
+            value: 0
+        });
     });
 
     it('should move focus to the approve button when focusTrapped is true', async () => {

--- a/libs/core/message-box/message-box.component.spec.ts
+++ b/libs/core/message-box/message-box.component.spec.ts
@@ -1,7 +1,8 @@
 import { Component, NgModule, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { NavigationStart, Router, RouterEvent, RouterModule } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { FocusTrapService } from '@fundamental-ngx/cdk/utils';
 import { FD_DIALOG_FOCUS_TRAP_ERROR } from '@fundamental-ngx/core/dialog';
 import { Subject } from 'rxjs';
 import { MessageBoxComponent } from './message-box.component';
@@ -54,9 +55,9 @@ describe('MessageBoxComponent', () => {
         });
     }));
 
-    function setup(providers: { token: any; provider: { useValue: any } }[] = []): void {
+    async function setup(providers: { token: any; provider: { useValue: any } }[] = []): Promise<void> {
         providers.forEach((provider) => TestBed.overrideProvider(provider.token, provider.provider));
-        TestBed.compileComponents();
+        await TestBed.compileComponents();
 
         fixture = TestBed.createComponent(TemplateTestComponent);
         component = fixture.componentInstance;
@@ -65,21 +66,21 @@ describe('MessageBoxComponent', () => {
         router = TestBed.inject(Router);
     }
 
-    it('should create', () => {
-        setup();
+    it('should create', async () => {
+        await setup();
         expect(component).toBeTruthy();
         expect(messageBoxComponent).toBeTruthy();
     });
 
-    it('should create w/o Router', () => {
-        setup([{ token: Router, provider: { useValue: null } }]);
+    it('should create w/o Router', async () => {
+        await setup([{ token: Router, provider: { useValue: null } }]);
         expect(router).toBeNull();
         expect(component).toBeTruthy();
         expect(messageBoxComponent).toBeTruthy();
     });
 
-    it('should close after esc pressed', () => {
-        setup();
+    it('should close after esc pressed', async () => {
+        await setup();
 
         const dismissSpy = jest.spyOn(messageBoxRef, 'dismiss');
 
@@ -89,10 +90,10 @@ describe('MessageBoxComponent', () => {
         expect(dismissSpy).toHaveBeenCalled();
     });
 
-    it('should close after backdrop clicked', () => {
+    it('should close after backdrop clicked', async () => {
         const customDialogConfig = { ...new MessageBoxConfig(), backdropClickCloseable: true };
 
-        setup([{ token: MessageBoxConfig, provider: { useValue: customDialogConfig } }]);
+        await setup([{ token: MessageBoxConfig, provider: { useValue: customDialogConfig } }]);
 
         const dismissSpy = jest.spyOn(messageBoxRef, 'dismiss');
         fixture.detectChanges();
@@ -103,15 +104,15 @@ describe('MessageBoxComponent', () => {
         expect(dismissSpy).toHaveBeenCalled();
     });
 
-    it('should set custom position', () => {
+    it('should set custom position', async () => {
         const customMessageBoxConfig = { ...new MessageBoxConfig(), position: { bottom: '100px', right: '50px' } };
-        setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
+        await setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
 
         expect(messageBoxComponent.dialogWindow.nativeElement.style.right).toEqual('50px');
         expect(messageBoxComponent.dialogWindow.nativeElement.style.bottom).toEqual('100px');
     });
 
-    it('should set custom size', () => {
+    it('should set custom size', async () => {
         const customSize = {
             width: '500px',
             height: '600px',
@@ -122,7 +123,7 @@ describe('MessageBoxComponent', () => {
         };
         const customMessageBoxConfig = { ...new MessageBoxConfig(), ...customSize };
 
-        setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
+        await setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
 
         expect(messageBoxComponent.dialogWindow.nativeElement.style.width).toEqual(customSize.width);
         expect(messageBoxComponent.dialogWindow.nativeElement.style.height).toEqual(customSize.height);
@@ -132,37 +133,37 @@ describe('MessageBoxComponent', () => {
         expect(messageBoxComponent.dialogWindow.nativeElement.style.maxHeight).toEqual(customSize.maxHeight);
     });
 
-    it('should have custom classes', () => {
+    it('should have custom classes', async () => {
         const customMessageBoxConfig = {
             ...new MessageBoxConfig(),
             backdropClass: 'customBackdropClass',
             dialogPanelClass: 'customPanelClass'
         };
-        setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
+        await setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
 
         expect(fixture.nativeElement.querySelector('.fd-message-box').classList).toContain('customBackdropClass');
         expect(fixture.nativeElement.querySelector('.fd-message-box__content').classList).toContain('customPanelClass');
     });
 
-    it('should display in mobile mode', () => {
+    it('should display in mobile mode', async () => {
         const customMessageBoxConfig = { ...new MessageBoxConfig(), mobile: true };
-        setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
+        await setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
 
         expect(fixture.nativeElement.querySelector('.fd-message-box__content').classList).toContain(
             'fd-message-box__content--mobile'
         );
     });
 
-    it('should display in mobile mode with no stretch', () => {
+    it('should display in mobile mode with no stretch', async () => {
         const customMessageBoxConfig = { ...new MessageBoxConfig(), mobileOuterSpacing: true };
-        setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
+        await setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
 
         expect(fixture.nativeElement.querySelector('.fd-message-box__content').classList).toContain(
             'fd-message-box__content--no-mobile-stretch'
         );
     });
 
-    it('should use custom attributes', () => {
+    it('should use custom attributes', async () => {
         const customMessageBoxConfig = {
             ...new MessageBoxConfig(),
             id: 'customId',
@@ -170,7 +171,7 @@ describe('MessageBoxComponent', () => {
             ariaLabelledBy: 'customAriLabelledBy',
             ariaDescribedBy: 'customAriaDescribedBy'
         };
-        setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
+        await setup([{ token: MessageBoxConfig, provider: { useValue: customMessageBoxConfig } }]);
 
         const messageBoxWindowEl = fixture.nativeElement.querySelector('.fd-message-box__content');
 
@@ -180,12 +181,82 @@ describe('MessageBoxComponent', () => {
         expect(messageBoxWindowEl.getAttribute('aria-describedby')).toEqual(customMessageBoxConfig.ariaDescribedBy);
     });
 
-    it('should close the message box on router navigation start', () => {
-        setup();
+    it('should close the message box on router navigation start', async () => {
+        await setup();
         const event = new NavigationStart(42, '/');
         const spy = jest.spyOn(messageBoxRef, 'dismiss');
         routerEventsSubject.next(event);
 
         expect(spy).toHaveBeenCalled();
+    });
+});
+
+describe('MessageBoxComponent — setupFocusTrap call count', () => {
+    describe('when focusTrapped is true', () => {
+        let fixture: ComponentFixture<TemplateTestComponent>;
+        let focusTrapService: { createFocusTrap: jest.Mock; deactivateFocusTrap: jest.Mock };
+
+        beforeEach(async () => {
+            focusTrapService = {
+                createFocusTrap: jest.fn().mockReturnValue('trap-id'),
+                deactivateFocusTrap: jest.fn()
+            };
+
+            const cfg = new MessageBoxConfig();
+            cfg.focusTrapped = true;
+
+            await TestBed.configureTestingModule({
+                imports: [TestModule, RouterModule, RouterTestingModule],
+                providers: [
+                    { provide: MessageBoxConfig, useValue: cfg },
+                    { provide: MessageBoxRef, useValue: new MessageBoxRef() },
+                    { provide: FocusTrapService, useValue: focusTrapService },
+                    { provide: FD_DIALOG_FOCUS_TRAP_ERROR, useValue: true }
+                ]
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(TemplateTestComponent);
+            fixture.detectChanges();
+        });
+
+        it('should call createFocusTrap exactly once', fakeAsync(() => {
+            tick(0);
+            fixture.detectChanges();
+            expect(focusTrapService.createFocusTrap).toHaveBeenCalledTimes(1);
+        }));
+    });
+
+    describe('when focusTrapped is false', () => {
+        let fixture: ComponentFixture<TemplateTestComponent>;
+        let focusTrapService: { createFocusTrap: jest.Mock; deactivateFocusTrap: jest.Mock };
+
+        beforeEach(async () => {
+            focusTrapService = {
+                createFocusTrap: jest.fn().mockReturnValue('trap-id'),
+                deactivateFocusTrap: jest.fn()
+            };
+
+            const cfg = new MessageBoxConfig();
+            cfg.focusTrapped = false;
+
+            await TestBed.configureTestingModule({
+                imports: [TestModule, RouterModule, RouterTestingModule],
+                providers: [
+                    { provide: MessageBoxConfig, useValue: cfg },
+                    { provide: MessageBoxRef, useValue: new MessageBoxRef() },
+                    { provide: FocusTrapService, useValue: focusTrapService },
+                    { provide: FD_DIALOG_FOCUS_TRAP_ERROR, useValue: true }
+                ]
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(TemplateTestComponent);
+            fixture.detectChanges();
+        });
+
+        it('should not call createFocusTrap', fakeAsync(() => {
+            tick(0);
+            fixture.detectChanges();
+            expect(focusTrapService.createFocusTrap).not.toHaveBeenCalled();
+        }));
     });
 });

--- a/libs/core/message-box/message-box.component.ts
+++ b/libs/core/message-box/message-box.component.ts
@@ -1,5 +1,4 @@
 import {
-    AfterViewInit,
     ChangeDetectionStrategy,
     Component,
     ElementRef,
@@ -43,7 +42,7 @@ import { MessageBoxRef } from './utils/message-box-ref.class';
 })
 export class MessageBoxComponent
     extends DialogBase
-    implements AfterViewInit, OnInit, OnChanges, OnDestroy, CssClassBuilder, MessageBoxHost
+    implements OnInit, OnChanges, OnDestroy, CssClassBuilder, MessageBoxHost
 {
     /** Custom classes */
     @Input()
@@ -110,17 +109,6 @@ export class MessageBoxComponent
     /** @hidden */
     ngOnChanges(): void {
         this.buildComponentCssClass();
-    }
-
-    /** @hidden */
-    ngAfterViewInit(): void {
-        // Manually call parent setup methods for test environments where afterNextRender may not execute
-        if (this.dialogWindow) {
-            this.setupFocusTrap();
-            this.applyStyles();
-            this.setupResizeObserver();
-            this._ref?.loaded();
-        }
     }
 
     /** @hidden */

--- a/libs/docs/core/message-box/examples/object-based/object-based-message-box-example.component.html
+++ b/libs/docs/core/message-box/examples/object-based/object-based-message-box-example.component.html
@@ -1,4 +1,10 @@
 <button fd-button label="Open from object" (click)="open()"></button>
+<button fd-button fdType="ghost" label="Open without focus trap" (click)="openWithoutFocusTrap()"></button>
+
+<p class="fd-margin-top--sm fd-margin-bottom--sm">
+    Use <code>focusTrapped: false</code> for notification-style message boxes where the user should remain able to
+    interact with the page. Focus stays where it was when the dialog opened.
+</p>
 
 <p>{{ closeReason }}</p>
 

--- a/libs/docs/core/message-box/examples/object-based/object-based-message-box-example.component.ts
+++ b/libs/docs/core/message-box/examples/object-based/object-based-message-box-example.component.ts
@@ -48,4 +48,29 @@ export class ObjectBasedMessageBoxExampleComponent {
             }
         });
     }
+
+    openWithoutFocusTrap(): void {
+        const content: MessageBoxContent = {
+            title: this.title,
+            content: this.content,
+            approveButton: 'Ok',
+            cancelButton: 'Cancel',
+            approveButtonCallback: () => messageBoxRef.close('Approved'),
+            cancelButtonCallback: () => messageBoxRef.close('Canceled'),
+            closeButtonCallback: () => messageBoxRef.dismiss('Dismissed')
+        };
+
+        const messageBoxRef = this._messageBoxService.open(content, { focusTrapped: false });
+
+        messageBoxRef.afterClosed.subscribe({
+            next: (result) => {
+                this.closeReason = 'Message box closed with result: ' + result;
+                this._cdr.detectChanges();
+            },
+            error: (error) => {
+                this.closeReason = 'Message box dismissed with result: ' + error;
+                this._cdr.detectChanges();
+            }
+        });
+    }
 }


### PR DESCRIPTION
## Summary
  - Fixes `focusTrapped: false` being ignored in `MessageBoxService.open()` — the approve button was always receiving focus on open regardless of the config value. Closes #14173.
  - Removes a duplicate `setupFocusTrap()` call in `MessageBoxComponent.ngAfterViewInit` that was redundant with the `afterNextRender` call already in `DialogBase`.

  ## Test plan
1. Open the MessageBox docs page → "Object-based" example → click "Open from object" → confirm focus moves to the "Ok" button.
2. Click "Open without focus trap" → confirm focus stays on the trigger button, not the "Ok" button.