### PR TITLE
chore(ci): downgrade to npm 10.x to avoid sigstore bug in npm 11.x/12.x

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -73,13 +73,12 @@ jobs:
                   name: ${{ secrets.GH_NAME }}
                   email: ${{ secrets.GH_EMAIL }}
 
-            # npm 11.5.0+ auto-detects OIDC in GitHub Actions and handles trusted publishing.
-            # The bundled npm 10.x doesn't support this, so we upgrade.
-            # We cannot run `npm install -g npm@latest` directly because npm 10.9.7
-            # crashes with MODULE_NOT_FOUND when replacing its own files mid-execution.
-            # Instead, we use npx to run a fresh copy of npm@latest for the upgrade.
-            - name: Upgrade npm for OIDC trusted publishing
-              run: npx --yes npm@latest install -g npm@latest
+            # Downgrade to npm 10.x to avoid sigstore dependency bug in npm 11.x/12.x
+            # See: https://github.com/npm/cli/issues/9722
+            # npm 10.x is stable and doesn't have the missing sigstore module issue
+            # We use NODE_AUTH_TOKEN for authentication instead of npm 11.5+ auto-OIDC
+            - name: Downgrade to npm 10.x (avoid sigstore bug)
+              run: npx --yes npm@10 install -g npm@10
 
             - name: Initialize the Nx Cloud distributed CI run
               run: npx nx-cloud start-ci-run
@@ -160,13 +159,8 @@ jobs:
             - name: Reset dependency placeholders after pack
               run: node scripts/reset-placeholders.js
 
-            - name: Configure npm for trusted publishing
-              run: |
-                  npm config delete //registry.npmjs.org/:_authToken || true
-                  npm config set provenance false
-
             # Use NX Release to publish all packages at once
-            # Authentication is handled via npm 11.5.0+ auto-OIDC (detects GitHub Actions + id-token: write)
+            # Authentication is handled via NODE_AUTH_TOKEN (standard npm registry authentication)
             # NX Release publishes from dist/libs/{projectName} as configured in nx.json
             # NPM tag is determined by release-tags action:
             # - prerelease: for RC versions (e.g., 0.58.0-rc.19)
@@ -179,6 +173,7 @@ jobs:
                   npx nx release publish --tag="${{ steps.releaseTags.outputs.npm }}" --registry=https://registry.npmjs.org/
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             # Create git commit and tag after successful build and publish
             # We do this here instead of during 'nx release version' to ensure we only commit


### PR DESCRIPTION
## Summary
Downgrades npm from 11.x/12.x back to 10.x to avoid the missing `sigstore` module bug that breaks package publishing.

## Root Cause
npm 11.x and 12.x have a bug where the `sigstore` module dependency is missing, causing `npm publish` to fail with `Cannot find module 'sigstore'`. This is a known upstream issue: https://github.com/npm/cli/issues/9722

Previous attempts to disable provenance (#14341, #14342, #14343) didn't work because npm still tries to **load** the sigstore module even when provenance is disabled.

## Solution
- Downgrade to npm 10.x which is stable and doesn't have this bug
- Use `NODE_AUTH_TOKEN` for npm authentication (standard approach, works with npm 10.x)
- Remove the provenance config workarounds since they're not needed with npm 10.x

## Changes
1. Changed npm upgrade step to downgrade to npm@10 instead
2. Added `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the publish step for authentication
3. Removed the `Configure npm for trusted publishing` step (not needed)
4. Updated comments to reflect the new approach

## Trade-offs
- Lose npm 11.5+ auto-OIDC feature, but `NODE_AUTH_TOKEN` works just as well
- Stay on npm 10.x until the upstream sigstore bug is fixed

## Testing
This should work because:
- npm 10.x is proven stable (was working before PR #14339)
- `NODE_AUTH_TOKEN` is the standard npm authentication method
- No configuration workarounds needed

## Related
- Fixes the release workflow failure from #14339
- Supersedes #14341, #14342, #14343 (previous fix attempts)
- Upstream bug: https://github.com/npm/cli/issues/9722