### PR TITLE
chore(ci): set npm provenance config globally and explicitly in .npmrc

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -160,10 +160,12 @@ jobs:
             - name: Reset dependency placeholders after pack
               run: node scripts/reset-placeholders.js
 
-            - name: Configure npm for trusted publishing
+            - name: Configure npm to disable provenance
               run: |
                   npm config delete //registry.npmjs.org/:_authToken || true
-                  npm config set provenance false
+                  npm config set provenance false --location=global
+                  echo "provenance=false" >> ~/.npmrc
+                  cat ~/.npmrc
 
             # Use NX Release to publish all packages at once
             # Authentication is handled via npm 11.5.0+ auto-OIDC (detects GitHub Actions + id-token: write)


### PR DESCRIPTION
## Summary
Fixes the npm publish failure by setting `provenance=false` both globally and directly in `~/.npmrc` to ensure npm respects the configuration regardless of how it's invoked through Yarn/NX.

## Root Cause
npm 11.x + Node.js 22 has a missing `sigstore` module dependency that breaks provenance attestation. Previous attempts to disable provenance via environment variable (`NPM_CONFIG_PROVENANCE`) and via `npm config set` didn't work because npm wasn't picking up the configuration when invoked through the Yarn → NX → npm chain.

## Solution
1. Set `npm config set provenance false --location=global` to configure npm globally
2. Explicitly write `provenance=false` to `~/.npmrc` as a fallback
3. Log the `.npmrc` contents for debugging

This ensures npm will respect the provenance setting no matter how it's invoked.

## Related
- Related to #14339 (original PR that triggered the issue)
- Supersedes #14341 and #14342 (previous fix attempts)

**Note:** This is a hotfix to unblock releases. The proper long-term fix is to either wait for npm to fix the sigstore dependency issue or downgrade to an npm version that works.