### PR TITLE
fix(core): track time column rows by value to prevent DOM re-creation

### DIFF
--- a/libs/core/time/time-column/time-column.component.html
+++ b/libs/core/time/time-column/time-column.component.html
@@ -34,7 +34,7 @@
         (dragStateChange)="handleDrag($event)"
         fdCarousel
     >
-        @for (row of rows; track row; let index = $index) {
+        @for (row of rows; track row.value; let index = $index) {
             <li
                 class="fd-time__item"
                 fdCarouselItem


### PR DESCRIPTION
fixes #14359

  @for tracked rows by object identity, but <fd-time> rebuilds the arrays with
  fresh refs each cycle, so NG0956 fired and all rows were recreated. Track by
  the stable  instead.

