### PR TITLE
fix(core): add User menu a11y improvements

### DIFF
--- a/libs/core/user-menu/components/user-menu-body.component.spec.ts
+++ b/libs/core/user-menu/components/user-menu-body.component.spec.ts
@@ -1,40 +1,59 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RtlService } from '@fundamental-ngx/cdk/utils';
+import { KeyboardSupportService, RtlService } from '@fundamental-ngx/cdk/utils';
 import { UserMenuHeaderDirective } from '../directives/user-menu-header.directive';
 import { UserMenuBodyComponent } from './user-menu-body.component';
 import { UserMenuContentContainerComponent } from './user-menu-content-container.component';
+import { UserMenuListItemComponent } from './user-menu-list-item.component';
+import { UserMenuListComponent } from './user-menu-list.component';
 
 @Component({
     template: `
         <fd-user-menu-body #elRef>
             <div fd-user-menu-header></div>
-            <div fd-user-menu-content-container></div>
+            <div fd-user-menu-content-container>
+                <fd-user-menu-list>
+                    <li fd-user-menu-list-item text="Item 1"></li>
+                    <li fd-user-menu-list-item text="Item 2"></li>
+                    <li fd-user-menu-list-item text="Item 3"></li>
+                </fd-user-menu-list>
+            </div>
         </fd-user-menu-body>
     `,
     standalone: true,
-    imports: [UserMenuBodyComponent, UserMenuHeaderDirective, UserMenuContentContainerComponent]
+    imports: [
+        UserMenuBodyComponent,
+        UserMenuHeaderDirective,
+        UserMenuContentContainerComponent,
+        UserMenuListComponent,
+        UserMenuListItemComponent
+    ]
 })
-class TestComponent {
+class TestComponentWithListItems {
     @ViewChild('elRef', { read: ElementRef })
     elRef: ElementRef;
+
+    @ViewChild(UserMenuBodyComponent)
+    bodyComponent: UserMenuBodyComponent;
 }
 
 describe('UserMenuBodyComponent', () => {
-    let component: TestComponent;
-    let fixture: ComponentFixture<TestComponent>;
+    let component: TestComponentWithListItems;
+    let fixture: ComponentFixture<TestComponentWithListItems>;
+    let bodyElement: HTMLElement;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [TestComponent],
-            providers: [RtlService]
+            imports: [TestComponentWithListItems],
+            providers: [RtlService, KeyboardSupportService]
         }).compileComponents();
     }));
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(TestComponent);
+        fixture = TestBed.createComponent(TestComponentWithListItems);
         component = fixture.debugElement.componentInstance;
         fixture.detectChanges();
+        bodyElement = component.elRef.nativeElement;
     });
 
     it('should create', () => {
@@ -42,6 +61,94 @@ describe('UserMenuBodyComponent', () => {
     });
 
     it('should assign class', () => {
-        expect(component.elRef.nativeElement.classList).toContain('fd-user-menu__body');
+        expect(bodyElement.classList).toContain('fd-user-menu__body');
+    });
+
+    describe('focus management', () => {
+        it('should reset list focus when focus leaves menu entirely', (done) => {
+            const listItems = component.bodyComponent['_listItems'];
+
+            // Simulate roving tabindex state where second item was focused
+            listItems.toArray()[0]._tabIndex$.set(-1);
+            listItems.toArray()[1]._tabIndex$.set(0);
+            listItems.toArray()[2]._tabIndex$.set(-1);
+
+            // Create focusout event with relatedTarget outside the menu
+            const event = new FocusEvent('focusout', {
+                bubbles: true,
+                relatedTarget: document.body
+            });
+
+            bodyElement.dispatchEvent(event);
+
+            // Wait for setTimeout(0) to complete
+            setTimeout(() => {
+                // Should reset to first item having tabindex 0
+                expect(listItems.toArray()[0]._tabIndex$()).toBe(0);
+                expect(listItems.toArray()[1]._tabIndex$()).toBe(-1);
+                expect(listItems.toArray()[2]._tabIndex$()).toBe(-1);
+                done();
+            }, 10);
+        });
+
+        it('should not reset list focus when focus moves within menu', () => {
+            const listItems = component.bodyComponent['_listItems'];
+
+            // Simulate roving tabindex state where second item was focused
+            listItems.toArray()[0]._tabIndex$.set(-1);
+            listItems.toArray()[1]._tabIndex$.set(0);
+            listItems.toArray()[2]._tabIndex$.set(-1);
+
+            // Create focusout event with relatedTarget inside the menu
+            const thirdItem = listItems.toArray()[2]['_elementRef'].nativeElement;
+            const event = new FocusEvent('focusout', {
+                bubbles: true,
+                relatedTarget: thirdItem
+            });
+
+            bodyElement.dispatchEvent(event);
+
+            // Should NOT reset - tabindex state should remain unchanged
+            expect(listItems.toArray()[0]._tabIndex$()).toBe(-1);
+            expect(listItems.toArray()[1]._tabIndex$()).toBe(0);
+            expect(listItems.toArray()[2]._tabIndex$()).toBe(-1);
+        });
+
+        it('should handle focusout with null relatedTarget', (done) => {
+            const listItems = component.bodyComponent['_listItems'];
+
+            // Simulate roving tabindex state where second item was focused
+            listItems.toArray()[0]._tabIndex$.set(-1);
+            listItems.toArray()[1]._tabIndex$.set(0);
+            listItems.toArray()[2]._tabIndex$.set(-1);
+
+            // Create focusout event with null relatedTarget (rapid focus transition)
+            const event = new FocusEvent('focusout', {
+                bubbles: true,
+                relatedTarget: null
+            });
+
+            bodyElement.dispatchEvent(event);
+
+            // Wait for setTimeout(0) to check activeElement
+            setTimeout(() => {
+                // If activeElement is outside menu, should reset
+                if (!bodyElement.contains(document.activeElement as HTMLElement)) {
+                    expect(listItems.toArray()[0]._tabIndex$()).toBe(0);
+                }
+                done();
+            }, 10);
+        });
+    });
+
+    describe('stopPropagation on click', () => {
+        it('should stop click event propagation', () => {
+            const event = new MouseEvent('click', { bubbles: true });
+            const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
+
+            bodyElement.dispatchEvent(event);
+
+            expect(stopPropagationSpy).toHaveBeenCalled();
+        });
     });
 });

--- a/libs/core/user-menu/components/user-menu-body.component.ts
+++ b/libs/core/user-menu/components/user-menu-body.component.ts
@@ -125,8 +125,10 @@ export class UserMenuBodyComponent implements AfterViewInit {
      * so Tab re-entry starts at the first item instead of the last-focused item.
      *
      * First checks relatedTarget synchronously for quick exits, then uses
-     * setTimeout(0) to handle cases where focus transitions through multiple
-     * items before leaving (relatedTarget can be temporarily null during rapid moves).
+     * setTimeout(0) to defer the check until after the current event loop tick,
+     * handling cases where focus transitions through multiple items before leaving
+     * (relatedTarget can be temporarily null during rapid moves, but activeElement
+     * will be correctly set after the current event completes).
      * @hidden
      */
     onFocusOut(event: FocusEvent): void {

--- a/libs/core/user-menu/components/user-menu-body.component.ts
+++ b/libs/core/user-menu/components/user-menu-body.component.ts
@@ -123,25 +123,29 @@ export class UserMenuBodyComponent implements AfterViewInit {
     /**
      * Reset roving tabindex when focus leaves the menu entirely,
      * so Tab re-entry starts at the first item instead of the last-focused item.
-     * Uses requestAnimationFrame to ensure focus has settled before checking.
+     *
+     * First checks relatedTarget synchronously for quick exits, then uses
+     * setTimeout(0) to handle cases where focus transitions through multiple
+     * items before leaving (relatedTarget can be temporarily null during rapid moves).
      * @hidden
      */
     onFocusOut(event: FocusEvent): void {
         const relatedTarget = event.relatedTarget as HTMLElement;
         const currentTarget = event.currentTarget as HTMLElement;
 
-        // Check if focus is leaving the menu body entirely
-        // Use requestAnimationFrame to allow focus to settle - during rapid transitions,
-        // relatedTarget might be null temporarily before focus actually moves
-        if (!relatedTarget || !currentTarget.contains(relatedTarget)) {
-            requestAnimationFrame(() => {
-                // Recheck if focus is still outside the menu after the frame
-                const activeElement = document.activeElement as HTMLElement;
-                if (!activeElement || !currentTarget.contains(activeElement)) {
-                    this._resetListFocus();
-                }
-            });
+        // Synchronous check: if relatedTarget is known and inside menu, don't reset
+        if (relatedTarget && currentTarget.contains(relatedTarget)) {
+            return;
         }
+
+        // Deferred check: ensure focus has fully settled before resetting
+        // This handles rapid transitions where relatedTarget might be null temporarily
+        setTimeout(() => {
+            const activeElement = document.activeElement as HTMLElement;
+            if (!activeElement || !currentTarget.contains(activeElement)) {
+                this._resetListFocus();
+            }
+        }, 0);
     }
 
     /** @hidden */

--- a/libs/core/user-menu/components/user-menu-body.component.ts
+++ b/libs/core/user-menu/components/user-menu-body.component.ts
@@ -119,6 +119,22 @@ export class UserMenuBodyComponent implements AfterViewInit {
         event.stopPropagation();
     }
 
+    /**
+     * Reset roving tabindex when focus leaves the menu entirely,
+     * so Tab re-entry starts at the first item instead of the last-focused item.
+     * @hidden
+     */
+    @HostListener('focusout', ['$event'])
+    onFocusOut(event: FocusEvent): void {
+        const relatedTarget = event.relatedTarget as HTMLElement;
+        const currentTarget = event.currentTarget as HTMLElement;
+
+        // Check if focus is leaving the menu body entirely
+        if (!relatedTarget || !currentTarget.contains(relatedTarget)) {
+            this._resetListFocus();
+        }
+    }
+
     /** @hidden */
     ngAfterViewInit(): void {
         this._listItems.changes
@@ -211,5 +227,19 @@ export class UserMenuBodyComponent implements AfterViewInit {
     closeDialog(dialogRef): void {
         dialogRef.dismiss('Close');
         this.clearSubmenu();
+    }
+
+    /** @hidden */
+    private _resetListFocus(): void {
+        if (!this._listItems || this._listItems.length === 0) {
+            return;
+        }
+
+        const items = this._listItems.toArray();
+        // Reset tabindex: first item gets 0, rest get -1
+        items[0]._tabIndex$.set(0);
+        for (let i = 1; i < items.length; i++) {
+            items[i]._tabIndex$.set(-1);
+        }
     }
 }

--- a/libs/core/user-menu/components/user-menu-body.component.ts
+++ b/libs/core/user-menu/components/user-menu-body.component.ts
@@ -6,7 +6,6 @@ import {
     ContentChildren,
     DestroyRef,
     ElementRef,
-    HostListener,
     QueryList,
     TemplateRef,
     ViewEncapsulation,
@@ -30,13 +29,16 @@ import { TitleComponent } from '@fundamental-ngx/core/title';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { Subject, startWith } from 'rxjs';
 import { UserMenuUserNameDirective } from '../directives/user-menu-user-name.directive';
+import { resetListFocus } from '../utils/focus-utils';
 import { UserMenuListItemComponent } from './user-menu-list-item.component';
 
 @Component({
     selector: 'fd-user-menu-body',
     templateUrl: './user-menu-body.component.html',
     host: {
-        class: 'fd-user-menu__body'
+        class: 'fd-user-menu__body',
+        '(click)': 'onClick($event)',
+        '(focusout)': 'onFocusOut($event)'
     },
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -114,7 +116,6 @@ export class UserMenuBodyComponent implements AfterViewInit {
     private readonly _destroyRef = inject(DestroyRef);
 
     /** @hidden */
-    @HostListener('click', ['$event'])
     onClick(event: MouseEvent): void {
         event.stopPropagation();
     }
@@ -122,16 +123,24 @@ export class UserMenuBodyComponent implements AfterViewInit {
     /**
      * Reset roving tabindex when focus leaves the menu entirely,
      * so Tab re-entry starts at the first item instead of the last-focused item.
+     * Uses requestAnimationFrame to ensure focus has settled before checking.
      * @hidden
      */
-    @HostListener('focusout', ['$event'])
     onFocusOut(event: FocusEvent): void {
         const relatedTarget = event.relatedTarget as HTMLElement;
         const currentTarget = event.currentTarget as HTMLElement;
 
         // Check if focus is leaving the menu body entirely
+        // Use requestAnimationFrame to allow focus to settle - during rapid transitions,
+        // relatedTarget might be null temporarily before focus actually moves
         if (!relatedTarget || !currentTarget.contains(relatedTarget)) {
-            this._resetListFocus();
+            requestAnimationFrame(() => {
+                // Recheck if focus is still outside the menu after the frame
+                const activeElement = document.activeElement as HTMLElement;
+                if (!activeElement || !currentTarget.contains(activeElement)) {
+                    this._resetListFocus();
+                }
+            });
         }
     }
 
@@ -235,11 +244,6 @@ export class UserMenuBodyComponent implements AfterViewInit {
             return;
         }
 
-        const items = this._listItems.toArray();
-        // Reset tabindex: first item gets 0, rest get -1
-        items[0]._tabIndex$.set(0);
-        for (let i = 1; i < items.length; i++) {
-            items[i]._tabIndex$.set(-1);
-        }
+        resetListFocus(this._listItems.toArray());
     }
 }

--- a/libs/core/user-menu/components/user-menu-control.component.spec.ts
+++ b/libs/core/user-menu/components/user-menu-control.component.spec.ts
@@ -44,13 +44,11 @@ describe('UserMenuControlComponent', () => {
 
             const event = new KeyboardEvent('keydown', { key: 'Enter' });
             jest.spyOn(event, 'preventDefault');
-            jest.spyOn(event, 'stopPropagation');
 
             controlElement.dispatchEvent(event);
             fixture.detectChanges();
 
             expect(event.preventDefault).toHaveBeenCalled();
-            expect(event.stopPropagation).toHaveBeenCalled();
             expect(clickedSpy).toHaveBeenCalled();
         });
 
@@ -60,13 +58,11 @@ describe('UserMenuControlComponent', () => {
 
             const event = new KeyboardEvent('keydown', { key: ' ' });
             jest.spyOn(event, 'preventDefault');
-            jest.spyOn(event, 'stopPropagation');
 
             controlElement.dispatchEvent(event);
             fixture.detectChanges();
 
             expect(event.preventDefault).toHaveBeenCalled();
-            expect(event.stopPropagation).toHaveBeenCalled();
             expect(clickedSpy).toHaveBeenCalled();
         });
 
@@ -81,13 +77,13 @@ describe('UserMenuControlComponent', () => {
             expect(clickedSpy).not.toHaveBeenCalled();
         });
 
-        it('should stop propagation to prevent unintended bubbling', () => {
+        it('should allow event to bubble for popover handling', () => {
             const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
             const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
 
             controlElement.dispatchEvent(event);
 
-            expect(stopPropagationSpy).toHaveBeenCalled();
+            expect(stopPropagationSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/libs/core/user-menu/components/user-menu-control.component.spec.ts
+++ b/libs/core/user-menu/components/user-menu-control.component.spec.ts
@@ -10,11 +10,15 @@ import { UserMenuControlComponent } from './user-menu-control.component';
 class TestHostComponent {
     @ViewChild('elRef', { read: ElementRef })
     elRef: ElementRef;
+
+    @ViewChild(UserMenuControlComponent)
+    controlComponent: UserMenuControlComponent;
 }
 
 describe('UserMenuControlComponent', () => {
     let component: TestHostComponent;
     let fixture: ComponentFixture<TestHostComponent>;
+    let controlElement: HTMLElement;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
@@ -26,9 +30,88 @@ describe('UserMenuControlComponent', () => {
         fixture = TestBed.createComponent(TestHostComponent);
         component = fixture.debugElement.componentInstance;
         fixture.detectChanges();
+        controlElement = component.elRef.nativeElement;
     });
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    describe('keyboard navigation', () => {
+        it('should emit clicked event on Enter key', () => {
+            const clickedSpy = jest.fn();
+            component.controlComponent.clicked.subscribe(clickedSpy);
+
+            const event = new KeyboardEvent('keydown', { key: 'Enter' });
+            jest.spyOn(event, 'preventDefault');
+            jest.spyOn(event, 'stopPropagation');
+
+            controlElement.dispatchEvent(event);
+            fixture.detectChanges();
+
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(event.stopPropagation).toHaveBeenCalled();
+            expect(clickedSpy).toHaveBeenCalled();
+        });
+
+        it('should emit clicked event on Space key', () => {
+            const clickedSpy = jest.fn();
+            component.controlComponent.clicked.subscribe(clickedSpy);
+
+            const event = new KeyboardEvent('keydown', { key: ' ' });
+            jest.spyOn(event, 'preventDefault');
+            jest.spyOn(event, 'stopPropagation');
+
+            controlElement.dispatchEvent(event);
+            fixture.detectChanges();
+
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(event.stopPropagation).toHaveBeenCalled();
+            expect(clickedSpy).toHaveBeenCalled();
+        });
+
+        it('should not emit clicked event on other keys', () => {
+            const clickedSpy = jest.fn();
+            component.controlComponent.clicked.subscribe(clickedSpy);
+
+            const event = new KeyboardEvent('keydown', { key: 'Tab' });
+            controlElement.dispatchEvent(event);
+            fixture.detectChanges();
+
+            expect(clickedSpy).not.toHaveBeenCalled();
+        });
+
+        it('should stop propagation to prevent unintended bubbling', () => {
+            const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
+            const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
+
+            controlElement.dispatchEvent(event);
+
+            expect(stopPropagationSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('mouse interaction', () => {
+        it('should emit clicked event on click', () => {
+            const clickedSpy = jest.fn();
+            component.controlComponent.clicked.subscribe(clickedSpy);
+
+            controlElement.click();
+            fixture.detectChanges();
+
+            expect(clickedSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('focus', () => {
+        it('should be focusable with tabindex 0', () => {
+            expect(controlElement.getAttribute('tabindex')).toBe('0');
+        });
+
+        it('should focus element when focus() is called', () => {
+            component.controlComponent.focus();
+
+            expect(document.activeElement).toBe(controlElement);
+        });
     });
 });

--- a/libs/core/user-menu/components/user-menu-control.component.ts
+++ b/libs/core/user-menu/components/user-menu-control.component.ts
@@ -13,7 +13,7 @@ import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Output, V
     imports: []
 })
 export class UserMenuControlComponent {
-    /** Event emitted event when control element is clicked */
+    /** Event emitted when control element is clicked */
     @Output()
     clicked: EventEmitter<void> = new EventEmitter<void>();
 
@@ -25,10 +25,16 @@ export class UserMenuControlComponent {
         this.clicked.emit();
     }
 
-    /** @hidden */
+    /**
+     * Handles keyboard activation (Enter or Space).
+     * Prevents default to avoid scrolling on Space and stops propagation
+     * to prevent unintended bubbling to parent elements.
+     * @hidden
+     */
     onKeydown(event: KeyboardEvent): void {
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
+            event.stopPropagation();
             this.clicked.emit();
         }
     }

--- a/libs/core/user-menu/components/user-menu-control.component.ts
+++ b/libs/core/user-menu/components/user-menu-control.component.ts
@@ -33,6 +33,15 @@ export class UserMenuControlComponent {
     }
 
     /** @hidden */
+    @HostListener('keydown', ['$event'])
+    onKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            this.clicked.emit();
+        }
+    }
+
+    /** @hidden */
     focus(): void {
         this.el.nativeElement.focus();
     }

--- a/libs/core/user-menu/components/user-menu-control.component.ts
+++ b/libs/core/user-menu/components/user-menu-control.component.ts
@@ -27,14 +27,14 @@ export class UserMenuControlComponent {
 
     /**
      * Handles keyboard activation (Enter or Space).
-     * Prevents default to avoid scrolling on Space and stops propagation
-     * to prevent unintended bubbling to parent elements.
+     * Prevents default to avoid scrolling on Space.
+     * Emits clicked event for mobile mode; in popover mode, the event
+     * bubbles to the popover component which handles the toggle.
      * @hidden
      */
     onKeydown(event: KeyboardEvent): void {
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
-            event.stopPropagation();
             this.clicked.emit();
         }
     }

--- a/libs/core/user-menu/components/user-menu-control.component.ts
+++ b/libs/core/user-menu/components/user-menu-control.component.ts
@@ -1,12 +1,4 @@
-import {
-    ChangeDetectionStrategy,
-    Component,
-    ElementRef,
-    EventEmitter,
-    HostListener,
-    Output,
-    ViewEncapsulation
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Output, ViewEncapsulation } from '@angular/core';
 
 @Component({
     selector: 'fd-user-menu-control',
@@ -14,7 +6,9 @@ import {
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
-        tabindex: '0'
+        tabindex: '0',
+        '(click)': 'onClick()',
+        '(keydown)': 'onKeydown($event)'
     },
     imports: []
 })
@@ -27,13 +21,11 @@ export class UserMenuControlComponent {
     constructor(private el: ElementRef<HTMLElement>) {}
 
     /** @hidden */
-    @HostListener('click')
     onClick(): void {
         this.clicked.emit();
     }
 
     /** @hidden */
-    @HostListener('keydown', ['$event'])
     onKeydown(event: KeyboardEvent): void {
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();

--- a/libs/core/user-menu/components/user-menu-list-item.component.ts
+++ b/libs/core/user-menu/components/user-menu-list-item.component.ts
@@ -48,6 +48,12 @@ let uniqueSubtitleId = 0;
 export class UserMenuListItemComponent implements KeyboardSupportItemInterface {
     /** @hidden Event name for child menu item state changes */
     private static readonly STATE_CHANGE_EVENT = 'fdMenuItemStateChange';
+
+    /** @hidden Event name for sibling close coordination */
+    private static readonly SIBLING_CLOSE_EVENT = 'fdMenuItemCloseSubmenu';
+
+    /** @hidden Event name for force closing nested submenus */
+    private static readonly FORCE_CLOSE_EVENT = 'fdMenuItemForceClose';
     /** Event emitter for isOpenChange event that controls the submenu popover body */
     @Output()
     readonly isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
@@ -150,13 +156,20 @@ export class UserMenuListItemComponent implements KeyboardSupportItemInterface {
     /** @hidden Cleanup function for child state listener */
     private _childStateListenerCleanup: (() => void) | null = null;
 
+    /** @hidden Cleanup function for sibling close listener */
+    private _siblingCloseListenerCleanup: (() => void) | null = null;
+
     /** @hidden Grace period in ms before closing submenu on mouseleave */
     private readonly _hoverCloseDelay = 150;
 
     constructor() {
+        afterNextRender(() => this._setupEventListeners(), { injector: this._injector });
+
         this._destroyRef.onDestroy(() => {
             this._childStateListenerCleanup?.();
             this._childStateListenerCleanup = null;
+            this._siblingCloseListenerCleanup?.();
+            this._siblingCloseListenerCleanup = null;
             this._cancelHoverCloseTimer();
         });
     }
@@ -220,13 +233,24 @@ export class UserMenuListItemComponent implements KeyboardSupportItemInterface {
 
     /** @hidden Open submenu on host mouseenter (non-mobile only) */
     onHostMouseEnter(): void {
-        if (!this.hasSubmenu() || this.mobile()) {
+        if (this.mobile()) {
             return;
         }
+
         this._cancelHoverCloseTimer();
-        const popoverInstance = this.popover();
-        if (popoverInstance && !this.isOpen()) {
-            popoverInstance.open();
+
+        // Focus this item to maintain keyboard navigation state
+        this.focus();
+
+        // Close sibling submenus at the same nesting level
+        this._closeSiblingSubmenus();
+
+        // Open this item's submenu if it has one
+        if (this.hasSubmenu()) {
+            const popoverInstance = this.popover();
+            if (popoverInstance && !this.isOpen()) {
+                popoverInstance.open();
+            }
         }
     }
 
@@ -316,6 +340,8 @@ export class UserMenuListItemComponent implements KeyboardSupportItemInterface {
         if (isOpen) {
             this._setupChildStateListener(popoverBodyEl?._elementRef.nativeElement);
         } else {
+            // When closing, also close all nested child submenus
+            this._closeAllNestedSubmenus(popoverBodyEl?._elementRef.nativeElement);
             // Reset state when closing
             this._openChildCount = 0;
             this._pendingClose = false;
@@ -404,5 +430,134 @@ export class UserMenuListItemComponent implements KeyboardSupportItemInterface {
             clearTimeout(this._hoverCloseTimer);
             this._hoverCloseTimer = null;
         }
+    }
+
+    /**
+     * Closes sibling menu items' submenus at the same nesting level.
+     * Uses custom DOM events to coordinate between siblings.
+     * Only dispatches if there are siblings that actually have submenus.
+     * @hidden
+     */
+    private _closeSiblingSubmenus(): void {
+        const thisElement = this._elementRef.nativeElement as HTMLElement;
+        const parentElement = thisElement.parentElement;
+
+        if (!parentElement) {
+            return;
+        }
+
+        // Check if any siblings have submenus before dispatching the event
+        // This prevents unnecessary closes when navigating within a submenu that has no submenu siblings
+        const siblings = Array.from(parentElement.children);
+        const hasSubmenuSiblings = siblings.some((sibling) => {
+            if (sibling === thisElement) {
+                return false;
+            }
+            // Check if this sibling has a popover (indicating a submenu)
+            return sibling.querySelector('fd-popover') !== null;
+        });
+
+        if (!hasSubmenuSiblings) {
+            // No siblings with submenus, no need to dispatch close event
+            return;
+        }
+
+        // Dispatch an event that siblings will listen for
+        const event = new CustomEvent(UserMenuListItemComponent.SIBLING_CLOSE_EVENT, {
+            detail: { sourceElement: thisElement },
+            bubbles: false // Don't bubble, only direct siblings should hear it
+        });
+        parentElement.dispatchEvent(event);
+    }
+
+    /**
+     * Recursively closes all nested child submenus within a popover body.
+     * Called when a submenu is closing to ensure all descendants are also closed.
+     * @hidden
+     */
+    private _closeAllNestedSubmenus(popoverBodyEl: HTMLElement): void {
+        if (!popoverBodyEl) {
+            return;
+        }
+
+        // Find all menu items with popovers inside this popover body
+        const childItems = popoverBodyEl.querySelectorAll('[fd-user-menu-list-item]');
+
+        childItems.forEach((itemEl: Element) => {
+            const popover = itemEl.querySelector('fd-popover');
+            if (popover) {
+                // Find the popover body of this child item
+                const childPopoverBody = popover.querySelector('fd-popover-body');
+                if (childPopoverBody) {
+                    // Recursively close any nested submenus first
+                    this._closeAllNestedSubmenus(childPopoverBody as HTMLElement);
+                }
+
+                // Close this child item's popover by dispatching a close event
+                const closeEvent = new CustomEvent(UserMenuListItemComponent.FORCE_CLOSE_EVENT, {
+                    bubbles: false
+                });
+                itemEl.dispatchEvent(closeEvent);
+            }
+        });
+    }
+
+    /**
+     * Helper method to close the popover if it's open.
+     * Reduces code duplication across event handlers.
+     * @hidden
+     */
+    private _closePopover(): void {
+        const popoverInstance = this.popover();
+        if (popoverInstance && this.isOpen()) {
+            popoverInstance.close();
+        }
+    }
+
+    /**
+     * Set up event listeners for coordinating submenu behavior.
+     * Called after next render when DOM is ready.
+     * @hidden
+     */
+    private _setupEventListeners(): void {
+        const thisElement = this._elementRef.nativeElement as HTMLElement;
+        const parentElement = thisElement.parentElement;
+
+        if (!parentElement) {
+            return;
+        }
+
+        // Listen for sibling close events from the parent
+        const handleSiblingClose = (event: Event): void => {
+            const customEvent = event as CustomEvent<{ sourceElement: HTMLElement }>;
+            const sourceElement = customEvent.detail.sourceElement;
+
+            // Ignore events from ourselves or non-siblings
+            if (sourceElement === thisElement || sourceElement.parentElement !== parentElement) {
+                return;
+            }
+
+            // Ignore if in different popover contexts
+            const thisPopoverBody = thisElement.closest('fd-popover-body');
+            const sourcePopoverBody = sourceElement.closest('fd-popover-body');
+            if (thisPopoverBody !== sourcePopoverBody) {
+                return;
+            }
+
+            this._closePopover();
+        };
+
+        // Listen for force close events (used when recursively closing nested submenus)
+        const handleForceClose = (): void => {
+            this._closePopover();
+        };
+
+        parentElement.addEventListener(UserMenuListItemComponent.SIBLING_CLOSE_EVENT, handleSiblingClose);
+        thisElement.addEventListener(UserMenuListItemComponent.FORCE_CLOSE_EVENT, handleForceClose);
+
+        this._siblingCloseListenerCleanup = () => {
+            parentElement.removeEventListener(UserMenuListItemComponent.SIBLING_CLOSE_EVENT, handleSiblingClose);
+            thisElement.removeEventListener(UserMenuListItemComponent.FORCE_CLOSE_EVENT, handleForceClose);
+        };
     }
 }

--- a/libs/core/user-menu/user-menu.component.html
+++ b/libs/core/user-menu/user-menu.component.html
@@ -32,9 +32,7 @@
         </fd-popover-body>
     </fd-popover>
 } @else {
-    <span (click)="openDialog(dialogTemplate)">
-        <ng-container *ngTemplateOutlet="control"></ng-container>
-    </span>
+    <ng-container *ngTemplateOutlet="control"></ng-container>
 
     <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>
         <fd-dialog [dialogConfig]="dialogConfig" [dialogRef]="dialog">

--- a/libs/core/user-menu/user-menu.component.html
+++ b/libs/core/user-menu/user-menu.component.html
@@ -32,7 +32,6 @@
         </fd-popover-body>
     </fd-popover>
 } @else {
-    <!-- Mobile mode: control's clicked event is handled via subscription in ngAfterViewInit -->
     <ng-container *ngTemplateOutlet="control"></ng-container>
 
     <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>

--- a/libs/core/user-menu/user-menu.component.html
+++ b/libs/core/user-menu/user-menu.component.html
@@ -32,6 +32,7 @@
         </fd-popover-body>
     </fd-popover>
 } @else {
+    <!-- Mobile mode: control's clicked event is handled via subscription in ngAfterViewInit -->
     <ng-container *ngTemplateOutlet="control"></ng-container>
 
     <ng-template [fdDialogTemplate] let-dialog let-dialogConfig="dialogConfig" #dialogTemplate>

--- a/libs/core/user-menu/user-menu.component.spec.ts
+++ b/libs/core/user-menu/user-menu.component.spec.ts
@@ -67,37 +67,41 @@ describe('UserMenuComponent', () => {
         expect(component.elRef.nativeElement.classList).toContain('fd-user-menu');
     });
 
-    describe('popover mode - initial focus', () => {
-        it('should focus first list item when popover opens', fakeAsync(() => {
+    describe('initial focus behavior', () => {
+        it('should focus first list item (not first focusable element) when popover opens in non-mobile mode', fakeAsync(() => {
             const listItems = userMenu['_listItems']();
 
             expect(listItems.length).toBeGreaterThan(0);
 
             const firstItemFocusSpy = jest.spyOn(listItems[0], 'focus');
 
-            // Open the menu
+            // Open the menu in non-mobile mode (popover)
             userMenu.open();
             fixture.detectChanges();
 
             // Wait for requestAnimationFrame
             tick(20);
 
+            // Verify the first list item's focus() method was called explicitly
+            // (not relying on default popover focus behavior which would focus first focusable element)
             expect(firstItemFocusSpy).toHaveBeenCalled();
         }));
 
-        it('should not focus first item when opening in mobile mode', fakeAsync(() => {
+        it('should not call focus on first list item when open() is called in mobile mode', fakeAsync(() => {
             // Set mobile on the actual user menu component
             userMenu.mobile = jest.fn().mockReturnValue(true) as any;
 
             const listItems = userMenu['_listItems']();
             const firstItemFocusSpy = jest.spyOn(listItems[0], 'focus');
 
-            // Open the menu
+            // Call open() directly (note: in actual usage, mobile mode opens via control click → openDialog())
             userMenu.open();
             fixture.detectChanges();
             tick(20);
 
-            // Should not focus - mobile mode uses dialog
+            // open() method should not focus the first list item in mobile mode
+            // (the condition at line 280 checks !this.mobile())
+            // Note: openDialog() separately handles focusing the first list item when the dialog actually opens
             expect(firstItemFocusSpy).not.toHaveBeenCalled();
         }));
     });
@@ -135,23 +139,5 @@ describe('UserMenuComponent', () => {
 
             expect(controlFocusSpy).toHaveBeenCalled();
         });
-    });
-
-    describe('mobile mode subscription', () => {
-        it('should only subscribe to control clicks when in mobile mode', fakeAsync(() => {
-            // Set mobile on the actual user menu component
-            userMenu.mobile = jest.fn().mockReturnValue(true) as any;
-            fixture.detectChanges();
-
-            // Trigger ngAfterViewInit
-            tick();
-
-            const control = userMenu['userMenuControl']();
-            expect(control).toBeDefined();
-
-            // The subscription should be active in mobile mode
-            // This is verified by the code structure - explicit test would require
-            // triggering the click and checking if dialog opens
-        }));
     });
 });

--- a/libs/core/user-menu/user-menu.component.spec.ts
+++ b/libs/core/user-menu/user-menu.component.spec.ts
@@ -1,36 +1,62 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { RtlService } from '@fundamental-ngx/cdk/utils';
 import { DialogService } from '@fundamental-ngx/core/dialog';
+import { UserMenuBodyComponent } from './components/user-menu-body.component';
+import { UserMenuControlComponent } from './components/user-menu-control.component';
+import { UserMenuListItemComponent } from './components/user-menu-list-item.component';
+import { UserMenuListComponent } from './components/user-menu-list.component';
 import { UserMenuComponent } from './user-menu.component';
 
 @Component({
-    template: `<fd-user-menu #elRef>User Menu Test</fd-user-menu>`,
+    template: `
+        <fd-user-menu #elRef>
+            <fd-user-menu-control>
+                <button>Menu</button>
+            </fd-user-menu-control>
+            <fd-user-menu-body>
+                <fd-user-menu-list>
+                    <li fd-user-menu-list-item text="Item 1"></li>
+                    <li fd-user-menu-list-item text="Item 2"></li>
+                    <li fd-user-menu-list-item text="Item 3"></li>
+                </fd-user-menu-list>
+            </fd-user-menu-body>
+        </fd-user-menu>
+    `,
     standalone: true,
-    imports: [UserMenuComponent]
+    imports: [
+        UserMenuComponent,
+        UserMenuControlComponent,
+        UserMenuBodyComponent,
+        UserMenuListComponent,
+        UserMenuListItemComponent
+    ]
 })
-class TestHostComponent {
+class TestComponentWithItems {
     @ViewChild('elRef', { read: ElementRef })
     elRef: ElementRef;
 
-    hasIcons = false;
+    @ViewChild(UserMenuComponent)
+    userMenuComponent: UserMenuComponent;
 }
 
 describe('UserMenuComponent', () => {
-    let component: TestHostComponent;
-    let fixture: ComponentFixture<TestHostComponent>;
+    let component: TestComponentWithItems;
+    let fixture: ComponentFixture<TestComponentWithItems>;
+    let userMenu: UserMenuComponent;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
-            imports: [TestHostComponent],
+            imports: [TestComponentWithItems],
             providers: [RtlService, DialogService]
         }).compileComponents();
     }));
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(TestHostComponent);
+        fixture = TestBed.createComponent(TestComponentWithItems);
         component = fixture.debugElement.componentInstance;
         fixture.detectChanges();
+        userMenu = component.userMenuComponent;
     });
 
     it('should create', () => {
@@ -39,5 +65,93 @@ describe('UserMenuComponent', () => {
 
     it('should assign class', () => {
         expect(component.elRef.nativeElement.classList).toContain('fd-user-menu');
+    });
+
+    describe('popover mode - initial focus', () => {
+        it('should focus first list item when popover opens', fakeAsync(() => {
+            const listItems = userMenu['_listItems']();
+
+            expect(listItems.length).toBeGreaterThan(0);
+
+            const firstItemFocusSpy = jest.spyOn(listItems[0], 'focus');
+
+            // Open the menu
+            userMenu.open();
+            fixture.detectChanges();
+
+            // Wait for requestAnimationFrame
+            tick(20);
+
+            expect(firstItemFocusSpy).toHaveBeenCalled();
+        }));
+
+        it('should not focus first item when opening in mobile mode', fakeAsync(() => {
+            // Set mobile on the actual user menu component
+            userMenu.mobile = jest.fn().mockReturnValue(true) as any;
+
+            const listItems = userMenu['_listItems']();
+            const firstItemFocusSpy = jest.spyOn(listItems[0], 'focus');
+
+            // Open the menu
+            userMenu.open();
+            fixture.detectChanges();
+            tick(20);
+
+            // Should not focus - mobile mode uses dialog
+            expect(firstItemFocusSpy).not.toHaveBeenCalled();
+        }));
+    });
+
+    describe('focus reset on close', () => {
+        it('should reset list focus when menu closes', () => {
+            const listItems = userMenu['_listItems']();
+
+            // Simulate roving tabindex where second item was focused
+            listItems[0]._tabIndex$.set(-1);
+            listItems[1]._tabIndex$.set(0);
+            listItems[2]._tabIndex$.set(-1);
+
+            // Close the menu
+            userMenu.close();
+            fixture.detectChanges();
+
+            // Should reset to first item having tabindex 0
+            expect(listItems[0]._tabIndex$()).toBe(0);
+            expect(listItems[1]._tabIndex$()).toBe(-1);
+            expect(listItems[2]._tabIndex$()).toBe(-1);
+        });
+
+        it('should restore focus to control when closing in popover mode', () => {
+            const control = userMenu['userMenuControl']();
+            const controlFocusSpy = jest.spyOn(control!, 'focus');
+
+            // Open first
+            userMenu.open();
+            fixture.detectChanges();
+
+            // Then close
+            userMenu.close();
+            fixture.detectChanges();
+
+            expect(controlFocusSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('mobile mode subscription', () => {
+        it('should only subscribe to control clicks when in mobile mode', fakeAsync(() => {
+            // Set mobile on the actual user menu component
+            userMenu.mobile = jest.fn().mockReturnValue(true) as any;
+            fixture.detectChanges();
+
+            // Trigger ngAfterViewInit
+            tick();
+
+            const control = userMenu['userMenuControl']();
+            expect(control).toBeDefined();
+
+            // The subscription should be active in mobile mode
+            // This is verified by the code structure - explicit test would require
+            // triggering the click and checking if dialog opens
+        }));
     });
 });

--- a/libs/core/user-menu/user-menu.component.spec.ts
+++ b/libs/core/user-menu/user-menu.component.spec.ts
@@ -110,6 +110,10 @@ describe('UserMenuComponent', () => {
         it('should reset list focus when menu closes', () => {
             const listItems = userMenu['_listItems']();
 
+            // Open the menu first
+            userMenu.open();
+            fixture.detectChanges();
+
             // Simulate roving tabindex where second item was focused
             listItems[0]._tabIndex$.set(-1);
             listItems[1]._tabIndex$.set(0);

--- a/libs/core/user-menu/user-menu.component.ts
+++ b/libs/core/user-menu/user-menu.component.ts
@@ -17,6 +17,7 @@ import {
     Renderer2,
     signal,
     TemplateRef,
+    viewChild,
     ViewEncapsulation
 } from '@angular/core';
 
@@ -108,6 +109,9 @@ export class UserMenuComponent implements AfterViewInit {
     protected readonly userMenuBody = contentChild(UserMenuBodyComponent, { descendants: true });
 
     /** @hidden */
+    protected readonly dialogTemplate = viewChild<TemplateRef<any>>('dialogTemplate');
+
+    /** @hidden */
     protected readonly navigationArrow = computed(() =>
         this._rtlService.rtl() ? 'navigation-right-arrow' : 'navigation-left-arrow'
     );
@@ -137,6 +141,25 @@ export class UserMenuComponent implements AfterViewInit {
         effect(() => {
             const isMobile = this.mobile();
             this._listItems()?.forEach((item) => item.mobile.set(isMobile));
+        });
+
+        // Subscribe to user menu control clicks for mobile mode
+        effect(() => {
+            const control = this.userMenuControl();
+            if (!control) {
+                return;
+            }
+
+            const subscription = control.clicked.subscribe(() => {
+                if (this.mobile()) {
+                    const template = this.dialogTemplate();
+                    if (template) {
+                        this.openDialog(template);
+                    }
+                }
+            });
+
+            this._destroyRef.onDestroy(() => subscription.unsubscribe());
         });
     }
 

--- a/libs/core/user-menu/user-menu.component.ts
+++ b/libs/core/user-menu/user-menu.component.ts
@@ -203,7 +203,9 @@ export class UserMenuComponent implements AfterViewInit {
     /** Method that closes the user menu */
     close(): void {
         this.isOpenChangeHandle(false);
-        this._closeAllSubmenus();
+        if (this.mobile()) {
+            this._closeAllSubmenus();
+        }
         this._clearSubmenu();
         this._dialogRef?.close();
     }

--- a/libs/core/user-menu/user-menu.component.ts
+++ b/libs/core/user-menu/user-menu.component.ts
@@ -157,20 +157,7 @@ export class UserMenuComponent implements AfterViewInit {
         const isMobile = this.mobile();
         this._listItems()?.forEach((item) => item.mobile.set(isMobile));
 
-        // Subscribe to user menu control clicks for mobile mode
-        // Switch to control's clicked observable when control becomes available
-        toObservable(this.userMenuControl, { injector: this._injector })
-            .pipe(
-                filter((control) => !!control && this.mobile()),
-                switchMap((control) => control!.clicked),
-                takeUntilDestroyed(this._destroyRef)
-            )
-            .subscribe(() => {
-                const template = this.dialogTemplate();
-                if (template) {
-                    this.openDialog(template);
-                }
-            });
+        this._setupMobileControlSubscription();
 
         const el = this.userNameEl()?.nativeElement;
 
@@ -216,16 +203,7 @@ export class UserMenuComponent implements AfterViewInit {
     /** Method that closes the user menu */
     close(): void {
         this.isOpenChangeHandle(false);
-
-        if (this._listItems().length > 0) {
-            this._listItems().forEach((item) => {
-                item.isOpen.set(false);
-                item._elementRef?.nativeElement.querySelector('.fd-menu__link')?.classList.remove('is-active');
-            });
-
-            this._resetListFocus();
-        }
-
+        this._closeAllSubmenus();
         this._clearSubmenu();
         this._dialogRef?.close();
     }
@@ -282,6 +260,8 @@ export class UserMenuComponent implements AfterViewInit {
 
         if (!isOpen && !this.mobile()) {
             this.userMenuControl()?.focus();
+            // Close all nested submenus when the menu closes
+            this._closeAllSubmenus();
         }
 
         const userMenuControlEl = this.userMenuControlElement()?.nativeElement;
@@ -305,12 +285,54 @@ export class UserMenuComponent implements AfterViewInit {
         }
     }
 
+    /**
+     * Set up subscription to user menu control clicks for mobile mode.
+     * Switches to control's clicked observable when control becomes available.
+     * @hidden
+     */
+    private _setupMobileControlSubscription(): void {
+        toObservable(this.userMenuControl, { injector: this._injector })
+            .pipe(
+                filter((control) => !!control && this.mobile()),
+                switchMap((control) => control!.clicked),
+                takeUntilDestroyed(this._destroyRef)
+            )
+            .subscribe(() => {
+                const template = this.dialogTemplate();
+                if (template) {
+                    this.openDialog(template);
+                }
+            });
+    }
+
     /** @hidden */
     private _clearSubmenu(): void {
         const userMenuBody = this.userMenuBody();
         if (userMenuBody) {
             userMenuBody.clearSubmenu();
         }
+    }
+
+    /**
+     * Closes all nested submenus by explicitly calling popover.close() on each item.
+     * This ensures that when the main menu closes (e.g., via click outside),
+     * all nested submenu popovers are also closed.
+     * Iterates in reverse order to close deeply nested submenus before their parents.
+     * @hidden
+     */
+    private _closeAllSubmenus(): void {
+        // Close in reverse order to ensure deeply nested items close first
+        const items = this._listItems();
+        for (let i = items.length - 1; i >= 0; i--) {
+            const item = items[i];
+            const popoverInstance = item.popover();
+            if (popoverInstance && item.isOpen()) {
+                popoverInstance.close();
+            }
+            item.isOpen.set(false);
+            item._elementRef?.nativeElement.querySelector('.fd-menu__link')?.classList.remove('is-active');
+        }
+        this._resetListFocus();
     }
 
     /**

--- a/libs/core/user-menu/user-menu.component.ts
+++ b/libs/core/user-menu/user-menu.component.ts
@@ -225,7 +225,7 @@ export class UserMenuComponent implements AfterViewInit {
                 item._elementRef?.nativeElement.querySelector('.fd-menu__link')?.classList.remove('is-active');
             });
 
-            this._listItems()[0]?._tabIndex$.set(0);
+            this._resetListFocus();
         }
 
         this._clearSubmenu();
@@ -310,6 +310,28 @@ export class UserMenuComponent implements AfterViewInit {
         const userMenuBody = this.userMenuBody();
         if (userMenuBody) {
             userMenuBody.clearSubmenu();
+        }
+    }
+
+    /**
+     * Resets roving tabindex to the first list item.
+     *
+     * Roving tabindex preserves focus within the list (important for submenus),
+     * but when tabbing back into the menu from outside, focus should start at
+     * the first item, not the last-focused item. Called when focus leaves the menu.
+     *
+     * @hidden
+     */
+    private _resetListFocus(): void {
+        const items = this._listItems();
+        if (items.length === 0) {
+            return;
+        }
+
+        // Reset tabindex: first item gets 0, rest get -1
+        items[0]._tabIndex$.set(0);
+        for (let i = 1; i < items.length; i++) {
+            items[i]._tabIndex$.set(-1);
         }
     }
 }

--- a/libs/core/user-menu/user-menu.component.ts
+++ b/libs/core/user-menu/user-menu.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import {
+    afterNextRender,
     AfterViewInit,
     booleanAttribute,
     ChangeDetectionStrategy,
@@ -12,6 +13,7 @@ import {
     effect,
     ElementRef,
     inject,
+    Injector,
     input,
     output,
     Renderer2,
@@ -134,7 +136,11 @@ export class UserMenuComponent implements AfterViewInit {
     /** @hidden */
     private _dialogRef: DialogRef | undefined;
 
+    /** @hidden */
     private readonly _destroyRef = inject(DestroyRef);
+
+    /** @hidden */
+    private readonly _injector = inject(Injector);
 
     /** @hidden */
     constructor() {
@@ -237,6 +243,20 @@ export class UserMenuComponent implements AfterViewInit {
             contentDensity: ContentDensityMode.COZY
         });
 
+        // Focus the first list item after dialog renders
+        // Need longer delay to override dialog's focus management
+        afterNextRender(
+            () => {
+                setTimeout(() => {
+                    const firstListItem = this._listItems()[0];
+                    if (firstListItem) {
+                        firstListItem.focus();
+                    }
+                }, 100);
+            },
+            { injector: this._injector }
+        );
+
         const refSub = this._dialogRef.afterClosed.subscribe({
             next: () => {
                 this.userMenuControl()?.focus();
@@ -262,6 +282,17 @@ export class UserMenuComponent implements AfterViewInit {
 
         if (!isOpen && !this.mobile()) {
             this.userMenuControl()?.focus();
+        }
+
+        // Focus first list item when popover opens
+        if (isOpen && !this.mobile()) {
+            // Use setTimeout to ensure the popover body is rendered
+            setTimeout(() => {
+                const firstListItem = this._listItems()[0];
+                if (firstListItem) {
+                    firstListItem.focus();
+                }
+            });
         }
 
         const userMenuControlEl = this.userMenuControlElement()?.nativeElement;

--- a/libs/core/user-menu/user-menu.component.ts
+++ b/libs/core/user-menu/user-menu.component.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import {
-    afterNextRender,
     AfterViewInit,
     booleanAttribute,
     ChangeDetectionStrategy,
@@ -15,6 +14,7 @@ import {
     inject,
     Injector,
     input,
+    isDevMode,
     output,
     Renderer2,
     signal,
@@ -22,6 +22,8 @@ import {
     viewChild,
     ViewEncapsulation
 } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { asyncScheduler, filter, observeOn, switchMap } from 'rxjs';
 
 import { KeyboardSupportService, RtlService, TemplateDirective } from '@fundamental-ngx/cdk/utils';
 import { ContentDensityMode, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
@@ -43,6 +45,7 @@ import { UserMenuControlComponent } from './components/user-menu-control.compone
 import { UserMenuListItemComponent } from './components/user-menu-list-item.component';
 import { UserMenuControlElementDirective } from './directives/user-menu-control-element.directive';
 import { UserMenuUserNameDirective } from './directives/user-menu-user-name.directive';
+import { resetListFocus } from './utils/focus-utils';
 
 @Component({
     selector: 'fd-user-menu',
@@ -148,15 +151,22 @@ export class UserMenuComponent implements AfterViewInit {
             const isMobile = this.mobile();
             this._listItems()?.forEach((item) => item.mobile.set(isMobile));
         });
+    }
+
+    /** @hidden */
+    ngAfterViewInit(): void {
+        const isMobile = this.mobile();
+        this._listItems()?.forEach((item) => item.mobile.set(isMobile));
 
         // Subscribe to user menu control clicks for mobile mode
-        effect(() => {
-            const control = this.userMenuControl();
-            if (!control) {
-                return;
-            }
-
-            const subscription = control.clicked.subscribe(() => {
+        // Use toObservable + switchMap to auto-unsubscribe when control changes
+        toObservable(this.userMenuControl, { injector: this._injector })
+            .pipe(
+                filter((control) => !!control),
+                switchMap((control) => control!.clicked),
+                takeUntilDestroyed(this._destroyRef)
+            )
+            .subscribe(() => {
                 if (this.mobile()) {
                     const template = this.dialogTemplate();
                     if (template) {
@@ -164,15 +174,6 @@ export class UserMenuComponent implements AfterViewInit {
                     }
                 }
             });
-
-            this._destroyRef.onDestroy(() => subscription.unsubscribe());
-        });
-    }
-
-    /** @hidden */
-    ngAfterViewInit(): void {
-        const isMobile = this.mobile();
-        this._listItems()?.forEach((item) => item.mobile.set(isMobile));
 
         const el = this.userNameEl()?.nativeElement;
 
@@ -243,19 +244,26 @@ export class UserMenuComponent implements AfterViewInit {
             contentDensity: ContentDensityMode.COZY
         });
 
-        // Focus the first list item after dialog renders
-        // Need longer delay to override dialog's focus management
-        afterNextRender(
-            () => {
-                setTimeout(() => {
+        // Focus first list item when dialog loads
+        // Use observeOn(asyncScheduler) to ensure dialog has fully rendered
+        toObservable(this._dialogRef.isLoaded, { injector: this._injector })
+            .pipe(
+                filter((loaded) => loaded),
+                observeOn(asyncScheduler),
+                takeUntilDestroyed(this._destroyRef)
+            )
+            .subscribe(() => {
+                try {
                     const firstListItem = this._listItems()[0];
                     if (firstListItem) {
                         firstListItem.focus();
                     }
-                }, 100);
-            },
-            { injector: this._injector }
-        );
+                } catch (error) {
+                    if (isDevMode()) {
+                        console.error('Failed to focus first user menu item', error);
+                    }
+                }
+            });
 
         const refSub = this._dialogRef.afterClosed.subscribe({
             next: () => {
@@ -284,17 +292,6 @@ export class UserMenuComponent implements AfterViewInit {
             this.userMenuControl()?.focus();
         }
 
-        // Focus first list item when popover opens
-        if (isOpen && !this.mobile()) {
-            // Use setTimeout to ensure the popover body is rendered
-            setTimeout(() => {
-                const firstListItem = this._listItems()[0];
-                if (firstListItem) {
-                    firstListItem.focus();
-                }
-            });
-        }
-
         const userMenuControlEl = this.userMenuControlElement()?.nativeElement;
 
         this.userMenuControlElement()?.nativeElement &&
@@ -303,6 +300,17 @@ export class UserMenuComponent implements AfterViewInit {
                 : this._renderer.removeClass(userMenuControlEl, 'is-active'));
 
         this._changeDetectionRef.detectChanges();
+
+        // Focus first list item when popover opens
+        // Use requestAnimationFrame to allow popover rendering to complete
+        if (isOpen && !this.mobile()) {
+            requestAnimationFrame(() => {
+                const firstListItem = this._listItems()[0];
+                if (firstListItem) {
+                    firstListItem.focus();
+                }
+            });
+        }
     }
 
     /** @hidden */
@@ -323,15 +331,6 @@ export class UserMenuComponent implements AfterViewInit {
      * @hidden
      */
     private _resetListFocus(): void {
-        const items = this._listItems();
-        if (items.length === 0) {
-            return;
-        }
-
-        // Reset tabindex: first item gets 0, rest get -1
-        items[0]._tabIndex$.set(0);
-        for (let i = 1; i < items.length; i++) {
-            items[i]._tabIndex$.set(-1);
-        }
+        resetListFocus(this._listItems());
     }
 }

--- a/libs/core/user-menu/user-menu.component.ts
+++ b/libs/core/user-menu/user-menu.component.ts
@@ -14,7 +14,6 @@ import {
     inject,
     Injector,
     input,
-    isDevMode,
     output,
     Renderer2,
     signal,
@@ -23,7 +22,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { asyncScheduler, filter, observeOn, switchMap } from 'rxjs';
+import { filter, switchMap } from 'rxjs';
 
 import { KeyboardSupportService, RtlService, TemplateDirective } from '@fundamental-ngx/cdk/utils';
 import { ContentDensityMode, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
@@ -159,19 +158,17 @@ export class UserMenuComponent implements AfterViewInit {
         this._listItems()?.forEach((item) => item.mobile.set(isMobile));
 
         // Subscribe to user menu control clicks for mobile mode
-        // Use toObservable + switchMap to auto-unsubscribe when control changes
+        // Switch to control's clicked observable when control becomes available
         toObservable(this.userMenuControl, { injector: this._injector })
             .pipe(
-                filter((control) => !!control),
+                filter((control) => !!control && this.mobile()),
                 switchMap((control) => control!.clicked),
                 takeUntilDestroyed(this._destroyRef)
             )
             .subscribe(() => {
-                if (this.mobile()) {
-                    const template = this.dialogTemplate();
-                    if (template) {
-                        this.openDialog(template);
-                    }
+                const template = this.dialogTemplate();
+                if (template) {
+                    this.openDialog(template);
                 }
             });
 
@@ -245,24 +242,19 @@ export class UserMenuComponent implements AfterViewInit {
         });
 
         // Focus first list item when dialog loads
-        // Use observeOn(asyncScheduler) to ensure dialog has fully rendered
+        // Use requestAnimationFrame for consistent timing with popover mode
         toObservable(this._dialogRef.isLoaded, { injector: this._injector })
             .pipe(
                 filter((loaded) => loaded),
-                observeOn(asyncScheduler),
                 takeUntilDestroyed(this._destroyRef)
             )
             .subscribe(() => {
-                try {
+                requestAnimationFrame(() => {
                     const firstListItem = this._listItems()[0];
                     if (firstListItem) {
                         firstListItem.focus();
                     }
-                } catch (error) {
-                    if (isDevMode()) {
-                        console.error('Failed to focus first user menu item', error);
-                    }
-                }
+                });
             });
 
         const refSub = this._dialogRef.afterClosed.subscribe({
@@ -331,6 +323,10 @@ export class UserMenuComponent implements AfterViewInit {
      * @hidden
      */
     private _resetListFocus(): void {
-        resetListFocus(this._listItems());
+        const items = this._listItems();
+        if (!items || items.length === 0) {
+            return;
+        }
+        resetListFocus(items);
     }
 }

--- a/libs/core/user-menu/utils/focus-utils.spec.ts
+++ b/libs/core/user-menu/utils/focus-utils.spec.ts
@@ -1,0 +1,87 @@
+import { signal } from '@angular/core';
+import { UserMenuListItemComponent } from '../components/user-menu-list-item.component';
+import { resetListFocus } from './focus-utils';
+
+describe('focus-utils', () => {
+    describe('resetListFocus', () => {
+        it('should set first item tabindex to 0 and rest to -1', () => {
+            // Create mock list items
+            const items = [
+                { _tabIndex$: signal(-1) },
+                { _tabIndex$: signal(0) },
+                { _tabIndex$: signal(-1) }
+            ] as unknown as UserMenuListItemComponent[];
+
+            resetListFocus(items);
+
+            expect(items[0]._tabIndex$()).toBe(0);
+            expect(items[1]._tabIndex$()).toBe(-1);
+            expect(items[2]._tabIndex$()).toBe(-1);
+        });
+
+        it('should handle single item', () => {
+            const items = [{ _tabIndex$: signal(-1) }] as unknown as UserMenuListItemComponent[];
+
+            resetListFocus(items);
+
+            expect(items[0]._tabIndex$()).toBe(0);
+        });
+
+        it('should handle empty array', () => {
+            const items: UserMenuListItemComponent[] = [];
+
+            // Should not throw
+            expect(() => resetListFocus(items)).not.toThrow();
+        });
+
+        it('should handle null/undefined', () => {
+            // Should not throw
+            expect(() => resetListFocus(null as any)).not.toThrow();
+            expect(() => resetListFocus(undefined as any)).not.toThrow();
+        });
+
+        it('should reset correctly when all items have tabindex -1', () => {
+            const items = [
+                { _tabIndex$: signal(-1) },
+                { _tabIndex$: signal(-1) },
+                { _tabIndex$: signal(-1) }
+            ] as unknown as UserMenuListItemComponent[];
+
+            resetListFocus(items);
+
+            expect(items[0]._tabIndex$()).toBe(0);
+            expect(items[1]._tabIndex$()).toBe(-1);
+            expect(items[2]._tabIndex$()).toBe(-1);
+        });
+
+        it('should reset correctly when middle item had tabindex 0', () => {
+            const items = [
+                { _tabIndex$: signal(-1) },
+                { _tabIndex$: signal(0) },
+                { _tabIndex$: signal(-1) },
+                { _tabIndex$: signal(-1) }
+            ] as unknown as UserMenuListItemComponent[];
+
+            resetListFocus(items);
+
+            expect(items[0]._tabIndex$()).toBe(0);
+            expect(items[1]._tabIndex$()).toBe(-1);
+            expect(items[2]._tabIndex$()).toBe(-1);
+            expect(items[3]._tabIndex$()).toBe(-1);
+        });
+
+        it('should reset correctly when last item had tabindex 0', () => {
+            const items = [
+                { _tabIndex$: signal(-1) },
+                { _tabIndex$: signal(-1) },
+                { _tabIndex$: signal(0) }
+            ] as unknown as UserMenuListItemComponent[];
+
+            resetListFocus(items);
+
+            expect(items[0]._tabIndex$()).toBe(0);
+            expect(items[1]._tabIndex$()).toBe(-1);
+            expect(items[2]._tabIndex$()).toBe(-1);
+        });
+    });
+});

--- a/libs/core/user-menu/utils/focus-utils.ts
+++ b/libs/core/user-menu/utils/focus-utils.ts
@@ -1,0 +1,20 @@
+import { UserMenuListItemComponent } from '../components/user-menu-list-item.component';
+
+/**
+ * Resets roving tabindex to the first list item.
+ *
+ * Roving tabindex preserves focus within the list (important for submenus),
+ * but when tabbing back into the menu from outside, focus should start at
+ * the first item, not the last-focused item. Called when focus leaves the menu.
+ */
+export function resetListFocus(items: readonly UserMenuListItemComponent[]): void {
+    if (!items || items.length === 0) {
+        return;
+    }
+
+    // Reset tabindex: first item gets 0, rest get -1
+    items[0]._tabIndex$.set(0);
+    for (let i = 1; i < items.length; i++) {
+        items[i]._tabIndex$.set(-1);
+    }
+}

--- a/libs/core/user-menu/utils/focus-utils.ts
+++ b/libs/core/user-menu/utils/focus-utils.ts
@@ -3,9 +3,12 @@ import { UserMenuListItemComponent } from '../components/user-menu-list-item.com
 /**
  * Resets roving tabindex to the first list item.
  *
- * Roving tabindex preserves focus within the list (important for submenus),
- * but when tabbing back into the menu from outside, focus should start at
- * the first item, not the last-focused item. Called when focus leaves the menu.
+ * In a roving tabindex pattern, only one item has tabindex="0" at a time,
+ * allowing arrow keys to navigate within the list. This function resets
+ * the pattern so the first item becomes tabbable again.
+ *
+ * Typically called when focus leaves the menu to ensure that when users
+ * Tab back in, focus starts at the first item rather than the last-focused item.
  */
 export function resetListFocus(items: readonly UserMenuListItemComponent[]): void {
     if (!items || items.length === 0) {

--- a/libs/docs/core/user-menu/examples/user-menu-default-example.component.html
+++ b/libs/docs/core/user-menu/examples/user-menu-default-example.component.html
@@ -17,6 +17,7 @@
                 size="l"
                 label="Lisa Miller"
                 zoomGlyph="edit"
+                [clickable]="true"
                 (zoomGlyphClicked)="onZoomGlyphClick()"
                 title="Edit avatar"
             ></fd-avatar>

--- a/libs/docs/core/user-menu/examples/user-menu-mobile-example.component.html
+++ b/libs/docs/core/user-menu/examples/user-menu-mobile-example.component.html
@@ -17,6 +17,7 @@
                 size="l"
                 label="Lisa Miller"
                 zoomGlyph="edit"
+                [clickable]="true"
                 (zoomGlyphClicked)="onZoomGlyphClick()"
                 title="Edit avatar"
             ></fd-avatar>


### PR DESCRIPTION
## Related Issue(s)
part of https://github.com/SAP/fundamental-ngx/issues/14363

## Description
Fixes four keyboard accessibility issues in the user menu component:

### 1. Enter/Space keys not opening mobile dialog
The user menu control now responds to Enter and Space keys in mobile mode, matching standard button behavior.

**Test:** Tab to the avatar control in mobile mode, press Enter or Space → dialog opens.

### 2. Avatar focus in documentation
Fixed examples by adding `[clickable]="true"` to make avatars keyboard-accessible.

### 3. Initial focus on menu open
When the popover/dialog opens, focus now moves directly to the first `fd-user-menu-list-item` instead of other interactive elements in the header (like edit buttons or close button).

<img width="893" height="1291" alt="Screenshot 2026-07-21 at 5 23 09 PM" src="https://github.com/user-attachments/assets/428b82eb-ce23-4de0-ad4f-dbb599a9c6ed" />
<img width="529" height="1014" alt="Screenshot 2026-07-21 at 5 22 56 PM" src="https://github.com/user-attachments/assets/642bcd31-332c-4c18-a271-2335c941ef41" />


### 4. Focus reset when re-entering the menu (discovered bug)
**Problem:** The menu uses roving tabindex to preserve focus position (important for submenus). When a user navigated with arrow keys to item 3, then tabbed out, the browser would return focus to item 3 when tabbing back in instead of starting at item 1.

**Fix:** Added `focusout` listener that resets tabindex to the first item when focus leaves the menu entirely, while preserving roving tabindex behavior within the menu.


Before:

https://github.com/user-attachments/assets/e5a1ec75-dbd4-4c79-9856-0aeb175b18ae


After:


https://github.com/user-attachments/assets/6e96a152-aa49-46a3-a601-fb3b034a17da

