### PR TITLE
chore(ci): disable npm provenance to fix publish failure

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -171,12 +171,14 @@ jobs:
             # - archive: for hotfix releases on older versions
             # - latest: for stable releases
             # IMPORTANT: Disable distributed execution for publishing (needs local dist/ files and npm auth)
+            # IMPORTANT: Disable provenance due to Node.js 22 + npm missing sigstore dependency issue
             - name: Publish packages to NPM using NX Release
               run: |
                   echo "📦 Publishing all packages with npm tag: ${{ steps.releaseTags.outputs.npm }}"
                   npx nx release publish --tag="${{ steps.releaseTags.outputs.npm }}" --registry=https://registry.npmjs.org/
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
+                  NPM_CONFIG_PROVENANCE: false
 
             # Create git commit and tag after successful build and publish
             # We do this here instead of during 'nx release version' to ensure we only commit


### PR DESCRIPTION
## Problem

The release workflow for PR #14339 failed during npm publish with:
```
Cannot find module 'sigstore'
```

This is a known issue with Node.js 22 + npm 11.x where the `sigstore` dependency is missing from npm's bundled dependencies, breaking provenance attestation during publish.

## Solution

Disable npm provenance by setting `NPM_CONFIG_PROVENANCE=false` in the publish step until the upstream npm/sigstore issue is resolved.

## Impact

- ✅ Allows packages to be published successfully
- ⚠️ Temporarily disables npm provenance attestation (can be re-enabled once npm fixes the sigstore issue)

## References

- Failed workflow run: https://github.com/SAP/fundamental-ngx/actions/runs/29022812071
- Related upstream issues: npm/cli#7657, npm/cli#7096

## Testing

This change will be verified when the release workflow runs successfully after merge.