### PR TITLE
fix(ui5): use relative import in theming-bridge template to fix lint boundary error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -153,7 +153,7 @@ module.exports = pluginTs.config(
             '@nx/enforce-module-boundaries': [
                 'error',
                 {
-                    allow: ['jest.config.base'],
+                    allow: ['jest.config.base', '@fundamental-ngx/ui5-webcomponents.*/theming'],
                     depConstraints: [
                         {
                             sourceTag: 'scope:cdk',


### PR DESCRIPTION
fix(ui5): use relative import in theming-bridge template to fix lint boundary error