### PR TITLE
chore: create internal team wiki for processes and commands

### DIFF
--- a/docs/internal/commands.md
+++ b/docs/internal/commands.md
@@ -1,0 +1,137 @@
+# Common Commands Reference
+
+**Purpose:** Quick reference for frequently used commands in the Fundamental NGX project. Copy-paste ready commands for building, testing, linting, and managing the NX monorepo.
+
+---
+
+## Building
+
+```bash
+# Build a specific library
+nx run core:build
+nx run platform:build
+
+# Build all affected libraries (recommended)
+nx affected:build
+
+# Build with verbose output
+nx run core:build --verbose
+```
+
+## Testing
+
+```bash
+# Run all tests for a library
+nx run core:test
+
+# Run specific test file
+nx run core:test --testfile=button.component.spec.ts
+
+# Run affected tests only
+nx affected:test
+
+# Run tests in watch mode
+nx run core:test --watch
+```
+
+## Linting
+
+```bash
+# Lint specific project
+npx nx lint core
+npx nx lint platform
+npx nx lint docs
+
+# Lint with auto-fix
+npx nx lint core --fix
+
+# Lint all projects
+npx nx run-many --target=lint --all
+
+# Lint only affected projects (recommended)
+npx nx affected --target=lint
+```
+
+## Formatting
+
+```bash
+# Format all files (run after code changes)
+yarn format
+
+# Check formatting without changes
+yarn format:check
+```
+
+## Development
+
+```bash
+# Start docs app
+yarn start
+
+# Show dependency graph
+nx graph
+```
+
+## Cache & Cleanup
+
+```bash
+# Clear NX cache (if builds are stale)
+nx reset
+
+# Build skipping cache
+yarn build --skip-nx-cache
+
+# Full UI5 Web Components rebuild (clears and regenerates all wrappers)
+yarn cleanup
+nx run ui5-webcomponents-base:generate --skip-nx-cache
+nx run ui5-webcomponents:generate --skip-nx-cache
+nx run ui5-webcomponents-ai:generate --skip-nx-cache
+nx run ui5-webcomponents-fiori:generate --skip-nx-cache
+nx run ui5-webcomponents-base:build --skip-nx-cache
+nx run ui5-webcomponents:build --skip-nx-cache
+nx run ui5-webcomponents-ai:build --skip-nx-cache
+nx run ui5-webcomponents-fiori:build --skip-nx-cache
+```
+
+## NG15 Downport Branch Setup
+
+Switch between the Angular 15 downport branch (Yarn 1.x + Node 18) and main branch (Yarn 4.x + Node 22).
+
+```bash
+# Switch to Angular 15 downport branch
+git checkout ng-15-downport
+
+# Going back to Yarn 1.x (for ng-15-downport)
+sudo corepack disable
+sudo npm i -g yarn
+# Install Node 18 (use nvm or your preferred method)
+rm -rf node_modules dist
+yarn install
+
+# ---
+
+# Going to Yarn 4.x (back to main branch)
+sudo npm uninstall -g yarn
+sudo corepack enable
+# Install Node 22 (use nvm or your preferred method)
+rm -rf node_modules dist
+yarn install
+```
+
+**Notes:**
+
+- Angular 15 downport branch uses **Yarn 1.x** and **Node 18**
+- Main branch uses **Yarn 4.x** and **Node 22**
+- Always clean `node_modules` and `dist` when switching
+
+## Working with affected
+
+```bash
+# See what's affected by your changes
+nx affected:graph
+
+# Run all affected targets
+nx affected:build
+nx affected:test
+nx affected:lint
+```

--- a/docs/internal/deployment.md
+++ b/docs/internal/deployment.md
@@ -1,0 +1,167 @@
+# Deployment Processes
+
+**Purpose:** Step-by-step deployment procedures for Netlify, GitHub Pages, and release workflows. Includes commands, prerequisites, and access requirements.
+
+---
+
+## Netlify Deploy Older Versions (Manual)
+
+Deploy older version documentation to Netlify so users can access historical docs. Netlify cleans up old branch deployments automatically, so we manually configure specific versions to persist.
+
+**Why:** Users need access to older version documentation pages. This process ensures specific versions remain deployed on Netlify.
+
+**Prerequisites:**
+
+- Netlify admin access to [Fundamental NGX](https://app.netlify.com/sites/fundamental-ngx/configuration/deploys)
+- Version tag to deploy (e.g., `v0.63.0`)
+
+**Reference:** [Sprint Reviews Wiki - Netlify Deploying Previews](https://github.tools.sap/TI-DX-Fundamental/sprint-reviews/wiki/Netlify-deploying-previews)
+
+---
+
+**Example:** Deploy version `0.63.0`
+
+**Step 1:** Configure Netlify branch deployment
+
+1. Go to [Netlify deployment configuration](https://app.netlify.com/sites/fundamental-ngx/configuration/deploys)
+2. Scroll to [Branches and deploy contexts](https://app.netlify.com/sites/fundamental-ngx/configuration/deploys#branches-and-deploy-contexts)
+3. Click **Configure**
+4. Add `docs/0.63` to the **Additional Branches** field
+5. Click **Save**
+
+**Step 2:** Create and push the docs branch
+
+```bash
+# Checkout the version tag
+git checkout v0.63.0
+
+# Create docs branch (format: docs/X.YY)
+git checkout -b docs/0.63
+
+# Push the branch to trigger Netlify build
+git push --set-upstream origin docs/0.63
+```
+
+**Step 3:** Monitor deployment
+
+1. Go to [Netlify deploys](https://app.netlify.com/sites/fundamental-ngx/deploys)
+2. Look for `Branch Deploy: docs/0.63@...`
+3. Click to view deployment details
+4. Once complete, deployment link will be: `https://docs-0-63--fundamental-ngx.netlify.app/`
+
+**Notes:**
+
+- Use two-digit minor versions in branch names: `docs/0.63`, not `docs/0.63.0`
+- The deployment creates a version dropdown in the docs UI (see version selector in deployed docs)
+- Only configure branches for versions users actively need — don't deploy every version
+
+---
+
+## Netlify Deploy via gh-pages (Alternative)
+
+Deploy a specific version tag to Netlify using gh-pages.
+
+**Prerequisites:**
+
+- Admin rights on the repository
+
+**Steps:**
+
+```bash
+# Checkout the version tag
+git checkout v0.63.1
+
+# Install dependencies (frozen lockfile)
+yarn install --frozen-lockfile
+
+# Build docs for production
+npx nx run docs:compile:production --skip-nx-cache
+
+# Deploy to gh-pages
+npx gh-pages \
+  --dist dist/apps/docs \
+  --message "docs: deploy v0.63.1 [ci skip]" \
+  --dotfiles
+```
+
+---
+
+## Hotfix Release
+
+Create a patch release from a previous version by cherry-picking specific fixes.
+
+**Prerequisites:**
+
+- Access to NPM to verify the latest released version
+- Cherry-pick commit hashes ready
+
+**Steps:**
+
+```bash
+# Sync with remote
+git pull
+git fetch --tags
+
+# Checkout the last released version (check NPM for latest)
+# Example: v0.54.5
+git checkout v0.54.5
+
+# Create hotfix branch with bumped version (+1 patch)
+# Example: v0.54.6
+git checkout -b fix/v0.54.6-fixes
+
+# Clean install dependencies
+rm -rf node_modules
+yarn install
+
+# Cherry-pick the fixes in order
+git cherry-pick commit-hash-1
+git cherry-pick commit-hash-2
+git cherry-pick commit-hash-3
+
+# Run hotfix release script
+yarn hotfix-release
+```
+
+**Notes:**
+
+- Version numbers are examples — always check NPM for the actual latest release
+- The new branch name should reflect the bumped version (last version + 0.0.1)
+- Cherry-pick commits in the order they were originally applied to avoid conflicts
+
+---
+
+## CI/CD Deployment
+
+Deployment is automated via GitHub Actions when:
+
+- A new release tag is pushed
+- Changes are merged to `main` (deploys preview)
+
+**Manual trigger:**
+
+```bash
+# Trigger deployment workflow manually (via GitHub CLI)
+gh workflow run deploy.yml
+```
+
+---
+
+## Troubleshooting Deployment
+
+### Build fails with cache errors
+
+```bash
+# Clear NX cache and retry
+nx reset
+npx nx run docs:compile:production
+```
+
+### gh-pages push rejected
+
+Ensure you have admin rights and the branch is not protected:
+
+```bash
+# Check remote settings
+git remote -v
+```

--- a/docs/internal/releases.md
+++ b/docs/internal/releases.md
@@ -1,0 +1,113 @@
+# Release Processes
+
+**Purpose:** Step-by-step procedures for releasing new versions of Fundamental NGX, including UI5 Web Components updates, standard releases, and hotfix releases.
+
+---
+
+## UI5 Web Components Release
+
+Release a new version of the library with updated UI5 Web Components.
+
+**Reference:** [Fundamental Library Wiki - Create Release of Fundamental NGX](https://github.tools.sap/Fundamental-Library/fundamental-library/wiki/Create-release-of-Fundamental-NGX)
+
+**Prerequisites:**
+
+- Access to the GitHub repository and Actions
+- `yarn` and `nx` available in your environment
+
+---
+
+### Step 1 — Prepare the Branch
+
+1. Create a branch from the latest `main`:
+
+    ```bash
+    git checkout main
+    git pull
+    git checkout -b chore/ui5wc-{{WCVersion}}
+    ```
+
+2. Bump the UI5 core components to the latest version.
+
+    **Check [UI5/webcomponents#10568](https://github.com/UI5/webcomponents/issues/10568) for the latest release** — they usually release around the **5th of each month**, and we release afterwards.
+
+3. Update `package.json` with the new version, then reinstall dependencies:
+    ```bash
+    rm -rf node_modules && yarn
+    ```
+
+---
+
+### Step 2 — Regenerate UI5 Web Component Wrappers
+
+Run the following commands in order:
+
+```bash
+# Remove existing generated wrapper components
+yarn cleanup
+
+# Regenerate wrappers
+nx run ui5-webcomponents-base:generate --skip-nx-cache
+nx run ui5-webcomponents:generate --skip-nx-cache
+nx run ui5-webcomponents-ai:generate --skip-nx-cache
+nx run ui5-webcomponents-fiori:generate --skip-nx-cache
+
+# Build all UI5 wrapper libraries
+nx run ui5-webcomponents-base:build --skip-nx-cache
+nx run ui5-webcomponents:build --skip-nx-cache
+nx run ui5-webcomponents-ai:build --skip-nx-cache
+nx run ui5-webcomponents-fiori:build --skip-nx-cache
+```
+
+---
+
+### Step 3 — Verify the Documentation App
+
+```bash
+yarn start
+```
+
+- Review the UI5 Web Components **release notes** and test any newly added or changed functionality in the docs app.
+- Check for **newly added components** and create issues to track adding them to the documentation for the wrappers.
+    > **Do not** add new component docs to the current PR — track them as separate issues.
+
+---
+
+### Step 4 — Create a PR with the Changes
+
+```bash
+git add .
+git commit -m "chore(deps): ui5-webcomponents version {{WCVersion}}"
+git push --set-upstream origin chore/ui5wc-{{WCVersion}}
+```
+
+Create a pull request and wait for approval and merge.
+
+---
+
+### Step 5 — Trigger the Release
+
+1. Once the above PR is merged, go to **GitHub → Actions**
+2. Select **"Create Release"** workflow
+3. Click **"Run workflow"**, selecting the `main` branch
+4. Click **"Run workflow"** to confirm
+
+---
+
+### Step 6 — Verify the Release
+
+1. Under **Actions**, confirm the release workflow completed successfully.
+2. Under **Releases**, confirm the latest release tag is present.
+3. Optionally, verify the new version is published on **npm**.
+
+---
+
+## Standard Release
+
+> TODO: Add standard release process (non-UI5 version bump)
+
+---
+
+## Hotfix Release
+
+See [Hotfix Release in deployment.md](./deployment.md#hotfix-release) for the hotfix process.

--- a/docs/internal/scripts.md
+++ b/docs/internal/scripts.md
@@ -1,0 +1,155 @@
+# Useful Scripts
+
+**Purpose:** Collection of shell scripts, one-liners, and automation helpers for common tasks. Copy-paste and modify as needed.
+
+---
+
+## Git & Version Management
+
+### Create a release branch
+
+```bash
+# Create and push a release branch
+git checkout -b release/v0.64.0 main
+git push -u origin release/v0.64.0
+```
+
+### Tag a release
+
+```bash
+# Create annotated tag
+git tag -a v0.64.0 -m "Release 0.64.0"
+git push origin v0.64.0
+```
+
+### Find commits in a version range
+
+```bash
+# List commits between two tags
+git log v0.63.0..v0.64.0 --oneline
+```
+
+---
+
+## Code Search & Analysis
+
+### Find all usages of a component
+
+```bash
+# Search for component selector in templates
+grep -r "fd-button" libs/ apps/ --include="*.html"
+
+# Search for import statements
+grep -r "from '@fundamental-ngx/core/button'" libs/ apps/ --include="*.ts"
+```
+
+### Find deprecated APIs
+
+```bash
+# Search for @deprecated annotations
+grep -r "@deprecated" libs/ --include="*.ts" -A 2
+```
+
+### Count lines of code by library
+
+```bash
+# Count TypeScript lines in core
+find libs/core -name "*.ts" -not -path "*/node_modules/*" | xargs wc -l
+```
+
+---
+
+## Testing & Quality
+
+### Run tests for changed files only
+
+```bash
+# Run affected tests since main
+nx affected:test --base=main --head=HEAD
+```
+
+### Find flaky tests
+
+```bash
+# Run tests 10 times and report failures
+for i in {1..10}; do
+  echo "Run $i"
+  npx playwright test || echo "FAILED on run $i"
+done
+```
+
+### Update all snapshots for a specific component
+
+```bash
+# Update snapshots for button tests
+npx playwright test --update-snapshots --grep "button"
+```
+
+---
+
+## Build & Bundle Analysis
+
+### Analyze bundle size
+
+```bash
+# Build and analyze docs bundle
+npx nx run docs:build:production --stats-json
+npx webpack-bundle-analyzer dist/apps/docs/stats.json
+```
+
+### Check build output size
+
+```bash
+# Build and show sizes
+npx nx run core:build
+du -sh dist/libs/core
+```
+
+---
+
+## Cleanup
+
+### Remove all node_modules and rebuild
+
+```bash
+# Nuclear option: clean everything
+rm -rf node_modules dist .nx
+yarn install
+nx reset
+```
+
+### Clear NX cache for specific project
+
+```bash
+# Clear cache for one library
+nx reset
+rm -rf node_modules/.cache/nx
+```
+
+### Remove untracked files (dry run first!)
+
+```bash
+# See what would be deleted
+git clean -dn
+
+# Actually delete untracked files
+git clean -df
+```
+
+---
+
+## Bulk Operations
+
+### Update all component imports
+
+```bash
+# Replace old import path with new one
+find libs/ apps/ -name "*.ts" -exec sed -i '' 's|@fundamental-ngx/core|@fundamental-ngx/core/button|g' {} +
+```
+
+### Format specific files
+
+```bash
+# Format only changed files
+git diff --name-only --diff-filter=ACMR | grep -E '\.(ts|html|scss)$' | xargs prettier --write
+```

--- a/docs/internal/testing.md
+++ b/docs/internal/testing.md
@@ -1,0 +1,89 @@
+# Testing Guide
+
+**Purpose:** Commands and workflows for running unit tests, E2E tests, visual regression tests, and updating snapshots. Covers Playwright, Jest, and screenshot testing.
+
+---
+
+## E2E Testing (Playwright)
+
+```bash
+# Run all E2E tests
+npx playwright test
+
+# Run specific test suite
+npx playwright test --grep "core/button"
+
+# Run tests in headed mode (see browser)
+npx playwright test --headed
+
+# Run tests in debug mode
+npx playwright test --debug
+
+# Update snapshots
+npx playwright test --update-snapshots
+
+# View test report
+npx playwright show-report
+```
+
+---
+
+## Unit Tests (Jest)
+
+```bash
+# Run all unit tests for a library
+nx run core:test
+
+# Run specific test file
+nx run core:test --testfile=button.component.spec.ts
+
+# Run tests in watch mode
+nx run core:test --watch
+
+# Run tests with coverage
+nx run core:test --coverage
+
+# Run affected tests only (faster)
+nx affected:test
+```
+
+---
+
+## Visual Regression Tests
+
+```bash
+# Update visual snapshots (after intentional UI changes)
+npx playwright test --update-snapshots
+
+# Run only visual tests
+npx playwright test --grep "visual"
+
+# Compare snapshots
+npx playwright show-report
+```
+
+---
+
+## Troubleshooting
+
+### Snapshot mismatches
+
+If snapshots fail unexpectedly:
+
+1. Check if the change is intentional
+2. Review the diff in the HTML report: `npx playwright show-report`
+3. Update if correct: `npx playwright test --update-snapshots`
+
+### Flaky tests
+
+```bash
+# Run a test multiple times to detect flakiness
+npx playwright test --repeat-each=10 --grep "flaky-test"
+```
+
+### Test hangs or times out
+
+```bash
+# Increase timeout for slow tests
+npx playwright test --timeout=60000
+```

--- a/docs/internal/translations.md
+++ b/docs/internal/translations.md
@@ -1,0 +1,264 @@
+# Translation Management (i18n)
+
+**Purpose:** Simple, step-by-step guide for managing translation keys in Fundamental NGX. Covers adding new translations, updating existing ones, and removing obsolete keys.
+
+**Reference:**
+
+- [i18n-manage CLI Reference](https://github.com/SAP/fundamental-ngx/blob/main/libs/nx-plugin/src/executors/i18n-manage/README.md)
+- [i18n Package README](https://github.com/SAP/fundamental-ngx/blob/main/libs/i18n/README.md)
+
+---
+
+## Adding a New Translation
+
+**When:** You need to add a new translatable string to a component.
+
+### Step 1: Update the Interface
+
+Open `libs/i18n/src/lib/models/fd-language.ts` and add your key to the `FdLanguage` interface:
+
+```typescript
+coreButton: {
+    /** Submit button label */
+    submit: FdLanguageKey;
+    /** Cancel button label */
+    cancel: FdLanguageKey;
+    /** YOUR NEW KEY - Description for translators */
+    yourNewKey: FdLanguageKey;
+}
+```
+
+**Important:** Always add a comment describing what the text is for — this helps translators.
+
+---
+
+### Step 2: Run the Add Command
+
+```bash
+nx run i18n:i18n-manage --command=add --key=coreButton.yourNewKey --value="Your English Text"
+```
+
+**What happens:**
+
+- Adds the key to all 37 language files (`.properties` files)
+- Sets the English text for `en` locale
+- Other locales get the same English text as a placeholder
+- Auto-regenerates TypeScript files
+
+---
+
+### Step 3: Verify
+
+```bash
+# Validate all translation files
+nx run i18n:i18n-manage --command=validate
+```
+
+✅ Done! Your translation key is now available across all languages.
+
+---
+
+## Updating an Existing Translation
+
+**When:** You need to change the text of an existing translation key.
+
+```bash
+nx run i18n:i18n-manage --command=update --key=coreButton.submit --value="Submit Changes"
+```
+
+**What happens:**
+
+- Updates the English text for the key
+- Other language files keep their existing translations (translator review needed)
+
+---
+
+## Renaming a Translation Key
+
+**When:** You need to change the name of a translation key (refactoring).
+
+```bash
+nx run i18n:i18n-manage --command=rename --key=coreButton.oldName --newKey=coreButton.newName
+```
+
+**What happens:**
+
+- Renames the key in all 37 language files
+- Preserves all existing translations and comments
+
+**Next step:** Update your component code to use the new key name.
+
+---
+
+## Removing a Translation Key
+
+**When:** A translation key is no longer used.
+
+```bash
+nx run i18n:i18n-manage --command=remove --key=coreButton.obsoleteKey
+```
+
+**What happens:**
+
+- Removes the key from all 37 language files
+- Auto-regenerates TypeScript files
+
+**Before removing:** Search your codebase to ensure the key is not used:
+
+```bash
+grep -r "obsoleteKey" libs/ apps/
+```
+
+---
+
+## Searching for a Translation
+
+**When:** You need to find a translation key by name or text.
+
+```bash
+# Search by key name or value (case-insensitive)
+nx run i18n:i18n-manage --command=search --searchTerm=submit
+```
+
+**Returns:** All matching keys with their values across all languages.
+
+---
+
+## Common Scenarios
+
+### Adding a Translation with Parameters
+
+If your translation needs dynamic values (e.g., "Hello, {name}"):
+
+1. Update the interface:
+
+```typescript
+coreGreeting: {
+    /** Greeting message with user name */
+    hello: FdLanguageKey<{ name: string }>;
+}
+```
+
+2. Add the key with ICU syntax:
+
+```bash
+nx run i18n:i18n-manage --command=add --key=coreGreeting.hello --value="Hello, {name}"
+```
+
+3. Use in your component:
+
+```typescript
+this.translationService.instant('coreGreeting.hello', { name: 'John' });
+// Output: "Hello, John"
+```
+
+---
+
+### Organizing Keys by Component
+
+Translation keys follow this naming pattern:
+
+```
+<library><ComponentName>.<keyName>
+```
+
+Examples:
+
+- `coreButton.submit` — Core library, Button component
+- `platformTable.noData` — Platform library, Table component
+- `btpToolHeader.title` — BTP library, ToolHeader component
+
+---
+
+### Comment Types (Auto-detected)
+
+The CLI auto-detects comment types based on key names:
+
+| Comment Type | Used For           | Example Key            |
+| ------------ | ------------------ | ---------------------- |
+| `XBUT`       | Button labels      | `coreButton.submit`    |
+| `XTIT`       | Titles/headings    | `coreDialog.title`     |
+| `XLBL`       | Labels             | `coreInput.label`      |
+| `XMSG`       | Messages           | `coreTable.noData`     |
+| `XTOL`       | Tooltips           | `coreButton.tooltip`   |
+| `XACT`       | Accessibility text | `coreButton.ariaLabel` |
+
+You can override the auto-detection:
+
+```bash
+nx run i18n:i18n-manage --command=add --key=coreButton.submit --value="Submit" --commentType=XBUT
+```
+
+---
+
+## Files You Should/Shouldn't Edit
+
+### ✅ Edit Manually
+
+- `libs/i18n/src/lib/models/fd-language.ts` — The interface definition
+
+### ❌ Never Edit (Auto-Generated)
+
+- `libs/i18n/src/lib/models/fd-language-key-identifier.ts`
+- `libs/i18n/src/lib/translations/translations_*.ts`
+- All `.properties` files (use the CLI instead)
+
+---
+
+## Troubleshooting
+
+### Error: "Property does not exist on type FdLanguage"
+
+**Cause:** You forgot Step 1 (updating `fd-language.ts`)
+
+**Fix:** Add your key to the `FdLanguage` interface first, then run the CLI command.
+
+---
+
+### Error: "Key already exists"
+
+**Cause:** The key you're trying to add is already in the translation files.
+
+**Fix:** Use `--command=update` instead of `--command=add`, or choose a different key name.
+
+---
+
+### Validation fails after adding a key
+
+**Cause:** The key might not match the interface, or there's a syntax error.
+
+**Fix:**
+
+1. Run validation to see details:
+    ```bash
+    nx run i18n:i18n-manage --command=validate
+    ```
+2. Check that your key in `fd-language.ts` matches what you added via CLI
+3. Ensure ICU syntax is correct (e.g., `{paramName}` not `{{paramName}}`)
+
+---
+
+## Quick Reference
+
+```bash
+# Add new translation
+nx run i18n:i18n-manage --command=add --key=coreComponent.key --value="English text"
+
+# Update existing translation
+nx run i18n:i18n-manage --command=update --key=coreComponent.key --value="New text"
+
+# Rename translation key
+nx run i18n:i18n-manage --command=rename --key=old.key --newKey=new.key
+
+# Remove translation key
+nx run i18n:i18n-manage --command=remove --key=coreComponent.key
+
+# Search translations
+nx run i18n:i18n-manage --command=search --searchTerm=submit
+
+# Validate all translations
+nx run i18n:i18n-manage --command=validate
+
+# Sort translation keys alphabetically
+nx run i18n:i18n-manage --command=sort
+```

--- a/docs/internal/troubleshooting.md
+++ b/docs/internal/troubleshooting.md
@@ -1,0 +1,154 @@
+# Troubleshooting
+
+**Purpose:** Common issues encountered during development and their solutions. If you hit a problem, check here first before debugging.
+
+---
+
+## Build Issues
+
+### "Module not found" after pulling latest
+
+**Cause:** Dependencies changed or node_modules out of sync
+
+**Fix:**
+
+```bash
+yarn install
+nx reset
+```
+
+### NX cache returning stale builds
+
+**Cause:** NX cache not invalidated after changes
+
+**Fix:**
+
+```bash
+nx reset
+nx run <project>:build
+```
+
+### Build fails with "Heap out of memory"
+
+**Cause:** Node.js default memory limit too low
+
+**Fix:**
+
+```bash
+export NODE_OPTIONS="--max-old-space-size=4096"
+nx run <project>:build
+```
+
+---
+
+## Test Issues
+
+### Tests pass locally but fail in CI
+
+**Cause:** Environment differences (timezone, locale, browser version)
+
+**Fix:**
+
+- Check Playwright version matches CI
+- Run tests with CI environment variables:
+    ```bash
+    CI=true npx playwright test
+    ```
+
+### Snapshot tests fail after OS upgrade
+
+**Cause:** Font rendering differences between OS versions
+
+**Fix:**
+
+```bash
+# Regenerate snapshots on the new OS
+npx playwright test --update-snapshots
+```
+
+---
+
+## Lint / Format Issues
+
+### ESLint errors after merge
+
+**Cause:** ESLint rules changed or new files don't match formatting
+
+**Fix:**
+
+```bash
+yarn format
+nx affected:lint --fix
+```
+
+### "member-ordering" lint errors
+
+**Cause:** Class members not in correct order (decorated props → signal inputs/outputs → public → protected → private)
+
+**Fix:** Reorder members manually or run:
+
+```bash
+nx run <project>:lint --fix
+```
+
+---
+
+## Git Issues
+
+### Merge conflicts in package.json
+
+**Cause:** Conflicting dependency updates
+
+**Fix:**
+
+```bash
+# Accept incoming changes
+git checkout --theirs package.json yarn.lock
+yarn install
+```
+
+### Accidentally committed to main
+
+**Cause:** Forgot to create a feature branch
+
+**Fix:**
+
+```bash
+# Move commits to a new branch
+git branch feature/my-fix
+git reset --hard origin/main
+git checkout feature/my-fix
+```
+
+---
+
+## Yarn / Dependency Issues
+
+### "Workspace not found" errors
+
+**Cause:** Yarn 4 workspace resolution issue
+
+**Fix:**
+
+```bash
+yarn install --check-cache
+```
+
+### Dependency resolution conflicts
+
+**Cause:** Peer dependency mismatch
+
+**Fix:**
+
+```bash
+# Check peer dependencies
+yarn npm info <package>
+
+# Force resolution (last resort)
+# Add to package.json:
+{
+  "resolutions": {
+    "<package>": "<version>"
+  }
+}
+```


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

Add docs/internal/ directory structure for team knowledge

- `commands.md`: common NX commands, linting, caching, NG15 setup
- `deployment.md`: Netlify deployment, hotfix release process
- `testing.md`: E2E, unit tests, snapshot updates
- `troubleshooting.md`: common issues and solutions
- `scripts.md`: shell scripts and automation helpers
- `releases.md`: UI5 Web Components release process
- `translations.md`: simplified i18n management guide