### PR TITLE
docs(core): align dayjs date-picker i18n example with adapter model

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -121,7 +121,7 @@ jobs:
                   ref: ${{ github.event.pull_request.head.sha }}
                   fetch-depth: 0
 
-            - uses: nrwl/nx-set-shas@v4.3.0
+            - uses: nrwl/nx-set-shas@v5.0.1
               name: Derive appropriate SHAs for base and head for nx-affected commands
               with:
                   main-branch-name: main

--- a/libs/docs/core/date-picker/date-picker-docs.component.html
+++ b/libs/docs/core/date-picker/date-picker-docs.component.html
@@ -1,4 +1,4 @@
-<!-- <fd-docs-section-title id="simple" componentName="date-picker"> Simple Date Picker </fd-docs-section-title>
+<fd-docs-section-title id="simple" componentName="date-picker"> Simple Date Picker </fd-docs-section-title>
 <description>
     You can use two-way data binding to select a date or range of dates on a calendar. Calendars internally utilize an
     interface called <code>CalendarDay</code>, which contains the property <code>date</code>. To select a date you will
@@ -63,7 +63,7 @@
 </component-example>
 <code-example [exampleFiles]="datePickerMultiRange"></code-example>
 
-<separator></separator> -->
+<separator></separator>
 
 <fd-docs-section-title id="internationalization" componentName="date-picker">
     Internationalization
@@ -84,7 +84,7 @@
     <fd-datepicker-i18n-example></fd-datepicker-i18n-example>
 </component-example>
 <code-example [exampleFiles]="datePickerI18N"></code-example>
-<!-- 
+
 <separator></separator>
 
 <fd-docs-section-title id="todayButton" componentName="date-picker">Today Selection Button</fd-docs-section-title>
@@ -343,4 +343,4 @@
 <component-example name="ex14">
     <fd-date-picker-legend-example></fd-date-picker-legend-example>
 </component-example>
-<code-example [exampleFiles]="legendExamples"></code-example> -->
+<code-example [exampleFiles]="legendExamples"></code-example>

--- a/libs/docs/core/date-picker/date-picker-docs.component.html
+++ b/libs/docs/core/date-picker/date-picker-docs.component.html
@@ -1,4 +1,4 @@
-<fd-docs-section-title id="simple" componentName="date-picker"> Simple Date Picker </fd-docs-section-title>
+<!-- <fd-docs-section-title id="simple" componentName="date-picker"> Simple Date Picker </fd-docs-section-title>
 <description>
     You can use two-way data binding to select a date or range of dates on a calendar. Calendars internally utilize an
     interface called <code>CalendarDay</code>, which contains the property <code>date</code>. To select a date you will
@@ -63,7 +63,7 @@
 </component-example>
 <code-example [exampleFiles]="datePickerMultiRange"></code-example>
 
-<separator></separator>
+<separator></separator> -->
 
 <fd-docs-section-title id="internationalization" componentName="date-picker">
     Internationalization
@@ -74,7 +74,8 @@
     <br />
     Since FdDatetimeAdapter implementation relies on native date api for parsing and formatting dates, it might not work
     correctly with some of the locales out of the box. We recommend switching to the DayjsDatetimeAdapter for more
-    flexibility.
+    flexibility. When using DayjsDatetimeAdapter, bind the picker value to <code>dayjs()</code>-based values instead of
+    <code>FdDate</code>.
     <br />
     Please check examples and documentation on:
     <b> <a routerLink="/core/dayjs-datetime-adapter" target="_blank"> DayJS date time adapter </a> </b>.
@@ -83,7 +84,7 @@
     <fd-datepicker-i18n-example></fd-datepicker-i18n-example>
 </component-example>
 <code-example [exampleFiles]="datePickerI18N"></code-example>
-
+<!-- 
 <separator></separator>
 
 <fd-docs-section-title id="todayButton" componentName="date-picker">Today Selection Button</fd-docs-section-title>
@@ -342,4 +343,4 @@
 <component-example name="ex14">
     <fd-date-picker-legend-example></fd-date-picker-legend-example>
 </component-example>
-<code-example [exampleFiles]="legendExamples"></code-example>
+<code-example [exampleFiles]="legendExamples"></code-example> -->

--- a/libs/docs/core/date-picker/examples/date-picker-i18n-example.component.ts
+++ b/libs/docs/core/date-picker/examples/date-picker-i18n-example.component.ts
@@ -2,11 +2,12 @@ import { Component, LOCALE_ID } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { DatePickerComponent } from '@fundamental-ngx/core/date-picker';
-import { DATE_TIME_FORMATS, DatetimeAdapter, FdDate, FdDatetimeModule } from '@fundamental-ngx/core/datetime';
+import { DATE_TIME_FORMATS, DatetimeAdapter, FdDatetimeModule } from '@fundamental-ngx/core/datetime';
 import { FormLabelComponent } from '@fundamental-ngx/core/form';
 import { SegmentedButtonModule } from '@fundamental-ngx/core/segmented-button';
 import { DAYJS_DATETIME_FORMATS, DayjsDatetimeAdapter } from '@fundamental-ngx/datetime-adapter';
 import { patchLanguage } from '@fundamental-ngx/i18n';
+import dayjs, { Dayjs } from 'dayjs';
 import 'dayjs/locale/bg';
 import 'dayjs/locale/de';
 import 'dayjs/locale/fr';
@@ -77,10 +78,10 @@ const CUSTOM_DATETIME_FORMATS = {
     ]
 })
 export class DatePickerI18nExampleComponent {
-    date = FdDate.getNow();
+    date: Dayjs = dayjs();
     locale = 'fr';
 
-    constructor(private datetimeAdapter: DatetimeAdapter<FdDate>) {}
+    constructor(private datetimeAdapter: DatetimeAdapter<Dayjs>) {}
 
     setLocale(locale: string): void {
         this.locale = locale;

--- a/libs/docs/core/date-picker/examples/date-picker-i18n-example.component.ts
+++ b/libs/docs/core/date-picker/examples/date-picker-i18n-example.component.ts
@@ -2,7 +2,7 @@ import { Component, LOCALE_ID } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { DatePickerComponent } from '@fundamental-ngx/core/date-picker';
-import { DATE_TIME_FORMATS, DatetimeAdapter, FdDatetimeModule } from '@fundamental-ngx/core/datetime';
+import { DATE_TIME_FORMATS, DatetimeAdapter } from '@fundamental-ngx/core/datetime';
 import { FormLabelComponent } from '@fundamental-ngx/core/form';
 import { SegmentedButtonModule } from '@fundamental-ngx/core/segmented-button';
 import { DAYJS_DATETIME_FORMATS, DayjsDatetimeAdapter } from '@fundamental-ngx/datetime-adapter';
@@ -68,14 +68,7 @@ const CUSTOM_DATETIME_FORMATS = {
             useValue: CUSTOM_DATETIME_FORMATS
         }
     ],
-    imports: [
-        FormLabelComponent,
-        SegmentedButtonModule,
-        ButtonComponent,
-        DatePickerComponent,
-        FormsModule,
-        FdDatetimeModule
-    ]
+    imports: [FormLabelComponent, SegmentedButtonModule, ButtonComponent, DatePickerComponent, FormsModule]
 })
 export class DatePickerI18nExampleComponent {
     date: Dayjs = dayjs();

--- a/libs/docs/core/datetime-adapters/datetime-adapters-docs.component.html
+++ b/libs/docs/core/datetime-adapters/datetime-adapters-docs.component.html
@@ -18,6 +18,8 @@
 <description>
     The Dayjs adapter lets you use <a href="https://day.js.org" target="_blank">Day.js</a> objects directly with
     date/time components. It supports locale switching, custom formats, UTC mode, and strict parsing. <br /><br />
+    When you provide <code>DayjsDatetimeAdapter</code>, bind your picker model to <code>Dayjs</code> values such as
+    <code>dayjs()</code>. Do not mix it with <code>FdDate</code> model values. <br /><br />
     For application-wide setup, add <code>provideDayjsDatetimeAdapter()</code> to your app or route providers. The
     example below shows the equivalent manual approach with explicit <code>DatetimeAdapter</code> and
     <code>DATE_TIME_FORMATS</code> providers &mdash; useful when you only need it in a specific component.


### PR DESCRIPTION
## Related Issue(s)

closes none, defect hunting before release

## Description
This fixes the core date-picker i18n docs example after the datetime adapter changes.

The example was providing `DayjsDatetimeAdapter` but initializing the bound model with `FdDate.getNow()`. That created a model/adapter mismatch. After the recent adapter changes, that mismatch now fails during date-picker initialization with:

`DayjsDatetimeAdapter: Cannot format invalid date.`

### Root Cause

The Dayjs adapter expects Dayjs model values.

The i18n example was still binding an `FdDate` value while also overriding `DatetimeAdapter` with `DayjsDatetimeAdapter`. In the date-picker `writeValue()` flow, the incoming model is parsed and then formatted immediately. With the custom Dayjs parse format used by the example, the `FdDate` seed value no longer round-trips into a valid Dayjs instance, so formatting throws.

### Changes

- Updated the core date-picker i18n example to use `dayjs()` / `Dayjs` instead of `FdDate.getNow()`
- Updated the injected adapter generic type to `DatetimeAdapter<Dayjs>`
- Added a documentation note to the Dayjs adapter docs clarifying that `DayjsDatetimeAdapter` must be paired with Dayjs model values
- Added the same note to the date-picker i18n docs section

### Impact

This is not a general breaking change for all date-picker i18n users.

Consumers only need to update if they were mixing:
- `DayjsDatetimeAdapter` with `FdDate` model values

Consumers do not need changes if they already use:
- `DayjsDatetimeAdapter` with Dayjs values
- `FdDatetimeAdapter` with `FdDate` values

## Screenshots

### Before
<img width="1806" height="513" alt="Screenshot 2026-07-17 at 2 36 49 PM" src="https://github.com/user-attachments/assets/cf1228e9-1c22-4875-b2fe-6646782f8b7c" />


### After
<img width="1805" height="497" alt="Screenshot 2026-07-17 at 3 03 34 PM" src="https://github.com/user-attachments/assets/3f8350e0-036f-4195-9a25-24d856463c9f" />
