### PR TITLE
fix: skip linux snapshot check in merge commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-if [ "$(uname)" = "Darwin" ]; then
+if [ "$(uname)" = "Darwin" ] && [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
     staged_linux=$(git diff --cached --name-only --diff-filter=ACM | grep '^apps/e2e-harness/e2e/snapshots/linux/' || true)
     if [ -n "$staged_linux" ]; then
         echo "Refusing commit: Linux snapshots staged from a Mac."


### PR DESCRIPTION
## Related Issue(s)

<!-- If this PR fixes multiple issues, please use the full syntax(`closes #issue-number`) for each issue so that each issue gets automatically closed on PR merge; for example: `closes #0001, closes #0002`, and so on. -->

closes none

## Description

Adds `&& [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]` to the pre-commit condition. Git writes a MERGE_HEAD file while a merge is in progress (including the final merge commit), so this skips the Linux snapshot check for merge commits while still blocking accidental manual staging of Linux snapshots on a Mac.
