### PR TITLE
fix(datetime-adapter): accept single-digit M/D in DayjsDatetimeAdapter parse (#13534)

### DIFF
--- a/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.spec.ts
+++ b/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.spec.ts
@@ -1535,3 +1535,50 @@ describe('DayjsDatetimeAdapter — M-4 round-trip regression (PR #14016)', () =>
         expect(parsed!.minute()).toBe(33);
     });
 });
+
+describe('single-digit M/D/YYYY parsing (regression #13534)', () => {
+    let adapter: DayjsDatetimeAdapter;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [provideDayjsDatetimeAdapter()]
+        });
+        adapter = TestBed.inject(DatetimeAdapter) as DayjsDatetimeAdapter;
+        adapter.setLocale('en');
+    });
+
+    it('parses "10/7/2025" against "L" as Oct 7 2025 (en)', () => {
+        // adapter locale = 'en', en L = MM/DD/YYYY
+        const result = adapter.parse('10/7/2025', 'L');
+        expect(result?.isValid()).toBe(true);
+        expect(result?.format('YYYY-MM-DD')).toBe('2025-10-07');
+    });
+
+    it('parses "10/07/2025" against "L" as Oct 7 2025 (en, padded — no regression)', () => {
+        const result = adapter.parse('10/07/2025', 'L');
+        expect(result?.format('YYYY-MM-DD')).toBe('2025-10-07');
+    });
+
+    it('parses "7/10/2025" against "L" as Oct 7 2025 (fr)', () => {
+        adapter.setLocale('fr'); // fr L = DD/MM/YYYY
+        const result = adapter.parse('7/10/2025', 'L');
+        expect(result?.format('YYYY-MM-DD')).toBe('2025-10-07');
+    });
+
+    it('parses "7.10.2025" against "L" as Oct 7 2025 (de)', () => {
+        adapter.setLocale('de'); // de L = DD.MM.YYYY
+        const result = adapter.parse('7.10.2025', 'L');
+        expect(result?.format('YYYY-MM-DD')).toBe('2025-10-07');
+    });
+
+    it('still rejects overflow "13/45/2025" against "L" (en)', () => {
+        // Negative test — overflow guard from PR #14016 must still hold.
+        const result = adapter.parse('13/45/2025', 'L');
+        expect(result?.isValid()).toBeFalsy();
+    });
+
+    it('still rejects overflow "2/30/2025" against "L" (en, day overflow)', () => {
+        const result = adapter.parse('2/30/2025', 'L');
+        expect(result?.isValid()).toBeFalsy();
+    });
+});

--- a/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.ts
+++ b/libs/datetime-adapter/src/lib/dayjs-datetime-adapter.ts
@@ -459,11 +459,19 @@ export class DayjsDatetimeAdapter extends DatetimeAdapter<Dayjs> {
                 .replace(/h{1,2}(:mm(?::ss)?) ?[aA]/g, 'HH$1') // lowercase h → HH
                 .replace(/(HH?)(:mm(?::ss)?) ?[aA]/g, 'HH$2'); // uppercase HH + stray A → HH
 
+            // Lenient variants accept single-digit M/D. dayjs's MM/DD requires
+            // exactly 2 digits even in non-strict mode, so unpadded user input
+            // (e.g. "10/7/2025", "7.10.2025") fails without these.
+            const lenient = expandedFormat.replace(/M{2,}/g, 'M').replace(/D{2,}/g, 'D');
+            const lenient24h = normalized24h.replace(/M{2,}/g, 'M').replace(/D{2,}/g, 'D');
+
             const rawFormats: string[] = [
                 expandedFormat, // original (expanded)
                 normalized24h, // 24h variant for inputs where AM/PM was pre-stripped
                 expandedFormat.replace(/ ?[Hh]{1,2}:?mm(?::?ss)?(?: ?[aA])?/, '').trim(), // remove time
                 dayjs.Ls[this.locale()]?.formats?.['L'],
+                lenient,
+                lenient24h,
                 'YYYY-MM-DD'
             ].filter((f): f is string => !!f);
 


### PR DESCRIPTION
Fixes #13534

## Bug

`<fd-date-picker>` + `DayjsDatetimeAdapter`. Single-digit day or month input (`10/7/2025` en, `7/10/2025` fr, `7.10.2025` de) is silently rejected — no date selected, calendar opens at today. Zero-padded variants work. Regression from **PR #13387** (v0.57.2, Jul 2025).

## Cause

PR #13387 replaced the previous free-form `dayjs(date, undefined)` fallback with a closed list of zero-padded format strings (`MM/DD/YYYY`, etc.). dayjs's `customParseFormat` rejects unpadded segments against `MM`/`DD` in both strict and loose mode, so unpadded input matches nothing → invalid date.

## Fix

`libs/datetime-adapter/src/lib/dayjs-datetime-adapter.ts` — append two lenient variants (`M/D/YYYY` style) to the fallback list, after the existing zero-padded entries. Padded input still wins on the first entry (byte-identical); unpadded input falls through to the lenient entry.

`_hasNoOverflow` guard from PR #14016 is untouched — still rejects `13/45/2025`, `2/30/2025`.

## How to test

**Unit:** 6 new tests in `dayjs-datetime-adapter.spec.ts` (4 happy-path en/fr/de + 2 negative overflow).
```
nx run datetime-adapter:test
```

**Browser:** `yarn start` → `/core/dayjs-datetime-adapter` → "Switching Locale" example:
- English: `10/7/2025` → Oct 7 selected
- French: `7/10/2025` → Oct 7 selected
- Deutsch: `7.10.2025` → Oct 7 selected
- `13/45/2025` → no selection (overflow rejected)

## Sibling adapters

Verified dayjs-only: `FdDatetimeAdapter` uses a permissive `\d{1,2}` regex; `MomentDatetimeAdapter` uses moment's non-strict default. Neither is affected.
