### PR TITLE
docs(ui5): add illustration import note to fiori docs-app page

### DIFF
--- a/libs/docs/ui5-webcomponents-fiori/illustrated-message/illustrated-message-docs.html
+++ b/libs/docs/ui5-webcomponents-fiori/illustrated-message/illustrated-message-docs.html
@@ -1,5 +1,8 @@
 <fd-docs-section-title id="default" componentName="illustrated-message">Illustrated Message</fd-docs-section-title>
-<description> Illustrated Message component examples to display informative messages with illustrations. </description>
+<description>
+    Illustrated Message component examples to display informative messages with illustrations. Note: Most illustrations
+    must be explicitly imported—see the example below for the correct pattern.
+</description>
 <component-example>
     <ui5-illustrated-message-sample></ui5-illustrated-message-sample>
 </component-example>

--- a/libs/ui5-webcomponents-ai/README.md
+++ b/libs/ui5-webcomponents-ai/README.md
@@ -43,6 +43,22 @@ export class ExampleComponent {
 }
 ```
 
+### Use Secondary Entry Points
+
+For best bundle size, use secondary entry points rather than the barrel import. When you import from the barrel, all components are bundled together because each component registers its web component as a side effect during initialization, preventing tree-shaking.
+
+**Larger bundle:**
+```typescript
+import { PromptInput } from '@fundamental-ngx/ui5-webcomponents-ai';
+```
+
+**Smaller bundle:**
+```typescript
+import { PromptInput } from '@fundamental-ngx/ui5-webcomponents-ai/prompt-input';
+```
+
+Secondary entry points bundle only what you use — the difference yields significantly smaller bundle sizes.
+
 ### Using Angular Components Inside UI5 Components
 
 Angular components often use selectors with hyphens (e.g. `<app-item>`, `<app-value>`).

--- a/libs/ui5-webcomponents-fiori/README.md
+++ b/libs/ui5-webcomponents-fiori/README.md
@@ -48,6 +48,32 @@ export class ExampleComponent {
 }
 ```
 
+### Use Secondary Entry Points
+
+For best bundle size, use secondary entry points rather than the barrel import. When you import from the barrel, all 66 components are bundled together because each component registers its web component as a side effect during initialization, preventing tree-shaking.
+
+**Larger bundle:**
+```typescript
+import { IllustratedMessage } from '@fundamental-ngx/ui5-webcomponents-fiori';
+```
+
+**Smaller bundle:**
+```typescript
+import { IllustratedMessage } from '@fundamental-ngx/ui5-webcomponents-fiori/illustrated-message';
+```
+
+Secondary entry points bundle only what you use — the difference is times smaller bundle size.
+
+### Illustrations
+
+UI5 fiori loads only the `BeforeSearch` illustration by default. To use other illustrations, import them explicitly:
+
+```typescript
+import '@ui5/webcomponents-fiori/dist/illustrations/NoData.js';
+```
+
+Do not barrel-import the entire illustration set—import only what you use. Each illustration is added individually when needed.
+
 ### Using Angular Components Inside UI5 Components
 
 Angular components often use selectors with hyphens (e.g. `<app-item>`, `<app-value>`).

--- a/libs/ui5-webcomponents/README.md
+++ b/libs/ui5-webcomponents/README.md
@@ -43,6 +43,22 @@ export class ExampleComponent {
 }
 ```
 
+### Use Secondary Entry Points
+
+For best bundle size, use secondary entry points rather than the barrel import. When you import from the barrel, all components are bundled together because each component registers its web component as a side effect during initialization, preventing tree-shaking.
+
+**Larger bundle:**
+```typescript
+import { Button } from '@fundamental-ngx/ui5-webcomponents';
+```
+
+**Smaller bundle:**
+```typescript
+import { Button } from '@fundamental-ngx/ui5-webcomponents/button';
+```
+
+Secondary entry points bundle only what you use — the difference yields significantly smaller bundle sizes.
+
 ### Using Angular Components Inside UI5 Components
 
 Angular components often use selectors with hyphens (e.g. `<app-item>`, `<app-value>`).


### PR DESCRIPTION
closes #13899

## Summary

Document secondary entry points across UI5 wrappers to reduce bundle size. When importing from the barrel, side-effect WC registration prevents tree-shaking. Add illustration import guidance to fiori - only `BeforeSearch` is bundled by default.
