### PR TITLE
chore: add missing UI5 comment annotations for product switch targets

### DIFF
--- a/libs/i18n/src/lib/translations/translations.properties
+++ b/libs/i18n/src/lib/translations/translations.properties
@@ -284,8 +284,11 @@ corePagination.previousLabel = Previous
 corePagination.totalResultsLabel = {totalCount} Results
 #XFLD: Label for the product switch component
 coreProductSwitch.ariaLabel = App Launcher
+#XACT: Accessible description for a product switch item that opens in a new browser tab
 coreProductSwitch.targetBlank = opens in a new browser tab
+#XACT: Accessible description for a product switch item that opens in the parent frame
 coreProductSwitch.targetParent = opens in the parent frame
+#XACT: Accessible description for a product switch item that opens in the full browser window
 coreProductSwitch.targetTop = opens in the full browser window
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription = This radio button is read-only and cannot be changed.

--- a/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
+++ b/libs/i18n/src/lib/translations/translations_en_US_sappsd.properties
@@ -284,8 +284,11 @@ corePagination.previousLabel=[[[Ƥŗēʋįŏűş∙∙∙∙∙∙]]]
 corePagination.totalResultsLabel=[[[{totalCount} Řēşűĺţş]]]
 #XFLD: Label for the product switch component
 coreProductSwitch.ariaLabel=[[[Āρρ Ļąűŋċĥēŗ∙∙∙∙∙∙∙]]]
+#XACT: Accessible description for a product switch item that opens in a new browser tab
 coreProductSwitch.targetBlank=[[[ŏρēŋş įŋ ą ŋēŵ ƃŗŏŵşēŗ ţąƃ∙∙∙∙∙∙∙]]]
+#XACT: Accessible description for a product switch item that opens in the parent frame
 coreProductSwitch.targetParent=[[[ŏρēŋş įŋ ţĥē ρąŗēŋţ ƒŗąɱē∙∙∙∙∙∙∙]]]
+#XACT: Accessible description for a product switch item that opens in the full browser window
 coreProductSwitch.targetTop=[[[ŏρēŋş įŋ ţĥē ƒűĺĺ ƃŗŏŵşēŗ ŵįŋƌŏŵ∙∙∙∙∙∙∙∙∙∙]]]
 #XACT: Aria description for readonly radio buttons
 coreRadio.readOnlyDescription=[[[Ţĥįş ŗąƌįŏ ƃűţţŏŋ įş ŗēąƌ-ŏŋĺŷ ąŋƌ ċąŋŋŏţ ƃē ċĥąŋğēƌ.∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙]]]


### PR DESCRIPTION

## Related Issue(s)

closes none

## Description
Add the required SAP UI5 comment metadata for the product switch target
translation keys in the properties files so i18n validation passes.