### PR TITLE
chore(docs): correct API filter button hover state contrast

### DIFF
--- a/libs/docs/shared/src/lib/core-helpers/api/api.component.scss
+++ b/libs/docs/shared/src/lib/core-helpers/api/api.component.scss
@@ -95,9 +95,9 @@
         box-shadow: var(--sapContent_Shadow1);
 
         &:hover {
-            background: var(--sapButton_Active_Background);
-            border-color: var(--sapButton_Active_BorderColor);
-            color: var(--sapContent_ContrastTextColor);
+            background: var(--sapButton_Emphasized_Hover_Background);
+            border-color: var(--sapButton_Emphasized_Hover_BorderColor);
+            color: var(--sapButton_Emphasized_Hover_TextColor);
             box-shadow: var(--sapContent_Shadow2);
         }
     }
@@ -239,9 +239,9 @@
         color: var(--sapContent_ContrastTextColor);
 
         &:hover {
-            background: var(--sapButton_Active_Background);
-            border-color: var(--sapButton_Active_BorderColor);
-            color: var(--sapContent_ContrastTextColor);
+            background: var(--sapButton_Emphasized_Hover_Background);
+            border-color: var(--sapButton_Emphasized_Hover_BorderColor);
+            color: var(--sapButton_Emphasized_Hover_TextColor);
         }
 
         &:focus-visible {


### PR DESCRIPTION


## Description

The "All" filter buttons and the Components pill in the API documentation had matching background and text colors on hover, making the text invisible. Added explicit hover styles to ensure proper contrast for both normal and selected button states.

## Screenshots
**Before**
<img width="1077" height="334" alt="Screenshot 2026-07-10 at 1 49 13 PM" src="https://github.com/user-attachments/assets/71d46654-d89e-44a7-b21d-d2ca95bee0b4" />


**After:**
<img width="835" height="254" alt="Screenshot 2026-07-10 at 1 49 37 PM" src="https://github.com/user-attachments/assets/3df9ba2f-c62c-46b3-a097-83cedf465a72" />
