### PR TITLE
fix(cdk): filter disabled tabbables and stabilize tabbable docs example

### DIFF
--- a/libs/cdk/utils/services/tabbable-element.service.spec.ts
+++ b/libs/cdk/utils/services/tabbable-element.service.spec.ts
@@ -1,0 +1,296 @@
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { TestBed } from '@angular/core/testing';
+import { TabbableElementService } from './tabbable-element.service';
+
+describe('TabbableElementService', () => {
+    let service: TabbableElementService;
+    let checker: InteractivityChecker;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [TabbableElementService, InteractivityChecker]
+        });
+        service = TestBed.inject(TabbableElementService);
+        checker = TestBed.inject(InteractivityChecker);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    describe('getTabbableElement', () => {
+        it('should return the root element if it is tabbable and not disabled', () => {
+            const button = document.createElement('button');
+            document.body.appendChild(button);
+
+            jest.spyOn(checker, 'isTabbable').mockReturnValue(true);
+            jest.spyOn(checker, 'isFocusable').mockReturnValue(true);
+
+            const result = service.getTabbableElement(button);
+
+            expect(result).toBe(button);
+
+            document.body.removeChild(button);
+        });
+
+        it('should skip root element when skipSelf is true', () => {
+            const container = document.createElement('div');
+            const button = document.createElement('button');
+            container.appendChild(button);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockReturnValue(true);
+            jest.spyOn(checker, 'isFocusable').mockReturnValue(true);
+
+            const result = service.getTabbableElement(container, false, true);
+
+            expect(result).toBe(button);
+
+            document.body.removeChild(container);
+        });
+
+        it('should return the first tabbable child element', () => {
+            const container = document.createElement('div');
+            const span = document.createElement('span');
+            const button = document.createElement('button');
+            container.appendChild(span);
+            container.appendChild(button);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockImplementation((el) => el.tagName === 'BUTTON');
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBe(button);
+
+            document.body.removeChild(container);
+        });
+
+        it('should return the last tabbable child when focusLastElement is true', () => {
+            const container = document.createElement('div');
+            const button1 = document.createElement('button');
+            const button2 = document.createElement('button');
+            container.appendChild(button1);
+            container.appendChild(button2);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockImplementation((el) => el.tagName === 'BUTTON');
+
+            const result = service.getTabbableElement(container, true);
+
+            expect(result).toBe(button2);
+
+            document.body.removeChild(container);
+        });
+
+        it('should return null if no tabbable element is found', () => {
+            const container = document.createElement('div');
+            const span = document.createElement('span');
+            container.appendChild(span);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockReturnValue(false);
+            jest.spyOn(checker, 'isFocusable').mockReturnValue(false);
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBeNull();
+
+            document.body.removeChild(container);
+        });
+    });
+
+    describe('disabled element filtering', () => {
+        it('should filter out elements with disabled attribute', () => {
+            const container = document.createElement('div');
+            const disabledButton = document.createElement('button');
+            const enabledButton = document.createElement('button');
+            disabledButton.setAttribute('disabled', 'true');
+            container.appendChild(disabledButton);
+            container.appendChild(enabledButton);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockImplementation((el) => el.tagName === 'BUTTON');
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBe(enabledButton);
+
+            document.body.removeChild(container);
+        });
+
+        it('should filter out elements with aria-disabled="true"', () => {
+            const container = document.createElement('div');
+            const ariaDisabledButton = document.createElement('button');
+            const enabledButton = document.createElement('button');
+            ariaDisabledButton.setAttribute('aria-disabled', 'true');
+            container.appendChild(ariaDisabledButton);
+            container.appendChild(enabledButton);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockImplementation((el) => el.tagName === 'BUTTON');
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBe(enabledButton);
+
+            document.body.removeChild(container);
+        });
+
+        it('should filter out elements with is-disabled class', () => {
+            const container = document.createElement('div');
+            const disabledButton = document.createElement('button');
+            const enabledButton = document.createElement('button');
+            disabledButton.classList.add('is-disabled');
+            container.appendChild(disabledButton);
+            container.appendChild(enabledButton);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockImplementation((el) => el.tagName === 'BUTTON');
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBe(enabledButton);
+
+            document.body.removeChild(container);
+        });
+
+        it('should filter out elements that are focusable but not tabbable', () => {
+            const container = document.createElement('div');
+            const focusableOnly = document.createElement('div');
+            focusableOnly.setAttribute('tabindex', '-1');
+            const tabbableButton = document.createElement('button');
+            container.appendChild(focusableOnly);
+            container.appendChild(tabbableButton);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockReturnValue(true);
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBe(tabbableButton);
+
+            document.body.removeChild(container);
+        });
+
+        it('should handle multiple disabled conditions on the same element', () => {
+            const container = document.createElement('div');
+            const disabledButton = document.createElement('button');
+            const enabledButton = document.createElement('button');
+            disabledButton.setAttribute('disabled', 'true');
+            disabledButton.setAttribute('aria-disabled', 'true');
+            disabledButton.classList.add('is-disabled');
+            container.appendChild(disabledButton);
+            container.appendChild(enabledButton);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockImplementation((el) => el.tagName === 'BUTTON');
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBe(enabledButton);
+
+            document.body.removeChild(container);
+        });
+
+        it('should allow aria-disabled="false" elements', () => {
+            const container = document.createElement('div');
+            const button = document.createElement('button');
+            button.setAttribute('aria-disabled', 'false');
+            container.appendChild(button);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockImplementation((el) => el.tagName === 'BUTTON');
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBe(button);
+
+            document.body.removeChild(container);
+        });
+
+        it('should check isTabbable before isFocusable for performance', () => {
+            const container = document.createElement('div');
+            const button = document.createElement('button');
+            container.appendChild(button);
+            document.body.appendChild(container);
+
+            const tabbableSpy = jest.spyOn(checker, 'isTabbable').mockReturnValue(false);
+            const focusableSpy = jest.spyOn(checker, 'isFocusable').mockReturnValue(true);
+
+            service.getTabbableElement(container);
+
+            expect(tabbableSpy).toHaveBeenCalled();
+            // isFocusable should not be called if isTabbable returns false
+            expect(focusableSpy).not.toHaveBeenCalled();
+
+            document.body.removeChild(container);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle SVG elements with childNodes instead of children', () => {
+            const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            svg.appendChild(circle);
+            document.body.appendChild(svg);
+
+            jest.spyOn(checker, 'isTabbable').mockReturnValue(false);
+            jest.spyOn(checker, 'isFocusable').mockReturnValue(false);
+
+            const result = service.getTabbableElement(svg as any);
+
+            expect(result).toBeNull();
+
+            document.body.removeChild(svg);
+        });
+
+        it('should handle text nodes and comments gracefully', () => {
+            const container = document.createElement('div');
+            const textNode = document.createTextNode('text');
+            const comment = document.createComment('comment');
+            const button = document.createElement('button');
+            container.appendChild(textNode);
+            container.appendChild(comment);
+            container.appendChild(button);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockImplementation((el) => el.tagName === 'BUTTON');
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBe(button);
+
+            document.body.removeChild(container);
+        });
+
+        it('should handle deeply nested elements', () => {
+            const container = document.createElement('div');
+            const level1 = document.createElement('div');
+            const level2 = document.createElement('div');
+            const button = document.createElement('button');
+            level2.appendChild(button);
+            level1.appendChild(level2);
+            container.appendChild(level1);
+            document.body.appendChild(container);
+
+            jest.spyOn(checker, 'isTabbable').mockImplementation((el) => el.tagName === 'BUTTON');
+            jest.spyOn(checker, 'isFocusable').mockImplementation((el) => el.tagName === 'BUTTON');
+
+            const result = service.getTabbableElement(container);
+
+            expect(result).toBe(button);
+
+            document.body.removeChild(container);
+        });
+    });
+});

--- a/libs/cdk/utils/services/tabbable-element.service.ts
+++ b/libs/cdk/utils/services/tabbable-element.service.ts
@@ -39,11 +39,7 @@ export class TabbableElementService {
     }
 
     private _isTabbableElement(element: HTMLElement): boolean {
-        return (
-            this._checker.isTabbable(element) &&
-            !this._isElementDisabled(element) &&
-            this._checker.isFocusable(element, { ignoreVisibility: true })
-        );
+        return this._checker.isTabbable(element) && !this._isElementDisabled(element);
     }
 
     private _isElementDisabled(element: HTMLElement): boolean {

--- a/libs/cdk/utils/services/tabbable-element.service.ts
+++ b/libs/cdk/utils/services/tabbable-element.service.ts
@@ -12,9 +12,11 @@ export class TabbableElementService {
 
     /** Get the first tabbable element from a DOM subtree (inclusive). */
     getTabbableElement(root: HTMLElement, focusLastElement = false, skipSelf = false): HTMLElement | null {
-        if (!skipSelf && this._checker.isFocusable(root) && this._checker.isTabbable(root)) {
+        if (!skipSelf && this._isTabbableElement(root)) {
             return root;
         }
+
+        const elementNodeType = this._document?.ELEMENT_NODE ?? 1;
 
         // Iterate in DOM order. Note that IE doesn't have `children` for SVG, so we fall
         // back to `childNodes` which includes text nodes, comments etc.
@@ -24,7 +26,7 @@ export class TabbableElementService {
 
         for (let i = 0; i < children.length; i++) {
             const tabbableChild =
-                children[i].nodeType === this._document?.ELEMENT_NODE
+                children[i].nodeType === elementNodeType
                     ? this.getTabbableElement(children[i] as HTMLElement, focusLastElement)
                     : null;
 
@@ -34,5 +36,21 @@ export class TabbableElementService {
         }
 
         return null;
+    }
+
+    private _isTabbableElement(element: HTMLElement): boolean {
+        return (
+            this._checker.isTabbable(element) &&
+            !this._isElementDisabled(element) &&
+            this._checker.isFocusable(element, { ignoreVisibility: true })
+        );
+    }
+
+    private _isElementDisabled(element: HTMLElement): boolean {
+        return (
+            element.hasAttribute('disabled') ||
+            element.getAttribute('aria-disabled') === 'true' ||
+            element.classList.contains('is-disabled')
+        );
     }
 }

--- a/libs/docs/cdk/tabbable/examples/default/tabbable-default-example.component.html
+++ b/libs/docs/cdk/tabbable/examples/default/tabbable-default-example.component.html
@@ -8,5 +8,5 @@
 </section>
 
 <p>
-    Found tabbable element with class: <code>{{ tabbableElementClass }}</code>
+    Found tabbable element with class: <code>{{ tabbableElementClass() }}</code>
 </p>

--- a/libs/docs/cdk/tabbable/examples/default/tabbable-default-example.component.ts
+++ b/libs/docs/cdk/tabbable/examples/default/tabbable-default-example.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, inject, signal, ViewChild } from '@angular/core';
 import { DisabledBehaviorDirective, TabbableElementService } from '@fundamental-ngx/cdk/utils';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 
@@ -11,13 +11,28 @@ export class TabbableDefaultExampleComponent implements AfterViewInit {
     @ViewChild('section')
     section: ElementRef<HTMLElement>;
 
-    tabbableElementClass: string | undefined;
+    /**
+     * Class name(s) of the currently detected tabbable element.
+     * Populated after view init once host bindings have been applied.
+     */
+    readonly tabbableElementClass = signal('');
 
     tabbableElementService = inject(TabbableElementService);
 
     ngAfterViewInit(): void {
-        this.tabbableElementClass = this.tabbableElementService.getTabbableElement(
-            this.section.nativeElement
-        )?.className;
+        this._updateTabbableClass();
+
+        // Run a second pass after the current render cycle to catch deferred host updates.
+        // DisabledBehaviorDirective applies host bindings (disabled attribute, is-disabled class)
+        // in a deferred manner, so the initial ngAfterViewInit pass may detect buttons before
+        // their disabled state is fully reflected in the DOM.
+        queueMicrotask(() => this._updateTabbableClass());
+    }
+
+    private _updateTabbableClass(): void {
+        const rootElement = this.section.nativeElement;
+        const tabbableElement = this.tabbableElementService.getTabbableElement(rootElement, false, true);
+
+        this.tabbableElementClass.set(tabbableElement?.getAttribute('class') ?? '');
     }
 }


### PR DESCRIPTION
## Related Issue(s)

related to https://github.com/SAP/fundamental-ngx/issues/14364

## Description
The docs example under CDK Tabbable started showing an empty result instead of the expected enabled button class.
### Root Cause
1. Disabled states were not fully filtered in tabbable detection, so elements marked as non-interactive via accessibility/state classes could still be selected.
2. The docs example update flow was not consistently reflected in the rendered output in the current runtime setup.

### Changes
1. Updated tabbable detection logic in [tabbable-element.service.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):

- Excludes elements that are disabled by:
- disabled attribute
- aria-disabled="true"
- is-disabled class
- Keeps first-match traversal semantics while respecting skipSelf and focusLastElement behavior.

2. Updated docs example in [tabbable-default-example.component.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):

- Uses signal-backed state for the displayed class value.
- Runs detection in a stable two-pass flow (initial + microtask) to avoid stale/empty display.

3. Updated template binding in [tabbable-default-example.component.html](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html):

- Reads signal value directly in template.

## Screenshots
### Before
<img width="1248" height="805" alt="Screenshot 2026-07-20 at 4 15 29 PM" src="https://github.com/user-attachments/assets/01d7b9ac-edd5-45fd-88d3-5e524ad85dc2" />

### After
<img width="1584" height="764" alt="Screenshot 2026-07-20 at 4 15 39 PM" src="https://github.com/user-attachments/assets/dea994af-d9e1-4386-a251-b7c9015cd94d" />
