### PR TITLE
feat(platform): add closeOnOutsideClick option to hint configuration

### DIFF
--- a/libs/docs/platform/settings-generator/examples/dialog/settings-generator-dialog-example.component.ts
+++ b/libs/docs/platform/settings-generator/examples/dialog/settings-generator-dialog-example.component.ts
@@ -209,6 +209,13 @@ export class SettingsGeneratorDialogExampleComponent implements AfterViewInit {
                                         fieldColumnLayout: {
                                             S: 11,
                                             M: 6
+                                        },
+                                        hint: {
+                                            content: 'Enter a valid email address',
+                                            glyph: 'hint',
+                                            placement: 'right',
+                                            trigger: [{ trigger: 'click', openAction: true, closeAction: false }],
+                                            closeOnOutsideClick: true
                                         }
                                     }
                                 },

--- a/libs/platform/form/form-group/form-field/form-field.component.html
+++ b/libs/platform/form/form-group/form-field/form-field.component.html
@@ -137,6 +137,7 @@
                     [glyph]="hintOptions.glyph"
                     [placement]="hintOptions.placement ?? null"
                     [triggers]="hintOptions.trigger ?? []"
+                    [closeOnOutsideClick]="hintOptions.closeOnOutsideClick ?? false"
                     tabindex="0"
                 >
                 </fd-icon>

--- a/libs/platform/form/form-group/form-group-header/form-group-header.component.html
+++ b/libs/platform/form/form-group/form-group-header/form-group-header.component.html
@@ -16,6 +16,7 @@
                 [glyph]="options.glyph"
                 [placement]="options.placement ?? null"
                 [triggers]="options.trigger ?? []"
+                [closeOnOutsideClick]="options.closeOnOutsideClick ?? false"
                 tabindex="0"
             ></fd-icon>
         </span>

--- a/libs/platform/form/form-group/form-group.component.html
+++ b/libs/platform/form/form-group/form-group.component.html
@@ -66,6 +66,7 @@
                 [glyph]="_hintOptions!.glyph"
                 [placement]="_hintOptions!.placement ?? null"
                 [triggers]="_hintOptions!.trigger ?? []"
+                [closeOnOutsideClick]="_hintOptions!.closeOnOutsideClick ?? false"
                 tabindex="0"
             ></fd-icon>
         </span>

--- a/libs/platform/shared/form/hint-options.ts
+++ b/libs/platform/shared/form/hint-options.ts
@@ -20,6 +20,8 @@ export interface HintOptions {
     placement?: HintPlacement;
     /** Icon name of the inline help element */
     glyph?: string;
+    /** Whether the hint popover should close when clicking outside its boundaries */
+    closeOnOutsideClick?: boolean;
 }
 
 export interface FieldHintOptions extends HintOptions {


### PR DESCRIPTION
## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/12556

## Description

Extend HintOptions interface to support closing hint popovers when clicking outside their boundaries. This allows form developers to configure hint popovers to automatically close on outside clicks via guiOptions.

- Add closeOnOutsideClick property to HintOptions interface
- Wire property through form component templates
- Add example in Settings Generator dialog demonstrating the feature

## Screenshots
Settings Generator in Platform, Dialog example
<img width="1630" height="1225" alt="Screenshot 2026-08-11 at 3 27 49 PM" src="https://github.com/user-attachments/assets/08458116-ec5a-4127-9d78-77b581e525ad" />
