### PR TITLE
fix(core): change Product Switch name to App Launcher

### DIFF
--- a/libs/docs/core/docs-data.json
+++ b/libs/docs/core/docs-data.json
@@ -221,7 +221,7 @@
         },
         {
             "url": "core/product-switch",
-            "name": "Product Switch"
+            "name": "Product Switch (App Launcher)"
         },
         {
             "url": "core/quick-view",

--- a/libs/docs/core/product-switch/product-switch-docs-header/product-switch-docs-header.component.html
+++ b/libs/docs/core/product-switch/product-switch-docs-header/product-switch-docs-header.component.html
@@ -1,7 +1,8 @@
 <fd-doc-page>
-    <header>Product Switch</header>
+    <header>Product Switch (App Launcher)</header>
     <description>
-        Product Switch provides a role based access to all products or LoBs. It shows only one level of navigation.
+        Product Switch, also known as App Launcher, provides a role based access to all products or LoBs. It shows only
+        one level of navigation.
     </description>
     <import module="ProductSwitchModule" subPackage="product-switch"></import>
 

--- a/libs/docs/core/product-switch/product-switch-docs.component.html
+++ b/libs/docs/core/product-switch/product-switch-docs.component.html
@@ -1,10 +1,10 @@
 <fd-docs-section-title id="basic" componentName="product-switch">
-    Basic Product Switch inside <code>Shellbar</code>.
+    Basic Product Switch (App Launcher) inside <code>Shellbar</code>.
 </fd-docs-section-title>
 <description>
-    Product switch with enabled <code>Drag And Drop</code>. The DnD functionality can be switched off by passing
-    <code>[dragAndDropEnabled]="false"</code> to component. The event thrown on drop can be handled by binding to
-    <code>(productsChange)</code>. The element can stick to it's position, it can be achieved by passing
+    Product Switch (App Launcher) with enabled <code>Drag And Drop</code>. The DnD functionality can be switched off by
+    passing <code>[dragAndDropEnabled]="false"</code> to component. The event thrown on drop can be handled by binding
+    to <code>(productsChange)</code>. The element can stick to it's position, it can be achieved by passing
     <code>stickToPosition: true</code> value to the interface object. Example of usage is in <code>Home</code> product.
     Use <code>(isOpenChange)</code> to listen for open/close state changes.
 </description>
@@ -16,7 +16,7 @@
 <separator></separator>
 
 <fd-docs-section-title id="small" componentName="product-switch">
-    Product Switch With Less Than 7 Items
+    Product Switch (App Launcher) With Less Than 7 Items
 </fd-docs-section-title>
 <description> When the product switch has less than 7 items, it has 3 columns and 2 rows. </description>
 <component-example>
@@ -28,7 +28,8 @@
 
 <fd-docs-section-title id="list" componentName="product-switch"> List Mode </fd-docs-section-title>
 <description>
-    For narrow screens the Product Switch transforms to a List by itself. Add the <code>[forceListMode]="true"</code>
+    For narrow screens the Product Switch (App Launcher) transforms to a List by itself. Add the
+    <code>[forceListMode]="true"</code>
     to force the list layout, even on larger screens.
 </description>
 <component-example>

--- a/libs/docs/ui5-webcomponents-fiori/docs-data.json
+++ b/libs/docs/ui5-webcomponents-fiori/docs-data.json
@@ -48,7 +48,7 @@
         },
         {
             "url": "ui5-webcomponents-fiori/product-switch",
-            "name": "Product Switch"
+            "name": "Product Switch (App Launcher)"
         },
         {
             "url": "ui5-webcomponents-fiori/search",

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel = Previous
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel = {totalCount} Results
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel = Product Switch
+coreProductSwitch.ariaLabel = App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription = This radio button is read-only and cannot be changed.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} Results'
     },
     coreProductSwitch: {
-        ariaLabel: 'Product Switch'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'This radio button is read-only and cannot be changed.'

--- a/libs/i18n/src/lib/translations/translations_ar.properties
+++ b/libs/i18n/src/lib/translations/translations_ar.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=السابق
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} من النتائج
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=تبديل المنتج
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=زر الاختيار هذا للقراءة فقط ولا يمكن تغييره.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} من النتائج'
     },
     coreProductSwitch: {
-        ariaLabel: 'تبديل المنتج'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'زر الاختيار هذا للقراءة فقط ولا يمكن تغييره.'

--- a/libs/i18n/src/lib/translations/translations_bg.properties
+++ b/libs/i18n/src/lib/translations/translations_bg.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Назад
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} резултата
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Превключвател за продукти
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Този радио бутон е само за четене и не може да се променя.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} резултата'
     },
     coreProductSwitch: {
-        ariaLabel: 'Превключвател за продукти'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Този радио бутон е само за четене и не може да се променя.'

--- a/libs/i18n/src/lib/translations/translations_cs.properties
+++ b/libs/i18n/src/lib/translations/translations_cs.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Předchozí
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel=Počet výsledků: {totalCount}
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Přepínač produktů
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Tento přepínač je jen ke čtení a nelze jej změnit.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: 'Počet výsledků: {totalCount}'
     },
     coreProductSwitch: {
-        ariaLabel: 'Přepínač produktů'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Tento přepínač je jen ke čtení a nelze jej změnit.'

--- a/libs/i18n/src/lib/translations/translations_da.properties
+++ b/libs/i18n/src/lib/translations/translations_da.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Forrige
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} Resultater
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Produktskift
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Denne valgknap er skrivebeskyttet og kan ikke ændres.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} Resultater'
     },
     coreProductSwitch: {
-        ariaLabel: 'Produktskift'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Denne valgknap er skrivebeskyttet og kan ikke ændres.'

--- a/libs/i18n/src/lib/translations/translations_de.properties
+++ b/libs/i18n/src/lib/translations/translations_de.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Zurück
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} Ergebnisse
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Product Switch
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Dieses Optionsfeld ist schreibgeschützt und kann nicht geändert werden.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} Ergebnisse'
     },
     coreProductSwitch: {
-        ariaLabel: 'Product Switch'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Dieses Optionsfeld ist schreibgeschützt und kann nicht geändert werden.'

--- a/libs/i18n/src/lib/translations/translations_el.properties
+++ b/libs/i18n/src/lib/translations/translations_el.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Προηγούμενο
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} Αποτελέσματα
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Διακόπτης Προϊόντος
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Αυτό το κουμπί επιλογής είναι μόνο για ανάγνωση και δεν μπορεί να αλλάξει.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} Αποτελέσματα'
     },
     coreProductSwitch: {
-        ariaLabel: 'Διακόπτης Προϊόντος'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Αυτό το κουμπί επιλογής είναι μόνο για ανάγνωση και δεν μπορεί να αλλάξει.'

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=[[[Ƥŗēʋįŏűş∙∙∙∙∙∙]]]
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel=[[[{totalCount} Řēşűĺţş]]]
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=[[[Ƥŗŏƌűċţ Ŝŵįţċĥ∙∙∙∙∙]]]
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=[[[Ţĥįş ŗąƌįŏ ƃűţţŏŋ įş ŗēąƌ-ŏŋĺŷ ąŋƌ ċąŋŋŏţ ƃē ċĥąŋğēƌ.∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙]]]
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '[[[{totalCount} Řēşűĺţş]]]'
     },
     coreProductSwitch: {
-        ariaLabel: '[[[Ƥŗŏƌűċţ Ŝŵįţċĥ∙∙∙∙∙]]]'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: '[[[Ţĥįş ŗąƌįŏ ƃűţţŏŋ įş ŗēąƌ-ŏŋĺŷ ąŋƌ ċąŋŋŏţ ƃē ċĥąŋğēƌ.∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙]]]'

--- a/libs/i18n/src/lib/translations/translations_es.properties
+++ b/libs/i18n/src/lib/translations/translations_es.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Anterior
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} resultados
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Cambiar producto
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Este botón de selección es de solo lectura y no se puede modificar.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} resultados'
     },
     coreProductSwitch: {
-        ariaLabel: 'Cambiar producto'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Este botón de selección es de solo lectura y no se puede modificar.'

--- a/libs/i18n/src/lib/translations/translations_fi.properties
+++ b/libs/i18n/src/lib/translations/translations_fi.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Edellinen
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} tulosta
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Tuotteen vaihto
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Tämä valintanappi on kirjoitussuojattu, eikä sitä voi muuttaa.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} tulosta'
     },
     coreProductSwitch: {
-        ariaLabel: 'Tuotteen vaihto'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Tämä valintanappi on kirjoitussuojattu, eikä sitä voi muuttaa.'

--- a/libs/i18n/src/lib/translations/translations_fr.properties
+++ b/libs/i18n/src/lib/translations/translations_fr.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Précédente
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} résultats
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Changement de produit
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Cette case d'option est en lecture seule et ne peut pas être modifiée.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -205,7 +205,7 @@ export default {
         totalResultsLabel: '{totalCount} résultats'
     },
     coreProductSwitch: {
-        ariaLabel: 'Changement de produit'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: "Cette case d'option est en lecture seule et ne peut pas être modifiée."

--- a/libs/i18n/src/lib/translations/translations_he.properties
+++ b/libs/i18n/src/lib/translations/translations_he.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=הקודם
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} תוצאות
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=מתג מוצר
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=לחצן הבחירה הוא לקריאה בלבד ולא ניתן לשנות אותו.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} תוצאות'
     },
     coreProductSwitch: {
-        ariaLabel: 'מתג מוצר'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'לחצן הבחירה הוא לקריאה בלבד ולא ניתן לשנות אותו.'

--- a/libs/i18n/src/lib/translations/translations_hi.properties
+++ b/libs/i18n/src/lib/translations/translations_hi.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel = पिछला
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel = {totalCount} परिणाम
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel = उत्पाद स्विच
+coreProductSwitch.ariaLabel = App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=This radio button is read-only and cannot be changed.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} परिणाम'
     },
     coreProductSwitch: {
-        ariaLabel: 'उत्पाद स्विच'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'This radio button is read-only and cannot be changed.'

--- a/libs/i18n/src/lib/translations/translations_hr.properties
+++ b/libs/i18n/src/lib/translations/translations_hr.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Prethodno
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel=Rezultata: {totalCount}
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Prebacivač proizvoda
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Ovaj radio gumb je samo za čitanje i ne može se mijenjati.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: 'Rezultata: {totalCount}'
     },
     coreProductSwitch: {
-        ariaLabel: 'Prebacivač proizvoda'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Ovaj radio gumb je samo za čitanje i ne može se mijenjati.'

--- a/libs/i18n/src/lib/translations/translations_hu.properties
+++ b/libs/i18n/src/lib/translations/translations_hu.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Előző
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} találat
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Termékváltás
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Ez a választókapcsoló írásvédett, ezért nem módosítható.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} találat'
     },
     coreProductSwitch: {
-        ariaLabel: 'Termékváltás'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Ez a választókapcsoló írásvédett, ezért nem módosítható.'

--- a/libs/i18n/src/lib/translations/translations_it.properties
+++ b/libs/i18n/src/lib/translations/translations_it.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Indietro
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} risultati
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Switch prodotti
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Questo pulsante di opzione è di sola lettura e non può essere modificato.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} risultati'
     },
     coreProductSwitch: {
-        ariaLabel: 'Switch prodotti'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Questo pulsante di opzione è di sola lettura e non può essere modificato.'

--- a/libs/i18n/src/lib/translations/translations_iw.properties
+++ b/libs/i18n/src/lib/translations/translations_iw.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=הקודם
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} תוצאות
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=מתג מוצר
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=לחצן הבחירה הוא לקריאה בלבד ולא ניתן לשנות אותו.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_iw.ts
+++ b/libs/i18n/src/lib/translations/translations_iw.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} תוצאות'
     },
     coreProductSwitch: {
-        ariaLabel: 'מתג מוצר'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'לחצן הבחירה הוא לקריאה בלבד ולא ניתן לשנות אותו.'

--- a/libs/i18n/src/lib/translations/translations_ja.properties
+++ b/libs/i18n/src/lib/translations/translations_ja.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=前へ
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel=結果: {totalCount}件
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=製品切替
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=このラジオボタンは読み取り専用のため変更できません。
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '結果: {totalCount}件'
     },
     coreProductSwitch: {
-        ariaLabel: '製品切替'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'このラジオボタンは読み取り専用のため変更できません。'

--- a/libs/i18n/src/lib/translations/translations_ka.properties
+++ b/libs/i18n/src/lib/translations/translations_ka.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel = წინა
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel = სულ {totalCount} შედეგი
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel = გადამრთველი
+coreProductSwitch.ariaLabel = App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=This radio button is read-only and cannot be changed.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: 'სულ {totalCount} შედეგი'
     },
     coreProductSwitch: {
-        ariaLabel: 'გადამრთველი'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'This radio button is read-only and cannot be changed.'

--- a/libs/i18n/src/lib/translations/translations_kk.properties
+++ b/libs/i18n/src/lib/translations/translations_kk.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Алдыңғы
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} нәтиже
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Өнім ауыстырып-қосқышы
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Бұл ауыстырып-қосқыш жазудан қорғалған және оны өзгерту мүмкін емес.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} нәтиже'
     },
     coreProductSwitch: {
-        ariaLabel: 'Өнім ауыстырып-қосқышы'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Бұл ауыстырып-қосқыш жазудан қорғалған және оны өзгерту мүмкін емес.'

--- a/libs/i18n/src/lib/translations/translations_ko.properties
+++ b/libs/i18n/src/lib/translations/translations_ko.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=이전
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount}개 결과
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=제품 전환
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=이 라디오 버튼은 읽기 전용이므로 변경할 수 없습니다.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount}개 결과'
     },
     coreProductSwitch: {
-        ariaLabel: '제품 전환'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: '이 라디오 버튼은 읽기 전용이므로 변경할 수 없습니다.'

--- a/libs/i18n/src/lib/translations/translations_ms.properties
+++ b/libs/i18n/src/lib/translations/translations_ms.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Sebelumnya
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} Hasil
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Suis Produk
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Butang radio ini adalah baca sahaja dan tidak boleh diubah.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} Hasil'
     },
     coreProductSwitch: {
-        ariaLabel: 'Suis Produk'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Butang radio ini adalah baca sahaja dan tidak boleh diubah.'

--- a/libs/i18n/src/lib/translations/translations_nl.properties
+++ b/libs/i18n/src/lib/translations/translations_nl.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Vorige
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} resultaten
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Overstappen op ander product
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Dit keuzerondje is alleen-lezen en kan niet worden gewijzigd.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} resultaten'
     },
     coreProductSwitch: {
-        ariaLabel: 'Overstappen op ander product'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Dit keuzerondje is alleen-lezen en kan niet worden gewijzigd.'

--- a/libs/i18n/src/lib/translations/translations_no.properties
+++ b/libs/i18n/src/lib/translations/translations_no.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Forrige
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} resultater
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Produktindikator
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Denne valgknappen er skrivebeskyttet og kan ikke endres.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} resultater'
     },
     coreProductSwitch: {
-        ariaLabel: 'Produktindikator'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Denne valgknappen er skrivebeskyttet og kan ikke endres.'

--- a/libs/i18n/src/lib/translations/translations_pl.properties
+++ b/libs/i18n/src/lib/translations/translations_pl.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Poprzedni
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} wyniki(-ów)
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Przełącznik produktu
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Ten przycisk jest tylko do odczytu i nie można go zmienić.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} wyniki(-ów)'
     },
     coreProductSwitch: {
-        ariaLabel: 'Przełącznik produktu'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Ten przycisk jest tylko do odczytu i nie można go zmienić.'

--- a/libs/i18n/src/lib/translations/translations_pt.properties
+++ b/libs/i18n/src/lib/translations/translations_pt.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Anterior
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} resultados
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Alternância de produtos
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Este botão de opção é somente leitura e não pode ser alterado.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} resultados'
     },
     coreProductSwitch: {
-        ariaLabel: 'Alternância de produtos'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Este botão de opção é somente leitura e não pode ser alterado.'

--- a/libs/i18n/src/lib/translations/translations_ro.properties
+++ b/libs/i18n/src/lib/translations/translations_ro.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Înapoi
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} rezultate
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Comutator produse
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Acest buton radio este numai pentru citire și nu poate fi modificat.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} rezultate'
     },
     coreProductSwitch: {
-        ariaLabel: 'Comutator produse'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Acest buton radio este numai pentru citire și nu poate fi modificat.'

--- a/libs/i18n/src/lib/translations/translations_ru.properties
+++ b/libs/i18n/src/lib/translations/translations_ru.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Назад
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel=Результаты: {totalCount}
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Переключатель продуктов
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Эта зависимая кнопка доступна только для чтения и не может быть изменена.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: 'Результаты: {totalCount}'
     },
     coreProductSwitch: {
-        ariaLabel: 'Переключатель продуктов'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Эта зависимая кнопка доступна только для чтения и не может быть изменена.'

--- a/libs/i18n/src/lib/translations/translations_sh.properties
+++ b/libs/i18n/src/lib/translations/translations_sh.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Prethodno
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} rezultata
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Zamena proizvoda
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Ovo dugme odabira je samo za čitanje i ne može se promeniti.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} rezultata'
     },
     coreProductSwitch: {
-        ariaLabel: 'Zamena proizvoda'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Ovo dugme odabira je samo za čitanje i ne može se promeniti.'

--- a/libs/i18n/src/lib/translations/translations_sk.properties
+++ b/libs/i18n/src/lib/translations/translations_sk.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Predchádzajúci
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} výsledkov
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Prepínač produktov
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Tento prepínač je len na čítanie a nemožno ho zmeniť.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} výsledkov'
     },
     coreProductSwitch: {
-        ariaLabel: 'Prepínač produktov'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Tento prepínač je len na čítanie a nemožno ho zmeniť.'

--- a/libs/i18n/src/lib/translations/translations_sl.properties
+++ b/libs/i18n/src/lib/translations/translations_sl.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Prejšnji
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel=Št. rezultatov: {totalCount}
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Preklop med proizvodi
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Ta izbirni gumb je samo za branje in ga ni mogoče spremeniti.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: 'Št. rezultatov: {totalCount}'
     },
     coreProductSwitch: {
-        ariaLabel: 'Preklop med proizvodi'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Ta izbirni gumb je samo za branje in ga ni mogoče spremeniti.'

--- a/libs/i18n/src/lib/translations/translations_sq.properties
+++ b/libs/i18n/src/lib/translations/translations_sq.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel = E mëparshme
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel = {totalCount} Rezultate
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel = Ndërprerësi i produktit
+coreProductSwitch.ariaLabel = App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=This radio button is read-only and cannot be changed.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_sq.ts
+++ b/libs/i18n/src/lib/translations/translations_sq.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} Rezultate'
     },
     coreProductSwitch: {
-        ariaLabel: 'Ndërprerësi i produktit'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'This radio button is read-only and cannot be changed.'

--- a/libs/i18n/src/lib/translations/translations_sr.properties
+++ b/libs/i18n/src/lib/translations/translations_sr.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Prethodno
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} rezultata
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Zamena proizvoda
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Ovo dugme odabira je samo za čitanje i ne može se promeniti.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_sr.ts
+++ b/libs/i18n/src/lib/translations/translations_sr.ts
@@ -204,7 +204,7 @@ export default {
         totalResultsLabel: '{totalCount} rezultata'
     },
     coreProductSwitch: {
-        ariaLabel: 'Zamena proizvoda'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Ovo dugme odabira je samo za čitanje i ne može se promeniti.'

--- a/libs/i18n/src/lib/translations/translations_sv.properties
+++ b/libs/i18n/src/lib/translations/translations_sv.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Föregående
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} resultat
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Product Switch
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Den här alternativknappen är skrivskyddad och kan inte ändras.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} resultat'
     },
     coreProductSwitch: {
-        ariaLabel: 'Product Switch'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Den här alternativknappen är skrivskyddad och kan inte ändras.'

--- a/libs/i18n/src/lib/translations/translations_th.properties
+++ b/libs/i18n/src/lib/translations/translations_th.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=ก่อนหน้า
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} ผลลัพธ์
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=การสลับผลิตภัณฑ์
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=ปุ่มตัวเลือกนี้เป็นแบบอ่านอย่างเดียวและไม่สามารถเปลี่ยนแปลงได้
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} ผลลัพธ์'
     },
     coreProductSwitch: {
-        ariaLabel: 'การสลับผลิตภัณฑ์'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'ปุ่มตัวเลือกนี้เป็นแบบอ่านอย่างเดียวและไม่สามารถเปลี่ยนแปลงได้'

--- a/libs/i18n/src/lib/translations/translations_tr.properties
+++ b/libs/i18n/src/lib/translations/translations_tr.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Önceki
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} Sonuç
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Ürün Anahtarı
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Bu radyo düğmesi salt okunurdur ve değiştirilemez.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} Sonuç'
     },
     coreProductSwitch: {
-        ariaLabel: 'Ürün Anahtarı'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Bu radyo düğmesi salt okunurdur ve değiştirilemez.'

--- a/libs/i18n/src/lib/translations/translations_uk.properties
+++ b/libs/i18n/src/lib/translations/translations_uk.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=Назад
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel=Результатів: {totalCount}
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=Перемикач продуктів
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=Цей перемикач доступний тільки для читання і не може бути змінений.
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: 'Результатів: {totalCount}'
     },
     coreProductSwitch: {
-        ariaLabel: 'Перемикач продуктів'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: 'Цей перемикач доступний тільки для читання і не може бути змінений.'

--- a/libs/i18n/src/lib/translations/translations_zh_CN.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=上一页
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} 个结果
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=产品切换
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=此单选按钮为只读，无法更改。
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -201,7 +201,7 @@ export default {
         totalResultsLabel: '{totalCount} 个结果'
     },
     coreProductSwitch: {
-        ariaLabel: '产品切换'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: '此单选按钮为只读，无法更改。'

--- a/libs/i18n/src/lib/translations/translations_zh_TW.properties
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel=上一頁
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel={totalCount} 個結果
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel=產品切換
+coreProductSwitch.ariaLabel=App Launcher
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=此選項按鈕為唯讀且無法變更。
 #XACT: Aria label for the zero state of the Rating Indicator

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -202,7 +202,7 @@ export default {
         totalResultsLabel: '{totalCount} 個結果'
     },
     coreProductSwitch: {
-        ariaLabel: '產品切換'
+        ariaLabel: 'App Launcher'
     },
     coreRadio: {
         readOnlyDescription: '此選項按鈕為唯讀且無法變更。'


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

The designers informed us that Product Switch is now called App Launcher externally. 

- added the new name as an alternative to Product Switch (kept both names)
- updated docs and links
- updated translation files for the aria label and title props of the button