### PR TITLE
[WIP] fix(platform): add missing text alternatives to fdp-table group button and sort icon

### DIFF
--- a/libs/i18n/src/lib/models/fd-language-key-identifier.ts
+++ b/libs/i18n/src/lib/models/fd-language-key-identifier.ts
@@ -380,6 +380,8 @@ export type FdLanguageKeyIdentifier =
     | 'platformTable.cancelBtnLabel'
     | 'platformTable.clearFilters'
     | 'platformTable.collapseRowButtonTitle'
+    | 'platformTable.columnSortedAscLabel'
+    | 'platformTable.columnSortedDescLabel'
     | 'platformTable.confirmBtnLabel'
     | 'platformTable.defaultEmptyMessage'
     | 'platformTable.deselectAllCheckboxLabel'

--- a/libs/i18n/src/lib/models/fd-language.ts
+++ b/libs/i18n/src/lib/models/fd-language.ts
@@ -764,6 +764,8 @@ export interface FdLanguage {
         collapseRowButtonTitle: FdLanguageKey;
         expandRowButtonTitle: FdLanguageKey;
         rowNavigateButtonTitle: FdLanguageKey;
+        columnSortedAscLabel: FdLanguageKey<{ columnName: string }>;
+        columnSortedDescLabel: FdLanguageKey<{ columnName: string }>;
     };
     platformWizardGenerator: {
         summarySectionEditStep: FdLanguageKey;

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel = Cancel
 platformTable.clearFilters = Clear Filters
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle = Collapse row
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel = OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -517,6 +517,8 @@ export default {
         cancelBtnLabel: 'Cancel',
         clearFilters: 'Clear Filters',
         collapseRowButtonTitle: 'Collapse row',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'No data found',
         deselectAllCheckboxLabel: 'Deselect all',

--- a/libs/i18n/src/lib/translations/translations_ar.properties
+++ b/libs/i18n/src/lib/translations/translations_ar.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=إلغاء
 platformTable.clearFilters=مسح عوامل التصفية
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=طي الصف
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=موافق
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -518,6 +518,8 @@ export default {
         cancelBtnLabel: 'إلغاء',
         clearFilters: 'مسح عوامل التصفية',
         collapseRowButtonTitle: 'طي الصف',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'موافق',
         defaultEmptyMessage: 'لم يتم العثور على بيانات',
         deselectAllCheckboxLabel: 'إلغاء تحديد الكل',

--- a/libs/i18n/src/lib/translations/translations_bg.properties
+++ b/libs/i18n/src/lib/translations/translations_bg.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Отказ
 platformTable.clearFilters=Изчистване на филтрите
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Свиване на реда
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Отказ',
         clearFilters: 'Изчистване на филтрите',
         collapseRowButtonTitle: 'Свиване на реда',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Не са намерени данни',
         deselectAllCheckboxLabel: 'Отмяна на избора на всички',

--- a/libs/i18n/src/lib/translations/translations_cs.properties
+++ b/libs/i18n/src/lib/translations/translations_cs.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Zrušit
 platformTable.clearFilters=Vymazat filtry
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Sbalit řádek
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -518,6 +518,8 @@ export default {
         cancelBtnLabel: 'Zrušit',
         clearFilters: 'Vymazat filtry',
         collapseRowButtonTitle: 'Sbalit řádek',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Nebyla nalezena data',
         deselectAllCheckboxLabel: 'Zrušit celý výběr',

--- a/libs/i18n/src/lib/translations/translations_da.properties
+++ b/libs/i18n/src/lib/translations/translations_da.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Annuller
 platformTable.clearFilters=Ryd filtre
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Minimer række
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -518,6 +518,8 @@ export default {
         cancelBtnLabel: 'Annuller',
         clearFilters: 'Ryd filtre',
         collapseRowButtonTitle: 'Minimer række',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Ingen data fundet',
         deselectAllCheckboxLabel: 'Fravælg alle',

--- a/libs/i18n/src/lib/translations/translations_de.properties
+++ b/libs/i18n/src/lib/translations/translations_de.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Abbrechen
 platformTable.clearFilters=Filter zurücksetzen
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Zeile komprimieren
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -520,6 +520,8 @@ export default {
         cancelBtnLabel: 'Abbrechen',
         clearFilters: 'Filter zurücksetzen',
         collapseRowButtonTitle: 'Zeile komprimieren',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Keine Daten gefunden',
         deselectAllCheckboxLabel: 'Alle abwählen',

--- a/libs/i18n/src/lib/translations/translations_el.properties
+++ b/libs/i18n/src/lib/translations/translations_el.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Ακύρωση
 platformTable.clearFilters=Εκκαθάριση Φίλτρων
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Σύμπυξη σειράς
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Ακύρωση',
         clearFilters: 'Εκκαθάριση Φίλτρων',
         collapseRowButtonTitle: 'Σύμπυξη σειράς',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Δεν βρέθηκαν δεδομένα',
         deselectAllCheckboxLabel: 'Κατάργηση επιλογής όλων',

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=[[[Ĉąŋċēĺ∙∙∙∙∙∙∙∙]]]
 platformTable.clearFilters=[[[Ĉĺēąŗ Ƒįĺţēŗş∙∙∙∙∙∙]]]
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=[[[Ĉŏĺĺąρşē ŗŏŵ∙∙∙∙∙∙∙]]]
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=[[[ŎĶ∙∙]]]
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -520,6 +520,8 @@ export default {
         cancelBtnLabel: '[[[Ĉąŋċēĺ∙∙∙∙∙∙∙∙]]]',
         clearFilters: '[[[Ĉĺēąŗ Ƒįĺţēŗş∙∙∙∙∙∙]]]',
         collapseRowButtonTitle: '[[[Ĉŏĺĺąρşē ŗŏŵ∙∙∙∙∙∙∙]]]',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: '[[[ŎĶ∙∙]]]',
         defaultEmptyMessage: '[[[Ńŏ ƌąţą ƒŏűŋƌ∙∙∙∙∙∙]]]',
         deselectAllCheckboxLabel: '[[[Ďēşēĺēċţ ąĺĺ∙∙∙∙∙∙∙]]]',

--- a/libs/i18n/src/lib/translations/translations_es.properties
+++ b/libs/i18n/src/lib/translations/translations_es.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Cancelar
 platformTable.clearFilters=Borrar filtros
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Contraer fila
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=Aceptar
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -520,6 +520,8 @@ export default {
         cancelBtnLabel: 'Cancelar',
         clearFilters: 'Borrar filtros',
         collapseRowButtonTitle: 'Contraer fila',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'Aceptar',
         defaultEmptyMessage: 'No se han encontrado datos',
         deselectAllCheckboxLabel: 'Deseleccionar todo',

--- a/libs/i18n/src/lib/translations/translations_fi.properties
+++ b/libs/i18n/src/lib/translations/translations_fi.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Peruuta
 platformTable.clearFilters=Tyhjennä suodattimet
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Tiivistä rivi
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -518,6 +518,8 @@ export default {
         cancelBtnLabel: 'Peruuta',
         clearFilters: 'Tyhjennä suodattimet',
         collapseRowButtonTitle: 'Tiivistä rivi',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Tietoja ei löydy',
         deselectAllCheckboxLabel: 'Poista kaikki valinnat',

--- a/libs/i18n/src/lib/translations/translations_fr.properties
+++ b/libs/i18n/src/lib/translations/translations_fr.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Annuler
 platformTable.clearFilters=Effacer les filtres
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Réduire la ligne
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -521,6 +521,8 @@ export default {
         cancelBtnLabel: 'Annuler',
         clearFilters: 'Effacer les filtres',
         collapseRowButtonTitle: 'Réduire la ligne',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Aucune donnée trouvée',
         deselectAllCheckboxLabel: 'Tout désélectionner',

--- a/libs/i18n/src/lib/translations/translations_he.properties
+++ b/libs/i18n/src/lib/translations/translations_he.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=בטל
 platformTable.clearFilters=נקה מסננים
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=צמצם שורה
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -517,6 +517,8 @@ export default {
         cancelBtnLabel: 'בטל',
         clearFilters: 'נקה מסננים',
         collapseRowButtonTitle: 'צמצם שורה',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'לא נמצאו נתונים',
         deselectAllCheckboxLabel: 'בטל בחירה של הכול',

--- a/libs/i18n/src/lib/translations/translations_hi.properties
+++ b/libs/i18n/src/lib/translations/translations_hi.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel = Cancel
 platformTable.clearFilters = Clear Filters
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle = Collapse row
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel = OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -518,6 +518,8 @@ export default {
         cancelBtnLabel: 'Cancel',
         clearFilters: 'Clear Filters',
         collapseRowButtonTitle: 'Collapse row',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'डाटा प्राप्त नहीं हुआ',
         deselectAllCheckboxLabel: 'Deselect all',

--- a/libs/i18n/src/lib/translations/translations_hr.properties
+++ b/libs/i18n/src/lib/translations/translations_hr.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Odustani
 platformTable.clearFilters=Poništi filtre
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Sažmi redak
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Odustani',
         clearFilters: 'Poništi filtre',
         collapseRowButtonTitle: 'Sažmi redak',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Nisu pronađeni podaci',
         deselectAllCheckboxLabel: 'Poništi sve odabire',

--- a/libs/i18n/src/lib/translations/translations_hu.properties
+++ b/libs/i18n/src/lib/translations/translations_hu.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Mégse
 platformTable.clearFilters=Szűrők törlése
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Sor összecsukása
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Mégse',
         clearFilters: 'Szűrők törlése',
         collapseRowButtonTitle: 'Sor összecsukása',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Nem található adat',
         deselectAllCheckboxLabel: 'Összes kijelölésének megszüntetése',

--- a/libs/i18n/src/lib/translations/translations_it.properties
+++ b/libs/i18n/src/lib/translations/translations_it.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Annulla
 platformTable.clearFilters=Cancella filtri
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Comprimi riga
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -520,6 +520,8 @@ export default {
         cancelBtnLabel: 'Annulla',
         clearFilters: 'Cancella filtri',
         collapseRowButtonTitle: 'Comprimi riga',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Non sono stati trovati dati',
         deselectAllCheckboxLabel: 'Deseleziona tutto',

--- a/libs/i18n/src/lib/translations/translations_iw.properties
+++ b/libs/i18n/src/lib/translations/translations_iw.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=בטל
 platformTable.clearFilters=נקה מסננים
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=צמצם שורה
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_iw.ts
+++ b/libs/i18n/src/lib/translations/translations_iw.ts
@@ -517,6 +517,8 @@ export default {
         cancelBtnLabel: 'בטל',
         clearFilters: 'נקה מסננים',
         collapseRowButtonTitle: 'צמצם שורה',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'לא נמצאו נתונים',
         deselectAllCheckboxLabel: 'בטל בחירה של הכול',

--- a/libs/i18n/src/lib/translations/translations_ja.properties
+++ b/libs/i18n/src/lib/translations/translations_ja.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=キャンセル
 platformTable.clearFilters=フィルタをクリア
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=行を圧縮
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'キャンセル',
         clearFilters: 'フィルタをクリア',
         collapseRowButtonTitle: '行を圧縮',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'データが見つかりません。',
         deselectAllCheckboxLabel: 'すべて選択解除',

--- a/libs/i18n/src/lib/translations/translations_ka.properties
+++ b/libs/i18n/src/lib/translations/translations_ka.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel = Cancel
 platformTable.clearFilters = Clear Filters
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle = Collapse row
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel = OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -518,6 +518,8 @@ export default {
         cancelBtnLabel: 'Cancel',
         clearFilters: 'Clear Filters',
         collapseRowButtonTitle: 'Collapse row',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'მონაცემები ვერ მოიძებნა',
         deselectAllCheckboxLabel: 'Deselect all',

--- a/libs/i18n/src/lib/translations/translations_kk.properties
+++ b/libs/i18n/src/lib/translations/translations_kk.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Болдырмау
 platformTable.clearFilters=Сүзгілерді тазарту
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Жолды жию
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Болдырмау',
         clearFilters: 'Сүзгілерді тазарту',
         collapseRowButtonTitle: 'Жолды жию',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Дерек табылмады',
         deselectAllCheckboxLabel: 'Барлығының таңдауын алу',

--- a/libs/i18n/src/lib/translations/translations_ko.properties
+++ b/libs/i18n/src/lib/translations/translations_ko.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=취소
 platformTable.clearFilters=필터 지우기
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=행 접기
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=확인
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -517,6 +517,8 @@ export default {
         cancelBtnLabel: '취소',
         clearFilters: '필터 지우기',
         collapseRowButtonTitle: '행 접기',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: '확인',
         defaultEmptyMessage: '데이터를 찾을 수 없음',
         deselectAllCheckboxLabel: '모두 선택 취소',

--- a/libs/i18n/src/lib/translations/translations_ms.properties
+++ b/libs/i18n/src/lib/translations/translations_ms.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Batalkan
 platformTable.clearFilters=Kosongkan Penapis
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Runtuhkan baris
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -517,6 +517,8 @@ export default {
         cancelBtnLabel: 'Batalkan',
         clearFilters: 'Kosongkan Penapis',
         collapseRowButtonTitle: 'Runtuhkan baris',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Tiada data ditemui',
         deselectAllCheckboxLabel: 'Nyahpilih semua',

--- a/libs/i18n/src/lib/translations/translations_nl.properties
+++ b/libs/i18n/src/lib/translations/translations_nl.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Annuleren
 platformTable.clearFilters=Filters wissen
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Rij samenvouwen
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -520,6 +520,8 @@ export default {
         cancelBtnLabel: 'Annuleren',
         clearFilters: 'Filters wissen',
         collapseRowButtonTitle: 'Rij samenvouwen',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Geen gegevens gevonden',
         deselectAllCheckboxLabel: 'Alle selecties opheffen',

--- a/libs/i18n/src/lib/translations/translations_no.properties
+++ b/libs/i18n/src/lib/translations/translations_no.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Avbryt
 platformTable.clearFilters=Tøm filtre
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Komprimer rad
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -520,6 +520,8 @@ export default {
         cancelBtnLabel: 'Avbryt',
         clearFilters: 'Tøm filtre',
         collapseRowButtonTitle: 'Komprimer rad',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Finner ingen data',
         deselectAllCheckboxLabel: 'Opphev merking av alle',

--- a/libs/i18n/src/lib/translations/translations_pl.properties
+++ b/libs/i18n/src/lib/translations/translations_pl.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Anuluj
 platformTable.clearFilters=Wyczyść filtry
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Zwiń wiersz
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Anuluj',
         clearFilters: 'Wyczyść filtry',
         collapseRowButtonTitle: 'Zwiń wiersz',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Nie znaleziono danych',
         deselectAllCheckboxLabel: 'Odznacz wszystko',

--- a/libs/i18n/src/lib/translations/translations_pt.properties
+++ b/libs/i18n/src/lib/translations/translations_pt.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Cancelar
 platformTable.clearFilters=Limpar filtros
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Recolher linha
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -520,6 +520,8 @@ export default {
         cancelBtnLabel: 'Cancelar',
         clearFilters: 'Limpar filtros',
         collapseRowButtonTitle: 'Recolher linha',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Nenhum dado encontrado',
         deselectAllCheckboxLabel: 'Desmarcar tudo',

--- a/libs/i18n/src/lib/translations/translations_ro.properties
+++ b/libs/i18n/src/lib/translations/translations_ro.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Anulare
 platformTable.clearFilters=Golire filtre
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Comprimare linie
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -522,6 +522,8 @@ export default {
         cancelBtnLabel: 'Anulare',
         clearFilters: 'Golire filtre',
         collapseRowButtonTitle: 'Comprimare linie',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Nu s-au găsit date',
         deselectAllCheckboxLabel: 'Deselectare toate',

--- a/libs/i18n/src/lib/translations/translations_ru.properties
+++ b/libs/i18n/src/lib/translations/translations_ru.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Отмена
 platformTable.clearFilters=Очистить фильтры
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Свернуть строку
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=ОК
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Отмена',
         clearFilters: 'Очистить фильтры',
         collapseRowButtonTitle: 'Свернуть строку',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'ОК',
         defaultEmptyMessage: 'Данные не найдены',
         deselectAllCheckboxLabel: 'Отменить выделение',

--- a/libs/i18n/src/lib/translations/translations_sh.properties
+++ b/libs/i18n/src/lib/translations/translations_sh.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Odustani
 platformTable.clearFilters=Obriši filtere
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Sažmi red
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Odustani',
         clearFilters: 'Obriši filtere',
         collapseRowButtonTitle: 'Sažmi red',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Podaci nisu nađeni',
         deselectAllCheckboxLabel: 'Poništi odabir za sve',

--- a/libs/i18n/src/lib/translations/translations_sk.properties
+++ b/libs/i18n/src/lib/translations/translations_sk.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Zrušiť
 platformTable.clearFilters=Vymazať filtre
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Zbaliť riadok
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Zrušiť',
         clearFilters: 'Vymazať filtre',
         collapseRowButtonTitle: 'Zbaliť riadok',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Nenašli sa žiadne údaje',
         deselectAllCheckboxLabel: 'Zrušiť výber všetkého',

--- a/libs/i18n/src/lib/translations/translations_sl.properties
+++ b/libs/i18n/src/lib/translations/translations_sl.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Preklic
 platformTable.clearFilters=Počisti filtre
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Skrči vrstico
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=V redu
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Preklic',
         clearFilters: 'Počisti filtre',
         collapseRowButtonTitle: 'Skrči vrstico',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'V redu',
         defaultEmptyMessage: 'Podatki niso najdeni',
         deselectAllCheckboxLabel: 'Preklic izbire vseh',

--- a/libs/i18n/src/lib/translations/translations_sq.properties
+++ b/libs/i18n/src/lib/translations/translations_sq.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel = Cancel
 platformTable.clearFilters = Clear Filters
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle = Collapse row
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel = OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_sq.ts
+++ b/libs/i18n/src/lib/translations/translations_sq.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'Cancel',
         clearFilters: 'Clear Filters',
         collapseRowButtonTitle: 'Collapse row',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'No data found',
         deselectAllCheckboxLabel: 'Deselect all',

--- a/libs/i18n/src/lib/translations/translations_sv.properties
+++ b/libs/i18n/src/lib/translations/translations_sv.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Avbryt
 platformTable.clearFilters=Rensa filter
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Komprimera rad
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=OK
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -518,6 +518,8 @@ export default {
         cancelBtnLabel: 'Avbryt',
         clearFilters: 'Rensa filter',
         collapseRowButtonTitle: 'Komprimera rad',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'OK',
         defaultEmptyMessage: 'Inga data hittades',
         deselectAllCheckboxLabel: 'Avmarkera alla',

--- a/libs/i18n/src/lib/translations/translations_th.properties
+++ b/libs/i18n/src/lib/translations/translations_th.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=ยกเลิก
 platformTable.clearFilters=เคลียร์ตัวกรอง
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=ยุบรวมแถว
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=ตกลง
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -518,6 +518,8 @@ export default {
         cancelBtnLabel: 'ยกเลิก',
         clearFilters: 'เคลียร์ตัวกรอง',
         collapseRowButtonTitle: 'ยุบรวมแถว',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'ตกลง',
         defaultEmptyMessage: 'ไม่พบข้อมูล',
         deselectAllCheckboxLabel: 'ยกเลิกการเลือกทั้งหมด',

--- a/libs/i18n/src/lib/translations/translations_tr.properties
+++ b/libs/i18n/src/lib/translations/translations_tr.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=İptal
 platformTable.clearFilters=Filtreleri Temizle
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Satırı daralt
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=Tamam
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -519,6 +519,8 @@ export default {
         cancelBtnLabel: 'İptal',
         clearFilters: 'Filtreleri Temizle',
         collapseRowButtonTitle: 'Satırı daralt',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'Tamam',
         defaultEmptyMessage: 'Veri bulunamadı',
         deselectAllCheckboxLabel: 'Tümünün seçimini kaldır',

--- a/libs/i18n/src/lib/translations/translations_uk.properties
+++ b/libs/i18n/src/lib/translations/translations_uk.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=Скасувати
 platformTable.clearFilters=Очистити фільтри
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=Згорнути рядок
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=ОК
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -518,6 +518,8 @@ export default {
         cancelBtnLabel: 'Скасувати',
         clearFilters: 'Очистити фільтри',
         collapseRowButtonTitle: 'Згорнути рядок',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: 'ОК',
         defaultEmptyMessage: 'Даних не знайдено',
         deselectAllCheckboxLabel: 'Скасувати вибір',

--- a/libs/i18n/src/lib/translations/translations_zh_CN.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=取消
 platformTable.clearFilters=清除过滤器
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=折叠行
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=确定
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -515,6 +515,8 @@ export default {
         cancelBtnLabel: '取消',
         clearFilters: '清除过滤器',
         collapseRowButtonTitle: '折叠行',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: '确定',
         defaultEmptyMessage: '找不到数据',
         deselectAllCheckboxLabel: '取消全选',

--- a/libs/i18n/src/lib/translations/translations_zh_TW.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.properties
@@ -752,6 +752,10 @@ platformTable.cancelBtnLabel=取消
 platformTable.clearFilters=清除篩選器
 #XBUT: Label for the button, which collapses the clicked row in the table
 platformTable.collapseRowButtonTitle=摺疊列
+#XACT: ARIA label for sort icon when column is sorted ascending
+platformTable.columnSortedAscLabel=Sort by {columnName}, ascending
+#XACT: ARIA label for sort icon when column is sorted descending
+platformTable.columnSortedDescLabel=Sort by {columnName}, descending
 #XBUT: Label for the button, which confirms the changes made in the settings dialog
 platformTable.confirmBtnLabel=確定
 #XMSG: Text for the message displayed in Platform Table when no data is found

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -516,6 +516,8 @@ export default {
         cancelBtnLabel: '取消',
         clearFilters: '清除篩選器',
         collapseRowButtonTitle: '摺疊列',
+        columnSortedAscLabel: 'Sort by {columnName}, ascending',
+        columnSortedDescLabel: 'Sort by {columnName}, descending',
         confirmBtnLabel: '確定',
         defaultEmptyMessage: '找不到資料',
         deselectAllCheckboxLabel: '取消全選',

--- a/libs/platform/table/components/table-group-row/table-group-row.component.html
+++ b/libs/platform/table/components/table-group-row/table-group-row.component.html
@@ -6,6 +6,11 @@
     [focusable]="true"
     colspan="100%"
     [attr.aria-expanded]="row.expanded"
+    [attr.title]="
+        row.expanded
+            ? ('platformTable.collapseRowButtonTitle' | fdTranslate)()
+            : ('platformTable.expandRowButtonTitle' | fdTranslate)()
+    "
     [attr.data-nesting-level]="row.level + 1"
     (keydown.enter)="toggleGroupRow.emit(row)"
     (keydown.space)="toggleGroupRow.emit(row)"

--- a/libs/platform/table/components/table-group-row/table-group-row.component.ts
+++ b/libs/platform/table/components/table-group-row/table-group-row.component.ts
@@ -20,6 +20,7 @@ import {
     Nullable
 } from '@fundamental-ngx/cdk/utils';
 import { TableCellDirective, TableRowDirective } from '@fundamental-ngx/core/table';
+import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { TableColumn, TableRow, TableService } from '@fundamental-ngx/platform/table-helpers';
 
 @Component({
@@ -38,7 +39,7 @@ import { TableColumn, TableRow, TableService } from '@fundamental-ngx/platform/t
         role: 'row',
         '[attr.aria-expanded]': 'row.expanded'
     },
-    imports: [TableCellDirective, NgTemplateOutlet]
+    imports: [TableCellDirective, NgTemplateOutlet, FdTranslatePipe]
 })
 export class TableGroupRowComponent<T> extends TableRowDirective implements OnChanges {
     /** Table ID. */

--- a/libs/platform/table/components/table-header-cell-content/table-header-cell-content.component.html
+++ b/libs/platform/table/components/table-header-cell-content/table-header-cell-content.component.html
@@ -10,12 +10,16 @@
     @if (hasSorting$() || hasFilter$()) {
         <div class="fd-table__column-header-icons">
             @if (hasFilter$()) {
-                <fd-icon fd-table-icon glyph="filter"></fd-icon>
+                <fd-icon fd-table-icon glyph="filter" [ariaHidden]="true"></fd-icon>
             }
             @if (hasSorting$()) {
                 <fd-icon
                     fd-table-icon
-                    [ariaHidden]="true"
+                    [ariaLabel]="
+                        sorting$()?.direction === SORT_DIRECTION.ASC
+                            ? ('platformTable.columnSortedAscLabel' | fdTranslate: { columnName: column?.label })()
+                            : ('platformTable.columnSortedDescLabel' | fdTranslate: { columnName: column?.label })()
+                    "
                     [glyph]="sorting$()?.direction === SORT_DIRECTION.ASC ? 'sort-ascending' : 'sort-descending'"
                 ></fd-icon>
             }

--- a/libs/platform/table/components/table-header-cell-content/table-header-cell-content.component.ts
+++ b/libs/platform/table/components/table-header-cell-content/table-header-cell-content.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation, computed,
 import { Nullable } from '@fundamental-ngx/cdk/utils';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { TableIconDirective } from '@fundamental-ngx/core/table';
+import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { SortDirection, TableColumn, TableService } from '@fundamental-ngx/platform/table-helpers';
 
 @Component({
@@ -23,7 +24,7 @@ import { SortDirection, TableColumn, TableService } from '@fundamental-ngx/platf
             }
         `
     ],
-    imports: [NgTemplateOutlet, IconComponent, TableIconDirective, AsyncPipe, NgStyle]
+    imports: [NgTemplateOutlet, IconComponent, TableIconDirective, AsyncPipe, NgStyle, FdTranslatePipe]
 })
 export class TableHeaderCellContentComponent {
     /** Table Id */


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14021

## Description

Fixes ACC-255.1 / ACC-264.1 (WCAG Level A) — missing text alternatives on the group row expand/collapse cell and column sort icon in `fdp-table`.

### 1. Group row expand/collapse cell (`table-group-row`)

The interactive `<td>` that toggles group row expansion had no accessible name, so screen readers announced the state (`aria-expanded`) without identifying what the element was.

- Added `[attr.title]` to the group row `<td>` using the existing `platformTable.expandRowButtonTitle` / `platformTable.collapseRowButtonTitle` i18n keys, matching the pattern already in place for tree rows.
- Used `title` instead of `aria-label` to avoid the accessible name propagating into the row's computed name (which caused VoiceOver to repeat "Collapse row" twice).
- Imported `FdTranslatePipe` into `TableGroupRowComponent`.

### 2. Column sort icon (`table-header-cell-content`)

The sort direction icon in column headers was `aria-hidden`, giving screen reader users no indication of which column is sorted or in which direction.

- Replaced `[ariaHidden]="true"` on the sort `fd-icon` with `[ariaLabel]` bound to a new translated string. The `fd-icon` component automatically sets `role="img"` and clears `aria-hidden` when `ariaLabel` is provided.
- The label reflects the current sort direction: **"Sort by {columnName}, ascending"** or **"Sort by {columnName}, descending"**.
- Added `[ariaHidden]="true"` to the filter icon (previously missing) — it is a purely decorative status indicator whose state is already communicated by the visible "Filtered by: …" bar, so hiding it from AT is correct.
- The sort icon intentionally receives `ariaLabel` instead, because the `<th>`'s `aria-sort` attribute alone does not include the column name.
- Imported `FdTranslatePipe` into `TableHeaderCellContentComponent`.

### 3. New i18n keys (`platformTable` namespace)

Two new keys added across all 37 locales (English default, pending translation):

| Key | Default value |
|-----|--------------|
| `platformTable.columnSortedAscLabel` | `Sort by {columnName}, ascending` |
| `platformTable.columnSortedDescLabel` | `Sort by {columnName}, descending` |

## Test

Open the **Platform Table → Column Sorting** example in the docs app (`yarn start`). With VoiceOver (macOS) or NVDA (Windows):

- Focus a sorted column header — the sort icon should be announced as e.g. **"Sort by Description, ascending"**.
- Open the **Platform Table → Groupable** example. Focus a collapsed/expanded group row — it should be announced as **"Expand row"** or **"Collapse row"** without duplication.


## Screenshots

<img width="935" height="424" alt="Screenshot 2026-06-24 at 15 19 27" src="https://github.com/user-attachments/assets/2093a72e-9538-4007-8baf-cd6bcfd7097e" />
<img width="954" height="459" alt="Screenshot 2026-06-24 at 15 18 29" src="https://github.com/user-attachments/assets/0a1d581c-2dd7-4617-9bd4-2a9c4415fe1d" />

