### PR TITLE
fix(core, platform): added option to show Message Strip in Dynamic Page

### DIFF
--- a/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
+++ b/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
@@ -69,6 +69,13 @@
         <ng-template [ngTemplateOutlet]="_subtitleTemplate() ? subtitleRef : defaultSubtitle"></ng-template>
     </span>
 }
+
+@if (messageStrip()) {
+    <div class="fd-dynamic-page__message-strip-container">
+        <ng-content select="fd-message-strip"></ng-content>
+    </div>
+}
+
 <ng-template #dynamicPageGlobalActionsRef>
     <ng-content select="fd-dynamic-page-global-actions"></ng-content>
 </ng-template>

--- a/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
+++ b/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.html
@@ -70,9 +70,13 @@
     </span>
 }
 
-@if (messageStrip()) {
+@if (messageStrip() || messageStripTemplate()) {
     <div class="fd-dynamic-page__message-strip-container">
-        <ng-content select="fd-message-strip"></ng-content>
+        @if (messageStripTemplate()) {
+            <ng-template [ngTemplateOutlet]="messageStripTemplate()!"></ng-template>
+        } @else {
+            <ng-content select="fd-message-strip"></ng-content>
+        }
     </div>
 }
 

--- a/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.scss
+++ b/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.scss
@@ -2,3 +2,7 @@
     width: 100%;
     max-width: 60%;
 }
+
+.fd-dynamic-page__message-strip-container {
+    margin-block: 1rem 0.5rem;
+}

--- a/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.spec.ts
+++ b/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.spec.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BreadcrumbModule } from '@fundamental-ngx/core/breadcrumb';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { MessageStripComponent } from '@fundamental-ngx/core/message-strip';
 import { ToolbarModule } from '@fundamental-ngx/core/toolbar';
 import { DynamicPageModule } from '../../dynamic-page.module';
 import { DynamicPageService } from '../../dynamic-page.service';
@@ -438,5 +439,90 @@ describe('DynamicPageHeaderComponent with custom templates', () => {
 
         expect(subtitle.textContent.trim()).toBe('Subtitle collapsed');
         expect(title.textContent.trim()).toBe('Title collapsed');
+    });
+});
+
+describe('DynamicPageHeaderComponent with message strip', () => {
+    @Component({
+        template: `
+            <fd-dynamic-page-header [title]="title">
+                <fd-message-strip type="success" [dismissible]="false">
+                    Operation completed successfully
+                </fd-message-strip>
+            </fd-dynamic-page-header>
+        `,
+        imports: [DynamicPageModule, MessageStripComponent],
+        providers: [DynamicPageService]
+    })
+    class WithMessageStripTestComponent {
+        @ViewChild(DynamicPageHeaderComponent)
+        header: DynamicPageHeaderComponent;
+
+        title = 'Test title';
+    }
+
+    let fixture: ComponentFixture<WithMessageStripTestComponent>;
+    let header: DynamicPageHeaderComponent;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [WithMessageStripTestComponent],
+            providers: [DynamicPageService]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(WithMessageStripTestComponent);
+        fixture.detectChanges();
+        header = fixture.componentInstance.header;
+    });
+
+    it('should detect message strip when present', () => {
+        expect(header.messageStrip()).toBeTruthy();
+    });
+
+    it('should render message strip container when message strip is present', () => {
+        const container = fixture.nativeElement.querySelector('.fd-dynamic-page__message-strip-container');
+        expect(container).toBeTruthy();
+    });
+
+    it('should render message strip component', () => {
+        const messageStrip = fixture.nativeElement.querySelector('fd-message-strip');
+        expect(messageStrip).toBeTruthy();
+    });
+});
+
+describe('DynamicPageHeaderComponent without message strip', () => {
+    @Component({
+        template: ` <fd-dynamic-page-header [title]="title"> </fd-dynamic-page-header> `,
+        imports: [DynamicPageModule],
+        providers: [DynamicPageService]
+    })
+    class WithoutMessageStripTestComponent {
+        @ViewChild(DynamicPageHeaderComponent)
+        header: DynamicPageHeaderComponent;
+
+        title = 'Test title';
+    }
+
+    let fixture: ComponentFixture<WithoutMessageStripTestComponent>;
+    let header: DynamicPageHeaderComponent;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [WithoutMessageStripTestComponent],
+            providers: [DynamicPageService]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(WithoutMessageStripTestComponent);
+        fixture.detectChanges();
+        header = fixture.componentInstance.header;
+    });
+
+    it('should not detect message strip when not present', () => {
+        expect(header.messageStrip()).toBeFalsy();
+    });
+
+    it('should not render message strip container when message strip is not present', () => {
+        const container = fixture.nativeElement.querySelector('.fd-dynamic-page__message-strip-container');
+        expect(container).toBeFalsy();
     });
 });

--- a/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
+++ b/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
@@ -21,6 +21,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import { IgnoreClickOnSelectionDirective } from '@fundamental-ngx/cdk/utils';
 import { HeadingLevel } from '@fundamental-ngx/core/shared';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
+import { MessageStripComponent } from '../../../message-strip/message-strip.component';
 import { DYNAMIC_PAGE_CLASS_NAME, DynamicPageResponsiveSize } from '../../constants';
 import { DynamicPageHeaderSubtitleDirective } from '../../directives/dynamic-page-header-subtitle.directive';
 import { DynamicPageHeaderTitleDirective } from '../../directives/dynamic-page-header-title.directive';
@@ -110,6 +111,13 @@ export class DynamicPageHeaderComponent implements OnInit {
      * When provided via fdDynamicPageHeaderTitle directive, overrides the title text input.
      */
     readonly _titleTemplate = contentChild(DynamicPageHeaderTitleDirective);
+
+    /**
+     * @hidden
+     * Content child query for MessageStripComponent.
+     * When present, the message strip will be rendered below the subtitle in the header.
+     */
+    readonly messageStrip = contentChild(MessageStripComponent);
 
     /** @hidden */
     readonly _dynamicPageBreadcrumbComponent = contentChild(FD_DYNAMIC_PAGE_BREADCRUMB_COMPONENT, {

--- a/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
+++ b/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
@@ -11,6 +11,7 @@ import {
     input,
     OnInit,
     Renderer2,
+    TemplateRef,
     ViewEncapsulation
 } from '@angular/core';
 
@@ -111,6 +112,14 @@ export class DynamicPageHeaderComponent implements OnInit {
      * When provided via fdDynamicPageHeaderTitle directive, overrides the title text input.
      */
     readonly _titleTemplate = contentChild(DynamicPageHeaderTitleDirective);
+
+    /**
+     * Optional template ref for message strip content.
+     * When provided, the message strip container is rendered using this template
+     * instead of relying on ng-content projection.
+     * This is used by Platform Dynamic Page which cannot project via ng-content.
+     */
+    readonly messageStripTemplate = input<TemplateRef<any> | null>(null);
 
     /**
      * @hidden

--- a/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
+++ b/libs/core/dynamic-page/dynamic-page-header/header/dynamic-page-header.component.ts
@@ -20,9 +20,9 @@ import { DYNAMIC_PAGE_HEADER_TOKEN } from '@fundamental-ngx/core/shared';
 
 import { NgTemplateOutlet } from '@angular/common';
 import { IgnoreClickOnSelectionDirective } from '@fundamental-ngx/cdk/utils';
+import { MessageStripComponent } from '@fundamental-ngx/core/message-strip';
 import { HeadingLevel } from '@fundamental-ngx/core/shared';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
-import { MessageStripComponent } from '../../../message-strip/message-strip.component';
 import { DYNAMIC_PAGE_CLASS_NAME, DynamicPageResponsiveSize } from '../../constants';
 import { DynamicPageHeaderSubtitleDirective } from '../../directives/dynamic-page-header-subtitle.directive';
 import { DynamicPageHeaderTitleDirective } from '../../directives/dynamic-page-header-title.directive';

--- a/libs/core/facets/facet-group.component.scss
+++ b/libs/core/facets/facet-group.component.scss
@@ -10,3 +10,7 @@
 .fd-title.fd-margin-bottom--sm {
     margin-block-end: 1rem;
 }
+
+.fd-facet-group {
+    gap: 0;
+}

--- a/libs/docs/core/dynamic-page/examples/dynamic-page-facets-example/dynamic-page-facets-example.component.html
+++ b/libs/docs/core/dynamic-page/examples/dynamic-page-facets-example/dynamic-page-facets-example.component.html
@@ -76,6 +76,11 @@
                         </button>
                     </fd-toolbar>
                 </fd-dynamic-page-layout-actions>
+
+                <!-- Message Strip -->
+                <fd-message-strip type="success" [dismissible]="false">
+                    A non-dismissible success message strip.
+                </fd-message-strip>
             </fd-dynamic-page-header>
             <fd-dynamic-page-subheader
                 [collapsible]="true"

--- a/libs/docs/core/dynamic-page/examples/dynamic-page-facets-example/dynamic-page-facets-example.component.ts
+++ b/libs/docs/core/dynamic-page/examples/dynamic-page-facets-example/dynamic-page-facets-example.component.ts
@@ -14,6 +14,7 @@ import {
 import { FacetModule } from '@fundamental-ngx/core/facets';
 import { FormLabelComponent } from '@fundamental-ngx/core/form';
 import { LinkComponent } from '@fundamental-ngx/core/link';
+import { MessageStripComponent } from '@fundamental-ngx/core/message-strip';
 import { ObjectNumberComponent } from '@fundamental-ngx/core/object-number';
 import { ObjectStatusComponent } from '@fundamental-ngx/core/object-status';
 import { RatingIndicatorComponent } from '@fundamental-ngx/core/rating-indicator';
@@ -67,7 +68,8 @@ import { ToolbarComponent, ToolbarItemDirective, ToolbarSeparatorComponent } fro
         ObjectStatusComponent,
         ObjectNumberComponent,
         CdkScrollable,
-        BarModule
+        BarModule,
+        MessageStripComponent
     ]
 })
 export class DynamicPageFacetsExampleComponent {

--- a/libs/docs/platform/dynamic-page/examples/platform-dynamic-page-facets-example.component.html
+++ b/libs/docs/platform/dynamic-page/examples/platform-dynamic-page-facets-example.component.html
@@ -71,6 +71,11 @@
                         </button>
                     </fd-toolbar>
                 </fdp-dynamic-page-layout-actions>
+                <fdp-dynamic-page-message-strip>
+                    <fd-message-strip type="success" [dismissible]="false">
+                        A non-dismissible success message strip.
+                    </fd-message-strip>
+                </fdp-dynamic-page-message-strip>
             </fdp-dynamic-page-title>
             <fdp-dynamic-page-header
                 [collapsible]="true"

--- a/libs/docs/platform/dynamic-page/examples/platform-dynamic-page-facets-example.component.ts
+++ b/libs/docs/platform/dynamic-page/examples/platform-dynamic-page-facets-example.component.ts
@@ -9,7 +9,7 @@ import { FacetModule } from '@fundamental-ngx/core/facets';
 import { FormLabelComponent } from '@fundamental-ngx/core/form';
 import { IconComponent } from '@fundamental-ngx/core/icon';
 import { InlineHelpModule } from '@fundamental-ngx/core/inline-help';
-import { LinkComponent } from '@fundamental-ngx/core/link';
+import { MessageStripComponent } from '@fundamental-ngx/core/message-strip';
 import { ObjectNumberComponent } from '@fundamental-ngx/core/object-number';
 import { ObjectStatusComponent } from '@fundamental-ngx/core/object-status';
 import { RatingIndicatorComponent } from '@fundamental-ngx/core/rating-indicator';
@@ -33,7 +33,6 @@ import { PlatformDynamicPagePageOverflowService } from './platform-dynamic-page-
         DynamicPageHeaderTitleDirective,
         DynamicPageHeaderSubtitleDirective,
         BreadcrumbModule,
-        LinkComponent,
         AvatarComponent,
         ToolbarComponent,
         ToolbarItemDirective,
@@ -47,7 +46,8 @@ import { PlatformDynamicPagePageOverflowService } from './platform-dynamic-page-
         ObjectNumberComponent,
         IconComponent,
         InlineHelpModule,
-        BarModule
+        BarModule,
+        MessageStripComponent
     ]
 })
 export class PlatformDynamicPageFacetsExampleComponent implements OnDestroy {

--- a/libs/platform/dynamic-page/dynamic-page-header/message-strip/dynamic-page-message-strip.component.spec.ts
+++ b/libs/platform/dynamic-page/dynamic-page-header/message-strip/dynamic-page-message-strip.component.spec.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DynamicPageMessageStripComponent } from './dynamic-page-message-strip.component';
+
+@Component({
+    template: `
+        <fdp-dynamic-page-message-strip>
+            <div class="test-content">Message strip content</div>
+        </fdp-dynamic-page-message-strip>
+    `,
+    imports: [DynamicPageMessageStripComponent]
+})
+class TestHostComponent {}
+
+describe('DynamicPageMessageStripComponent', () => {
+    let fixture: ComponentFixture<TestHostComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [TestHostComponent]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestHostComponent);
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        const component = fixture.debugElement.query(By.directive(DynamicPageMessageStripComponent));
+        expect(component).toBeTruthy();
+    });
+
+    it('should expose contentTemplateRef', () => {
+        const instance = fixture.debugElement.query(By.directive(DynamicPageMessageStripComponent)).componentInstance;
+        expect(instance.contentTemplateRef()).toBeTruthy();
+    });
+
+    it('should not render content directly (wrapped in ng-template)', () => {
+        const content = fixture.nativeElement.querySelector('.test-content');
+        expect(content).toBeFalsy();
+    });
+});

--- a/libs/platform/dynamic-page/dynamic-page-header/message-strip/dynamic-page-message-strip.component.ts
+++ b/libs/platform/dynamic-page/dynamic-page-header/message-strip/dynamic-page-message-strip.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, TemplateRef, viewChild, ViewEncapsulation } from '@angular/core';
+
+@Component({
+    selector: 'fdp-dynamic-page-message-strip',
+    template: `
+        <ng-template #contentTemplateRef>
+            <ng-content></ng-content>
+        </ng-template>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    encapsulation: ViewEncapsulation.None
+})
+export class DynamicPageMessageStripComponent {
+    /**
+     * @hidden
+     * The component view is wrapped in ng-template so
+     * component's consumer have to use this templateRef to render it
+     * in its view.
+     *
+     * The template reference to the component view.
+     */
+    readonly contentTemplateRef = viewChild.required<TemplateRef<any>>('contentTemplateRef');
+}

--- a/libs/platform/dynamic-page/dynamic-page-header/title/dynamic-page-title.component.ts
+++ b/libs/platform/dynamic-page/dynamic-page-header/title/dynamic-page-title.component.ts
@@ -1,6 +1,7 @@
 import {
     ChangeDetectionStrategy,
     Component,
+    contentChild,
     ContentChild,
     Input,
     TemplateRef,
@@ -16,6 +17,7 @@ import { DynamicPageGlobalActionsComponent } from '../actions/global-actions/dyn
 import { DynamicPageLayoutActionsComponent } from '../actions/layout-actions/dynamic-page-layout-actions.component';
 import { DynamicPageBreadcrumbComponent } from '../breadcrumb/dynamic-page-breadcrumb.component';
 import { DynamicPageKeyInfoComponent } from '../key-info/dynamic-page-key-info.component';
+import { DynamicPageMessageStripComponent } from '../message-strip/dynamic-page-message-strip.component';
 import { DynamicPageTitleImageComponent } from './dynamic-page-title-image.component';
 
 /**
@@ -108,4 +110,7 @@ export class DynamicPageTitleComponent implements DynamicPageHeader {
      */
     @ViewChild('contentTemplateRef')
     contentTemplateRef: TemplateRef<any>;
+
+    /** reference to message strip component */
+    readonly messageStripComponent = contentChild(DynamicPageMessageStripComponent);
 }

--- a/libs/platform/dynamic-page/dynamic-page.component.html
+++ b/libs/platform/dynamic-page/dynamic-page.component.html
@@ -14,6 +14,7 @@
             [subtitle]="titleComponent.subtitle"
             [subtitleWrap]="titleComponent.subtitleWrap"
             [headingLevel]="headingLevel()"
+            [messageStripTemplate]="titleComponent.messageStripComponent()?.contentTemplateRef() ?? null"
         >
             @if (titleComponent.breadcrumbComponent) {
                 <fd-dynamic-page-breadcrumb>

--- a/libs/platform/dynamic-page/dynamic-page.component.spec.ts
+++ b/libs/platform/dynamic-page/dynamic-page.component.spec.ts
@@ -2,6 +2,7 @@ import { Component, ViewChild, input } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { MessageStripComponent } from '@fundamental-ngx/core/message-strip';
 import { TabsModule } from '@fundamental-ngx/core/tabs';
 import { ToolbarModule } from '@fundamental-ngx/core/toolbar';
 import { IconTabBarTabContentDirective } from '@fundamental-ngx/platform/icon-tab-bar';
@@ -337,5 +338,44 @@ describe('DynamicPageComponent Content Projection', () => {
 
     it('should project footer content', () => {
         expect(fixture.debugElement.query(By.css('#test-footer'))).toBeTruthy();
+    });
+});
+
+@Component({
+    template: `
+        <fdp-dynamic-page>
+            <fdp-dynamic-page-title title="Message strip title">
+                <fdp-dynamic-page-message-strip>
+                    <fd-message-strip type="success" [dismissible]="false">
+                        Operation completed successfully
+                    </fd-message-strip>
+                </fdp-dynamic-page-message-strip>
+            </fdp-dynamic-page-title>
+            <fdp-dynamic-page-header></fdp-dynamic-page-header>
+            <fdp-dynamic-page-content>DynamicPage Content Text</fdp-dynamic-page-content>
+        </fdp-dynamic-page>
+    `,
+    imports: [PlatformDynamicPageModule, MessageStripComponent]
+})
+class TestMessageStripProjectionComponent {}
+
+describe('DynamicPageComponent with message strip', () => {
+    let fixture: ComponentFixture<TestMessageStripProjectionComponent>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [TestMessageStripProjectionComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestMessageStripProjectionComponent);
+        fixture.detectChanges();
+    });
+
+    it('should render message strip inside the header container', () => {
+        const container = fixture.debugElement.query(By.css('.fd-dynamic-page__message-strip-container'));
+        expect(container).toBeTruthy();
+        expect(container.query(By.css('fd-message-strip'))).toBeTruthy();
     });
 });

--- a/libs/platform/dynamic-page/dynamic-page.module.ts
+++ b/libs/platform/dynamic-page/dynamic-page.module.ts
@@ -9,6 +9,7 @@ import { DynamicPageLayoutActionsComponent } from './dynamic-page-header/actions
 import { DynamicPageBreadcrumbComponent } from './dynamic-page-header/breadcrumb/dynamic-page-breadcrumb.component';
 import { DynamicPageHeaderComponent } from './dynamic-page-header/header/dynamic-page-header.component';
 import { DynamicPageKeyInfoComponent } from './dynamic-page-header/key-info/dynamic-page-key-info.component';
+import { DynamicPageMessageStripComponent } from './dynamic-page-header/message-strip/dynamic-page-message-strip.component';
 import { DynamicPageTitleImageComponent } from './dynamic-page-header/title/dynamic-page-title-image.component';
 import { DynamicPageTitleComponent } from './dynamic-page-header/title/dynamic-page-title.component';
 import { DynamicPageComponent } from './dynamic-page.component';
@@ -24,6 +25,7 @@ const components = [
     DynamicPageContentComponent,
     DynamicPageFooterComponent,
     DynamicPageTitleImageComponent,
+    DynamicPageMessageStripComponent,
     DynamicPageHeaderSubtitleDirective,
     DynamicPageHeaderTitleDirective
 ];

--- a/libs/platform/dynamic-page/index.ts
+++ b/libs/platform/dynamic-page/index.ts
@@ -16,6 +16,7 @@ export * from './dynamic-page-header/actions/layout-actions/dynamic-page-layout-
 export * from './dynamic-page-header/breadcrumb/dynamic-page-breadcrumb.component';
 export * from './dynamic-page-header/header/dynamic-page-header.component';
 export * from './dynamic-page-header/key-info/dynamic-page-key-info.component';
+export * from './dynamic-page-header/message-strip/dynamic-page-message-strip.component';
 export * from './dynamic-page-header/title/dynamic-page-title-image.component';
 export * from './dynamic-page-header/title/dynamic-page-title.component';
 export * from './dynamic-page.tokens';


### PR DESCRIPTION
## Related Issue(s)

closes https://github.com/SAP/fundamental-ngx/issues/14484

## Description
- fixed the spacings between the Facets in Dynamic Page (see the screenshots from the linked issue)
- added a Message Strip container that adds the appropriate spacings around a Message Strip in the header
- added the option to pass a message strip in the non-collapsible part of the header (also see the screenshots from the linked issue how it should show in collapses and non-collapsed state)
- updated Facets examples (Core and Platform)