### PR TITLE
chore: link versions wiki in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,10 +247,6 @@ If you encounter an issue, you can [create a ticket](https://github.com/SAP/fund
 
 Angular version support: features and enhancements target the latest version. Bugfixes can be downported to the version compiled with the previous Angular release. More details on the [Angular Versions Support](https://github.com/SAP/fundamental-ngx/wiki/Angular-Versions-Support) wiki page.
 
-## Version Support and Release Policy
-
-For currently supported versions and release timelines, see the [Version Support and Release Policy wiki](https://github.com/SAP/fundamental-ngx/wiki/Version-Support-and-Release-Policy#current-version-matrix).
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and [NEW_COMPONENT.md](NEW_COMPONENT.md) for a step-by-step guide to building new components.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ If you encounter an issue, you can [create a ticket](https://github.com/SAP/fund
 
 Angular version support: features and enhancements target the latest version. Bugfixes can be downported to the version compiled with the previous Angular release. More details on the [Angular Versions Support](https://github.com/SAP/fundamental-ngx/wiki/Angular-Versions-Support) wiki page.
 
+## Version Support and Release Policy
+
+For currently supported versions and release timelines, see the [Version Support and Release Policy wiki](https://github.com/SAP/fundamental-ngx/wiki/Version-Support-and-Release-Policy#current-version-matrix).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and [NEW_COMPONENT.md](NEW_COMPONENT.md) for a step-by-step guide to building new components.

--- a/apps/docs/src/styles.scss
+++ b/apps/docs/src/styles.scss
@@ -492,4 +492,34 @@ fd-card {
         font-size: var(--sapFontLargeSize);
         font-weight: 400;
     }
+
+    table {
+        margin-block: 1.5rem 0;
+        border-collapse: separate;
+        border-spacing: 0;
+        width: 100%;
+        border: $doc-border;
+        overflow: hidden;
+
+        th,
+        td {
+            padding: 0.75rem 1rem;
+            border: $doc-border;
+            text-align: left;
+        }
+
+        th {
+            font-weight: 600;
+            background: color-mix(in srgb, var(--sapGroup_ContentBackground) 80%, var(--sapBackgroundColor));
+            color: var(--sapTitleColor);
+        }
+
+        tr {
+            background: var(--sapGroup_ContentBackground);
+
+            &:nth-child(2n) {
+                background: color-mix(in srgb, var(--sapGroup_ContentBackground) 92%, var(--sapBackgroundColor));
+            }
+        }
+    }
 }

--- a/libs/docs/GETTING_STARTED.md
+++ b/libs/docs/GETTING_STARTED.md
@@ -49,6 +49,35 @@ Fundamental NGX is the SAP set of Angular component libraries implementing the S
 | [`@fundamental-ngx/mcp`](libs/mcp-server)      | MCP server for AI coding assistants |
 | [`@fundamental-ngx/nx-plugin`](libs/nx-plugin) | NX generators and executors         |
 
+## Version Support and Release Policy
+
+### Currently Supported Versions
+
+| fundamental-ngx | Angular |                         UI5 Web Components                          | Status                           |
+| :-------------- | :-----: | :-----------------------------------------------------------------: | :------------------------------- |
+| **0.64.0** 🎉   |   22    | [2.24.x](https://github.com/UI5/webcomponents/releases/tag/v2.24.0) | 🟢 ACTIVE                        |
+| **0.63.1** 📍   |   21    | [2.24.x](https://github.com/UI5/webcomponents/releases/tag/v2.24.0) | 🟡 LTS (Last Angular 21 release) |
+| ~~**0.63.0**~~  |   21    | [2.23.x](https://github.com/UI5/webcomponents/releases/tag/v2.23.0) | ⚫ Superseded by 0.63.x          |
+| ~~**0.62.4**~~  |   21    | [2.22.x](https://github.com/UI5/webcomponents/releases/tag/v2.22.0) | ⚫ Superseded by 0.63.x          |
+| ~~**0.62.0**~~  |   21    | [2.21.x](https://github.com/UI5/webcomponents/releases/tag/v2.21.0) | ⚫ Superseded by 0.63.x          |
+| ~~**0.61.0**~~  |   21    | [2.20.x](https://github.com/UI5/webcomponents/releases/tag/v2.20.0) | ⚫ Superseded by 0.63.x          |
+| ~~**0.60.x**~~  |   21    | [2.19.x](https://github.com/UI5/webcomponents/releases/tag/v2.19.0) | ⚫ Superseded by 0.63.x          |
+| ~~**0.59.x**~~  |   21    | [2.18.x](https://github.com/UI5/webcomponents/releases/tag/v2.18.1) | ⚫ Superseded by 0.63.x          |
+| **0.58.x** 📍   |   20    | [2.18.x](https://github.com/UI5/webcomponents/releases/tag/v2.18.1) | 🟡 LTS (Last Angular 20 release) |
+| ~~**0.57.x**~~  |   20    |                                N.A.                                 | ⚫ Superseded by 0.58.x          |
+
+**Support tiers:**
+
+- 🟢 **Active Support** — new features, all bug fixes, security patches, and documentation updates
+
+- 🟡 **LTS** — critical fixes only (security vulnerabilities, regressions, blocking bugs)
+
+- ⚫ **End of Life** — no updates (Angular 19 and lower)
+
+**⚠️ Upgrade recommendation:** Angular 20 and 21 are in LTS mode with critical fixes only. For active feature development and full support, upgrade to Angular 22.
+
+See the [complete version policy](https://github.com/SAP/fundamental-ngx/wiki/Version-Support-and-Release-Policy) for LTS backporting rules and release schedules.
+
 ## Quick Start
 
 ### Requirements
@@ -219,10 +248,6 @@ npx nx serve docs --configuration=core
 ```
 
 Navigate to `http://localhost:4200` to view the documentation.
-
-## Version Support and Release Policy
-
-For currently supported versions and release timelines, see the [Version Support and Release Policy wiki](https://github.com/SAP/fundamental-ngx/wiki/Version-Support-and-Release-Policy#current-version-matrix).
 
 ## Support
 

--- a/libs/docs/GETTING_STARTED.md
+++ b/libs/docs/GETTING_STARTED.md
@@ -220,6 +220,10 @@ npx nx serve docs --configuration=core
 
 Navigate to `http://localhost:4200` to view the documentation.
 
+## Version Support and Release Policy
+
+For currently supported versions and release timelines, see the [Version Support and Release Policy wiki](https://github.com/SAP/fundamental-ngx/wiki/Version-Support-and-Release-Policy#current-version-matrix).
+
 ## Support
 
 If you encounter an issue, [create a ticket](https://github.com/SAP/fundamental-ngx/issues).


### PR DESCRIPTION
## Related Issue(s)
closes none

## Description
link the wiki page with Version Support and Release Policy info + versions table in the docs homepage.