### PR TITLE
ci: disable npm provenance to fix publish failure

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -171,12 +171,14 @@ jobs:
             # - archive: for hotfix releases on older versions
             # - latest: for stable releases
             # IMPORTANT: Disable distributed execution for publishing (needs local dist/ files and npm auth)
+            # IMPORTANT: Disable provenance due to Node.js 22 + npm missing sigstore dependency issue
             - name: Publish packages to NPM using NX Release
               run: |
                   echo "📦 Publishing all packages with npm tag: ${{ steps.releaseTags.outputs.npm }}"
                   npx nx release publish --tag="${{ steps.releaseTags.outputs.npm }}" --registry=https://registry.npmjs.org/
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
+                  NPM_CONFIG_PROVENANCE: false
 
             # Create git commit and tag after successful build and publish
             # We do this here instead of during 'nx release version' to ensure we only commit

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ ng add @fundamental-ngx/core
 2. Add to `angular.json` assets:
     ```json
     { "glob": "**/css_variables.css", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/", "output": "./assets/theming-base/" },
-    { "glob": "**/*", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/", "output": "./assets/theming-base/baseTheme/fonts/" },
-    { "glob": "**/*", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/", "output": "./assets/theming-base/sap_horizon/fonts/" },
+    { "glob": "**/*", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/", "output": "./Base/baseLib/baseTheme/fonts/" },
+    { "glob": "**/*", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/", "output": "./Base/baseLib/sap_horizon/fonts/" },
     { "glob": "**/*", "input": "./node_modules/fundamental-styles/dist/theming/", "output": "./assets/fundamental-styles-theming/" }
     ```
 3. Add to `app.config.ts`:

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -48,12 +48,12 @@
                     {
                         "glob": "**/*",
                         "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/",
-                        "output": "./assets/theming-base/baseTheme/fonts/"
+                        "output": "./Base/baseLib/baseTheme/fonts/"
                     },
                     {
                         "glob": "**/*",
                         "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts",
-                        "output": "./assets/theming-base/sap_horizon/fonts/"
+                        "output": "./Base/baseLib/sap_horizon/fonts/"
                     },
                     {
                         "input": ".",

--- a/apps/e2e-harness/project.json
+++ b/apps/e2e-harness/project.json
@@ -53,12 +53,12 @@
                     {
                         "glob": "**/*",
                         "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts",
-                        "output": "./assets/theming-base/sap_horizon/fonts/"
+                        "output": "./Base/baseLib/sap_horizon/fonts/"
                     },
                     {
                         "glob": "**/*",
                         "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/",
-                        "output": "./assets/theming-base/baseTheme/fonts/"
+                        "output": "./Base/baseLib/baseTheme/fonts/"
                     },
                     {
                         "glob": "**/*",

--- a/libs/core/schematics/add-styles/add-styles.spec.ts
+++ b/libs/core/schematics/add-styles/add-styles.spec.ts
@@ -40,12 +40,12 @@ describe('add-styles schematic', () => {
                 {
                     glob: '**/*',
                     input: './node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/',
-                    output: './assets/theming-base/baseTheme/fonts/'
+                    output: './Base/baseLib/baseTheme/fonts/'
                 },
                 {
                     glob: '**/*',
                     input: './node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/',
-                    output: './assets/theming-base/sap_horizon/fonts/'
+                    output: './Base/baseLib/sap_horizon/fonts/'
                 },
                 {
                     glob: '**/*',

--- a/libs/core/schematics/add-styles/index.ts
+++ b/libs/core/schematics/add-styles/index.ts
@@ -51,12 +51,12 @@ function addAssetsToConfig(options: Schema): Rule {
                 {
                     glob: '**/*',
                     input: './node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/',
-                    output: './assets/theming-base/baseTheme/fonts/'
+                    output: './Base/baseLib/baseTheme/fonts/'
                 },
                 {
                     glob: '**/*',
                     input: './node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/',
-                    output: './assets/theming-base/sap_horizon/fonts/'
+                    output: './Base/baseLib/sap_horizon/fonts/'
                 },
                 {
                     glob: '**/*',

--- a/libs/docs/GETTING_STARTED.md
+++ b/libs/docs/GETTING_STARTED.md
@@ -101,8 +101,8 @@ See the [Theming guide](https://sap.github.io/fundamental-ngx/#/core/theming) fo
 2. Add to `angular.json` assets:
     ```json
     { "glob": "**/css_variables.css", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/", "output": "./assets/theming-base/" },
-    { "glob": "**/*", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/", "output": "./assets/theming-base/baseTheme/fonts/" },
-    { "glob": "**/*", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/", "output": "./assets/theming-base/sap_horizon/fonts/" },
+    { "glob": "**/*", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/", "output": "./Base/baseLib/baseTheme/fonts/" },
+    { "glob": "**/*", "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/", "output": "./Base/baseLib/sap_horizon/fonts/" },
     { "glob": "**/*", "input": "./node_modules/fundamental-styles/dist/theming/", "output": "./assets/fundamental-styles-theming/" }
     ```
 3. Add to `app.config.ts`:

--- a/libs/docs/core/theming/theming-header/theming-header.component.ts
+++ b/libs/docs/core/theming/theming-header/theming-header.component.ts
@@ -33,12 +33,12 @@ export class ThemingHeaderComponent {
 {
     "glob": "**/*",
     "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/",
-    "output": "./assets/theming-base/baseTheme/fonts/"
+    "output": "./Base/baseLib/baseTheme/fonts/"
 },
 {
     "glob": "**/*",
     "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/",
-    "output": "./assets/theming-base/sap_horizon/fonts/"
+    "output": "./Base/baseLib/sap_horizon/fonts/"
 }`,
         language: 'json'
     };

--- a/libs/docs/shared/src/lib/core-helpers/stackblitz/code-example-stack/angular.json
+++ b/libs/docs/shared/src/lib/core-helpers/stackblitz/code-example-stack/angular.json
@@ -31,12 +31,12 @@
                             {
                                 "glob": "**/*",
                                 "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/baseTheme/fonts/",
-                                "output": "./assets/theming-base/baseTheme/fonts/"
+                                "output": "./Base/baseLib/baseTheme/fonts/"
                             },
                             {
                                 "glob": "**/*",
                                 "input": "./node_modules/@sap-theming/theming-base-content/content/Base/baseLib/sap_horizon/fonts/",
-                                "output": "./assets/theming-base/sap_horizon/fonts/"
+                                "output": "./Base/baseLib/sap_horizon/fonts/"
                             },
                             {
                                 "glob": "**/*",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@angular/router": "21.1.0",
         "@fundamental-styles/cx": "0.41.8",
         "@nx/angular": "22.4.1",
-        "@sap-theming/theming-base-content": "11.36.3",
+        "@sap-theming/theming-base-content": "11.36.4",
         "@stackblitz/sdk": "1.9.0",
         "@swc/helpers": "0.5.11",
         "@ui5/tooling-webc": "~0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7921,13 +7921,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sap-theming/theming-base-content@npm:11.36.3":
-  version: 11.36.3
-  resolution: "@sap-theming/theming-base-content@npm:11.36.3"
-  checksum: 10/96eb3ac14829c7df486bd44bf8e989e9e4b147c6786e794b07755919c344ba3020bae19bd30154178467f509536a1a7dcfb99b2972fd0e1fc76b5bd5d3d0e402
-  languageName: node
-  linkType: hard
-
 "@sap-theming/theming-base-content@npm:11.36.4, @sap-theming/theming-base-content@npm:^11.36.0":
   version: 11.36.4
   resolution: "@sap-theming/theming-base-content@npm:11.36.4"
@@ -17753,7 +17746,7 @@ __metadata:
     "@nx/plugin": "npm:22.4.1"
     "@nx/workspace": "npm:22.4.1"
     "@playwright/test": "npm:^1.59.1"
-    "@sap-theming/theming-base-content": "npm:11.36.3"
+    "@sap-theming/theming-base-content": "npm:11.36.4"
     "@schematics/angular": "npm:21.1.0"
     "@stackblitz/sdk": "npm:1.9.0"
     "@swc-node/register": "npm:1.9.2"


### PR DESCRIPTION
## Problem

The release workflow for PR #14339 failed with:
```
Cannot find module 'sigstore'
```

This is a known issue with Node.js 22 + npm 11.x where the `sigstore` dependency is missing from npm's bundled dependencies, breaking provenance attestation.

## Solution

Disable npm provenance by setting `NPM_CONFIG_PROVENANCE=false` in the publish step until the upstream npm/sigstore issue is resolved.

## Refs

- Failed run: https://github.com/SAP/fundamental-ngx/actions/runs/29022812071
- Related: npm/cli#7657, npm/cli#7096

## Testing

This change will be verified when the workflow runs successfully after merge.