### PR TITLE
fix(core): stop popover reposition loop feeding on its own overlay style writes (#14474)

### DIFF
--- a/libs/core/popover/popover-service/popover.service.spec.ts
+++ b/libs/core/popover/popover-service/popover.service.spec.ts
@@ -696,5 +696,88 @@ describe('PopoverService', () => {
 
             document.body.removeChild(orphan);
         });
+
+        // ---------------------------------------------------------------------------------------
+        // Regression: self-feeding reposition loop. updatePosition() writes `style` on the overlay's
+        // own position elements; the observer watches that subtree, so it reacts to its own writes
+        // and loops. The guard must ignore mutations inside the overlay while still repositioning
+        // for genuine external shifts (the sibling tests above).
+        describe('self-feeding reposition loop guard', () => {
+            it('should NOT call updatePosition for a style mutation originating inside its own overlay', () => {
+                service.open();
+                fixture.detectChanges();
+
+                const overlayElement = service['_overlayRef'].overlayElement;
+                // Simulate the mutation CDK itself emits when updatePosition() rewrites the
+                // overlay's position styles: an attribute change whose target is inside the overlay.
+                const selfCausedRecord = {
+                    type: 'attributes',
+                    attributeName: 'style',
+                    target: overlayElement
+                } as unknown as MutationRecord;
+
+                updatePositionSpy = jest.spyOn(service['_overlayRef'], 'updatePosition');
+
+                mutationCallback([selfCausedRecord], {} as MutationObserver);
+
+                // Reacting to our own style write is what re-arms the loop. It must be skipped.
+                expect(updatePositionSpy).not.toHaveBeenCalled();
+            });
+
+            it('should still reposition for a genuine sibling mutation outside the overlay', () => {
+                // Guard must be target-aware: real external layout shifts must still reposition.
+                service.open();
+                fixture.detectChanges();
+
+                updatePositionSpy = jest.spyOn(service['_overlayRef'], 'updatePosition');
+
+                const siblingRecord = {
+                    type: 'attributes',
+                    attributeName: 'style',
+                    target: component.siblingRef.nativeElement
+                } as unknown as MutationRecord;
+
+                mutationCallback([siblingRecord], {} as MutationObserver);
+
+                expect(updatePositionSpy).toHaveBeenCalled();
+            });
+
+            it('should NOT call updatePosition for a style mutation on the overlay position wrapper (parent of overlayElement)', () => {
+                // CDK writes the churning `style` on the position wrapper, not on overlayElement --
+                // and the wrapper is overlayElement's parent, nested under .cdk-overlay-container:
+                //
+                //   .cdk-overlay-container
+                //     └─ .cdk-overlay-connected-position-bounding-box   <- churning style writes
+                //          └─ .cdk-overlay-pane (= overlayElement)
+                //
+                // So a guard checking overlayElement.contains(target) misses the wrapper and the
+                // loop survives. This test reconstructs that ancestry to lock the container guard in.
+                service.open();
+                fixture.detectChanges();
+
+                const overlayElement = service['_overlayRef'].overlayElement;
+                const container = document.createElement('div');
+                container.className = 'cdk-overlay-container';
+                const boundingBox = document.createElement('div');
+                boundingBox.className = 'cdk-overlay-connected-position-bounding-box';
+                container.appendChild(boundingBox);
+                boundingBox.appendChild(overlayElement);
+                document.body.appendChild(container);
+
+                const wrapperRecord = {
+                    type: 'attributes',
+                    attributeName: 'style',
+                    target: boundingBox
+                } as unknown as MutationRecord;
+
+                updatePositionSpy = jest.spyOn(service['_overlayRef'], 'updatePosition');
+
+                mutationCallback([wrapperRecord], {} as MutationObserver);
+
+                expect(updatePositionSpy).not.toHaveBeenCalled();
+
+                container.remove();
+            });
+        });
     });
 });

--- a/libs/core/popover/popover-service/popover.service.ts
+++ b/libs/core/popover/popover-service/popover.service.ts
@@ -976,7 +976,16 @@ export class PopoverService {
         }
 
         let animationFrame: number | null = null;
-        const scheduleUpdate = (): void => {
+        const scheduleUpdate = (records: MutationRecord[]): void => {
+            // Skip self-caused mutations, else we loop: updatePosition() writes `style` on the
+            // overlay's position wrapper (.cdk-overlay-connected-position-bounding-box), which this
+            // observer would see and react to. Test against .cdk-overlay-container, not
+            // overlayElement -- the wrapper is overlayElement's parent, so it isn't contained by it.
+            const overlayEl = this._overlayRef?.overlayElement;
+            const overlayContainer = overlayEl?.closest('.cdk-overlay-container') ?? overlayEl;
+            if (overlayContainer && records.every((record) => overlayContainer.contains(record.target as Node))) {
+                return;
+            }
             if (animationFrame !== null) {
                 return;
             }


### PR DESCRIPTION
## What & why

Opening the toolbar's **"More"** overflow menu at mobile width could **spike CPU or crash the tab**.

The popover watches for layout shifts (via a `MutationObserver`) so it can reposition itself. But repositioning writes `style` on the CDK overlay — which the watcher is watching — so it reacted to its own movement and looped: **~1000 style-writes/second** while idle. A dog chasing its tail.

- **Zoneless** : 60 Hz spin, 5–9% CPU. Survivable.
- **Zoned** (`Eager`): each frame also runs full change detection → main thread saturates → **crash**. What the reporter hit.

## The fix

`popover.service.ts` — make the observer **ignore its own mutations**. The callback now bails when every mutation target sits inside the CDK overlay container:

```ts
const overlayEl = this._overlayRef?.overlayElement;
const overlayContainer = overlayEl?.closest('.cdk-overlay-container') ?? overlayEl;
if (overlayContainer && records.every((record) => overlayContainer.contains(record.target as Node))) {
    return;
}
```

- **Guard the container, not `overlayElement`** — CDK writes the churning `style` on the *position wrapper*, which is `overlayElement`'s **parent**, so a `overlayElement.contains()` check misses it and the loop survives.
- **`every`, not `some`** — a batch with any real external mutation still repositions, so the sibling-shift feature is preserved.

## How to review

**Reproduce (before) / confirm (after):** open the "More" menu at mobile width in a zoned Angular 22 app, leave it idle, and run in DevTools:

```js
let n = 0;
const mo = new MutationObserver(m => n += m.length);
mo.observe(document.body, { attributes: true, subtree: true, attributeFilter: ['style'] });
setTimeout(() => { mo.disconnect(); console.log('idle style mutations in 1s:', n); }, 1000);
```


Closes #14474
