### PR TITLE
fix(core): use 100svh for dynamic page full height

### DIFF
--- a/libs/core/dynamic-page/dynamic-page.component.spec.ts
+++ b/libs/core/dynamic-page/dynamic-page.component.spec.ts
@@ -101,4 +101,11 @@ describe('DynamicPageComponent default values', () => {
         expect(dynamicPageComponent.size).toBe('small');
         expect(updateHeightSpy).toHaveBeenCalled();
     });
+
+    it('should compute full height using the small viewport unit (svh) so mobile browser chrome is excluded', () => {
+        const element = document.createElement('div');
+        const calc = (<any>dynamicPageComponent)._getCalculatedFullHeight(element);
+        expect(calc).toContain('svh');
+        expect(calc).not.toMatch(/\d+vh/);
+    });
 });

--- a/libs/core/dynamic-page/dynamic-page.component.ts
+++ b/libs/core/dynamic-page/dynamic-page.component.ts
@@ -233,7 +233,7 @@ export class DynamicPageComponent implements AfterViewInit, DynamicPage {
             return null;
         }
         const distanceFromTop = element.getBoundingClientRect().top;
-        return 'calc(100vh - ' + (distanceFromTop + this.offset) + 'px)';
+        return 'calc(100svh - ' + (distanceFromTop + this.offset) + 'px)';
     }
 
     /** @hidden */


### PR DESCRIPTION
Core Dynamic Page computed its full height with `100vh`. On mobile, the browser URL/toolbar chrome makes `100vh` taller than the visible viewport, pushing the footer off-screen. Switched to `100svh` (small viewport height), which excludes that chrome. `svh` is Baseline in all targeted browsers, so no fallback is needed.

Fixes #13701.