### PR TITLE
fix(core, platform): update multi-combobox tokens and reset selected flags on programmatic selectedItems change (#13553)

### DIFF
--- a/libs/core/multi-combobox/base-multi-combobox.class.ts
+++ b/libs/core/multi-combobox/base-multi-combobox.class.ts
@@ -730,6 +730,10 @@ export abstract class BaseMultiCombobox<T = any> {
             this._flatSuggestions.set(this.isGroup() ? flattenGroups(currentSuggestions) : currentSuggestions);
             this._fullFlatSuggestions.set(this._flatSuggestions());
 
+            if (!this._selectedItems().length && this._cva.value?.length) {
+                this._setSelectedItems(this._cva.value);
+            }
+
             this._setSelectedSuggestions();
 
             this._mapAndUpdateModel();

--- a/libs/core/multi-combobox/multi-combobox.component.spec.ts
+++ b/libs/core/multi-combobox/multi-combobox.component.spec.ts
@@ -1,8 +1,8 @@
 import { A } from '@angular/cdk/keycodes';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { Type } from '@angular/core';
+import { Component, Type } from '@angular/core';
 import { ComponentFixture, inject, TestBed, waitForAsync } from '@angular/core/testing';
-import { ControlValueAccessor, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ControlValueAccessor, FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { isSelectableOptionItem } from '@fundamental-ngx/cdk/forms';
 import { ContentDensityMode, mockedLocalContentDensityDirective } from '@fundamental-ngx/core/content-density';
 import { CVATestSteps, runValueAccessorTests } from 'ngx-cva-test-suite';
@@ -358,6 +358,222 @@ describe('MultiComboBox component', () => {
 
             expect(component._suggestions().some((item) => item.label === 'Blue')).toBe(true);
         });
+    });
+});
+
+describe('MultiComboBox — programmatic selectedItems (#13553)', () => {
+    let component: MultiComboboxComponent;
+    let fixture: ComponentFixture<MultiComboboxComponent>;
+    let overlayContainerEl: HTMLElement;
+
+    const dataSource = [
+        { name: 'Apple', type: 'Fruits' },
+        { name: 'Banana', type: 'Fruits' },
+        { name: 'Pineapple', type: 'Fruits' }
+    ];
+
+    function getTokenLabels(): string[] {
+        return Array.from(fixture.nativeElement.querySelectorAll('fd-token')).map((el) =>
+            (el as HTMLElement).textContent!.trim()
+        );
+    }
+
+    function getSelectedLabels(): string[] {
+        return Array.from(overlayContainerEl.querySelectorAll('li.fd-list__item.is-selected[role="option"]')).map(
+            (el) => (el as HTMLElement).textContent!.trim()
+        );
+    }
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [FormsModule, ReactiveFormsModule, MultiComboboxModule]
+        }).compileComponents();
+
+        inject([OverlayContainer], (overlayContainer: OverlayContainer) => {
+            overlayContainerEl = overlayContainer.getContainerElement();
+        })();
+    }));
+
+    beforeEach(waitForAsync(() => {
+        fixture = TestBed.createComponent(MultiComboboxComponent);
+        component = fixture.componentInstance;
+        fixture.componentRef.setInput('displayKey', 'name');
+        component.dataSourceDirective.dataSource = dataSource;
+        fixture.detectChanges();
+    }));
+
+    it('add (regression): [] → [Apple, Banana] via [selectedItems] without opening dropdown renders tokens', () => {
+        fixture.componentRef.setInput('selectedItems', [dataSource[0], dataSource[1]]);
+        fixture.detectChanges();
+
+        const labels = getTokenLabels();
+        expect(labels).toContain('Apple');
+        expect(labels).toContain('Banana');
+        expect(labels.length).toBe(2);
+    });
+
+    it('replace: [Apple] → [Banana] via [selectedItems] renders only Banana token; reopen shows only Banana checked', async () => {
+        fixture.componentRef.setInput('selectedItems', [dataSource[0]]);
+        fixture.detectChanges();
+        expect(getTokenLabels()).toEqual(['Apple']);
+
+        fixture.componentRef.setInput('selectedItems', [dataSource[1]]);
+        fixture.detectChanges();
+
+        const labels = getTokenLabels();
+        expect(labels).toEqual(['Banana']);
+
+        // Reopen-state assertion via signal — CDK overlay in jsdom doesn't reliably render
+        // is-selected on fd-list-item after a programmatic replace without user interaction.
+        // _setSelectedSuggestions() updates _fullFlatSuggestions (not _suggestions), so assert there.
+        const flat = component._fullFlatSuggestions();
+        const apple = flat.find((s) => s.label === 'Apple');
+        const banana = flat.find((s) => s.label === 'Banana');
+        expect(apple?.selected).toBe(false);
+        expect(banana?.selected).toBe(true);
+    });
+
+    it('clear: [Apple, Banana] → [] via [selectedItems] renders no tokens; reopen shows nothing checked', async () => {
+        fixture.componentRef.setInput('selectedItems', [dataSource[0], dataSource[1]]);
+        fixture.detectChanges();
+        expect(getTokenLabels().length).toBe(2);
+
+        fixture.componentRef.setInput('selectedItems', []);
+        fixture.detectChanges();
+
+        expect(getTokenLabels().length).toBe(0);
+
+        component._onPrimaryButtonClick(component.isOpen);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const selectedInOverlay = getSelectedLabels();
+        expect(selectedInOverlay.length).toBe(0);
+    });
+});
+
+@Component({
+    template: `<fd-multi-combobox displayKey="name" [formControl]="control"></fd-multi-combobox>`,
+    imports: [MultiComboboxModule, ReactiveFormsModule]
+})
+class MultiComboboxWithFormControlTestComponent {
+    control = new FormControl<{ name: string; type: string }[]>([]);
+}
+
+describe('MultiComboBox — FormControl.setValue() CVA path (#13553)', () => {
+    const formDataSource = [
+        { name: 'Apple', type: 'Fruits' },
+        { name: 'Banana', type: 'Fruits' },
+        { name: 'Pineapple', type: 'Fruits' }
+    ];
+
+    let hostFixture: ComponentFixture<MultiComboboxWithFormControlTestComponent>;
+    let host: MultiComboboxWithFormControlTestComponent;
+    let combobox: MultiComboboxComponent;
+
+    function getTokenLabels(): string[] {
+        return Array.from(hostFixture.nativeElement.querySelectorAll('fd-token')).map((el) =>
+            (el as HTMLElement).textContent!.trim()
+        );
+    }
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [FormsModule, ReactiveFormsModule, MultiComboboxModule, MultiComboboxWithFormControlTestComponent]
+        }).compileComponents();
+    }));
+
+    beforeEach(waitForAsync(() => {
+        hostFixture = TestBed.createComponent(MultiComboboxWithFormControlTestComponent);
+        host = hostFixture.componentInstance;
+        combobox = hostFixture.debugElement.query(By.directive(MultiComboboxComponent)).componentInstance;
+        combobox.dataSourceDirective.dataSource = formDataSource;
+        hostFixture.detectChanges();
+        // Wait for data source to populate _fullFlatSuggestions
+        return hostFixture.whenStable();
+    }));
+
+    it('FormControl.setValue() without [selectedItems] binding renders tokens and updates suggestion state', async () => {
+        // Precondition: no tokens, no selected suggestions
+        expect(getTokenLabels().length).toBe(0);
+        expect(combobox._selectedSuggestions().length).toBe(0);
+
+        // Act: programmatic setValue via FormControl (the CVA path — no [selectedItems] binding)
+        host.control.setValue([formDataSource[0], formDataSource[1]]);
+        hostFixture.detectChanges();
+        await hostFixture.whenStable();
+        hostFixture.detectChanges();
+
+        // Assert: tokens repaint
+        const labels = getTokenLabels();
+        expect(labels).toContain('Apple');
+        expect(labels).toContain('Banana');
+        expect(labels.length).toBe(2);
+
+        // Assert: internal suggestion state consistent
+        const flat = combobox._fullFlatSuggestions();
+        const apple = flat.find((s) => s.label === 'Apple');
+        const banana = flat.find((s) => s.label === 'Banana');
+        const pineapple = flat.find((s) => s.label === 'Pineapple');
+        expect(apple?.selected).toBe(true);
+        expect(banana?.selected).toBe(true);
+        expect(pineapple?.selected).toBe(false);
+    });
+});
+
+@Component({
+    template: `<fd-multi-combobox displayKey="name" [formControl]="control"></fd-multi-combobox>`,
+    imports: [MultiComboboxModule, ReactiveFormsModule]
+})
+class MultiComboboxWithPresetFormControlTestComponent {
+    readonly formDataSource = [
+        { name: 'Apple', type: 'Fruits' },
+        { name: 'Banana', type: 'Fruits' },
+        { name: 'Pineapple', type: 'Fruits' }
+    ];
+    control = new FormControl<{ name: string; type: string }[]>([this.formDataSource[0]]);
+}
+
+describe('MultiComboBox — FormControl initial value renders on datasource populate (#13553)', () => {
+    let hostFixture: ComponentFixture<MultiComboboxWithPresetFormControlTestComponent>;
+    let combobox: MultiComboboxComponent;
+
+    function getTokenLabels(): string[] {
+        return Array.from(hostFixture.nativeElement.querySelectorAll('fd-token')).map((el) =>
+            (el as HTMLElement).textContent!.trim()
+        );
+    }
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                FormsModule,
+                ReactiveFormsModule,
+                MultiComboboxModule,
+                MultiComboboxWithPresetFormControlTestComponent
+            ]
+        }).compileComponents();
+    }));
+
+    beforeEach(waitForAsync(() => {
+        hostFixture = TestBed.createComponent(MultiComboboxWithPresetFormControlTestComponent);
+        const host = hostFixture.componentInstance;
+        combobox = hostFixture.debugElement.query(By.directive(MultiComboboxComponent)).componentInstance;
+        combobox.dataSourceDirective.dataSource = host.formDataSource;
+        hostFixture.detectChanges();
+        return hostFixture.whenStable();
+    }));
+
+    it('FormControl initialized with a value renders tokens on load without opening the dropdown', async () => {
+        hostFixture.detectChanges();
+        await hostFixture.whenStable();
+        hostFixture.detectChanges();
+
+        const labels = getTokenLabels();
+        expect(labels).toContain('Apple');
+        expect(labels.length).toBe(1);
+        expect(combobox.isOpen).toBe(false);
     });
 });
 

--- a/libs/core/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/multi-combobox/multi-combobox.component.ts
@@ -54,7 +54,7 @@ import { PopoverFillMode } from '@fundamental-ngx/core/shared';
 import { contentDensityObserverProviders } from '@fundamental-ngx/core/content-density';
 import { TokenComponent, TokenizerComponent } from '@fundamental-ngx/core/token';
 import { Subject } from 'rxjs';
-import { debounceTime } from 'rxjs/operators';
+import { debounceTime, filter } from 'rxjs/operators';
 import { BaseMultiCombobox } from './base-multi-combobox.class';
 import { MobileMultiComboboxComponent } from './mobile/mobile-multi-combobox.component';
 import { MULTI_COMBOBOX_COMPONENT } from './multi-combobox.token';
@@ -576,6 +576,17 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
         this._assignCustomTemplates();
 
         this._initWindowResize();
+
+        this._cva.stateChanges
+            .pipe(
+                filter((event) => event === 'writeValue'),
+                takeUntilDestroyed(this._destroyRef)
+            )
+            .subscribe(() => {
+                if (this._fullFlatSuggestions().length) {
+                    this._setSelectedItems(this._cva.value);
+                }
+            });
     }
 
     /** @hidden */
@@ -927,6 +938,9 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
      */
     protected _setSelectedItems(value: T[]): void {
         this._selectedItems.set(coerceArraySafe(value));
+        if (this._fullFlatSuggestions().length) {
+            this._setSelectedSuggestions();
+        }
     }
 
     /**

--- a/libs/core/multi-combobox/multi-combobox.component.ts
+++ b/libs/core/multi-combobox/multi-combobox.component.ts
@@ -577,6 +577,9 @@ export class MultiComboboxComponent<T = any> extends BaseMultiCombobox<T> implem
 
         this._initWindowResize();
 
+        // Sync selected items when FormControl.setValue() is called (CVA.writeValue event).
+        // This catches programmatic value updates even without a [selectedItems] binding.
+        // Requires datasource to be populated for the lookup to succeed.
         this._cva.stateChanges
             .pipe(
                 filter((event) => event === 'writeValue'),

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.html
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.html
@@ -1,20 +1,43 @@
+<!-- Two idioms for multi-combobox state management:
+     1. Reactive Forms with CVA: Use FormControl + [formControlName] for form-integrated selection.
+     2. Pure Signal-based: Use signal() for lightweight local state without form overhead.
+-->
+
 <form [formGroup]="customForm">
+    <!-- Idiom 1: Reactive Forms with two-way binding via CVA -->
     <div fd-form-item>
-        <label fd-form-label for="field">Select some fruits:</label>
+        <label fd-form-label for="reactiveFormsCombo">Reactive Forms (FormControl + CVA):</label>
         <fd-multi-combobox
-            name="field"
-            inputId="field"
-            placeholder="Type some text..."
+            name="reactiveFormsCombo"
+            inputId="reactiveFormsCombo"
+            placeholder="Select items..."
             [dataSource]="dataSource"
             displayKey="name"
-            (selectionChange)="onSelect($event)"
-            formControlName="field"
-            [selectedItems]="selectedItems"
+            formControlName="reactiveFormsCombo"
         ></fd-multi-combobox>
+        <p>Form Value: {{ customForm.controls.reactiveFormsCombo.value | json }}</p>
+        <div>
+            <button fd-button type="button" (click)="selectAllFruits()">Select All Fruits</button>
+            <button fd-button type="button" (click)="clearReactiveForm()">Clear</button>
+        </div>
     </div>
-    <p>Selected Item: {{ selectedItems | json }}</p>
-    <p>Form Selected Item: {{ customForm.getRawValue() | json }}</p>
-    <p>Dirty: {{ customForm.controls.field.dirty }}</p>
-    <p>Touched: {{ customForm.controls.field.touched }}</p>
-    <p>Pristine: {{ customForm.controls.field.pristine }}</p>
 </form>
+
+<!-- Idiom 2: Pure signal-based state (no FormControl) -->
+<div fd-form-item>
+    <label fd-form-label for="pureSignalCombo">Pure Signal-based:</label>
+    <fd-multi-combobox
+        name="pureSignalCombo"
+        inputId="pureSignalCombo"
+        placeholder="Select items..."
+        [dataSource]="dataSource"
+        displayKey="name"
+        (selectionChange)="onPureSignalChange($event)"
+        [selectedItems]="pureSignalSelection()"
+    ></fd-multi-combobox>
+    <p>Signal Value: {{ pureSignalSelection() | json }}</p>
+    <div>
+        <button fd-button type="button" (click)="selectAllVegetables()">Select All Vegetables</button>
+        <button fd-button type="button" (click)="clearSignal()">Clear</button>
+    </div>
+</div>

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.ts
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.ts
@@ -51,12 +51,10 @@ export class MultiComboboxFormsExampleComponent {
     selectAllFruits(): void {
         const fruits = this.dataSource.filter((item) => item.type === 'Fruits');
         this.reactiveFormControl.setValue(fruits);
-        this.customForm.updateValueAndValidity();
     }
 
     clearReactiveForm(): void {
         this.reactiveFormControl.setValue([]);
-        this.customForm.updateValueAndValidity();
     }
 
     // Programmatic updates via signal

--- a/libs/docs/core/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.ts
+++ b/libs/docs/core/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.ts
@@ -1,11 +1,11 @@
 import { JsonPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DataSourceDirective } from '@fundamental-ngx/cdk/data-source';
 import { CvaDirective } from '@fundamental-ngx/cdk/forms';
+import { ButtonComponent } from '@fundamental-ngx/core/button';
 import { FormItemComponent, FormLabelComponent } from '@fundamental-ngx/core/form';
 import { MultiComboboxComponent, MultiComboboxSelectionChangeEvent } from '@fundamental-ngx/core/multi-combobox';
-
 @Component({
     selector: 'fd-multi-combobox-forms-example',
     templateUrl: './multi-combobox-forms-example.component.html',
@@ -18,6 +18,7 @@ import { MultiComboboxComponent, MultiComboboxSelectionChangeEvent } from '@fund
         CvaDirective,
         DataSourceDirective,
         MultiComboboxComponent,
+        ButtonComponent,
         JsonPipe
     ]
 })
@@ -33,13 +34,38 @@ export class MultiComboboxFormsExampleComponent {
         { name: 'Spinach', type: 'Vegetables' }
     ];
 
+    // Idiom 1: Reactive Forms with CVA directive binding
+    reactiveFormControl = new FormControl<typeof this.dataSource>([this.dataSource[3]]);
     customForm = new FormGroup({
-        field: new FormControl(this.dataSource[3])
+        reactiveFormsCombo: this.reactiveFormControl
     });
 
-    selectedItems = [this.dataSource[3]];
+    // Idiom 2: Pure signal-based state (no FormControl)
+    pureSignalSelection = signal([this.dataSource[3], this.dataSource[4]]);
 
-    onSelect(item: MultiComboboxSelectionChangeEvent): void {
-        this.selectedItems = item.selectedItems;
+    onPureSignalChange(item: MultiComboboxSelectionChangeEvent): void {
+        this.pureSignalSelection.set(item.selectedItems);
+    }
+
+    // Programmatic updates via FormControl
+    selectAllFruits(): void {
+        const fruits = this.dataSource.filter((item) => item.type === 'Fruits');
+        this.reactiveFormControl.setValue(fruits);
+        this.customForm.updateValueAndValidity();
+    }
+
+    clearReactiveForm(): void {
+        this.reactiveFormControl.setValue([]);
+        this.customForm.updateValueAndValidity();
+    }
+
+    // Programmatic updates via signal
+    selectAllVegetables(): void {
+        const vegetables = this.dataSource.filter((item) => item.type === 'Vegetables');
+        this.pureSignalSelection.set(vegetables);
+    }
+
+    clearSignal(): void {
+        this.pureSignalSelection.set([]);
     }
 }

--- a/libs/docs/platform/multi-combobox/examples/multi-combobox-delayed-datasource/multi-combobox-delayed-datasource-example.component.html
+++ b/libs/docs/platform/multi-combobox/examples/multi-combobox-delayed-datasource/multi-combobox-delayed-datasource-example.component.html
@@ -1,0 +1,24 @@
+<div>
+    <h3>Delayed Datasource Scenario</h3>
+
+    <button fd-button type="button" (click)="setValueBeforeDataload()">1. Set Banana + Carrot (before load)</button>
+
+    <button fd-button type="button" (click)="loadDataSourceDelayed()">2. Load Datasource (2 sec delay)</button>
+
+    <p>
+        Current State <strong>Datasource:</strong>
+        {{ dataSource().length === 0 ? 'EMPTY (not loaded yet)' : dataSource().length + ' items loaded' }}
+        <strong>Form Value:</strong>
+        <code>{{ formControl.value | json }}</code>
+    </p>
+
+    <fdp-multi-combobox
+        [dataSource]="dataSource()"
+        displayKey="name"
+        [formControl]="formControl"
+        placeholder="Select items (datasource delayed)..."
+        style="width: 100%; max-width: 400px"
+    ></fdp-multi-combobox>
+
+    <button fd-button type="button" (click)="reset()">Reset</button>
+</div>

--- a/libs/docs/platform/multi-combobox/examples/multi-combobox-delayed-datasource/multi-combobox-delayed-datasource-example.component.ts
+++ b/libs/docs/platform/multi-combobox/examples/multi-combobox-delayed-datasource/multi-combobox-delayed-datasource-example.component.ts
@@ -1,0 +1,63 @@
+import { JsonPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@fundamental-ngx/core/button';
+import { PlatformMultiComboboxModule } from '@fundamental-ngx/platform/form';
+
+/**
+ * Test scenario: Set selectedItems BEFORE datasource loads.
+ *
+ * This component intentionally delays datasource population to test
+ * whether the multi-combobox can handle:
+ * 1. Setting selectedItems via FormControl.setValue() before data is ready
+ * 2. Once datasource loads, verify tokens and checkboxes reconcile correctly
+ */
+@Component({
+    selector: 'fdp-multi-combobox-delayed-datasource-example',
+    templateUrl: './multi-combobox-delayed-datasource-example.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [ReactiveFormsModule, PlatformMultiComboboxModule, ButtonComponent, JsonPipe]
+})
+export class MultiComboboxDelayedDatasourceExampleComponent {
+    // Datasource starts empty, populated after delay
+    dataSource = signal<{ name: string; type: string }[]>([]);
+
+    // FormControl with initial value (set BEFORE datasource loads)
+    formControl = new FormControl<{ name: string; type: string }[]>([]);
+
+    // Trigger to simulate external data load
+    loadDataSourceDelayed(): void {
+        console.log('Loading datasource after 2 seconds...');
+        setTimeout(() => {
+            const data = [
+                { name: 'Apple', type: 'Fruits' },
+                { name: 'Banana', type: 'Fruits' },
+                { name: 'Pineapple', type: 'Fruits' },
+                { name: 'Strawberry', type: 'Fruits' },
+                { name: 'Broccoli', type: 'Vegetables' },
+                { name: 'Carrot', type: 'Vegetables' },
+                { name: 'Jalapeño', type: 'Vegetables' },
+                { name: 'Spinach', type: 'Vegetables' }
+            ];
+            this.dataSource.set(data);
+            console.log('Datasource loaded:', data);
+        }, 2000);
+    }
+
+    // Set selected items BEFORE datasource loads
+    setValueBeforeDataload(): void {
+        const selectedItems = [
+            { name: 'Banana', type: 'Fruits' },
+            { name: 'Carrot', type: 'Vegetables' }
+        ];
+        console.log('Setting formControl value BEFORE datasource loads:', selectedItems);
+        this.formControl.setValue(selectedItems);
+    }
+
+    // Clear for re-testing
+    reset(): void {
+        this.dataSource.set([]);
+        this.formControl.setValue([]);
+        console.log('Reset: datasource cleared, form value cleared');
+    }
+}

--- a/libs/docs/platform/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.html
+++ b/libs/docs/platform/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.html
@@ -1,18 +1,43 @@
-<fdp-form-group [noLabelLayout]="false" [formGroup]="customForm">
-    <fdp-form-field id="field" label="Array of Strings">
+<!-- Two idioms for multi-combobox state management:
+     1. Reactive Forms with CVA: Use FormControl + [formControlName] for form-integrated selection.
+     2. Pure Signal-based: Use signal() for lightweight local state without form overhead.
+-->
+
+<form [formGroup]="customForm">
+    <!-- Idiom 1: Reactive Forms with two-way binding via CVA -->
+    <div>
+        <label for="reactiveFormsCombo">Reactive Forms (FormControl + CVA):</label>
         <fdp-multi-combobox
-            name="field"
-            placeholder="Type some text..."
+            name="reactiveFormsCombo"
+            inputId="reactiveFormsCombo"
+            placeholder="Select items..."
             [dataSource]="dataSource"
             displayKey="name"
-            (selectionChange)="onSelect($event)"
-            formControlName="field"
-            [selectedItems]="selectedItems"
+            formControlName="reactiveFormsCombo"
         ></fdp-multi-combobox>
-        <p>Selected Item: {{ selectedItems | json }}</p>
-        <p>Form Selected Item: {{ customForm.getRawValue() | json }}</p>
-        <p>Dirty: {{ customForm.controls.field.dirty }}</p>
-        <p>Touched: {{ customForm.controls.field.touched }}</p>
-        <p>Pristine: {{ customForm.controls.field.pristine }}</p>
-    </fdp-form-field>
-</fdp-form-group>
+        <p>Form Value: {{ customForm.controls.reactiveFormsCombo.value | json }}</p>
+        <div>
+            <button fd-button type="button" (click)="selectAllFruits()">Select All Fruits</button>
+            <button fd-button type="button" (click)="clearReactiveForm()">Clear</button>
+        </div>
+    </div>
+</form>
+
+<!-- Idiom 2: Pure signal-based state (no FormControl) -->
+<div>
+    <label for="pureSignalCombo">Pure Signal-based:</label>
+    <fdp-multi-combobox
+        name="pureSignalCombo"
+        inputId="pureSignalCombo"
+        placeholder="Select items..."
+        [dataSource]="dataSource"
+        displayKey="name"
+        (selectionChange)="onPureSignalChange($event)"
+        [selectedItems]="pureSignalSelection()"
+    ></fdp-multi-combobox>
+    <p>Signal Value: {{ pureSignalSelection() | json }}</p>
+    <div>
+        <button fd-button type="button" (click)="selectAllVegetables()">Select All Vegetables</button>
+        <button fd-button type="button" (click)="clearSignal()">Clear</button>
+    </div>
+</div>

--- a/libs/docs/platform/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.ts
+++ b/libs/docs/platform/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.ts
@@ -1,20 +1,18 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
-
 import { JsonPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@fundamental-ngx/core/button';
 import {
     FdpFormGroupModule,
     MultiComboboxSelectionChangeEvent,
     PlatformMultiComboboxModule
 } from '@fundamental-ngx/platform/form';
-import { DATA_PROVIDERS } from '@fundamental-ngx/platform/shared';
 
 @Component({
     selector: 'fdp-multi-combobox-forms-example',
     templateUrl: './multi-combobox-forms-example.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [{ provide: DATA_PROVIDERS, useValue: new Map() }],
-    imports: [FdpFormGroupModule, FormsModule, ReactiveFormsModule, PlatformMultiComboboxModule, JsonPipe]
+    imports: [ReactiveFormsModule, FdpFormGroupModule, PlatformMultiComboboxModule, ButtonComponent, JsonPipe]
 })
 export class MultiComboboxFormsExampleComponent {
     dataSource = [
@@ -28,13 +26,38 @@ export class MultiComboboxFormsExampleComponent {
         { name: 'Spinach', type: 'Vegetables' }
     ];
 
+    // Idiom 1: Reactive Forms with CVA directive binding
+    reactiveFormControl = new FormControl<typeof this.dataSource>([this.dataSource[3]]);
     customForm = new FormGroup({
-        field: new FormControl(this.dataSource[3])
+        reactiveFormsCombo: this.reactiveFormControl
     });
 
-    selectedItems = [this.dataSource[3]];
+    // Idiom 2: Pure signal-based state (no FormControl)
+    pureSignalSelection = signal([this.dataSource[3], this.dataSource[4]]);
 
-    onSelect(item: MultiComboboxSelectionChangeEvent): void {
-        this.selectedItems = item.selectedItems;
+    onPureSignalChange(item: MultiComboboxSelectionChangeEvent): void {
+        this.pureSignalSelection.set(item.selectedItems);
+    }
+
+    // Programmatic updates via FormControl
+    selectAllFruits(): void {
+        const fruits = this.dataSource.filter((item) => item.type === 'Fruits');
+        this.reactiveFormControl.setValue(fruits);
+        this.customForm.updateValueAndValidity();
+    }
+
+    clearReactiveForm(): void {
+        this.reactiveFormControl.setValue([]);
+        this.customForm.updateValueAndValidity();
+    }
+
+    // Programmatic updates via signal
+    selectAllVegetables(): void {
+        const vegetables = this.dataSource.filter((item) => item.type === 'Vegetables');
+        this.pureSignalSelection.set(vegetables);
+    }
+
+    clearSignal(): void {
+        this.pureSignalSelection.set([]);
     }
 }

--- a/libs/docs/platform/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.ts
+++ b/libs/docs/platform/multi-combobox/examples/multi-combobox-forms/multi-combobox-forms-example.component.ts
@@ -43,12 +43,10 @@ export class MultiComboboxFormsExampleComponent {
     selectAllFruits(): void {
         const fruits = this.dataSource.filter((item) => item.type === 'Fruits');
         this.reactiveFormControl.setValue(fruits);
-        this.customForm.updateValueAndValidity();
     }
 
     clearReactiveForm(): void {
         this.reactiveFormControl.setValue([]);
-        this.customForm.updateValueAndValidity();
     }
 
     // Programmatic updates via signal

--- a/libs/docs/platform/multi-combobox/platform-multi-combobox-docs.component.html
+++ b/libs/docs/platform/multi-combobox/platform-multi-combobox-docs.component.html
@@ -90,6 +90,27 @@
 
 <separator></separator>
 
+<fd-docs-section-title id="delayed-datasource" componentName="multi-combobox">
+    Programmatic Value Set Before Datasource Loads
+</fd-docs-section-title>
+<description>
+    <p>
+        This example tests an edge case: setting the form value programmatically <strong>before</strong> the datasource
+        has loaded. Once the datasource populates, the component should reconcile the selected items and update both
+        tokens and dropdown checkboxes.
+    </p>
+    <p>
+        <strong>Use case:</strong> When a form is restored from saved state or URL parameters before async data loads,
+        the component should correctly identify and display matching items once they arrive.
+    </p>
+</description>
+<component-example>
+    <fdp-multi-combobox-delayed-datasource-example></fdp-multi-combobox-delayed-datasource-example>
+</component-example>
+<code-example [exampleFiles]="multiComboboxDelayedDatasourceExample"></code-example>
+
+<separator></separator>
+
 <fd-docs-section-title id="loading" componentName="multi-combobox"> Loading </fd-docs-section-title>
 <description>
     Combobox exposes <code>onDataRequested</code> and <code>onDataReceived</code> outputs, that can be used to implement

--- a/libs/docs/platform/multi-combobox/platform-multi-combobox-docs.component.ts
+++ b/libs/docs/platform/multi-combobox/platform-multi-combobox-docs.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@fundamental-ngx/docs/shared';
 import { MultiComboboxColumnsExampleComponent } from './examples/multi-combobox-columns/multi-combobox-columns-example.component';
 import { MultiComboboxDatasourceExampleComponent } from './examples/multi-combobox-datasource/multi-combobox-datasource-example.component';
+import { MultiComboboxDelayedDatasourceExampleComponent } from './examples/multi-combobox-delayed-datasource/multi-combobox-delayed-datasource-example.component';
 import { MultiComboboxFormsExampleComponent } from './examples/multi-combobox-forms/multi-combobox-forms-example.component';
 import { MultiComboboxGroupExampleComponent } from './examples/multi-combobox-group/multi-combobox-group-example.component';
 import { MultiComboboxLoadingExampleComponent } from './examples/multi-combobox-loading/multi-combobox-loading-example.component';
@@ -25,6 +26,10 @@ const multiComboboxMobileHtml = 'multi-combobox-mobile/multi-combobox-mobile-exa
 const multiComboboxMobileTs = 'multi-combobox-mobile/multi-combobox-mobile-example.component.ts';
 const multiComboboxFormsHtml = 'multi-combobox-forms/multi-combobox-forms-example.component.html';
 const multiComboboxFormsTs = 'multi-combobox-forms/multi-combobox-forms-example.component.ts';
+const multiComboboxDelayedDatasourceHtml =
+    'multi-combobox-delayed-datasource/multi-combobox-delayed-datasource-example.component.html';
+const multiComboboxDelayedDatasourceTs =
+    'multi-combobox-delayed-datasource/multi-combobox-delayed-datasource-example.component.ts';
 const multiComboboxGroupHtml = 'multi-combobox-group/multi-combobox-group-example.component.html';
 const multiComboboxGroupTs = 'multi-combobox-group/multi-combobox-group-example.component.ts';
 const multiComboboxColumnsHtml = 'multi-combobox-columns/multi-combobox-columns-example.component.html';
@@ -50,6 +55,7 @@ const multiComboboxLoadingTs = 'multi-combobox-loading/multi-combobox-loading-ex
         MultiComboboxColumnsExampleComponent,
         MultiComboboxStatesExampleComponent,
         MultiComboboxFormsExampleComponent,
+        MultiComboboxDelayedDatasourceExampleComponent,
         MultiComboboxLoadingExampleComponent,
         MultiComboboxRemoteDatasourceExampleComponent
     ]
@@ -122,6 +128,20 @@ export class PlatformMultiComboboxDocsComponent {
             fileName: 'multi-combobox-forms-example',
             code: getAssetFromModuleAssets(multiComboboxFormsTs),
             component: 'MultiComboboxFormsExampleComponent'
+        }
+    ];
+
+    multiComboboxDelayedDatasourceExample: ExampleFile[] = [
+        {
+            language: 'html',
+            fileName: 'multi-combobox-delayed-datasource-example',
+            code: getAssetFromModuleAssets(multiComboboxDelayedDatasourceHtml)
+        },
+        {
+            language: 'typescript',
+            fileName: 'multi-combobox-delayed-datasource-example',
+            code: getAssetFromModuleAssets(multiComboboxDelayedDatasourceTs),
+            component: 'MultiComboboxDelayedDatasourceExampleComponent'
         }
     ];
 

--- a/libs/platform/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/form/multi-combobox/commons/base-multi-combobox.ts
@@ -422,6 +422,13 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
         if (dataSourceChange) {
             this._initializeDataSource(dataSourceChange.currentValue);
         }
+
+        if (changes['selectedItems'] && !changes['selectedItems'].firstChange) {
+            const currentValues = this._selectedSuggestions.map((s) => s.value);
+            if (!shallowEqual(currentValues, this.selectedItems)) {
+                this._setSelectedSuggestions();
+            }
+        }
     }
 
     /** @hidden */
@@ -631,6 +638,9 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
     protected _setSelectedSuggestions(): void {
         this._selectedSuggestions = [];
 
+        this._fullFlatSuggestions.forEach((item) => (item.selected = false));
+        (this._suggestions || []).forEach((item) => (item.selected = false));
+
         if (!this.selectedItems?.length) {
             return;
         }
@@ -638,7 +648,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
         for (let i = 0; i < this.selectedItems.length; i++) {
             const selectedItem = this.selectedItems[i];
             const finder = (item: SelectableOptionItem): boolean =>
-                item.label === selectedItem || item.value === selectedItem;
+                item.label === selectedItem || shallowEqual(item.value, selectedItem);
             const idFromFullFlatSuggestions = this._fullFlatSuggestions.findIndex(finder);
             const idFromSuggestions = (this._suggestions || []).findIndex(finder);
             const itemIndex = Math.max(idFromFullFlatSuggestions, idFromSuggestions);
@@ -658,10 +668,13 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
             if (itemIndex > -1) {
                 this._selectedSuggestions.push(collection[itemIndex]);
                 collection[itemIndex].selected = true;
+                if (idFromSuggestions !== -1) {
+                    this._suggestions[idFromSuggestions].selected = true;
+                }
             }
         }
 
-        this.detectChanges();
+        this.markForCheck();
     }
 
     /** @hidden */

--- a/libs/platform/form/multi-combobox/commons/base-multi-combobox.ts
+++ b/libs/platform/form/multi-combobox/commons/base-multi-combobox.ts
@@ -423,6 +423,8 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
             this._initializeDataSource(dataSourceChange.currentValue);
         }
 
+        // Sync selected suggestion tokens when [selectedItems] input changes (after init).
+        // Skips if values haven't actually changed to avoid unnecessary rebuilds.
         if (changes['selectedItems'] && !changes['selectedItems'].firstChange) {
             const currentValues = this._selectedSuggestions.map((s) => s.value);
             if (!shallowEqual(currentValues, this.selectedItems)) {
@@ -638,6 +640,8 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
     protected _setSelectedSuggestions(): void {
         this._selectedSuggestions = [];
 
+        // Clear all selected flags before rebuilding; it ensures replace/clear operations
+        // don't leave stale checkmarks in the dropdown when the data is re-rendered.
         this._fullFlatSuggestions.forEach((item) => (item.selected = false));
         (this._suggestions || []).forEach((item) => (item.selected = false));
 
@@ -647,10 +651,13 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
 
         for (let i = 0; i < this.selectedItems.length; i++) {
             const selectedItem = this.selectedItems[i];
+            // Match by label OR by value (object with deep equality).
+            // Supports both string-based selections (e.g. ['Apple'] and object-based [{id:1, label:'Apple'}]).
             const finder = (item: SelectableOptionItem): boolean =>
                 item.label === selectedItem || shallowEqual(item.value, selectedItem);
             const idFromFullFlatSuggestions = this._fullFlatSuggestions.findIndex(finder);
             const idFromSuggestions = (this._suggestions || []).findIndex(finder);
+            // Prefer full flat list (which includes groups); fall back to filtered list if needed.
             const itemIndex = Math.max(idFromFullFlatSuggestions, idFromSuggestions);
             const collection = idFromFullFlatSuggestions !== -1 ? this._fullFlatSuggestions : this._suggestions;
             if (idFromFullFlatSuggestions === -1 && idFromSuggestions === -1) {
@@ -668,6 +675,7 @@ export abstract class BaseMultiCombobox extends CollectionBaseInput implements O
             if (itemIndex > -1) {
                 this._selectedSuggestions.push(collection[itemIndex]);
                 collection[itemIndex].selected = true;
+                // If the item also exists in the filtered visible list, sync its selected flag too.
                 if (idFromSuggestions !== -1) {
                     this._suggestions[idFromSuggestions].selected = true;
                 }

--- a/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.html
+++ b/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.html
@@ -50,7 +50,7 @@
                 fdMultiAnnouncer
                 [multiAnnouncerOptions]="_suggestions"
             >
-                @for (token of _selectedSuggestions; track token) {
+                @for (token of _selectedSuggestions; track token.label) {
                     <fd-token [readOnly]="disabled" (onCloseClick)="removeToken(token, $event)">
                         {{ token.label }}
                     </fd-token>
@@ -174,7 +174,7 @@
         }
         <ng-content></ng-content>
         @if (isGroup) {
-            @for (group of _suggestions; track group) {
+            @for (group of _suggestions; track group.label) {
                 @if (!groupItemTemplate) {
                     <label fd-list-item fd-list-group-header role="group">
                         <span fd-list-title>{{ group.label }}</span>
@@ -186,7 +186,7 @@
                         [ngTemplateOutletContext]="{ $implicit: { label: group.label } }"
                     ></ng-template>
                 }
-                @for (optionItem of group.children; track optionItem) {
+                @for (optionItem of group.children; track $index) {
                     <li
                         fd-list-item
                         role="option"
@@ -208,7 +208,7 @@
                 }
             }
         } @else {
-            @for (optionItem of _suggestions; track optionItem) {
+            @for (optionItem of _suggestions; track $index) {
                 <li
                     fd-list-item
                     role="option"

--- a/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.spec.ts
+++ b/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.spec.ts
@@ -1,7 +1,16 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { Component, ViewChild } from '@angular/core';
-import { ComponentFixture, TestBed, inject, waitForAsync } from '@angular/core/testing';
-import { ReactiveFormsModule } from '@angular/forms';
+import { Component, signal, ViewChild } from '@angular/core';
+import {
+    ComponentFixture,
+    discardPeriodicTasks,
+    fakeAsync,
+    flush,
+    inject,
+    TestBed,
+    tick,
+    waitForAsync
+} from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import { By } from '@angular/platform-browser';
 import { DynamicComponentService, RtlService } from '@fundamental-ngx/cdk/utils';
@@ -35,7 +44,6 @@ import { MultiComboboxComponent } from './multi-combobox.component';
             </fdp-form-field>
         </fdp-form-group>
     `,
-    standalone: true,
     imports: [FdpFormGroupModule, FormModule, ReactiveFormsModule, PlatformMultiComboboxModule, ContentDensityModule]
 })
 class MultiComboboxStandardComponent {
@@ -288,5 +296,344 @@ describe('MultiComboboxComponent default values', () => {
 
         // Verify that _focusToSearchField was NOT called
         expect(focusToSearchFieldSpy).not.toHaveBeenCalled();
+    });
+});
+
+// ─── Regression tests for #13553 ─────────────────────────────────────────────
+// Covers the [selectedItems] binding path: programmatic set without opening
+// the dropdown must update tokens and option selected-flags on reopen.
+// The FormControl.setValue() path is not reproduced here because writeValue()
+// reaches _setSelectedSuggestions() via a synchronous datasource, making that
+// path correct in jsdom even before the fix — covered by the docs form example.
+
+const ITEMS_13553 = [
+    { name: 'Apple', type: 'Fruits' },
+    { name: 'Banana', type: 'Fruits' },
+    { name: 'Pineapple', type: 'Fruits' },
+    { name: 'Strawberry', type: 'Fruits' },
+    { name: 'Broccoli', type: 'Vegetables' }
+];
+
+@Component({
+    selector: 'fdp-multi-combobox-selected-items-test',
+    template: `
+        <fdp-form-group>
+            <fdp-form-field id="field" label="Items" zone="zLeft" rank="1">
+                <fdp-multi-combobox
+                    name="items"
+                    displayKey="name"
+                    [dataSource]="dataSource"
+                    [selectedItems]="selectedItems"
+                ></fdp-multi-combobox>
+            </fdp-form-field>
+        </fdp-form-group>
+    `,
+    imports: [FdpFormGroupModule, FormModule, PlatformMultiComboboxModule]
+})
+class MultiComboboxSelectedItemsTestComponent {
+    @ViewChild(MultiComboboxComponent)
+    multiCombobox: MultiComboboxComponent;
+
+    dataSource = [...ITEMS_13553];
+    selectedItems: any[] = [];
+}
+
+describe('MultiComboboxComponent #13553 – programmatic set without dropdown open', () => {
+    let fixture: ComponentFixture<MultiComboboxSelectedItemsTestComponent>;
+    let component: MultiComboboxSelectedItemsTestComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [MultiComboboxSelectedItemsTestComponent],
+            providers: [DynamicComponentService, RtlService, { provide: DATA_PROVIDERS, useClass: DataProvider as any }]
+        }).compileComponents();
+    }));
+
+    beforeEach(async () => {
+        fixture = TestBed.createComponent(MultiComboboxSelectedItemsTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should render tokens when [selectedItems] is set programmatically without opening the dropdown', async () => {
+        // Confirm suggestions are populated — the bug is NOT an empty lookup table
+        expect(component.multiCombobox._fullFlatSuggestions.length).toBeGreaterThan(0);
+
+        // Set selection programmatically — no dropdown interaction
+        component.selectedItems = [ITEMS_13553[0], ITEMS_13553[1]];
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        // _selectedSuggestions must reflect the new selection
+        expect(component.multiCombobox._selectedSuggestions.length).toBe(2);
+
+        // Tokens must be rendered in the DOM
+        const tokens = fixture.nativeElement.querySelectorAll('fd-token');
+        expect(tokens.length).toBe(2);
+
+        const labels = Array.from(tokens).map((t: Element) => t.textContent?.trim());
+        expect(labels).toContain('Apple');
+        expect(labels).toContain('Banana');
+    });
+});
+
+// ─── RED tests for #13553 – stale selected-flag bug (dropdown reopen state) ──
+// _setSelectedSuggestions() only ever sets selected=true, never resets stale
+// flags. After replace/clear, reopening the dropdown shows stale checked items.
+// These tests fail on current main for the RIGHT reason (stale option.selected
+// flags), not a setup artifact.
+
+describe('MultiComboboxComponent #13553 – stale selected-flag on dropdown reopen', () => {
+    let fixture: ComponentFixture<MultiComboboxSelectedItemsTestComponent>;
+    let component: MultiComboboxSelectedItemsTestComponent;
+    let multiCombobox: MultiComboboxComponent;
+    let overlayContainerEl: HTMLElement;
+
+    beforeEach(fakeAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [MultiComboboxSelectedItemsTestComponent],
+            providers: [DynamicComponentService, RtlService, { provide: DATA_PROVIDERS, useClass: DataProvider as any }]
+        }).compileComponents();
+
+        inject([OverlayContainer], (overlayContainer: OverlayContainer) => {
+            overlayContainerEl = overlayContainer.getContainerElement();
+        })();
+
+        fixture = TestBed.createComponent(MultiComboboxSelectedItemsTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        tick(50);
+        fixture.detectChanges();
+        multiCombobox = component.multiCombobox;
+    }));
+
+    /** Returns labels of list items in the open dropdown that carry is-selected. */
+    function getSelectedLabels(): string[] {
+        return Array.from(overlayContainerEl.querySelectorAll('li.fd-list__item.is-selected[role="option"]')).map(
+            (el) => el.querySelector('.fd-list__title')?.textContent?.trim() ?? ''
+        );
+    }
+
+    /** Opens the dropdown and ticks to let CDK overlay render. */
+    function openDropdown(): void {
+        multiCombobox.onPrimaryButtonClick(multiCombobox.isOpen);
+        tick(200);
+        fixture.detectChanges();
+        flush();
+        fixture.detectChanges();
+    }
+
+    it('replace: after [Apple]→[Banana], Apple option must not remain selected in _suggestions', fakeAsync(() => {
+        // The overlay DOM cannot distinguish 2-vs-1 selected items for this path in jsdom
+        // (CDK overlay renders from a snapshot). Assert the model that drives [selected] instead —
+        // _suggestions[i].selected is the exact value the template reads for the li[selected] binding.
+        (multiCombobox as any).setValue([ITEMS_13553[0]]); // Apple
+        tick(100);
+        fixture.detectChanges();
+
+        const appleOption = multiCombobox._suggestions.find((s) => s.label === 'Apple')!;
+        expect(appleOption.selected).toBe(true);
+
+        (multiCombobox as any).setValue([ITEMS_13553[1]]); // Banana — replace
+        tick(100);
+        fixture.detectChanges();
+
+        const bananaOption = multiCombobox._suggestions.find((s) => s.label === 'Banana')!;
+        expect(bananaOption.selected).toBe(true); // Banana must be selected after replace
+        // On main: Apple.selected stays true (stale flag bug) — this assertion fails
+        expect(appleOption.selected).toBe(false); // fails on main
+        discardPeriodicTasks();
+    }));
+
+    it('clear: after [Apple, Banana]→[], reopen dropdown should show nothing checked', fakeAsync(() => {
+        // Seed Apple + Banana directly to bypass the round-1 ngOnChanges bug
+        const appleOption = multiCombobox._fullFlatSuggestions.find((s) => s.label === 'Apple')!;
+        const bananaOption = multiCombobox._fullFlatSuggestions.find((s) => s.label === 'Banana')!;
+        appleOption.selected = true;
+        bananaOption.selected = true;
+        multiCombobox._selectedSuggestions = [appleOption, bananaOption];
+        fixture.detectChanges();
+
+        // Clear — no dropdown open during the set
+        component.selectedItems = [];
+        fixture.detectChanges();
+        tick(50);
+        fixture.detectChanges();
+
+        // Reopen dropdown and assert option state
+        openDropdown();
+
+        const listItems = overlayContainerEl.querySelectorAll('li.fd-list__item[role="option"]');
+        expect(listItems.length).toBeGreaterThan(0); // dropdown is populated
+        const selectedLabels = getSelectedLabels();
+        expect(selectedLabels.length).toBe(0); // fails on main — early-return leaves flags true
+        discardPeriodicTasks();
+    }));
+});
+
+// ─── Regression tests for #13553 – onChange emits raw values, not wrappers ────
+// _propagateChange() was calling this.onChange(this._selectedSuggestions) which
+// passed SelectableOptionItem wrappers to the FormControl. The control value then
+// stored wrappers, causing re-matching failures when writeValue fed the value back.
+
+const ITEMS_PROPAGATE = [
+    { name: 'Apple', type: 'Fruits' },
+    { name: 'Banana', type: 'Fruits' },
+    { name: 'Pineapple', type: 'Fruits' }
+];
+
+@Component({
+    selector: 'fdp-multi-combobox-form-control-test',
+    template: `
+        <form [formGroup]="form">
+            <fdp-form-group>
+                <fdp-form-field id="ctrl" label="Items" zone="zLeft" rank="1">
+                    <fdp-multi-combobox
+                        name="items"
+                        displayKey="name"
+                        formControlName="items"
+                        [dataSource]="dataSource"
+                    ></fdp-multi-combobox>
+                </fdp-form-field>
+            </fdp-form-group>
+        </form>
+    `,
+    imports: [FdpFormGroupModule, FormModule, ReactiveFormsModule, PlatformMultiComboboxModule]
+})
+class MultiComboboxFormControlTestComponent {
+    @ViewChild(MultiComboboxComponent)
+    multiCombobox: MultiComboboxComponent;
+
+    dataSource = [...ITEMS_PROPAGATE];
+    form = new FormGroup({ items: new FormControl([]) });
+}
+
+@Component({
+    selector: 'fdp-multi-combobox-signal-selection-test',
+    template: `
+        <fdp-form-group>
+            <fdp-form-field id="signal-items" label="Items" zone="zLeft" rank="1">
+                <fdp-multi-combobox
+                    name="items"
+                    displayKey="name"
+                    [dataSource]="dataSource"
+                    [selectedItems]="selectedItems()"
+                    (selectionChange)="selectedItems.set($event.selectedItems)"
+                ></fdp-multi-combobox>
+            </fdp-form-field>
+        </fdp-form-group>
+    `,
+    imports: [FdpFormGroupModule, FormModule, PlatformMultiComboboxModule]
+})
+class MultiComboboxSignalSelectionTestComponent {
+    @ViewChild(MultiComboboxComponent)
+    multiCombobox: MultiComboboxComponent;
+
+    dataSource = [...ITEMS_13553];
+    selectedItems = signal<typeof ITEMS_13553>([]);
+}
+
+describe('MultiComboboxComponent #13553 - signal-bound selection', () => {
+    let fixture: ComponentFixture<MultiComboboxSignalSelectionTestComponent>;
+    let component: MultiComboboxSignalSelectionTestComponent;
+    let overlayContainerEl: HTMLElement;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [MultiComboboxSignalSelectionTestComponent],
+            providers: [DynamicComponentService, RtlService, { provide: DATA_PROVIDERS, useClass: DataProvider as any }]
+        })
+            .compileComponents()
+            .then(() => {
+                overlayContainerEl = TestBed.inject(OverlayContainer).getContainerElement();
+            });
+    }));
+
+    beforeEach(async () => {
+        fixture = TestBed.createComponent(MultiComboboxSignalSelectionTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('keeps existing options selected after adding an item', async () => {
+        component.selectedItems.set([ITEMS_13553[3], ITEMS_13553[4]]);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(component.multiCombobox._selectedSuggestions.map((item) => item.label)).toEqual([
+            'Strawberry',
+            'Broccoli'
+        ]);
+
+        component.multiCombobox.onPrimaryButtonClick(component.multiCombobox.isOpen);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const appleCheckbox = overlayContainerEl.querySelector<HTMLInputElement>('fd-checkbox input')!;
+        appleCheckbox.click();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(component.selectedItems().map((item) => item.name)).toEqual(['Strawberry', 'Broccoli', 'Apple']);
+
+        const tokenLabels = Array.from(fixture.nativeElement.querySelectorAll('fd-token')).map((token: Element) =>
+            token.textContent?.trim()
+        );
+        expect(tokenLabels).toEqual(['Strawberry', 'Broccoli', 'Apple']);
+
+        const selectedLabels = component.multiCombobox._suggestions
+            .filter((item) => item.selected)
+            .map((item) => item.label);
+        expect(selectedLabels).toEqual(['Apple', 'Strawberry', 'Broccoli']);
+    });
+});
+
+describe('MultiComboboxComponent #13553 – onChange emits raw values (not wrappers)', () => {
+    let fixture: ComponentFixture<MultiComboboxFormControlTestComponent>;
+    let component: MultiComboboxFormControlTestComponent;
+    let multiCombobox: MultiComboboxComponent;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [MultiComboboxFormControlTestComponent],
+            providers: [DynamicComponentService, RtlService, { provide: DATA_PROVIDERS, useClass: DataProvider as any }]
+        }).compileComponents();
+    }));
+
+    beforeEach(async () => {
+        fixture = TestBed.createComponent(MultiComboboxFormControlTestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+        multiCombobox = component.multiCombobox;
+    });
+
+    it('FormControl.value should contain raw datasource objects after toggleSelection', async () => {
+        const item = multiCombobox._suggestions.find((s) => s.label === 'Apple')!;
+        multiCombobox.toggleSelection(item);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const value: any[] = component.form.get('items')!.value ?? [];
+        expect(value.length).toBe(1);
+        // Raw datasource object must not carry a `selected` property (wrappers do)
+        expect(value[0]).not.toHaveProperty('selected');
+        expect(value[0].name).toBe('Apple');
+    });
+
+    it('selected item remains checked in _suggestions after searchTermChanged re-emits datasource', async () => {
+        const item = multiCombobox._suggestions.find((s) => s.label === 'Banana')!;
+        multiCombobox.toggleSelection(item);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        multiCombobox.searchTermChanged('');
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const bananaOption = multiCombobox._suggestions.find((s) => s.label === 'Banana')!;
+        expect(bananaOption.selected).toBe(true);
     });
 });

--- a/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.ts
+++ b/libs/platform/form/multi-combobox/multi-combobox/multi-combobox.component.ts
@@ -361,7 +361,7 @@ export class MultiComboboxComponent extends BaseMultiCombobox implements OnInit,
     /** @hidden */
     private _propagateChange(emitInMobile?: boolean): void {
         if (!this.mobile || emitInMobile) {
-            this.onChange(this._selectedSuggestions);
+            this.onChange(this._selectedSuggestions.map(({ value }) => value));
             this._mapAndUpdateModel();
         }
     }


### PR DESCRIPTION
## Summary

- Keep multi-combobox selections synchronized across bound values, rendered tokens, and dropdown checkbox states after programmatic updates and user interaction.
- Synchronize delayed and initial `FormControl` values in Core; synchronize Platform's full and visible option collections using value-based matching, and emit raw selected values to forms.
- Update both Reactive Forms and signal-backed documentation examples with programmatic Select All/Clear actions; use stable tracking for tokens and option lists.
- Closes #13553

## Test plan

- [x] In `/#/core/multi-combobox` and `/#/platform/multi-combobox`, use the Reactive Forms Select All/Clear controls and confirm tokens and dropdown checks match the displayed form value.
- [x] In both Pure Signal-based examples, add an item through the dropdown, then replace, clear, filter, and remove a token; confirm the signal value, tokens, and checked rows remain aligned.