### PR TITLE
chore: enforce correct BREAKING CHANGE footer format in commits

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -3,8 +3,6 @@ name: PR checks
 on:
     pull_request:
         types: [opened, synchronize, edited]
-    pull_request_target:
-        types: [edited]
 
 env:
     NODE_VERSION: '22.x'
@@ -20,58 +18,96 @@ permissions:
     contents: read
 
 jobs:
-    pr_lint:
+    pr_title_lint:
         runs-on: ubuntu-latest
-        name: Lint PR title and body
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        name: Validate PR title
         permissions:
-            pull-requests: write
             contents: read
+            pull-requests: read
+            statuses: write
         steps:
-            - name: Check for BREAKING CHANGES (plural)
+            - uses: amannn/action-semantic-pull-request@v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  types: |
+                      feat
+                      fix
+                      docs
+                      style
+                      refactor
+                      test
+                      build
+                      ci
+                      chore
+                  scopes: |
+                      core
+                      platform
+                      docs
+                      e2e
+                      release
+                      deps
+                      deps-dev
+                      changelog
+                      ci
+                      cx
+                      btp
+                      cdk
+                      shared
+                      i18n
+                      datetime-adapter
+                      moment-adapter
+                      ui5
+                      mcp
+                      skills
+                  requireScope: false
+                  # Ensure breaking changes use correct format
+                  # This validates the PR title when using GitHub's squash merge
+                  validateSingleCommit: false
+                  ignoreLabels: |
+                      ignore-semantic-pull-request
+
+    pr_body_lint:
+        runs-on: ubuntu-latest
+        name: Validate PR body breaking change format
+        permissions:
+            contents: read
+            pull-requests: read
+        steps:
+            - name: Check PR body for breaking change footer typos
               uses: actions/github-script@v7
               with:
                   script: |
-                      const pr = context.payload.pull_request;
-                      const title = pr.title;
-                      const body = pr.body || '';
+                      const body = context.payload.pull_request.body || '';
 
-                      // Only check for breaking change declarations, not mentions in descriptions
-                      // Match the actual breaking change footer format
-                      const breakingChangesRegex = /^BREAKING CHANGES:\s/m;
-                      const breakingChangeRegex = /^BREAKING CHANGE:\s/m;
+                      // Only check if there's a breaking change footer at all
+                      const hasAnyBreakingFooter = /^(BREAKING[ _-]?CHANG[EE]S?|breaking change):/im.test(body);
 
-                      const hasBreakingChangesPlural = breakingChangesRegex.test(body);
-                      const hasBreakingChange = breakingChangeRegex.test(body);
-
-                      if (hasBreakingChangesPlural) {
-                          const message = `⚠️ **Breaking Change Format Issue**
-
-                      Your PR body contains \`BREAKING CHANGES:\` (plural), but the conventional-commits parser requires \`BREAKING CHANGE:\` (singular) for version bumping to work correctly.
-
-                      Please update your PR description to use:
-                      \`\`\`
-                      BREAKING CHANGE: your description here
-                      \`\`\`
-
-                      Or use the \`!\` syntax in the PR title instead:
-                      \`\`\`
-                      ${title.replace(/^(\w+)(\([^)]+\))?:/, '$1$2!:')}
-                      \`\`\``;
-
-                          // Post a comment
-                          await github.rest.issues.createComment({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              issue_number: pr.number,
-                              body: message
-                          });
-
-                          // Fail the check
-                          core.setFailed('PR body contains "BREAKING CHANGES:" (plural). Use "BREAKING CHANGE:" (singular) instead.');
-                      } else {
-                          core.info('✓ No breaking change format issues detected');
+                      if (!hasAnyBreakingFooter) {
+                          core.info('✓ No breaking change footer found in PR body');
+                          return;
                       }
+
+                      // Check for typos in breaking change footers
+                      const typos = [
+                          { pattern: /^BREAKING CHANGES:/m, name: 'BREAKING CHANGES:' },      // plural
+                          { pattern: /^BREAKING-CHANGE:/m, name: 'BREAKING-CHANGE:' },        // dash
+                          { pattern: /^breaking change:/m, name: 'breaking change:' },        // lowercase
+                          { pattern: /^BREAKING_CHANGE:/m, name: 'BREAKING_CHANGE:' },        // underscore
+                          { pattern: /^BREAKINGCHANGE:/m, name: 'BREAKINGCHANGE:' }           // no separator
+                      ];
+
+                      for (const { pattern, name } of typos) {
+                          if (pattern.test(body)) {
+                              core.setFailed(
+                                  `PR body contains "${name}" but must use "BREAKING CHANGE:" (singular, uppercase, with space). ` +
+                                  `This matters when using GitHub's squash merge - the PR body becomes the commit footer.`
+                              );
+                              return;
+                          }
+                      }
+
+                      core.info('✓ Breaking change footer format is correct');
 
     nx_agents:
         name: Nx Cloud Agent ${{ matrix.agent }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -26,7 +26,7 @@ jobs:
             pull-requests: read
             statuses: write
         steps:
-            - uses: amannn/action-semantic-pull-request@v5
+            - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:
@@ -73,36 +73,62 @@ jobs:
         permissions:
             contents: read
             pull-requests: read
+            issues: write
         steps:
             - name: Check PR body for breaking change footer typos
               uses: actions/github-script@v7
               with:
                   script: |
                       const body = context.payload.pull_request.body || '';
+                      const commentMarker = '<!-- breaking-change-footer-lint -->';
 
-                      // Only check if there's a breaking change footer at all
-                      const hasAnyBreakingFooter = /^(BREAKING[ _-]?CHANG[EE]S?|breaking change):/im.test(body);
+                      async function upsertGuidanceComment(message) {
+                          const comments = await github.paginate(github.rest.issues.listComments, {
+                              ...context.repo,
+                              issue_number: context.issue.number,
+                              per_page: 100
+                          });
 
-                      if (!hasAnyBreakingFooter) {
+                          const existingComment = comments.find((comment) => comment.body?.includes(commentMarker));
+                          const commentBody = `${commentMarker}\n❌ ${message}\n\nUse this exact footer format:\n\n\`\`\`\nBREAKING CHANGE: <description>\n\`\`\``;
+
+                          if (existingComment) {
+                              await github.rest.issues.updateComment({
+                                  ...context.repo,
+                                  comment_id: existingComment.id,
+                                  body: commentBody
+                              });
+                              return;
+                          }
+
+                          await github.rest.issues.createComment({
+                              ...context.repo,
+                              issue_number: context.issue.number,
+                              body: commentBody
+                          });
+                      }
+
+                      const candidateFooterPattern = /^[ \t>*-]*breaking[ \t_-]*changes?[ \t]*:/im;
+                      const candidateFooterTokenPattern = /breaking[ \t_-]*changes?[ \t]*:/i;
+
+                      if (!candidateFooterPattern.test(body)) {
                           core.info('✓ No breaking change footer found in PR body');
                           return;
                       }
 
-                      // Check for typos in breaking change footers
-                      const typos = [
-                          { pattern: /^BREAKING CHANGES:/m, name: 'BREAKING CHANGES:' },      // plural
-                          { pattern: /^BREAKING-CHANGE:/m, name: 'BREAKING-CHANGE:' },        // dash
-                          { pattern: /^breaking change:/m, name: 'breaking change:' },        // lowercase
-                          { pattern: /^BREAKING_CHANGE:/m, name: 'BREAKING_CHANGE:' },        // underscore
-                          { pattern: /^BREAKINGCHANGE:/m, name: 'BREAKINGCHANGE:' }           // no separator
-                      ];
+                      for (const line of body.split(/\r?\n/)) {
+                          if (!candidateFooterPattern.test(line)) {
+                              continue;
+                          }
 
-                      for (const { pattern, name } of typos) {
-                          if (pattern.test(body)) {
-                              core.setFailed(
-                                  `PR body contains "${name}" but must use "BREAKING CHANGE:" (singular, uppercase, with space). ` +
-                                  `This matters when using GitHub's squash merge - the PR body becomes the commit footer.`
-                              );
+                          const token = line.match(candidateFooterTokenPattern)?.[0] ?? line.trim();
+                          if (line !== 'BREAKING CHANGE:' && !line.startsWith('BREAKING CHANGE: ')) {
+                              const errorMessage =
+                                  `PR body contains "${token}" but must use "BREAKING CHANGE:" exactly (singular, uppercase, one space, no prefix). ` +
+                                  `This matters when using GitHub's squash merge - the PR body becomes the commit footer.`;
+
+                              await upsertGuidanceComment(errorMessage);
+                              core.setFailed(errorMessage);
                               return;
                           }
                       }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -28,8 +28,40 @@ const Configuration = {
         ],
         'body-max-line-length': [2, 'always', 400],
         'footer-max-line-length': [2, 'always', 400],
-        'header-max-length': [2, 'always', 400]
-    }
+        'header-max-length': [2, 'always', 400],
+        'breaking-change-footer-format': [2, 'always']
+    },
+    plugins: [
+        {
+            rules: {
+                'breaking-change-footer-format': (parsed) => {
+                    const { body, footer } = parsed;
+                    const fullText = [body, footer].filter(Boolean).join('\n');
+
+                    // Check for common typos in breaking change footers
+                    const invalidPatterns = [
+                        { pattern: /^BREAKING CHANGES:/m, typo: 'BREAKING CHANGES:' }, // plural
+                        { pattern: /^BREAKING-CHANGE:/m, typo: 'BREAKING-CHANGE:' }, // dash instead of space
+                        { pattern: /^breaking change:/m, typo: 'breaking change:' }, // lowercase (exact match, not case-insensitive)
+                        { pattern: /^BREAKING_CHANGE:/m, typo: 'BREAKING_CHANGE:' }, // underscore
+                        { pattern: /^BREAKINGCHANGE:/m, typo: 'BREAKINGCHANGE:' } // no space/separator
+                    ];
+
+                    for (const { pattern, typo } of invalidPatterns) {
+                        if (pattern.test(fullText)) {
+                            return [
+                                false,
+                                `Breaking change footer contains "${typo}" but must use "BREAKING CHANGE:" (singular, uppercase, with space). ` +
+                                    `The conventional-commits parser requires this exact format for version bumping.`
+                            ];
+                        }
+                    }
+
+                    return [true];
+                }
+            }
+        }
+    ]
 };
 
 module.exports = Configuration;

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -38,20 +38,20 @@ const Configuration = {
                     const { body, footer } = parsed;
                     const fullText = [body, footer].filter(Boolean).join('\n');
 
-                    // Check for common typos in breaking change footers
-                    const invalidPatterns = [
-                        { pattern: /^BREAKING CHANGES:/m, typo: 'BREAKING CHANGES:' }, // plural
-                        { pattern: /^BREAKING-CHANGE:/m, typo: 'BREAKING-CHANGE:' }, // dash instead of space
-                        { pattern: /^breaking change:/m, typo: 'breaking change:' }, // lowercase (exact match, not case-insensitive)
-                        { pattern: /^BREAKING_CHANGE:/m, typo: 'BREAKING_CHANGE:' }, // underscore
-                        { pattern: /^BREAKINGCHANGE:/m, typo: 'BREAKINGCHANGE:' } // no space/separator
-                    ];
+                    // Catch typo variants like pluralization, separators, casing, spacing, and markdown list prefixes.
+                    const candidateFooterPattern = /^[ \t>*-]*breaking[ \t_-]*changes?[ \t]*:/im;
+                    const candidateFooterTokenPattern = /breaking[ \t_-]*changes?[ \t]*:/i;
 
-                    for (const { pattern, typo } of invalidPatterns) {
-                        if (pattern.test(fullText)) {
+                    for (const line of fullText.split(/\r?\n/)) {
+                        if (!candidateFooterPattern.test(line)) {
+                            continue;
+                        }
+
+                        const token = line.match(candidateFooterTokenPattern)?.[0] ?? line.trim();
+                        if (line !== 'BREAKING CHANGE:' && !line.startsWith('BREAKING CHANGE: ')) {
                             return [
                                 false,
-                                `Breaking change footer contains "${typo}" but must use "BREAKING CHANGE:" (singular, uppercase, with space). ` +
+                                `Breaking change footer contains "${token}" but must use "BREAKING CHANGE:" exactly (singular, uppercase, one space, no prefix). ` +
                                     `The conventional-commits parser requires this exact format for version bumping.`
                             ];
                         }

--- a/libs/nx-plugin/src/commitlint-breaking-change-footer-format.spec.ts
+++ b/libs/nx-plugin/src/commitlint-breaking-change-footer-format.spec.ts
@@ -1,0 +1,38 @@
+const configuration = require('../../../commitlint.config.js');
+
+describe('commitlint breaking-change-footer-format rule', () => {
+    const rule = configuration.plugins[0].rules['breaking-change-footer-format'];
+
+    function validate(body?: string, footer?: string): [boolean, string?] {
+        return rule({ body, footer });
+    }
+
+    it('should allow canonical breaking change footer', () => {
+        expect(validate(undefined, 'BREAKING CHANGE: API contract changed')[0]).toBe(true);
+        expect(validate(undefined, 'BREAKING CHANGE:')[0]).toBe(true);
+    });
+
+    it('should reject non-canonical breaking change footer variants', () => {
+        const invalidLines = [
+            'BREAKING CHANGES: API contract changed',
+            'BREAKING-CHANGE: API contract changed',
+            'BREAKING_CHANGE: API contract changed',
+            'BREAKINGCHANGE: API contract changed',
+            'Breaking Change: API contract changed',
+            'BREAKING CHANGE : API contract changed',
+            '  BREAKING CHANGE: API contract changed',
+            '- BREAKING CHANGE: API contract changed'
+        ];
+
+        for (const line of invalidLines) {
+            const [isValid, message] = validate(undefined, line);
+            expect(isValid).toBe(false);
+            expect(message).toContain('BREAKING CHANGE:');
+        }
+    });
+
+    it('should ignore regular body text that is not a breaking change footer', () => {
+        const [isValid] = validate('This PR introduces breaking changes in examples.', undefined);
+        expect(isValid).toBe(true);
+    });
+});


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14403

## Description

1. Hardened BREAKING CHANGE footer validation in commit messages:

- Updated `commitlint.config.js` with stricter regex-based detection. It now catches variants such as:

    -   BREAKING CHANGES:
    -   BREAKING-CHANGE:
    -   BREAKING_CHANGE:
    -   BREAKINGCHANGE:
    - Breaking Change:
    - spacing/prefix variants (for example list-prefixed lines)

**Only canonical format is accepted:**

- BREAKING CHANGE:
- BREAKING CHANGE: description

2. Hardened PR body validation for squash-merge safety:

- Updated `on-pull-request.yml` job pr_body_lint.
- Added stricter `line-by-line` validation using the same canonical rule.
- Added contributor guidance comment on failure (upsert behavior to avoid spam).
- Added permissions needed for comment creation.

3. Pinned PR title action to immutable commit:

- Updated on-pull-request.yml`
- Changed from moving tag `v5` to: `amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825` (with comment showing it corresponds to v5)


4. Added automated regression test:

- New file `commitlint-breaking-change-footer-format.spec.ts`
- Verifies valid and invalid footer patterns for the custom commitlint rule.

### Why this matters

- Prevents release/versioning issues caused by non-canonical BREAKING CHANGE text.
- Protects squash-merge path where PR body becomes commit message content.
- Improves contributor feedback by commenting exact fix guidance directly on PR.
- Makes CI more secure and reproducible via immutable action pinning.

--------------------------------------------------------------------------------------
**Explanation of this line**
uses: `amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825`


- v5 is a label on a box.
- The long SHA is the exact serial number of one specific box.

If you use only v5, the label can later point to a different box.
If you use the SHA, you always get the exact same box every time.

So this change makes CI predictable and safer:

- Same action code on every run.
- Easier debugging and auditing.
- Lower supply-chain risk.

Supersedes [#14380](https://github.com/SAP/fundamental-ngx/pull/14380)