### PR TITLE
fix(core): prevent inline-help text from being announced twice by screen readers

### DIFF
--- a/libs/core/inline-help/inline-help.directive.ts
+++ b/libs/core/inline-help/inline-help.directive.ts
@@ -40,7 +40,7 @@ let inlineHelpId = 0;
     providers: [PopoverService],
     host: {
         '[class.fd-inline-help__trigger]': 'true',
-        '[attr.aria-describedby]': 'bodyId()'
+        '[attr.aria-describedby]': 'ariaDescribedBy()'
     }
 })
 export class InlineHelpDirective {
@@ -124,6 +124,13 @@ export class InlineHelpDirective {
         bodyRole: this.bodyRole,
         bodyId: this.bodyId
     });
+
+    /** @hidden Computed aria-describedby - only set when popover is closed to avoid duplication */
+    protected readonly ariaDescribedBy = computed(() =>
+        // When popover is open, the visible content is already accessible
+        // Only reference bodyId when closed for linear reading mode support
+        this._popoverService.isOpen() ? null : this.bodyId()
+    );
 
     /** @hidden */
     private readonly _popoverService = inject(PopoverService);
@@ -213,6 +220,7 @@ export class InlineHelpDirective {
         if (srElement.style) {
             srElement.style.cssText = `position: absolute !important; height: 1px; width: 1px; overflow: hidden; clip: rect(1px, 1px, 1px, 1px);`;
         }
+
         this._renderer.appendChild(this._elementRef.nativeElement, srElement);
     }
 }


### PR DESCRIPTION

## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14241

## Description
### Problem
The `fd-inline-help` directive was causing screen readers (VoiceOver, JAWS) to announce the help text twice when the popover was open:

1. Once from the hidden screen-reader element (added for JAWS linear reading mode support in #9276)
2. Once from the visible popover content (via aria-describedby)

### Solution
Conditionally set `aria-describedby` based on the popover's open state:

When closed: `aria-describedby` references the popover body (enables linear reading mode access via the hidden element)
When open: `aria-describedby` is removed (visible content is naturally accessible, prevents duplication)

This preserves the fix for #9276 (JAWS linear reading mode) while eliminating the duplicate announcement in #14241.