### PR TITLE
chore: detect BREAKING CHANGES (plural) in PR body and fail check

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -2,9 +2,7 @@ name: PR checks
 
 on:
     pull_request:
-        types: [opened, synchronize, edited]
-    pull_request_target:
-        types: [edited]
+        types: [opened, edited, synchronize]
 
 env:
     NODE_VERSION: '22.x'
@@ -23,7 +21,6 @@ jobs:
     pr_lint:
         runs-on: ubuntu-latest
         name: Lint PR title and body
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         permissions:
             pull-requests: write
             contents: read

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -2,6 +2,9 @@ name: PR checks
 
 on:
     pull_request:
+        types: [opened, synchronize, edited]
+    pull_request_target:
+        types: [edited]
 
 env:
     NODE_VERSION: '22.x'
@@ -17,6 +20,59 @@ permissions:
     contents: read
 
 jobs:
+    pr_lint:
+        runs-on: ubuntu-latest
+        name: Lint PR title and body
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        permissions:
+            pull-requests: write
+            contents: read
+        steps:
+            - name: Check for BREAKING CHANGES (plural)
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const pr = context.payload.pull_request;
+                      const title = pr.title;
+                      const body = pr.body || '';
+
+                      // Debug logging
+                      console.log('PR Body:', body);
+                      console.log('Checking for "BREAKING CHANGES:":', body.includes('BREAKING CHANGES:'));
+                      console.log('Checking for "BREAKING CHANGE:":', body.includes('BREAKING CHANGE:'));
+
+                      const hasBreakingChangesPlural = body.includes('BREAKING CHANGES:');
+                      const hasBreakingChange = body.includes('BREAKING CHANGE:');
+
+                      if (hasBreakingChangesPlural) {
+                          const message = `⚠️ **Breaking Change Format Issue**
+
+                      Your PR body contains \`BREAKING CHANGES:\` (plural), but the conventional-commits parser requires \`BREAKING CHANGE:\` (singular) for version bumping to work correctly.
+
+                      Please update your PR description to use:
+                      \`\`\`
+                      BREAKING CHANGE: your description here
+                      \`\`\`
+
+                      Or use the \`!\` syntax in the PR title instead:
+                      \`\`\`
+                      ${title.replace(/^(\w+)(\([^)]+\))?:/, '$1$2!:')}
+                      \`\`\``;
+
+                          // Post a comment
+                          await github.rest.issues.createComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: pr.number,
+                              body: message
+                          });
+
+                          // Fail the check
+                          core.setFailed('PR body contains "BREAKING CHANGES:" (plural). Use "BREAKING CHANGE:" (singular) instead.');
+                      } else if (hasBreakingChange) {
+                          core.info('✓ PR correctly uses "BREAKING CHANGE:" (singular)');
+                      }
+
     nx_agents:
         name: Nx Cloud Agent ${{ matrix.agent }}
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description
Adds a GitHub Actions check that detects `BREAKING CHANGES:` (plural) in PR descriptions and fails the PR check, preventing accidental version bump issues.

## Problem

We (well, mostly Inna) frequently use `BREAKING CHANGES:` (plural) instead of `BREAKING CHANGE:` (singular) in PR descriptions. The conventional-commits parser only recognizes the singular form, causing version bumps to be skipped even when breaking changes are present.

## Solution

- Added `pr_lint` job to `.github/workflows/on-pull-request.yml`
- Scans PR body for `BREAKING CHANGES:` (plural) on PR creation/edit
- Posts a helpful comment explaining the issue with fix instructions
- Fails the check to prevent merge until corrected
- Suggests both fix options: singular format or `!` syntax in PR title

## Testing

- [x] Push this branch and create a test PR with `BREAKING CHANGES:` in the body
- [x] Verify the check fails and comment appears
- [x] Edit PR body to `BREAKING CHANGE:` (singular)
- [x] Verify the check passes
