### PR TITLE
fix(core): screen reader announces selection state for fd-list items

### DIFF
--- a/libs/core/list/list-component.interface.ts
+++ b/libs/core/list/list-component.interface.ts
@@ -16,5 +16,7 @@ export interface ListComponentInterface {
 
     role: Nullable<string>;
 
+    selection: boolean;
+
     setItemActive(index: number): void;
 }

--- a/libs/core/list/list-item/list-item.component.html
+++ b/libs/core/list/list-item/list-item.component.html
@@ -4,6 +4,13 @@
         <ng-content select="fd-radio-button"></ng-content>
     </div>
 }
+@if (_isSelectable) {
+    <span [id]="_selectionDescribedById" class="fd-list__item--sr-only" aria-hidden="true">{{
+        selected
+            ? ('coreList.listItemSelectedAriaLabel' | fdTranslate)()
+            : ('coreList.listItemNotSelectedAriaLabel' | fdTranslate)()
+    }}</span>
+}
 @if (unread && (!_list || _list.byline)) {
     <fd-icon class="fd-list__notification" glyph="circle-task-2"></fd-icon>
 }

--- a/libs/core/list/list-item/list-item.component.spec.ts
+++ b/libs/core/list/list-item/list-item.component.spec.ts
@@ -1,6 +1,8 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { CheckboxComponent } from '@fundamental-ngx/core/checkbox';
 import { ListModule } from '../list.module';
 
 @Component({
@@ -30,6 +32,29 @@ class TestComponent {
     link = false;
     noData = false;
     action = false;
+}
+
+@Component({
+    template: `
+        <ul fd-list [selection]="true">
+            <li #listItem fd-list-item [selected]="selected">
+                <fd-checkbox #checkbox [(ngModel)]="checked"></fd-checkbox>
+                List item with checkbox
+            </li>
+        </ul>
+    `,
+    standalone: true,
+    imports: [ListModule, CheckboxComponent]
+})
+class SelectionListTestComponent {
+    @ViewChild('listItem', { read: ElementRef })
+    listItemRef: ElementRef;
+
+    @ViewChild('checkbox')
+    checkbox: CheckboxComponent;
+
+    selected = false;
+    checked = false;
 }
 
 describe('ListItemComponent', () => {
@@ -93,5 +118,76 @@ describe('ListItemComponent', () => {
         component.ref.nativeElement.dispatchEvent(upEvent);
 
         expect(component.linkRef.nativeElement.classList).not.toContain('is-active');
+    });
+
+    it('should not render selection span for non-selectable items', () => {
+        const span = component.ref.nativeElement.querySelector('.fd-list__item--sr-only');
+        expect(span).toBeNull();
+    });
+
+    it('should not set aria-describedby for non-selectable items', () => {
+        expect(component.ref.nativeElement.getAttribute('aria-describedby')).toBeNull();
+    });
+});
+
+describe('ListItemComponent in selection mode', () => {
+    let fixture: ComponentFixture<SelectionListTestComponent>;
+    let component: SelectionListTestComponent;
+    let liveAnnouncer: LiveAnnouncer;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [SelectionListTestComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SelectionListTestComponent);
+        component = fixture.componentInstance;
+        liveAnnouncer = TestBed.inject(LiveAnnouncer);
+        fixture.detectChanges();
+    });
+
+    it('should render the sr-only selection span', () => {
+        const span = component.listItemRef.nativeElement.querySelector('.fd-list__item--sr-only');
+        expect(span).toBeTruthy();
+    });
+
+    it('should set aria-describedby pointing to the sr-only span', () => {
+        const span = component.listItemRef.nativeElement.querySelector('.fd-list__item--sr-only');
+        const describedById = component.listItemRef.nativeElement.getAttribute('aria-describedby');
+        expect(describedById).toBe(span.id);
+    });
+
+    it('should show "Not Selected" in the sr-only span when item is not selected', () => {
+        const span = component.listItemRef.nativeElement.querySelector('.fd-list__item--sr-only');
+        expect(span.textContent.trim()).toBe('Not Selected');
+    });
+
+    it('should show "Selected" in the sr-only span when item is selected', () => {
+        component.selected = true;
+        fixture.detectChanges();
+        const span = component.listItemRef.nativeElement.querySelector('.fd-list__item--sr-only');
+        expect(span.textContent.trim()).toBe('Selected');
+    });
+
+    it('should announce new state via LiveAnnouncer when list item is clicked to check', () => {
+        const announceSpy = jest.spyOn(liveAnnouncer, 'announce');
+
+        component.listItemRef.nativeElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        fixture.detectChanges();
+
+        expect(announceSpy).toHaveBeenCalledWith('Selected', 'polite');
+    });
+
+    it('should announce "Not Selected" via LiveAnnouncer when list item is clicked to uncheck', () => {
+        component.listItemRef.nativeElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        fixture.detectChanges();
+
+        const announceSpy = jest.spyOn(liveAnnouncer, 'announce');
+        component.listItemRef.nativeElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        fixture.detectChanges();
+
+        expect(announceSpy).toHaveBeenCalledWith('Not Selected', 'polite');
     });
 });

--- a/libs/core/list/list-item/list-item.component.spec.ts
+++ b/libs/core/list/list-item/list-item.component.spec.ts
@@ -1,4 +1,3 @@
-import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
@@ -133,7 +132,6 @@ describe('ListItemComponent', () => {
 describe('ListItemComponent in selection mode', () => {
     let fixture: ComponentFixture<SelectionListTestComponent>;
     let component: SelectionListTestComponent;
-    let liveAnnouncer: LiveAnnouncer;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
@@ -144,7 +142,6 @@ describe('ListItemComponent in selection mode', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(SelectionListTestComponent);
         component = fixture.componentInstance;
-        liveAnnouncer = TestBed.inject(LiveAnnouncer);
         fixture.detectChanges();
     });
 
@@ -171,23 +168,19 @@ describe('ListItemComponent in selection mode', () => {
         expect(span.textContent.trim()).toBe('Selected');
     });
 
-    it('should announce new state via LiveAnnouncer when list item is clicked to check', () => {
-        const announceSpy = jest.spyOn(liveAnnouncer, 'announce');
-
+    it('should update sr-only span to "Selected" when list item is clicked to check', () => {
         component.listItemRef.nativeElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         fixture.detectChanges();
-
-        expect(announceSpy).toHaveBeenCalledWith('Selected', 'polite');
+        const span = component.listItemRef.nativeElement.querySelector('.fd-list__item--sr-only');
+        expect(span.textContent.trim()).toBe('Selected');
     });
 
-    it('should announce "Not Selected" via LiveAnnouncer when list item is clicked to uncheck', () => {
+    it('should update sr-only span to "Not Selected" when list item is clicked to uncheck', () => {
         component.listItemRef.nativeElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         fixture.detectChanges();
-
-        const announceSpy = jest.spyOn(liveAnnouncer, 'announce');
         component.listItemRef.nativeElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         fixture.detectChanges();
-
-        expect(announceSpy).toHaveBeenCalledWith('Not Selected', 'polite');
+        const span = component.listItemRef.nativeElement.querySelector('.fd-list__item--sr-only');
+        expect(span.textContent.trim()).toBe('Not Selected');
     });
 });

--- a/libs/core/list/list-item/list-item.component.ts
+++ b/libs/core/list/list-item/list-item.component.ts
@@ -28,12 +28,13 @@ import { CheckboxComponent, FD_CHECKBOX_COMPONENT } from '@fundamental-ngx/core/
 import { FormItemComponent } from '@fundamental-ngx/core/form';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { FD_RADIO_BUTTON_COMPONENT, RadioButtonComponent } from '@fundamental-ngx/core/radio';
+import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { Subject } from 'rxjs';
 import { startWith } from 'rxjs/operators';
 import { ListLinkDirective } from '../directives/list-link.directive';
 import { ListTitleDirective } from '../directives/list-title.directive';
 import { ListFocusItem } from '../list-focus-item.model';
-import { FD_LIST_LINK_DIRECTIVE, FD_LIST_UNREAD_INDICATOR } from '../tokens';
+import { FD_LIST_COMPONENT, FD_LIST_LINK_DIRECTIVE, FD_LIST_UNREAD_INDICATOR } from '../tokens';
 
 let listItemUniqueId = 0;
 
@@ -49,7 +50,8 @@ let listItemUniqueId = 0;
         class: 'fd-list__item',
         '[attr.tabindex]': '_normalizedTabIndex()',
         '[attr.id]': 'id',
-        '[class.fd-list__item--suggestion]': 'suggestion()'
+        '[class.fd-list__item--suggestion]': 'suggestion()',
+        '[attr.aria-describedby]': '_isSelectable ? _selectionDescribedById : null'
     },
     providers: [
         {
@@ -63,14 +65,13 @@ let listItemUniqueId = 0;
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    imports: [FormItemComponent, DecimalPipe, IconComponent],
+    imports: [FormItemComponent, DecimalPipe, IconComponent, FdTranslatePipe],
     exportAs: 'fdListItem'
 })
 export class ListItemComponent<T = any> extends ListFocusItem<T> implements AfterContentInit, ListItemInterface {
     /** Whether list item is selected */
     @Input()
     @HostBinding('class.is-selected')
-    @HostBinding('attr.aria-selected')
     selected: boolean;
 
     /** Whether there is no data inside list item */
@@ -128,6 +129,11 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
     /** The ID of the list item element */
     @Input()
     id: Nullable<string> = 'fd-list-item-' + ++listItemUniqueId;
+
+    /** @hidden ID of the hidden selection state span, referenced by aria-describedby on the host */
+    get _selectionDescribedById(): string {
+        return `${this.id}-selection-described-by`;
+    }
 
     /** Whether to prevent built-in click event logic on the list item.
      * Helpful when using lists with checkboxes or radio buttons when the list item should be clickable, but should not select/deselect the list item. */
@@ -198,13 +204,16 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
     readonly suggestion = input(false, { transform: booleanAttribute });
 
     /** @hidden */
-    private _role = 'listitem'; // default for li elements
+    private _role = 'listitem';
 
     /** @hidden An RxJS Subject that will kill the data stream upon component’s destruction (for unsubscribing)  */
     private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
     private readonly _onLinkListChanged$ = new Subject<void>();
+
+    /** @hidden */
+    private readonly _parentList = inject(FD_LIST_COMPONENT, { optional: true });
 
     /** @hidden */
     private _radio: RadioButtonComponent;
@@ -221,6 +230,11 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
     @HostBinding('attr.role')
     protected get roleAttr(): string {
         return this.ariaRole || this._role;
+    }
+
+    /** @hidden True when the parent list is in selection mode. */
+    get _isSelectable(): boolean {
+        return !!this._parentList?.selection;
     }
 
     /** @hidden */

--- a/libs/core/list/list-item/list-item.component.ts
+++ b/libs/core/list/list-item/list-item.component.ts
@@ -19,6 +19,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { DecimalPipe } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -28,7 +29,7 @@ import { CheckboxComponent, FD_CHECKBOX_COMPONENT } from '@fundamental-ngx/core/
 import { FormItemComponent } from '@fundamental-ngx/core/form';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { FD_RADIO_BUTTON_COMPONENT, RadioButtonComponent } from '@fundamental-ngx/core/radio';
-import { FdTranslatePipe } from '@fundamental-ngx/i18n';
+import { FdTranslatePipe, resolveTranslationSignal } from '@fundamental-ngx/i18n';
 import { Subject } from 'rxjs';
 import { startWith } from 'rxjs/operators';
 import { ListLinkDirective } from '../directives/list-link.directive';
@@ -221,6 +222,15 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
     /** @hidden */
     private _checkbox: CheckboxComponent;
 
+    /** @hidden Translated "Selected" string */
+    private readonly _selectedLabel = resolveTranslationSignal('coreList.listItemSelectedAriaLabel');
+
+    /** @hidden Translated "Not Selected" string */
+    private readonly _notSelectedLabel = resolveTranslationSignal('coreList.listItemNotSelectedAriaLabel');
+
+    /** @hidden */
+    private readonly _liveAnnouncer = inject(LiveAnnouncer);
+
     /** @hidden */
     constructor(private readonly _changeDetectorRef: ChangeDetectorRef) {
         super();
@@ -243,9 +253,11 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
         if (KeyUtil.isKeyCode(event, [ENTER, SPACE])) {
             if (this.checkbox && !this.checkbox.disabled) {
                 this.checkbox.nextValue();
+                this._syncSelectionFromControl();
                 this._muteEvent(event);
             } else if (this.radio && !this.radio.disabled) {
                 this.radio.labelClicked(event, false);
+                this._syncSelectionFromControl();
                 this._muteEvent(event);
             } else if (this.interactive) {
                 this.selected = !this.selected;
@@ -281,9 +293,11 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
                     // so we should only process clicks if clicked on the list-item, not checkbox itself
                     this.checkbox.nextValue();
                 }
+                this._syncSelectionFromControl();
             }
             if (this.radio && !this.radio.disabled && !this.link) {
                 this.radio.labelClicked(event, false);
+                this._syncSelectionFromControl();
             }
         }
     }
@@ -330,5 +344,15 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
     private _muteEvent(event: Event): void {
         event.stopPropagation();
         event.preventDefault();
+    }
+
+    /** @hidden Reads checked state from embedded checkbox/radio, updates `selected`, and announces the new state. */
+    private _syncSelectionFromControl(): void {
+        if (this.checkbox) {
+            this.selected = this.checkbox.isChecked;
+        } else if (this.radio) {
+            this.selected = this.radio.checked;
+        }
+        this._liveAnnouncer.announce(this.selected ? this._selectedLabel() : this._notSelectedLabel(), 'polite');
     }
 }

--- a/libs/core/list/list-item/list-item.component.ts
+++ b/libs/core/list/list-item/list-item.component.ts
@@ -19,7 +19,6 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
-import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { ENTER, SPACE } from '@angular/cdk/keycodes';
 import { DecimalPipe } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -29,7 +28,7 @@ import { CheckboxComponent, FD_CHECKBOX_COMPONENT } from '@fundamental-ngx/core/
 import { FormItemComponent } from '@fundamental-ngx/core/form';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { FD_RADIO_BUTTON_COMPONENT, RadioButtonComponent } from '@fundamental-ngx/core/radio';
-import { FdTranslatePipe, resolveTranslationSignal } from '@fundamental-ngx/i18n';
+import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { Subject } from 'rxjs';
 import { startWith } from 'rxjs/operators';
 import { ListLinkDirective } from '../directives/list-link.directive';
@@ -222,15 +221,6 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
     /** @hidden */
     private _checkbox: CheckboxComponent;
 
-    /** @hidden Translated "Selected" string */
-    private readonly _selectedLabel = resolveTranslationSignal('coreList.listItemSelectedAriaLabel');
-
-    /** @hidden Translated "Not Selected" string */
-    private readonly _notSelectedLabel = resolveTranslationSignal('coreList.listItemNotSelectedAriaLabel');
-
-    /** @hidden */
-    private readonly _liveAnnouncer = inject(LiveAnnouncer);
-
     /** @hidden */
     constructor(private readonly _changeDetectorRef: ChangeDetectorRef) {
         super();
@@ -346,13 +336,12 @@ export class ListItemComponent<T = any> extends ListFocusItem<T> implements Afte
         event.preventDefault();
     }
 
-    /** @hidden Reads checked state from embedded checkbox/radio, updates `selected`, and announces the new state. */
+    /** @hidden Reads checked state from embedded checkbox/radio and writes it to `selected`. */
     private _syncSelectionFromControl(): void {
         if (this.checkbox) {
             this.selected = this.checkbox.isChecked;
         } else if (this.radio) {
             this.selected = this.radio.checked;
         }
-        this._liveAnnouncer.announce(this.selected ? this._selectedLabel() : this._notSelectedLabel(), 'polite');
     }
 }

--- a/libs/core/list/list.component.scss
+++ b/libs/core/list/list.component.scss
@@ -1,5 +1,19 @@
 @import 'fundamental-styles/dist/list.css';
 
+.fd-list__item--sr-only {
+    position: absolute;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    width: 1px;
+    border: 0;
+    margin-inline: -1px;
+    margin-block: -1px;
+    padding-inline: 0;
+    padding-block: 0;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
 // TODO: move to fundamental-styles
 .fd-list {
     max-width: 100% !important;

--- a/libs/i18n/src/lib/models/fd-language-key-identifier.ts
+++ b/libs/i18n/src/lib/models/fd-language-key-identifier.ts
@@ -81,6 +81,8 @@ export type FdLanguageKeyIdentifier =
     | 'coreGridList.listItemStatusDraft'
     | 'coreGridList.listItemStatusLocked'
     | 'coreInfoLabel.srOnlyText'
+    | 'coreList.listItemSelectedAriaLabel'
+    | 'coreList.listItemNotSelectedAriaLabel'
     | 'coreLink.emphasized'
     | 'coreLink.subtle'
     | 'coreMessageStrip.announcementError'

--- a/libs/i18n/src/lib/models/fd-language.ts
+++ b/libs/i18n/src/lib/models/fd-language.ts
@@ -145,6 +145,12 @@ export interface FdLanguage {
         listItemStatusLocked: FdLanguageKey;
         listItemStatusDraft: FdLanguageKey;
     };
+    coreList: {
+        /** Visually hidden label announced by screen readers when a list item is selected */
+        listItemSelectedAriaLabel: FdLanguageKey;
+        /** Visually hidden label announced by screen readers when a list item is not selected */
+        listItemNotSelectedAriaLabel: FdLanguageKey;
+    };
     coreLink: {
         emphasized: FdLanguageKey;
         subtle: FdLanguageKey;

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -154,6 +154,9 @@ coreGridList.listItemStatusDraft = Draft
 coreGridList.listItemStatusLocked = Locked
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText = Info Label
+#XACT: Visually hidden label announced by screen readers when a list item is selected
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 #XACT: Screen reader text explaining that link is emphasized
 coreLink.emphasized = Emphasized
 #XACT: Screen reader text explaining that link is subtle

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Info Label'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Emphasized',
         subtle: 'Subtle'

--- a/libs/i18n/src/lib/translations/translations_ar.properties
+++ b/libs/i18n/src/lib/translations/translations_ar.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=مؤمَّن
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=تسمية المعلومات
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=مؤكَّد
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=غامض

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'تسمية المعلومات'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'مؤكَّد',
         subtle: 'غامض'

--- a/libs/i18n/src/lib/translations/translations_bg.properties
+++ b/libs/i18n/src/lib/translations/translations_bg.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Заключено
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Информационен етикет
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Акцентирано
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Неясни

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Информационен етикет'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Акцентирано',
         subtle: 'Неясни'

--- a/libs/i18n/src/lib/translations/translations_cs.properties
+++ b/libs/i18n/src/lib/translations/translations_cs.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Blokováno
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Informační označení
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Zvýrazněno
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Jemné

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Informační označení'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Zvýrazněno',
         subtle: 'Jemné'

--- a/libs/i18n/src/lib/translations/translations_da.properties
+++ b/libs/i18n/src/lib/translations/translations_da.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Låst
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Oplysningsetiket
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Fremhævet
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Diskret

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Oplysningsetiket'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Fremhævet',
         subtle: 'Diskret'

--- a/libs/i18n/src/lib/translations/translations_de.properties
+++ b/libs/i18n/src/lib/translations/translations_de.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Gesperrt
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Info-Label
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Hervorgehoben
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Subtil

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Info-Label'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Hervorgehoben',
         subtle: 'Subtil'

--- a/libs/i18n/src/lib/translations/translations_el.properties
+++ b/libs/i18n/src/lib/translations/translations_el.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Κλειδωμένο
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Ετικέτα Πληροφοριών
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Τονισμένο
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Διακριτικό

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Ετικέτα Πληροφοριών'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Τονισμένο',
         subtle: 'Διακριτικό'

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=[[[Ļŏċķēƌ∙∙∙∙∙∙∙∙]]]
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=[[[Ĭŋƒŏ Ļąƃēĺ∙∙∙∙]]]
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=[[[Ĕɱρĥąşįžēƌ∙∙∙∙]]]
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=[[[Ŝűƃţĺē∙∙∙∙∙∙∙∙]]]

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: '[[[Ĭŋƒŏ Ļąƃēĺ∙∙∙∙]]]'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: '[[[Ĕɱρĥąşįžēƌ∙∙∙∙]]]',
         subtle: '[[[Ŝűƃţĺē∙∙∙∙∙∙∙∙]]]'

--- a/libs/i18n/src/lib/translations/translations_es.properties
+++ b/libs/i18n/src/lib/translations/translations_es.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Bloqueado
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Etiqueta de información
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Destacado
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Discreto

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Etiqueta de información'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Destacado',
         subtle: 'Discreto'

--- a/libs/i18n/src/lib/translations/translations_fi.properties
+++ b/libs/i18n/src/lib/translations/translations_fi.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Lukittu
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Infoetiketti
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Korostettu
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Hillitty

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Infoetiketti'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Korostettu',
         subtle: 'Hillitty'

--- a/libs/i18n/src/lib/translations/translations_fr.properties
+++ b/libs/i18n/src/lib/translations/translations_fr.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Verrouillé
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Étiquette d'information
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Mis en évidence
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Subtil

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: "Étiquette d'information"
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Mis en évidence',
         subtle: 'Subtil'

--- a/libs/i18n/src/lib/translations/translations_he.properties
+++ b/libs/i18n/src/lib/translations/translations_he.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=נעול
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=תווית מידע
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=מודגש
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=עדין

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'תווית מידע'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'מודגש',
         subtle: 'עדין'

--- a/libs/i18n/src/lib/translations/translations_hi.properties
+++ b/libs/i18n/src/lib/translations/translations_hi.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked = बंद
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText = Info Label
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized = Emphasized
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle = Subtle

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Info Label'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Emphasized',
         subtle: 'Subtle'

--- a/libs/i18n/src/lib/translations/translations_hr.properties
+++ b/libs/i18n/src/lib/translations/translations_hr.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Zaključano
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Oznaka informacija
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Naglašeno
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Rafinirano

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Oznaka informacija'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Naglašeno',
         subtle: 'Rafinirano'

--- a/libs/i18n/src/lib/translations/translations_hu.properties
+++ b/libs/i18n/src/lib/translations/translations_hu.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Zárolva
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Infócímke
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Kiemelt
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Nem kiemelt

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Infócímke'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Kiemelt',
         subtle: 'Nem kiemelt'

--- a/libs/i18n/src/lib/translations/translations_it.properties
+++ b/libs/i18n/src/lib/translations/translations_it.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Bloccato
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Etichetta informativa
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Evidenziato
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Discreto

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Etichetta informativa'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Evidenziato',
         subtle: 'Discreto'

--- a/libs/i18n/src/lib/translations/translations_iw.properties
+++ b/libs/i18n/src/lib/translations/translations_iw.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=נעול
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=תווית מידע
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=מודגש
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=עדין

--- a/libs/i18n/src/lib/translations/translations_iw.ts
+++ b/libs/i18n/src/lib/translations/translations_iw.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'תווית מידע'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'מודגש',
         subtle: 'עדין'

--- a/libs/i18n/src/lib/translations/translations_ja.properties
+++ b/libs/i18n/src/lib/translations/translations_ja.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=ロック済み
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=情報ラベル
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=強調
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=淡色

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: '情報ラベル'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: '強調',
         subtle: '淡色'

--- a/libs/i18n/src/lib/translations/translations_ka.properties
+++ b/libs/i18n/src/lib/translations/translations_ka.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked = დაბლოკილი
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText = Info Label
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized = Emphasized
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle = Subtle

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Info Label'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Emphasized',
         subtle: 'Subtle'

--- a/libs/i18n/src/lib/translations/translations_kk.properties
+++ b/libs/i18n/src/lib/translations/translations_kk.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Құлыпталды
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Ақпараттық белгі
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Ерекшеленген
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Білінбейтін

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Ақпараттық белгі'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Ерекшеленген',
         subtle: 'Білінбейтін'

--- a/libs/i18n/src/lib/translations/translations_ko.properties
+++ b/libs/i18n/src/lib/translations/translations_ko.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=잠김
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=정보 레이블
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=강조됨
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=미약

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: '정보 레이블'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: '강조됨',
         subtle: '미약'

--- a/libs/i18n/src/lib/translations/translations_ms.properties
+++ b/libs/i18n/src/lib/translations/translations_ms.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Dikunci
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Label Maklumat
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Diserlahkan
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Tak Ketara

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Label Maklumat'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Diserlahkan',
         subtle: 'Tak Ketara'

--- a/libs/i18n/src/lib/translations/translations_nl.properties
+++ b/libs/i18n/src/lib/translations/translations_nl.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Vergrendeld
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Infolabel
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Benadrukt
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Subtiel

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Infolabel'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Benadrukt',
         subtle: 'Subtiel'

--- a/libs/i18n/src/lib/translations/translations_no.properties
+++ b/libs/i18n/src/lib/translations/translations_no.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Sperret
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Infoetikett
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Uthevet
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Subtil

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Infoetikett'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Uthevet',
         subtle: 'Subtil'

--- a/libs/i18n/src/lib/translations/translations_pl.properties
+++ b/libs/i18n/src/lib/translations/translations_pl.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Zablokowane
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Etykieta informacyjna
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Wyróżniony
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Delikatny

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Etykieta informacyjna'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Wyróżniony',
         subtle: 'Delikatny'

--- a/libs/i18n/src/lib/translations/translations_pt.properties
+++ b/libs/i18n/src/lib/translations/translations_pt.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Bloqueado
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Rótulo de informação
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Realçado
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Discreto

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Rótulo de informação'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Realçado',
         subtle: 'Discreto'

--- a/libs/i18n/src/lib/translations/translations_ro.properties
+++ b/libs/i18n/src/lib/translations/translations_ro.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Blocat
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Etichetă informații
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Evidențiat
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Discret

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Etichetă informații'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Evidențiat',
         subtle: 'Discret'

--- a/libs/i18n/src/lib/translations/translations_ru.properties
+++ b/libs/i18n/src/lib/translations/translations_ru.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Заблокировано
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Информационная метка
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Выделенная
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Незаметная

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Информационная метка'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Выделенная',
         subtle: 'Незаметная'

--- a/libs/i18n/src/lib/translations/translations_sh.properties
+++ b/libs/i18n/src/lib/translations/translations_sh.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Zaključano
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Info oznaka
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Naglašeno
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Suptilno

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Info oznaka'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Naglašeno',
         subtle: 'Suptilno'

--- a/libs/i18n/src/lib/translations/translations_sk.properties
+++ b/libs/i18n/src/lib/translations/translations_sk.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Blokované
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Označenie s informáciami
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Zvýraznené
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Jednoduché

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Označenie s informáciami'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Zvýraznené',
         subtle: 'Jednoduché'

--- a/libs/i18n/src/lib/translations/translations_sl.properties
+++ b/libs/i18n/src/lib/translations/translations_sl.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Zaklenjeno
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Infooznaka
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Izpostavljeno
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Neizpostavljeno

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -114,6 +114,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Infooznaka'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Izpostavljeno',
         subtle: 'Neizpostavljeno'

--- a/libs/i18n/src/lib/translations/translations_sq.properties
+++ b/libs/i18n/src/lib/translations/translations_sq.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked = I kyçur
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText = Info Label
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized = Emphasized
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle = Subtle

--- a/libs/i18n/src/lib/translations/translations_sq.ts
+++ b/libs/i18n/src/lib/translations/translations_sq.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Info Label'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Emphasized',
         subtle: 'Subtle'

--- a/libs/i18n/src/lib/translations/translations_sv.properties
+++ b/libs/i18n/src/lib/translations/translations_sv.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Låst
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Infoetikett
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Markerad
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Diskret

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Infoetikett'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Markerad',
         subtle: 'Diskret'

--- a/libs/i18n/src/lib/translations/translations_th.properties
+++ b/libs/i18n/src/lib/translations/translations_th.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=ถูกล็อค
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=ป้ายชื่อข้อมูล
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=เน้น
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=ไม่เน้น

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'ป้ายชื่อข้อมูล'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'เน้น',
         subtle: 'ไม่เน้น'

--- a/libs/i18n/src/lib/translations/translations_tr.properties
+++ b/libs/i18n/src/lib/translations/translations_tr.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Kilitli
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Bilgi Etiketi
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Vurgulu
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=İnce

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Bilgi Etiketi'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Vurgulu',
         subtle: 'İnce'

--- a/libs/i18n/src/lib/translations/translations_uk.properties
+++ b/libs/i18n/src/lib/translations/translations_uk.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=Заблоковано
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=Інформаційна мітка
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=Підкреслено
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=Приховано

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: 'Інформаційна мітка'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: 'Підкреслено',
         subtle: 'Приховано'

--- a/libs/i18n/src/lib/translations/translations_zh_CN.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=已锁定
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=信息标签
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=已强调
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=隐蔽

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -112,6 +112,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: '信息标签'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: '已强调',
         subtle: '隐蔽'

--- a/libs/i18n/src/lib/translations/translations_zh_TW.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.properties
@@ -155,6 +155,8 @@ coreGridList.listItemStatusLocked=已鎖定
 #XACT: Screen reader announcement for the info label
 coreInfoLabel.srOnlyText=資訊標籤
 #XACT: Screen reader text explaining that link is emphasized
+coreList.listItemSelectedAriaLabel = Selected
+coreList.listItemNotSelectedAriaLabel = Not Selected
 coreLink.emphasized=強調
 #XACT: Screen reader text explaining that link is subtle
 coreLink.subtle=輕微

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -113,6 +113,10 @@ export default {
     coreInfoLabel: {
         srOnlyText: '資訊標籤'
     },
+    coreList: {
+        listItemSelectedAriaLabel: 'Selected',
+        listItemNotSelectedAriaLabel: 'Not Selected'
+    },
     coreLink: {
         emphasized: '強調',
         subtle: '輕微'


### PR DESCRIPTION
## Related Issue(s)

closes [#14316](https://github.com/SAP/fundamental-ngx/issues/14316)

## Description

### Problem

When `fd-list` is used in selection mode, screen readers do not announce whether a list item is selected. Navigating to a selected item produces no "Selected" announcement.

### Root cause

`aria-selected` alone is not sufficient — some screen reader / browser combinations [don't announce it](https://stackoverflow.com/questions/71468332/select2-li-aria-selected-true-is-not-read-as-selected-by-screen-reader) for `role="listitem"` elements, or announce it multiple times when combined with inner checkbox state.

### Fix

 **`aria-describedby` span** — a visually-hidden `<span>` inside each selectable list item shows "Selected" or "Not Selected". The host `<li>` references it via `aria-describedby`, so the state is announced once when the item receives focus.


The span is only announced when the parent list has `[selection]="true"`. Plain list items (icon lists, link lists, etc.) are unaffected.

## Changed files

| File                                                           | Change                                                                                                                                                                                                                                                      |
| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `libs/core/list/list-item/list-item.component.html`            | Conditionally rendered hidden span with "Selected" / "Not Selected"; only shown for selectable items                                                                                                                                                        |
| `libs/core/list/list-item/list-item.component.ts`              | `aria-describedby` on host, `_selectionDescribedById` / `_isSelectable` getters,`_syncSelectionFromControl()`, inject `FD_LIST_COMPONENT`, `FdTranslatePipe` and `resolveTranslationSignal` imports |
| `libs/core/list/list-item/list-item.component.spec.ts`         | Tests for sr-only span presence, `aria-describedby` wiring, correct text on toggle                                                                                                                                               |
| `libs/core/list/list-component.interface.ts`                   | Expose existing `selection` property on the interface so list items can read it                                                                                                                                                                             |
| `libs/core/list/list.component.scss`                           | Add `.fd-list__item--sr-only` visually-hidden CSS class                                                                                                                                                                                                     |
| `libs/i18n/src/lib/models/fd-language.ts`                      | New `coreList` section with `listItemSelectedAriaLabel` and `listItemNotSelectedAriaLabel`                                                                                                                                                                  |
| `libs/i18n/src/lib/models/fd-language-key-identifier.ts`       | Register both new keys                                                                                                                                                                                                                                      |
| `libs/i18n/src/lib/translations/translations.ts` + all locales | `coreList: { listItemSelectedAriaLabel: 'Selected', listItemNotSelectedAriaLabel: 'Not Selected' }`                                                                                                                                                         |


## Screenshots

### Before:

<img width="387" height="179" alt="Screenshot 2026-06-30 at 17 04 19" src="https://github.com/user-attachments/assets/4ad0f36f-0fa0-43a0-a31f-741959902f3d" />
<img width="406" height="197" alt="Screenshot 2026-06-30 at 17 05 23" src="https://github.com/user-attachments/assets/85f13d6b-800a-4f2d-b995-f411c5374f2e" />

### After:

<img width="404" height="167" alt="Screenshot 2026-06-30 at 17 02 24" src="https://github.com/user-attachments/assets/e90839b6-22a9-45b1-8048-0aad98c64d80" />
<img width="403" height="174" alt="Screenshot 2026-06-30 at 17 02 54" src="https://github.com/user-attachments/assets/1a175949-54ef-4422-857d-bbae93419728" />






