### PR TITLE
fix(platform): f2 key should move focus in and out of child item on fdk focusable items

### DIFF
--- a/libs/cdk/utils/directives/focusable-item/focusable-item.directive.spec.ts
+++ b/libs/cdk/utils/directives/focusable-item/focusable-item.directive.spec.ts
@@ -316,6 +316,18 @@ describe('FocusableItemDirective', () => {
             expect(focusSpy).toHaveBeenCalled();
         });
 
+        it('should focus cell on F2 when child is focused (bidirectional toggle)', () => {
+            const childButton = element.querySelector('button') as HTMLElement;
+            childButton.focus();
+            const focusSpy = jest.spyOn(element, 'focus');
+
+            const event = new KeyboardEvent('keydown', { keyCode: F2, bubbles: true });
+            Object.defineProperty(event, 'keyCode', { value: F2 });
+            element.dispatchEvent(event);
+
+            expect(focusSpy).toHaveBeenCalled();
+        });
+
         it('should not handle keydown when not focusable', () => {
             directive.setFocusable(false);
             const keydownSpy = jest.fn();

--- a/libs/cdk/utils/directives/focusable-item/focusable-item.directive.ts
+++ b/libs/cdk/utils/directives/focusable-item/focusable-item.directive.ts
@@ -215,8 +215,7 @@ export class FocusableItemDirective implements FocusableItem, HasElementRef {
         const activeEl = this._document.activeElement;
         const isFocused = activeEl === this.elementRef.nativeElement;
         const shouldFocusChild = KeyUtil.isKeyCode(event, [ENTER, MAC_ENTER, F2]) && !event.shiftKey && isFocused;
-        const shouldFocusCell =
-            ((KeyUtil.isKeyCode(event, F2) && event.shiftKey) || KeyUtil.isKeyCode(event, ESCAPE)) && !isFocused;
+        const shouldFocusCell = KeyUtil.isKeyCode(event, [ESCAPE, F2]) && !isFocused;
 
         if (shouldFocusChild) {
             event.stopPropagation();


### PR DESCRIPTION
fixes #14117 