### PR TITLE
fix(core, platform): resolve zoneless change detection issues in Flexible Column Layout, Textarea (Platform) and Multi Input (Platform)

### DIFF
--- a/libs/core/flexible-column-layout/flexible-column-layout.component.html
+++ b/libs/core/flexible-column-layout/flexible-column-layout.component.html
@@ -6,15 +6,15 @@
     <!-- Start/Left/First Column -->
     <div
         class="fd-flexible-column-layout__column"
-        [style.width.%]="_columnLayout.start"
-        [style.visibility]="_columnLayout.start === 0 ? 'hidden' : 'visible'"
-        [style.height]="_columnLayout.start === 0 ? '0' : 'auto'"
-        [attr.aria-hidden]="_columnLayout.start === 0"
+        [style.width.%]="_columnLayout().start"
+        [style.visibility]="_columnLayout().start === 0 ? 'hidden' : 'visible'"
+        [style.height]="_columnLayout().start === 0 ? '0' : 'auto'"
+        [attr.aria-hidden]="_columnLayout().start === 0"
     >
         <ng-template [ngTemplateOutlet]="startColumn"></ng-template>
     </div>
     <!-- Left Separator -->
-    @if (_leftColumnSeparator) {
+    @if (_leftColumnSeparator()) {
         <div
             class="fd-flexible-column-layout__separator"
             [attr.aria-label]="separatorAriaLabel"
@@ -26,18 +26,18 @@
                 fdType="transparent"
                 class="fd-flexible-column-layout__button"
                 [ariaLabel]="
-                    (_leftColumnSeparator === 'left' ? collapseTitleStartBtn : expandTitleStartBtn) ||
-                    (_leftColumnSeparator === 'left' ? collapseTitle : expandTitle) ||
+                    (_leftColumnSeparator() === 'left' ? collapseTitleStartBtn : expandTitleStartBtn) ||
+                    (_leftColumnSeparator() === 'left' ? collapseTitle : expandTitle) ||
                     ''
                 "
                 [title]="
-                    (_leftColumnSeparator === 'left' ? collapseTitleStartBtn : expandTitleStartBtn) ||
-                    (_leftColumnSeparator === 'left' ? collapseTitle : expandTitle) ||
+                    (_leftColumnSeparator() === 'left' ? collapseTitleStartBtn : expandTitleStartBtn) ||
+                    (_leftColumnSeparator() === 'left' ? collapseTitle : expandTitle) ||
                     ''
                 "
             >
                 <fd-icon
-                    [glyph]="_leftColumnSeparator ? 'slim-arrow-' + _leftColumnSeparator : ''"
+                    [glyph]="_leftColumnSeparator() ? 'slim-arrow-' + _leftColumnSeparator() : ''"
                     role="presentation"
                 ></fd-icon>
             </button>
@@ -46,15 +46,15 @@
     <!-- Middle/Second Column -->
     <div
         class="fd-flexible-column-layout__column"
-        [style.width.%]="_columnLayout.mid"
-        [style.visibility]="_columnLayout.mid === 0 ? 'hidden' : 'visible'"
-        [style.height]="_columnLayout.mid === 0 ? '0' : 'auto'"
-        [attr.aria-hidden]="_columnLayout.mid === 0"
+        [style.width.%]="_columnLayout().mid"
+        [style.visibility]="_columnLayout().mid === 0 ? 'hidden' : 'visible'"
+        [style.height]="_columnLayout().mid === 0 ? '0' : 'auto'"
+        [attr.aria-hidden]="_columnLayout().mid === 0"
     >
         <ng-template [ngTemplateOutlet]="midColumn"></ng-template>
     </div>
     <!-- Right Separator -->
-    @if (_rightColumnSeparator) {
+    @if (_rightColumnSeparator()) {
         <div
             class="fd-flexible-column-layout__separator"
             [attr.aria-label]="separatorAriaLabel"
@@ -66,18 +66,18 @@
                 fdType="transparent"
                 class="fd-flexible-column-layout__button"
                 [ariaLabel]="
-                    (_rightColumnSeparator === 'left' ? collapseTitleEndBtn : expandTitleEndBtn) ||
-                    (_rightColumnSeparator === 'left' ? collapseTitle : expandTitle) ||
+                    (_rightColumnSeparator() === 'left' ? collapseTitleEndBtn : expandTitleEndBtn) ||
+                    (_rightColumnSeparator() === 'left' ? collapseTitle : expandTitle) ||
                     ''
                 "
                 [title]="
-                    (_rightColumnSeparator === 'left' ? collapseTitleEndBtn : expandTitleEndBtn) ||
-                    (_rightColumnSeparator === 'left' ? collapseTitle : expandTitle) ||
+                    (_rightColumnSeparator() === 'left' ? collapseTitleEndBtn : expandTitleEndBtn) ||
+                    (_rightColumnSeparator() === 'left' ? collapseTitle : expandTitle) ||
                     ''
                 "
             >
                 <fd-icon
-                    [glyph]="_rightColumnSeparator ? 'slim-arrow-' + _rightColumnSeparator : ''"
+                    [glyph]="_rightColumnSeparator() ? 'slim-arrow-' + _rightColumnSeparator() : ''"
                     role="presentation"
                 ></fd-icon>
             </button>
@@ -86,10 +86,10 @@
     <!-- End/Right/Third Column -->
     <div
         class="fd-flexible-column-layout__column"
-        [style.width.%]="_columnLayout.end"
-        [style.visibility]="_columnLayout.end === 0 ? 'hidden' : 'visible'"
-        [style.height]="_columnLayout.end === 0 ? '0' : 'auto'"
-        [attr.aria-hidden]="_columnLayout.end === 0"
+        [style.width.%]="_columnLayout().end"
+        [style.visibility]="_columnLayout().end === 0 ? 'hidden' : 'visible'"
+        [style.height]="_columnLayout().end === 0 ? '0' : 'auto'"
+        [attr.aria-hidden]="_columnLayout().end === 0"
     >
         <ng-template [ngTemplateOutlet]="endColumn"></ng-template>
     </div>

--- a/libs/core/flexible-column-layout/flexible-column-layout.component.spec.ts
+++ b/libs/core/flexible-column-layout/flexible-column-layout.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component, input, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { whenStable } from '@fundamental-ngx/core/tests';
@@ -65,12 +65,12 @@ class TestFlexibleColumnLayoutComponent {
 
     readonly layout = input<FlexibleColumnLayout>(ONE_COLUMN_START_FULL_SCREEN);
     readonly backgroundDesign = input('translucent');
-    readonly expandTitle = input<string>(undefined);
-    readonly collapseTitle = input<string>(undefined);
-    readonly expandTitleStartBtn = input<string>(undefined);
-    readonly collapseTitleStartBtn = input<string>(undefined);
-    readonly expandTitleEndBtn = input<string>(undefined);
-    readonly collapseTitleEndBtn = input<string>(undefined);
+    readonly expandTitle = input<string | undefined>(undefined);
+    readonly collapseTitle = input<string | undefined>(undefined);
+    readonly expandTitleStartBtn = input<string | undefined>(undefined);
+    readonly collapseTitleStartBtn = input<string | undefined>(undefined);
+    readonly expandTitleEndBtn = input<string | undefined>(undefined);
+    readonly collapseTitleEndBtn = input<string | undefined>(undefined);
 }
 describe('FlexibleColumnLayoutComponent', () => {
     let testComponent: TestFlexibleColumnLayoutComponent;
@@ -315,6 +315,30 @@ describe('FlexibleColumnLayoutComponent', () => {
         expect(separators.length).toBe(1);
     });
 
+    it('should update rendered layout on resize without manual detectChanges', fakeAsync(() => {
+        setViewport(1023);
+
+        fixture.componentRef.setInput('layout', TWO_COLUMNS_MID_EXPANDED);
+        fixture.detectChanges();
+
+        let midColumn: HTMLElement = fixture.debugElement.queryAll(By.css('.fd-flexible-column-layout__column'))[1]
+            .nativeElement;
+        expect(midColumn.style.width).toBe('67%');
+
+        setViewport(900);
+        tick(150);
+
+        expect(testComponent.flexibleColumnLayout.layout).toBe(ONE_COLUMN_MID_FULL_SCREEN);
+
+        fixture.detectChanges();
+
+        midColumn = fixture.debugElement.queryAll(By.css('.fd-flexible-column-layout__column'))[1].nativeElement;
+        expect(midColumn.style.width).toBe('100%');
+
+        const separators = fixture.debugElement.queryAll(By.css('.fd-flexible-column-layout__separator'));
+        expect(separators.length).toBe(0);
+    }));
+
     describe('separator direction values', () => {
         it('should have no separators for single-column layouts', async () => {
             await whenStable(fixture);
@@ -322,8 +346,8 @@ describe('FlexibleColumnLayoutComponent', () => {
             fixture.componentRef.setInput('layout', ONE_COLUMN_START_FULL_SCREEN);
             fixture.detectChanges();
 
-            expect(testComponent.flexibleColumnLayout._leftColumnSeparator).toBeNull();
-            expect(testComponent.flexibleColumnLayout._rightColumnSeparator).toBeNull();
+            expect(testComponent.flexibleColumnLayout._leftColumnSeparator()).toBeNull();
+            expect(testComponent.flexibleColumnLayout._rightColumnSeparator()).toBeNull();
         });
 
         it('should set left separator to "left" for TWO_COLUMNS_START_EXPANDED', async () => {
@@ -333,8 +357,8 @@ describe('FlexibleColumnLayoutComponent', () => {
             fixture.componentRef.setInput('layout', TWO_COLUMNS_START_EXPANDED);
             fixture.detectChanges();
 
-            expect(testComponent.flexibleColumnLayout._leftColumnSeparator).toBe('left');
-            expect(testComponent.flexibleColumnLayout._rightColumnSeparator).toBeNull();
+            expect(testComponent.flexibleColumnLayout._leftColumnSeparator()).toBe('left');
+            expect(testComponent.flexibleColumnLayout._rightColumnSeparator()).toBeNull();
         });
 
         it('should set left separator to "right" for TWO_COLUMNS_MID_EXPANDED', async () => {
@@ -344,8 +368,8 @@ describe('FlexibleColumnLayoutComponent', () => {
             fixture.componentRef.setInput('layout', TWO_COLUMNS_MID_EXPANDED);
             fixture.detectChanges();
 
-            expect(testComponent.flexibleColumnLayout._leftColumnSeparator).toBe('right');
-            expect(testComponent.flexibleColumnLayout._rightColumnSeparator).toBeNull();
+            expect(testComponent.flexibleColumnLayout._leftColumnSeparator()).toBe('right');
+            expect(testComponent.flexibleColumnLayout._rightColumnSeparator()).toBeNull();
         });
 
         it('should set both separators for THREE_COLUMNS_MID_EXPANDED', async () => {
@@ -355,8 +379,8 @@ describe('FlexibleColumnLayoutComponent', () => {
             fixture.componentRef.setInput('layout', THREE_COLUMNS_MID_EXPANDED);
             fixture.detectChanges();
 
-            expect(testComponent.flexibleColumnLayout._leftColumnSeparator).toBe('right');
-            expect(testComponent.flexibleColumnLayout._rightColumnSeparator).toBe('left');
+            expect(testComponent.flexibleColumnLayout._leftColumnSeparator()).toBe('right');
+            expect(testComponent.flexibleColumnLayout._rightColumnSeparator()).toBe('left');
         });
 
         it('should set right separator to "right" for THREE_COLUMNS_END_EXPANDED', async () => {
@@ -366,7 +390,7 @@ describe('FlexibleColumnLayoutComponent', () => {
             fixture.componentRef.setInput('layout', THREE_COLUMNS_END_EXPANDED);
             fixture.detectChanges();
 
-            expect(testComponent.flexibleColumnLayout._rightColumnSeparator).toBe('right');
+            expect(testComponent.flexibleColumnLayout._rightColumnSeparator()).toBe('right');
         });
     });
 

--- a/libs/core/flexible-column-layout/flexible-column-layout.component.ts
+++ b/libs/core/flexible-column-layout/flexible-column-layout.component.ts
@@ -11,6 +11,7 @@ import {
     OnDestroy,
     OnInit,
     Output,
+    signal,
     SimpleChanges,
     TemplateRef,
     ViewEncapsulation
@@ -91,7 +92,12 @@ export class FlexibleColumnLayoutComponent implements AfterViewInit, OnChanges, 
      * 'ThreeColumnsStartMinimized' | 'ThreeColumnsEndMinimized'
      */
     @Input()
-    layout: FlexibleColumnLayout = ONE_COLUMN_START_FULL_SCREEN;
+    set layout(value: FlexibleColumnLayout) {
+        this._layout.set(value);
+    }
+    get layout(): FlexibleColumnLayout {
+        return this._layout();
+    }
 
     /**
      * Mapping of the layout name and the column layout in %
@@ -160,7 +166,7 @@ export class FlexibleColumnLayoutComponent implements AfterViewInit, OnChanges, 
      * if the separator is visible
      * Options include: 'left', 'right' and null
      */
-    _leftColumnSeparator: ColumnSeparatorValue = null;
+    readonly _leftColumnSeparator = signal<ColumnSeparatorValue>(null);
 
     /**
      * @hidden
@@ -169,14 +175,19 @@ export class FlexibleColumnLayoutComponent implements AfterViewInit, OnChanges, 
      * if the separator is visible
      * Options include: 'left', 'right' and null
      */
-    _rightColumnSeparator: ColumnSeparatorValue = null;
+    readonly _rightColumnSeparator = signal<ColumnSeparatorValue>(null);
 
     /**
      * @hidden
      * the column layout representing the distribution of the width
      * between the first (start), the middle and the last(end) column
      */
-    _columnLayout: { start: number; mid: number; end: number } = this.layoutDefinitions[this.layout];
+    readonly _columnLayout = signal<{ start: number; mid: number; end: number }>(
+        this.layoutDefinitions[ONE_COLUMN_START_FULL_SCREEN]
+    );
+
+    /** @hidden */
+    private readonly _layout = signal<FlexibleColumnLayout>(ONE_COLUMN_START_FULL_SCREEN);
 
     /**
      * @hidden
@@ -448,9 +459,9 @@ export class FlexibleColumnLayoutComponent implements AfterViewInit, OnChanges, 
      * makes a call to determine the new value of the right separator
      */
     private _updateColumnLayoutParameters(): void {
-        this._columnLayout = this.layoutDefinitions[this.layout];
-        this._leftColumnSeparator = this._getLeftColumnSeparatorValue();
-        this._rightColumnSeparator = this._getRightColumnSeparatorValue();
+        this._columnLayout.set(this.layoutDefinitions[this.layout]);
+        this._leftColumnSeparator.set(this._getLeftColumnSeparatorValue());
+        this._rightColumnSeparator.set(this._getRightColumnSeparatorValue());
     }
 
     /**

--- a/libs/platform/form/multi-input/base-multi-input.ts
+++ b/libs/platform/form/multi-input/base-multi-input.ts
@@ -23,6 +23,7 @@ import {
     OnDestroy,
     Output,
     QueryList,
+    signal,
     SimpleChanges,
     TemplateRef,
     ViewChild
@@ -252,12 +253,12 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
     /** @hidden
      * Max width of list container
      * */
-    maxWidth?: number;
+    readonly maxWidth = signal<number | null>(null);
 
     /** @hidden
      * Min width of list container
      * */
-    minWidth?: number;
+    readonly minWidth = signal<number | null>(null);
 
     /**
      * Need for opening mobile version
@@ -591,8 +592,8 @@ export abstract class BaseMultiInput extends CollectionBaseInput implements Afte
         const body = document.body;
         const rect = (this._element.querySelector('fd-input-group') as HTMLElement).getBoundingClientRect();
         const scrollBarWidth = body.offsetWidth - body.clientWidth;
-        this.maxWidth = window.innerWidth - scrollBarWidth - rect.left;
-        this.minWidth = rect.width - 2;
+        this.maxWidth.set(window.innerWidth - scrollBarWidth - rect.left);
+        this.minWidth.set(rect.width - 2);
     }
 
     /**

--- a/libs/platform/form/multi-input/multi-input.component.html
+++ b/libs/platform/form/multi-input/multi-input.component.html
@@ -10,7 +10,7 @@
         [focusTrapped]="true"
         [triggers]="triggers"
         [disabled]="disabled || readonly"
-        [maxWidth]="autoResize ? (maxWidth ?? null) : (minWidth ?? null)"
+        [maxWidth]="autoResize ? maxWidth() : minWidth()"
         [closeOnOutsideClick]="closeOnOutsideClick"
     >
         <fd-popover-control>

--- a/libs/platform/form/multi-input/multi-input.component.spec.ts
+++ b/libs/platform/form/multi-input/multi-input.component.spec.ts
@@ -98,6 +98,26 @@ describe('PlatformMultiInputComponent', () => {
         expect(component.platformMultiInputComponent.addOnButtonClicked.emit).toHaveBeenCalled();
         expect(component.platformMultiInputComponent.showList).not.toHaveBeenCalled();
     });
+
+    it('should recalculate popover widths on window resize when autoResize is enabled', () => {
+        const inputGroup = fixture.nativeElement.querySelector('fd-input-group') as HTMLElement;
+        jest.spyOn(inputGroup, 'getBoundingClientRect').mockReturnValue({ left: 100, width: 300 } as DOMRect);
+
+        component.platformMultiInputComponent.autoResize = true;
+        component.platformMultiInputComponent['_initWindowResize']();
+
+        window.innerWidth = 1200;
+        window.dispatchEvent(new Event('resize'));
+
+        expect(component.platformMultiInputComponent.maxWidth()).toBe(1100);
+        expect(component.platformMultiInputComponent.minWidth()).toBe(298);
+
+        window.innerWidth = 900;
+        window.dispatchEvent(new Event('resize'));
+
+        expect(component.platformMultiInputComponent.maxWidth()).toBe(800);
+        expect(component.platformMultiInputComponent.minWidth()).toBe(298);
+    });
 });
 
 const MULTI_INPUT_IDENTIFIER = 'platform-multi-input-unit-test';

--- a/libs/platform/form/text-area/text-area.component.html
+++ b/libs/platform/form/text-area/text-area.component.html
@@ -23,14 +23,14 @@
 @if (showExceededText) {
     <div class="fd-textarea-counter" aria-live="polite" aria-atomic="true" [attr.id]="id + '-counter'" #counter>
         <!-- render spaces instead of the actual value while translation string is loading in order to avoid content jumps -->
-        @if (counterExcessOrRemaining === 'excess') {
+        @if (counterExcessOrRemaining() === 'excess') {
             <span
                 [innerHtml]="
                     (
-                        (exceededCharCount === 1
+                        (exceededCharCount() === 1
                             ? 'platformTextarea.counterMessageCharactersOverTheLimitSingular'
                             : 'platformTextarea.counterMessageCharactersOverTheLimitPlural'
-                        ) | fdTranslate: { count: exceededCharCount } : '&nbsp;&nbsp;'
+                        ) | fdTranslate: { count: exceededCharCount() } : '&nbsp;&nbsp;'
                     )()
                 "
             ></span>
@@ -38,10 +38,10 @@
             <span
                 [innerHtml]="
                     (
-                        (exceededCharCount === 1
+                        (exceededCharCount() === 1
                             ? 'platformTextarea.counterMessageCharactersRemainingSingular'
                             : 'platformTextarea.counterMessageCharactersRemainingPlural'
-                        ) | fdTranslate: { count: exceededCharCount } : '&nbsp;&nbsp;'
+                        ) | fdTranslate: { count: exceededCharCount() } : '&nbsp;&nbsp;'
                     )()
                 "
             ></span>

--- a/libs/platform/form/text-area/text-area.component.spec.ts
+++ b/libs/platform/form/text-area/text-area.component.spec.ts
@@ -1,6 +1,6 @@
 import { DELETE } from '@angular/cdk/keycodes';
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
@@ -208,6 +208,22 @@ describe('Advanced Textarea', () => {
         const result = textareaCounterElement.nativeElement.textContent.toString().trim();
         expect(result).toBe('2 characters remaining');
     });
+
+    it('should update the counter message after paste', fakeAsync(() => {
+        fixture.detectChanges();
+
+        const textareaElement = host.textareaComponent;
+        textareaElement.maxLength = 5;
+        textareaElement.value = 'abcdefgg';
+
+        textareaElement.handlePasteInteraction();
+        tick();
+        fixture.detectChanges();
+
+        const textareaCounterElement = fixture.debugElement.query(By.css('.fd-textarea-counter'));
+        const result = textareaCounterElement.nativeElement.textContent.toString().trim();
+        expect(result).toBe('3 characters over the limit');
+    }));
 
     it('should not focus when textarea is disabled', async () => {
         await wait(fixture);

--- a/libs/platform/form/text-area/text-area.component.ts
+++ b/libs/platform/form/text-area/text-area.component.ts
@@ -8,6 +8,7 @@ import {
     HostListener,
     Input,
     OnInit,
+    signal,
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
@@ -99,9 +100,12 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
     set value(value: any) {
         if (value) {
             super.setValue(value);
+            this.updateCounterInteractions();
         } else {
             // when custom value not set, we should set/reset counter to maxlength value when it becomes undefined
-            this.exceededCharCount = this.maxLength ? this.maxLength : 0;
+            this._textAreaCharCount.set(0);
+            this.counterExcessOrRemaining.set(this.remainingText);
+            this.exceededCharCount.set(this.maxLength ? this.maxLength : 0);
             // reset state by resetting value
             super.setValue('');
         }
@@ -118,17 +122,17 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
     hasTextExceeded = false;
 
     /** @hidden excess character count */
-    exceededCharCount = 0;
+    readonly exceededCharCount = signal(0);
 
     /** @hidden a string placeholder that toggles between 'remaining' and 'excess' for the select ICU expression */
-    counterExcessOrRemaining = 'remaining';
+    readonly counterExcessOrRemaining = signal<'remaining' | 'excess'>('remaining');
 
     /** @hidden flag to check if there is an initial value set */
     isValueCustomSet = false;
 
     /** @hidden */
     /** to keep track of number of characters in the textarea */
-    private _textAreaCharCount = 0;
+    private readonly _textAreaCharCount = signal(0);
 
     /** @hidden */
     private _isPasted = false;
@@ -172,8 +176,8 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         if (this._shouldTrackTextLimit && KeyUtil.isKeyCode(event, [DELETE, BACKSPACE])) {
             // for the custom value set and showExceededText=false case, on any key press, remove excess characters
             if (this.value) {
-                this._textAreaCharCount = this.value.length;
-                if (this._textAreaCharCount > this.maxLength) {
+                this._textAreaCharCount.set(this.value.length);
+                if (this._textAreaCharCount() > this.maxLength) {
                     // remove excess characters
                     this.value = this.value.substring(0, this.maxLength);
                     this.isValueCustomSet = false; // since value is now changed, it is no longer custom set
@@ -189,7 +193,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
         }
         // if not custom set, set counter to max length value, else it calculates remaining/exceeded characters.
         if (!this.value) {
-            this.exceededCharCount = this.maxLength || 0;
+            this.exceededCharCount.set(this.maxLength || 0);
         } else {
             this.isValueCustomSet = true;
         }
@@ -229,7 +233,7 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
 
     /** update the counter message and related interactions */
     updateCounterInteractions(): void {
-        this._textAreaCharCount = this.value?.length ?? 0;
+        this._textAreaCharCount.set(this.value?.length ?? 0);
 
         if (this.maxLength) {
             // newly added to avoid unnecessary iteration, remove if issue found
@@ -239,17 +243,17 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
 
     /** if exceeded maxlength when set as a value in code, highlight the exceeded text. */
     validateLengthOnCustomSet(): void {
-        if (this._textAreaCharCount > this.maxLength) {
+        if (this._textAreaCharCount() > this.maxLength) {
             if (this._isPasted) {
                 this._targetElement.focus();
-                this._targetElement.setSelectionRange(this.maxLength, this._textAreaCharCount);
+                this._targetElement.setSelectionRange(this.maxLength, this._textAreaCharCount());
             }
 
-            this.counterExcessOrRemaining = this.excessText;
-            this.exceededCharCount = this._textAreaCharCount - this.maxLength;
+            this.counterExcessOrRemaining.set(this.excessText);
+            this.exceededCharCount.set(this._textAreaCharCount() - this.maxLength);
         } else {
-            this.counterExcessOrRemaining = this.remainingText;
-            this.exceededCharCount = this.maxLength - this._textAreaCharCount;
+            this.counterExcessOrRemaining.set(this.remainingText);
+            this.exceededCharCount.set(this.maxLength - this._textAreaCharCount());
         }
 
         this._isPasted = false;
@@ -306,12 +310,10 @@ export class TextAreaComponent extends BaseInput implements AfterViewChecked, On
     getUpdatedState(): FormStates {
         if (this._getContentLength() > this.maxLength) {
             this.hasTextExceeded = true; // set flag for error message to also change accordingly
-            this.counterExcessOrRemaining = this.excessText;
 
             return this.state;
         }
         this.hasTextExceeded = false;
-        this.counterExcessOrRemaining = this.remainingText;
 
         return this.state; // return any other errors found by parent form field
     }


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14436

## Description

In zoneless change detection with `OnPush` strategy, component state must be reactive. Properties used in templates need to be signals so Angular can track changes automatically without `markForCheck()` calls. The text-area component was also writing to signals during template rendering (via `getUpdatedState()` method binding), which is forbidden in Angular 22+.

- Flexible Column Layout now uses signals for layout and separator state, so window resize updates re-render correctly.
- Platform Multi Input now uses signals for the popover width state, so the options list resizes correctly on window resize.
- Platform Textarea now uses signals for the character counter state, so paste updates repaint the counter immediately without writing to signals during template render.