### PR TITLE
fix(core): prevent duplicate subscription in segmented-button button changes listener

### DIFF
--- a/libs/core/segmented-button/segmented-button.component.spec.ts
+++ b/libs/core/segmented-button/segmented-button.component.spec.ts
@@ -1,5 +1,5 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { Component, ElementRef, ViewChild, signal } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { runValueAccessorTests } from 'ngx-cva-test-suite';
@@ -244,4 +244,100 @@ describe('Segmented button component CVA', () => {
         getComponentValue: (fixture) => (fixture.componentInstance.segmentedButton as any)._currentValue,
         getValues: () => [1, 2, 3] // Setting the same values as select options in host template
     });
+});
+
+@Component({
+    selector: 'fd-test-dynamic-host',
+    template: `
+        <fd-segmented-button>
+            <button fd-button label="Button" value="first"></button>
+            <button fd-button label="Button" value="second"></button>
+            @if (showThird()) {
+                <button #third fd-button label="Button" value="third"></button>
+            }
+        </fd-segmented-button>
+    `,
+    standalone: true,
+    imports: [ButtonComponent, SegmentedButtonModule]
+})
+class HostWithDynamicButtonComponent {
+    @ViewChild(SegmentedButtonComponent) segmentedButton: SegmentedButtonComponent;
+    showThird = signal(false);
+}
+
+describe('SegmentedButtonComponent — duplicate subscription fix', () => {
+    let fixture: ComponentFixture<HostComponent>;
+    let component: HostComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [HostComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(waitForAsync(() => {
+        fixture = TestBed.createComponent(HostComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        return fixture.whenStable();
+    }));
+
+    it('should not duplicate work when setDisabledState cycles re-trigger _listenToButtonChanges', fakeAsync(() => {
+        const segBtn = component.segmentedButton as any;
+        const spy = jest.spyOn(segBtn, '_pickButtonsByValues');
+
+        // Cycle disable/enable 5 times — each enable triggers _listenToButtonChanges()
+        for (let i = 0; i < 5; i++) {
+            segBtn.setDisabledState(true);
+            tick();
+            segBtn.setDisabledState(false);
+            tick();
+        }
+        // Flush the asyncScheduler delay from startWith(1) on each subscription
+        tick(0);
+
+        spy.mockClear();
+
+        // Force a QueryList.changes emission
+        (segBtn._buttons as any).notifyOnChanges();
+        tick(0);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+    }));
+});
+
+describe('SegmentedButtonComponent — QueryList.changes regression', () => {
+    let fixture: ComponentFixture<HostWithDynamicButtonComponent>;
+    let component: HostWithDynamicButtonComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [HostWithDynamicButtonComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(waitForAsync(() => {
+        fixture = TestBed.createComponent(HostWithDynamicButtonComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        return fixture.whenStable();
+    }));
+
+    it('should re-apply button attributes when a button is added after view init', fakeAsync(() => {
+        // Initially only 2 buttons
+        const segBtn = component.segmentedButton as any;
+        expect(segBtn._buttons.length).toBe(2);
+
+        // Add the third button via signal
+        component.showThird.set(true);
+        fixture.detectChanges();
+        tick(0);
+
+        const buttons = fixture.nativeElement.querySelectorAll('[fd-button]');
+        const thirdButton = buttons[2];
+
+        expect(thirdButton.getAttribute('role')).toBe('option');
+        expect(thirdButton.getAttribute('aria-posinset')).toBe('3');
+        expect(thirdButton.getAttribute('aria-setsize')).toBe('3');
+    }));
 });

--- a/libs/core/segmented-button/segmented-button.component.spec.ts
+++ b/libs/core/segmented-button/segmented-button.component.spec.ts
@@ -265,7 +265,7 @@ class HostWithDynamicButtonComponent {
     showThird = signal(false);
 }
 
-describe('SegmentedButtonComponent — duplicate subscription fix', () => {
+describe('SegmentedButtonComponent — _listenToButtonChanges does not duplicate work', () => {
     let fixture: ComponentFixture<HostComponent>;
     let component: HostComponent;
 
@@ -293,7 +293,7 @@ describe('SegmentedButtonComponent — duplicate subscription fix', () => {
             segBtn.setDisabledState(false);
             tick();
         }
-        // Flush the asyncScheduler delay from startWith(1) on each subscription
+        // Flush the asyncScheduler delay from observeOn() in _listenToButtonChanges
         tick(0);
 
         spy.mockClear();

--- a/libs/core/segmented-button/segmented-button.component.ts
+++ b/libs/core/segmented-button/segmented-button.component.ts
@@ -34,7 +34,7 @@ import {
 } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent, FD_BUTTON_COMPONENT } from '@fundamental-ngx/core/button';
 import { FD_LANGUAGE_SIGNAL, TranslationResolver } from '@fundamental-ngx/i18n';
-import { EMPTY, Subject, asyncScheduler, fromEvent, merge } from 'rxjs';
+import { EMPTY, Subject, Subscription, asyncScheduler, fromEvent, merge } from 'rxjs';
 import { filter, observeOn, startWith, takeUntil, tap } from 'rxjs/operators';
 
 export type SegmentedButtonValue = string | (string | null)[] | null;
@@ -115,6 +115,9 @@ export class SegmentedButtonComponent implements AfterViewInit, ControlValueAcce
 
     /** An RxJS Subject that will kill the data stream upon queryList changes (for unsubscribing)  */
     private readonly _onRefresh$: Subject<void> = new Subject<void>();
+
+    /** @hidden Outer subscription for QueryList.changes; torn down on re-subscribe. */
+    private _buttonChangesSub: Subscription | null = null;
 
     /** @hidden */
     private readonly _langSignal = inject(FD_LANGUAGE_SIGNAL);
@@ -243,8 +246,9 @@ export class SegmentedButtonComponent implements AfterViewInit, ControlValueAcce
         }
 
         this._onRefresh$.next();
+        this._buttonChangesSub?.unsubscribe();
 
-        merge(this._buttons.changes ?? EMPTY, this._focusableItems.changes ?? EMPTY)
+        this._buttonChangesSub = merge(this._buttons.changes ?? EMPTY, this._focusableItems.changes ?? EMPTY)
             .pipe(startWith(1), observeOn(asyncScheduler), takeUntilDestroyed(this._destroyRef))
             .subscribe(() => {
                 if (!this._buttons || !this._focusableItems) {


### PR DESCRIPTION
`_listenToButtonChanges()` was called from both `ngAfterViewInit` and `setDisabledState(false)`, each creating a new outer subscription to `QueryList.changes` without tearing down the previous one. After N enable/disable cycles, every change emission re-ran the inner work N+1 times.

Track the outer subscription as a field; unsubscribe before resubscribing. `takeUntilDestroyed` on the pipe handles destroy-time cleanup.

Keep the change surgical only

Closes #13358

