### PR TITLE
feat(cdk, core): add onLocaleChange helper and migrate datetime locale effects

### DIFF
--- a/libs/cdk/utils/functions/index.ts
+++ b/libs/cdk/utils/functions/index.ts
@@ -7,6 +7,7 @@ export * from './is-odd';
 export * from './key-util';
 export * from './lodash-utils';
 export * from './module-deprecations-provider';
+export * from './on-locale-change';
 export * from './parser-file-size';
 export * from './random-color-accent';
 export * from './range';

--- a/libs/cdk/utils/functions/on-locale-change.spec.ts
+++ b/libs/cdk/utils/functions/on-locale-change.spec.ts
@@ -1,0 +1,58 @@
+import { Injector, runInInjectionContext, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { onLocaleChange } from './on-locale-change';
+
+describe('onLocaleChange', () => {
+    let injector: Injector;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        injector = TestBed.inject(Injector);
+    });
+
+    it('should NOT call fn on the initial (set-up) read', () => {
+        const locale = signal('en');
+        const fn = jest.fn();
+
+        runInInjectionContext(injector, () => {
+            onLocaleChange({ locale }, fn);
+        });
+
+        TestBed.tick();
+        expect(fn).not.toHaveBeenCalled();
+    });
+
+    it('should call fn on each subsequent locale change', () => {
+        const locale = signal('en');
+        const fn = jest.fn();
+
+        runInInjectionContext(injector, () => {
+            onLocaleChange({ locale }, fn);
+        });
+
+        TestBed.tick(); // initial read, skipped
+        expect(fn).not.toHaveBeenCalled();
+
+        locale.set('de');
+        TestBed.tick();
+        expect(fn).toHaveBeenCalledTimes(1);
+
+        locale.set('fr');
+        TestBed.tick();
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not call fn when locale is set to the same value', () => {
+        const locale = signal('en');
+        const fn = jest.fn();
+
+        runInInjectionContext(injector, () => {
+            onLocaleChange({ locale }, fn);
+        });
+
+        TestBed.tick();
+        locale.set('en'); // same value -> signal does not notify
+        TestBed.tick();
+        expect(fn).not.toHaveBeenCalled();
+    });
+});

--- a/libs/cdk/utils/functions/on-locale-change.ts
+++ b/libs/cdk/utils/functions/on-locale-change.ts
@@ -1,0 +1,20 @@
+import { effect } from '@angular/core';
+
+/**
+ * Run `fn` whenever `source.locale` changes, skipping the first
+ * (initialization) read. Must be called in an injection context.
+ *
+ * @param source Any object exposing a `locale` signal (e.g. a `DatetimeAdapter`).
+ * @param fn Recompute callback invoked on every locale change after the first.
+ */
+export function onLocaleChange(source: { locale: () => unknown }, fn: () => void): void {
+    let initiated = false;
+    effect(() => {
+        source.locale();
+        if (!initiated) {
+            initiated = true;
+            return;
+        }
+        fn();
+    });
+}

--- a/libs/core/calendar/calendar-header/calendar-header.component.ts
+++ b/libs/core/calendar/calendar-header/calendar-header.component.ts
@@ -2,7 +2,6 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    effect,
     ElementRef,
     EventEmitter,
     Input,
@@ -14,6 +13,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
+import { onLocaleChange } from '@fundamental-ngx/cdk/utils';
 import { DatetimeAdapter } from '@fundamental-ngx/core/datetime';
 
 import { ButtonComponent } from '@fundamental-ngx/core/button';
@@ -217,21 +217,15 @@ export class CalendarHeaderComponent<D> implements OnInit, OnChanges {
     private _amountOfYearsPerPeriod = 1;
 
     /** @hidden */
-    private _initiated = false;
-
-    /** @hidden */
     constructor(
         private _changeDetRef: ChangeDetectorRef,
         private _calendarService: CalendarService,
         private _dateTimeAdapter: DatetimeAdapter<D>
     ) {
-        effect(() => {
-            this._dateTimeAdapter.locale();
-            if (this._initiated) {
-                this._calculateMonthNames();
-                this._calculateLabels();
-                this._changeDetRef.markForCheck();
-            }
+        onLocaleChange(this._dateTimeAdapter, () => {
+            this._calculateMonthNames();
+            this._calculateLabels();
+            this._changeDetRef.markForCheck();
         });
     }
 
@@ -247,7 +241,6 @@ export class CalendarHeaderComponent<D> implements OnInit, OnChanges {
 
     /** @hidden */
     ngOnInit(): void {
-        this._initiated = true;
         this._calendarService.leftArrowId = this._prevButtonId;
 
         this._calculateMonthNames();

--- a/libs/core/calendar/calendar-views/calendar-aggregated-year-view/calendar-aggregated-year-view.component.ts
+++ b/libs/core/calendar/calendar-views/calendar-aggregated-year-view/calendar-aggregated-year-view.component.ts
@@ -12,10 +12,10 @@ import {
     Output,
     SimpleChanges,
     ViewEncapsulation,
-    effect,
     inject
 } from '@angular/core';
 
+import { onLocaleChange } from '@fundamental-ngx/cdk/utils';
 import { DATE_TIME_FORMATS, DateTimeFormats, DatetimeAdapter } from '@fundamental-ngx/core/datetime';
 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -138,12 +138,9 @@ export class CalendarAggregatedYearViewComponent<D> implements OnInit, OnChanges
         // default values
         this._currentYear = _dateTimeAdapter.getYear(_dateTimeAdapter.today());
 
-        effect(() => {
-            this._dateTimeAdapter.locale();
-            if (this._initiated) {
-                this._constructYearsGrid();
-                this._changeDetectorRef.markForCheck();
-            }
+        onLocaleChange(this._dateTimeAdapter, () => {
+            this._constructYearsGrid();
+            this._changeDetectorRef.markForCheck();
         });
     }
 

--- a/libs/core/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
+++ b/libs/core/calendar/calendar-views/calendar-day-view/calendar-day-view.component.ts
@@ -28,7 +28,7 @@ import { DateRange } from '../../models/date-range';
 
 import { NgClass } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { Nullable, onLocaleChange } from '@fundamental-ngx/cdk/utils';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { shallowEqual } from 'fast-equals';
 import { CalendarLegendFocusingService } from '../../calendar-legend/calendar-legend-focusing.service';
@@ -334,13 +334,10 @@ export class CalendarDayViewComponent<D> implements OnInit, OnChanges, Focusable
         });
 
         // Effect to react to locale changes
-        effect(() => {
-            this._dateTimeAdapter.locale();
-            if (this._isInitiated) {
-                this._refreshShortWeekDays();
-                this._buildDayViewGrid();
-                this.changeDetRef.markForCheck();
-            }
+        onLocaleChange(this._dateTimeAdapter, () => {
+            this._refreshShortWeekDays();
+            this._buildDayViewGrid();
+            this.changeDetRef.markForCheck();
         });
     }
 

--- a/libs/core/calendar/calendar-views/calendar-month-view/calendar-month-view.component.ts
+++ b/libs/core/calendar/calendar-views/calendar-month-view/calendar-month-view.component.ts
@@ -12,14 +12,13 @@ import {
     Output,
     SimpleChanges,
     ViewEncapsulation,
-    effect,
     inject
 } from '@angular/core';
 
 import { DATE_TIME_FORMATS, DateTimeFormats, DatetimeAdapter } from '@fundamental-ngx/core/datetime';
 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { Nullable, onLocaleChange } from '@fundamental-ngx/cdk/utils';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { CalendarService } from '../../calendar.service';
 import { CalendarMonth } from '../../models/calendar-month';
@@ -111,12 +110,9 @@ export class CalendarMonthViewComponent<D> implements OnInit, OnChanges, Focusab
         @Inject(DATE_TIME_FORMATS) private _dateTimeFormats: DateTimeFormats,
         private _dateTimeAdapter: DatetimeAdapter<D>
     ) {
-        effect(() => {
-            this._dateTimeAdapter.locale();
-            if (this._initiated) {
-                this._constructMonthGrid();
-                this._changeDetectorRef.markForCheck();
-            }
+        onLocaleChange(this._dateTimeAdapter, () => {
+            this._constructMonthGrid();
+            this._changeDetectorRef.markForCheck();
         });
     }
 

--- a/libs/core/calendar/calendar-views/calendar-year-view/calendar-year-view.component.ts
+++ b/libs/core/calendar/calendar-views/calendar-year-view/calendar-year-view.component.ts
@@ -12,14 +12,13 @@ import {
     Output,
     SimpleChanges,
     ViewEncapsulation,
-    effect,
     inject
 } from '@angular/core';
 
 import { DATE_TIME_FORMATS, DateTimeFormats, DatetimeAdapter } from '@fundamental-ngx/core/datetime';
 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { Nullable, onLocaleChange } from '@fundamental-ngx/cdk/utils';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { CalendarService } from '../../calendar.service';
 import { CalendarYear, CalendarYearGrid } from '../../models/calendar-year-grid';
@@ -146,12 +145,9 @@ export class CalendarYearViewComponent<D> implements OnInit, OnChanges, Focusabl
         this._currentYear = _dateTimeAdapter.getYear(_dateTimeAdapter.today());
         this._firstYearInList = this._currentYear;
 
-        effect(() => {
-            this._dateTimeAdapter.locale();
-            if (this._initiated) {
-                this._constructYearGrid();
-                this._changeDetectorRef.markForCheck();
-            }
+        onLocaleChange(this._dateTimeAdapter, () => {
+            this._constructYearGrid();
+            this._changeDetectorRef.markForCheck();
         });
     }
 

--- a/libs/core/calendar/calendar.component.ts
+++ b/libs/core/calendar/calendar.component.ts
@@ -2,7 +2,6 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    effect,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -23,7 +22,7 @@ import { ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator } fro
 import { DATE_TIME_FORMATS, DatetimeAdapter, DateTimeFormats } from '@fundamental-ngx/core/datetime';
 import { SpecialDayRule } from '@fundamental-ngx/core/shared';
 
-import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { Nullable, onLocaleChange } from '@fundamental-ngx/cdk/utils';
 import {
     ContentDensityModule,
     ContentDensityObserver,
@@ -351,8 +350,7 @@ export class CalendarComponent<D> implements OnInit, OnChanges, ControlValueAcce
         this.selectedDate = this._dateTimeAdapter.today();
         this._changeDetectorRef.markForCheck();
 
-        effect(() => {
-            this._dateTimeAdapter.locale();
+        onLocaleChange(this._dateTimeAdapter, () => {
             this._adapterStartingDayOfWeek = (this._dateTimeAdapter.getFirstDayOfWeek() + 1) as DaysOfWeek;
             this._changeDetectorRef.markForCheck();
         });

--- a/libs/core/date-picker/date-picker.component.ts
+++ b/libs/core/date-picker/date-picker.component.ts
@@ -7,7 +7,6 @@ import {
     Component,
     ComponentRef,
     DestroyRef,
-    effect,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -31,7 +30,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator } from '@angular/forms';
 import { FormStates } from '@fundamental-ngx/cdk/forms';
-import { DynamicComponentService, FocusTrapService, Nullable } from '@fundamental-ngx/cdk/utils';
+import { DynamicComponentService, FocusTrapService, Nullable, onLocaleChange } from '@fundamental-ngx/cdk/utils';
 import { BarComponent, BarElementDirective, BarRightDirective } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import {
@@ -526,8 +525,7 @@ export class DatePickerComponent<D>
             throw createMissingDateImplementationError('DATE_TIME_FORMATS');
         }
 
-        effect(() => {
-            this._dateTimeAdapter.locale();
+        onLocaleChange(this._dateTimeAdapter, () => {
             this.formatInputDate(this.selectedDate);
             this._changeDetectionRef.markForCheck();
         });

--- a/libs/core/datetime-picker/datetime-picker.component.ts
+++ b/libs/core/datetime-picker/datetime-picker.component.ts
@@ -5,7 +5,6 @@ import {
     ChangeDetectorRef,
     Component,
     ComponentRef,
-    effect,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -57,7 +56,7 @@ import { Placement, SpecialDayRule } from '@fundamental-ngx/core/shared';
 
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { FormStates } from '@fundamental-ngx/cdk/forms';
-import { DynamicComponentService, FocusTrapService, Nullable } from '@fundamental-ngx/cdk/utils';
+import { DynamicComponentService, FocusTrapService, Nullable, onLocaleChange } from '@fundamental-ngx/cdk/utils';
 import { BarComponent, BarElementDirective, BarRightDirective } from '@fundamental-ngx/core/bar';
 import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { MobileModeConfig } from '@fundamental-ngx/core/mobile-mode';
@@ -514,15 +513,12 @@ export class DatetimePickerComponent<D>
         // default model value
         this.date = _dateTimeAdapter.now();
 
-        let localeEffectInitialized = false;
-        effect(() => {
-            this._dateTimeAdapter.locale();
-            if (localeEffectInitialized && this._inputFieldDate) {
+        onLocaleChange(this._dateTimeAdapter, () => {
+            if (this._inputFieldDate) {
                 this._setInput(this.date);
                 this._calculateTimeOptions();
                 this._changeDetRef.markForCheck();
             }
-            localeEffectInitialized = true;
         });
     }
 

--- a/libs/core/time-picker/time-picker.component.ts
+++ b/libs/core/time-picker/time-picker.component.ts
@@ -3,7 +3,6 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    effect,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -45,7 +44,7 @@ import { TimeComponent } from '@fundamental-ngx/core/time';
 
 import { NgTemplateOutlet } from '@angular/common';
 import { FormStates } from '@fundamental-ngx/cdk/forms';
-import { Nullable } from '@fundamental-ngx/cdk/utils';
+import { Nullable, onLocaleChange } from '@fundamental-ngx/cdk/utils';
 import { FdTranslatePipe } from '@fundamental-ngx/i18n';
 import { createMissingDateImplementationError } from './errors';
 
@@ -342,8 +341,7 @@ export class TimePickerComponent<D>
             throw createMissingDateImplementationError('DATE_TIME_FORMATS');
         }
 
-        effect(() => {
-            this._dateTimeAdapter.locale();
+        onLocaleChange(this._dateTimeAdapter, () => {
             this._calculateTimeOptions();
             this._formatTimeInputField();
             this._changeDetectorRef.markForCheck();

--- a/libs/core/time/time.component.ts
+++ b/libs/core/time/time.component.ts
@@ -5,7 +5,6 @@ import {
     ChangeDetectorRef,
     Component,
     computed,
-    effect,
     ElementRef,
     forwardRef,
     inject,
@@ -21,7 +20,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-import { KeyUtil, RtlService } from '@fundamental-ngx/cdk/utils';
+import { KeyUtil, onLocaleChange, RtlService } from '@fundamental-ngx/cdk/utils';
 import { DatetimeAdapter } from '@fundamental-ngx/core/datetime';
 
 import { ContentDensityObserver, contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
@@ -207,8 +206,7 @@ export class TimeComponent<D> implements OnInit, OnChanges, AfterViewInit, Contr
 
         this.time = this._getDefaultValue();
 
-        effect(() => {
-            this._dateTimeAdapter.locale();
+        onLocaleChange(this._dateTimeAdapter, () => {
             this._setUpViewGrid();
             this._changeDetectorRef.markForCheck();
         });


### PR DESCRIPTION
## Summary

- Adds `onLocaleChange(source, fn)` to `@fundamental-ngx/cdk/utils` — a CDK helper that runs a callback whenever a locale signal changes, skipping the initialization read. Standardizes the inconsistent post-#14016 locale-effect pattern across datetime components.
- Migrates 10 core datetime components (calendar views, calendar header, date-picker, datetime-picker, time-picker, time) from hand-rolled `effect` + skip-first-run guards to `onLocaleChange`.
- The helper uses a structural type `{ locale: () => unknown }` to stay within the `scope:cdk` module boundary — no new dependency on `DatetimeAdapter` in `cdk`.

Closes #14226

## Test plan

- [ ] **In-browser locale recompute** : open the datetime-picker *i18n* example, switch adapter locale en-us → fr — formatted date/time should flip to French format. Open the time-picker *Locale* example, switch en-US → ar-EG — value should render in Arabic-Indic numerals.
- [ ] Browser console shows no new Angular errors on the above pages (one pre-existing `FD_LANGUAGE is deprecated` error in the datetime-picker complex-i18n example is unrelated to this PR).