### PR TITLE
chore(ci): use curl instead of npm CLI to query registry in version floor

### DIFF
--- a/.github/actions/helpers/npm-published-version.js
+++ b/.github/actions/helpers/npm-published-version.js
@@ -22,47 +22,36 @@ const RELEASE_PACKAGE_NAMES = [
     '@fundamental-ngx/mcp'
 ];
 
-/** Per-package hard cap so a dead/slow registry degrades in seconds, not minutes. */
-const NPM_VIEW_TIMEOUT_MS = 15000;
+const REGISTRY = 'https://registry.npmjs.org';
+const TIMEOUT_S = 10;
 
 /**
  * Highest valid version among a package's `prerelease` / `latest` dist-tags,
- * or null if it can't be read. Uses execFileSync with an argv array (no shell)
- * to avoid any injection surface.
+ * or null if it can't be read. Uses curl against the npm registry HTTP API —
+ * no npm CLI config files, no PATH issues inside composite actions.
  *
  * @param {string} packageName
- * @param {string} registry
  * @returns {string | null}
  */
-function highestPublishedForPackage(packageName, registry) {
+function highestPublishedForPackage(packageName) {
     try {
-        // --fetch-retries=0 and a short --fetch-timeout make a registry outage
-        // fail fast (npm would otherwise retry with backoff for minutes).
-        const args = ['view', packageName, 'dist-tags', '--json', '--fetch-retries=0', '--fetch-timeout=10000'];
-        if (registry) {
-            args.push('--registry', registry);
-        }
-        const raw = execFileSync('npm', args, {
+        // Encode scoped package name: @scope/name -> @scope%2fname
+        const encoded = packageName.replace('/', '%2f');
+        const url = `${REGISTRY}/${encoded}`;
+        const raw = execFileSync('curl', ['--silent', '--fail', '--max-time', String(TIMEOUT_S), '--location', url], {
             encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'pipe'],
-            timeout: NPM_VIEW_TIMEOUT_MS
-        }).trim();
+            timeout: (TIMEOUT_S + 2) * 1000
+        });
 
-        if (!raw) {
+        const distTags = JSON.parse(raw)['dist-tags'];
+        if (!distTags) {
             return null;
         }
 
-        const distTags = JSON.parse(raw);
         const candidates = [distTags.prerelease, distTags.latest].filter((v) => semver.valid(v));
-
-        if (candidates.length === 0) {
-            return null;
-        }
-
-        return semver.rsort(candidates)[0];
+        return candidates.length > 0 ? semver.rsort(candidates)[0] : null;
     } catch (e) {
-        // Unpublished package, registry error, offline, timeout, malformed JSON.
-        // Non-fatal: this package simply does not contribute to the floor.
         console.warn(`Could not read npm dist-tags for ${packageName}: ${e.message}`);
         return null;
     }
@@ -76,15 +65,12 @@ function highestPublishedForPackage(packageName, registry) {
  * release commit hides its tag from `git tag --merged HEAD`, so the resolver
  * would recompute an already-published version and 403. Used as a version floor
  * to make that impossible. The max spans all packages to catch partial-publish
- * drift. Best-effort: a total npm outage returns null and never blocks releases.
+ * drift. Best-effort: a total registry outage returns null and never blocks releases.
  *
- * @param {string} [registry] - Optional registry URL (defaults to npm's configured one)
  * @returns {string | null} - Highest published version, or null
  */
-module.exports = (registry = null) => {
-    const versions = RELEASE_PACKAGE_NAMES.map((name) => highestPublishedForPackage(name, registry)).filter((v) =>
-        semver.valid(v)
-    );
+module.exports = () => {
+    const versions = RELEASE_PACKAGE_NAMES.map(highestPublishedForPackage).filter((v) => semver.valid(v));
 
     if (versions.length === 0) {
         console.log('No npm-published versions could be resolved; skipping npm floor.');

--- a/.github/actions/helpers/npm-published-version.spec.js
+++ b/.github/actions/helpers/npm-published-version.spec.js
@@ -18,14 +18,15 @@ describe('npm-published-version', () => {
     });
 
     // Helper: make execFileSync respond per package name based on a { name: distTags } map.
-    // Any package not present in the map throws (simulating an unpublished package / error).
+    // Any package not in the map throws (simulating a 404 / network error).
     const mockRegistry = (distTagsByPackage) => {
         mockedExecFileSync.mockImplementation((cmd, args) => {
-            const name = args[1]; // ['view', <name>, 'dist-tags', '--json']
-            if (Object.prototype.hasOwnProperty.call(distTagsByPackage, name)) {
-                return JSON.stringify(distTagsByPackage[name]);
+            const url = args.find((a) => a.startsWith('https://'));
+            const match = Object.keys(distTagsByPackage).find((name) => url && url.includes(name.replace('/', '%2f')));
+            if (match) {
+                return JSON.stringify({ 'dist-tags': distTagsByPackage[match] });
             }
-            throw new Error(`E404 - not found: ${name}`);
+            throw new Error(`E404 - not found: ${url}`);
         });
     };
 
@@ -50,7 +51,6 @@ describe('npm-published-version', () => {
     });
 
     it('should take the max across packages when versions drift (partial publish)', () => {
-        // All packages at rc.3 except one that reached rc.4 — floor must be rc.4.
         const map = {};
         packageNames.forEach((name) => {
             map[name] = { prerelease: '0.64.1-rc.3' };
@@ -62,11 +62,9 @@ describe('npm-published-version', () => {
     });
 
     it('should ignore packages that error and use the ones that resolve', () => {
-        // Only one package published; the rest 404. Floor comes from the published one.
         mockRegistry({ '@fundamental-ngx/core': { prerelease: '0.64.1-rc.4' } });
 
         expect(npmPublishedVersion()).toBe('0.64.1-rc.4');
-        // 12 of 13 threw -> 12 warnings
         expect(mockedWarn).toHaveBeenCalledTimes(packageNames.length - 1);
     });
 
@@ -89,22 +87,21 @@ describe('npm-published-version', () => {
         expect(npmPublishedVersion()).toBeNull();
     });
 
-    it('should handle empty stdout from npm as a non-contributing package', () => {
-        mockedExecFileSync.mockReturnValue('');
+    it('should handle empty stdout from curl as a non-contributing package', () => {
+        mockedExecFileSync.mockReturnValue('{}');
 
         expect(npmPublishedVersion()).toBeNull();
     });
 
-    it('should invoke npm via argv array (no shell string) and pass a registry when given', () => {
+    it('should invoke curl with the registry URL containing the encoded package name', () => {
         mockRegistry({ '@fundamental-ngx/core': { prerelease: '0.64.1-rc.4' } });
 
-        npmPublishedVersion('https://registry.npmjs.org/');
+        npmPublishedVersion();
 
-        const call = mockedExecFileSync.mock.calls[0];
-        expect(call[0]).toBe('npm');
-        expect(Array.isArray(call[1])).toBe(true);
-        expect(call[1]).toEqual(
-            expect.arrayContaining(['view', 'dist-tags', '--json', '--registry', 'https://registry.npmjs.org/'])
+        const coreCall = mockedExecFileSync.mock.calls.find((c) => c[1].some((a) => a.includes('%2fcore')));
+        expect(coreCall[0]).toBe('curl');
+        expect(coreCall[1].find((a) => a.startsWith('https://'))).toBe(
+            'https://registry.npmjs.org/@fundamental-ngx%2fcore'
         );
     });
 });


### PR DESCRIPTION
npm CLI spawned via execFileSync inside a node20 composite action fails silently - PATH resolution and npm config files are unreliable in that context. curl is always available on the runner and has no config interference. Also drops the @actions/core dependency.