### PR TITLE
fix(core): combobox click-outside parity with Tab out

### DIFF
--- a/apps/e2e-harness/e2e/specs/interaction/combobox.spec.ts
+++ b/apps/e2e-harness/e2e/specs/interaction/combobox.spec.ts
@@ -1,5 +1,62 @@
 import { expect, test } from '../../fixtures/base.fixture';
 
+test.describe('core/combobox click-outside parity with Tab out', () => {
+    // Regression for issue #13481: click-outside must revert invalid input the same way Tab out does.
+    // Uses the reactive-form example (objects mode: communicateByObject=true).
+
+    const setupKiwiThenAppend123 = async (page: import('@playwright/test').Page): Promise<void> => {
+        const combobox = page.locator('fd-combobox').first();
+        const input = combobox.locator('input[role="combobox"]');
+
+        // Select Kiwi via the dropdown
+        await input.click();
+        await input.pressSequentially('Kiwi', { delay: 30 });
+        const listbox = page.locator('[role="listbox"]');
+        await expect(listbox).toBeVisible();
+        const kiwiOption = listbox.locator('[role="option"]').filter({ hasText: 'Kiwi' });
+        await kiwiOption.click();
+        await expect(input).toHaveValue('Kiwi');
+
+        // Re-focus and append "123" — just type the suffix; cursor is at end after refocus
+        await input.click();
+        await input.pressSequentially('123', { delay: 50 });
+        await expect(input).toHaveValue('Kiwi123');
+    };
+
+    test.beforeEach(async ({ goto }) => {
+        await goto('core/combobox/forms');
+    });
+
+    test('scenario 1 — Tab out reverts invalid input to last valid selection', async ({ page }) => {
+        await setupKiwiThenAppend123(page);
+
+        await page.keyboard.press('Tab');
+
+        const combobox = page.locator('fd-combobox').first();
+        const input = combobox.locator('input[role="combobox"]');
+        await expect(input).toHaveValue('Kiwi');
+
+        const jsonValue = page.locator('small').first();
+        await expect(jsonValue).toContainText('"displayedValue": "Kiwi"');
+        await expect(jsonValue).toContainText('"value": "KiwiValue"');
+    });
+
+    test('scenario 2 — click outside reverts invalid input to last valid selection', async ({ page }) => {
+        await setupKiwiThenAppend123(page);
+
+        // Click the value readout of the second combobox — outside the first combobox and its CDK overlay
+        await page.locator('small').last().click();
+
+        const combobox = page.locator('fd-combobox').first();
+        const input = combobox.locator('input[role="combobox"]');
+        await expect(input).toHaveValue('Kiwi');
+
+        const jsonValue = page.locator('small').first();
+        await expect(jsonValue).toContainText('"displayedValue": "Kiwi"');
+        await expect(jsonValue).toContainText('"value": "KiwiValue"');
+    });
+});
+
 test.describe('core/combobox', () => {
     test.beforeEach(async ({ goto }) => {
         await goto('core/combobox/combobox');

--- a/libs/core/combobox/combobox.component.spec.ts
+++ b/libs/core/combobox/combobox.component.spec.ts
@@ -693,4 +693,264 @@ describe('ComboboxComponent', () => {
             expect(component.getValue()).toBe('someValue');
         });
     });
+
+    describe('click-outside parity with Tab out', () => {
+        interface FruitItem {
+            displayedValue: string;
+            value: string;
+        }
+
+        const kiwiItem: FruitItem = { displayedValue: 'Kiwi', value: 'KiwiValue' };
+        const bananaItem: FruitItem = { displayedValue: 'Banana', value: 'BananaValue' };
+
+        /** Sets both the component inputText and the native DOM input value so handleBlur() sees the correct text. */
+        function setInputText(cmp: ComboboxComponent, fix: ComponentFixture<ComboboxComponent>, value: string): void {
+            cmp.inputText = value;
+            const nativeInput = fix.nativeElement.querySelector('input');
+            if (nativeInput) {
+                nativeInput.value = value;
+            }
+            fix.detectChanges();
+        }
+
+        beforeEach(() => {
+            fixture = TestBed.createComponent(ComboboxComponent<FruitItem>);
+            component = fixture.componentInstance;
+            component.dropdownValues = [kiwiItem, bananaItem];
+            component.displayFn = (item: FruitItem): string => item?.displayedValue ?? '';
+            component.searchFn = () => {};
+            fixture.detectChanges();
+        });
+
+        it('1.1 objects mode closeAndSelect: outside-click reverts invalid text to last valid selection (Tab-out parity)', () => {
+            component.communicateByObject = true;
+            fixture.detectChanges();
+
+            // Select Kiwi — _value = kiwiItem, inputText = 'Kiwi'
+            component.onMenuClickHandler(kiwiItem);
+            expect(component.getValue()).toBe(kiwiItem);
+            expect(component.inputText).toBe('Kiwi');
+
+            // Re-open popover to simulate the state where user types into an open dropdown
+            component.isOpenChangeHandle(true);
+
+            // User types invalid text → _value becomes null via _propagateChange
+            setInputText(component, fixture, 'Kiwi123');
+            expect(component.getValue()).toBeNull();
+            expect(component.inputText).toBe('Kiwi123');
+
+            // Simulate click-outside: mousedown on document (outside the combobox host)
+            document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            fixture.detectChanges();
+
+            // Expected (Tab-out parity): inputText reverts to 'Kiwi' (last valid selection) and value restores
+            expect(component.inputText).toBe('Kiwi');
+            expect(component.getValue()).toBe(kiwiItem);
+        });
+
+        it('1.2 objects mode close strategy: outside-click also reverts invalid text (Tab-out parity)', () => {
+            component.communicateByObject = true;
+            component.tabOutStrategy = 'close';
+            fixture.detectChanges();
+
+            // Select Kiwi — _value = kiwiItem, inputText = 'Kiwi'
+            component.onMenuClickHandler(kiwiItem);
+            expect(component.getValue()).toBe(kiwiItem);
+
+            // Re-open and type invalid text
+            component.isOpenChangeHandle(true);
+            setInputText(component, fixture, 'Kiwi123');
+            expect(component.getValue()).toBeNull();
+
+            // Simulate click-outside via mousedown on document
+            document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            fixture.detectChanges();
+
+            // Expected (Tab-out parity with 'close' strategy): inputText reverts to 'Kiwi'
+            expect(component.inputText).toBe('Kiwi');
+            expect(component.getValue()).toBe(kiwiItem);
+        });
+
+        it('1.3 display-value mode: click-outside and Tab out are already equivalent (regression guard)', () => {
+            // No communicateByObject — _value is always the typed text
+            component.dropdownValues = ['Kiwi', 'Banana'];
+            component.displayFn = (item: any): string => item ?? '';
+            fixture.detectChanges();
+
+            // Select Kiwi
+            component.onMenuClickHandler('Kiwi');
+            expect(component.getValue()).toBe('Kiwi');
+
+            // Re-open and type extra chars — in display-value mode _value = typed text (truthy)
+            component.isOpenChangeHandle(true);
+            setInputText(component, fixture, 'Kiwi123');
+            expect(component.getValue()).toBe('Kiwi123');
+
+            // Simulate click-outside — in display-value mode _value is truthy so _close() keeps inputText
+            component.isOpenChangeHandle(false);
+
+            // Both Tab and click-outside should leave inputText as 'Kiwi123' in display-value mode
+            expect(component.inputText).toBe('Kiwi123');
+            expect(component.getValue()).toBe('Kiwi123');
+        });
+
+        it('1.4 should not revert input value when user re-focuses a populated combobox to edit it', () => {
+            component.communicateByObject = true;
+            fixture.detectChanges();
+
+            // Step 1: user picks Kiwi via item click
+            component.onMenuClickHandler(kiwiItem);
+            expect(component.getValue()).toBe(kiwiItem);
+            expect(component.inputText).toBe('Kiwi');
+
+            // Step 2: user clicks the input to start editing — triggers focus → _syncDomValueToModel
+            // Simulate via handleAutoComplete with the existing text (no forceClose)
+            component.handleAutoComplete({ term: 'Kiwi', forceClose: false });
+            expect(component.inputText).toBe('Kiwi');
+
+            // Step 3: user types '123' appended to the existing text
+            component.isOpenChangeHandle(true);
+            setInputText(component, fixture, 'Kiwi123');
+            // _propagateChange fires — form value becomes null (no match)
+            expect(component.getValue()).toBeNull();
+
+            // Step 4: user is still in the field (popover open), mid-edit — NO outside click here.
+            // The popover is open; nothing should revert the input.
+            expect(component.inputText).toBe('Kiwi123');
+        });
+
+        it('1.5 should preserve accepted autocomplete term when forceClose fires', () => {
+            component.communicateByObject = true;
+            fixture.detectChanges();
+
+            // Prime the native DOM value to match what the AutoCompleteDirective would have written
+            // before calling handleAutoComplete — without this, _syncDomValueToModel reads '' and reverts
+            setInputText(component, fixture, 'Kiwi');
+
+            // Simulate autocomplete accepting 'Kiwi' with forceClose
+            component.handleAutoComplete({ term: 'Kiwi', forceClose: true });
+
+            // inputText must remain 'Kiwi' — the autocomplete acceptance is a controlled close
+            // and must NOT trigger _close()'s revert logic
+            expect(component.inputText).toBe('Kiwi');
+        });
+
+        it('1.6 should not revert input value when user re-focuses a populated combobox to edit it (v3 regression)', () => {
+            component.communicateByObject = true;
+            fixture.detectChanges();
+
+            // Step 1: pick Kiwi — _value = kiwiItem, inputText = 'Kiwi', DOM = 'Kiwi'
+            component.onMenuClickHandler(kiwiItem);
+            expect(component.getValue()).toBe(kiwiItem);
+            expect(component.inputText).toBe('Kiwi');
+
+            // Step 2: simulate re-focus click on the input
+            const inputEl: HTMLInputElement = fixture.nativeElement.querySelector('input');
+            inputEl.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+            inputEl.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+            fixture.detectChanges();
+
+            // Step 3: user types '123' — model stays at 'Kiwi' + '123' = 'Kiwi123'
+            // Use setInputText so both model and DOM are in sync (as typing would do)
+            setInputText(component, fixture, 'Kiwi123');
+
+            // _propagateChange fires — form value becomes null (no match for 'Kiwi123')
+            expect(component.getValue()).toBeNull();
+
+            // inputText must stay 'Kiwi123' — re-focusing must not have reverted it
+            expect(component.inputText).toBe('Kiwi123');
+        });
+
+        it('1.7 should call _close on mousedown outside the combobox host (v3 outside-click subscription)', () => {
+            component.communicateByObject = true;
+            fixture.detectChanges();
+
+            // Pick Kiwi, then open popover and set invalid text
+            component.onMenuClickHandler(kiwiItem);
+            component.isOpenChangeHandle(true);
+            setInputText(component, fixture, 'Kiwi123');
+            expect(component.getValue()).toBeNull();
+            expect(component.open).toBe(true);
+
+            // Dispatch mousedown on document.body — genuine outside-click
+            document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            fixture.detectChanges();
+
+            // _close() should have fired → inputText reverts to 'Kiwi', value reverts to kiwiItem
+            expect(component.inputText).toBe('Kiwi');
+            expect(component.getValue()).toBe(kiwiItem);
+        });
+
+        it('1.8 should NOT call _close on mousedown inside the combobox host', () => {
+            component.communicateByObject = true;
+            fixture.detectChanges();
+
+            // Pick Kiwi, then open popover and set invalid text
+            component.onMenuClickHandler(kiwiItem);
+            component.isOpenChangeHandle(true);
+            setInputText(component, fixture, 'Kiwi123');
+            expect(component.getValue()).toBeNull();
+            expect(component.open).toBe(true);
+
+            // Dispatch mousedown on the combobox's input (inside host)
+            const inputEl = fixture.nativeElement.querySelector('input');
+            inputEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            fixture.detectChanges();
+
+            // No revert — click was inside the host
+            expect(component.inputText).toBe('Kiwi123');
+            expect(component.getValue()).toBeNull();
+        });
+
+        it('1.9 should revert input on outside-click when popover is already closed (no-match auto-close)', () => {
+            component.communicateByObject = true;
+            fixture.detectChanges();
+
+            // Step 1: pick Kiwi via item click — _value = kiwiItem, inputText = 'Kiwi'
+            component.onMenuClickHandler(kiwiItem);
+            expect(component.getValue()).toBe(kiwiItem);
+            expect(component.inputText).toBe('Kiwi');
+
+            // Step 2: mimic "user typed Kiwi123 → no matches → popover auto-closed"
+            // The popover is already closed; dirty text remains in the input.
+            component.open = false;
+            setInputText(component, fixture, 'Kiwi123');
+            component.displayedValues = [];
+            fixture.detectChanges();
+
+            expect(component.open).toBe(false);
+            expect(component.inputText).toBe('Kiwi123');
+            // _propagateChange set value to null because 'Kiwi123' matches nothing
+            expect(component.getValue()).toBeNull();
+
+            // Step 3: user clicks outside — should revert even though popover is already closed
+            document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            fixture.detectChanges();
+
+            expect(component.inputText).toBe('Kiwi');
+            expect(component.getValue()).toBe(kiwiItem);
+        });
+
+        it('1.10 should NOT revert when input already matches the model (no-op dirty gate)', () => {
+            component.communicateByObject = true;
+            fixture.detectChanges();
+
+            // Pick Kiwi — input is 'Kiwi', _value is kiwiItem, popover closes
+            component.onMenuClickHandler(kiwiItem);
+            expect(component.getValue()).toBe(kiwiItem);
+            expect(component.inputText).toBe('Kiwi');
+            expect(component.open).toBe(false);
+
+            // Spy on _close before dispatching — it must NOT be called
+            const closeSpy = jest.spyOn(component as any, '_close');
+
+            // Click outside — input matches model, dirty-check must short-circuit
+            document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            fixture.detectChanges();
+
+            expect(closeSpy).not.toHaveBeenCalled();
+            expect(component.inputText).toBe('Kiwi');
+            expect(component.getValue()).toBe(kiwiItem);
+        });
+    });
 });

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -18,6 +18,7 @@ import {
     Component,
     ContentChild,
     ContentChildren,
+    DestroyRef,
     ElementRef,
     EventEmitter,
     Injector,
@@ -35,6 +36,7 @@ import {
     forwardRef,
     input
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Subscription, fromEvent } from 'rxjs';
 
@@ -358,7 +360,7 @@ export class ComboboxComponent<T = any>
     byline = false;
 
     /**
-     * Action to perform when user shifts focus from the dropdown.
+     * Action to perform when the user shifts focus away from the dropdown (Tab or click outside).
      * - `close` will close the dropdown preserving previously selected value.
      * - `closeAndSelect` will close the dropdown and select last focused dropdown item.
      */
@@ -474,6 +476,9 @@ export class ComboboxComponent<T = any>
     /** @hidden */
     private _value: any;
 
+    /** Last value confirmed by an explicit selection (item click) or external writeValue. */
+    private _lastConfirmedValue: any;
+
     /** @hidden */
     constructor(
         private readonly _overlay: Overlay,
@@ -482,9 +487,31 @@ export class ComboboxComponent<T = any>
         private readonly _viewContainerRef: ViewContainerRef,
         private readonly _dynamicComponentService: DynamicComponentService,
         private readonly _focusTrapService: FocusTrapService,
-        readonly _contentDensityObserver: ContentDensityObserver
+        readonly _contentDensityObserver: ContentDensityObserver,
+        private readonly _elementRef: ElementRef<HTMLElement>,
+        destroyRef: DestroyRef
     ) {
         this._repositionScrollStrategy = this._overlay.scrollStrategies.reposition({ autoClose: true });
+
+        fromEvent<MouseEvent>(document, 'mousedown')
+            .pipe(takeUntilDestroyed(destroyRef))
+            .subscribe((event) => {
+                if (!this.closeOnOutsideClick) {
+                    return;
+                }
+                const target = event.target as Node;
+                if (this._elementRef.nativeElement.contains(target)) {
+                    return;
+                }
+                const overlayPane = this._popoverOverlayPane();
+                if (overlayPane?.contains(target)) {
+                    return;
+                }
+                if (!this._isInputDirtyVsModel()) {
+                    return;
+                }
+                this._close();
+            });
     }
 
     /** @hidden */
@@ -603,6 +630,7 @@ export class ComboboxComponent<T = any>
     dialogDismiss(term: any): void {
         this.inputText = this.displayFn(term);
         this.setValue(term);
+        this._lastConfirmedValue = term;
         this.isOpenChangeHandle(false);
     }
 
@@ -667,6 +695,7 @@ export class ComboboxComponent<T = any>
 
         this.inputTextValue = this.displayFn(valueToDisplay);
         this.setValue(valueToDisplay);
+        this._lastConfirmedValue = valueToDisplay;
         this._cdRef.markForCheck();
     }
 
@@ -783,7 +812,9 @@ export class ComboboxComponent<T = any>
 
     /** @hidden */
     _close(): void {
-        this.inputText = this._value ? this.inputText : '';
+        const revertText = this._lastConfirmedValue != null ? this.displayFn(this._lastConfirmedValue) : '';
+        this.inputText = revertText;
+        this.searchInputElement.nativeElement.value = revertText;
         if (this.tabOutStrategy === 'closeAndSelect') {
             const focusedItem = this.listComponent.getActiveItem();
             if (focusedItem && !this.inputText) {
@@ -799,6 +830,20 @@ export class ComboboxComponent<T = any>
     isSelected(term: any): boolean {
         const termValue = this.communicateByObject ? term : this.displayFn(term);
         return this.getValue() === termValue;
+    }
+
+    /** @hidden */
+    private _popoverOverlayPane(): Element | null {
+        // The combobox template sets additionalBodyClass="fd-popover-custom-list" on the popover body.
+        // That class is placed inside the .cdk-overlay-pane by the CDK overlay portal.
+        // Walking up finds the pane, which contains all dropdown list content.
+        return document.querySelector('.fd-popover-custom-list')?.closest('.cdk-overlay-pane') ?? null;
+    }
+
+    /** @hidden */
+    private _isInputDirtyVsModel(): boolean {
+        const expected = this._lastConfirmedValue != null ? this.displayFn(this._lastConfirmedValue) : '';
+        return this.inputText !== expected;
     }
 
     /** Method that picks other value moved from current one by offset, called only when combobox is closed */
@@ -852,6 +897,7 @@ export class ComboboxComponent<T = any>
         if (this.closeOnSelect && shouldClosePopover) {
             this.isOpenChangeHandle(false);
         }
+        this._lastConfirmedValue = term;
         if (this.fillOnSelect) {
             this.setValue(term);
             this.inputText = this.displayFn(term);

--- a/libs/core/combobox/combobox.component.ts
+++ b/libs/core/combobox/combobox.component.ts
@@ -34,6 +34,7 @@ import {
     ViewContainerRef,
     ViewEncapsulation,
     forwardRef,
+    inject,
     input
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -479,6 +480,10 @@ export class ComboboxComponent<T = any>
     /** Last value confirmed by an explicit selection (item click) or external writeValue. */
     private _lastConfirmedValue: any;
 
+    private readonly _elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+    private readonly _destroyRef = inject(DestroyRef);
+
     /** @hidden */
     constructor(
         private readonly _overlay: Overlay,
@@ -487,14 +492,12 @@ export class ComboboxComponent<T = any>
         private readonly _viewContainerRef: ViewContainerRef,
         private readonly _dynamicComponentService: DynamicComponentService,
         private readonly _focusTrapService: FocusTrapService,
-        readonly _contentDensityObserver: ContentDensityObserver,
-        private readonly _elementRef: ElementRef<HTMLElement>,
-        destroyRef: DestroyRef
+        readonly _contentDensityObserver: ContentDensityObserver
     ) {
         this._repositionScrollStrategy = this._overlay.scrollStrategies.reposition({ autoClose: true });
 
         fromEvent<MouseEvent>(document, 'mousedown')
-            .pipe(takeUntilDestroyed(destroyRef))
+            .pipe(takeUntilDestroyed(this._destroyRef))
             .subscribe((event) => {
                 if (!this.closeOnOutsideClick) {
                     return;


### PR DESCRIPTION
Click outside the field after typing invalid text now reverts the displayed value AND the form control to the last confirmed selection, matching Tab-out's existing behavior.

Closes #13481

## Test plan

Navigate to `/#/core/combobox#reactive-form` on the docs app.

**1. Click-outside reverts invalid input (objects mode)**
- Select "Kiwi" from the dropdown → form value shows `{displayedValue: "Kiwi", value: "KiwiValue"}`
- Append `123` so the input reads `Kiwi123`
- Click somewhere outside the combobox
- ✅ Input reverts to `Kiwi`, form value reverts to `{Kiwi, KiwiValue}`

**2. Tab-out still works (regression check)**
- Repeat the setup above
- Press Tab instead of clicking outside
- ✅ Same result: input `Kiwi`, form value `{Kiwi, KiwiValue}`

**3. Re-editing after selection is not broken**
- Select "Kiwi"
- Click the input again to re-focus
- Type `123` → input should show `Kiwi123`
- ✅ No auto-revert while typing; revert only happens on Tab / click outside

**4. Clicking inside the combobox (clear button, dropdown item) does not revert**
- Select "Kiwi", append `123`
- Click the × clear button → ✅ clears the field, does not revert to Kiwi
- Or: open the dropdown and click a different item → ✅ commits the new selection

**5. `communicateByObject="false"` (display-value mode)**
- Repeat scenario 1 with a combobox not using object communication
- ✅ Click-outside and Tab-out both revert to the last valid selection consistently