### PR TITLE
chore(ci): install sigstore globally to fix npm provenance attestation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -82,9 +82,10 @@ jobs:
               run: npx --yes npm@latest install -g npm@latest
 
             # WORKAROUND: npm 11.x/12.x has missing sigstore dependency (npm/cli#9722)
-            # Install sigstore globally so npm can find it when generating provenance attestations
+            # Install sigstore@^4.1.1 globally so npm can find it when generating provenance attestations
+            # Pinned to 4.1.1 for stability - npm 11.x was built against sigstore 4.x
             - name: Install sigstore dependency for npm provenance
-              run: npm install -g sigstore
+              run: npm install -g sigstore@^4.1.1
 
             - name: Initialize the Nx Cloud distributed CI run
               run: npx nx-cloud start-ci-run

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -81,6 +81,11 @@ jobs:
             - name: Upgrade npm for OIDC trusted publishing
               run: npx --yes npm@latest install -g npm@latest
 
+            # WORKAROUND: npm 11.x/12.x has missing sigstore dependency (npm/cli#9722)
+            # Install sigstore globally so npm can find it when generating provenance attestations
+            - name: Install sigstore dependency for npm provenance
+              run: npm install -g sigstore
+
             - name: Initialize the Nx Cloud distributed CI run
               run: npx nx-cloud start-ci-run
 
@@ -160,13 +165,10 @@ jobs:
             - name: Reset dependency placeholders after pack
               run: node scripts/reset-placeholders.js
 
-            - name: Configure npm for trusted publishing
-              run: |
-                  npm config delete //registry.npmjs.org/:_authToken || true
-                  npm config set provenance false
-
             # Use NX Release to publish all packages at once
-            # Authentication is handled via npm 11.5.0+ auto-OIDC (detects GitHub Actions + id-token: write)
+            # Authentication is handled via OIDC trusted publishing (id-token: write permission)
+            # setup-node with registry-url configures .npmrc for OIDC token exchange
+            # NPM_CONFIG_PROVENANCE generates signed provenance attestations
             # NX Release publishes from dist/libs/{projectName} as configured in nx.json
             # NPM tag is determined by release-tags action:
             # - prerelease: for RC versions (e.g., 0.58.0-rc.19)
@@ -179,6 +181,7 @@ jobs:
                   npx nx release publish --tag="${{ steps.releaseTags.outputs.npm }}" --registry=https://registry.npmjs.org/
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
+                  NPM_CONFIG_PROVENANCE: true
 
             # Create git commit and tag after successful build and publish
             # We do this here instead of during 'nx release version' to ensure we only commit


### PR DESCRIPTION
## Summary
Installs `sigstore` globally to fix the missing module error while **keeping provenance enabled** for OSPO compliance.

## Root Cause
npm 11.x/12.x has a bug where the `sigstore` module dependency is missing from npm's installation, causing `npm publish` with provenance to fail with `Cannot find module 'sigstore'`. This is a known upstream issue: https://github.com/npm/cli/issues/9722

## Why Not Disable Provenance?
The workflow was configured to use **OIDC trusted publishing with provenance attestations** (#14091) for OSPO security/supply-chain requirements. Disabling provenance would violate this requirement.

## Solution
- Install `sigstore` globally with `npm install -g sigstore` after upgrading npm
- This provides the missing dependency npm needs for provenance attestation
- **Keep `NPM_CONFIG_PROVENANCE: true`** to maintain OSPO compliance
- Remove the `provenance false` config workarounds from previous attempts

## Changes
1. Added step to install sigstore globally after npm upgrade
2. Restored `NPM_CONFIG_PROVENANCE: true` in the publish step
3. Removed the `Configure npm for trusted publishing` workaround step
4. Updated comments to reflect OIDC + provenance approach

## Testing
This should work because:
- We're providing the missing dependency npm is looking for
- Provenance attestation can proceed normally with sigstore available
- OIDC trusted publishing remains intact

## Related
- Fixes the release workflow failure from #14339
- Supersedes #14341, #14342, #14343, #14344 (previous fix attempts)
- Maintains OSPO compliance from #14091
- Upstream bug: https://github.com/npm/cli/issues/9722