### PR TITLE
fix(core): move aria-label from role-less span to fd-icon in InputGroupComponent

### DIFF
--- a/libs/core/input-group/input-group.component.html
+++ b/libs/core/input-group/input-group.component.html
@@ -48,16 +48,11 @@
                 </button>
             </span>
         } @else {
-            <span
-                fd-input-group-addon
-                [id]="_addOnNonButtonId"
-                [placement]="placement"
-                [attr.aria-label]="glyphAriaLabel || glyph || addOnText"
-            >
+            <span fd-input-group-addon [id]="_addOnNonButtonId" [placement]="placement">
                 @if (!glyph) {
                     {{ addOnText }}
                 } @else {
-                    <fd-icon [glyph]="glyph" [font]="glyphFont"></fd-icon>
+                    <fd-icon [glyph]="glyph" [font]="glyphFont" [ariaLabel]="glyphAriaLabel || glyph"></fd-icon>
                 }
             </span>
         }

--- a/libs/core/input-group/input-group.component.spec.ts
+++ b/libs/core/input-group/input-group.component.spec.ts
@@ -44,6 +44,89 @@ describe('InputGroupComponent', () => {
         });
         component._buttonClicked({} as any);
     });
+
+    describe('Accessibility - Non-Button Icon Addon (aria-label placement)', () => {
+        it('should NOT place aria-label on role-less span when glyph is provided (non-button)', () => {
+            component.glyph = 'search';
+            component.glyphAriaLabel = 'Search Icon';
+            fixture.detectChanges();
+
+            const addonSpan = fixture.nativeElement.querySelector('[fd-input-group-addon]');
+            expect(addonSpan).toBeTruthy();
+            expect(addonSpan.getAttribute('aria-label')).toBeNull();
+        });
+
+        it('should place ariaLabel on fd-icon when glyph is provided (non-button)', () => {
+            component.glyph = 'search';
+            component.glyphAriaLabel = 'Search Icon';
+            fixture.detectChanges();
+
+            const icon = fixture.nativeElement.querySelector('fd-icon');
+            expect(icon).toBeTruthy();
+            expect(icon.getAttribute('aria-label')).toBe('Search Icon');
+            // When ariaLabel is set, role should be 'img' (from IconComponent)
+            expect(icon.getAttribute('role')).toBe('img');
+        });
+
+        it('should fallback to glyph name when glyphAriaLabel is not provided (non-button)', () => {
+            component.glyph = 'search';
+            component.glyphAriaLabel = null;
+            fixture.detectChanges();
+
+            const icon = fixture.nativeElement.querySelector('fd-icon');
+            expect(icon).toBeTruthy();
+            expect(icon.getAttribute('aria-label')).toBe('search');
+            expect(icon.getAttribute('role')).toBe('img');
+        });
+
+        it('should NOT have aria-label on icon when only text add-on is provided (non-button)', () => {
+            component.addOnText = 'USD';
+            component.button = false;
+            fixture.detectChanges();
+
+            const icon = fixture.nativeElement.querySelector('fd-icon');
+            expect(icon).toBeFalsy(); // Icon should not exist when only text is shown
+            const addonSpan = fixture.nativeElement.querySelector('[fd-input-group-addon]');
+            expect(addonSpan).toBeTruthy();
+            expect(addonSpan.getAttribute('aria-label')).toBeNull();
+            expect(addonSpan.textContent).toContain('USD');
+        });
+    });
+
+    describe('Accessibility - Button Addon (aria-label placement)', () => {
+        it('should place ariaLabel on fd-button when glyph is provided (button addon)', () => {
+            component.glyph = 'search';
+            component.glyphAriaLabel = 'Search Button';
+            component.button = true;
+            fixture.detectChanges();
+
+            const button = fixture.nativeElement.querySelector('button[fd-button]');
+            expect(button).toBeTruthy();
+            expect(button.getAttribute('aria-label')).toBe('Search Button');
+        });
+
+        it('should fallback to glyph name when glyphAriaLabel is not provided (button addon)', () => {
+            component.glyph = 'search';
+            component.glyphAriaLabel = null;
+            component.button = true;
+            fixture.detectChanges();
+
+            const button = fixture.nativeElement.querySelector('button[fd-button]');
+            expect(button).toBeTruthy();
+            expect(button.getAttribute('aria-label')).toBe('search');
+        });
+
+        it('should use addOnText as fallback for ariaLabel when no glyph (button addon)', () => {
+            component.glyph = null;
+            component.addOnText = 'USD';
+            component.button = true;
+            fixture.detectChanges();
+
+            const button = fixture.nativeElement.querySelector('button[fd-button]');
+            expect(button).toBeTruthy();
+            expect(button.getAttribute('aria-label')).toBe('USD');
+        });
+    });
 });
 
 describe('InputGroup component CVA', () => {


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/14451

## Description
The non-button icon add-on was placing aria-label on a plain <span> with no ARIA
role, violating the ARIA spec which requires aria-label to be on elements with
roles that support "Name from author". This produced invalid ARIA flagged by
WCAG 2.1 Level A audits.

Moved the accessible name to the <fd-icon> component via [ariaLabel] input,
which correctly sets role="img" and aria-label when needed. Text-only add-ons
require no aria-label since visible text provides the accessible name.

Added comprehensive test coverage for both non-button and button add-on branches
to ensure correct aria-label placement in all scenarios.