### PR TITLE
fix(platform): announce Reset button action to screen readers in fdp-table View Settings

### DIFF
--- a/libs/i18n/src/lib/models/fd-language-key-identifier.ts
+++ b/libs/i18n/src/lib/models/fd-language-key-identifier.ts
@@ -486,6 +486,7 @@ export type FdLanguageKeyIdentifier =
     | 'platformTable.navigationColumnTitle'
     | 'platformTable.noVisibleColumnsMessage'
     | 'platformTable.resetChangesButtonLabel'
+    | 'platformTable.resetConfirmationAnnouncement'
     | 'platformTable.rowNavigateButtonTitle'
     | 'platformTable.selectAllCheckboxLabel'
     | 'platformTable.selectAllCheckboxLongLabel'

--- a/libs/i18n/src/lib/models/fd-language.ts
+++ b/libs/i18n/src/lib/models/fd-language.ts
@@ -835,6 +835,8 @@ export interface FdLanguage {
         rowNavigateButtonTitle: FdLanguageKey;
         expandAllAnnouncementLabel: FdLanguageKey;
         collapseAllAnnouncementLabel: FdLanguageKey;
+        /** Reset button announcement message */
+        resetConfirmationAnnouncement: FdLanguageKey;
     };
     platformWizardGenerator: {
         summarySectionEditStep: FdLanguageKey;

--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -960,6 +960,8 @@ platformTable.P13SortDialogSortOrderSelectOptionAsc = Ascending
 platformTable.P13SortDialogSortOrderSelectOptionDesc = Descending
 #XBUT: Text for the reset changes button in Platform Table
 platformTable.resetChangesButtonLabel = Reset
+#XFLD: Reset button announcement message
+platformTable.resetConfirmationAnnouncement = Values Reset
 #XBUT: Label for the button indicating that a table row is navigable
 platformTable.rowNavigateButtonTitle = Navigate
 #XFLD: Label for the checkbox, which selects all rows in the table

--- a/libs/i18n/src/lib/translations/translations.ts
+++ b/libs/i18n/src/lib/translations/translations.ts
@@ -626,6 +626,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Ascending',
         P13SortDialogSortOrderSelectOptionDesc: 'Descending',
         resetChangesButtonLabel: 'Reset',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigate',
         selectAllCheckboxLabel: 'Select all',
         selectAllCheckboxLongLabel: 'Checkbox, unchecked, click to select all',

--- a/libs/i18n/src/lib/translations/translations_ar.ts
+++ b/libs/i18n/src/lib/translations/translations_ar.ts
@@ -627,6 +627,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'تصاعدي',
         P13SortDialogSortOrderSelectOptionDesc: 'تنازلي',
         resetChangesButtonLabel: 'إعادة التعيين',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'تنقل',
         selectAllCheckboxLabel: 'تحديد الكل',
         selectAllCheckboxLongLabel: 'خانة الاختيار، غير محددة، انقر لتحديد الكل',

--- a/libs/i18n/src/lib/translations/translations_bg.ts
+++ b/libs/i18n/src/lib/translations/translations_bg.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Възходящо',
         P13SortDialogSortOrderSelectOptionDesc: 'Низходящо',
         resetChangesButtonLabel: 'Изчистване',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Навигация',
         selectAllCheckboxLabel: 'Избиране на всички',
         selectAllCheckboxLongLabel: 'Поле за отметка: без отметка. Кликнете, за да изберете всичко',

--- a/libs/i18n/src/lib/translations/translations_cs.ts
+++ b/libs/i18n/src/lib/translations/translations_cs.ts
@@ -627,6 +627,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Vzestupně',
         P13SortDialogSortOrderSelectOptionDesc: 'Sestupně',
         resetChangesButtonLabel: 'Resetovat',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Přejít',
         selectAllCheckboxLabel: 'Vybrat vše',
         selectAllCheckboxLongLabel: 'Zaškrtávací pole, nezaškrtnuto, kliknutím vyberete vše',

--- a/libs/i18n/src/lib/translations/translations_da.ts
+++ b/libs/i18n/src/lib/translations/translations_da.ts
@@ -627,6 +627,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Stigende',
         P13SortDialogSortOrderSelectOptionDesc: 'Faldende',
         resetChangesButtonLabel: 'Nulstil',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Naviger',
         selectAllCheckboxLabel: 'Vælg alle',
         selectAllCheckboxLongLabel: 'Afkrydsningsfelt, ikke-markeret, klik for at markere alle',

--- a/libs/i18n/src/lib/translations/translations_de.ts
+++ b/libs/i18n/src/lib/translations/translations_de.ts
@@ -629,6 +629,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Aufsteigend',
         P13SortDialogSortOrderSelectOptionDesc: 'Absteigend',
         resetChangesButtonLabel: 'Zurücksetzen',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigieren',
         selectAllCheckboxLabel: 'Alle auswählen',
         selectAllCheckboxLongLabel: 'Ankreuzfeld, nicht markiert, zur Auswahl aller Zeilen klicken',

--- a/libs/i18n/src/lib/translations/translations_el.ts
+++ b/libs/i18n/src/lib/translations/translations_el.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Αύξουσα σειρά',
         P13SortDialogSortOrderSelectOptionDesc: 'Φθίνουσα σειρά',
         resetChangesButtonLabel: 'Επαναφορά',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Πλοήγηση',
         selectAllCheckboxLabel: 'Επιλογή όλων',
         selectAllCheckboxLongLabel: 'Πλαίσιο ελέγχου, αποεπιλέχθηκε, κάντε κλικ για επιλογή όλων',

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.ts
@@ -629,6 +629,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: '[[[Āşċēŋƌįŋğ∙∙∙∙∙]]]',
         P13SortDialogSortOrderSelectOptionDesc: '[[[Ďēşċēŋƌįŋğ∙∙∙∙]]]',
         resetChangesButtonLabel: '[[[Řēşēţ∙∙∙∙∙∙∙∙∙]]]',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: '[[[Ńąʋįğąţē∙∙∙∙∙∙]]]',
         selectAllCheckboxLabel: '[[[Ŝēĺēċţ ąĺĺ∙∙∙∙]]]',
         selectAllCheckboxLongLabel: '[[[Ĉĥēċķƃŏχ, űŋċĥēċķēƌ, ċĺįċķ ţŏ şēĺēċţ ąĺĺ∙∙∙∙∙∙∙∙∙∙∙∙∙∙]]]',

--- a/libs/i18n/src/lib/translations/translations_es.ts
+++ b/libs/i18n/src/lib/translations/translations_es.ts
@@ -629,6 +629,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Ascendente',
         P13SortDialogSortOrderSelectOptionDesc: 'Descendente',
         resetChangesButtonLabel: 'Restablecer',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navegar',
         selectAllCheckboxLabel: 'Seleccionar todos',
         selectAllCheckboxLongLabel: 'Casilla de verificación, sin seleccionar, hacer clic para seleccionar todo',

--- a/libs/i18n/src/lib/translations/translations_fi.ts
+++ b/libs/i18n/src/lib/translations/translations_fi.ts
@@ -627,6 +627,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Nouseva',
         P13SortDialogSortOrderSelectOptionDesc: 'Laskeva',
         resetChangesButtonLabel: 'Palauta',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigoi',
         selectAllCheckboxLabel: 'Valitse kaikki',
         selectAllCheckboxLongLabel: 'Valintaruutu, ei valittu, valitse kaikki napsauttamalla',

--- a/libs/i18n/src/lib/translations/translations_fr.ts
+++ b/libs/i18n/src/lib/translations/translations_fr.ts
@@ -630,6 +630,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Ordre croissant',
         P13SortDialogSortOrderSelectOptionDesc: 'Ordre décroissant',
         resetChangesButtonLabel: 'Réinitialiser',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Naviguer',
         selectAllCheckboxLabel: 'Sélectionner tout',
         selectAllCheckboxLongLabel: 'Case à cocher, décochée, cliquer pour tout sélectionner',

--- a/libs/i18n/src/lib/translations/translations_he.ts
+++ b/libs/i18n/src/lib/translations/translations_he.ts
@@ -625,6 +625,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'סדר עולה',
         P13SortDialogSortOrderSelectOptionDesc: 'סדר יורד',
         resetChangesButtonLabel: 'אפס',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'נווט',
         selectAllCheckboxLabel: 'בחר הכול',
         selectAllCheckboxLongLabel: 'תיבת סימון, לא סומנה, לחץ כדי לבחור הכול',

--- a/libs/i18n/src/lib/translations/translations_hi.ts
+++ b/libs/i18n/src/lib/translations/translations_hi.ts
@@ -627,6 +627,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'बढ़ते क्रम',
         P13SortDialogSortOrderSelectOptionDesc: 'घटते क्रम',
         resetChangesButtonLabel: 'रीसेट करें',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigate',
         selectAllCheckboxLabel: 'Select all',
         selectAllCheckboxLongLabel: 'Checkbox, unchecked, click to select all',

--- a/libs/i18n/src/lib/translations/translations_hr.ts
+++ b/libs/i18n/src/lib/translations/translations_hr.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Uzlazno',
         P13SortDialogSortOrderSelectOptionDesc: 'Silazno',
         resetChangesButtonLabel: 'Ponovo postavi',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigiraj',
         selectAllCheckboxLabel: 'Odaberi sve',
         selectAllCheckboxLongLabel: 'Potvrdni okvir, neoznačen, klikni za odabir svega',

--- a/libs/i18n/src/lib/translations/translations_hu.ts
+++ b/libs/i18n/src/lib/translations/translations_hu.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Növekvő',
         P13SortDialogSortOrderSelectOptionDesc: 'Csökkenő',
         resetChangesButtonLabel: 'Alaphelyzetbe állítás',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigálás',
         selectAllCheckboxLabel: 'Összes kiválasztása',
         selectAllCheckboxLongLabel: 'Jelölőnégyzet, nincs bejelölve, kattintson az összes kijelöléséhez',

--- a/libs/i18n/src/lib/translations/translations_it.ts
+++ b/libs/i18n/src/lib/translations/translations_it.ts
@@ -629,6 +629,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Crescente',
         P13SortDialogSortOrderSelectOptionDesc: 'Decrescente',
         resetChangesButtonLabel: 'Reimposta',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Esplora',
         selectAllCheckboxLabel: 'Seleziona tutto',
         selectAllCheckboxLongLabel: 'Casella di controllo, deselezionata, fare clic per selezionare tutto',

--- a/libs/i18n/src/lib/translations/translations_iw.ts
+++ b/libs/i18n/src/lib/translations/translations_iw.ts
@@ -625,6 +625,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'סדר עולה',
         P13SortDialogSortOrderSelectOptionDesc: 'סדר יורד',
         resetChangesButtonLabel: 'אפס',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'נווט',
         selectAllCheckboxLabel: 'בחר הכול',
         selectAllCheckboxLongLabel: 'תיבת סימון, לא סומנה, לחץ כדי לבחור הכול',

--- a/libs/i18n/src/lib/translations/translations_ja.ts
+++ b/libs/i18n/src/lib/translations/translations_ja.ts
@@ -627,6 +627,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: '昇順',
         P13SortDialogSortOrderSelectOptionDesc: '降順',
         resetChangesButtonLabel: 'リセット',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: '移動',
         selectAllCheckboxLabel: 'すべて選択',
         selectAllCheckboxLongLabel: 'チェックボックス: チェックが外れています。クリックするとすべて選択します。',

--- a/libs/i18n/src/lib/translations/translations_ka.ts
+++ b/libs/i18n/src/lib/translations/translations_ka.ts
@@ -627,6 +627,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'ზრდადი',
         P13SortDialogSortOrderSelectOptionDesc: 'კლებადი',
         resetChangesButtonLabel: 'გააუქმეთ ცვლილებები',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigate',
         selectAllCheckboxLabel: 'Select all',
         selectAllCheckboxLongLabel: 'Checkbox, unchecked, click to select all',

--- a/libs/i18n/src/lib/translations/translations_kk.ts
+++ b/libs/i18n/src/lib/translations/translations_kk.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Артуы бойынша',
         P13SortDialogSortOrderSelectOptionDesc: 'Кемуі бойынша',
         resetChangesButtonLabel: 'Қалпына келтіру',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Өту',
         selectAllCheckboxLabel: 'Барлығын таңдау',
         selectAllCheckboxLongLabel: 'Құсбелгі ұяшығы, құсбелгі қойылмаған, барлығын таңдау үшін басыңыз',

--- a/libs/i18n/src/lib/translations/translations_ko.ts
+++ b/libs/i18n/src/lib/translations/translations_ko.ts
@@ -625,6 +625,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: '오름차순',
         P13SortDialogSortOrderSelectOptionDesc: '내림차순',
         resetChangesButtonLabel: '재설정',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: '탐색',
         selectAllCheckboxLabel: '모두 선택',
         selectAllCheckboxLongLabel: '확인란, 선택 취소됨, 클릭하여 모두 선택',

--- a/libs/i18n/src/lib/translations/translations_ms.ts
+++ b/libs/i18n/src/lib/translations/translations_ms.ts
@@ -626,6 +626,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Menaik',
         P13SortDialogSortOrderSelectOptionDesc: 'Menurun',
         resetChangesButtonLabel: 'Tetapkan semula',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigasi',
         selectAllCheckboxLabel: 'Pilih semua',
         selectAllCheckboxLongLabel: 'Kotak semak, dinyahtanda, klik untuk memilih semua',

--- a/libs/i18n/src/lib/translations/translations_nl.ts
+++ b/libs/i18n/src/lib/translations/translations_nl.ts
@@ -629,6 +629,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Oplopend',
         P13SortDialogSortOrderSelectOptionDesc: 'Aflopend',
         resetChangesButtonLabel: 'Opnieuw instellen',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigeren',
         selectAllCheckboxLabel: 'Alles selecteren',
         selectAllCheckboxLongLabel: 'Selectievakje, uitgeschakeld, klik om alles te selecteren',

--- a/libs/i18n/src/lib/translations/translations_no.ts
+++ b/libs/i18n/src/lib/translations/translations_no.ts
@@ -629,6 +629,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Stigende',
         P13SortDialogSortOrderSelectOptionDesc: 'Synkende',
         resetChangesButtonLabel: 'Tilbakestill',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Naviger',
         selectAllCheckboxLabel: 'Merk alle',
         selectAllCheckboxLongLabel: 'Avmerkingsboks, ikke merket av, klikk for å velge alle',

--- a/libs/i18n/src/lib/translations/translations_pl.ts
+++ b/libs/i18n/src/lib/translations/translations_pl.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Rosnąco',
         P13SortDialogSortOrderSelectOptionDesc: 'Malejąco',
         resetChangesButtonLabel: 'Resetuj',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Nawigacja',
         selectAllCheckboxLabel: 'Zaznacz wszystko',
         selectAllCheckboxLongLabel: 'Pole wyboru, niezaznaczone, kliknij, aby zaznaczyć wszystko',

--- a/libs/i18n/src/lib/translations/translations_pt.ts
+++ b/libs/i18n/src/lib/translations/translations_pt.ts
@@ -629,6 +629,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Crescente',
         P13SortDialogSortOrderSelectOptionDesc: 'Decrescente',
         resetChangesButtonLabel: 'Redefinir',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navegar',
         selectAllCheckboxLabel: 'Selecionar tudo',
         selectAllCheckboxLongLabel: 'Caixa de seleção, desmarcado, clicar para selecionar tudo',

--- a/libs/i18n/src/lib/translations/translations_ro.ts
+++ b/libs/i18n/src/lib/translations/translations_ro.ts
@@ -631,6 +631,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Ordine crescătoare',
         P13SortDialogSortOrderSelectOptionDesc: 'Ordine descrescătoare',
         resetChangesButtonLabel: 'Resetare',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigare',
         selectAllCheckboxLabel: 'Selectare toate',
         selectAllCheckboxLongLabel: 'Casetă de selectare, debifată, efectuați click pentru a selecta tot',

--- a/libs/i18n/src/lib/translations/translations_ru.ts
+++ b/libs/i18n/src/lib/translations/translations_ru.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'По восходящей',
         P13SortDialogSortOrderSelectOptionDesc: 'По нисходящей',
         resetChangesButtonLabel: 'Сбросить',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Перейти',
         selectAllCheckboxLabel: 'Выбрать все',
         selectAllCheckboxLongLabel: 'Флажок, не выбрано, щелкнуть, чтобы выбрать все',

--- a/libs/i18n/src/lib/translations/translations_sh.ts
+++ b/libs/i18n/src/lib/translations/translations_sh.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Po rastućem redosledu',
         P13SortDialogSortOrderSelectOptionDesc: 'Po opadajućem redosledu',
         resetChangesButtonLabel: 'Ponovo postavi',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Usmeri',
         selectAllCheckboxLabel: 'Odaberi sve',
         selectAllCheckboxLongLabel: 'Kvadratić za potvrdu, nije označeno, kliknite da biste odabrali sve',

--- a/libs/i18n/src/lib/translations/translations_sk.ts
+++ b/libs/i18n/src/lib/translations/translations_sk.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Vzostupne',
         P13SortDialogSortOrderSelectOptionDesc: 'Zostupne',
         resetChangesButtonLabel: 'Resetovať',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigovať',
         selectAllCheckboxLabel: 'Vybrať všetko',
         selectAllCheckboxLongLabel: 'Začiarkavacie políčko, nezačiarknuté, kliknutím vyberte všetko',

--- a/libs/i18n/src/lib/translations/translations_sl.ts
+++ b/libs/i18n/src/lib/translations/translations_sl.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Naraščajoče',
         P13SortDialogSortOrderSelectOptionDesc: 'Padajoče',
         resetChangesButtonLabel: 'Ponastavi',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigacija',
         selectAllCheckboxLabel: 'Izberi vse',
         selectAllCheckboxLongLabel: 'Potrditveno polje, neoznačeno, kliknite za izbiro vseh',

--- a/libs/i18n/src/lib/translations/translations_sq.ts
+++ b/libs/i18n/src/lib/translations/translations_sq.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Në ngritje',
         P13SortDialogSortOrderSelectOptionDesc: 'Në zbritje',
         resetChangesButtonLabel: 'Rivendos',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigate',
         selectAllCheckboxLabel: 'Select all',
         selectAllCheckboxLongLabel: 'Checkbox, unchecked, click to select all',

--- a/libs/i18n/src/lib/translations/translations_sr.ts
+++ b/libs/i18n/src/lib/translations/translations_sr.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Po rastućem redosledu',
         P13SortDialogSortOrderSelectOptionDesc: 'Po opadajućem redosledu',
         resetChangesButtonLabel: 'Ponovo postavi',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Usmeri',
         selectAllCheckboxLabel: 'Odaberi sve',
         selectAllCheckboxLongLabel: 'Kvadratić za potvrdu, nije označeno, kliknite da biste odabrali sve',

--- a/libs/i18n/src/lib/translations/translations_sv.ts
+++ b/libs/i18n/src/lib/translations/translations_sv.ts
@@ -627,6 +627,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Stigande',
         P13SortDialogSortOrderSelectOptionDesc: 'Fallande',
         resetChangesButtonLabel: 'Återställ',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Navigera',
         selectAllCheckboxLabel: 'Välj alla',
         selectAllCheckboxLongLabel: 'Kryssruta ej, markerad, klicka för att markera alla',

--- a/libs/i18n/src/lib/translations/translations_th.ts
+++ b/libs/i18n/src/lib/translations/translations_th.ts
@@ -627,6 +627,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'จากน้อยไปหามาก',
         P13SortDialogSortOrderSelectOptionDesc: 'จากมากไปหาน้อย',
         resetChangesButtonLabel: 'รีเซ็ต',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'เนวิเกต',
         selectAllCheckboxLabel: 'เลือกทั้งหมด',
         selectAllCheckboxLongLabel: 'เช็คบ็อกซ์, ยกเลิกการเลือกแล้ว, คลิกเพื่อเลือกทั้งหมด',

--- a/libs/i18n/src/lib/translations/translations_tr.ts
+++ b/libs/i18n/src/lib/translations/translations_tr.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'Artan',
         P13SortDialogSortOrderSelectOptionDesc: 'Azalan',
         resetChangesButtonLabel: 'Sıfırla',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Git',
         selectAllCheckboxLabel: 'Tümünü seç',
         selectAllCheckboxLongLabel: 'Onay kutusu, seçim kaldırıldı, tümünü seçmek için tıklayın',

--- a/libs/i18n/src/lib/translations/translations_uk.ts
+++ b/libs/i18n/src/lib/translations/translations_uk.ts
@@ -628,6 +628,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: 'За зростанням',
         P13SortDialogSortOrderSelectOptionDesc: 'За спаданням',
         resetChangesButtonLabel: 'Скинути',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: 'Перейти',
         selectAllCheckboxLabel: 'Вибрати все',
         selectAllCheckboxLongLabel: 'Поле для прапорця, прапорець знято, натисніть, щоб вибрати все',

--- a/libs/i18n/src/lib/translations/translations_zh_CN.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_CN.ts
@@ -623,6 +623,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: '升序',
         P13SortDialogSortOrderSelectOptionDesc: '降序',
         resetChangesButtonLabel: '重置',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: '导航',
         selectAllCheckboxLabel: '全选',
         selectAllCheckboxLongLabel: '复选框，未选中，单击以全部选中',

--- a/libs/i18n/src/lib/translations/translations_zh_TW.ts
+++ b/libs/i18n/src/lib/translations/translations_zh_TW.ts
@@ -624,6 +624,7 @@ export default {
         P13SortDialogSortOrderSelectOptionAsc: '升冪',
         P13SortDialogSortOrderSelectOptionDesc: '降冪',
         resetChangesButtonLabel: '重設',
+        resetConfirmationAnnouncement: 'Values Reset',
         rowNavigateButtonTitle: '瀏覽',
         selectAllCheckboxLabel: '全選',
         selectAllCheckboxLongLabel: '核取方塊、未勾選、按一下以全選',

--- a/libs/platform/table/components/table-view-settings-dialog/settings-dialog/settings-dialog.component.ts
+++ b/libs/platform/table/components/table-view-settings-dialog/settings-dialog/settings-dialog.component.ts
@@ -1,6 +1,7 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { CdkScrollable } from '@angular/cdk/overlay';
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, forwardRef, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, inject, input, signal } from '@angular/core';
 import { InitialFocusDirective, Nullable, TemplateDirective } from '@fundamental-ngx/cdk/utils';
 import {
     BarElementDirective,
@@ -16,7 +17,7 @@ import {
     DialogRef
 } from '@fundamental-ngx/core/dialog';
 import { TitleComponent } from '@fundamental-ngx/core/title';
-import { FdTranslatePipe } from '@fundamental-ngx/i18n';
+import { FD_LANGUAGE_SIGNAL, FdTranslatePipe, TranslationResolver } from '@fundamental-ngx/i18n';
 import { IconTabBarComponent, IconTabBarItem, IconTabBarTabComponent } from '@fundamental-ngx/platform/icon-tab-bar';
 import { CollectionFilter, CollectionSort, Table } from '@fundamental-ngx/platform/table-helpers';
 import { RESETTABLE_TOKEN, ResetButtonComponent, Resettable } from '../../reset-button/reset-button.component';
@@ -100,6 +101,9 @@ export class SettingsDialogComponent implements Resettable {
     /** Signal to track if the dialog is valid (OK button can be clicked) */
     readonly isDialogValid = signal(true);
 
+    /** Input for custom reset announcement message. If not provided, uses the translated default from i18n */
+    readonly resetAnnouncementMessage = input<string | null>(null);
+
     /** @hidden Initial sorting configuration */
     _initialSorting = signal<Nullable<CollectionSort>>(null);
 
@@ -123,6 +127,15 @@ export class SettingsDialogComponent implements Resettable {
 
     /** @hidden Tracks reset availability per tab */
     private _resetAvailabilityByTab = signal<Record<string, boolean>>({});
+
+    /** @hidden Live announcer for screen reader announcements */
+    private _liveAnnouncer = inject(LiveAnnouncer);
+
+    /** @hidden Language signal for getting current language */
+    private _langSignal = inject(FD_LANGUAGE_SIGNAL);
+
+    /** @hidden Translation resolver for getting translations synchronously */
+    private _translationResolver = inject(TranslationResolver);
 
     /**
      * Constructor that initializes dialog data and sets initial values for sorting, filtering, grouping, and columns.
@@ -225,6 +238,9 @@ export class SettingsDialogComponent implements Resettable {
             this._pendingColumnsChanges = initialColumns;
         }
         this.updateResetAvailability(this.activeTab()!, false);
+
+        // Announce reset to screen readers
+        this._announceReset();
     }
 
     /**
@@ -424,5 +440,25 @@ export class SettingsDialogComponent implements Resettable {
             columnOrder,
             columns: initialColumnsArray
         });
+    }
+
+    /**
+     * Announce the reset action to screen readers.
+     * @hidden
+     */
+    private _announceReset(): void {
+        // Get the announcement message: use custom input if provided, otherwise use translation
+        let message = this.resetAnnouncementMessage();
+        if (!message) {
+            // Resolve the translation key synchronously
+            message = this._translationResolver.resolve(
+                this._langSignal(),
+                'platformTable.resetConfirmationAnnouncement'
+            );
+        }
+
+        // Announce the message to screen readers using LiveAnnouncer
+        // 'polite' priority ensures it doesn't interrupt other announcements
+        this._liveAnnouncer.announce(message, 'polite');
     }
 }


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/14450

## Description

When the Reset button is clicked in View Settings dialogs (Filter, Sort, Settings/Columns),
the component now announces the reset action to assistive technologies via LiveAnnouncer.
This provides screen reader users with confirmation that the reset has been applied,
addressing WCAG 2.1 Level AA status change requirements.

- Add resetAnnouncementMessage input() for customizable announcement text
- Use translated string from platformTable.resetConfirmationAnnouncement by default
- Implement LiveAnnouncer with 'polite' priority to avoid interrupting announcements
- Fixes missing screen reader feedback reported for VoiceOver users