### PR TITLE
fix(btp): restore focus to parent nav item after snapped popover closes

### DIFF
--- a/libs/btp/navigation/components/navigation-item/navigation-list-item.component.spec.ts
+++ b/libs/btp/navigation/components/navigation-item/navigation-list-item.component.spec.ts
@@ -92,7 +92,7 @@ describe('NavigationListItemComponent', () => {
         // Mock the link$ signal to return a truthy value
         component.link$.set({ elementRef: { nativeElement: document.createElement('a') } } as any);
 
-        const restoreFocusSpy = jest.spyOn(component as any, '_restoreFocusAfterPopoverClose');
+        const restoreFocusSpy = jest.spyOn(component as any, 'restoreFocusAfterPopoverClose');
 
         navComponent.isSnapped$.set(true);
         component.popoverOpen$.set(true);
@@ -105,7 +105,7 @@ describe('NavigationListItemComponent', () => {
     }));
 
     it('should not restore focus when popover closes in non-snapped mode', fakeAsync(() => {
-        const restoreFocusSpy = jest.spyOn(component as any, '_restoreFocusAfterPopoverClose');
+        const restoreFocusSpy = jest.spyOn(component as any, 'restoreFocusAfterPopoverClose');
 
         navComponent.isSnapped$.set(false);
         component.popoverOpen$.set(true);
@@ -118,7 +118,7 @@ describe('NavigationListItemComponent', () => {
     }));
 
     it('should not restore focus when popover opens', fakeAsync(() => {
-        const restoreFocusSpy = jest.spyOn(component as any, '_restoreFocusAfterPopoverClose');
+        const restoreFocusSpy = jest.spyOn(component as any, 'restoreFocusAfterPopoverClose');
 
         navComponent.isSnapped$.set(true);
         component.popoverOpen$.set(false);

--- a/libs/btp/navigation/components/navigation-item/navigation-list-item.component.spec.ts
+++ b/libs/btp/navigation/components/navigation-item/navigation-list-item.component.spec.ts
@@ -1,5 +1,5 @@
 import { signal } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 import { FdbNavigationListItem } from '../../models/navigation-list-item.class';
 import { FdbNavigation } from '../../models/navigation.class';
@@ -87,4 +87,46 @@ describe('NavigationListItemComponent', () => {
         component.expanded = true;
         expect(component.expanded).toBe(true);
     });
+
+    it('should restore focus to parent link when popover closes in snapped mode', fakeAsync(() => {
+        // Mock the link$ signal to return a truthy value
+        component.link$.set({ elementRef: { nativeElement: document.createElement('a') } } as any);
+
+        const restoreFocusSpy = jest.spyOn(component as any, '_restoreFocusAfterPopoverClose');
+
+        navComponent.isSnapped$.set(true);
+        component.popoverOpen$.set(true);
+        fixture.detectChanges();
+
+        component.popoverOpen$.set(false);
+        fixture.detectChanges();
+
+        expect(restoreFocusSpy).toHaveBeenCalled();
+    }));
+
+    it('should not restore focus when popover closes in non-snapped mode', fakeAsync(() => {
+        const restoreFocusSpy = jest.spyOn(component as any, '_restoreFocusAfterPopoverClose');
+
+        navComponent.isSnapped$.set(false);
+        component.popoverOpen$.set(true);
+        fixture.detectChanges();
+
+        component.popoverOpen$.set(false);
+        fixture.detectChanges();
+
+        expect(restoreFocusSpy).not.toHaveBeenCalled();
+    }));
+
+    it('should not restore focus when popover opens', fakeAsync(() => {
+        const restoreFocusSpy = jest.spyOn(component as any, '_restoreFocusAfterPopoverClose');
+
+        navComponent.isSnapped$.set(true);
+        component.popoverOpen$.set(false);
+        fixture.detectChanges();
+
+        component.popoverOpen$.set(true);
+        fixture.detectChanges();
+
+        expect(restoreFocusSpy).not.toHaveBeenCalled();
+    }));
 });

--- a/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
+++ b/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
@@ -546,10 +546,8 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
         // _onPopoverOpen(), which is only called for service-internal closes.
         effect(() => {
             const isOpen = this.popoverOpen$();
-            if (!isOpen && this._popoverWasOpen && this.navigation.isSnapped$()) {
-                setTimeout(() => {
-                    this.focusLink();
-                }, 0);
+            if (!isOpen && this._popoverWasOpen && this.navigation.isSnapped$() && this.link$()) {
+                this._restoreFocusAfterPopoverClose();
             }
             this._popoverWasOpen = isOpen;
         });
@@ -901,6 +899,20 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
                 this.overflowSubmenuMaxHeight.set(`${availableHeight}px`);
             }
         });
+    }
+
+    /**
+     * Restores focus to the parent link after popover closes in snapped mode.
+     * Defers focus until after overlay DOM teardown.
+     * @hidden
+     */
+    protected _restoreFocusAfterPopoverClose(): void {
+        afterNextRender(
+            () => {
+                this.focusLink();
+            },
+            { injector: this._injector }
+        );
     }
 
     private _focusPopoverLink(): void {

--- a/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
+++ b/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
@@ -547,7 +547,7 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
         effect(() => {
             const isOpen = this.popoverOpen$();
             if (!isOpen && this._popoverWasOpen && this.navigation.isSnapped$() && this.link$()) {
-                this._restoreFocusAfterPopoverClose();
+                this.restoreFocusAfterPopoverClose();
             }
             this._popoverWasOpen = isOpen;
         });
@@ -906,7 +906,7 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
      * Defers focus until after overlay DOM teardown.
      * @hidden
      */
-    protected _restoreFocusAfterPopoverClose(): void {
+    protected restoreFocusAfterPopoverClose(): void {
         afterNextRender(
             () => {
                 this.focusLink();

--- a/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
+++ b/libs/btp/navigation/components/navigation-item/navigation-list-item.component.ts
@@ -522,6 +522,9 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
     /** @hidden */
     private readonly _overflowSubmenuContainer = viewChild<ElementRef>('overflowSubmenuContainer');
 
+    /** @hidden Tracks the previous popover open state to detect true→false transitions. */
+    private _popoverWasOpen = false;
+
     /** @hidden */
     constructor() {
         super();
@@ -534,6 +537,21 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
             } else {
                 this._keyManager?.destroy();
             }
+        });
+
+        // Restore focus to the parent link whenever the popover transitions from open
+        // to closed in snapped mode. This covers ALL close paths (closeAllPopups,
+        // service-driven close via Escape/click-outside, keyboard handlers) because it
+        // reacts directly to the popoverOpen$ signal rather than relying on
+        // _onPopoverOpen(), which is only called for service-internal closes.
+        effect(() => {
+            const isOpen = this.popoverOpen$();
+            if (!isOpen && this._popoverWasOpen && this.navigation.isSnapped$()) {
+                setTimeout(() => {
+                    this.focusLink();
+                }, 0);
+            }
+            this._popoverWasOpen = isOpen;
         });
 
         // We need to track child directives change and set list items based on that.
@@ -822,16 +840,6 @@ export class NavigationListItemComponent extends FdbNavigationListItem implement
                 },
                 { injector: this._injector }
             );
-        } else {
-            // When popover closes, return focus to the parent link (for snapped state)
-            if (this.navigation.isSnapped$()) {
-                afterNextRender(
-                    () => {
-                        this.focusLink();
-                    },
-                    { injector: this._injector }
-                );
-            }
         }
     }
 


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14456

## Description
When a child item is selected from a snapped-mode popover, the parent navigation item was losing focus after the popover closed.

**Root cause:** the popover was migrated to a model() signal in [#13886](https://github.com/SAP/fundamental-ngx/pull/13886).
Angular's model() output only fires when the value is set programmatically from inside the component (service-driven closes like Escape/click-outside).

When the parent closes the popover via `closeAllPopups → popoverOpen$.set(false)→ [isOpen]` input binding, the model output does NOT re-emit, so `_onPopoverOpen()` was never called for the child-item-click path.

The previous `_onZoneStable()` approach in `_onPopoverOpen()` happened to work before this because the old @Output() EventEmitter fired for all close paths.

**Fix:** add an effect() that watches `popoverOpen$` directly for true→false transitions in snapped mode. This covers all close paths regardless of how the popover was closed, and uses setTimeout(0) to allow the overlay DOM to tear down before programmatically focusing the parent link.