### PR TITLE
fix(core): make fd-panel-title wrap instead of truncating

### DIFF
--- a/libs/core/panel/panel-title/panel-title.directive.spec.ts
+++ b/libs/core/panel/panel-title/panel-title.directive.spec.ts
@@ -1,16 +1,18 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild, signal } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { PanelTitleDirective } from './panel-title.directive';
 
 @Component({
-    template: `<h5 #directiveElement fd-panel-title>Test Panel Title Text</h5>`,
+    template: `<h5 #directiveElement fd-panel-title [wrap]="wrap()">Test Panel Title Text</h5>`,
     standalone: true,
     imports: [PanelTitleDirective]
 })
 class TestComponent {
     @ViewChild('directiveElement')
     ref: ElementRef;
+
+    wrap = signal(true);
 }
 
 describe('PanelTitleDirective', () => {
@@ -34,6 +36,16 @@ describe('PanelTitleDirective', () => {
     });
 
     it('should assign class', () => {
-        expect(component.ref.nativeElement.className).toBe('fd-panel__title');
+        expect(component.ref.nativeElement.classList).toContain('fd-panel__title');
+    });
+
+    it('should apply fd-panel__title--wrap by default', () => {
+        expect(component.ref.nativeElement.classList).toContain('fd-panel__title--wrap');
+    });
+
+    it('should remove fd-panel__title--wrap when wrap is false', () => {
+        component.wrap.set(false);
+        fixture.detectChanges();
+        expect(component.ref.nativeElement.classList).not.toContain('fd-panel__title--wrap');
     });
 });

--- a/libs/core/panel/panel-title/panel-title.directive.ts
+++ b/libs/core/panel/panel-title/panel-title.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, input } from '@angular/core';
+import { booleanAttribute, Directive, input } from '@angular/core';
 
 let panelTitleUniqueId = 0;
 
@@ -14,10 +14,14 @@ let panelTitleUniqueId = 0;
     selector: '[fd-panel-title]',
     host: {
         class: 'fd-panel__title',
+        '[class.fd-panel__title--wrap]': 'wrap()',
         '[attr.id]': 'id()'
     }
 })
 export class PanelTitleDirective {
     /** Id of the host element. */
     readonly id = input('fd-panel-title-' + panelTitleUniqueId++);
+
+    /** Whether the title text wraps instead of truncating with ellipsis. Enabled by default to satisfy WCAG 1.4.10 Reflow. */
+    readonly wrap = input(true, { transform: booleanAttribute });
 }

--- a/libs/docs/core/panel/examples/panel-fixed-example.component.html
+++ b/libs/docs/core/panel/examples/panel-fixed-example.component.html
@@ -1,5 +1,7 @@
 <fd-panel [fixed]="true">
-    <h5 fd-panel-title>Panel Header</h5>
+    <h5 fd-panel-title>
+        Some long panel header that should wrap instead of truncating with ellipsis in case there is no space
+    </h5>
     <div fd-panel-content ariaLabel="Panel Content" id="panel-content-2">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ut laoreet lorem. Vestibulum ante ipsum primis
         in faucibus orci luctus et ultrices posuere cubilia curae; Aenean sagittis aliquam justo et suscipit. Nam


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14271

## Description

Three files changed to fix WCAG 1.4.10 (Reflow) on fd-panel headers:

### panel-title.directive.ts
- Added `wrap` signal input (`default: true`) that toggles the `fd-panel__title--wrap` host class — fundamental-styles already defines this class to override the built-in white-space: nowrap / text-overflow: ellipsis truncation. Defaults to true so all panel titles wrap at narrow viewports without any consumer opt-in.

### panel-title.directive.spec.ts

- Updated the test component to bind `[wrap]="wrap()"` via a signal().
- Updated the existing class assertion to use classList.toContain (since the class list now has two entries).
- Added two new tests: one verifying fd-panel__title--wrap is present by default, one verifying it's removed when wrap is set to false.

### panel-fixed-example.component.html

- Updated the example title to a longer string to demonstrate wrapping at narrow viewports.

## Screenshots

<img width="792" height="608" alt="Screenshot 2026-07-17 at 15 34 46" src="https://github.com/user-attachments/assets/6cda5345-71e0-43ae-8a07-f8dc782a9c15" />

