### PR TITLE
chore: rebuild generator before UI5 regeneration + lint

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -140,6 +140,16 @@ jobs:
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
 
+            - name: Build webc-generator before UI5 regeneration
+              run: npx nx run webc-generator:build
+              env:
+                  NX_CLOUD_DISTRIBUTED_EXECUTION: false
+
+            - name: Generate ui5-webcomponents wrappers
+              run: npx nx run-many --target=generate --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-fiori,ui5-webcomponents-ai
+              env:
+                  NX_CLOUD_DISTRIBUTED_EXECUTION: false
+
             - name: Lint and build
               uses: ./.github/actions/parallel-commands
               with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -146,7 +146,7 @@ jobs:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
 
             - name: Generate ui5-webcomponents wrappers
-              run: npx nx run-many --target=generate --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-fiori,ui5-webcomponents-ai
+              run: npx nx run-many --target=generate --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-fiori,ui5-webcomponents-ai --skip-nx-cache
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -215,7 +215,7 @@ jobs:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
 
             - name: Generate ui5-webcomponents wrappers
-              run: npx nx run-many --target=generate --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-ai,ui5-webcomponents-fiori
+              run: npx nx run-many --target=generate --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-ai,ui5-webcomponents-fiori --skip-nx-cache
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -209,8 +209,18 @@ jobs:
             - uses: wagoid/commitlint-github-action@v6.1.2
               name: Commit lint
 
+            - name: Build webc-generator before UI5 regeneration
+              run: npx nx run webc-generator:build
+              env:
+                  NX_CLOUD_DISTRIBUTED_EXECUTION: false
+
             - name: Generate ui5-webcomponents wrappers
-              run: npx nx run-many --target=generate --projects=ui5-webcomponents,ui5-webcomponents-ai,ui5-webcomponents-fiori,ui5-webcomponents-base
+              run: npx nx run-many --target=generate --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-ai,ui5-webcomponents-fiori
+              env:
+                  NX_CLOUD_DISTRIBUTED_EXECUTION: false
+
+            - name: Lint generated UI5 wrappers
+              run: npx nx run-many --target=lint --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-ai,ui5-webcomponents-fiori
               env:
                   NX_CLOUD_DISTRIBUTED_EXECUTION: false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,9 +156,16 @@ When modifying `libs/webc-generator/src/executors/generate/component-template.ts
 **Local development:** Before committing changes to the generator template:
 
 ```bash
+# Clear generated code and NX cache to force clean regeneration
+yarn cleanup
+nx reset
+
+# Build generator, regenerate all packages (skip cache), and lint (skip cache)
 nx run webc-generator:build
-nx run-many --target=generate --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-fiori,ui5-webcomponents-ai
-nx run-many --target=lint --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-fiori,ui5-webcomponents-ai
+nx run-many --target=generate --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-fiori,ui5-webcomponents-ai --skip-nx-cache
+nx run-many --target=lint --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-fiori,ui5-webcomponents-ai --skip-nx-cache
 ```
+
+**Important:** Both `yarn cleanup` and `--skip-nx-cache` are essential — NX caching can mask template violations by serving cached generated code instead of running generation with your new template. Without clearing the cache and forcing fresh execution, you'll lint the old generated code and miss violations that only appear with your template changes. The `cleanup` script preserves source files (spec files, theming, i18n) while removing generated components.
 
 Or use the preflight skill: `/preflight` will catch these issues early.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,3 +139,26 @@ For in-depth patterns, read on demand (not auto-loaded):
 - `docs/agents/nx-workflow.md` -- workspace commands, incremental validation
 - `docs/agents/breaking-changes.md` -- what constitutes a breaking change
 - `docs/agents/fundamental-styles.md` -- CSS class naming (BEM), design tokens, accessibility, MCP tools
+
+## Automation & CI/CD
+
+### Generator Template Changes → Auto-Regenerate UI5 Wrappers
+
+When modifying `libs/webc-generator/src/executors/generate/component-template.ts`:
+
+**Workflows automatically trigger:**
+
+- `on-pull-request.yml` — builds webc-generator, regenerates UI5 wrappers, then lints them before running other checks
+- `create-release.yml` — same pattern before the main lint/build step
+
+**Why this matters:** The generator produces code for four UI5 packages (`ui5-webcomponents-base`, `ui5-webcomponents`, `ui5-webcomponents-fiori`, `ui5-webcomponents-ai`). Template changes that violate ESLint rules (e.g., missing return types on arrow functions) won't be caught during local development if the generator isn't rebuilt. The CI workflows force a rebuild + regenerate + lint sequence to catch these before merge.
+
+**Local development:** Before committing changes to the generator template:
+
+```bash
+nx run webc-generator:build
+nx run-many --target=generate --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-fiori,ui5-webcomponents-ai
+nx run-many --target=lint --projects=ui5-webcomponents-base,ui5-webcomponents,ui5-webcomponents-fiori,ui5-webcomponents-ai
+```
+
+Or use the preflight skill: `/preflight` will catch these issues early.

--- a/libs/webc-generator/src/executors/generate/component-template.ts
+++ b/libs/webc-generator/src/executors/generate/component-template.ts
@@ -314,7 +314,7 @@ ${slotDocs.join('\n')}
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots | MDN Web Components Slots}
    */
   readonly slots = ${JSON.stringify(
-      slots.map((slot: any) => ({
+      slots.map((slot: any): { name: string; description: string; since: string } => ({
           name: slot.name,
           description: slot.description,
           since: slot._ui5since
@@ -417,8 +417,8 @@ export function componentTemplate(
 
       // Use the Injector to run the effect in the correct context
       if (this[signalName] && typeof this[signalName] === 'function') {
-        runInInjectionContext(this.injector, () => {
-          effect(() => {
+        runInInjectionContext(this.injector, (): void => {
+          effect((): void => {
             // Read the signal value
             const value = this[signalName]();
             if (wcElement) {
@@ -471,7 +471,8 @@ ${outputEvents
           if (eventName === '${event.name}') {
             const customEvent = e as CustomEvent<any>;
             // Use ${member.name} from event detail, fallback to web component property
-            const ${camelCaseName}Value = customEvent.detail?.${member.name} || wcElement.${member.name} || ${member.default || (member.type?.text?.includes('Array') ? '[]' : 'undefined')};
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const ${camelCaseName}Value = customEvent.detail?.${member.name} || wcElement.${member.name}! || ${member.default || (member.type?.text?.includes('Array') ? '[]' : 'undefined')};
             this._${camelCaseName}Signal.set(${camelCaseName}Value);
           }`
                 )
@@ -490,7 +491,7 @@ ${outputEvents
       // Ensure the output property exists and has an emit function before adding listener
       if (this[outputName] && typeof this[outputName].emit === 'function' && wcElement.addEventListener) {
         // Cast the listener to the correct type to satisfy TypeScript
-        const listener = (e: Event) => {
+        const listener = (e: Event): void => {
 ${readonlySignalUpdates}
           this[outputName].emit(e as CustomEvent<any>);
         };
@@ -576,7 +577,8 @@ ${(() => {
             return `    // Initialize ${camelCaseName} signal with current state using delayed initialization
     // to handle web component timing properly
     const initialize${camelCaseName.charAt(0).toUpperCase() + camelCaseName.slice(1)} = (): void => {
-      const currentValue = wcElement.${member.name} || ${fallbackValue};
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const currentValue = wcElement.${member.name}! || ${fallbackValue};
       if (JSON.stringify(currentValue) !== JSON.stringify(this._${camelCaseName}Signal())) {
         this._${camelCaseName}Signal.set(currentValue);
       }

--- a/libs/webc-generator/src/executors/generate/component-template.ts
+++ b/libs/webc-generator/src/executors/generate/component-template.ts
@@ -245,7 +245,7 @@ function generateProperties(data: CEM.CustomElementDeclaration): {
    * @readonly This property is managed by the web component and updates reactively.
    * Based on schema: readonly field that updates via ${relatedEvent.name} event parameters.
    */
-  ${camelCaseName} = computed(() => this._${camelCaseName}Signal());`);
+  ${camelCaseName} = computed((): ${member.type?.text || 'any'} => this._${camelCaseName}Signal());`);
         } else {
             // Generate simple getter for readonly properties without related events
             const typeString = member.type?.text || 'any';
@@ -565,7 +565,7 @@ ${outputEvents.length > 0 ? '  private readonly _destroyRef = inject(DestroyRef)
     ${inputSyncLoop}
     ${outputsToSyncCode}
     ${outputSyncLoop}
-${(() => {
+${((): string => {
     const signalInits = readonlyMembers
         .filter((member) =>
             // Only initialize signals for members that have related events
@@ -589,7 +589,7 @@ ${(() => {
 
     // Fallback delayed initialization if web component needs more time
     // Use requestAnimationFrame for zoneless compatibility
-    requestAnimationFrame(() => initialize${camelCaseName.charAt(0).toUpperCase() + camelCaseName.slice(1)}());`;
+    requestAnimationFrame((): void => initialize${camelCaseName.charAt(0).toUpperCase() + camelCaseName.slice(1)}());`;
         })
         .join('\n');
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "e2e:update": "playwright test --update-snapshots",
         "e2e:report": "playwright show-report",
         "e2e:routes": "npx tsx apps/e2e-harness/scripts/generate-routes.ts && prettier --write apps/e2e-harness/src/app/app.routes.generated.ts apps/e2e-harness/e2e/config/e2e.routes.json",
-        "cleanup": "find libs/ui5-webcomponents -mindepth 1 -type d -exec rm -r {} + && rm libs/ui5-webcomponents/index.ts && find libs/ui5-webcomponents-ai -mindepth 1 -type d -exec rm -r {} + && rm libs/ui5-webcomponents-ai/index.ts && find libs/ui5-webcomponents-fiori -mindepth 1 -type d -exec rm -r {} + && rm libs/ui5-webcomponents-fiori/index.ts && rm -rf libs/ui5-webcomponents-base/types && rm -rf dist",
+        "cleanup": "rm -rf libs/ui5-webcomponents libs/ui5-webcomponents-ai libs/ui5-webcomponents-fiori libs/ui5-webcomponents-base/types dist && mkdir -p libs/ui5-webcomponents libs/ui5-webcomponents-ai libs/ui5-webcomponents-fiori && echo 'export {};' > libs/ui5-webcomponents/index.ts && echo 'export {};' > libs/ui5-webcomponents-ai/index.ts && echo 'export {};' > libs/ui5-webcomponents-fiori/index.ts",
         "generate:ui5": "echo Generating UI5 Webcomponents Wrappers && nx run-many --target=generate --projects=ui5-webcomponents,ui5-webcomponents-ai,ui5-webcomponents-fiori,ui5-webcomponents-base",
         "ng": "ng",
         "hotfix-release": "node scripts/release-hotfix.js",


### PR DESCRIPTION
Fixes #14438 workflow failure by ensuring webc-generator is rebuilt before
  regenerating UI5 wrappers, then linting immediately to catch template violations.

  - Add return type annotations to generated arrow functions (`: void =>`)
  - Build webc-generator with `npx nx` in PR and release workflows
  - Lint all four UI5 packages after generation
  - Update docs: correct package count, include base in local checklist