### PR TITLE
fix(core): add option to configure popover placement in Multi Input

### DIFF
--- a/libs/core/multi-input/multi-input.component.html
+++ b/libs/core/multi-input/multi-input.component.html
@@ -19,6 +19,7 @@
                     class="fd-multi-input-popover-custom"
                     [focusTrapped]="true"
                     [focusAutoCapture]="false"
+                    [placement]="placement()"
                 >
                     <fd-popover-control>
                         <form (submit)="_onSubmit()">

--- a/libs/core/multi-input/multi-input.component.ts
+++ b/libs/core/multi-input/multi-input.component.ts
@@ -432,6 +432,9 @@ export class MultiInputComponent<ItemType = any, ValueType = any>
      */
     readonly maxVisibleTokens = input(12);
 
+    /** Placement of the popover relative to the input.*/
+    readonly placement = input<'top' | 'bottom'>('bottom');
+
     /** @hidden */
     get _optionItems(): _OptionItem<ItemType, ValueType>[] {
         return this.optionItems$.value;

--- a/libs/docs/core/multi-input/examples/multi-input-example/multi-input-example.component.html
+++ b/libs/docs/core/multi-input/examples/multi-input-example/multi-input-example.component.html
@@ -51,9 +51,10 @@ Selected: {{ selectedDisabledAutoComplete | json }}
 
 <br /><br />
 
-<label fd-label for="multiInputDisabledAutoComplete">With Object Values</label>
+<label fd-label for="multiInputDisabledAutoComplete">With Object Values and top placement</label>
 <fd-multi-input
     inputId="multiInputWithObjectValues"
+    placement="top"
     [dropdownValues]="objectValues"
     [displayFn]="objectValuesDisplayFn"
     [valueFn]="objectValuesValueFn"

--- a/libs/docs/core/multi-input/multi-input-docs.component.html
+++ b/libs/docs/core/multi-input/multi-input-docs.component.html
@@ -9,6 +9,11 @@
         To open suggestions dropdown with keyboard, use combination of <code>alt key + arrow down key</code> when
         focusing input field.
     </p>
+    <p>
+        The dropdown menu position can be configured using the <code>[placement]</code> input, which accepts
+        <code>'top'</code> or <code>'bottom'</code>. By default, the dropdown opens below the input
+        (<code>'bottom'</code>).
+    </p>
 </description>
 <component-example>
     <fd-multi-input-example></fd-multi-input-example>


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14235

## Description
Exposes Popover placement as an input property of Multi Input

## Screenshots
<img width="1224" height="783" alt="Screenshot 2026-06-25 at 2 34 40 PM" src="https://github.com/user-attachments/assets/673d8933-09a2-475e-977e-4dcac6ec4d71" />
