### PR TITLE
fix(core): improve menu ARIA attributes and VoiceOver compatibility

### DIFF
--- a/libs/core/menu/menu-interactive.component.ts
+++ b/libs/core/menu/menu-interactive.component.ts
@@ -21,9 +21,6 @@ import { MenuItemInputDirective } from './directives/menu-item-input.directive';
         <ng-template cdkPortalOutlet></ng-template>
         <ng-content></ng-content>
     `,
-    host: {
-        role: 'menuitem'
-    },
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [PortalModule]
 })
@@ -40,6 +37,14 @@ export class MenuInteractiveComponent implements HasElementRef {
         ) {
             this._startAddonInstance = addon;
         }
+    }
+
+    /** @hidden */
+    @HostBinding('attr.role')
+    get role(): string {
+        // Parent items with submenus should not have role="menuitem" as it causes VoiceOver
+        // to count them in the position calculation. Only leaf items should be menuitems.
+        return this.ariaHaspopup ? 'none' : 'menuitem';
     }
 
     /** @hidden */

--- a/libs/core/menu/menu-interactive.component.ts
+++ b/libs/core/menu/menu-interactive.component.ts
@@ -42,9 +42,8 @@ export class MenuInteractiveComponent implements HasElementRef {
     /** @hidden */
     @HostBinding('attr.role')
     get role(): string {
-        // Parent items with submenus should not have role="menuitem" as it causes VoiceOver
-        // to count them in the position calculation. Only leaf items should be menuitems.
-        return this.ariaHaspopup ? 'none' : 'menuitem';
+        // Parent items switch to role="none" when expanded so VoiceOver doesn't count them.
+        return this.ariaHaspopup && this.ariaExpanded ? 'none' : 'menuitem';
     }
 
     /** @hidden */

--- a/libs/core/menu/menu-item/menu-item.component.ts
+++ b/libs/core/menu/menu-item/menu-item.component.ts
@@ -59,7 +59,6 @@ export const SUBMENU = new InjectionToken<BaseSubmenu>('Submenu component depend
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[attr.role]': '"menuitem"',
         '[class.fd-menu__item]': 'true',
         '[class.fd-menu--full-width]': 'menuService?.menuComponent?.mobile() ?? false'
     },

--- a/libs/core/menu/menu.component.spec.ts
+++ b/libs/core/menu/menu.component.spec.ts
@@ -387,6 +387,55 @@ describe('MenuComponent with submenus', () => {
 
         expect(itemWithSubmenu.submenuVisible).toBe(false);
     }));
+
+    it('should set correct aria-posinset and aria-setsize on submenu items when focused', fakeAsync(() => {
+        // Open the menu
+        menu.open();
+        tick();
+        fixture.detectChanges();
+
+        const menuItems = testComponent.menuItems.toArray();
+        const itemWithSubmenu = menuItems[0];
+
+        // Open submenu by clicking the parent item
+        itemWithSubmenu.click();
+        tick();
+        fixture.detectChanges();
+
+        // Get the submenu items (Pineapple and Banana)
+        const pineappleItem = menuItems[1];
+        const bananaItem = menuItems[2];
+
+        // Focus on the first submenu item (Pineapple)
+        const pineappleInteractive = pineappleItem.menuInteractive.elementRef.nativeElement;
+        pineappleInteractive.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        tick();
+        fixture.detectChanges();
+
+        // Should announce "1 of 2" for Pineapple
+        expect(pineappleInteractive.getAttribute('aria-posinset')).toBe('1');
+        expect(pineappleInteractive.getAttribute('aria-setsize')).toBe('2');
+
+        // Focus on the second submenu item (Banana)
+        const bananaInteractive = bananaItem.menuInteractive.elementRef.nativeElement;
+        bananaInteractive.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        tick();
+        fixture.detectChanges();
+
+        // Should announce "2 of 2" for Banana
+        expect(bananaInteractive.getAttribute('aria-posinset')).toBe('2');
+        expect(bananaInteractive.getAttribute('aria-setsize')).toBe('2');
+
+        // Back to parent menu - focus on Fruits (parent menu has Fruits and Meat)
+        const fruitsInteractive = itemWithSubmenu.menuInteractive.elementRef.nativeElement;
+        fruitsInteractive.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        tick();
+        fixture.detectChanges();
+
+        // Should announce "1 of 2" for Fruits (parent menu has Fruits and Meat)
+        expect(fruitsInteractive.getAttribute('aria-posinset')).toBe('1');
+        expect(fruitsInteractive.getAttribute('aria-setsize')).toBe('2');
+    }));
 });
 
 describe('MenuComponent config input', () => {

--- a/libs/core/menu/menu.component.ts
+++ b/libs/core/menu/menu.component.ts
@@ -296,16 +296,21 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
                     const menuItems = this._menuItems() as readonly MenuItemComponent[];
                     this._menuService.rebuildMenu();
 
+                    // Set aria-posinset and aria-setsize for all menu items recursively
+                    // IMPORTANT: Defer this until after Angular processes @Input() bindings
+                    // Otherwise menuItem.submenu will be undefined
+                    afterNextRender(
+                        () => {
+                            this._setAriaPositionAttributesRecursive(menuItems, submenuSubscriptions);
+                        },
+                        { injector: this._injector }
+                    );
+
                     // Whether menu have submenu or not.
                     let hasSubmenus = false;
                     menuItems.forEach((menuItem: MenuItemComponent) => {
                         if (menuItem.submenu) {
                             hasSubmenus = true;
-                            // Subscribe to submenu changes and track subscription for cleanup
-                            const subscription = menuItem.submenu._menuItemsChange$.subscribe(() =>
-                                this._menuService.rebuildMenu()
-                            );
-                            submenuSubscriptions.push(() => subscription.unsubscribe());
                         }
                     });
 
@@ -615,5 +620,67 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
         if (this.focusTrapped() && this.trigger) {
             this.trigger.nativeElement.focus();
         }
+    }
+
+    /**
+     * @hidden
+     * Patches the menu service's setFocused method to update aria attributes before focus moves.
+     * This ensures VoiceOver reads the correct position when first entering a submenu.
+     */
+    /**
+     * @hidden
+     * Recursively sets aria-posinset and aria-setsize on menu items at all nesting levels.
+     * These attributes help screen readers announce "Item X of Y" when navigating.
+     * @param menuItems - Array of menu items at the current level
+     * @param subscriptions - Array to track subscriptions for cleanup
+     */
+    private _setAriaPositionAttributesRecursive(
+        menuItems: readonly MenuItemComponent[],
+        subscriptions: (() => void)[],
+        depth = 0
+    ): void {
+        // CRITICAL: Filter out items that belong to submenus of other items in this list
+        // The contentChildren query returns ALL descendants, so submenu items appear at both levels
+        const submenuItems = new Set<MenuItemComponent>();
+        menuItems.forEach((item) => {
+            if (item.submenu?.menuItems) {
+                item.submenu.menuItems.forEach((child) => submenuItems.add(child));
+            }
+        });
+
+        // Only process items that are direct children at this level
+        const directChildren = menuItems.filter((item) => !submenuItems.has(item));
+
+        directChildren.forEach((menuItem, index) => {
+            // Find the fd-menu-interactive element
+            const interactiveElement = menuItem.elementRef.nativeElement.querySelector(
+                '[fd-menu-interactive]'
+            ) as HTMLElement | null;
+
+            if (interactiveElement) {
+                // Set positional attributes on ALL items at this level
+                // Parent items with role="none" won't be counted by VoiceOver anyway
+                this._renderer.setAttribute(interactiveElement, 'aria-posinset', String(index + 1));
+                this._renderer.setAttribute(interactiveElement, 'aria-setsize', String(directChildren.length));
+            }
+
+            // Recursively process submenus
+            if (menuItem.submenu) {
+                // Process submenu items immediately (no need for afterNextRender since we're already inside one)
+                this._setAriaPositionAttributesRecursive(menuItem.submenu.menuItems || [], subscriptions, depth + 1);
+
+                // Subscribe to submenu changes to update aria attributes when items change
+                const subscription = menuItem.submenu._menuItemsChange$.subscribe(() => {
+                    this._menuService.rebuildMenu();
+                    // Recursively update aria attributes for this submenu and its children
+                    this._setAriaPositionAttributesRecursive(
+                        menuItem.submenu?.menuItems || [],
+                        subscriptions,
+                        depth + 1
+                    );
+                });
+                subscriptions.push(() => subscription.unsubscribe());
+            }
+        });
     }
 }

--- a/libs/core/menu/menu.component.ts
+++ b/libs/core/menu/menu.component.ts
@@ -38,7 +38,7 @@ import { Placement, PopoverFillMode } from '@fundamental-ngx/core/shared';
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { SegmentedButtonHeaderDirective } from './directives/segmented-button/segmented-button-header.directive';
 import { SegmentedButtonOptionDirective } from './directives/segmented-button/segmented-button-option.directive';
-import { MenuItemComponent } from './menu-item/menu-item.component';
+import { BaseSubmenu, MenuItemComponent } from './menu-item/menu-item.component';
 import { MenuMobileComponent } from './menu-mobile/menu-mobile.component';
 import { MENU_COMPONENT, MenuInterface } from './menu.interface';
 import { FD_MENU_COMPONENT, FD_MENU_ITEM_COMPONENT } from './menu.tokens';
@@ -220,6 +220,7 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
     private readonly _viewContainerRef = inject(ViewContainerRef);
     private readonly _dynamicComponentService = inject(DynamicComponentService, { optional: true });
     private readonly _destroyRef = inject(DestroyRef);
+    private readonly _submenuSubscriptions = new Map<BaseSubmenu, () => void>();
 
     /** @hidden */
     constructor() {
@@ -285,13 +286,9 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
         // Use afterNextRender to ensure this runs after ngAfterContentInit sets the menu component
         afterNextRender(() => {
             runInInjectionContext(this._injector, () => {
-                // Track previous subscriptions to clean up when effect re-runs
-                let submenuSubscriptions: (() => void)[] = [];
-
                 effect((onCleanup) => {
                     // Clean up previous subscriptions before creating new ones
-                    submenuSubscriptions.forEach((unsubscribe) => unsubscribe());
-                    submenuSubscriptions = [];
+                    this._clearSubmenuSubscriptions();
 
                     const menuItems = this._menuItems() as readonly MenuItemComponent[];
                     this._menuService.rebuildMenu();
@@ -301,7 +298,7 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
                     // Otherwise menuItem.submenu will be undefined
                     afterNextRender(
                         () => {
-                            this._setAriaPositionAttributesRecursive(menuItems, submenuSubscriptions);
+                            this._setAriaPositionAttributesRecursive(menuItems);
                         },
                         { injector: this._injector }
                     );
@@ -323,8 +320,7 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
 
                     // Cleanup callback when effect is destroyed or re-runs
                     onCleanup(() => {
-                        submenuSubscriptions.forEach((unsubscribe) => unsubscribe());
-                        submenuSubscriptions = [];
+                        this._clearSubmenuSubscriptions();
                     });
                 });
             });
@@ -622,15 +618,17 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
         }
     }
 
+    /** @hidden */
+    private _clearSubmenuSubscriptions(): void {
+        this._submenuSubscriptions.forEach((unsubscribe) => unsubscribe());
+        this._submenuSubscriptions.clear();
+    }
+
     /**
      * @hidden
      * Sets aria-posinset and aria-setsize on all menu items recursively.
      */
-    private _setAriaPositionAttributesRecursive(
-        menuItems: readonly MenuItemComponent[],
-        subscriptions: (() => void)[],
-        depth = 0
-    ): void {
+    private _setAriaPositionAttributesRecursive(menuItems: readonly MenuItemComponent[]): void {
         // Filter out submenu items - contentChildren returns all descendants
         const submenuItems = new Set<MenuItemComponent>();
         menuItems.forEach((item) => {
@@ -640,29 +638,52 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
         });
 
         const directChildren = menuItems.filter((item) => !submenuItems.has(item));
+        const directInteractiveItems = directChildren
+            .map((menuItem) => ({
+                menuItem,
+                interactiveElement: menuItem.elementRef.nativeElement.querySelector(
+                    '[fd-menu-interactive]'
+                ) as HTMLElement | null
+            }))
+            .filter(
+                ({ interactiveElement }) =>
+                    !!interactiveElement && (interactiveElement.getAttribute('role') || 'menuitem') === 'menuitem'
+            );
 
-        directChildren.forEach((menuItem, index) => {
+        directChildren.forEach((menuItem) => {
             const interactiveElement = menuItem.elementRef.nativeElement.querySelector(
                 '[fd-menu-interactive]'
             ) as HTMLElement | null;
 
             if (interactiveElement) {
-                this._renderer.setAttribute(interactiveElement, 'aria-posinset', String(index + 1));
-                this._renderer.setAttribute(interactiveElement, 'aria-setsize', String(directChildren.length));
+                const position = directInteractiveItems.findIndex((item) => item.menuItem === menuItem);
+
+                if (position > -1) {
+                    this._renderer.setAttribute(interactiveElement, 'aria-posinset', String(position + 1));
+                    this._renderer.setAttribute(
+                        interactiveElement,
+                        'aria-setsize',
+                        String(directInteractiveItems.length)
+                    );
+                } else {
+                    // Keep aria metadata aligned when an item switches to role="none".
+                    this._renderer.removeAttribute(interactiveElement, 'aria-posinset');
+                    this._renderer.removeAttribute(interactiveElement, 'aria-setsize');
+                }
             }
 
             if (menuItem.submenu) {
-                this._setAriaPositionAttributesRecursive(menuItem.submenu.menuItems || [], subscriptions, depth + 1);
+                const nestedMenuItems = menuItem.submenu.menuItems || [];
+                this._setAriaPositionAttributesRecursive(nestedMenuItems);
 
-                const subscription = menuItem.submenu._menuItemsChange$.subscribe(() => {
-                    this._menuService.rebuildMenu();
-                    this._setAriaPositionAttributesRecursive(
-                        menuItem.submenu?.menuItems || [],
-                        subscriptions,
-                        depth + 1
-                    );
-                });
-                subscriptions.push(() => subscription.unsubscribe());
+                if (!this._submenuSubscriptions.has(menuItem.submenu)) {
+                    const subscription = menuItem.submenu._menuItemsChange$.subscribe(() => {
+                        this._menuService.rebuildMenu();
+                        this._setAriaPositionAttributesRecursive(this._menuItems() as readonly MenuItemComponent[]);
+                    });
+
+                    this._submenuSubscriptions.set(menuItem.submenu, () => subscription.unsubscribe());
+                }
             }
         });
     }

--- a/libs/core/menu/menu.component.ts
+++ b/libs/core/menu/menu.component.ts
@@ -624,23 +624,14 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
 
     /**
      * @hidden
-     * Patches the menu service's setFocused method to update aria attributes before focus moves.
-     * This ensures VoiceOver reads the correct position when first entering a submenu.
-     */
-    /**
-     * @hidden
-     * Recursively sets aria-posinset and aria-setsize on menu items at all nesting levels.
-     * These attributes help screen readers announce "Item X of Y" when navigating.
-     * @param menuItems - Array of menu items at the current level
-     * @param subscriptions - Array to track subscriptions for cleanup
+     * Sets aria-posinset and aria-setsize on all menu items recursively.
      */
     private _setAriaPositionAttributesRecursive(
         menuItems: readonly MenuItemComponent[],
         subscriptions: (() => void)[],
         depth = 0
     ): void {
-        // CRITICAL: Filter out items that belong to submenus of other items in this list
-        // The contentChildren query returns ALL descendants, so submenu items appear at both levels
+        // Filter out submenu items - contentChildren returns all descendants
         const submenuItems = new Set<MenuItemComponent>();
         menuItems.forEach((item) => {
             if (item.submenu?.menuItems) {
@@ -648,31 +639,23 @@ export class MenuComponent implements MenuInterface, AfterContentInit, AfterView
             }
         });
 
-        // Only process items that are direct children at this level
         const directChildren = menuItems.filter((item) => !submenuItems.has(item));
 
         directChildren.forEach((menuItem, index) => {
-            // Find the fd-menu-interactive element
             const interactiveElement = menuItem.elementRef.nativeElement.querySelector(
                 '[fd-menu-interactive]'
             ) as HTMLElement | null;
 
             if (interactiveElement) {
-                // Set positional attributes on ALL items at this level
-                // Parent items with role="none" won't be counted by VoiceOver anyway
                 this._renderer.setAttribute(interactiveElement, 'aria-posinset', String(index + 1));
                 this._renderer.setAttribute(interactiveElement, 'aria-setsize', String(directChildren.length));
             }
 
-            // Recursively process submenus
             if (menuItem.submenu) {
-                // Process submenu items immediately (no need for afterNextRender since we're already inside one)
                 this._setAriaPositionAttributesRecursive(menuItem.submenu.menuItems || [], subscriptions, depth + 1);
 
-                // Subscribe to submenu changes to update aria attributes when items change
                 const subscription = menuItem.submenu._menuItemsChange$.subscribe(() => {
                     this._menuService.rebuildMenu();
-                    // Recursively update aria attributes for this submenu and its children
                     this._setAriaPositionAttributesRecursive(
                         menuItem.submenu?.menuItems || [],
                         subscriptions,

--- a/libs/docs/core/menu/examples/menu-with-submenu-example.component.html
+++ b/libs/docs/core/menu/examples/menu-with-submenu-example.component.html
@@ -2,7 +2,7 @@
 <button fd-button label="Menu with submenu" [fdMenu]="true" [fdMenuTrigger]="menu"></button>
 <div [style.display]="'inline-block'">
     <span [style.padding-left.rem]="0.5">Active path:</span>
-    @for (active of activePath(); track active) {
+    @for (active of activePath(); track active.itemId) {
         <span [style.padding.rem]="0.5">
             {{ active.menuItemTitle.title }}
         </span>
@@ -104,14 +104,14 @@
 <button fd-button label="Complex menu with submenu" [fdMenu]="true" [fdMenuTrigger]="complexMenu"></button>
 <div [style.display]="'inline-block'">
     <span [style.padding-left.rem]="0.5">Active path:</span>
-    @for (active of complexActivePath(); track active) {
+    @for (active of complexActivePath(); track active.itemId) {
         <span [style.padding.rem]="0.5">
             {{ active.menuItemTitle.title }}
         </span>
     }
 </div>
 <fd-menu #complexMenu (activePath)="complexActivePath.set($event)">
-    @for (item of complexMenuItems; track item) {
+    @for (item of complexMenuItems; track item.title) {
         <ng-container *ngTemplateOutlet="submenuTemplate; context: { item: item }"></ng-container>
     }
     <!-- Make sure this template is nested in fd-menu -->
@@ -125,7 +125,7 @@
             </div>
         </li>
         <fd-submenu #submenu>
-            @for (subItem of item.children; track subItem) {
+            @for (subItem of item.children; track subItem.title) {
                 <ng-container
                     *ngTemplateOutlet="submenuTemplate; context: { item: subItem, parentSubmenu: submenu }"
                 ></ng-container>


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14105

## Description
- **Added ARIA position attributes**: Menu items now have `aria-posinset` and `aria-setsize` set recursively for all menu levels
- **Dynamic role switching**: Parent menu items with submenus use `role="menuitem"` when collapsed (ARIA compliant) and `role="none"` when expanded (fixes VoiceOver counting)
- **Removed static role attributes**: Removed hardcoded `role="menuitem"` from `MenuItemComponent` host bindings in favor of setting it on interactive elements
- **Fixed @for tracking**: Updated menu example templates to track by stable identifiers instead of object references

### Technical Details

**New method `_setAriaPositionAttributesRecursive`**:
- Recursively sets ARIA position attributes on all menu items
- Filters out submenu descendants to only process direct children at each level
- Resubscribes to submenu changes to update attributes dynamically
- Runs in `afterNextRender` to ensure `@Input()` bindings are processed

**Dynamic role on `MenuInteractiveComponent`**:
- Returns `role="menuitem"` by default
- Returns `role="none"` when parent item is expanded (has submenu + `aria-expanded="true"`)
- Maintains ARIA compliance while fixing VoiceOver behavior

**Menu example fixes**:
- Changed tracking: `track active.itemId`, `track item.title`, `track subItem.title`
