### PR TITLE
fix(core): provide fix for linearGradient console error in Status Indicator

### DIFF
--- a/libs/core/status-indicator/status-indicator.component.ts
+++ b/libs/core/status-indicator/status-indicator.component.ts
@@ -136,14 +136,19 @@ export class StatusIndicatorComponent implements AfterViewInit, HasElementRef {
 
     /** @hidden */
     protected readonly binaryString = signal<string>('');
+
     /** @hidden */
-    protected readonly x1 = signal<string>('');
+    protected readonly x1 = signal<string>('0');
+
     /** @hidden */
-    protected readonly y1 = signal<string>('');
+    protected readonly y1 = signal<string>('0');
+
     /** @hidden */
-    protected readonly x2 = signal<string>('');
+    protected readonly x2 = signal<string>('0');
+
     /** @hidden */
-    protected readonly y2 = signal<string>('');
+    protected readonly y2 = signal<string>('0');
+
     /** @hidden */
     protected readonly pointsArray = signal<string[]>([]);
 


### PR DESCRIPTION

## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/14358

## Description
The issue was that x1, y1, x2, and y2 signals were initialized with empty strings, causing SVG parsing errors when the `<linearGradient>` rendered before `ngAfterViewInit` populated them with valid values.

The fix initializes them with valid default values ('0', '0', '0', '0') that represent a valid vertical linear gradient. These will be overridden by the correct values once `_angleCalculation()` runs in `ngAfterViewInit`.