### PR TITLE
fix(platform): expose BaseInput required as input without changing validation ownership

### DIFF
--- a/libs/platform/form/input/input.component.ts
+++ b/libs/platform/form/input/input.component.ts
@@ -54,14 +54,6 @@ export class InputComponent extends BaseInput implements OnInit, AfterViewInit {
     @Input()
     type: InputType = 'text';
 
-    /**
-     * @hidden
-     * This `required` field is used internally by other components such as Input Group.
-     * Input group will not be able to set required value to input, until `required` is input through the`@Input` property.
-     */
-    @Input()
-    declare required: boolean;
-
     /** return the value in the text box */
     @Input()
     set value(value: any) {

--- a/libs/platform/shared/form/base.input.ts
+++ b/libs/platform/shared/form/base.input.ts
@@ -127,6 +127,10 @@ export abstract class BaseInput
     @Input()
     readonly: boolean;
 
+    /** Whether the input is required. */
+    @Input({ transform: booleanAttribute })
+    required = false;
+
     /**
      * Tell the component if we are in editing mode.
      */
@@ -170,9 +174,6 @@ export abstract class BaseInput
      * See @FormFieldControl
      */
     focused = false;
-
-    /** set when input field is mandatory form field */
-    required: boolean;
 
     /** @hidden */
     innerErrorsTemplate?: TemplateRef<any>;


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/13671

## Description

Make **required** available on `BaseInput` as a boolean-coerced input and remove the redundant required declaration from `InputComponent`.

Keep required validation ownership in form-field to avoid behavioral changes:

- form-field remains the single source for adding required validators
- form-field still propagates required to controls
- standalone controls can accept required for native/ARIA behavior without changing form validation flow

No breaking API changes and no validation semantics changes.


### Problem
BaseInput had a required property but it was not an Angular input. This forced some components to redeclare required locally and made required handling inconsistent across input-based platform components.

Kept form-field as the only owner of required validation logic. This preserves existing behavior, avoids regressions, and prevents dual source of truth between control-level and form-field-level required validation.

Used `@Input` instead of signal input here because:
- current architecture mutates required from form-field into the control, which aligns naturally with a mutable input property
- signal input would require broader refactoring and ownership redesign to avoid conflicts