### PR TITLE
fix(core): remove aria-selected on default Card with role region

### DIFF
--- a/libs/core/card/card.component.ts
+++ b/libs/core/card/card.component.ts
@@ -58,8 +58,8 @@ let cardId = 0;
         '[attr.aria-labelledby]': 'cardTitle()?.id() || cardMediaHeading()?.id()',
         '[attr.aria-describedby]': 'ariaDescribedbyComputed()',
         '[attr.aria-label]': 'ariaLabel()',
-        '[attr.aria-selected]': 'selected()',
         '[tabindex]': 'role() === "listitem" ? 0 : -1',
+        '[attr.aria-selected]': 'role() === "listitem" ? selected() : null',
         '[attr.aria-posinset]': 'role() === "listitem" ? ariaPosinset() : null',
         '[attr.aria-setsize]': 'role() === "listitem" ? ariaSetsize() : null',
         '(keydown)': 'keydownHandler($event)'


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14416

## Description
Fixes an accessibility bug in fd-card where `aria-selected` was always rendered on the host, including the default case `role="region"`.

According to `WAI-ARIA`, `aria-selected` is not valid for `role="region"`. This produced invalid markup, triggered scanner findings, and was reported by JAWS.
