### PR TITLE
fix(platform): restore initial sidebar focus in settings generator dialog

### DIFF
--- a/libs/platform/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-layout.component.html
+++ b/libs/platform/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-layout.component.html
@@ -34,7 +34,13 @@
     <div class="fdp-settings-generator__list-container" #listElement>
         <ul fd-list [byline]="true" [navigationIndicator]="true">
             @for (item of settings?.items; track item; let i = $index) {
-                <li (click)="_setSelectedIndex(i)" fd-list-item [selected]="i === _selectedIndex" [id]="item.id">
+                <li
+                    (click)="_setSelectedIndex(i)"
+                    fd-list-item
+                    [selected]="i === _selectedIndex"
+                    [id]="item.id"
+                    #sidebarItem
+                >
                     <a fd-list-link [navigated]="i === _selectedIndex" [navigationIndicator]="_isMobile">
                         @if (item.thumbnail) {
                             <span fd-list-thumbnail>

--- a/libs/platform/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-layout.component.ts
+++ b/libs/platform/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-layout.component.ts
@@ -8,9 +8,8 @@ import {
     HostBinding,
     inject,
     OnInit,
-    QueryList,
     ViewChild,
-    ViewChildren,
+    viewChildren,
     ViewEncapsulation
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -71,10 +70,6 @@ export class SettingsGeneratorSidebarLayoutComponent
     private _listElement: ElementRef;
 
     /** @hidden */
-    @ViewChildren('sidebarItem', { read: ElementRef })
-    private readonly _sidebarItems: QueryList<ElementRef<HTMLElement>>;
-
-    /** @hidden */
     searchTerm: string;
 
     /**
@@ -113,6 +108,9 @@ export class SettingsGeneratorSidebarLayoutComponent
 
     /** @hidden */
     private _initialSelectedItemSet = false;
+
+    /** @hidden */
+    private readonly _sidebarItems = viewChildren('sidebarItem', { read: ElementRef });
 
     /** @hidden */
     get _mobileSidebarVisible(): boolean {
@@ -232,10 +230,29 @@ export class SettingsGeneratorSidebarLayoutComponent
     /** @hidden */
     private _focusSelectedSidebarItem(): void {
         queueMicrotask(() => {
-            const target = this._sidebarItems.get(this._selectedIndex) ?? this._sidebarItems.first;
+            // Try to focus immediately in case sidebar items are already rendered.
+            if (this._focusFromSidebarItems()) {
+                return;
+            }
 
-            target?.nativeElement.focus();
+            // Retry on the next paint because signal query results may arrive after this microtask.
+            requestAnimationFrame(() => {
+                this._focusFromSidebarItems();
+            });
         });
+    }
+
+    /** @hidden */
+    private _focusFromSidebarItems(): boolean {
+        const sidebarItems = this._sidebarItems();
+        const target = sidebarItems[this._selectedIndex] ?? sidebarItems[0];
+
+        if (!target) {
+            return false;
+        }
+
+        target.nativeElement.focus();
+        return true;
     }
 
     /** @hidden */

--- a/libs/platform/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-layout.component.ts
+++ b/libs/platform/settings-generator/layouts/settings-generator-sidebar-layout/settings-generator-sidebar-layout.component.ts
@@ -8,7 +8,9 @@ import {
     HostBinding,
     inject,
     OnInit,
+    QueryList,
     ViewChild,
+    ViewChildren,
     ViewEncapsulation
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -67,6 +69,10 @@ export class SettingsGeneratorSidebarLayoutComponent
     /** @hidden */
     @ViewChild('listElement', { read: ElementRef })
     private _listElement: ElementRef;
+
+    /** @hidden */
+    @ViewChildren('sidebarItem', { read: ElementRef })
+    private readonly _sidebarItems: QueryList<ElementRef<HTMLElement>>;
 
     /** @hidden */
     searchTerm: string;
@@ -152,7 +158,7 @@ export class SettingsGeneratorSidebarLayoutComponent
             this._settingsGeneratorContent.setActiveTab(pathArray[1]);
         }
 
-        setTimeout(() => {
+        queueMicrotask(() => {
             element.nativeElement.focus();
         });
     }
@@ -182,11 +188,13 @@ export class SettingsGeneratorSidebarLayoutComponent
                     // In mobile view, we don't need to set initial index, since the section won't be visible to the end user.
                     if (!this._initialSelectedItemSet && !this._isMobile) {
                         this._setSelectedIndex(this._selectedIndex > -1 ? this._selectedIndex : 0);
+                        this._focusSelectedSidebarItem();
                         this._initialSelectedItemSet = true;
                     }
 
                     if (!this._isMobile && this._selectedIndex === -1) {
                         this._setSelectedIndex(0);
+                        this._focusSelectedSidebarItem();
                     }
 
                     this._cdr.detectChanges();
@@ -219,6 +227,15 @@ export class SettingsGeneratorSidebarLayoutComponent
     /** @hidden */
     private _getNormalizedSidebarWidth(width: string | SidebarWidthConfiguration): SidebarWidthConfiguration {
         return typeof width === 'string' ? { minWidth: width, maxWidth: width, width } : width;
+    }
+
+    /** @hidden */
+    private _focusSelectedSidebarItem(): void {
+        queueMicrotask(() => {
+            const target = this._sidebarItems.get(this._selectedIndex) ?? this._sidebarItems.first;
+
+            target?.nativeElement.focus();
+        });
     }
 
     /** @hidden */

--- a/libs/platform/settings-generator/settings-generator.component.spec.ts
+++ b/libs/platform/settings-generator/settings-generator.component.spec.ts
@@ -33,7 +33,7 @@ describe('SettingsGeneratorComponent', () => {
         fixture.detectChanges();
 
         expect(settingsSpy).toHaveBeenCalledTimes(1);
-        expect(settingsSpy).toHaveBeenLastCalledWith(settings);
+        expect(settingsSpy).toHaveBeenCalledWith(settings);
     });
 
     it('should set appropriate layout', () => {
@@ -58,5 +58,40 @@ describe('SettingsGeneratorComponent', () => {
         fixture.detectChanges();
 
         expect((component as any)._currentLayout).toBeFalsy();
+    });
+
+    it('should focus the first sidebar item when opened on desktop', async () => {
+        const requestAnimationFrameSpy = jest
+            .spyOn(globalThis, 'requestAnimationFrame')
+            .mockImplementation((callback: FrameRequestCallback) => {
+                callback(0);
+                return 1;
+            });
+
+        component.settings = {
+            appearance: 'sidebar',
+            sidebarWidth: '20rem',
+            items: [{ id: 'general', title: 'General', items: [] }]
+        } as any;
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const firstSidebarItem = fixture.nativeElement.querySelector('#general') as HTMLElement | null;
+        const layoutRef = (component as any)._layoutComponentRef;
+
+        expect(layoutRef).toBeTruthy();
+        const focusSpy = jest.spyOn(firstSidebarItem as HTMLElement, 'focus');
+
+        (layoutRef.instance as any)._selectedIndex = 0;
+        (layoutRef.instance as any)._focusSelectedSidebarItem();
+        await Promise.resolve();
+
+        expect(firstSidebarItem).toBeTruthy();
+        expect(focusSpy).toHaveBeenCalled();
+
+        requestAnimationFrameSpy.mockRestore();
+        focusSpy.mockRestore();
     });
 });


### PR DESCRIPTION


## Related Issue(s)
closes https://github.com/SAP/fundamental-ngx/issues/13827

## Description
When the Settings Generator was rendered in a dialog, initial focus was landing on the footer submit button. The expected behavior is to place focus on the first item in the sidebar, which was the behavior in earlier versions.

- restore initial focus to the first selected sidebar item when Platform Settings Generator is opened inside a dialog
- prevent focus from falling through to the footer submit action
- simplify the focus targeting logic by using Angular view queries for sidebar items
