### PR TITLE
chore(ci): set npm provenance config directly before publish

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -161,7 +161,9 @@ jobs:
               run: node scripts/reset-placeholders.js
 
             - name: Configure npm for trusted publishing
-              run: npm config delete //registry.npmjs.org/:_authToken || true
+              run: |
+                  npm config delete //registry.npmjs.org/:_authToken || true
+                  npm config set provenance false
 
             # Use NX Release to publish all packages at once
             # Authentication is handled via npm 11.5.0+ auto-OIDC (detects GitHub Actions + id-token: write)
@@ -171,14 +173,12 @@ jobs:
             # - archive: for hotfix releases on older versions
             # - latest: for stable releases
             # IMPORTANT: Disable distributed execution for publishing (needs local dist/ files and npm auth)
-            # IMPORTANT: Disable provenance due to Node.js 22 + npm missing sigstore dependency issue
             - name: Publish packages to NPM using NX Release
               run: |
                   echo "📦 Publishing all packages with npm tag: ${{ steps.releaseTags.outputs.npm }}"
                   npx nx release publish --tag="${{ steps.releaseTags.outputs.npm }}" --registry=https://registry.npmjs.org/
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
-                  NPM_CONFIG_PROVENANCE: false
 
             # Create git commit and tag after successful build and publish
             # We do this here instead of during 'nx release version' to ensure we only commit


### PR DESCRIPTION
## Problem

After merging #14341, the release workflow still failed with the same sigstore error. The `NPM_CONFIG_PROVENANCE` environment variable wasn't being respected by npm when invoked through Yarn/NX.

## Root Cause

The project uses Yarn 4, which internally calls npm for publishing. The environment variable approach doesn't reliably propagate through this chain.

## Solution

Set npm config directly using `npm config set provenance false` before the publish step. This ensures npm picks up the config regardless of how it's invoked (directly, through Yarn, or through NX).

## Changes

- Modified the "Configure npm for trusted publishing" step to explicitly set `provenance=false` in npm config
- Removed the `NPM_CONFIG_PROVENANCE` environment variable (no longer needed)

## Testing

This will be verified when the workflow runs successfully after merge.