### PR TITLE
fix(ui5): enable SPA navigation for [routerLink] on UI5 href components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ libs/ui5-webcomponents-fiori/index.ts
 !libs/ui5-webcomponents-base/theming/
 !libs/ui5-webcomponents-base/theming-bridge/
 !libs/ui5-webcomponents-base/i18n/
+!libs/ui5-webcomponents-base/router-link/
 !libs/ui5-webcomponents/theming-bridge/
 libs/ui5-webcomponents/theming-bridge/*
 !libs/ui5-webcomponents/theming-bridge/*.spec.ts

--- a/libs/ui5-webcomponents-base/router-link/index.ts
+++ b/libs/ui5-webcomponents-base/router-link/index.ts
@@ -1,0 +1,1 @@
+export * from './ui5-router-link-bridge.directive';

--- a/libs/ui5-webcomponents-base/router-link/ng-package.json
+++ b/libs/ui5-webcomponents-base/router-link/ng-package.json
@@ -1,0 +1,5 @@
+{
+    "lib": {
+        "entryFile": "./index.ts"
+    }
+}

--- a/libs/ui5-webcomponents-base/router-link/ui5-router-link-bridge.directive.spec.ts
+++ b/libs/ui5-webcomponents-base/router-link/ui5-router-link-bridge.directive.spec.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { Router, RouterLink, provideRouter } from '@angular/router';
+import { Router, RouterLink, UrlTree, provideRouter } from '@angular/router';
 import { Ui5RouterLinkBridgeDirective } from './ui5-router-link-bridge.directive';
 
 @Component({ selector: 'fd-test-target', template: 'Target' })
@@ -35,18 +35,18 @@ describe('Ui5RouterLinkBridgeDirective', () => {
     });
 
     describe('plain left-click (no modifiers, button 0)', () => {
-        it('calls router.navigateByUrl() with the resolved URL', fakeAsync(() => {
-            const navigateSpy = jest.spyOn(router, 'navigateByUrl');
+        it('calls router.navigateByUrl() with the resolved /target URL', fakeAsync(() => {
             const fixture = TestBed.createComponent(TestHostComponent);
             fixture.detectChanges();
             tick();
 
+            const navigateSpy = jest.spyOn(router, 'navigateByUrl');
             const host = fixture.nativeElement.querySelector('#host') as HTMLElement;
             host.dispatchEvent(makeClickCustomEvent({ button: 0 }));
-            fixture.detectChanges();
-            tick();
 
-            expect(navigateSpy).toHaveBeenCalledWith(expect.objectContaining({ root: expect.anything() }), expect.anything());
+            expect(navigateSpy).toHaveBeenCalled();
+            const passedTree = navigateSpy.mock.calls[0][0];
+            expect(router.serializeUrl(passedTree as UrlTree)).toBe('/target');
         }));
 
         it('calls event.preventDefault() to suppress shadow-DOM anchor navigation', fakeAsync(() => {
@@ -104,6 +104,23 @@ describe('Ui5RouterLinkBridgeDirective', () => {
             const host = fixture.nativeElement.querySelector('#host') as HTMLElement;
             host.dispatchEvent(makeClickCustomEvent({ button: 1 }));
             fixture.detectChanges();
+            tick();
+
+            expect(navigateSpy).not.toHaveBeenCalled();
+        }));
+    });
+
+    describe('teardown', () => {
+        it('removes the capture-phase click listener on destroy', fakeAsync(() => {
+            const navigateSpy = jest.spyOn(router, 'navigateByUrl');
+            const fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            tick();
+
+            const host = fixture.nativeElement.querySelector('#host') as HTMLElement;
+            fixture.destroy();
+
+            host.dispatchEvent(makeClickCustomEvent({ button: 0 }));
             tick();
 
             expect(navigateSpy).not.toHaveBeenCalled();

--- a/libs/ui5-webcomponents-base/router-link/ui5-router-link-bridge.directive.spec.ts
+++ b/libs/ui5-webcomponents-base/router-link/ui5-router-link-bridge.directive.spec.ts
@@ -1,0 +1,136 @@
+import { Component } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router, RouterLink, provideRouter } from '@angular/router';
+import { Ui5RouterLinkBridgeDirective } from './ui5-router-link-bridge.directive';
+
+@Component({ selector: 'fd-test-target', template: 'Target' })
+class TargetComponent {}
+
+@Component({
+    selector: 'fd-test-host',
+    template: `<div routerLink="/target" ui5RouterLinkBridge id="host"></div>`,
+    imports: [RouterLink, Ui5RouterLinkBridgeDirective]
+})
+class TestHostComponent {}
+
+function makeClickCustomEvent(
+    overrides: Partial<{ button: number; ctrlKey: boolean; metaKey: boolean; shiftKey: boolean; altKey: boolean }> = {}
+): CustomEvent {
+    return new CustomEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        detail: { button: 0, ctrlKey: false, metaKey: false, shiftKey: false, altKey: false, ...overrides }
+    });
+}
+
+describe('Ui5RouterLinkBridgeDirective', () => {
+    let router: Router;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [TestHostComponent],
+            providers: [provideRouter([{ path: 'target', component: TargetComponent }])]
+        }).compileComponents();
+        router = TestBed.inject(Router);
+    });
+
+    describe('plain left-click (no modifiers, button 0)', () => {
+        it('calls router.navigateByUrl() with the resolved URL', fakeAsync(() => {
+            const navigateSpy = jest.spyOn(router, 'navigateByUrl');
+            const fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            tick();
+
+            const host = fixture.nativeElement.querySelector('#host') as HTMLElement;
+            host.dispatchEvent(makeClickCustomEvent({ button: 0 }));
+            fixture.detectChanges();
+            tick();
+
+            expect(navigateSpy).toHaveBeenCalledWith(expect.objectContaining({ root: expect.anything() }), expect.anything());
+        }));
+
+        it('calls event.preventDefault() to suppress shadow-DOM anchor navigation', fakeAsync(() => {
+            const fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            tick();
+
+            const host = fixture.nativeElement.querySelector('#host') as HTMLElement;
+            const event = makeClickCustomEvent({ button: 0 });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            host.dispatchEvent(event);
+            fixture.detectChanges();
+            tick();
+
+            expect(preventDefaultSpy).toHaveBeenCalled();
+        }));
+    });
+
+    describe('modifier clicks (new-tab intent)', () => {
+        it('does NOT call router.navigateByUrl() on Ctrl+click', fakeAsync(() => {
+            const navigateSpy = jest.spyOn(router, 'navigateByUrl');
+            const fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            tick();
+
+            const host = fixture.nativeElement.querySelector('#host') as HTMLElement;
+            host.dispatchEvent(makeClickCustomEvent({ button: 0, ctrlKey: true }));
+            fixture.detectChanges();
+            tick();
+
+            expect(navigateSpy).not.toHaveBeenCalled();
+        }));
+
+        it('does NOT call router.navigateByUrl() on Meta+click', fakeAsync(() => {
+            const navigateSpy = jest.spyOn(router, 'navigateByUrl');
+            const fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            tick();
+
+            const host = fixture.nativeElement.querySelector('#host') as HTMLElement;
+            host.dispatchEvent(makeClickCustomEvent({ button: 0, metaKey: true }));
+            fixture.detectChanges();
+            tick();
+
+            expect(navigateSpy).not.toHaveBeenCalled();
+        }));
+
+        it('does NOT call router.navigateByUrl() on middle-click (button 1)', fakeAsync(() => {
+            const navigateSpy = jest.spyOn(router, 'navigateByUrl');
+            const fixture = TestBed.createComponent(TestHostComponent);
+            fixture.detectChanges();
+            tick();
+
+            const host = fixture.nativeElement.querySelector('#host') as HTMLElement;
+            host.dispatchEvent(makeClickCustomEvent({ button: 1 }));
+            fixture.detectChanges();
+            tick();
+
+            expect(navigateSpy).not.toHaveBeenCalled();
+        }));
+    });
+
+    describe('without RouterLink on the host', () => {
+        it('does nothing when RouterLink is absent', fakeAsync(() => {
+            @Component({
+                selector: 'fd-no-routerlink-host',
+                template: `<div ui5RouterLinkBridge id="host"></div>`,
+                imports: [Ui5RouterLinkBridgeDirective]
+            })
+            class NoRouterLinkHostComponent {}
+
+            TestBed.resetTestingModule();
+            TestBed.configureTestingModule({
+                imports: [NoRouterLinkHostComponent],
+                providers: [provideRouter([])]
+            }).compileComponents();
+
+            const fixture = TestBed.createComponent(NoRouterLinkHostComponent);
+            fixture.detectChanges();
+            tick();
+
+            const host = fixture.nativeElement.querySelector('#host') as HTMLElement;
+            expect(() => host.dispatchEvent(makeClickCustomEvent())).not.toThrow();
+        }));
+    });
+});

--- a/libs/ui5-webcomponents-base/router-link/ui5-router-link-bridge.directive.ts
+++ b/libs/ui5-webcomponents-base/router-link/ui5-router-link-bridge.directive.ts
@@ -1,0 +1,54 @@
+import { Directive, ElementRef, inject, OnInit } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+
+/**
+ * Enables in-app (SPA) navigation for `[routerLink]` on UI5 wrapper components.
+ *
+ * UI5 replaces the native click with a `CustomEvent` that has no `button` property.
+ * Angular's `RouterLink` reads `event.button`, gets `undefined`, and bails — leaving
+ * the shadow `<a href>` to navigate natively. This directive intercepts the event in
+ * capture phase, handles plain left-clicks via `router.navigateByUrl()`, and blocks
+ * RouterLink from seeing modifier/middle clicks via `stopImmediatePropagation()`.
+ *
+ * Applied automatically via `hostDirectives` on generated wrappers with an `href` input.
+ * See `libs/webc-generator/src/executors/generate/component-template.ts`.
+ */
+@Directive({
+    selector: '[ui5RouterLinkBridge]'
+})
+export class Ui5RouterLinkBridgeDirective implements OnInit {
+    private readonly _router = inject(Router);
+    private readonly _routerLink = inject(RouterLink, { optional: true, self: true });
+    private readonly _elementRef = inject(ElementRef<HTMLElement>);
+
+    ngOnInit(): void {
+        const routerLink = this._routerLink;
+        if (!routerLink) {
+            return;
+        }
+        this._elementRef.nativeElement.addEventListener('click', (event: Event) => {
+            this._handleClick(event as CustomEvent, routerLink);
+        }, true);
+    }
+
+    private _handleClick(event: CustomEvent, routerLink: RouterLink): void {
+        const detail = event.detail ?? {};
+        const button = detail.button ?? 0;
+        const isModified = detail.ctrlKey || detail.metaKey || detail.shiftKey || detail.altKey;
+
+        if (button !== 0 || isModified) {
+            // Prevent RouterLink from seeing this event — RouterLink reads event.button as
+            // undefined on UI5 CustomEvents and would navigate regardless of modifier state.
+            event.stopImmediatePropagation();
+            return;
+        }
+
+        const urlTree = routerLink.urlTree;
+        if (urlTree === null) {
+            return;
+        }
+
+        event.preventDefault();
+        this._router.navigateByUrl(urlTree);
+    }
+}

--- a/libs/ui5-webcomponents-base/router-link/ui5-router-link-bridge.directive.ts
+++ b/libs/ui5-webcomponents-base/router-link/ui5-router-link-bridge.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, OnInit } from '@angular/core';
+import { DestroyRef, Directive, ElementRef, inject, OnInit } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 
 /**
@@ -20,15 +20,17 @@ export class Ui5RouterLinkBridgeDirective implements OnInit {
     private readonly _router = inject(Router);
     private readonly _routerLink = inject(RouterLink, { optional: true, self: true });
     private readonly _elementRef = inject(ElementRef<HTMLElement>);
+    private readonly _destroyRef = inject(DestroyRef);
 
     ngOnInit(): void {
         const routerLink = this._routerLink;
         if (!routerLink) {
             return;
         }
-        this._elementRef.nativeElement.addEventListener('click', (event: Event) => {
-            this._handleClick(event as CustomEvent, routerLink);
-        }, true);
+        const el = this._elementRef.nativeElement;
+        const handler = (event: Event): void => this._handleClick(event as CustomEvent, routerLink);
+        el.addEventListener('click', handler, true);
+        this._destroyRef.onDestroy(() => el.removeEventListener('click', handler, true));
     }
 
     private _handleClick(event: CustomEvent, routerLink: RouterLink): void {

--- a/libs/webc-generator/src/executors/generate/component-template.spec.ts
+++ b/libs/webc-generator/src/executors/generate/component-template.spec.ts
@@ -504,6 +504,83 @@ describe('componentTemplate', () => {
         });
     });
 
+    describe('RouterLink bridge (href components)', () => {
+        const hrefDeclaration: CEM.CustomElementDeclaration = {
+            kind: 'class',
+            name: 'Link',
+            tagName: 'ui5-link',
+            customElement: true,
+            members: [
+                {
+                    kind: 'field',
+                    name: 'href',
+                    privacy: 'public',
+                    type: { text: 'string | undefined' }
+                } as CEM.ClassField
+            ]
+        };
+
+        const noHrefDeclaration: CEM.CustomElementDeclaration = {
+            kind: 'class',
+            name: 'Button',
+            tagName: 'ui5-button',
+            customElement: true
+        };
+
+        it('imports Ui5RouterLinkBridgeDirective for components with href', () => {
+            const result = componentTemplate(hrefDeclaration, [], PACKAGE);
+            expect(result).toContain(
+                `import { Ui5RouterLinkBridgeDirective } from '@fundamental-ngx/ui5-webcomponents-base/router-link'`
+            );
+        });
+
+        it('adds Ui5RouterLinkBridgeDirective to hostDirectives for components with href', () => {
+            const result = componentTemplate(hrefDeclaration, [], PACKAGE);
+            expect(result).toContain('hostDirectives: [Ui5RouterLinkBridgeDirective]');
+        });
+
+        it('does NOT import Ui5RouterLinkBridgeDirective for components without href', () => {
+            const result = componentTemplate(noHrefDeclaration, [], PACKAGE);
+            expect(result).not.toContain('Ui5RouterLinkBridgeDirective');
+        });
+
+        it('does NOT add hostDirectives for components without href (unless CVA requires it)', () => {
+            const result = componentTemplate(noHrefDeclaration, [], PACKAGE);
+            expect(result).not.toContain('hostDirectives');
+        });
+    });
+
+    describe('output listener cleanup (NG0953 prevention)', () => {
+        const eventDeclaration: CEM.CustomElementDeclaration = {
+            kind: 'class',
+            name: 'Button',
+            tagName: 'ui5-button',
+            customElement: true,
+            events: [
+                {
+                    name: 'click',
+                    _ui5privacy: 'public',
+                    type: { text: 'CustomEvent' }
+                } as CEM.Event
+            ]
+        };
+
+        it('injects DestroyRef when component has outputs', () => {
+            const result = componentTemplate(eventDeclaration, [], PACKAGE);
+            expect(result).toContain('DestroyRef');
+        });
+
+        it('removes event listeners on destroy', () => {
+            const result = componentTemplate(eventDeclaration, [], PACKAGE);
+            expect(result).toContain('removeEventListener');
+        });
+
+        it('does not inject DestroyRef when component has no outputs', () => {
+            const result = componentTemplate(minimalDeclaration, [], PACKAGE);
+            expect(result).not.toContain('DestroyRef');
+        });
+    });
+
     describe('input synchronization', () => {
         const linkDeclaration: CEM.CustomElementDeclaration = {
             kind: 'class',

--- a/libs/webc-generator/src/executors/generate/component-template.ts
+++ b/libs/webc-generator/src/executors/generate/component-template.ts
@@ -368,9 +368,26 @@ export function componentTemplate(
     // Get CVA configuration based on component metadata
     const cvaConfig = getCvaConfig(data, packageName);
 
-    // Add hostDirective if CVA is needed
-    const cvaHostDirective = cvaConfig ? `  hostDirectives: [${cvaConfig.hostDirective}],\n` : '';
     const cvaImport = cvaConfig ? cvaConfig.import : '';
+
+    // Detect whether this component has an href input
+    const hasHref = (data.members ?? []).some((m) => m.kind === 'field' && m.privacy === 'public' && m.name === 'href');
+
+    const routerLinkBridgeImport = hasHref
+        ? `import { Ui5RouterLinkBridgeDirective } from '@fundamental-ngx/ui5-webcomponents-base/router-link';`
+        : '';
+
+    // Build hostDirectives array — may include CVA and/or RouterLinkBridge
+    const hostDirectiveEntries: string[] = [];
+    if (cvaConfig) {
+        hostDirectiveEntries.push(cvaConfig.hostDirective);
+    }
+    if (hasHref) {
+        hostDirectiveEntries.push('Ui5RouterLinkBridgeDirective');
+    }
+
+    const hostDirectivesDeclaration =
+        hostDirectiveEntries.length > 0 ? `  hostDirectives: [${hostDirectiveEntries.join(', ')}],\n` : '';
 
     // Build providers array - always includes content density, plus CVA if needed
     const contentDensityProvider = `    contentDensityObserverProviders({
@@ -466,18 +483,22 @@ ${outputEvents
         outputEvents.length > 0
             ? `
     // Synchronize outputs (events)
+    const _listeners: Array<() => void> = [];
     for (const outputName of outputsToSync) {
       // Map Angular output name to UI5 web component event name
       const eventName = outputName.replace('ui5', '').replace(/([A-Z])/g, '-$1').toLowerCase().substring(1);
       // Ensure the output property exists and has an emit function before adding listener
       if (this[outputName] && typeof this[outputName].emit === 'function' && wcElement.addEventListener) {
         // Cast the listener to the correct type to satisfy TypeScript
-        wcElement.addEventListener(eventName, (e) => {
+        const listener = (e: Event) => {
 ${readonlySignalUpdates}
           this[outputName].emit(e as CustomEvent<any>);
-        });
+        };
+        wcElement.addEventListener(eventName, listener);
+        _listeners.push(() => wcElement.removeEventListener(eventName, listener));
       }
     }
+    this._destroyRef.onDestroy(() => _listeners.forEach((fn) => fn()));
   `
             : '';
 
@@ -495,7 +516,7 @@ import {
   Injector,
   booleanAttribute,
   computed,
-  signal
+  signal${outputEvents.length > 0 ? ',\n  DestroyRef' : ''}
 } from '@angular/core';
 import '${packageName}/dist/${className}.js';
 import { default as _${className} } from '${packageName}/dist/${className}.js';
@@ -506,6 +527,7 @@ import {
   ContentDensityMode
 } from '@fundamental-ngx/core/content-density';
 ${cvaImport}
+${routerLinkBridgeImport}
 ${componentImports.join('\n')}
 
 @Component({
@@ -513,7 +535,7 @@ ${componentImports.join('\n')}
   selector: '${tagName}, [${tagName}]',
   template: '<ng-content></ng-content>',
   exportAs: 'ui5${className}',
-${cvaHostDirective}${providersArray}  changeDetection: ChangeDetectionStrategy.OnPush,
+${hostDirectivesDeclaration}${providersArray}  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ${className} implements AfterViewInit {
 ${generateInputs(data, componentEnums, className)} // className is now passed
@@ -531,7 +553,7 @@ ${generateSlotsDocumentation(data)}
    * @private
    */
   private readonly _contentDensityObserver = inject(ContentDensityObserver);
-${privateProperties}
+${outputEvents.length > 0 ? '  private readonly _destroyRef = inject(DestroyRef);\n' : ''}${privateProperties}
   get element(): _${className} {
     return this.elementRef.nativeElement;
   }


### PR DESCRIPTION
fixes #14337

**What**

`[routerLink]` on `ui5-link`, `ui5-breadcrumbs-item` and other UI5 href components was causing a full page reload instead of SPA navigation.

**Why**

UI5 replaces the native click with a `CustomEvent` that has no `button` property. Angular's `RouterLink` reads `event.button`, gets `undefined`, and bails - leaving the shadow `<a href>` to navigate natively.

**How**

Added `Ui5RouterLinkBridgeDirective` (new `router-link` secondary entry in `ui5-webcomponents-base`). It intercepts the click in capture phase and calls `router.navigateByUrl()` for plain left-clicks. Modifier/middle clicks are passed through to the browser normally.

The generator now wires the directive automatically via `hostDirectives` on any wrapper with an `href` input. Also fixed `NG0953` - native event listeners on generated wrappers are now cleaned up on destroy.

**Affected:** `ui5-link`, `ui5-breadcrumbs-item`, `ui5-navigation-menu-item`, `ui5-shell-bar-branding`, `ui5-side-navigation-item`, `ui5-side-navigation-sub-item`