### PR TITLE
fix(core): change Product Switch name to App Launcher

### DIFF
--- a/libs/docs/core/docs-data.json
+++ b/libs/docs/core/docs-data.json
@@ -221,7 +221,7 @@
         },
         {
             "url": "core/product-switch",
-            "name": "Product Switch"
+            "name": "Product Switch (App Launcher)"
         },
         {
             "url": "core/quick-view",

--- a/libs/docs/core/product-switch/product-switch-docs-header/product-switch-docs-header.component.html
+++ b/libs/docs/core/product-switch/product-switch-docs-header/product-switch-docs-header.component.html
@@ -1,7 +1,8 @@
 <fd-doc-page>
-    <header>Product Switch</header>
+    <header>Product Switch (App Launcher)</header>
     <description>
-        Product Switch provides a role based access to all products or LoBs. It shows only one level of navigation.
+        Product Switch, also known as App Launcher, provides a role based access to all products or LoBs. It shows only
+        one level of navigation.
     </description>
     <import module="ProductSwitchModule" subPackage="product-switch"></import>
 

--- a/libs/docs/core/product-switch/product-switch-docs.component.html
+++ b/libs/docs/core/product-switch/product-switch-docs.component.html
@@ -1,10 +1,10 @@
 <fd-docs-section-title id="basic" componentName="product-switch">
-    Basic Product Switch inside <code>Shellbar</code>.
+    Basic Product Switch (App Launcher) inside <code>Shellbar</code>.
 </fd-docs-section-title>
 <description>
-    Product switch with enabled <code>Drag And Drop</code>. The DnD functionality can be switched off by passing
-    <code>[dragAndDropEnabled]="false"</code> to component. The event thrown on drop can be handled by binding to
-    <code>(productsChange)</code>. The element can stick to it's position, it can be achieved by passing
+    Product switch (App Launcher) with enabled <code>Drag And Drop</code>. The DnD functionality can be switched off by
+    passing <code>[dragAndDropEnabled]="false"</code> to component. The event thrown on drop can be handled by binding
+    to <code>(productsChange)</code>. The element can stick to it's position, it can be achieved by passing
     <code>stickToPosition: true</code> value to the interface object. Example of usage is in <code>Home</code> product.
     Use <code>(isOpenChange)</code> to listen for open/close state changes.
 </description>
@@ -16,7 +16,9 @@
 <separator></separator>
 
 <fd-docs-section-title id="large" componentName="product-switch"> Large </fd-docs-section-title>
-<description> Product switch is displayed with a maximum of 4 columns on large desktop screens. </description>
+<description>
+    Product Switch (App Launcher) is displayed with a maximum of 4 columns on large desktop screens.
+</description>
 <component-example>
     <fd-product-switch-large-example></fd-product-switch-large-example>
 </component-example>
@@ -38,7 +40,8 @@
 
 <fd-docs-section-title id="list" componentName="product-switch"> List Mode </fd-docs-section-title>
 <description>
-    For narrow screens the Product Switch transforms to a List by itself. Add the <code>[forceListMode]="true"</code>
+    For narrow screens the Product Switch (App Launcher) transforms to a List by itself. Add the
+    <code>[forceListMode]="true"</code>
     to force the list layout, even on larger screens.
 </description>
 <component-example>

--- a/libs/docs/ui5-webcomponents-fiori/docs-data.json
+++ b/libs/docs/ui5-webcomponents-fiori/docs-data.json
@@ -48,7 +48,7 @@
         },
         {
             "url": "ui5-webcomponents-fiori/product-switch",
-            "name": "Product Switch"
+            "name": "Product Switch (App Launcher)"
         },
         {
             "url": "ui5-webcomponents-fiori/search",

--- a/libs/docs/ui5-webcomponents-fiori/product-switch/product-switch-docs.html
+++ b/libs/docs/ui5-webcomponents-fiori/product-switch/product-switch-docs.html
@@ -1,8 +1,10 @@
-<fd-docs-section-title id="basic" componentName="product-switch"> Basic Product Switch </fd-docs-section-title>
+<fd-docs-section-title id="basic" componentName="product-switch">
+    Basic Product Switch (App Launcher)</fd-docs-section-title
+>
 <description>
-    The Product Switch component is a container for <code>ui5-product-switch-item</code> components that allows users to
-    quickly navigate between different products or applications. It displays a grid of clickable tiles, each
-    representing a product or application. Each item can have a title, subtitle, and icon to provide clear visual
+    The Product Switch (App Launcher) component is a container for <code>ui5-product-switch-item</code> components that
+    allows users to quickly navigate between different products or applications. It displays a grid of clickable tiles,
+    each representing a product or application. Each item can have a title, subtitle, and icon to provide clear visual
     identification.
 </description>
 <component-example>
@@ -14,11 +16,11 @@
 
 <fd-docs-section-title id="icons" componentName="product-switch"> Custom Icons and Images </fd-docs-section-title>
 <description>
-    Product switch items can display either standard UI5 icons using the <code>icon</code> property or custom images
-    using the <code>image</code> slot. The image slot takes precedence over the icon property. When using the image
-    slot, it's recommended to use a non-interactive <code>ui5-avatar</code> component with size S, Square shape, and
-    Transparent colorScheme for best alignment. This example demonstrates both approaches - using standard icons and
-    custom avatar images.
+    Product Switch (App Launcher) items can display either standard UI5 icons using the <code>icon</code> property or
+    custom images using the <code>image</code> slot. The image slot takes precedence over the icon property. When using
+    the image slot, it's recommended to use a non-interactive <code>ui5-avatar</code> component with size S, Square
+    shape, and Transparent colorScheme for best alignment. This example demonstrates both approaches - using standard
+    icons and custom avatar images.
 </description>
 <component-example>
     <ui5-doc-product-switch-icons-sample />
@@ -28,7 +30,7 @@
 <separator />
 
 <fd-docs-section-title id="in-shell-bar" componentName="product-switch">
-    Product Switch In Shell Bar
+    Product Switch (App Launcher) In Shell Bar
 </fd-docs-section-title>
 <description> Press the "grid" on the right-most part of the ShellBar to show the ProductSwitch. </description>
 <component-example>

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -275,7 +275,7 @@ corePagination.previousLabel = Previous
 #XFLD: Label for the {totalCount} Results text
 corePagination.totalResultsLabel = {totalCount} Results
 #XFLD: Label for the product switch component
-coreProductSwitch.ariaLabel = Product Switch
+coreProductSwitch.ariaLabel = App Launcher
 coreProductSwitch.targetBlank = opens in a new browser tab
 coreProductSwitch.targetParent = opens in the parent frame
 coreProductSwitch.targetTop = opens in the full browser window

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -203,7 +203,7 @@ export default {
         totalResultsLabel: '{totalCount} Results'
     },
     coreProductSwitch: {
-        ariaLabel: 'Product Switch',
+        ariaLabel: 'App Launcher',
         targetBlank: 'opens in a new browser tab',
         targetParent: 'opens in the parent frame',
         targetTop: 'opens in the full browser window'


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

The designers informed us that Product Switch is now called App Launcher externally. 

- added the new name as an alternative to Product Switch (kept both names)
- updated docs and links
- updated translation files for the aria label and title props of the button