### PR TITLE
chore(deps): pin websocket-driver to version 0.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,8 @@
         "tar": "7.5.8",
         "@ui5/project": "4.0.10",
         "sigstore@npm:^3.0.0": "npm:4.1.1",
-        "sigstore@npm:^4.0.0": "npm:4.1.1"
+        "sigstore@npm:^4.0.0": "npm:4.1.1",
+        "websocket-driver": "0.7.5"
     },
     "lint-staged": {
         "*.{js,ts,html,md,json,yml,css,scss}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -28885,14 +28885,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+"websocket-driver@npm:0.7.5":
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 10/17197d265d5812b96c728e70fd6fe7d067471e121669768fe0c7100c939d997ddfc807d371a728556e24fc7238aa9d58e630ea4ff5fd4cfbb40f3d0a240ef32d
+  checksum: 10/0671fef8c79ba1b1b2fa6b7d95cb034d059410e7c4cfd7ef42063a254e12ca2917806c3a5026206b33abf25a5d44a651c547b8f74d9ec94c9fe4df6fa1bc63f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Related Issue(s)

addresses https://github.com/SAP/fundamental-ngx/security/dependabot/552

## Description

Fixes a security vulnerability related to `websoket-driver`.

### Impact
The frame format in draft versions of the WebSocket protocol includes a length header that allows an arbitrarily large integer to be encoded as a sequence of bytes with the high bit set. By sending an indefinite sequence of bytes with values 0x80 or above, a client can make the server parse these bytes into an ever-growing integer. Since JavaScript numbers are 64-bit floating point values, this number will eventually lose precision and lead to the subsequent payload being parsed incorrectly.

### Patches
The issue has been patched in version 0.7.5 by rejecting the message if the length header exceeds the configured maximum message length. All users should upgrade to this version.

### The chain in our codebase:

**webpack-dev-server → sockjs → faye-websocket → websocket-driver@0.7.4**

Both paths (via `sockjs` directly and via `faye-websocket`) lead to `websocket-driver@0.7.4`, which needs to be `>=0.7.5`.

### The fix
The fix is a Yarn `resolution` override in `package.json`, since this is a transitive dev dependency and we can't upgrade `webpack-dev-server` or `sockjs` to get a patched version (neither has released one yet with the fix). 