### PR TITLE
docs: update Angular 21 to Angular 22 in docs, skills and MCP

### DIFF
--- a/.claude/rules/angular-conventions.md
+++ b/.claude/rules/angular-conventions.md
@@ -3,7 +3,7 @@ paths: ['libs/**/*.ts']
 alwaysApply: false
 ---
 
-# Angular 21+ Conventions (fundamental-ngx)
+# Angular 22+ Conventions (fundamental-ngx)
 
 ## Quick Decision Guide
 

--- a/.claude/skills/best-practices/SKILL.md
+++ b/.claude/skills/best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: best-practices
-description: Audit existing code against project conventions and Angular 21+ best practices
+description: Audit existing code against project conventions and Angular 22+ best practices
 argument-hint: [component-path-or-folder]
 context: fork
 agent: general-purpose
@@ -15,7 +15,7 @@ Audit the code at `$ARGUMENTS` against the project's conventions. Unlike `/revie
 
 ## Checklist
 
-### 1. Angular 21+ Patterns
+### 1. Angular 22+ Patterns
 
 - [ ] **New code** uses `input()` / `output()` / `model()` / `linkedSignal()`. Existing `@Input()` / `@Output()` decorators are acceptable.
 - [ ] `host: {}` in decorator — no `@HostBinding()` / `@HostListener()`

--- a/.claude/skills/migrate/SKILL.md
+++ b/.claude/skills/migrate/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: migrate
-description: Migrate a component or directive to Angular 21+ signal-based patterns
+description: Migrate a component or directive to Angular 22+ signal-based patterns
 argument-hint: [component-path-or-folder]
 ---
 
-# Angular 21+ Migration: $ARGUMENTS
+# Angular 22+ Migration: $ARGUMENTS
 
 If `$ARGUMENTS` is empty, ask the user for a component path or folder before proceeding.
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr
-description: Review a pull request against project conventions and Angular 21+ best practices
+description: Review a pull request against project conventions and Angular 22+ best practices
 argument-hint: [PR-number]
 context: fork
 agent: general-purpose
@@ -23,7 +23,7 @@ Fetch the PR details:
 
 For each changed file, check the applicable sections below. Report findings grouped by severity: **Blocking** (must fix), **Suggestion** (should fix), **Nit** (optional).
 
-### 1. Angular 21+ Patterns
+### 1. Angular 22+ Patterns
 
 - [ ] **New code** uses `input()` / `output()` / `model()` / `linkedSignal()`. Existing `@Input()` / `@Output()` decorators being modified should prefer migration to signal functions, but it's not blocking.
 - [ ] `host: {}` in decorator — no `@HostBinding()` / `@HostListener()`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ This file serves as the standard GitHub Copilot configuration pointer. GitHub Co
 
 The main documentation includes:
 
-- Angular 21+ component patterns with signals
+- Angular 22+ component patterns with signals
 - NX monorepo architecture guidelines
 - Commit message and PR conventions
 - Testing patterns and requirements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 <!--
-Document: Angular 21+ Development Guidelines for Fundamental NGX
+Document: Angular 22+ Development Guidelines for Fundamental NGX
 Last Updated: April 17, 2026
 Version: 5.1
-Purpose: Comprehensive guide for AI agents and developers working with Angular 21+ in NX monorepo
+Purpose: Comprehensive guide for AI agents and developers working with Angular 22+ in NX monorepo
 Note: Detailed documentation has been split into separate files in docs/agents/
 -->
 
-# Angular 21+ Development Guidelines
+# Angular 22+ Development Guidelines
 
 ## Table of Contents
 
@@ -94,7 +94,7 @@ All components use `fd-` prefix: `fd-button`, `fd-dialog`, `fd-card`
 | ------------------------------------- | ----------------------------------------- | ----------------------------------- |
 | `@HostBinding()` / `@HostListener()`  | Use `host: {}` in decorator               | Better tree-shaking, AOT            |
 | `@Input()` / `@Output()` decorators   | Use `input()` / `output()`                | Signal-based, auto change detection |
-| `standalone: true` in decorator       | Omit it (default in Angular 21+)          | Cleaner code                        |
+| `standalone: true` in decorator       | Omit it (default in Angular 22+)          | Cleaner code                        |
 | `ngClass` / `ngStyle`                 | Use `class` / `style` bindings            | Direct binding is simpler           |
 | `*ngIf` / `*ngFor` / `*ngSwitch`      | Use `@if` / `@for` / `@switch`            | New control flow syntax             |
 | `BehaviorSubject` for local state     | Use `signal()`                            | Simpler, automatic cleanup          |
@@ -106,7 +106,7 @@ All components use `fd-` prefix: `fd-button`, `fd-dialog`, `fd-card`
 | `effect(() => sig.set(derived))`      | Use `computed()` or `linkedSignal`        | Effects are for side effects only   |
 | Conditional signal read in `effect`   | Read tracked signals before `if`          | Unread signal = untracked dep       |
 | Protected after private members       | Protected before private                  | ESLint member ordering              |
-| `allowSignalWrites: true` in effect   | Remove the option                         | Deprecated in Angular 21+           |
+| `allowSignalWrites: true` in effect   | Remove the option                         | Deprecated in Angular 22+           |
 
 ---
 
@@ -152,7 +152,7 @@ nx run <library>:test --testfile=<file>.spec.ts
 
 ## Component Structure
 
-### Modern Angular 21+ Component
+### Modern Angular 22+ Component
 
 ```typescript
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Fundamental NGX
 
-Angular component library (Angular 21+, NX monorepo, Yarn 4).
+Angular component library (Angular 22+, NX monorepo, Yarn 4).
 All components standalone by default.
 
 ## Architecture
@@ -95,12 +95,12 @@ Invoke with `/skill-name` (e.g. `/preflight`). Skills live in `.claude/skills/`.
 | `build-table`       | Build a platform data table with sorting, filtering, pagination, and row selection |
 | `build-page-layout` | Build a page layout using `fd-dynamic-page` or `fdp-dynamic-page`                  |
 | `scaffold`          | Generate a working component (dialog, table, card, form, shell, layout-grid)       |
-| `migrate`           | Migrate a component or directive to Angular 21+ signal-based patterns              |
+| `migrate`           | Migrate a component or directive to Angular 22+ signal-based patterns              |
 | `create-test`       | Generate or update unit tests following project testing conventions                |
 | `i18n-manage`       | Add, rename, or remove i18n translation keys across the codebase                   |
 | `adopt-styles`      | Adopt breaking changes from `fundamental-styles` into Angular components           |
 | `update-docs`       | Verify and update documentation examples against the current public API            |
-| `best-practices`    | Audit code against project conventions and Angular 21+ best practices              |
+| `best-practices`    | Audit code against project conventions and Angular 22+ best practices              |
 | `a11y-audit`        | Audit a component for WCAG AA accessibility compliance                             |
 | `review-pr`         | Review a pull request against project conventions                                  |
 | `preflight`         | Run local quality gates before creating a PR                                       |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Angular wrappers for the [@ui5/webcomponents](https://sap.github.io/ui5-webcompo
 ### Requirements
 
 - Angular 22 or newer
-- TypeScript 5.9 or newer
+- TypeScript 6 or newer
 - Node.js (LTS)
 
 **Peer dependencies** (installed automatically by `ng add`, required for manual installs):

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
 </a>
 
-**The official SAP-maintained Angular library for UI5 Web Components and the SAP design system.** Ships 1000+ components across 14 packages, targeting Angular 21+.
+**The official SAP-maintained Angular library for UI5 Web Components and the SAP design system.** Ships 1000+ components across 14 packages, targeting Angular 22+.
 
 [Documentation](https://sap.github.io/fundamental-ngx) | [Component Playground](https://sap.github.io/fundamental-ngx)
 
@@ -65,7 +65,7 @@ Angular wrappers for the [@ui5/webcomponents](https://sap.github.io/ui5-webcompo
 
 ### Requirements
 
-- Angular 21 or newer
+- Angular 22 or newer
 - TypeScript 5.9 or newer
 - Node.js (LTS)
 

--- a/docs/agents/angular-patterns.md
+++ b/docs/agents/angular-patterns.md
@@ -1,6 +1,6 @@
-# Angular 21+ Patterns - Detailed Reference
+# Angular 22+ Patterns - Detailed Reference
 
-> This document provides detailed patterns and examples for Angular 21+ development in the Fundamental NGX project.
+> This document provides detailed patterns and examples for Angular 22+ development in the Fundamental NGX project.
 
 ## Table of Contents
 
@@ -263,7 +263,7 @@ effect(() => {
 
 ### Signal Writes in Effects
 
-Signal writes are **allowed by default** in Angular 21+. The `allowSignalWrites` option is deprecated.
+Signal writes are **allowed by default** in Angular 22+. The `allowSignalWrites` option is deprecated.
 
 ```typescript
 // Correct - no options needed
@@ -515,9 +515,9 @@ afterRender(
 
 ## Resource API (Experimental)
 
-> **Warning:** `resource()`, `rxResource()`, and `httpResource()` are in **developer preview** as of Angular 21. Known issues include: `value()` throws when in error state, `fixture.whenStable()` doesn't resolve with pending resources, errors don't trigger `ErrorHandler`, and the error signal is typed as `unknown`. Use with caution and expect API changes.
+> **Warning:** `resource()`, `rxResource()`, and `httpResource()` are in **developer preview** as of Angular 22. Known issues include: `value()` throws when in error state, `fixture.whenStable()` doesn't resolve with pending resources, errors don't trigger `ErrorHandler`, and the error signal is typed as `unknown`. Use with caution and expect API changes.
 
-Angular 21 introduces experimental `resource()` API for async data fetching:
+Angular 22 introduced experimental `resource()` API for async data fetching:
 
 ```typescript
 export class UserProfile {
@@ -570,7 +570,7 @@ export class ExampleComponent implements CssClassBuilder {
 }
 ```
 
-### After (Angular 21+ with signals)
+### After (Angular 22+ with signals)
 
 ```typescript
 @Component({

--- a/docs/agents/di-patterns.md
+++ b/docs/agents/di-patterns.md
@@ -1,6 +1,6 @@
 # Dependency Injection Patterns
 
-> This document covers advanced dependency injection patterns for Angular 21+ development in Fundamental NGX.
+> This document covers advanced dependency injection patterns for Angular 22+ development in Fundamental NGX.
 
 ## Table of Contents
 

--- a/docs/agents/testing-guidelines.md
+++ b/docs/agents/testing-guidelines.md
@@ -1,6 +1,6 @@
 # Testing Guidelines
 
-> This document covers testing patterns and best practices for Angular 21+ development in Fundamental NGX.
+> This document covers testing patterns and best practices for Angular 22+ development in Fundamental NGX.
 
 ## Table of Contents
 

--- a/libs/btp/README.md
+++ b/libs/btp/README.md
@@ -12,7 +12,7 @@
 
 ## Requirements
 
-Angular 21 or newer. Prior knowledge of Angular is recommended.
+Angular 22 or newer. Prior knowledge of Angular is recommended.
 
 ## Getting Started
 

--- a/libs/cdk/README.md
+++ b/libs/cdk/README.md
@@ -14,7 +14,7 @@ See the [Component Documentation](https://sap.github.io/fundamental-ngx) for exa
 
 ## Requirements
 
-Angular 21 or newer. Prior knowledge of Angular is recommended.
+Angular 22 or newer. Prior knowledge of Angular is recommended.
 
 ## Getting Started
 

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -14,7 +14,7 @@ See the [Component Documentation](https://sap.github.io/fundamental-ngx) for exa
 
 ## Requirements
 
-Angular 21 or newer. Prior knowledge of Angular is recommended.
+Angular 22 or newer. Prior knowledge of Angular is recommended.
 
 ## Getting Started
 

--- a/libs/cx/README.md
+++ b/libs/cx/README.md
@@ -14,7 +14,7 @@ See the [Component Documentation](https://sap.github.io/fundamental-ngx) for exa
 
 ## Requirements
 
-Angular 21 or newer. Prior knowledge of Angular is recommended.
+Angular 22 or newer. Prior knowledge of Angular is recommended.
 
 ## Getting Started
 

--- a/libs/docs/GETTING_STARTED.md
+++ b/libs/docs/GETTING_STARTED.md
@@ -54,9 +54,9 @@ Fundamental NGX is the SAP set of Angular component libraries implementing the S
 ### Requirements
 
 - **Node.js**: LTS version recommended
-- **Angular**: Version 21 or newer
+- **Angular**: Version 22 or newer
 - **npm**: Included with Node.js
-- **TypeScript**: 5.9 or newer
+- **TypeScript**: 6 or newer
 
 **Peer dependencies** (installed automatically by `ng add`, required for manual installs):
 

--- a/libs/mcp-server/src/data/usage-guides.ts
+++ b/libs/mcp-server/src/data/usage-guides.ts
@@ -522,7 +522,7 @@ themingInitializer()
             }
         ],
         commonPitfalls: [
-            'Package name change: replace @ui5/webcomponents-ngx with @fundamental-ngx/ui5-webcomponents. The old package declares peerDependencies on @angular/core ^20 and is incompatible with Angular 21. Do not use --legacy-peer-deps to force it in.',
+            'Package name change: replace @ui5/webcomponents-ngx with @fundamental-ngx/ui5-webcomponents. The old package declares peerDependencies on @angular/core ^20 and is incompatible with Angular 22. Do not use --legacy-peer-deps to force it in.',
             'Import paths changed: old package used @ui5/webcomponents-ngx/dist/generated/... New package uses @fundamental-ngx/ui5-webcomponents/<component-name> (e.g. @fundamental-ngx/ui5-webcomponents/input, @fundamental-ngx/ui5-webcomponents/button).',
             'All kebab-case attribute bindings must become camelCase Angular property bindings. A template like value-state="Error" will silently pass "Error" as a string to the web component\'s HTML attribute (not the Angular input), bypassing type checking and possibly having no effect.',
             'ValueState "Error" no longer exists — the type now only accepts "None" | "Positive" | "Critical" | "Negative" | "Information". Passing the old string "Error" compiles but produces no visual error state at runtime. Always use "Negative" for validation errors.',
@@ -563,7 +563,7 @@ npm install @fundamental-ngx/ui5-webcomponents @fundamental-ngx/cdk
         summary:
             'Angular wrappers for UI5 Web Components, published under @fundamental-ngx/ui5-webcomponents. ' +
             'The older @ui5/webcomponents-ngx package is deprecated and incompatible with Angular 20+. ' +
-            'Always use @fundamental-ngx/ui5-webcomponents which supports Angular 21 natively.',
+            'Always use @fundamental-ngx/ui5-webcomponents which supports Angular 22 natively.',
         decisionTree: [
             {
                 question: 'Which UI5 package should I install?',
@@ -580,14 +580,14 @@ npm install @fundamental-ngx/ui5-webcomponents @fundamental-ngx/cdk
                         answer: '@ui5/webcomponents-ngx (deprecated — do not use)',
                         recommendation:
                             'This package is deprecated and declares peerDependencies on @angular/core ^20 — it is ' +
-                            'incompatible with Angular 21. Migrate to @fundamental-ngx/ui5-webcomponents.',
+                            'incompatible with Angular 22. Migrate to @fundamental-ngx/ui5-webcomponents.',
                         example: ''
                     }
                 ]
             }
         ],
         commonPitfalls: [
-            '@ui5/webcomponents-ngx is deprecated. The successor is @fundamental-ngx/ui5-webcomponents from this monorepo. Using the old package with --legacy-peer-deps on Angular 21 may appear to install but will cause build or runtime errors.',
+            '@ui5/webcomponents-ngx is deprecated. The successor is @fundamental-ngx/ui5-webcomponents from this monorepo. Using the old package with --legacy-peer-deps on Angular 22 may appear to install but will cause build or runtime errors.',
             '@fundamental-ngx/cdk is a required peer dependency that npm does not always install automatically. If you see "Could not resolve @fundamental-ngx/cdk/utils" or similar import errors, install it explicitly: npm install @fundamental-ngx/cdk',
             'UI5 component import paths follow the pattern @fundamental-ngx/ui5-webcomponents/<component-name>. Example: import { Ui5ButtonComponent } from "@fundamental-ngx/ui5-webcomponents/button".',
             'All three @fundamental-ngx packages (core, cdk, ui5-webcomponents) must be the same semver minor version. Mixing 0.61.x with 0.62.x will cause peer-dep conflicts.',

--- a/libs/platform/README.md
+++ b/libs/platform/README.md
@@ -14,7 +14,7 @@ See the [Component Documentation](https://sap.github.io/fundamental-ngx) for exa
 
 ## Requirements
 
-Angular 21 or newer. Prior knowledge of Angular is recommended.
+Angular 22 or newer. Prior knowledge of Angular is recommended.
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "license": "Apache-2.0",
     "main": "dist/libs/core/index.js",
-    "description": "The official SAP Angular library for UI5 Web Components and Fiori design system. 1000+ components for Angular 21+.",
+    "description": "The official SAP Angular library for UI5 Web Components and Fiori design system. 1000+ components for Angular 22+.",
     "keywords": [
         "angular",
         "ui5",


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

Updates all mentions of Angular 21 to `Angular 22` in docs, skills and MCP.
Updates all mentions of TypeScript 5 to `TypeScript 6`.

BREAKING CHANGES:
Migrate and adopt Angular 22 and Typesctipt 6