### PR TITLE
chore(ci): treat npm-published version as a floor in release version resolver

### DIFF
--- a/.github/actions/helpers/get-version.js
+++ b/.github/actions/helpers/get-version.js
@@ -1,21 +1,24 @@
 const getFileContents = require('./get-file-contents');
+const npmPublishedVersion = require('./npm-published-version');
 const { execSync } = require('child_process');
 const semver = require('semver');
 
 /**
- * Get the version from git tags (NX Release compatible) or fall back to package.json.
- * This aligns with NX Release's currentVersionResolver: "git-tag" configuration.
+ * Resolve the current version, aligning with NX Release's "git-tag" resolver.
  *
- * Priority:
- * 1. Git tags (latest semver tag by semver comparison, including prereleases)
- * 2. libs/core/package.json (contains actual version)
- * 3. package.json (workspace root - fallback)
+ * Current branch: highest of git tag (reachable from HEAD), libs/core/package.json,
+ * and the npm-published version. npm acts as a floor because git tags aren't the
+ * authority on "already published" — an orphaned release commit hides its tag from
+ * `git tag --merged HEAD`, so the resolver would otherwise recompute an already-
+ * published version and 403 on publish. See npm-published-version.js.
  *
- * @param branch - Optional branch to get version from
+ * @param branch - Optional branch to read the version from
  * @returns {string} - The current version
  */
 module.exports = (branch = null) => {
-    // If checking a specific branch, use libs/core/package.json (has actual version)
+    // If checking a specific branch, use libs/core/package.json (has actual version).
+    // The npm floor is intentionally NOT applied here: this path is used for hotfix
+    // main-sync comparisons and must stay pure and synchronous.
     if (branch) {
         try {
             return getFileContents('libs/core/package.json', branch).version;
@@ -43,21 +46,24 @@ module.exports = (branch = null) => {
             // Sort by semver (including prereleases) and get the highest version
             // semver.rsort handles prerelease comparison correctly:
             // e.g., 0.59.0-rc.0 > 0.58.1 (because 0.59.0 > 0.58.1)
-            const sortedVersions = semver.rsort(validVersions);
-            const tagVersion = sortedVersions[0];
+            let resolved = semver.rsort(validVersions)[0];
 
-            // Also check package.json version - use whichever is higher
-            // This handles cases where a release commit bumped package.json but tag creation failed
+            // Floor 1: package.json version.
+            // Handles cases where a release commit bumped package.json but tag creation failed.
             try {
                 const packageVersion = getFileContents('libs/core/package.json', null).version;
-                if (semver.valid(packageVersion) && semver.gt(packageVersion, tagVersion)) {
-                    return packageVersion;
-                }
+                resolved = higherOf(resolved, packageVersion);
             } catch (e) {
                 // Ignore errors reading package.json
             }
 
-            return tagVersion;
+            // Floor 2: npm-published version.
+            // Handles the orphaned-release-commit race where the pushed tag is not
+            // reachable from HEAD but the version is already live on npm. Best-effort:
+            // returns null (no-op) if npm cannot be reached.
+            resolved = higherOf(resolved, npmPublishedVersion());
+
+            return resolved;
         }
     } catch (e) {
         // Git command failed or no tags found, fall through to package.json
@@ -74,3 +80,18 @@ module.exports = (branch = null) => {
         }
     }
 };
+
+/**
+ * Return the higher valid semver of `current` / `candidate`.
+ * A null/invalid candidate never lowers `current`.
+ *
+ * @param {string} current - Assumed valid semver
+ * @param {string | null | undefined} candidate
+ * @returns {string}
+ */
+function higherOf(current, candidate) {
+    if (semver.valid(candidate) && semver.gt(candidate, current)) {
+        return candidate;
+    }
+    return current;
+}

--- a/.github/actions/helpers/get-version.spec.js
+++ b/.github/actions/helpers/get-version.spec.js
@@ -1,11 +1,13 @@
 // Mock dependencies before requiring the module
 jest.mock('child_process');
 jest.mock('./get-file-contents');
+jest.mock('./npm-published-version', () => jest.fn());
 
 describe('get-version', () => {
     let getVersion;
     let mockedExecSync;
     let mockedGetFileContents;
+    let mockedNpmPublishedVersion;
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -14,6 +16,9 @@ describe('get-version', () => {
         // Re-require the mocked dependencies and store references
         mockedExecSync = require('child_process').execSync;
         mockedGetFileContents = require('./get-file-contents');
+        mockedNpmPublishedVersion = require('./npm-published-version');
+        // Default: npm floor contributes nothing unless a test opts in.
+        mockedNpmPublishedVersion.mockReturnValue(null);
         // Now require the module under test (it will use the mocked dependencies)
         getVersion = require('./get-version');
     });
@@ -295,6 +300,84 @@ describe('get-version', () => {
             const result = getVersion();
 
             expect(result).toBe('0.59.1-rc.19');
+        });
+    });
+
+    describe('npm published version floor', () => {
+        // Root cause of the failed release run 30101584110: a prior run published
+        // 0.64.1-rc.4 to npm and pushed tag v0.64.1-rc.4, but its release commit
+        // orphaned (never landed on main). The next run's `git tag --merged HEAD`
+        // could not see the orphaned tag, so it recomputed rc.4 and got a 403 on
+        // publish. npm is the authority on "already published" and must act as a floor.
+
+        it('should return the npm-published version when it is higher than the highest reachable tag (the rc.4 bug)', () => {
+            // Reachable tags top out at rc.3 (orphaned rc.4 tag is invisible to --merged HEAD)
+            mockedExecSync.mockReturnValue('v0.64.1-rc.3\nv0.64.1-rc.2\nv0.64.1-rc.1\n');
+            mockedGetFileContents.mockReturnValue({ version: '0.64.1-rc.3' });
+            // npm already has rc.4
+            mockedNpmPublishedVersion.mockReturnValue('0.64.1-rc.4');
+
+            const result = getVersion();
+
+            // Must return rc.4 so the bump produces rc.5, not another rc.4
+            expect(result).toBe('0.64.1-rc.4');
+        });
+
+        it('should NOT lower the result when npm is behind the git tags', () => {
+            mockedExecSync.mockReturnValue('v0.64.1-rc.5\nv0.64.1-rc.4\n');
+            mockedGetFileContents.mockReturnValue({ version: '0.64.1-rc.5' });
+            mockedNpmPublishedVersion.mockReturnValue('0.64.1-rc.4');
+
+            const result = getVersion();
+
+            expect(result).toBe('0.64.1-rc.5');
+        });
+
+        it('should return the npm version when npm latest is higher than tags and package.json', () => {
+            mockedExecSync.mockReturnValue('v0.64.1-rc.4\nv0.64.1-rc.3\n');
+            mockedGetFileContents.mockReturnValue({ version: '0.64.1-rc.4' });
+            mockedNpmPublishedVersion.mockReturnValue('0.65.0');
+
+            const result = getVersion();
+
+            expect(result).toBe('0.65.0');
+        });
+
+        it('should fall back to the git tag version when the npm lookup returns null (query failed)', () => {
+            mockedExecSync.mockReturnValue('v0.64.1-rc.3\nv0.64.1-rc.2\n');
+            mockedGetFileContents.mockReturnValue({ version: '0.64.1-rc.3' });
+            // Total npm failure is represented as null by the helper
+            mockedNpmPublishedVersion.mockReturnValue(null);
+
+            const result = getVersion();
+
+            expect(result).toBe('0.64.1-rc.3');
+        });
+
+        it('should use the npm floor over package.json when both are considered', () => {
+            // Simulates partial-publish drift surfaced via the npm helper's own max:
+            // helper already reduced across all packages and returned rc.4
+            mockedExecSync.mockReturnValue('v0.64.1-rc.3\n');
+            mockedGetFileContents.mockReturnValue({ version: '0.64.1-rc.2' });
+            mockedNpmPublishedVersion.mockReturnValue('0.64.1-rc.4');
+
+            const result = getVersion();
+
+            expect(result).toBe('0.64.1-rc.4');
+        });
+
+        it('should NOT query npm when a specific branch is requested', () => {
+            mockedGetFileContents.mockImplementation((file, branch) => {
+                if (file === 'libs/core/package.json' && branch === 'main') {
+                    return { version: '0.64.0' };
+                }
+                throw new Error('Unexpected call');
+            });
+
+            const result = getVersion('main');
+
+            expect(result).toBe('0.64.0');
+            expect(mockedNpmPublishedVersion).not.toHaveBeenCalled();
         });
     });
 });

--- a/.github/actions/helpers/npm-published-version.js
+++ b/.github/actions/helpers/npm-published-version.js
@@ -1,0 +1,98 @@
+const { execFileSync } = require('child_process');
+const semver = require('semver');
+const { info, warning } = require('@actions/core');
+
+/**
+ * npm package names published by the release pipeline. Kept in sync with
+ * RELEASE_PACKAGES in create-release.yml. Note: `mcp-server` publishes as
+ * `@fundamental-ngx/mcp`.
+ */
+const RELEASE_PACKAGE_NAMES = [
+    '@fundamental-ngx/i18n',
+    '@fundamental-ngx/cdk',
+    '@fundamental-ngx/core',
+    '@fundamental-ngx/platform',
+    '@fundamental-ngx/moment-adapter',
+    '@fundamental-ngx/datetime-adapter',
+    '@fundamental-ngx/cx',
+    '@fundamental-ngx/btp',
+    '@fundamental-ngx/ui5-webcomponents-base',
+    '@fundamental-ngx/ui5-webcomponents',
+    '@fundamental-ngx/ui5-webcomponents-fiori',
+    '@fundamental-ngx/ui5-webcomponents-ai',
+    '@fundamental-ngx/mcp'
+];
+
+/** Per-package hard cap so a dead/slow registry degrades in seconds, not minutes. */
+const NPM_VIEW_TIMEOUT_MS = 15000;
+
+/**
+ * Highest valid version among a package's `prerelease` / `latest` dist-tags,
+ * or null if it can't be read. Uses execFileSync with an argv array (no shell)
+ * to avoid any injection surface.
+ *
+ * @param {string} packageName
+ * @param {string} registry
+ * @returns {string | null}
+ */
+function highestPublishedForPackage(packageName, registry) {
+    try {
+        // --fetch-retries=0 and a short --fetch-timeout make a registry outage
+        // fail fast (npm would otherwise retry with backoff for minutes).
+        const args = ['view', packageName, 'dist-tags', '--json', '--fetch-retries=0', '--fetch-timeout=10000'];
+        if (registry) {
+            args.push('--registry', registry);
+        }
+        const raw = execFileSync('npm', args, {
+            encoding: 'utf8',
+            stdio: ['pipe', 'pipe', 'pipe'],
+            timeout: NPM_VIEW_TIMEOUT_MS
+        }).trim();
+
+        if (!raw) {
+            return null;
+        }
+
+        const distTags = JSON.parse(raw);
+        const candidates = [distTags.prerelease, distTags.latest].filter((v) => semver.valid(v));
+
+        if (candidates.length === 0) {
+            return null;
+        }
+
+        return semver.rsort(candidates)[0];
+    } catch (e) {
+        // Unpublished package, registry error, offline, timeout, malformed JSON.
+        // Non-fatal: this package simply does not contribute to the floor.
+        warning(`Could not read npm dist-tags for ${packageName}: ${e.message}`);
+        return null;
+    }
+}
+
+/**
+ * Highest version published to npm across all release packages, or null if none
+ * could be read.
+ *
+ * npm — not git tags — is the authority on "already published". An orphaned
+ * release commit hides its tag from `git tag --merged HEAD`, so the resolver
+ * would recompute an already-published version and 403. Used as a version floor
+ * to make that impossible. The max spans all packages to catch partial-publish
+ * drift. Best-effort: a total npm outage returns null and never blocks releases.
+ *
+ * @param {string} [registry] - Optional registry URL (defaults to npm's configured one)
+ * @returns {string | null} - Highest published version, or null
+ */
+module.exports = (registry = null) => {
+    const versions = RELEASE_PACKAGE_NAMES.map((name) => highestPublishedForPackage(name, registry)).filter((v) =>
+        semver.valid(v)
+    );
+
+    if (versions.length === 0) {
+        info('No npm-published versions could be resolved; skipping npm floor.');
+        return null;
+    }
+
+    return semver.rsort(versions)[0];
+};
+
+module.exports.RELEASE_PACKAGE_NAMES = RELEASE_PACKAGE_NAMES;

--- a/.github/actions/helpers/npm-published-version.spec.js
+++ b/.github/actions/helpers/npm-published-version.spec.js
@@ -1,0 +1,113 @@
+// Mock dependencies before requiring the module
+jest.mock('child_process');
+jest.mock('@actions/core', () => ({
+    info: jest.fn(),
+    warning: jest.fn()
+}));
+
+describe('npm-published-version', () => {
+    let npmPublishedVersion;
+    let mockedExecFileSync;
+    let mockedWarning;
+    let packageNames;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.resetModules();
+        mockedExecFileSync = require('child_process').execFileSync;
+        mockedWarning = require('@actions/core').warning;
+        npmPublishedVersion = require('./npm-published-version');
+        packageNames = npmPublishedVersion.RELEASE_PACKAGE_NAMES;
+    });
+
+    // Helper: make execFileSync respond per package name based on a { name: distTags } map.
+    // Any package not present in the map throws (simulating an unpublished package / error).
+    const mockRegistry = (distTagsByPackage) => {
+        mockedExecFileSync.mockImplementation((cmd, args) => {
+            const name = args[1]; // ['view', <name>, 'dist-tags', '--json']
+            if (Object.prototype.hasOwnProperty.call(distTagsByPackage, name)) {
+                return JSON.stringify(distTagsByPackage[name]);
+            }
+            throw new Error(`E404 - not found: ${name}`);
+        });
+    };
+
+    it('should return the highest version across all packages (prerelease dist-tag)', () => {
+        const map = {};
+        packageNames.forEach((name) => {
+            map[name] = { prerelease: '0.64.1-rc.4', latest: '0.64.0' };
+        });
+        mockRegistry(map);
+
+        expect(npmPublishedVersion()).toBe('0.64.1-rc.4');
+    });
+
+    it('should prefer latest when it is higher than prerelease', () => {
+        const map = {};
+        packageNames.forEach((name) => {
+            map[name] = { prerelease: '0.64.1-rc.4', latest: '0.65.0' };
+        });
+        mockRegistry(map);
+
+        expect(npmPublishedVersion()).toBe('0.65.0');
+    });
+
+    it('should take the max across packages when versions drift (partial publish)', () => {
+        // All packages at rc.3 except one that reached rc.4 — floor must be rc.4.
+        const map = {};
+        packageNames.forEach((name) => {
+            map[name] = { prerelease: '0.64.1-rc.3' };
+        });
+        map['@fundamental-ngx/core'] = { prerelease: '0.64.1-rc.4' };
+        mockRegistry(map);
+
+        expect(npmPublishedVersion()).toBe('0.64.1-rc.4');
+    });
+
+    it('should ignore packages that error and use the ones that resolve', () => {
+        // Only one package published; the rest 404. Floor comes from the published one.
+        mockRegistry({ '@fundamental-ngx/core': { prerelease: '0.64.1-rc.4' } });
+
+        expect(npmPublishedVersion()).toBe('0.64.1-rc.4');
+        // 12 of 13 threw -> 12 warnings
+        expect(mockedWarning).toHaveBeenCalledTimes(packageNames.length - 1);
+    });
+
+    it('should return null when every package lookup fails (total npm failure)', () => {
+        mockedExecFileSync.mockImplementation(() => {
+            throw new Error('getaddrinfo ENOTFOUND registry.npmjs.org');
+        });
+
+        expect(npmPublishedVersion()).toBeNull();
+        expect(mockedWarning).toHaveBeenCalledTimes(packageNames.length);
+    });
+
+    it('should return null when dist-tags contain no valid semver', () => {
+        const map = {};
+        packageNames.forEach((name) => {
+            map[name] = { prerelease: undefined, latest: undefined };
+        });
+        mockRegistry(map);
+
+        expect(npmPublishedVersion()).toBeNull();
+    });
+
+    it('should handle empty stdout from npm as a non-contributing package', () => {
+        mockedExecFileSync.mockReturnValue('');
+
+        expect(npmPublishedVersion()).toBeNull();
+    });
+
+    it('should invoke npm via argv array (no shell string) and pass a registry when given', () => {
+        mockRegistry({ '@fundamental-ngx/core': { prerelease: '0.64.1-rc.4' } });
+
+        npmPublishedVersion('https://registry.npmjs.org/');
+
+        const call = mockedExecFileSync.mock.calls[0];
+        expect(call[0]).toBe('npm');
+        expect(Array.isArray(call[1])).toBe(true);
+        expect(call[1]).toEqual(
+            expect.arrayContaining(['view', 'dist-tags', '--json', '--registry', 'https://registry.npmjs.org/'])
+        );
+    });
+});


### PR DESCRIPTION
An orphaned release commit hides its tag from `git tag --merged HEAD`, so the resolver recomputes an already-published version and 403s on publish. Query npm dist-tags across all release packages and use the highest as a version floor. Best-effort: a total npm outage falls back to git tags.