### PR TITLE
fix(core): scroll active element into view upon opening select

### DIFF
--- a/libs/core/select/select.component.spec.ts
+++ b/libs/core/select/select.component.spec.ts
@@ -410,6 +410,20 @@ describe('SelectComponent', () => {
         );
     });
 
+    describe('scroll behavior on open', () => {
+        it('should scroll to the selected item when the panel is opened', async () => {
+            component.value = 'value-3';
+            await wait(fixture);
+
+            const scrollSpy = jest.spyOn(_keyService, '_scrollActiveOptionIntoView').mockImplementation(() => {});
+
+            component.open();
+            await wait(fixture);
+
+            expect(scrollSpy).toHaveBeenCalled();
+        });
+    });
+
     describe('filtering ', () => {
         let fixtureFilter: ComponentFixture<TestFilteringWrapperComponent>;
         beforeEach(() => {

--- a/libs/core/select/select.component.ts
+++ b/libs/core/select/select.component.ts
@@ -583,7 +583,7 @@ export class SelectComponent<T = any>
         this._changeDetectorRef.markForCheck();
         this._controlElementRef.nativeElement.focus();
         this.isOpenChange.emit(true);
-        // _optionPanel is null until the CDK overlay portal renders. Scroll after the next render.
+        // Wait for layout: option offsetHeight is 0 until the overlay is painted.
         afterNextRender(
             () => {
                 if (this._isOpen && this._optionPanel) {

--- a/libs/core/select/select.component.ts
+++ b/libs/core/select/select.component.ts
@@ -27,6 +27,7 @@ import {
     ViewChild,
     ViewContainerRef,
     ViewEncapsulation,
+    afterNextRender,
     computed,
     inject,
     isDevMode
@@ -582,6 +583,15 @@ export class SelectComponent<T = any>
         this._changeDetectorRef.markForCheck();
         this._controlElementRef.nativeElement.focus();
         this.isOpenChange.emit(true);
+        // _optionPanel is null until the CDK overlay portal renders. Scroll after the next render.
+        afterNextRender(
+            () => {
+                if (this._isOpen && this._optionPanel) {
+                    this._keyManagerService._scrollActiveOptionIntoView();
+                }
+            },
+            { injector: this._injector }
+        );
     }
 
     /** @hidden */


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14275

## Description

Scroll active element into view upon opening select. Defer with `afterNextRender` scroll until the overlay is painted.

## Screenshots

**Before:**

https://github.com/user-attachments/assets/dfb71157-069f-491f-a64b-d48e8e22c23d


**After:**

https://github.com/user-attachments/assets/f088b234-4708-4b03-87ff-c2434f2426ca


